### PR TITLE
[AR-153] Add type for sectionType

### DIFF
--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -90,10 +90,20 @@ export function isInternalAnchorLink(navItem: NavbarItem): navItem is NavbarItem
   return navItem.itemType === 'INTERNAL_ANCHOR'
 }
 
+export type SectionType =
+  | 'FAQ'
+  | 'HERO_CENTERED'
+  | 'HERO_WITH_IMAGE'
+  | 'NAV_AND_LINK_SECTIONS_FOOTER'
+  | 'PARTICIPATION_DETAIL'
+  | 'PHOTO_BLURB_GRID'
+  | 'RAW_HTML'
+  | 'SOCIAL_MEDIA'
+  | 'STEP_OVERVIEW'
 
 export type HtmlSection = {
   id: string,
-  sectionType: string,
+  sectionType: SectionType,
   anchorRef?: string,
   rawContent: string | null,
   sectionConfig: string | null

--- a/ui-participant/src/landing/sections/HtmlPageView.tsx
+++ b/ui-participant/src/landing/sections/HtmlPageView.tsx
@@ -6,7 +6,7 @@ import HeroCenteredTemplate from './HeroCenteredTemplate'
 import HeroWithImageTemplate from './HeroWithImageTemplate'
 import StepOverviewTemplate from './StepOverviewTemplate'
 import SocialMediaTemplate from './SocialMediaTemplate'
-import { HtmlPage, HtmlSection, SectionConfig } from 'api/api'
+import { HtmlPage, HtmlSection, SectionConfig, SectionType } from 'api/api'
 import RawHtmlTemplate from './RawHtmlTemplate'
 import PhotoBlurbGrid from './PhotoBlurbGrid'
 import ParticipationDetailTemplate from './ParticipationDetailTemplate'
@@ -15,7 +15,7 @@ import NavAndLinkSectionsFooter from './NavAndLinkSectionsFooter'
 type TemplateComponent = ({ anchorRef, config, rawContent }:
                             { anchorRef?: string, config: SectionConfig, rawContent: string | null }) => JSX.Element
 
-const templateComponents: { [index: string]: TemplateComponent } = {
+const templateComponents: Record<SectionType, TemplateComponent> = {
   'FAQ': FrequentlyAskedQuestionsTemplate,
   'HERO_CENTERED': HeroCenteredTemplate,
   'HERO_WITH_IMAGE': HeroWithImageTemplate,


### PR DESCRIPTION
This adds a type for the `sectionType` field of sections configured for landing pages.

Although sectionType is only used once (in HtmlSectionView), I think this is useful as documentation for the configuration schema.

https://github.com/broadinstitute/pearl/blob/25e6d28b89eb54a9d5f208002b127781ea9fdb62/ui-participant/src/landing/sections/HtmlPageView.tsx#L39-L44

Changing the type of `templateComponents` to [Record](https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeys-type) ensures that `templateComponents` contains a template for all possible values of `sectionType`.

Generally, I think this sort of typing would be useful in other places where we have a string "type" field, such as button configuration, for making sure that we handle all possible values of the type.