### PR TITLE
[AR-134] Mobile friendly layout for StepOverview

### DIFF
--- a/ui-participant/src/landing/sections/StepOverviewTemplate.tsx
+++ b/ui-participant/src/landing/sections/StepOverviewTemplate.tsx
@@ -1,9 +1,7 @@
 import _ from 'lodash'
-import React, { Fragment } from 'react'
+import React from 'react'
 import { ButtonConfig } from 'api/api'
 import PearlImage, { PearlImageProps } from 'util/PearlImage'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faArrowRight } from '@fortawesome/free-solid-svg-icons'
 import ReactMarkdown from 'react-markdown'
 
 type StepProps = {


### PR DESCRIPTION
Currently, StepOverview does not wrap, which breaks the page layout on small screens.

![Screenshot 2023-03-01 at 5 30 47 PM](https://user-images.githubusercontent.com/1156625/222280446-1ef68e84-815d-412f-aabc-790de0590193.png)

This changes it to stack vertically on screens less than 992px.

![Screenshot 2023-03-01 at 5 29 13 PM](https://user-images.githubusercontent.com/1156625/222280538-d8f51d9f-e68e-4fc3-bfe3-c81bb8d49790.png)
![Screenshot 2023-03-01 at 5 28 57 PM](https://user-images.githubusercontent.com/1156625/222280701-4d7ae012-e35e-428a-9b76-e6d68ef9d30f.png)
