### PR TITLE
[AR-190] Fix logout behavior and navigation

### DIFF
--- a/ui-participant/src/App.tsx
+++ b/ui-participant/src/App.tsx
@@ -75,16 +75,16 @@ function App() {
     <>
       <EnvironmentAlert portalEnvironment={portal.portalEnvironments[0]}/>
       <PortalPasswordGate portal={portal}>
-        <ConfigProvider>
-          <ConfigConsumer>
-            {config =>
-              <AuthProvider {...getOidcConfig(config.b2cTenantName, config.b2cClientId)}>
-                <UserProvider>
-                  <div
-                    className="App d-flex flex-column min-vh-100 bg-white"
-                    style={brandStyles(brandConfig)}
-                  >
-                    <BrowserRouter>
+        <div
+          className="App d-flex flex-column min-vh-100 bg-white"
+          style={brandStyles(brandConfig)}
+        >
+          <BrowserRouter>
+            <ConfigProvider>
+              <ConfigConsumer>
+                {config =>
+                  <AuthProvider {...getOidcConfig(config.b2cTenantName, config.b2cClientId)}>
+                    <UserProvider>
                       <Routes>
                         <Route path="/hub/*" element={<ProtectedRoute><HubRouter/></ProtectedRoute>}/>
                         <Route path="/studies/:studyShortcode">
@@ -98,13 +98,13 @@ function App() {
                         </Route>
                         <Route path="*" element={<div>unmatched route</div>}/>
                       </Routes>
-                    </BrowserRouter>
-                  </div>
-                </UserProvider>
-              </AuthProvider>
-            }
-          </ConfigConsumer>
-        </ConfigProvider>
+                    </UserProvider>
+                  </AuthProvider>
+                }
+              </ConfigConsumer>
+            </ConfigProvider>
+          </BrowserRouter>
+        </div>
       </PortalPasswordGate>
     </>
 

--- a/ui-participant/src/hub/HubNavbar.tsx
+++ b/ui-participant/src/hub/HubNavbar.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { NavLink } from 'react-router-dom'
-import Api, { getImageUrl } from 'api/api'
+import { getImageUrl } from 'api/api'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { useUser } from '../providers/UserProvider'
 
@@ -11,12 +11,11 @@ export default function HubNavbar() {
 
   /** send a logout to the api then logout */
   function doLogout() {
-    Api.logout().then(() => {
+    try {
       logoutUser()
-      window.location.href = '/'
-    }).catch(e => {
+    } catch (e) {
       alert(`an error occurred during logout ${e}`)
-    })
+    }
   }
 
   return <nav className="LandingNavbar navbar navbar-expand-lg navbar-light">


### PR DESCRIPTION
B2C log-out was leaving the user on the sign-in page instead of the landing page. Unauthed log-out was flickering the unauthed sign-in page before returning to the landing page. This fixes both of those behaviors.

To test:
1. With `REACT_APP_UNAUTHED_LOGIN=true` in `.env.local`, start the participant UI with `HTTPS=true npm start`.
2. Log in as consented@test.com.
3. Log out and notice that there is no annoying page flickering on the way to the main landing page.
4. Stop the participant UI and restart it without `REACT_APP_UNAUTHED_LOGIN` set.2. Log in as consented@test.com.
5. Log out and notice that you now return to the landing page instead of the sign-in page.
