### PR TITLE
DDO-2678 Refactor Image Build Pipeline to Support Publishing Admin and Participant

### DIFF
--- a/.github/actions/build-push-image/action.yaml
+++ b/.github/actions/build-push-image/action.yaml
@@ -31,7 +31,7 @@ runs:
       shell: bash
       run: |
         IMAGE_NAME="${{ inputs.image-repo }}/${{inputs.image-name }}:${{ inputs.version-tag }}"
-        echo "name=${IMAGE}" >> $GITHUB_OUTPUT
+        echo "name=${IMAGE_NAME}" >> $GITHUB_OUTPUT
     - name: Auth to Google
       uses: google-github-actions/auth@v1
       with:

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -118,7 +118,7 @@ jobs:
   notify-upon-completion:
     runs-on: ubuntu-latest
     if: always()
-    needs: [set-version-in-dev, publish-job, get-version-tag]
+    needs: [set-version-in-dev, get-version-tag]
     steps:
       - uses: broadinstitute/action-slack@v3.8.0
         env: 


### PR DESCRIPTION
Adds support for publishing both participant and admin images. These images will be published separately but versioned together. The two images are built and published in parallel so as to avoid the pipeline taking too long.

Also extracts out the common used to actually perform the build push of any image in this repo into a reusable workflow under `.github/workflows`. The reusable workflow is then invoked twice for the admin and participant images respectively.

Unfortunately, this type of thing is difficult to test with out actually running the pipeline so this may take a few tries, I doubt I got this one right on the first attempt.