### PR TITLE
[AR-134] Update style for active nav links

### DIFF
--- a/ui-participant/src/index.scss
+++ b/ui-participant/src/index.scss
@@ -61,6 +61,12 @@ a {
   --bs-nav-link-hover-color: var(--brand-color-shift-20);
 }
 
+.App .navbar-nav .nav-link.active {
+  color: var(--brand-color);
+  text-decoration: underline;
+  text-underline-offset: 0.25em;
+}
+
 [aria-expanded="false"] .hidden-when-collapsed {
   display: none;
 }


### PR DESCRIPTION
To more closely match designs, underline the active nav link in the top bar and keep it the brand color.

## Before
![Screenshot 2023-03-20 at 9 24 43 AM](https://user-images.githubusercontent.com/1156625/226353671-9deedf2c-e535-4163-ba68-1d9584864904.png)

## After
![Screenshot 2023-03-20 at 9 24 31 AM](https://user-images.githubusercontent.com/1156625/226353689-8af72c62-e0bc-4187-87aa-9c9cb4820bdb.png)
