### PR TITLE
Trim leading/trailing whitespace from question titles in scratch box

### DIFF
--- a/ui-admin/src/util/pearlSurveyUtils.tsx
+++ b/ui-admin/src/util/pearlSurveyUtils.tsx
@@ -1,6 +1,5 @@
 import _flatten from 'lodash/flatten'
 import _camelCase from 'lodash/camelCase'
-import _trim from 'lodash/trim'
 import { IPage, Question } from 'survey-core'
 
 /**
@@ -170,8 +169,9 @@ export function questionFromRawText(rawText: string): QuestionObj {
     }
   })
 
+  const title = textLines[0].trim()
   const newQuestionObj: QuestionObj = {
-    title: _trim(textLines[0]),
+    title,
     choices,
     type: choices.length > 0 ? 'radiogroup' : 'text',
     nameSuffix: '',


### PR DESCRIPTION
I found this useful to avoid having to manually clean up question titles.