### PR TITLE
Run publish and deploy workflow when a tag is pushed

### DIFF
--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -1,5 +1,8 @@
 name: Publish and deploy
-on: create
+on:
+  push:
+    tags:
+      - [0-9]+.[0-9]+.[0-9]+
 
 env:
   SERVICE_NAME: ${{ github.event.repository.name }}


### PR DESCRIPTION
Every time I open a PR, I get an email notification that the Publish and Deploy workflow has failed. See past workflow runs at https://github.com/broadinstitute/pearl/actions/workflows/java-publish.yml

It looks like that’s because it runs when either a branch or tag is created, and if it was triggered by a branch, the first step (where it tries to parse a tag) fails.
https://github.com/broadinstitute/pearl/blob/6dd8d5d07cac599d0157466edf270a97cda3cde7/.github/workflows/java-publish.yml#L2
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#create

This changes the workflow to run when a tag specifying a version number is pushed.
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-only-when-a-push-of-specific-tags-occurs