### PR TITLE
Improve error message when site configuration includes an invalid section type

### DIFF
--- a/ui-participant/src/landing/sections/HtmlPageView.tsx
+++ b/ui-participant/src/landing/sections/HtmlPageView.tsx
@@ -40,7 +40,8 @@ export default function HtmlPageView({ page }: { page: HtmlPage }) {
 export function HtmlSectionView({ section }: { section: HtmlSection }) {
   const Template = templateComponents[section.sectionType]
   if (!Template) {
-    throw new Error(`Page configuration error: Unknown section type "${section.sectionType}"`)
+    console.warn(`Page configuration error: Unknown section type "${section.sectionType}"`)
+    return null
   }
   const parsedConfig: SectionConfig = section.sectionConfig ? JSON.parse(section.sectionConfig) : {}
   return <Template config={parsedConfig} anchorRef={section.anchorRef} rawContent={section.rawContent}/>


### PR DESCRIPTION
This may not be worth adding (I'm not sure how often we'll be adding new section types), but it could be occasionally useful for developers.

I added a new section type (banner image) in #121 and populated my local environment with a site configuration including some of those sections. Upon returning to the development branch after submitting a PR, the UI crashes with an error:

> Uncaught Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
>
> Check the render method of `HtmlSectionView`.

It took a minute to realize what the problem was, so I thought I'd add a more descriptive error message for the next developer who encounters this.
