### PR TITLE
[AR-134] Resolve React warnings on OurHealth landing page

### DIFF
--- a/ui-participant/src/landing/sections/FrequentlyAskedQuestionsTemplate.tsx
+++ b/ui-participant/src/landing/sections/FrequentlyAskedQuestionsTemplate.tsx
@@ -44,8 +44,8 @@ function FrequentlyAskedQuestionsTemplate({
       <div className="border-bottom"></div>
       <div className="fs-5 fw-normal">
         {
-          _.map(questions, ({ question, answer }) => {
-            return <div className="border-bottom p-3">
+          _.map(questions, ({ question, answer }, i) => {
+            return <div key={i} className="border-bottom p-3">
               <button type="button" className="btn btn-lg btn-link text-black fw-bold text-decoration-none"
                 data-bs-toggle="collapse" data-bs-target={targetFor(question)}>
                 + {question}

--- a/ui-participant/src/landing/sections/HeroCenteredTemplate.tsx
+++ b/ui-participant/src/landing/sections/HeroCenteredTemplate.tsx
@@ -38,18 +38,18 @@ function HeroCenteredTemplate({
       <h1 className="fs-1 fw-normal lh-sm mb-4">
         <ReactMarkdown>{title ? title : ''}</ReactMarkdown>
       </h1>
-      <p className="fs-5 " style={blurbStyle}>
+      <div className="fs-5 " style={blurbStyle}>
         <ReactMarkdown>{blurb ? blurb : ''}</ReactMarkdown>
-      </p>
+      </div>
     </div>
     <div className="col-lg-6 mx-auto">
       <PearlImage image={image} className="img-fluid"/>
     </div>
     <div className="d-grid gap-2 d-sm-flex justify-content-sm-center">
       {
-        _.map(buttons, button => {
+        _.map(buttons, (button, i) => {
           // TODO: allow customization of button styling
-          return <ConfiguredButton config={button} className='btn btn-light btn-lg px-4 me-md-2'/>
+          return <ConfiguredButton key={i} config={button} className='btn btn-light btn-lg px-4 me-md-2'/>
         })
       }
     </div>

--- a/ui-participant/src/landing/sections/HeroWithImageTemplate.tsx
+++ b/ui-participant/src/landing/sections/HeroWithImageTemplate.tsx
@@ -46,9 +46,9 @@ function HeroWithImageTemplate({
         <h1 className="fs-1 fw-normal lh-sm">
           <ReactMarkdown>{title ? title : ''}</ReactMarkdown>
         </h1>
-        <p className="fs-5">
+        <div className="fs-5">
           <ReactMarkdown>{blurb ? blurb : ''}</ReactMarkdown>
-        </p>
+        </div>
         <div className="d-grid gap-2 d-md-flex justify-content-md-start">
           {
             _.map(buttons, (buttonConfig, i) =>

--- a/ui-participant/src/landing/sections/StepOverviewTemplate.tsx
+++ b/ui-participant/src/landing/sections/StepOverviewTemplate.tsx
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import React from 'react'
+import React, { Fragment } from 'react'
 import { ButtonConfig } from 'api/api'
 import PearlImage, { PearlImageProps } from 'util/PearlImage'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -39,7 +39,7 @@ function StepOverviewTemplate({
       <div className="col-md-10 d-flex">
         {
           _.map(steps, ({ image, duration, blurb }: StepProps, i: number) => {
-            return <>
+            return <Fragment key={i}>
               {i > 0 ? <FontAwesomeIcon className="fa-2x p-3 mt-5" icon={faArrowRight}/> : null}
               <div className="d-flex flex-column">
 
@@ -54,15 +54,15 @@ function StepOverviewTemplate({
                   </p>
                 </div>
               </div>
-            </>
+            </Fragment>
           })
         }
       </div>
     </div>
     <div className="d-grid gap-2 d-md-flex pt-4 justify-content-center">
       {
-        _.map(buttons, ({ text, href }) => {
-          return <a href={href} role={'button'} className="btn btn-primary btn-lg px-4 me-md-2">{text}</a>
+        _.map(buttons, ({ text, href }, i) => {
+          return <a key={i} href={href} role={'button'} className="btn btn-primary btn-lg px-4 me-md-2">{text}</a>
         })
       }
     </div>


### PR DESCRIPTION
Currently, there are several React warnings on the OurHealth landing page.

They fall into two categories:
- Missing keys on children in lists.
- Invalid DOM nesting.

For children in lists, this sets the key to the index in the list. This isn't ideal, but should be fine since these lists are coming from configuration and the order isn't expected to change.
https://reactjs.org/docs/lists-and-keys.html#keys

ReactMarkdown renders paragraph tags and paragraphs cannot be nested. This replaces the p tags wrapping ReactMarkdown with divs.