### PR TITLE
[AR-134] Add button to expand navbar on mobile

### DIFF
--- a/ui-participant/src/landing/LandingNavbar.tsx
+++ b/ui-participant/src/landing/LandingNavbar.tsx
@@ -26,18 +26,26 @@ export default function LandingNavbar() {
         <img className="Navbar-logo" style={{ maxHeight: '30px' }}
           src={getImageUrl(localContent.navLogoCleanFileName, localContent.navLogoVersion)} alt="logo"/>
       </NavLink>
+      <button
+        aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation"
+        className="navbar-toggler"
+        data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown"
+        type="button"
+      >
+        <span className="navbar-toggler-icon" />
+      </button>
       <div className="collapse navbar-collapse" id="navbarNavDropdown">
         <ul className="navbar-nav">
-          {navLinks.map((navLink: NavbarItem, index: number) => <li key={index}>
+          {navLinks.map((navLink: NavbarItem, index: number) => <li key={index} className="nav-item">
             <CustomNavLink navLink={navLink}/>
           </li>)}
         </ul>
         <ul className="navbar-nav ms-auto">
           {user.isAnonymous && <li className="nav-item">
-            <NavLink className="nav-link" to="/hub">Login</NavLink>
+            <NavLink className="nav-link ms-3" to="/hub">Login</NavLink>
           </li>}
           {!user.isAnonymous && <li className="nav-item dropdown">
-            <a className="nav-link dropdown-toggle" href="#"
+            <a className="nav-link ms-3 dropdown-toggle" href="#"
               role="button" data-bs-toggle="dropdown" aria-expanded="false">
               {user.username}
             </a>


### PR DESCRIPTION
Currently, the navigation bar is not visible on screens less than 992 pixels wide. This adds the button to expand/collapse navigation on small screens.

![Screenshot 2023-02-28 at 1 35 20 PM](https://user-images.githubusercontent.com/1156625/221947455-6b96c520-cd31-45d8-9224-58f4bbfabb9e.png)

Followed the example at https://getbootstrap.com/docs/5.3/components/navbar/#supported-content.