### PR TITLE
Ensure that Deploy Notifications Occur on Failure as well as Success

### DIFF
--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -100,6 +100,7 @@ jobs:
   
   notify-upon-completion:
     runs-on: ubuntu-latest
+    if: always()
     needs: [set-version-in-dev, publish-job]
     steps:
       - uses: broadinstitute/action-slack@v3.8.0


### PR DESCRIPTION
It turns out I did miss something setting this up, notifications were only being sent upon successful deploys. There was an example of a deploy that failed due to modifications to liquibase changelogs last Friday that did not notify
https://github.com/broadinstitute/pearl/actions/runs/4207744600

This ensures that notifications fire always.