### PR TITLE
[AR-194] Pass portalShortcode and portalHomeLink to sign-up/sign-in flow

### DIFF
--- a/ui-participant/src/login/Login.tsx
+++ b/ui-participant/src/login/Login.tsx
@@ -1,12 +1,15 @@
 import React, { useEffect } from 'react'
 import { useAuth } from 'react-oidc-context'
+import { getEnvSpec } from 'api/api'
 
 /** component for showing a login dialog that hides other content on the page */
 function Login() {
   const auth = useAuth()
+  const envSpec = getEnvSpec()
 
-  const signIn = async () => {
-    auth.signinRedirect()
+  const signIn = () => {
+    auth.signinRedirect(
+      { extraQueryParams: { portalShortcode: envSpec.shortcode, portalHomeLink: window.location.origin } })
   }
 
   useEffect(() => {


### PR DESCRIPTION
In cooperation with https://github.com/broadinstitute/terraform-ap-deployments/pull/981, begin polishing the B2C sign-up/sign-in pages.

To test: Run the participant UI locally, go to the OurHealth portal, and click "Log In". It should look a little less Microsofty and have an OurHealth logo. Clicking the logo should return to the OurHealth portal landing page.