### PR TITLE
Enrollee populator

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeDao.java
@@ -6,6 +6,7 @@ import bio.terra.pearl.core.service.CascadeTree;
 import org.jdbi.v3.core.Jdbi;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Component
@@ -17,6 +18,10 @@ public class EnrolleeDao extends BaseJdbiDao<Enrollee> {
     @Override
     protected Class<Enrollee> getClazz() {
         return Enrollee.class;
+    }
+
+    public Optional<Enrollee> findOneByShortcode(String shortcode) {
+        return findByProperty("shortcode", shortcode);
     }
 
     public void deleteByStudyEnvironmentId(UUID studyEnvironmentId, CascadeTree cascade) {

--- a/core/src/main/java/bio/terra/pearl/core/dao/study/StudyEnvironmentDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/study/StudyEnvironmentDao.java
@@ -1,12 +1,16 @@
 package bio.terra.pearl.core.dao.study;
 
 import bio.terra.pearl.core.dao.BaseJdbiDao;
+import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
+import org.apache.commons.lang3.StringUtils;
 import org.jdbi.v3.core.Jdbi;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Component
 public class StudyEnvironmentDao extends BaseJdbiDao<StudyEnvironment> {
@@ -21,6 +25,20 @@ public class StudyEnvironmentDao extends BaseJdbiDao<StudyEnvironment> {
 
     public List<StudyEnvironment> findByStudy(UUID studyId) {
         return findAllByProperty("study_id", studyId);
+    }
+
+    public Optional<StudyEnvironment> findByStudy(String shortcode, EnvironmentName environmentName) {
+        List<String> primaryCols = getQueryColumns.stream().map(col -> "a." + col)
+                .collect(Collectors.toList());
+        return jdbi.withHandle(handle ->
+                handle.createQuery("select " + StringUtils.join(primaryCols, ", ") + " from " + tableName
+                        + " a join study on study_id = study.id"
+                        + " where study.shortcode = :shortcode and environment_name = :environmentName")
+                        .bind("shortcode", shortcode)
+                        .bind("environmentName", environmentName)
+                        .mapTo(clazz)
+                        .findOne()
+        );
     }
 
     public void deleteByStudyId(UUID studyId) {

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeService.java
@@ -1,10 +1,12 @@
 package bio.terra.pearl.core.service.participant;
 
 import bio.terra.pearl.core.dao.participant.EnrolleeDao;
+import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.service.CascadeTree;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -13,6 +15,18 @@ public class EnrolleeService {
 
     public EnrolleeService(EnrolleeDao enrolleeDao) {
         this.enrolleeDao = enrolleeDao;
+    }
+
+    public Optional<Enrollee> findOneByShortcode(String shortcode) {
+        return enrolleeDao.findOneByShortcode(shortcode);
+    }
+
+    public Enrollee create(Enrollee enrollee) {
+        return enrolleeDao.create(enrollee);
+    }
+
+    public void delete(UUID enrolleeId, CascadeTree cascadeTree) {
+        enrolleeDao.delete(enrolleeId);
     }
 
     @Transactional

--- a/core/src/main/java/bio/terra/pearl/core/service/study/StudyEnvironmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/study/StudyEnvironmentService.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.service.study;
 
 import bio.terra.pearl.core.dao.study.StudyEnvironmentDao;
+import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.study.StudyEnvironmentConfig;
 import bio.terra.pearl.core.service.CascadeProperty;
@@ -9,10 +10,7 @@ import bio.terra.pearl.core.service.participant.EnrolleeService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 @Service
 public class StudyEnvironmentService {
@@ -33,6 +31,9 @@ public class StudyEnvironmentService {
         return new HashSet<>(studyEnvironmentDao.findByStudy(studyId));
     }
 
+    public Optional<StudyEnvironment> findByStudy(String studyShortcode, EnvironmentName environmentName) {
+        return studyEnvironmentDao.findByStudy(studyShortcode, environmentName);
+    }
 
     @Transactional
     public StudyEnvironment create(StudyEnvironment studyEnv) {

--- a/populate/src/main/java/bio/terra/pearl/populate/dto/FilePopulatable.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/dto/FilePopulatable.java
@@ -1,5 +1,0 @@
-package bio.terra.pearl.populate.dto;
-
-public interface FilePopulatable {
-    public String getPopulateFileName();
-}

--- a/populate/src/main/java/bio/terra/pearl/populate/dto/PopulateEnrolleeDto.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/dto/PopulateEnrolleeDto.java
@@ -1,0 +1,11 @@
+package bio.terra.pearl.populate.dto;
+
+import bio.terra.pearl.core.model.participant.Enrollee;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter @NoArgsConstructor
+public class PopulateEnrolleeDto extends Enrollee {
+    private String linkedUsername;
+}

--- a/populate/src/main/java/bio/terra/pearl/populate/dto/PopulateStudyDto.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/dto/PopulateStudyDto.java
@@ -1,15 +1,20 @@
 package bio.terra.pearl.populate.dto;
 
 import bio.terra.pearl.core.model.study.Study;
+import bio.terra.pearl.core.model.study.StudyEnvironment;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.experimental.SuperBuilder;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-@Getter @Setter @SuperBuilder
-@NoArgsConstructor
+@Getter @Setter @NoArgsConstructor
 public class PopulateStudyDto extends Study {
-    private List<String> participantFiles;
+    private List<PopulateStudyEnvironmentDto> studyEnvironmentDtos = new ArrayList<>();
+    public Set<StudyEnvironment> getStudyEnvironments() {
+        return studyEnvironmentDtos.stream().collect(Collectors.toSet());
+    }
 }

--- a/populate/src/main/java/bio/terra/pearl/populate/dto/PopulateStudyEnvironmentDto.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/dto/PopulateStudyEnvironmentDto.java
@@ -1,0 +1,17 @@
+package bio.terra.pearl.populate.dto;
+
+import bio.terra.pearl.core.model.study.StudyEnvironment;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+public class PopulateStudyEnvironmentDto extends StudyEnvironment {
+    private List<String> enrolleeFiles;
+}

--- a/populate/src/main/java/bio/terra/pearl/populate/service/AdminUserPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/AdminUserPopulator.java
@@ -6,9 +6,6 @@ import bio.terra.pearl.populate.dto.AdminUserDto;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.io.IOException;
 
 @Service
 public class AdminUserPopulator extends Populator<AdminUser> {
@@ -25,13 +22,7 @@ public class AdminUserPopulator extends Populator<AdminUser> {
         this.adminUserService = adminUserService;
     }
 
-    @Transactional
     @Override
-    public AdminUser populate(String fileName, FilePopulateConfig config) throws IOException {
-        String content = filePopulateService.readFile(fileName, config);
-        return populateFromString(content, config);
-    }
-
     public AdminUser populateFromString(String content, FilePopulateConfig config) throws JsonProcessingException {
         AdminUserDto adminUserDto = objectMapper.readValue(content, AdminUserDto.class);
         return adminUserService.createAdminUser(adminUserDto);

--- a/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
@@ -1,0 +1,52 @@
+package bio.terra.pearl.populate.service;
+
+import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.participant.ParticipantUser;
+import bio.terra.pearl.core.model.study.StudyEnvironment;
+import bio.terra.pearl.core.service.CascadeTree;
+import bio.terra.pearl.core.service.participant.EnrolleeService;
+import bio.terra.pearl.core.service.participant.ParticipantUserService;
+import bio.terra.pearl.core.service.study.StudyEnvironmentService;
+import bio.terra.pearl.populate.dto.PopulateEnrolleeDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@Service
+public class EnrolleePopulator extends Populator<Enrollee> {
+    private EnrolleeService enrolleeService;
+    private StudyEnvironmentService studyEnvironmentService;
+    private ParticipantUserService participantUserService;
+
+    public EnrolleePopulator(FilePopulateService filePopulateService,
+                            ObjectMapper objectMapper,
+                            EnrolleeService enrolleeService, 
+                             StudyEnvironmentService studyEnvironmentService,
+                             ParticipantUserService participantUserService) {
+        this.objectMapper = objectMapper;
+        this.filePopulateService = filePopulateService;
+        this.enrolleeService = enrolleeService;
+        this.studyEnvironmentService = studyEnvironmentService;
+        this.participantUserService = participantUserService;
+    }
+
+    @Override
+    public Enrollee populateFromString(String fileString, FilePopulateConfig config) throws IOException {
+        PopulateEnrolleeDto enrolleeDto = objectMapper.readValue(fileString, PopulateEnrolleeDto.class);
+        Optional<Enrollee> existingEnrollee = enrolleeService.findOneByShortcode(enrolleeDto.getShortcode());
+        existingEnrollee.ifPresent(exEnrollee ->
+                enrolleeService.delete(exEnrollee.getId(), CascadeTree.NONE)
+        );
+        StudyEnvironment attachedEnv = studyEnvironmentService
+                .findByStudy(config.getStudyShortcode(), config.getEnvironmentName()).get();
+        enrolleeDto.setStudyEnvironmentId(attachedEnv.getId());
+        ParticipantUser attachedUser = participantUserService
+                .findOne(enrolleeDto.getLinkedUsername(), config.getEnvironmentName()).get();
+        enrolleeDto.setParticipantUserId(attachedUser.getId());
+        Enrollee enrollee = enrolleeService.create(enrolleeDto);
+        return enrollee;
+    }
+}
+

--- a/populate/src/main/java/bio/terra/pearl/populate/service/FilePopulateConfig.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/FilePopulateConfig.java
@@ -1,23 +1,41 @@
 package bio.terra.pearl.populate.service;
 
 
-import lombok.AllArgsConstructor;
+import bio.terra.pearl.core.model.EnvironmentName;
 import lombok.Getter;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+/**
+ * Stores the path and current filename to populate from.  Also tracks any contextual information, such as the current
+ * study that entities may need for creation.
+ */
 @Getter
-@AllArgsConstructor
 public class FilePopulateConfig {
     // current basePath we are populating from
     private String basePath;
     // the rootFile name that we started populating from
     private String rootFileName;
 
+    private String studyShortcode;
+
+    private EnvironmentName environmentName;
+
     public FilePopulateConfig(String filePathName) {
         Path filePath = Paths.get(filePathName);
         this.rootFileName = filePath.getFileName().toString();
         this.basePath = filePath.getParent().toString();
+    }
+
+    public FilePopulateConfig newFrom(String relativeFilePath) {
+        return newFrom(relativeFilePath, studyShortcode, environmentName);
+    }
+
+    public FilePopulateConfig newFrom(String relativeFilePath, String studyShortcode, EnvironmentName environmentName) {
+        FilePopulateConfig newConfig = new FilePopulateConfig(getBasePath() + "/" + relativeFilePath);
+        newConfig.studyShortcode = studyShortcode;
+        newConfig.environmentName = environmentName;
+        return newConfig;
     }
 }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/FilePopulateService.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/FilePopulateService.java
@@ -1,6 +1,5 @@
 package bio.terra.pearl.populate.service;
 
-import bio.terra.pearl.populate.dto.FilePopulatable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
@@ -49,20 +48,6 @@ public class FilePopulateService {
         String pathName = System.getProperty("user.dir") + "/" + ABSOLUTE_SEED_ROOT + popSpec.getBasePath() + "/" + relativePath;
         Path filePath = Path.of(pathName);
         return Files.newInputStream(filePath);
-    }
-
-    public String readPopulationFile(FilePopulatable thing, FilePopulateConfig popSpec) throws IOException {
-        if (thing.getPopulateFileName() != null) {
-            return readFile(thing.getPopulateFileName(), popSpec);
-        }
-        return null;
-    }
-
-    public byte[] readBinaryPopulationFile(FilePopulatable thing, FilePopulateConfig popSpec) throws IOException {
-        if (thing.getPopulateFileName() != null) {
-            return readBinaryFile(thing.getPopulateFileName(), popSpec);
-        }
-        return null;
     }
 
 }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/Populator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/Populator.java
@@ -12,11 +12,11 @@ public abstract class Populator<T extends BaseEntity> {
 
     public T populate(String filePathName) throws IOException {
         FilePopulateConfig config = new FilePopulateConfig(filePathName);
-        return populate(config.getRootFileName(), config);
+        return populate(config);
     }
 
-    public T populate(String fileName, FilePopulateConfig config) throws IOException {
-        String fileString = filePopulateService.readFile(fileName, config);
+    public T populate(FilePopulateConfig config) throws IOException {
+        String fileString = filePopulateService.readFile(config.getRootFileName(), config);
         return populateFromString(fileString, config);
     }
 

--- a/populate/src/main/java/bio/terra/pearl/populate/service/PortalPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/PortalPopulator.java
@@ -1,10 +1,10 @@
 package bio.terra.pearl.populate.service;
 
+import bio.terra.pearl.core.model.participant.ParticipantUser;
+import bio.terra.pearl.core.model.participant.PortalParticipantUser;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.study.PortalStudy;
 import bio.terra.pearl.core.model.study.Study;
-import bio.terra.pearl.core.model.participant.ParticipantUser;
-import bio.terra.pearl.core.model.participant.PortalParticipantUser;
 import bio.terra.pearl.core.service.CascadeTree;
 import bio.terra.pearl.core.service.participant.PortalParticipantUserService;
 import bio.terra.pearl.core.service.portal.PortalService;
@@ -59,24 +59,24 @@ public class PortalPopulator extends Populator<Portal> {
             portalService.delete(portal.getId(), new CascadeTree(PortalService.AllowedCascades.STUDY))
         );
         Portal portal = portalService.create(portalDto);
-        for (String studyFileName : portalDto.getPopulateStudyFiles()) {
-            populateStudy(studyFileName, config, portal);
-        }
         for (String userFileName : portalDto.getParticipantUserFiles()) {
             populateParticipantUser(userFileName, config, portal);
+        }
+        for (String studyFileName : portalDto.getPopulateStudyFiles()) {
+            populateStudy(studyFileName, config, portal);
         }
         return portal;
     }
 
     private void populateStudy(String studyFileName, FilePopulateConfig config, Portal portal) throws IOException {
-        Study newStudy = studyPopulator.populate(studyFileName, config);
+        Study newStudy = studyPopulator.populate(config.newFrom(studyFileName));
         PortalStudy portalStudy = portalStudyService.create(portal.getId(), newStudy.getId());
         portal.getPortalStudies().add(portalStudy);
         portalStudy.setStudy(newStudy);
     }
 
     private void populateParticipantUser(String userFileName, FilePopulateConfig config, Portal portal) throws IOException {
-        ParticipantUser newUser = participantUserPopulator.populate(userFileName, config);
+        ParticipantUser newUser = participantUserPopulator.populate(config.newFrom(userFileName));
         PortalParticipantUser ppUser = ppUserService.create(portal.getId(), newUser.getId());
         portal.getPortalParticipantUsers().add(ppUser);
         ppUser.setParticipantUser(newUser);

--- a/populate/src/main/resources/seed/portals/ourhealth/portal.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/portal.json
@@ -2,7 +2,7 @@
   "name": "OurHealth",
   "shortcode": "ourhealth",
   "populateStudyFiles": [
-    "study.json"
+    "studies/main/study.json"
   ],
   "participantUserFiles": [
     "participants/jsalk.json"

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/main/enrollees/jsalk.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/main/enrollees/jsalk.json
@@ -1,0 +1,4 @@
+{
+  "linkedUsername": "jsalk@test.com",
+  "shortcode": "JOSALK"
+}

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/main/study.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/main/study.json
@@ -1,7 +1,7 @@
 {
   "name": "Longitudinal heart health study",
   "shortcode": "ourheart",
-  "studyEnvironments": [
+  "studyEnvironmentDtos": [
     {
       "environmentName": "sandbox",
       "studyEnvironmentConfig": {
@@ -9,7 +9,10 @@
         "passwordProtected": false,
         "password": "broad_institute",
         "initialized": true
-      }
+      },
+      "enrolleeFiles": [
+        "enrollees/jsalk.json"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This adds a trivial populator for enrollees, and the corresponding create/delete methods.  

TO TEST:
1. reset DB
2. Run populateCliApp with args "portal" "portals/ourhealth/portal.json"
3. confirm an enrollee with shortcode JOSALK gets populated to your DB
4. edit `portals/ourhealth/studies/main/enrollees/jsalk.json` to change the shortcode from JOSALK to something else
5. rerun the PopulateCliApp with the same arguments.
6. Confirm your enrollee table now has the updated participant shortcode