### PR TITLE
DDO-2260 Update local UI instructions for new B2C tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ From the command line:
   ```
   cd ui-admin
   npm install
-  REACT_APP_B2C_TENANT_NAME=terradevb2c REACT_APP_B2C_CLIENT_ID=$(vault read -field value secret/dsde/terra/azure/dev/b2c/application_id) npm start
+  REACT_APP_B2C_TENANT_NAME=ddpdevb2c REACT_APP_B2C_CLIENT_ID=$(vault read -field value secret/dsp/ddp/b2c/dev/application_id) npm start
   ```
 (note that you can just run `npm start` if you don't need to test B2C login functionality)
 Then go to `localhost:3000` 


### PR DESCRIPTION
Updating instructions for running the UI locally with B2C to use the new ddp tenant rather than the Terra one. I've validated that this works with my own local env but would appreciate someone else giving it a try as well when you have time.