### PR TITLE
Solid background color for pre-enroll survey page

### DIFF
--- a/ui-participant/src/studies/enroll/PreEnroll.tsx
+++ b/ui-participant/src/studies/enroll/PreEnroll.tsx
@@ -17,8 +17,14 @@ export default function PreEnrollView({ enrollContext }: { enrollContext: StudyE
   const navigate = useNavigate()
   // for now, we assume all pre-screeners are a single page
   const pager = { pageNumber: 0, updatePageNumber: () => 0 }
-  const { surveyModel, refreshSurvey, SurveyComponent } =
-    useSurveyJSModel(survey, null, handleComplete, pager)
+  const { surveyModel, refreshSurvey, SurveyComponent } = useSurveyJSModel(
+    survey,
+    null,
+    handleComplete,
+    pager,
+    undefined,
+    { extraCssClasses: { container: 'my-0' } }
+  )
 
   /** submit the form */
   function handleComplete() {
@@ -60,7 +66,5 @@ export default function PreEnrollView({ enrollContext }: { enrollContext: StudyE
     updatePreEnrollResponseId(null)
   }, [])
 
-  return <div>
-    {SurveyComponent}
-  </div>
+  return <div className="d-flex flex-grow-1">{SurveyComponent}</div>
 }

--- a/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
+++ b/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
@@ -92,7 +92,7 @@ function StudyEnrollOutletMatched({ portal, studyEnv, studyShortcode }:
   const enrollContext: StudyEnrollContext = {
     studyShortcode, studyEnv, user, preEnrollResponseId, updatePreEnrollResponseId
   }
-  return <div>
+  return <>
     <LandingNavbar/>
     <Routes>
       <Route path="preEnroll" element={<PreEnrollView enrollContext={enrollContext}/>}/>
@@ -100,5 +100,5 @@ function StudyEnrollOutletMatched({ portal, studyEnv, studyShortcode }:
       <Route path="register/*" element={<PortalRegistrationRouter portal={portal} returnTo={null}/>}/>
       <Route index element={<PageLoadingIndicator />}/>
     </Routes>
-  </div>
+  </>
 }

--- a/ui-participant/src/util/surveyJsUtils.tsx
+++ b/ui-participant/src/util/surveyJsUtils.tsx
@@ -1,3 +1,5 @@
+import classNames from 'classnames'
+import { get, set } from 'lodash'
 import React, { useEffect, useState } from 'react'
 
 import * as SurveyCore from 'survey-core'
@@ -48,6 +50,9 @@ export function useRoutablePageNumber(): PageNumberControl {
   }
 }
 
+type UseSurveyJsModelOpts = {
+  extraCssClasses?: Record<string, string>
+}
 
 /**
  * handle setting up the surveyJS model for the given form/survey.
@@ -63,9 +68,23 @@ export function useRoutablePageNumber(): PageNumberControl {
  * survey on completion and display a completion banner.  To continue displaying the form, use the
  * `refreshSurvey` function
  * @param pager the control object for paging the survey
+ * @param profile
+ * @param opts optional configuration for the survey
+ * @param opts.extraCssClasses mapping of element to CSS classes to add to that element. See
+ * https://surveyjs.io/form-library/examples/survey-customcss/reactjs#content-docs for a list of available elements.
  */
-export function useSurveyJSModel(form: SurveyJSForm, resumeData: ResumableData | null,
-  onComplete: () => void, pager: PageNumberControl, profile?: Profile) {
+export function useSurveyJSModel(
+  form: SurveyJSForm,
+  resumeData: ResumableData | null,
+  onComplete: () => void,
+  pager: PageNumberControl,
+  profile?: Profile,
+  opts: UseSurveyJsModelOpts = {}
+) {
+  const {
+    extraCssClasses = {}
+  } = opts
+
   const [surveyModel, setSurveyModel] = useState<SurveyModel | null>(null)
 
   /** hand a page change by updating state of both the surveyJS model and our internal state*/
@@ -78,6 +97,10 @@ export function useSurveyJSModel(form: SurveyJSForm, resumeData: ResumableData |
   function refreshSurvey(refreshData: ResumableData | null, pagerPageNumber: number | null) {
     StylesManager.applyTheme('modern')
     const newSurveyModel = new Model(extractSurveyContent(form))
+
+    Object.entries(extraCssClasses).forEach(([elementPath, className]) => {
+      set(newSurveyModel.css, elementPath, classNames(get(newSurveyModel.css, elementPath), className))
+    })
 
     if (refreshData) {
       newSurveyModel.data = refreshData.data
@@ -278,4 +301,3 @@ export function extractSurveyContent(survey: SurveyJSForm) {
 type PearlQuestion = Question & {
   questionTemplateName?: string
 }
-


### PR DESCRIPTION
On the pre-enroll survey page, the background color from the SurveyJS survey covers only part of the page. This makes the background color consistent for the full page. This required adding an option to `useSurveyJSModel` to provide CSS classes for survey elements ([SurveyJS docs on custom CSS](https://surveyjs.io/form-library/examples/survey-customcss/reactjs#content-docs)) so that we could override the 80px bottom margin that the Modern theme adds to "container" elements.

## Before
<img width="725" alt="Screenshot 2023-03-24 at 8 55 59 AM" src="https://user-images.githubusercontent.com/1156625/227533104-e22c8c67-3d05-45d6-929f-b72207daefb8.png">

## After
<img width="726" alt="Screenshot 2023-03-24 at 8 55 49 AM" src="https://user-images.githubusercontent.com/1156625/227533129-2dd8e155-503d-4a7e-b962-09de146f515f.png">
