### PR TITLE
[AR-9] Make primary brand color configurable

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/site/LocalizedSiteContent.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/site/LocalizedSiteContent.java
@@ -27,4 +27,5 @@ public class LocalizedSiteContent extends BaseEntity {
     private int navLogoVersion;
     private UUID footerSectionId;
     private HtmlSection footerSection;
+    private String primaryBrandColor;
 }

--- a/core/src/main/resources/db/changelog/changesets/2023_03_21_primary_brand_color.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2023_03_21_primary_brand_color.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: "primary_brand_color"
+      author: nwatts
+      changes:
+        - addColumn:
+            tableName: localized_site_content
+            columns:
+              - column: { name: primary_brand_color , type: text }

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -47,6 +47,9 @@ databaseChangeLog:
   - include:
       file: changesets/2023_03_14_notification_config_reminders.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2023_03_21_primary_brand_color.yaml
+      relativeToChangelogFile: true
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements
 # are atomic. When they are grouped in a changeset and one fails the changeset cannot be

--- a/populate/src/main/resources/seed/portals/ourhealth/siteContent/siteContent.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/siteContent/siteContent.json
@@ -6,6 +6,7 @@
     "language": "en",
     "navLogoCleanFileName": "ourhealth-logo.png",
     "navLogoVersion": 1,
+    "primaryBrandColor": "rgb(155, 36, 133)",
     "footerSectionFile": "footerSection.json",
     "landingPage": {
       "title": "OurHealth portal home",

--- a/ui-participant/src/App.tsx
+++ b/ui-participant/src/App.tsx
@@ -51,6 +51,11 @@ const brandStyles = (config: BrandConfiguration = {}): CSSProperties => {
 function App() {
   const { localContent, portal } = usePortalEnv()
 
+  const brandConfig: BrandConfiguration = {}
+  if (localContent.primaryBrandColor) {
+    brandConfig.brandColor = localContent.primaryBrandColor
+  }
+
   let landingRoutes: JSX.Element[] = []
   if (localContent.navbarItems) {
     landingRoutes = localContent.navbarItems
@@ -77,9 +82,7 @@ function App() {
                 <UserProvider>
                   <div
                     className="App d-flex flex-column min-vh-100 bg-white"
-                    style={brandStyles({
-                      brandColor: 'rgb(155, 36, 133)' // TODO: Get brand color from localContent
-                    })}
+                    style={brandStyles(brandConfig)}
                   >
                     <BrowserRouter>
                       <Routes>

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -56,6 +56,7 @@ export type LocalSiteContent = {
   navLogoCleanFileName: string,
   navLogoVersion: number,
   footerSection?: HtmlSection
+  primaryBrandColor?: string
 }
 
 export type HtmlPage = {


### PR DESCRIPTION
#97 introduced a `brandColor` to the participant UI. The brand color is used for styling buttons and links. Currently, the OurHealth brand color is hard coded in the UI. This makes it configurable via siteContent.json. If not configured, it falls back to Bootstrap's blue.