### PR TITLE
adding more explicit dependencies on copyWebapp task

### DIFF
--- a/api-admin/build.gradle
+++ b/api-admin/build.gradle
@@ -13,10 +13,12 @@ apply from: 'publishing.gradle'
 
 
 dependencies {
+
     implementation 'bio.terra:terra-common-lib'
     implementation project(':core')
     implementation project(':populate')
     implementation project(':ui-admin')
+    ':api-admin:copyWebApp'
     implementation 'org.apache.commons:commons-dbcp2'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -47,6 +49,8 @@ test.dependsOn(copyWebApp)
 spotbugsTest.dependsOn(copyWebApp)
 jar.dependsOn(copyWebApp)
 compileTestJava.dependsOn(copyWebApp)
+jibDockerBuild.dependsOn(copyWebApp)
+jibBuildTar.dependsOn(copyWebApp)
 
 test {
     useJUnitPlatform ()


### PR DESCRIPTION
I *think* the error was that jibDockerBuild didn't depend properly on the ui admin tasks.  So we're going to retry with more explicit settings