### PR TITLE
[AR-180] Show hub navbar on mobile

### DIFF
--- a/ui-participant/src/hub/HubNavbar.tsx
+++ b/ui-participant/src/hub/HubNavbar.tsx
@@ -25,6 +25,14 @@ export default function HubNavbar() {
         <img className="Navbar-logo" style={{ maxHeight: '30px' }}
           src={getImageUrl(localContent.navLogoCleanFileName, localContent.navLogoVersion)} alt="logo"/>
       </NavLink>
+      <button
+        aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation"
+        className="navbar-toggler"
+        data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown"
+        type="button"
+      >
+        <span className="navbar-toggler-icon" />
+      </button>
       <div className="collapse navbar-collapse" id="navbarNavDropdown">
         <ul className="navbar-nav ms-auto">
           {user.isAnonymous && <li className="nav-item">


### PR DESCRIPTION
Currently, on screens less than 992px wide, the navbar does not appear on the hub page. This prevents users from logging out. This adds the hamburger menu button to show the collapsed navbar.

This does for the hub page what #81 did for landing pages.