### PR TITLE
[AR-135] Mobile friendly layout for HeroCenteredTemplate

### DIFF
--- a/ui-participant/src/landing/sections/HeroCenteredTemplate.tsx
+++ b/ui-participant/src/landing/sections/HeroCenteredTemplate.tsx
@@ -33,25 +33,31 @@ function HeroCenteredTemplate({
   const blurbStyle = {
     textAlign: cleanBlurbAlign as CanvasTextAlign
   }
-  return <div className="py-5 text-center" style={{ background, backgroundColor, color }}>
-    <div className="col-lg-6 mx-auto">
-      <h1 className="fs-1 fw-normal lh-sm mb-4">
-        <ReactMarkdown>{title ? title : ''}</ReactMarkdown>
-      </h1>
-      <div className="fs-5 " style={blurbStyle}>
-        <ReactMarkdown>{blurb ? blurb : ''}</ReactMarkdown>
-      </div>
-    </div>
-    <div className="col-lg-6 mx-auto">
-      <PearlImage image={image} className="img-fluid"/>
-    </div>
-    <div className="d-grid gap-2 d-sm-flex justify-content-sm-center">
-      {
-        _.map(buttons, (button, i) => {
-          // TODO: allow customization of button styling
-          return <ConfiguredButton key={i} config={button} className='btn btn-light btn-lg px-4 me-md-2'/>
-        })
-      }
+  return <div className="row mx-0" style={{ background, backgroundColor, color }}>
+    <div className="col-12 col-sm-10 col-lg-6 mx-auto py-5 text-center">
+      {!!title && (
+        <h1 className="fs-1 fw-normal lh-sm mb-4">
+          <ReactMarkdown>{title}</ReactMarkdown>
+        </h1>
+      )}
+      {!!blurb && (
+        <div className="fs-5 " style={blurbStyle}>
+          <ReactMarkdown>{blurb}</ReactMarkdown>
+        </div>
+      )}
+      {!!image && (
+        <PearlImage image={image} className="img-fluid mb-4"/>
+      )}
+      {(buttons ?? []).length > 0 && (
+        <div className="d-grid gap-2 d-sm-flex justify-content-sm-center">
+          {
+            _.map(buttons, (button, i) => {
+              // TODO: allow customization of button styling
+              return <ConfiguredButton key={i} config={button} className='btn btn-light btn-lg px-4 me-md-2'/>
+            })
+          }
+        </div>
+      )}
     </div>
   </div>
 }


### PR DESCRIPTION
These screenshots are using some extra configuration to test this template with all elements (title, blurb, image, and buttons).

## Before

Content was flush with the edge of the screen and also overflowed, making the page horizontally scrollable.

![Screenshot 2023-03-03 at 1 01 59 PM](https://user-images.githubusercontent.com/1156625/222794545-0086c58e-5e1b-405e-8015-06d5d5953c7c.png)
![Screenshot 2023-03-03 at 1 02 05 PM](https://user-images.githubusercontent.com/1156625/222794547-b5c8bcba-f7af-4a85-a893-e85c4579f376.png)

## After

![Screenshot 2023-03-03 at 1 01 21 PM](https://user-images.githubusercontent.com/1156625/222794620-5e7ebd3c-a956-4272-90c0-c5d0f0c9c06e.png)

