### PR TITLE
[AR-134] Update spacing in hero centered template

### DIFF
--- a/ui-participant/src/landing/sections/HeroCenteredTemplate.tsx
+++ b/ui-participant/src/landing/sections/HeroCenteredTemplate.tsx
@@ -42,10 +42,13 @@ function HeroCenteredTemplate(props: HeroCenteredTemplateProps) {
   const hasImage = !!image
   const hasButtons = (buttons || []).length > 0
 
+  const hasContentFollowingTitle = hasBlurb || hasImage || hasButtons
+  const hasContentFollowingImage = hasButtons
+
   return <div id={anchorRef} className="row mx-0" style={getSectionStyle(config)}>
     <div className="col-12 col-sm-10 col-lg-6 mx-auto py-5 text-center">
       {hasTitle && (
-        <h1 className={classNames('fs-1 fw-normal lh-sm', hasBlurb || hasImage || hasButtons ? 'mb-4' : 'mb-0')}>
+        <h1 className={classNames('fs-1 fw-normal lh-sm', hasContentFollowingTitle ? 'mb-4' : 'mb-0')}>
           <ReactMarkdown disallowedElements={['p']} unwrapDisallowed>{title}</ReactMarkdown>
         </h1>
       )}
@@ -55,7 +58,7 @@ function HeroCenteredTemplate(props: HeroCenteredTemplateProps) {
         </div>
       )}
       {hasImage && (
-        <PearlImage image={image} className={classNames('img-fluid', { 'mb-4': hasButtons })} />
+        <PearlImage image={image} className={classNames('img-fluid', { 'mb-4': hasContentFollowingImage })} />
       )}
       {hasButtons && (
         <div className="d-grid gap-2 d-sm-flex justify-content-sm-center">


### PR DESCRIPTION
On the Participation and FAQ pages, we use a HeroCenteredTemplate configured with only a title to get a page title section with a gradient background. This adjusts the spacing within HeroCenteredTemplate so that the title is vertically centered within the section. To do that, it removes margins from elements if there is no following element.

## Before
![Screenshot 2023-03-21 at 9 55 28 AM](https://user-images.githubusercontent.com/1156625/226630248-0ccd69e8-766c-4936-8967-e99c8de18c4a.png)

## After
![Screenshot 2023-03-21 at 9 55 19 AM](https://user-images.githubusercontent.com/1156625/226630244-852dccbf-46ad-486f-b78e-f91e082dcc74.png)

