### PR TITLE
[AR-153] Remove duplicate npm install in CI workflows

### DIFF
--- a/.github/workflows/javascript-admin-ci.yml
+++ b/.github/workflows/javascript-admin-ci.yml
@@ -16,6 +16,5 @@ jobs:
         with:
           node-version: '16.x'
       - run: npm ci
-      - run: npm install
       - run: npm run build --if-present
       - run: npm test

--- a/.github/workflows/javascript-participant-ci.yml
+++ b/.github/workflows/javascript-participant-ci.yml
@@ -16,6 +16,5 @@ jobs:
         with:
           node-version: '16.x'
       - run: npm ci
-      - run: npm install
       - run: npm run build --if-present
       - run: npm test


### PR DESCRIPTION
[npm ci](https://docs.npmjs.com/cli/v9/commands/npm-ci) installs packages with some additional restrictions over `npm install`.

There's no need to run both `npm ci` and `npm install` in the same workflow.