### PR TITLE
Make section styling options consistent

### DIFF
--- a/ui-participant/src/landing/sections/FrequentlyAskedQuestionsTemplate.tsx
+++ b/ui-participant/src/landing/sections/FrequentlyAskedQuestionsTemplate.tsx
@@ -6,6 +6,8 @@ import _ from 'lodash'
 import React from 'react'
 import ReactMarkdown from 'react-markdown'
 
+import { getSectionStyle } from 'util/styleUtils'
+
 const idFor = (question: string): string => {
   return _.kebabCase(question)
 }
@@ -20,11 +22,9 @@ type FaqQuestion = {
 }
 
 type FrequentlyAskedQuestionsConfig = {
-  backgroundColor?: string, // background color for the block
   blurb?: string, //  text below the title
   questions?: FaqQuestion[], // the questions
   title?: string, // large heading text
-  color?: string // foreground text color
 }
 
 type FrequentlyAskedQuestionsProps = {
@@ -36,18 +36,14 @@ type FrequentlyAskedQuestionsProps = {
  * Template for rendering a Frequently Asked Questions block.
  */
 function FrequentlyAskedQuestionsTemplate(props: FrequentlyAskedQuestionsProps) {
+  const { anchorRef, config } = props
   const {
-    anchorRef,
-    config: {
-      backgroundColor,
-      blurb,
-      color,
-      questions,
-      title = 'Frequently Asked Questions'
-    }
-  } = props
+    blurb,
+    questions,
+    title = 'Frequently Asked Questions'
+  } = config
 
-  return <div id={anchorRef} className="row mx-0 justify-content-center" style={{ backgroundColor, color }}>
+  return <div id={anchorRef} className="row mx-0 justify-content-center" style={getSectionStyle(config)}>
     <div className="col-12 col-sm-8 col-lg-6">
       <h1 className="fs-1 fw-normal lh-sm mt-5 mb-4 text-center">{title}</h1>
       <div className="fs-4 mb-4 text-center">

--- a/ui-participant/src/landing/sections/HeroCenteredTemplate.tsx
+++ b/ui-participant/src/landing/sections/HeroCenteredTemplate.tsx
@@ -2,17 +2,17 @@ import _ from 'lodash'
 import React from 'react'
 import { ButtonConfig } from 'api/api'
 import ReactMarkdown from 'react-markdown'
+
+import PearlImage, { PearlImageConfig } from 'util/PearlImage'
+import { getSectionStyle } from 'util/styleUtils'
+
 import ConfiguredButton from './ConfiguredButton'
-import PearlImage, { PearlImageConfig } from '../../util/PearlImage'
 
 type HeroCenteredTemplateConfig = {
-  background?: string, // background CSS style (e.g. `linear-gradient(...)`)
-  backgroundColor?: string, // background color for the block
   blurb?: string, //  text below the title
   blurbAlign?: string // left|right|center  where to align the blurb text.  default is 'center'
   buttons?: ButtonConfig[], // array of objects containing `text` and `href` attributes
   title?: string, // large heading text
-  color?: string, // foreground text color
   image?: PearlImageConfig   // image to display under blurb
 }
 
@@ -27,20 +27,15 @@ const blurbAlignAllowed = ['center', 'right', 'left']
  * Template for rendering a hero with centered content.
  */
 function HeroCenteredTemplate(props: HeroCenteredTemplateProps) {
-  const {
-    anchorRef,
-    config: {
-      background, backgroundColor, color,
-      blurb, blurbAlign, buttons, title, image
-    }
-  } = props
+  const { anchorRef, config } = props
+  const { blurb, blurbAlign, buttons, title, image } = config
 
   const blurbAlignIndex = blurbAlignAllowed.indexOf(blurbAlign ?? 'center')
   const cleanBlurbAlign: string = blurbAlignAllowed[blurbAlignIndex === -1 ? 0 : blurbAlignIndex] ?? 'center'
   const blurbStyle = {
     textAlign: cleanBlurbAlign as CanvasTextAlign
   }
-  return <div id={anchorRef} className="row mx-0" style={{ background, backgroundColor, color }}>
+  return <div id={anchorRef} className="row mx-0" style={getSectionStyle(config)}>
     <div className="col-12 col-sm-10 col-lg-6 mx-auto py-5 text-center">
       {!!title && (
         <h1 className="fs-1 fw-normal lh-sm mb-4">

--- a/ui-participant/src/landing/sections/HeroWithImageTemplate.tsx
+++ b/ui-participant/src/landing/sections/HeroWithImageTemplate.tsx
@@ -1,15 +1,15 @@
 import classNames from 'classnames'
 import _ from 'lodash'
-import React, { CSSProperties } from 'react'
-import { ButtonConfig, getImageUrl } from 'api/api'
-import PearlImage, { PearlImageConfig } from '../../util/PearlImage'
-import ConfiguredButton from './ConfiguredButton'
+import React from 'react'
 import ReactMarkdown from 'react-markdown'
 
+import { ButtonConfig } from 'api/api'
+import PearlImage, { PearlImageConfig } from 'util/PearlImage'
+import { getSectionStyle } from 'util/styleUtils'
+
+import ConfiguredButton from './ConfiguredButton'
+
 type HeroWithImageTemplateConfig = {
-  background?: string, // background CSS style (e.g. `linear-gradient(...)`)
-  backgroundColor?: string, // background color for the block
-  backgroundImage?: PearlImageConfig, // background image
   blurb?: string, //  text below the title
   buttons?: ButtonConfig[], // array of objects containing `text` and `href` attributes
   fullWidth?: boolean, // span the full page width or not
@@ -29,26 +29,17 @@ type HeroWithImageTemplateProps = {
  * Template for a hero with text content on the left and an image on the right.
  */
 function HeroWithImageTemplate(props: HeroWithImageTemplateProps) {
+  const { anchorRef, config } = props
   const {
-    anchorRef,
-    config: {
-      background,
-      backgroundImage,
-      blurb,
-      buttons,
-      fullWidth = false,
-      image,
-      imagePosition,
-      imageWidthPercentage: configuredImageWidthPercentage,
-      logos,
-      title
-    }
-  } = props
-
-  const styleProps: CSSProperties = { background }
-  if (backgroundImage) {
-    styleProps.backgroundImage = `url('${getImageUrl(backgroundImage.cleanFileName, backgroundImage.version)}')`
-  }
+    blurb,
+    buttons,
+    fullWidth = false,
+    image,
+    imagePosition,
+    imageWidthPercentage: configuredImageWidthPercentage,
+    logos,
+    title
+  } = config
 
   const isLeftImage = imagePosition === 'left' // default is right, so left has to be explicitly specified
   const imageWidthPercentage = _.isNumber(configuredImageWidthPercentage)
@@ -60,7 +51,7 @@ function HeroWithImageTemplate(props: HeroWithImageTemplateProps) {
     <div
       className={classNames('row', 'mx-0', isLeftImage ? 'flex-row' : 'flex-row-reverse')}
       id={anchorRef}
-      style={styleProps}
+      style={getSectionStyle(config)}
     >
       <div
         className={classNames(

--- a/ui-participant/src/landing/sections/ParticipationDetailTemplate.tsx
+++ b/ui-participant/src/landing/sections/ParticipationDetailTemplate.tsx
@@ -1,13 +1,15 @@
 import classNames from 'classnames'
-import React, { CSSProperties } from 'react'
-import { ButtonConfig } from 'api/api'
-import PearlImage, { PearlImageConfig } from '../../util/PearlImage'
+import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faClock } from '@fortawesome/free-regular-svg-icons'
+
+import { ButtonConfig } from 'api/api'
+import PearlImage, { PearlImageConfig } from 'util/PearlImage'
+import { getSectionStyle } from 'util/styleUtils'
+
 import ConfiguredButton from './ConfiguredButton'
 
 type ParticipationDetailTemplateConfig = {
-  background?: string, // background CSS style (e.g. `linear-gradient(...)`)
   blurb?: string, //  text below the title
   actionButton?: ButtonConfig, // array of objects containing `text` and `href` attributes
   title?: string, // large heading text
@@ -26,23 +28,19 @@ type ParticipationDetailTemplateProps = {
  * Template for a participation step description
  */
 function ParticipationDetailTemplate(props: ParticipationDetailTemplateProps) {
+  const { anchorRef, config } = props
   const {
-    anchorRef,
-    config: {
-      background,
-      blurb,
-      actionButton,
-      stepNumberText,
-      timeIndication,
-      image,
-      imagePosition,
-      title
-    }
-  } = props
+    blurb,
+    actionButton,
+    stepNumberText,
+    timeIndication,
+    image,
+    imagePosition,
+    title
+  } = config
 
-  const styleProps: CSSProperties = { background }
   const isLeftImage = imagePosition === 'left' // default is right, so left has to be explicitly specified
-  return <div id={anchorRef} className="row mx-0 py-5" style={styleProps}>
+  return <div id={anchorRef} className="row mx-0 py-5" style={getSectionStyle(config)}>
     <div
       className={classNames(
         'col-md-10 col-lg-8', 'mx-auto', 'row',

--- a/ui-participant/src/landing/sections/PhotoBlurbGrid.tsx
+++ b/ui-participant/src/landing/sections/PhotoBlurbGrid.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
-import PearlImage, { PearlImageConfig } from '../../util/PearlImage'
 import ReactMarkdown from 'react-markdown'
 
+import PearlImage, { PearlImageConfig } from 'util/PearlImage'
+import { getSectionStyle } from 'util/styleUtils'
+
 type PhotoBlurbGridConfig = {
-  background?: string, // background CSS style (e.g. `linear-gradient(...)`)
-  backgroundColor?: string, // background color for the block
-  color?: string,
   title?: string,
   subGrids?: SubGrid[]
 }
@@ -31,12 +30,10 @@ type PhotoBlurbGridProps = {
  * Template for rendering a hero with centered content.
  */
 function PhotoBlurbGrid(props: PhotoBlurbGridProps) {
-  const {
-    anchorRef,
-    config: { background, backgroundColor, color, subGrids, title }
-  } = props
+  const { anchorRef, config } = props
+  const { subGrids, title } = config
 
-  return <div id={anchorRef} className="py-5" style={{ background, backgroundColor, color }}>
+  return <div id={anchorRef} className="py-5" style={getSectionStyle(config)}>
     {title && <h1 className="fs-1 fw-normal lh-sm text-center mb-4">
       {title}
     </h1>}

--- a/ui-participant/src/landing/sections/SocialMediaTemplate.tsx
+++ b/ui-participant/src/landing/sections/SocialMediaTemplate.tsx
@@ -1,7 +1,9 @@
 import _ from 'lodash'
 import React from 'react'
+
 import { ButtonConfig } from 'api/api'
-import PearlImage from '../../util/PearlImage'
+import PearlImage from 'util/PearlImage'
+import { getSectionStyle } from 'util/styleUtils'
 
 type SocialMediaTemplateConfig = {
   blurb?: string, //  text below the title
@@ -22,19 +24,17 @@ type SocialMediaTemplateProps = {
  * TODO -- implement images
  */
 function SocialMediaTemplate(props: SocialMediaTemplateProps) {
+  const { anchorRef, config } = props
   const {
-    anchorRef,
-    config: {
-      blurb,
-      buttons,
-      facebookHref,
-      instagramHref,
-      title,
-      twitterHref
-    }
-  } = props
+    blurb,
+    buttons,
+    facebookHref,
+    instagramHref,
+    title,
+    twitterHref
+  } = config
 
-  return <div id={anchorRef} className="container py-5">
+  return <div id={anchorRef} className="container py-5" style={getSectionStyle(config)}>
     <div className="d-flex justify-content-center mt-5 mb-4">
       {twitterHref &&
         <PearlImage image={{ cleanFileName: 'twitter.png', version: 1, alt: 'Twitter' }}

--- a/ui-participant/src/landing/sections/StepOverviewTemplate.tsx
+++ b/ui-participant/src/landing/sections/StepOverviewTemplate.tsx
@@ -1,8 +1,10 @@
 import _ from 'lodash'
 import React from 'react'
+import ReactMarkdown from 'react-markdown'
+
 import { ButtonConfig } from 'api/api'
 import PearlImage, { PearlImageConfig } from 'util/PearlImage'
-import ReactMarkdown from 'react-markdown'
+import { getSectionStyle } from 'util/styleUtils'
 
 type StepConfig = {
   image: PearlImageConfig,
@@ -11,7 +13,6 @@ type StepConfig = {
 }
 
 type StepOverviewTemplateConfig = {
-  background?: string, // background CSS style (e.g. `linear-gradient(...)`)
   buttons?: ButtonConfig[], // array of objects containing `text` and `href` attributes
   title?: string, // large heading text
   steps?: StepConfig[]
@@ -26,18 +27,11 @@ type StepOverviewTemplateProps = {
  * Template for rendering a step overview
  */
 function StepOverviewTemplate(props: StepOverviewTemplateProps) {
-  const {
-    anchorRef,
-    config: {
-      background,
-      buttons,
-      steps,
-      title
-    }
-  } = props
+  const { anchorRef, config } = props
+  const { buttons, steps, title } = config
 
   // TODO: improve layout code for better flexing, especially with <> 4 steps
-  return <div id={anchorRef} style={{ background }} className="py-5">
+  return <div id={anchorRef} className="py-5" style={getSectionStyle(config)}>
     <h1 className="fs-1 fw-normal lh-sm mb-3 text-center">
       <ReactMarkdown>{title ? title : ''}</ReactMarkdown>
     </h1>

--- a/ui-participant/src/util/styleUtils.ts
+++ b/ui-participant/src/util/styleUtils.ts
@@ -1,0 +1,30 @@
+import { CSSProperties } from 'react'
+
+import { getImageUrl, SectionConfig } from 'api/api'
+import { isPlainObject } from 'util/validationUtils'
+
+const allowedStyles = [
+  'background',
+  'backgroundColor',
+  'color'
+] as const
+
+/** From section configuration, get styles to apply to the section's container */
+export const getSectionStyle = (config: SectionConfig): CSSProperties => {
+  const style: CSSProperties = allowedStyles.reduce(
+    (acc, property) => config[property]
+      ? { ...acc, [property]: config[property] }
+      : acc,
+    {}
+  )
+
+  // backgroundImage is not a pass-through style, so must be handled separately.
+  if (isPlainObject(config.backgroundImage)) {
+    const { cleanFileName, version } = config.backgroundImage
+    if (typeof cleanFileName === 'string' && typeof version === 'number') {
+      style.backgroundImage = `url('${getImageUrl(cleanFileName, version)}')`
+    }
+  }
+
+  return style
+}

--- a/ui-participant/src/util/validationUtils.ts
+++ b/ui-participant/src/util/validationUtils.ts
@@ -1,0 +1,5 @@
+import { isPlainObject as _isPlainObject } from 'lodash'
+
+export const isPlainObject = (config: unknown): config is Record<string, unknown> => {
+  return _isPlainObject(config)
+}


### PR DESCRIPTION
Sections are pretty inconsistent in what styling options they expose via section configuration. Most allow one or both of `background` and `backgroundColor`. Since, in CSS, `background` can be a shorthand for `backgroundColor`, it's pretty surprising and frustrating when `backgroundColor` works but `background` does not, or vice versa. One template allows setting a background image, and a few allow setting the text color.

This makes sections consistent in accepting `background`, `backgroundColor`, `backgroundImage`, and `color` from section configuration.