### PR TITLE
Run CI on PRs in merge queue

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -17,6 +17,7 @@ on:
     paths-ignore: [ '*.md']
   pull_request:
     branches: [ '**' ]
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/javascript-admin-ci.yml
+++ b/.github/workflows/javascript-admin-ci.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore: [ '*.md']
   pull_request:
     branches: [ '**' ]
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/javascript-participant-ci.yml
+++ b/.github/workflows/javascript-participant-ci.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore: [ '*.md']
   pull_request:
     branches: [ '**' ]
+  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION
This configures CI workflows to run on branches created by the merge queue, so that CI is run before merging the queue into the development branch.

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions