### PR TITLE
[AR-134] Make HeroWithImageTemplate mobile friendly

### DIFF
--- a/ui-participant/src/landing/sections/HeroWithImageTemplate.tsx
+++ b/ui-participant/src/landing/sections/HeroWithImageTemplate.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import _ from 'lodash'
 import React, { CSSProperties } from 'react'
 import { ButtonConfig, getImageUrl } from 'api/api'
@@ -37,12 +38,18 @@ function HeroWithImageTemplate({
     styleProps.backgroundImage = `url('${getImageUrl(backgroundImage.cleanFileName, backgroundImage.version)}')`
   }
   const isLeftImage = imagePosition === 'left' // default is right, so left has to be explicitly specified
-  return <div className="row" style={styleProps}>
-    <div className={`col-12 d-flex ${isLeftImage ? 'flex-row' : 'flex-row-reverse'}`}>
-      <div>
-        <PearlImage image={image} className="img-fluid"/>
-      </div>
-      <div className="p-5 d-flex flex-column flex-grow-1 justify-content-around" style={{ minWidth: '50%' }}>
+
+  return (
+    <div className={classNames('row', 'mx-0', isLeftImage ? 'flex-row' : 'flex-row-reverse')} style={styleProps}>
+      {!!image && (
+        <div className="col-12 col-lg-6 p-0">
+          <PearlImage image={image} className="img-fluid"/>
+        </div>
+      )}
+      <div
+        className="col-12 col-lg-6 py-3 p-sm-3 p-lg-5 d-flex flex-column flex-grow-1 justify-content-around"
+        style={{ minWidth: '50%' }}
+      >
         <h1 className="fs-1 fw-normal lh-sm">
           <ReactMarkdown>{title ? title : ''}</ReactMarkdown>
         </h1>
@@ -63,7 +70,7 @@ function HeroWithImageTemplate({
         </div>
       </div>
     </div>
-  </div>
+  )
 }
 
 export default HeroWithImageTemplate


### PR DESCRIPTION
Make the image and content in HeroWithImageTemplate stack vertically on small screens.

Haven't tried this with multiple buttons / logos, but this at least fixes the main layout and prevents the home page being horizontally scrollable.

## Before
![Screenshot 2023-03-02 at 4 43 34 PM](https://user-images.githubusercontent.com/1156625/222563508-77b11cec-bccb-431e-b9da-44a1eacc29af.png)

## After
![Screenshot 2023-03-02 at 4 43 16 PM](https://user-images.githubusercontent.com/1156625/222563502-46a61969-5125-47bd-ace1-521ace6e3ce7.png)

