### PR TITLE
DDO-2692 Make Server Port Configurable via Env Var for admin and participant

### DIFF
--- a/api-admin/src/main/resources/application.yml
+++ b/api-admin/src/main/resources/application.yml
@@ -34,7 +34,7 @@ server:
   compression:
     enabled: true
     mimeTypes: text/css,application/javascript
-  port: 8080
+  port: ${SERVER_PORT:8080}
 
 spring:
   # application name and version are used to populate the logging serviceContext

--- a/api-participant/src/main/resources/application.yml
+++ b/api-participant/src/main/resources/application.yml
@@ -32,7 +32,7 @@ server:
   compression:
     enabled: true
     mimeTypes: text/css,application/javascript
-  port: 8081
+  port: ${SERVER_PORT:8081}
 
 spring:
   # application name and version are used to populate the logging serviceContext


### PR DESCRIPTION
From the networking side I need the ability to specify what ports these APIs are exposed through in the AKS environment. I've already tested this change locally on my machine with the local dev flows to make sure it doesn't interfere with existing workflows.

To give more detail I need to be able to have both applications listen on port 8080 as the 2 APIs are effectively running on different machines. There are a variety of cluster level netwoking reasons why this is necessary. I completely get why it is the way it is for local dev.