### PR TITLE
[AR-207] Fix image style validation

### DIFF
--- a/ui-participant/src/landing/PearlImage.tsx
+++ b/ui-participant/src/landing/PearlImage.tsx
@@ -22,7 +22,7 @@ export const validatePearlImageConfig = (imageConfig: unknown): PearlImageConfig
   const className = requireOptionalString(config, 'className', message)
 
   // Only validate that style is an object. React will handle invalid keys.
-  const style = config.style ? requirePlainObject(config, 'style') : undefined
+  const style = config.style ? requirePlainObject(config.style, `${message}: Invalid style`) : undefined
 
   return {
     cleanFileName,


### PR DESCRIPTION
Fixup for #150. Currently, the input image configuration object is getting returned as the validated configuration's `style` property.