### PR TITLE
[AR-135] Mobile friendly layout for PhotoBlurbGrid

### DIFF
--- a/ui-participant/src/landing/sections/PhotoBlurbGrid.tsx
+++ b/ui-participant/src/landing/sections/PhotoBlurbGrid.tsx
@@ -27,24 +27,21 @@ type PhotoBio = {
  */
 function PhotoBlurbGrid({ config: { background, backgroundColor, color, subGrids, title } }:
                           { config: PhotoBlurbGridProps }) {
-  if (!subGrids) {
-    subGrids = []
-  }
   return <div style={{ background, backgroundColor, color }}>
     {title && <h1 className="fs-1 fw-normal lh-sm text-center">
       {title}
     </h1>}
-    {subGrids.map((subGrid, index) => <SubGridView subGrid={subGrid} key={index}/>)}
+    {(subGrids ?? []).map((subGrid, index) => <SubGridView key={index} subGrid={subGrid} />)}
   </div>
 }
 
 /** renders a subgrouping of photos (e.g. "Our researchers") */
 function SubGridView({ subGrid }: { subGrid: SubGrid }) {
-  return <div className="row justify-content-center">
-    <div className="col-md-8">
+  return <div className="row mx-0">
+    <div className="col-12 col-sm-10 col-lg-8 mx-auto">
       {subGrid.title && <h3 className="text-center mt-3">{subGrid.title}</h3>}
-      <div className="row">
-        {subGrid.photoBios.map((bio, index) => <PhotoBioView photoBio={bio} key={index}/>)}
+      <div className="row mx-0">
+        {subGrid.photoBios.map((bio, index) => <PhotoBioView key={index} photoBio={bio} />)}
       </div>
     </div>
   </div>
@@ -52,12 +49,14 @@ function SubGridView({ subGrid }: { subGrid: SubGrid }) {
 
 /** renders a single bio with pic */
 function PhotoBioView({ photoBio }: { photoBio: PhotoBio }) {
-  return <div className="col-md-4 gx-5 gy-3 d-flex flex-column">
-    <PearlImage image={photoBio.image}/>
-    <div>{photoBio.name} <span className="detail">{photoBio.title}</span></div>
-    <div className="detail" style={{ lineHeight: 1 }}>
-      <ReactMarkdown>{photoBio.blurb ? photoBio.blurb : ''}</ReactMarkdown>
-    </div>
+  return <div className="col-sm-6 col-md-4 gx-5 gy-3">
+    <PearlImage image={photoBio.image} className="img-fluid" />
+    <div className="my-2">{photoBio.name} <span className="detail">{photoBio.title}</span></div>
+    {!!photoBio.blurb && (
+      <div className="detail" style={{ lineHeight: 1 }}>
+        <ReactMarkdown>{photoBio.blurb}</ReactMarkdown>
+      </div>
+    )}
   </div>
 }
 


### PR DESCRIPTION
- Removes some margins so that nothing overflow the page and causes horizontal scroll.
- Adjusts the photo grid so that it shows 2 images per row on tablet size screens.
- Adds some spacing between the image and the name.
