### PR TITLE
[AR-220] Add empty alt tags to decorative images

### DIFF
--- a/populate/src/main/resources/seed/portals/ourhealth/siteContent/aboutUs.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/siteContent/aboutUs.json
@@ -9,7 +9,8 @@
       "sectionConfigJson": {
         "image": {
           "cleanFileName": "hands_banner.jpg",
-          "version": 1
+          "version": 1,
+          "alt": ""
         }
       }
     },{
@@ -30,7 +31,7 @@
       "sectionType": "HERO_WITH_IMAGE",
       "sectionConfigJson": {
         "title": "**We are dedicated to discovering the underlying genetic factors** for cardiometabolic disease risk in South Asian populations.",
-        "image": { "cleanFileName": "discover.svg", "version": 1, "style": {"padding": "3rem 0"}},
+        "image": { "cleanFileName": "discover.svg", "version": 1, "alt": "", "style": {"padding": "3rem 0"}},
         "imagePosition": "left",
         "background": "linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%)"
       }
@@ -60,7 +61,7 @@
       "sectionType": "HERO_WITH_IMAGE",
       "sectionConfigJson": {
         "title": "**South Asian datasets remain limited** in size, cultural diversity, and diasporic representation.",
-        "image": { "cleanFileName": "engage.svg", "version": 1, "style": {"padding": "3rem 0"}},
+        "image": { "cleanFileName": "engage.svg", "version": 1, "alt": "", "style": {"padding": "3rem 0"}},
         "imagePosition": "left",
         "background": "linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%)"
       }

--- a/populate/src/main/resources/seed/portals/ourhealth/siteContent/participation.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/siteContent/participation.json
@@ -21,7 +21,7 @@
           "href": "/docs/view/consent",
           "text": "View Consent"
         },
-        "image": { "cleanFileName": "consent_step.png", "version": 1},
+        "image": { "cleanFileName": "consent_step.png", "version": 1, "alt": "" },
         "imagePosition": "right"
       }
     },{
@@ -36,7 +36,7 @@
           "text": "View Surveys"
         },
         "background": "#F2F2F2",
-        "image": { "cleanFileName": "survey_step.png", "version": 1},
+        "image": { "cleanFileName": "survey_step.png", "version": 1, "alt": "" },
         "imagePosition": "left"
       }
     },{
@@ -50,7 +50,7 @@
           "href": "/docs/view/kitInstructions",
           "text": "View Kit Instructions"
         },
-        "image": { "cleanFileName": "saliva_step.png", "version": 1},
+        "image": { "cleanFileName": "saliva_step.png", "version": 1, "alt": "" },
         "imagePosition": "right"
       }
     },{
@@ -64,7 +64,7 @@
           "type": "mailingList",
           "text": "Join Email List"
         },
-        "image": { "cleanFileName": "engagement_step.png", "version": 1},
+        "image": { "cleanFileName": "engagement_step.png", "version": 1, "alt": "" },
         "imagePosition": "left",
         "background": "#F2F2F2"
       }

--- a/populate/src/main/resources/seed/portals/ourhealth/siteContent/scientificBackground.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/siteContent/scientificBackground.json
@@ -9,7 +9,8 @@
       "sectionConfigJson": {
         "image": {
           "cleanFileName": "scientists_banner.jpg",
-          "version": 1
+          "version": 1,
+          "alt": ""
         }
       }
     }, {

--- a/populate/src/main/resources/seed/portals/ourhealth/siteContent/siteContent.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/siteContent/siteContent.json
@@ -16,7 +16,7 @@
           "title": "Help us understand and improve cardiovascular disease risk among South Asian populations.",
           "blurb": "We're looking for participants to help us better understand - and ultimately overcome - the persistently high rates of cardiovascular diseases among South Asian populations.",
           "fullWidth": true,
-          "image": { "cleanFileName": "family.png", "version": 1},
+          "image": { "cleanFileName": "family.png", "version": 1, "alt": "" },
           "imagePosition": "right",
           "background": "linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%)",
           "buttons": [
@@ -59,7 +59,7 @@
           ],
           "imagePosition": "left",
           "imageWidthPercentage": 34,
-          "image": {"cleanFileName": "idea_bulb.png", "version": 1, "className": "p-3 p-lg-5"}
+          "image": {"cleanFileName": "idea_bulb.png", "version": 1, "alt": "", "className": "p-3 p-lg-5"}
         }
       },{
         "sectionType": "HERO_WITH_IMAGE",
@@ -73,7 +73,7 @@
               "studyShortcode": "ourheart"
             }
           ],
-          "image": {"cleanFileName": "people_laughing.jpg", "version": 1},
+          "image": {"cleanFileName": "people_laughing.jpg", "alt": "", "version": 1},
           "imagePosition": "left"
         }
       },{
@@ -82,19 +82,19 @@
           "background": "linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%)",
           "title": "How to Participate",
           "steps": [{
-            "image": {"cleanFileName": "step_1.png", "version": 1},
+            "image": {"cleanFileName": "step_1.png", "version": 1, "alt": ""},
             "duration": "1 minute",
             "blurb": "Answer eligibility questions and create your account."
           },{
-            "image": {"cleanFileName": "step_2.png", "version": 1},
+            "image": {"cleanFileName": "step_2.png", "version": 1, "alt": ""},
             "duration": "5 minutes",
             "blurb": "Read the consent form and decide if you’d like to join the study."
           },{
-            "image": {"cleanFileName": "step_3.png", "version": 1},
+            "image": {"cleanFileName": "step_3.png", "version": 1, "alt": ""},
             "duration": "25-45 minutes",
             "blurb": "Answer survey questions about you and your health."
           },{
-            "image": {"cleanFileName": "step_3.png", "version": 1},
+            "image": {"cleanFileName": "step_4.png", "version": 1, "alt": ""},
             "duration": "25-45 minutes",
             "blurb": "Provide your mailing address so we can send a sample kit."
           }],


### PR DESCRIPTION
Most images on the OurHealth landing pages are "decorative" and don't add information to the page. This adds empty alt tags to decorative images so that they are ignored by screen readers. 

https://www.w3.org/WAI/tutorials/images/decorative/