### PR TITLE
AR-216 fixing pre-enrollment survey editing

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/StudyEnvironmentController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/StudyEnvironmentController.java
@@ -29,6 +29,7 @@ public class StudyEnvironmentController implements StudyEnvironmentApi {
     this.studyEnvService = studyEnvService;
   }
 
+  /** currently only supports updating the preEnroll survey id */
   @Override
   public ResponseEntity<StudyEnvironmentDto> patch(
       String portalShortcode, String studyShortcode, String envName, StudyEnvironmentDto body) {

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -11,7 +11,7 @@ export type Study = {
 
 export type StudyEnvironmentUpdate = {
   id: string,
-  preRegSurveyId: string
+  preEnrollSurveyId: string
 }
 
 export type StudyEnvironment = {

--- a/ui-admin/src/study/surveys/PreEnrollView.tsx
+++ b/ui-admin/src/study/surveys/PreEnrollView.tsx
@@ -31,10 +31,10 @@ function RawPreRegView({ portalShortcode, currentEnv, survey, studyShortcode }:
     try {
       const updatedSurvey = await Api.createNewSurveyVersion(portalShortcode, currentSurvey)
       setCurrentSurvey(updatedSurvey)
-      const updatedEnv = { id: currentEnv.id, preRegSurveyId: updatedSurvey.id }
+      const updatedEnv = { ...currentEnv, preEnrollSurveyId: updatedSurvey.id }
       const updatedStudyEnv = await Api.updateStudyEnvironment(portalShortcode, studyShortcode,
         currentEnv.environmentName, updatedEnv)
-      currentEnv.preEnrollSurveyId = updatedStudyEnv.preRegSurveyId
+      currentEnv.preEnrollSurveyId = updatedStudyEnv.preEnrollSurveyId
       currentEnv.preEnrollSurvey = updatedSurvey
       Store.addNotification(successNotification(`Saved successfully`))
     } catch (e) {


### PR DESCRIPTION
This fixes the bug Erin found on Wednesday.  It's a remnant from when we renamed study preReg survey to preEnroll survey, to distinguish it from a pre-registration survey that takes place before you can sign up for the portal generally.

TO TEST:
1. go to `https://localhost:3000/ourhealth/studies/ourheart/env/sandbox`
2. click on the "Pre enrollment survey"
3. make a change to the save, and click "Save"
4. go back to the `https://localhost:3000/ourhealth/studies/ourheart/env/sandbox` page.  Confirm that v2 is now shown as the pre-enrollment survey (and for bonus points, confirm your changes now show up on the participant side)