### PR TITLE
DDO-2678 Fix Invalid Depedency Reference in GHA Publish Pipeline

### DIFF
--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -105,7 +105,7 @@ jobs:
   set-version-in-dev:
     # Put new version in ddp-azure-dev environment
     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
-    needs: [publish-job, report-to-sherlock, get-version-tag]
+    needs: [publish-admin-image, publish-participant-image, report-to-sherlock, get-version-tag]
     with:
       new-version: ${{ needs.get-version-tag.outputs.tag }}
       chart-name: 'd2p'


### PR DESCRIPTION
I missed a reference to the old image publishing pipeline job name which resulted in an invalid dependency graph of pipeline stages.