### PR TITLE
Update triggers for JS CI workflows

### DIFF
--- a/.github/workflows/javascript-admin-ci.yml
+++ b/.github/workflows/javascript-admin-ci.yml
@@ -1,6 +1,11 @@
 name: Node.js admin UI CI
 
-on: [push]
+on:
+  push:
+    branches: [ development ]
+    paths-ignore: [ '*.md']
+  pull_request:
+    branches: [ '**' ]
 
 jobs:
   build:

--- a/.github/workflows/javascript-participant-ci.yml
+++ b/.github/workflows/javascript-participant-ci.yml
@@ -1,6 +1,11 @@
 name: Node.js Participant UI CI
 
-on: [push]
+on:
+  push:
+    branches: [ development ]
+    paths-ignore: [ '*.md']
+  pull_request:
+    branches: [ '**' ]
 
 jobs:
   build:


### PR DESCRIPTION
I noticed that the "Node.js admin UI CI" and "Node.js participant UI CI" are running twice on the "bump <version>" commits from broadbot (see https://github.com/broadinstitute/pearl/actions).

It looks like they are being triggered by two push events: one for the commit and one for the tag. This changes their triggers to match those of "Java CI": pushes to the development branch and PRs.