### PR TITLE
[AR-134] Add social media links to home page

### DIFF
--- a/populate/src/main/resources/seed/portals/ourhealth/siteContent/siteContent.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/siteContent/siteContent.json
@@ -140,6 +140,22 @@
           }]
         }
       },{
+        "sectionType": "SOCIAL_MEDIA",
+        "sectionConfigJson": {
+          "twitterHandle": "ourhealthstudy",
+          "instagramHandle": "ourhealthstudy"
+        }
+      },{
+        "sectionType": "HERO_CENTERED",
+        "sectionConfigJson": {
+          "title": "Stay informed",
+          "blurb": "Sign up for our mailing list or follow us on social media.",
+          "buttons": [{
+            "type": "mailingList",
+            "text": "Join Mailing LIst"
+          }]
+        }
+      },{
         "sectionType": "HERO_CENTERED",
         "sectionConfigJson": {
           "title": "You can make an impact",

--- a/ui-participant/package-lock.json
+++ b/ui-participant/package-lock.json
@@ -8,9 +8,10 @@
       "name": "ui-participant",
       "version": "0.1.0",
       "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^6.2.0",
-        "@fortawesome/free-regular-svg-icons": "^6.2.1",
-        "@fortawesome/free-solid-svg-icons": "^6.2.0",
+        "@fortawesome/fontawesome-svg-core": "6.2.x",
+        "@fortawesome/free-brands-svg-icons": "6.2.x",
+        "@fortawesome/free-regular-svg-icons": "6.2.x",
+        "@fortawesome/free-solid-svg-icons": "6.2.x",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
@@ -2262,6 +2263,18 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.2.1.tgz",
       "integrity": "sha512-HELwwbCz6C1XEcjzyT1Jugmz2NNklMrSPjZOWMlc+ZsHIVk+XOvOXLGGQtFBwSyqfJDNgRq4xBCwWOaZ/d9DEA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.2.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-brands-svg-icons": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.2.1.tgz",
+      "integrity": "sha512-L8l4MfdHPmZlJ72PvzdfwOwbwcCAL0vx48tJRnI6u1PJXh+j2f3yDoKyQgO3qjEsgD5Fr2tQV/cPP8F/k6aUig==",
       "hasInstallScript": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.2.1"
@@ -19424,6 +19437,14 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.2.1.tgz",
       "integrity": "sha512-HELwwbCz6C1XEcjzyT1Jugmz2NNklMrSPjZOWMlc+ZsHIVk+XOvOXLGGQtFBwSyqfJDNgRq4xBCwWOaZ/d9DEA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.2.1"
+      }
+    },
+    "@fortawesome/free-brands-svg-icons": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.2.1.tgz",
+      "integrity": "sha512-L8l4MfdHPmZlJ72PvzdfwOwbwcCAL0vx48tJRnI6u1PJXh+j2f3yDoKyQgO3qjEsgD5Fr2tQV/cPP8F/k6aUig==",
       "requires": {
         "@fortawesome/fontawesome-common-types": "6.2.1"
       }

--- a/ui-participant/package.json
+++ b/ui-participant/package.json
@@ -3,9 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^6.2.0",
-    "@fortawesome/free-regular-svg-icons": "^6.2.1",
-    "@fortawesome/free-solid-svg-icons": "^6.2.0",
+    "@fortawesome/fontawesome-svg-core": "6.2.x",
+    "@fortawesome/free-brands-svg-icons": "6.2.x",
+    "@fortawesome/free-regular-svg-icons": "6.2.x",
+    "@fortawesome/free-solid-svg-icons": "6.2.x",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",

--- a/ui-participant/src/landing/sections/SocialMediaTemplate.tsx
+++ b/ui-participant/src/landing/sections/SocialMediaTemplate.tsx
@@ -1,3 +1,6 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core'
+import { faFacebook, faInstagram, faTwitter } from '@fortawesome/free-brands-svg-icons'
 import React from 'react'
 
 import { SectionConfig } from 'api/api'
@@ -5,59 +8,84 @@ import { getSectionStyle } from 'util/styleUtils'
 import { withValidatedSectionConfig } from 'util/withValidatedSectionConfig'
 import { requireOptionalString } from 'util/validationUtils'
 
-import PearlImage from '../PearlImage'
-
 import { TemplateComponentProps } from './templateUtils'
 
 type SocialMediaTemplateConfig = {
-  facebookHref?: string, // URL of Facebook page
-  instagramHref?: string, // URL of Instagram page
-  twitterHref?: string, // URL of Twitter page
+  facebookHandle?: string, // Facebook handle
+  instagramHandle?: string, // Instagram handle
+  twitterHandle?: string, // Twitter handle
 }
 
 /** Validate that a section configuration object conforms to SocialMediaTemplateConfig */
 const validateSocialMediaTemplateConfig = (config: SectionConfig): SocialMediaTemplateConfig => {
   const message = 'Invalid SocialMediaTemplateConfig'
-  const facebookHref = requireOptionalString(config, 'facebookHref', message)
-  const instagramHref = requireOptionalString(config, 'instagramHref', message)
-  const twitterHref = requireOptionalString(config, 'twitterHref', message)
+  const facebookHandle = requireOptionalString(config, 'facebookHandle', message)
+  const instagramHandle = requireOptionalString(config, 'instagramHandle', message)
+  const twitterHandle = requireOptionalString(config, 'twitterHandle', message)
   return {
-    facebookHref,
-    instagramHref,
-    twitterHref
+    facebookHandle,
+    instagramHandle,
+    twitterHandle
   }
+}
+
+
+type SocialMediaLinkProps = {
+  icon: IconDefinition
+  label: string
+  url: string
+}
+
+const SocialMediaLink = (props: SocialMediaLinkProps) => {
+  const { icon, label, url } = props
+  return (
+    <a className="px-2" href={url}>
+      <span className="visually-hidden">{label}</span>
+      <FontAwesomeIcon icon={icon} style={{ height: '3rem' }} />
+    </a>
+  )
 }
 
 type SocialMediaTemplateProps = TemplateComponentProps<SocialMediaTemplateConfig>
 
 /**
  * Template for a hero with social media links.
- * TODO -- implement images
  */
 function SocialMediaTemplate(props: SocialMediaTemplateProps) {
   const { anchorRef, config } = props
   const {
-    facebookHref,
-    instagramHref,
-    twitterHref
+    facebookHandle,
+    instagramHandle,
+    twitterHandle
   } = config
 
-  return <div id={anchorRef} className="container py-5" style={getSectionStyle(config)}>
-    <div className="d-flex justify-content-center mt-5 mb-4">
-      {twitterHref &&
-        <PearlImage image={{ cleanFileName: 'twitter.png', version: 1, alt: 'Twitter' }}
-          className="m-3" style={{ width: '56px' }}/>
-      }
-      {facebookHref &&
-        <PearlImage image={{ cleanFileName: 'facebook.png', version: 1, alt: 'Facebook' }}
-          className="m-3" style={{ width: '54px' }}/>
-      }
-      {instagramHref &&
-        <PearlImage image={{ cleanFileName: 'instagram.png', version: 1, alt: 'Instagram' }}
-          className="m-3" style={{ width: '49px' }}/>
-      }
+  return (
+    <div id={anchorRef} className="row py-5" style={getSectionStyle(config)}>
+      <div className="hstack justify-content-center gap-2">
+        {twitterHandle && (
+          <SocialMediaLink
+            icon={faTwitter}
+            label="Twitter"
+            url={`https://twitter.com/${twitterHandle}`}
+          />
+        )}
+        {facebookHandle && (
+          <SocialMediaLink
+            icon={faFacebook}
+            label="Facebook"
+            url={`https://facebook.com/${facebookHandle}`}
+          />
+        )}
+        {instagramHandle && (
+          <SocialMediaLink
+            icon={faInstagram}
+            label="Instagram"
+            url={`https://instagram.com/${instagramHandle}`}
+          />
+        )}
+      </div>
     </div>
-  </div>
+  )
 }
 
 export default withValidatedSectionConfig(validateSocialMediaTemplateConfig, SocialMediaTemplate)


### PR DESCRIPTION
Add Twitter and Instagram links to the OurHealth home page.

Along the way, updated the social media section template with FontAwesome icons instead of missing Pearl images and to be configured with only handles instead of full URLs.