### PR TITLE
[AR-207] Handle section configs that are not JSON encoded objects

### DIFF
--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -106,8 +106,8 @@ export type HtmlSection = {
   id: string,
   sectionType: SectionType,
   anchorRef?: string,
-  rawContent: string | null,
-  sectionConfig: string | null
+  rawContent?: string | null,
+  sectionConfig?: string | null
 }
 
 export type SurveyJSForm = {
@@ -254,8 +254,7 @@ export type Config = {
   b2cClientId: string
 }
 
-// eslint-disable-next-line  @typescript-eslint/no-explicit-any
-export type SectionConfig = { [index: string]: any }
+export type SectionConfig = Record<string, unknown>
 
 let bearerToken: string | null = null
 const API_ROOT = `${process.env.REACT_APP_API_ROOT}`
@@ -572,4 +571,3 @@ const ALLOWED_ENV_NAMES: Record<string, string> = {
   'irb': 'IRB',
   'live': 'LIVE'
 }
-

--- a/ui-participant/src/landing/sections/HtmlPageView.test.tsx
+++ b/ui-participant/src/landing/sections/HtmlPageView.test.tsx
@@ -1,31 +1,66 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
-import HtmlPageView from './HtmlPageView'
-import { HtmlPage } from 'api/api'
+import HtmlPageView, { HtmlSectionView } from './HtmlPageView'
+import { HtmlPage, HtmlSection } from 'api/api'
 
 
-test('handles trivial landing page', () => {
-  const simplePage: HtmlPage = {
-    sections: [],
-    title: 'Page title',
-    path: ''
-  }
-  const { container } = render(<HtmlPageView page={simplePage}/>)
-  expect(container).toBeEmptyDOMElement()
+describe('HTMLPageView', () => {
+  it('handles trivial landing page', () => {
+    const simplePage: HtmlPage = {
+      sections: [],
+      title: 'Page title',
+      path: ''
+    }
+    const { container } = render(<HtmlPageView page={simplePage}/>)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('handles landing page with one section', () => {
+    const simplePage: HtmlPage = {
+      sections: [{
+        sectionType: 'RAW_HTML',
+        anchorRef: 'foo',
+        rawContent: '<div>Hellllo</div>',
+        id: 'fakeId',
+        sectionConfig: null
+      }],
+      title: 'Page title',
+      path: ''
+    }
+    render(<HtmlPageView page={simplePage}/>)
+    expect(screen.getByText('Hellllo')).toBeInTheDocument()
+  })
 })
 
-test('handles landing page with one section', () => {
-  const simplePage: HtmlPage = {
-    sections: [{
-      sectionType: 'RAW_HTML',
-      anchorRef: 'foo',
-      rawContent: '<div>Hellllo</div>',
-      id: 'fakeId',
-      sectionConfig: null
-    }],
-    title: 'Page title',
-    path: ''
-  }
-  render(<HtmlPageView page={simplePage}/>)
-  expect(screen.getByText('Hellllo')).toBeInTheDocument()
+describe('HTMLSectionView', () => {
+  describe('misconfiguration does not cause render errors', () => {
+    beforeEach(() => {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      jest.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    it('absorbs configuration that is invalid JSON', () => {
+      const section: HtmlSection = {
+        id: 'misconfiguredSection',
+        sectionType: 'HERO_WITH_IMAGE',
+        sectionConfig: '{key:"value"}'
+      }
+
+      const { container } = render(<HtmlSectionView section={section} />)
+      expect(container).toBeEmptyDOMElement()
+      expect(console.warn).toHaveBeenCalled()
+    })
+
+    it('absorbs configuration that is not an object', () => {
+      const section: HtmlSection = {
+        id: 'misconfiguredSection',
+        sectionType: 'HERO_WITH_IMAGE',
+        sectionConfig: '"config"'
+      }
+
+      const { container } = render(<HtmlSectionView section={section} />)
+      expect(container).toBeEmptyDOMElement()
+      expect(console.warn).toHaveBeenCalled()
+    })
+  })
 })

--- a/ui-participant/src/util/validationUtils.ts
+++ b/ui-participant/src/util/validationUtils.ts
@@ -1,0 +1,5 @@
+import { isPlainObject as _isPlainObject } from 'lodash'
+
+export const isPlainObject = (config: unknown): config is Record<string, unknown> => {
+  return _isPlainObject(config)
+}


### PR DESCRIPTION
Part 1 of making landing page templates more resilient to misconfiguration.

Each section returned from the API has a `sectionConfig` that is intended to contain JSON encoded configuration for the section. This makes the frontend tolerant to invalid JSON and JSON that does not contain an object. In these cases, the template will log a warning and render nothing.