### PR TITLE
Rename template configuration types

### DIFF
--- a/ui-participant/src/landing/sections/FrequentlyAskedQuestionsTemplate.tsx
+++ b/ui-participant/src/landing/sections/FrequentlyAskedQuestionsTemplate.tsx
@@ -19,7 +19,7 @@ type FaqQuestion = {
   answer: string
 }
 
-type FrequentlyAskedQuestionsProps = {
+type FrequentlyAskedQuestionsConfig = {
   backgroundColor?: string, // background color for the block
   blurb?: string, //  text below the title
   questions?: FaqQuestion[], // the questions
@@ -27,19 +27,26 @@ type FrequentlyAskedQuestionsProps = {
   color?: string // foreground text color
 }
 
+type FrequentlyAskedQuestionsProps = {
+  anchorRef?: string
+  config: FrequentlyAskedQuestionsConfig
+}
+
 /**
  * Template for rendering a Frequently Asked Questions block.
  */
-function FrequentlyAskedQuestionsTemplate({
-  anchorRef,
-  config: {
-    backgroundColor,
-    blurb,
-    color,
-    questions,
-    title = 'Frequently Asked Questions'
-  }
-}: { anchorRef?: string, config: FrequentlyAskedQuestionsProps }) {
+function FrequentlyAskedQuestionsTemplate(props: FrequentlyAskedQuestionsProps) {
+  const {
+    anchorRef,
+    config: {
+      backgroundColor,
+      blurb,
+      color,
+      questions,
+      title = 'Frequently Asked Questions'
+    }
+  } = props
+
   return <div id={anchorRef} className="row mx-0 justify-content-center" style={{ backgroundColor, color }}>
     <div className="col-12 col-sm-8 col-lg-6">
       <h1 className="fs-1 fw-normal lh-sm mt-5 mb-4 text-center">{title}</h1>

--- a/ui-participant/src/landing/sections/HeroCenteredTemplate.tsx
+++ b/ui-participant/src/landing/sections/HeroCenteredTemplate.tsx
@@ -5,7 +5,7 @@ import ReactMarkdown from 'react-markdown'
 import ConfiguredButton from './ConfiguredButton'
 import PearlImage, { PearlImageConfig } from '../../util/PearlImage'
 
-type HeroCenteredTemplateProps = {
+type HeroCenteredTemplateConfig = {
   background?: string, // background CSS style (e.g. `linear-gradient(...)`)
   backgroundColor?: string, // background color for the block
   blurb?: string, //  text below the title
@@ -16,19 +16,25 @@ type HeroCenteredTemplateProps = {
   image?: PearlImageConfig   // image to display under blurb
 }
 
+type HeroCenteredTemplateProps = {
+  anchorRef?: string
+  config: HeroCenteredTemplateConfig
+}
+
 const blurbAlignAllowed = ['center', 'right', 'left']
 
 /**
  * Template for rendering a hero with centered content.
  */
-function HeroCenteredTemplate({
-  anchorRef,
-  config: {
-    background, backgroundColor, color,
-    blurb, blurbAlign, buttons, title, image
-  }
-}:
-                                { anchorRef?: string, config: HeroCenteredTemplateProps }) {
+function HeroCenteredTemplate(props: HeroCenteredTemplateProps) {
+  const {
+    anchorRef,
+    config: {
+      background, backgroundColor, color,
+      blurb, blurbAlign, buttons, title, image
+    }
+  } = props
+
   const blurbAlignIndex = blurbAlignAllowed.indexOf(blurbAlign ?? 'center')
   const cleanBlurbAlign: string = blurbAlignAllowed[blurbAlignIndex === -1 ? 0 : blurbAlignIndex] ?? 'center'
   const blurbStyle = {

--- a/ui-participant/src/landing/sections/HeroWithImageTemplate.tsx
+++ b/ui-participant/src/landing/sections/HeroWithImageTemplate.tsx
@@ -6,7 +6,7 @@ import PearlImage, { PearlImageConfig } from '../../util/PearlImage'
 import ConfiguredButton from './ConfiguredButton'
 import ReactMarkdown from 'react-markdown'
 
-type HeroLeftWithImageTemplateProps = {
+type HeroLeftWithImageTemplateConfig = {
   background?: string, // background CSS style (e.g. `linear-gradient(...)`)
   backgroundColor?: string, // background color for the block
   backgroundImage?: PearlImageConfig, // background image
@@ -18,22 +18,29 @@ type HeroLeftWithImageTemplateProps = {
   logos?: PearlImageConfig[]
 }
 
+type HeroLeftWithImageTemplateProps = {
+  anchorRef?: string
+  config: HeroLeftWithImageTemplateConfig
+}
+
 /**
  * Template for a hero with text content on the left and an image on the right.
  */
-function HeroWithImageTemplate({
-  anchorRef,
-  config: {
-    background,
-    blurb,
-    buttons,
-    image,
-    imagePosition,
-    backgroundImage,
-    logos,
-    title
-  }
-}: { anchorRef?: string, config: HeroLeftWithImageTemplateProps }) {
+function HeroWithImageTemplate(props: HeroLeftWithImageTemplateProps) {
+  const {
+    anchorRef,
+    config: {
+      background,
+      blurb,
+      buttons,
+      image,
+      imagePosition,
+      backgroundImage,
+      logos,
+      title
+    }
+  } = props
+
   const styleProps: CSSProperties = { background }
   if (backgroundImage) {
     styleProps.backgroundImage = `url('${getImageUrl(backgroundImage.cleanFileName, backgroundImage.version)}')`

--- a/ui-participant/src/landing/sections/NavAndLinkSectionsFooter.tsx
+++ b/ui-participant/src/landing/sections/NavAndLinkSectionsFooter.tsx
@@ -3,7 +3,7 @@ import _ from 'lodash'
 import LandingNavbar from '../LandingNavbar'
 
 
-type NavAndLinkSectionsFooterProps = {
+type NavAndLinkSectionsFooterConfig = {
   background?: string, // background CSS style (e.g. `linear-gradient(...)`)
   includeNavbar?: boolean,
   itemSections?: ItemSection[]
@@ -20,8 +20,14 @@ type FooterItem = {
   externalLink: string
 }
 
+type NavAndLinkSectionsFooterProps = {
+  config: NavAndLinkSectionsFooterConfig
+}
+
 /** renders a footer-style section */
-export default function NavAndLinkSectionsFooter({ config }: { config: NavAndLinkSectionsFooterProps }) {
+export default function NavAndLinkSectionsFooter(props: NavAndLinkSectionsFooterProps) {
+  const { config } = props
+
   return <>
     {config.includeNavbar && <LandingNavbar/>}
     <div className="d-flex justify-content-center py-3">

--- a/ui-participant/src/landing/sections/ParticipationDetailTemplate.tsx
+++ b/ui-participant/src/landing/sections/ParticipationDetailTemplate.tsx
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faClock } from '@fortawesome/free-regular-svg-icons'
 import ConfiguredButton from './ConfiguredButton'
 
-type ParticipationDetailTemplateProps = {
+type ParticipationDetailTemplateConfig = {
   background?: string, // background CSS style (e.g. `linear-gradient(...)`)
   blurb?: string, //  text below the title
   actionButton?: ButtonConfig, // array of objects containing `text` and `href` attributes
@@ -17,22 +17,29 @@ type ParticipationDetailTemplateProps = {
   imagePosition?: string // left or right.  Default is right
 }
 
+type ParticipationDetailTemplateProps = {
+  anchorRef?: string
+  config: ParticipationDetailTemplateConfig
+}
+
 /**
  * Template for a participation step description
  */
-function ParticipationDetailTemplate({
-  anchorRef,
-  config: {
-    background,
-    blurb,
-    actionButton,
-    stepNumberText,
-    timeIndication,
-    image,
-    imagePosition,
-    title
-  }
-}: { anchorRef?: string, config: ParticipationDetailTemplateProps }) {
+function ParticipationDetailTemplate(props: ParticipationDetailTemplateProps) {
+  const {
+    anchorRef,
+    config: {
+      background,
+      blurb,
+      actionButton,
+      stepNumberText,
+      timeIndication,
+      image,
+      imagePosition,
+      title
+    }
+  } = props
+
   const styleProps: CSSProperties = { background }
   const isLeftImage = imagePosition === 'left' // default is right, so left has to be explicitly specified
   return <div id={anchorRef} className="row mx-0 py-5" style={styleProps}>

--- a/ui-participant/src/landing/sections/PhotoBlurbGrid.tsx
+++ b/ui-participant/src/landing/sections/PhotoBlurbGrid.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PearlImage, { PearlImageConfig } from '../../util/PearlImage'
 import ReactMarkdown from 'react-markdown'
 
-type PhotoBlurbGridProps = {
+type PhotoBlurbGridConfig = {
   background?: string, // background CSS style (e.g. `linear-gradient(...)`)
   backgroundColor?: string, // background color for the block
   color?: string,
@@ -22,11 +22,20 @@ type PhotoBio = {
   blurb: string
 }
 
+type PhotoBlurbGridProps = {
+  anchorRef?: string
+  config: PhotoBlurbGridConfig
+}
+
 /**
  * Template for rendering a hero with centered content.
  */
-function PhotoBlurbGrid({ anchorRef, config: { background, backgroundColor, color, subGrids, title } }:
-                          { anchorRef?: string, config: PhotoBlurbGridProps }) {
+function PhotoBlurbGrid(props: PhotoBlurbGridProps) {
+  const {
+    anchorRef,
+    config: { background, backgroundColor, color, subGrids, title }
+  } = props
+
   return <div id={anchorRef} className="py-5" style={{ background, backgroundColor, color }}>
     {title && <h1 className="fs-1 fw-normal lh-sm text-center mb-4">
       {title}

--- a/ui-participant/src/landing/sections/RawHtmlTemplate.tsx
+++ b/ui-participant/src/landing/sections/RawHtmlTemplate.tsx
@@ -1,11 +1,17 @@
 import React from 'react'
 
+type RawHtmlTemplateProps = {
+  anchorRef?: string
+  rawContent: string | null
+}
+
 /**
  * renders raw html content
  * TODO -- determine whether we need to sanitize the content here or whether we trust our database and
  * @param content
  * @constructor
  */
-export default function RawHtmlTemplate({ anchorRef, rawContent }: { anchorRef?: string, rawContent: string | null }) {
+export default function RawHtmlTemplate(props: RawHtmlTemplateProps) {
+  const { anchorRef, rawContent } = props
   return <div id={anchorRef} dangerouslySetInnerHTML={{ __html: rawContent ? rawContent : '' }}></div>
 }

--- a/ui-participant/src/landing/sections/SocialMediaTemplate.tsx
+++ b/ui-participant/src/landing/sections/SocialMediaTemplate.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { ButtonConfig } from 'api/api'
 import PearlImage from '../../util/PearlImage'
 
-type SocialMediaTemplateProps = {
+type SocialMediaTemplateConfig = {
   blurb?: string, //  text below the title
   buttons?: ButtonConfig[], // array of objects containing `text` and `href` attributes
   title?: string, // large heading text
@@ -12,21 +12,28 @@ type SocialMediaTemplateProps = {
   twitterHref?: string, // URL of Twitter page
 }
 
+type SocialMediaTemplateProps = {
+  anchorRef?: string
+  config: SocialMediaTemplateConfig
+}
+
 /**
  * Template for a hero with social media links.
  * TODO -- implement images
  */
-function SocialMediaTemplate({
-  anchorRef,
-  config: {
-    blurb,
-    buttons,
-    facebookHref,
-    instagramHref,
-    title,
-    twitterHref
-  }
-}: { anchorRef?: string, config: SocialMediaTemplateProps }) {
+function SocialMediaTemplate(props: SocialMediaTemplateProps) {
+  const {
+    anchorRef,
+    config: {
+      blurb,
+      buttons,
+      facebookHref,
+      instagramHref,
+      title,
+      twitterHref
+    }
+  } = props
+
   return <div id={anchorRef} className="container py-5">
     <div className="d-flex justify-content-center mt-5 mb-4">
       {twitterHref &&

--- a/ui-participant/src/landing/sections/StepOverviewTemplate.tsx
+++ b/ui-participant/src/landing/sections/StepOverviewTemplate.tsx
@@ -4,31 +4,38 @@ import { ButtonConfig } from 'api/api'
 import PearlImage, { PearlImageConfig } from 'util/PearlImage'
 import ReactMarkdown from 'react-markdown'
 
-type StepProps = {
+type StepConfig = {
   image: PearlImageConfig,
   duration: string,
   blurb: string
 }
 
-type StepOverviewTemplateProps = {
+type StepOverviewTemplateConfig = {
   background?: string, // background CSS style (e.g. `linear-gradient(...)`)
   buttons?: ButtonConfig[], // array of objects containing `text` and `href` attributes
   title?: string, // large heading text
-  steps?: StepProps[]
+  steps?: StepConfig[]
+}
+
+type StepOverviewTemplateProps = {
+  anchorRef?: string
+  config: StepOverviewTemplateConfig
 }
 
 /**
  * Template for rendering a step overview
  */
-function StepOverviewTemplate({
-  anchorRef,
-  config: {
-    background,
-    buttons,
-    steps,
-    title
-  }
-}: { anchorRef?: string, config: StepOverviewTemplateProps }) {
+function StepOverviewTemplate(props: StepOverviewTemplateProps) {
+  const {
+    anchorRef,
+    config: {
+      background,
+      buttons,
+      steps,
+      title
+    }
+  } = props
+
   // TODO: improve layout code for better flexing, especially with <> 4 steps
   return <div id={anchorRef} style={{ background }} className="py-5">
     <h1 className="fs-1 fw-normal lh-sm mb-3 text-center">
@@ -36,7 +43,7 @@ function StepOverviewTemplate({
     </h1>
     <div className="row mx-0">
       {
-        _.map(steps, ({ image, duration, blurb }: StepProps, i: number) => {
+        _.map(steps, ({ image, duration, blurb }: StepConfig, i: number) => {
           return <div key={i} className="col-12 col-lg-3 d-flex flex-column align-items-center">
             <div className="w-75 d-flex flex-column align-items-center align-items-lg-start">
               <PearlImage image={image} className="img-fluid p-3" style={{ maxWidth: '200px' }}/>


### PR DESCRIPTION
What #98 did for PearlImage, this does for all template components.

Currently, types for template configuration are named "TemplateProps" and the template component props are typed inline. This renames types for configuration to "TemplateConfig" and adds a type "TemplateProps" for the component props. It also moves destructuring props to a separate line. This was a convention we adopted in Terra UI to make the type signature of functions clearer.