### PR TITLE
Set Service Context Block in Json Formatted Logs Correctly

### DIFF
--- a/api-admin/src/main/resources/application.yml
+++ b/api-admin/src/main/resources/application.yml
@@ -39,7 +39,7 @@ server:
 spring:
   # application name and version are used to populate the logging serviceContext
   # https://github.com/DataBiosphere/terra-common-lib/blob/480ab3daae282ddff0fef8dc329494a4422e32f1/src/main/java/bio/terra/common/logging/GoogleJsonLayout.java#L118
-  application.name: javatemplate
+  application.name: d2p-admin
   application.version: ${javatemplate.version.gitHash:unknown}
 
   datasource:

--- a/api-participant/src/main/resources/application.yml
+++ b/api-participant/src/main/resources/application.yml
@@ -40,7 +40,7 @@ server:
 spring:
   # application name and version are used to populate the logging serviceContext
   # https://github.com/DataBiosphere/terra-common-lib/blob/480ab3daae282ddff0fef8dc329494a4422e32f1/src/main/java/bio/terra/common/logging/GoogleJsonLayout.java#L118
-  application.name: javatemplate
+  application.name: d2p-participant
   application.version: ${javatemplate.version.gitHash:unknown}
 
   datasource:


### PR DESCRIPTION
In the json formatted logs on the cloud hosted servers, there is a a json block in the log entries that looks like:
`"serviceContext":{"service":"javatemplate","version":"6dc7c6c"}"`

This changes it so that it will say `d2p-admin` or `d2p-participant` respectively in json formatted logs.

I tested this locally with `bootRun` and disabling the `human-readable-logging` profile