### PR TITLE
[AR-134] Mobile friendly layout for ParticipationDetailTemplate

### DIFF
--- a/ui-participant/src/landing/sections/ParticipationDetailTemplate.tsx
+++ b/ui-participant/src/landing/sections/ParticipationDetailTemplate.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React, { CSSProperties } from 'react'
 import { ButtonConfig } from 'api/api'
 import PearlImage, { PearlImageProps } from '../../util/PearlImage'
@@ -33,12 +34,18 @@ function ParticipationDetailTemplate({
 }: { config: ParticipationDetailTemplateProps }) {
   const styleProps: CSSProperties = { background }
   const isLeftImage = imagePosition === 'left' // default is right, so left has to be explicitly specified
-  return <div className="row justify-content-center" style={styleProps}>
-    <div className={`col-md-8 d-flex py-5 ${isLeftImage ? 'flex-row' : 'flex-row-reverse'}`}>
-      <div className={`${isLeftImage ? 'pe-5' : 'ps-5'}`}>
-        <PearlImage image={image} className="img-fluid"/>
+  return <div className="row mx-0 py-5" style={styleProps}>
+    <div
+      className={classNames(
+        'col-md-10 col-lg-8', 'mx-auto', 'row',
+        'justify-content-between',
+        isLeftImage ? 'flex-row' : 'flex-row-reverse'
+      )}
+    >
+      <div className="col-6 col-md-3 mx-auto mx-md-0 text-center">
+        <PearlImage image={image} className="img-fluid mb-4 mb-md-0" />
       </div>
-      <div className="flex-grow-1">
+      <div className="col-md-8">
         <h4>
           {stepNumberText}
         </h4>


### PR DESCRIPTION
- Stack images vertically on small screens
- Add some padding between content and the edge of the screen
- Avoid overflow / horizontal scrolling

## Before
![Screenshot 2023-03-03 at 1 56 07 PM](https://user-images.githubusercontent.com/1156625/222804225-f8f4c30d-dc90-442c-8cee-e5c7e3c112c8.png)

## After
![Screenshot 2023-03-03 at 1 55 55 PM](https://user-images.githubusercontent.com/1156625/222804246-60c352ad-b27e-4c42-940e-fc6abd8960ed.png)

