### PR TITLE
AR-156: fixing back button for join routing

### DIFF
--- a/ui-participant/src/hub/HubNavbar.tsx
+++ b/ui-participant/src/hub/HubNavbar.tsx
@@ -28,7 +28,7 @@ export default function HubNavbar() {
       <div className="collapse navbar-collapse" id="navbarNavDropdown">
         <ul className="navbar-nav ms-auto">
           {user.isAnonymous && <li className="nav-item">
-            <NavLink className="nav-link" to="hub">Login</NavLink>
+            <NavLink className="nav-link" to="/hub">Login</NavLink>
           </li>}
           {!user.isAnonymous && <li className="nav-item dropdown">
             <a className="nav-link dropdown-toggle" href="#"

--- a/ui-participant/src/landing/LandingNavbar.tsx
+++ b/ui-participant/src/landing/LandingNavbar.tsx
@@ -61,7 +61,8 @@ export function CustomNavLink({ navLink }: { navLink: NavbarItem }) {
   }
 
   if (navLink.itemType === 'INTERNAL') {
-    return <NavLink to={navLink.htmlPage.path} className="nav-link ms-3">{navLink.label}</NavLink>
+    // we require navbar links to be absolute rather than relative links
+    return <NavLink to={`/${navLink.htmlPage.path}`} className="nav-link ms-3">{navLink.label}</NavLink>
   } else if (navLink.itemType === 'MAILING_LIST') {
     return <a role="button" className="nav-link ms-3" onClick={() => mailingList(navLink)}>{navLink.label}</a>
   } else if (navLink.itemType === 'EXTERNAL') {

--- a/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
+++ b/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
@@ -77,23 +77,26 @@ function StudyEnrollOutletMatched({ portal, studyEnv, studyShortcode }:
     const isAlreadyEnrolled = !!enrollees.find(rollee => rollee.studyEnvironmentId === studyEnv.id)
     if (isAlreadyEnrolled) {
       alert('you are already enrolled in this study')
-      navigate('/hub')
+      navigate('/hub', { replace: true })
       return
     }
     if (preEnrollSatisfied) {
       if (user.isAnonymous) {
-        navigate('register')
+        navigate('register', { replace: true })
       } else {
         // when preEnroll is satisfied, and we have a user, we're clear to create an Enrollee
         Api.createEnrollee({ studyShortcode, preEnrollResponseId }).then(response => {
           updateEnrollee(response.enrollee)
-          navigate('/hub', { state: { message: { content: 'Welcome to the study!', messageType: 'success' } } })
+          navigate('/hub', {
+            replace: true,
+            state: { message: { content: 'Welcome to the study!', messageType: 'success' } }
+          })
         }).catch(() => {
           alert('an error occurred, please try again, or contact support')
         })
       }
     } else {
-      navigate('preEnroll')
+      navigate('preEnroll', { replace: true })
     }
   }, [preEnrollSatisfied, user.username])
 


### PR DESCRIPTION
Testing during the onsite revealed lots of undesirable back-button and navLink behavior.  This updates to a perhaps-not-ideal flow, but certainly better than the broken state before.

This also fixes the navbar links so that they are always absolute paths, which avoids them malfunctioning in certain nested states

TO TEST:
1. go to `http://sandbox.ourhealth.localhost:3001/`
2. click "Join"
3. Press the back button.  Confirm you are taken back to the landing page
4. click "Join" again
5. click "About us" in the navbar, or any of the other links.
6. confirm they work as expected.
7. Go back to the landing page, click join again, and fill out the preregistration and submit the registration. 
8.  From the hub, hit the back button.  Confirm you are taken all the way back to the landing page -- we really don't want people going back and attempting to change their prereg or registration info. 
