### PR TITLE
Rename PearlImageProps type

### DIFF
--- a/ui-participant/src/landing/sections/HeroCenteredTemplate.tsx
+++ b/ui-participant/src/landing/sections/HeroCenteredTemplate.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { ButtonConfig } from 'api/api'
 import ReactMarkdown from 'react-markdown'
 import ConfiguredButton from './ConfiguredButton'
-import PearlImage, { PearlImageProps } from '../../util/PearlImage'
+import PearlImage, { PearlImageConfig } from '../../util/PearlImage'
 
 type HeroCenteredTemplateProps = {
   background?: string, // background CSS style (e.g. `linear-gradient(...)`)
@@ -13,7 +13,7 @@ type HeroCenteredTemplateProps = {
   buttons?: ButtonConfig[], // array of objects containing `text` and `href` attributes
   title?: string, // large heading text
   color?: string, // foreground text color
-  image?: PearlImageProps   // image to display under blurb
+  image?: PearlImageConfig   // image to display under blurb
 }
 
 const blurbAlignAllowed = ['center', 'right', 'left']

--- a/ui-participant/src/landing/sections/HeroWithImageTemplate.tsx
+++ b/ui-participant/src/landing/sections/HeroWithImageTemplate.tsx
@@ -2,20 +2,20 @@ import classNames from 'classnames'
 import _ from 'lodash'
 import React, { CSSProperties } from 'react'
 import { ButtonConfig, getImageUrl } from 'api/api'
-import PearlImage, { PearlImageProps } from '../../util/PearlImage'
+import PearlImage, { PearlImageConfig } from '../../util/PearlImage'
 import ConfiguredButton from './ConfiguredButton'
 import ReactMarkdown from 'react-markdown'
 
 type HeroLeftWithImageTemplateProps = {
   background?: string, // background CSS style (e.g. `linear-gradient(...)`)
   backgroundColor?: string, // background color for the block
-  backgroundImage?: PearlImageProps, // background image
+  backgroundImage?: PearlImageConfig, // background image
   blurb?: string, //  text below the title
   buttons?: ButtonConfig[], // array of objects containing `text` and `href` attributes
   title?: string, // large heading text
-  image?: PearlImageProps, // image
+  image?: PearlImageConfig, // image
   imagePosition?: string, // left or right.  Default is right
-  logos?: PearlImageProps[]
+  logos?: PearlImageConfig[]
 }
 
 /**

--- a/ui-participant/src/landing/sections/ParticipationDetailTemplate.tsx
+++ b/ui-participant/src/landing/sections/ParticipationDetailTemplate.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import React, { CSSProperties } from 'react'
 import { ButtonConfig } from 'api/api'
-import PearlImage, { PearlImageProps } from '../../util/PearlImage'
+import PearlImage, { PearlImageConfig } from '../../util/PearlImage'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faClock } from '@fortawesome/free-regular-svg-icons'
 import ConfiguredButton from './ConfiguredButton'
@@ -11,7 +11,7 @@ type ParticipationDetailTemplateProps = {
   blurb?: string, //  text below the title
   actionButton?: ButtonConfig, // array of objects containing `text` and `href` attributes
   title?: string, // large heading text
-  image?: PearlImageProps, // image
+  image?: PearlImageConfig, // image
   stepNumberText?: string, // e.g. STEP 1
   timeIndication?: string, // e.g. 45+ minutes
   imagePosition?: string // left or right.  Default is right

--- a/ui-participant/src/landing/sections/PhotoBlurbGrid.tsx
+++ b/ui-participant/src/landing/sections/PhotoBlurbGrid.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import PearlImage, { PearlImageProps } from '../../util/PearlImage'
+import PearlImage, { PearlImageConfig } from '../../util/PearlImage'
 import ReactMarkdown from 'react-markdown'
 
 type PhotoBlurbGridProps = {
@@ -16,7 +16,7 @@ type SubGrid = {
 }
 
 type PhotoBio = {
-  image: PearlImageProps,
+  image: PearlImageConfig,
   name: string,
   title: string,
   blurb: string

--- a/ui-participant/src/landing/sections/StepOverviewTemplate.tsx
+++ b/ui-participant/src/landing/sections/StepOverviewTemplate.tsx
@@ -1,11 +1,11 @@
 import _ from 'lodash'
 import React from 'react'
 import { ButtonConfig } from 'api/api'
-import PearlImage, { PearlImageProps } from 'util/PearlImage'
+import PearlImage, { PearlImageConfig } from 'util/PearlImage'
 import ReactMarkdown from 'react-markdown'
 
 type StepProps = {
-  image: PearlImageProps,
+  image: PearlImageConfig,
   duration: string,
   blurb: string
 }

--- a/ui-participant/src/util/PearlImage.tsx
+++ b/ui-participant/src/util/PearlImage.tsx
@@ -1,7 +1,7 @@
 import React, { CSSProperties } from 'react'
 import { getImageUrl } from 'api/api'
 
-export type PearlImageProps = {
+export type PearlImageConfig = {
   cleanFileName: string,
   version: number,
   alt?: string,
@@ -9,11 +9,15 @@ export type PearlImageProps = {
   style?: CSSProperties
 }
 
+type PearlImageProps = {
+  image?: PearlImageConfig
+  className?: string
+  style?: CSSProperties
+}
+
 /** renders an image that is part of a SiteContent spec */
-export default function PearlImage({ image, className, style }: {
-  image?: PearlImageProps,
-  className?: string, style?: CSSProperties
-}) {
+export default function PearlImage(props: PearlImageProps) {
+  const { image, className, style } = props
   const combinedClassNames = `${className ?? ''} ${image?.className ?? ''}`
   if (!image) {
     return <></>


### PR DESCRIPTION
This has confused me more than once. Currently, the `PearlImageProps` type is _not_ the type of the props for the `PearlImage` component. It's the type for one of the props: `config`.

This renames `PearlImageProps` to `PearlImageConfig` and adds a new `PearlImageProps` type that types the `PearlImage` component's props.

