### PR TITLE
AR-105 updating populate-from-classpath logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,16 @@ Open the root folder in IntelliJ.
       * Project Structure > Project Settings > Project > SDK
       * Preferences > Build, Execution, Deployment > Build Tools > Gradle > Gradle Projects > \[this project\] > Gradle JVM
          * Recommended setting for this is "Project SDK"
-   * create the following Spring Boot Run/Debug Configuration
-
-     ![run configuration](https://user-images.githubusercontent.com/2800795/195370172-f694b840-ae8f-4298-a43a-7ba87f944ebd.png)
-
-     In the project settings, make sure annotation processing is enabled (otherwise lombok getters/setters won't work)
-
+   * In the project settings, make sure annotation processing is enabled (otherwise lombok getters/setters won't work)
+   * Create two Spring Boot Run/Debug Configurations.
+     * ApiAdminApp (in api-admin module)
+       * set active profiles of "human-readable-logging" and "development"
+       * disable launch optimization
+     * ApiParticipantApp (in api-participant module)
+        * set active profiles of "human-readable-logging" and "development"
+        * disable launch optimization
+        
+         
 ### Running the application
 #### Admin tool (study manager, population)
 * API (api-admin module)

--- a/api-admin/src/main/resources/application-development.yml
+++ b/api-admin/src/main/resources/application-development.yml
@@ -1,0 +1,4 @@
+# for development, populate from local filesystem so you don't have to rebuild the jar to update population files
+env:
+  populate:
+    populate-from-classpath: false

--- a/api-admin/src/main/resources/application.yml
+++ b/api-admin/src/main/resources/application.yml
@@ -12,6 +12,8 @@ env:
     samplingRate: ${SAMPLING_PROBABILITY:0}
   sam:
     basePath: ${SAM_ADDRESS:https://sam.dsde-dev.broadinstitute.org}
+  populate:
+    populate-from-classpath: true
 
 # Below here is non-deployment-specific
 
@@ -92,6 +94,3 @@ terra.common:
   
 cors:
   enabled-path: http://localhost:3000,http://localhost:3005,http://*.localhost:3005,http://*.*.localhost:3005
-
-populate.populate-from-classpath: false
-


### PR DESCRIPTION
This fixes the configs so that populate-from-classpath is the default, since that's what we want in every environment except development.  It adds a new development profile to allow populating from local file system for fast development changes.

TO TEST:  (this is probably not worth testing since the main test will be if it fixes our deployments)
  1. nuke/reset db, and restart your api-admin app
  2. run scripts/populate_setup.sh
  3. run scripts/populate_portal.sh ourhealth
  4. confirm populate succeeds
  5. edit `populate/src/main/resources/seed/portals/ourhealth/portal.json` to have an obvious json syntax error
  6. rerun scripts/populate_portal.sh ourhealth
  7. confirm populate succeeds (because the populate is happening from the classpath, and so doesn't have your changes post-redeploy)
  8.  Revert the change you made in step 5.
  9. add "development" as an active profile to ApiAdminApp, and restart it.  
  10. repeat steps 3-7, and confirm that this time, step 7 produces an error on the populate, since it should now be picking up changes direct from the filesystem