### PR TITLE
[AR-134] Fix alignment of buttons in HeroCenteredTemplate

### DIFF
--- a/ui-participant/src/landing/sections/HeroCenteredTemplate.tsx
+++ b/ui-participant/src/landing/sections/HeroCenteredTemplate.tsx
@@ -81,7 +81,7 @@ function HeroCenteredTemplate(props: HeroCenteredTemplateProps) {
           {
             _.map(buttons, (button, i) => {
               // TODO: allow customization of button styling
-              return <ConfiguredButton key={i} config={button} className='btn-lg px-4 me-md-2'/>
+              return <ConfiguredButton key={i} config={button} className="btn-lg px-4 mx-md-1" />
             })
           }
         </div>


### PR DESCRIPTION
Currently, buttons in HeroCenteredTemplate sections are not exactly center aligned because the right padding from the "me-md-2" class causes them to be slightly offset to the left of center. This changes "me-md-2" to "mx-md-1", which balances the padding between both sides of the buttons and makes them centered on the page.