### PR TITLE
AR-162 adding profile view for admins

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeDao.java
@@ -75,7 +75,7 @@ public class EnrolleeDao extends BaseMutableJdbiDao<Enrollee> {
     public Enrollee loadForAdminView(Enrollee enrollee) {
         enrollee.getSurveyResponses().addAll(surveyResponseDao.findByEnrolleeIdWithLastSnapshot(enrollee.getId()));
         enrollee.getConsentResponses().addAll(consentResponseDao.findByEnrolleeId(enrollee.getId()));
-        enrollee.setProfile(profileDao.find(enrollee.getProfileId()).get());
+        enrollee.setProfile(profileDao.loadWithMailingAddress(enrollee.getProfileId()).get());
         enrollee.getParticipantTasks().addAll(participantTaskDao.findByEnrolleeId(enrollee.getId()));
         if (enrollee.getPreEnrollmentResponseId() != null) {
             enrollee.setPreEnrollmentResponse(preEnrollmentResponseDao.find(enrollee.getPreEnrollmentResponseId()).get());

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -110,7 +110,18 @@ export type Enrollee = {
 
 export type Profile = {
   givenName: string,
-  familyName: string
+  familyName: string,
+  contactEmail: string,
+  mailingAddress: MailingAddress
+}
+
+export type MailingAddress = {
+  street1: string,
+  street2: string,
+  city: string,
+  state: string,
+  country: string,
+  zip: string
 }
 
 export type ResumableData = {

--- a/ui-admin/src/study/participants/EnrolleeProfile.tsx
+++ b/ui-admin/src/study/participants/EnrolleeProfile.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { Enrollee, MailingAddress } from 'api/api'
+
+/**
+ * shows the enrollee profile.  Designed for read-only.  When we implement admin-profile editing capability,
+ * we should do it via a survey so we can reuse that editing and snapshot infrastructure
+ */
+export default function EnrolleeProfile({ enrollee }: {enrollee: Enrollee}) {
+  return <div>
+    <form>
+      <div>
+        <label className="form-label">
+          Given name: <input className="form-control" type="text" readOnly={true} value={enrollee.profile.givenName}/>
+        </label>
+        <label className="form-label">
+          Family name: <input className="form-control" type="text" readOnly={true} value={enrollee.profile.familyName}/>
+        </label>
+      </div>
+      <div className="mb-3">
+        <label className="form-label">
+          Contact email:
+          <input className="form-control" type="text" readOnly={true} value={enrollee.profile.contactEmail}/>
+        </label>
+      </div>
+      <h6>Mailing address</h6>
+      { enrollee.profile.mailingAddress && <MailingAddressView mailingAddress={enrollee.profile.mailingAddress}/>}
+      { !enrollee.profile.mailingAddress && <span className="detail">none</span>}
+    </form>
+  </div>
+}
+
+/** displays the mailing list -- does not yet support editing */
+export function MailingAddressView({ mailingAddress }: {mailingAddress: MailingAddress}) {
+  return <div>
+    <div>
+      <label className="form-label">
+        Street 1: <input className="form-control" type="text" readOnly={true} value={mailingAddress.street1}/>
+      </label>
+    </div><div>
+      <label className="form-label">
+        Street 2: <input className="form-control" type="text" readOnly={true} value={mailingAddress.street2}/>
+      </label>
+    </div><div>
+      <label className="form-label">
+        City: <input className="form-control" type="text" readOnly={true} value={mailingAddress.city}/>
+      </label>
+      <label className="form-label">
+        State: <input className="form-control" type="text" readOnly={true} value={mailingAddress.state}/></label>
+      <label className="form-label">
+        Country: <input className="form-control" type="text" readOnly={true} value={mailingAddress.country}/></label>
+      <label className="form-label">
+        Postal code: <input className="form-control" type="text" readOnly={true} value={mailingAddress.zip}/></label>
+    </div>
+  </div>
+}
+

--- a/ui-admin/src/study/participants/EnrolleeView.tsx
+++ b/ui-admin/src/study/participants/EnrolleeView.tsx
@@ -15,6 +15,7 @@ import EnrolleeConsentView from './consent/EnrolleeConsentView'
 import PreEnrollmentView from './survey/PreEnrollmentView'
 import EnrolleeNotifications from './EnrolleeNotifications'
 import DataChangeRecords from './DataChangeRecords'
+import EnrolleeProfile from './EnrolleeProfile'
 
 export type SurveyWithResponsesT = {
   survey: StudyEnvironmentSurvey,
@@ -134,7 +135,7 @@ export default function EnrolleeView({ enrollee, studyEnvContext }:
           </div>
           <div className="participantTabContent flex-grow-1 bg-white p-3">
             <Routes>
-              <Route path="profile" element={<div>profile</div>}/>
+              <Route path="profile" element={<EnrolleeProfile enrollee={enrollee}/>}/>
               <Route path="consents" element={<div>consents</div>}/>
               <Route path="preRegistration" element={
                 <PreEnrollmentView preEnrollSurvey={currentEnv.preEnrollSurvey}


### PR DESCRIPTION
Quick-and-dirty profile view for admins, meant to include it in the audit history PR.  

TO TEST:
1.  Restart adminApiApp
2. go to `http://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants/OHSALK/profile` 
3. confirm you see a rough profile view page
![image](https://user-images.githubusercontent.com/2800795/223853558-523cfe8a-935d-42e6-a022-960740d5ba92.png)
