### PR TITLE
[AR-220] Update landing page heading levels

### DIFF
--- a/ui-participant/src/landing/sections/FrequentlyAskedQuestionsTemplate.tsx
+++ b/ui-participant/src/landing/sections/FrequentlyAskedQuestionsTemplate.tsx
@@ -74,7 +74,7 @@ function FrequentlyAskedQuestionsTemplate(props: FrequentlyAskedQuestionsProps) 
   return <div id={anchorRef} className="row mx-0 justify-content-center" style={getSectionStyle(config)}>
     <div className="col-12 col-sm-8 col-lg-6">
       {!!title && (
-        <h1 className="fs-1 fw-normal lh-sm mt-5 mb-4 text-center">{title}</h1>
+        <h2 className="fs-1 fw-normal lh-sm mt-5 mb-4 text-center">{title}</h2>
       )}
       {!!blurb && (
         <div className="fs-4 mb-4 text-center">

--- a/ui-participant/src/landing/sections/HeroCenteredTemplate.tsx
+++ b/ui-participant/src/landing/sections/HeroCenteredTemplate.tsx
@@ -63,9 +63,9 @@ function HeroCenteredTemplate(props: HeroCenteredTemplateProps) {
   return <div id={anchorRef} className="row mx-0" style={getSectionStyle(config)}>
     <div className="col-12 col-sm-10 col-lg-6 mx-auto py-5 text-center">
       {hasTitle && (
-        <h1 className={classNames('fs-1 fw-normal lh-sm', hasContentFollowingTitle ? 'mb-4' : 'mb-0')}>
+        <h2 className={classNames('fs-1 fw-normal lh-sm', hasContentFollowingTitle ? 'mb-4' : 'mb-0')}>
           <ReactMarkdown disallowedElements={['p']} unwrapDisallowed>{title}</ReactMarkdown>
-        </h1>
+        </h2>
       )}
       {hasBlurb && (
         <div className="fs-4" style={{ textAlign: blurbAlign || 'center' }}>

--- a/ui-participant/src/landing/sections/HeroWithImageTemplate.tsx
+++ b/ui-participant/src/landing/sections/HeroWithImageTemplate.tsx
@@ -109,9 +109,9 @@ function HeroWithImageTemplate(props: HeroWithImageTemplateProps) {
           )}
         >
           {!!title && (
-            <h1 className="fs-1 fw-normal lh-sm">
+            <h2 className="fs-1 fw-normal lh-sm">
               <ReactMarkdown>{title}</ReactMarkdown>
-            </h1>
+            </h2>
           )}
           {!!blurb && (
             <div className="fs-4">

--- a/ui-participant/src/landing/sections/NavAndLinkSectionsFooter.tsx
+++ b/ui-participant/src/landing/sections/NavAndLinkSectionsFooter.tsx
@@ -77,7 +77,7 @@ export function NavAndLinkSectionsFooter(props: NavAndLinkSectionsFooterProps) {
       <div className="col-lg-8">
         {_.map(config.itemSections, (section, index) =>
           <div key={index} className="d-inline-block pb-3 px-2">
-            <h6>{section.title}</h6>
+            <h2 className="h6">{section.title}</h2>
             <div>
               {_.map(section.items, (item, index) => <FooterItem item={item} key={index}/>)}
             </div>

--- a/ui-participant/src/landing/sections/ParticipationDetailTemplate.tsx
+++ b/ui-participant/src/landing/sections/ParticipationDetailTemplate.tsx
@@ -82,11 +82,11 @@ function ParticipationDetailTemplate(props: ParticipationDetailTemplateProps) {
         </div>
       )}
       <div className={classNames({ 'col-md-8': hasImage })}>
-        <h4>
-          {stepNumberText}
-        </h4>
+        <h2>
+          <div className="h4">{stepNumberText}</div>
+          {title}
+        </h2>
         <p><FontAwesomeIcon icon={faClock}/> {timeIndication}</p>
-        <h2>{title}</h2>
         <p className="fs-4">
           {blurb}
         </p>

--- a/ui-participant/src/landing/sections/PhotoBlurbGrid.tsx
+++ b/ui-participant/src/landing/sections/PhotoBlurbGrid.tsx
@@ -62,19 +62,35 @@ function PhotoBlurbGrid(props: PhotoBlurbGridProps) {
   const { anchorRef, config } = props
   const { subGrids, title } = config
 
+  const hasTitle = !!title
+  // Heading levels must increase one at a time, so if the grid has no
+  // title, then the subgrid headings should be h2 elements.
+  const subGridHeadingLevel = hasTitle ? 3 : 2
+
   return <div id={anchorRef} className="py-5" style={getSectionStyle(config)}>
-    {title && <h1 className="fs-1 fw-normal lh-sm text-center mb-4">
-      {title}
-    </h1>}
-    {(subGrids ?? []).map((subGrid, index) => <SubGridView key={index} subGrid={subGrid}/>)}
+    {!!title && (
+      <h2 className="fs-1 fw-normal lh-sm text-center mb-4">
+        {title}
+      </h2>
+    )}
+    {(subGrids ?? []).map((subGrid, index) => {
+      return <SubGridView key={index} headingLevel={subGridHeadingLevel} subGrid={subGrid}/>
+    })}
   </div>
 }
 
+type SubGridViewProps = {
+  headingLevel: 2 | 3
+  subGrid: SubGrid
+}
+
 /** renders a subgrouping of photos (e.g. "Our researchers") */
-function SubGridView({ subGrid }: { subGrid: SubGrid }) {
+function SubGridView(props: SubGridViewProps) {
+  const { headingLevel, subGrid } = props
+  const Heading: 'h2' | 'h3' = `h${headingLevel}`
   return <div className="row mx-0">
     <div className="col-12 col-sm-10 col-lg-8 mx-auto">
-      {subGrid.title && <h3 className="text-center mb-4">{subGrid.title}</h3>}
+      {subGrid.title && <Heading className="text-center mb-4">{subGrid.title}</Heading>}
       <div className="row mx-0">
         {subGrid.photoBios.map((bio, index) => <PhotoBioView key={index} photoBio={bio}/>)}
       </div>

--- a/ui-participant/src/landing/sections/StepOverviewTemplate.tsx
+++ b/ui-participant/src/landing/sections/StepOverviewTemplate.tsx
@@ -53,9 +53,11 @@ function StepOverviewTemplate(props: StepOverviewTemplateProps) {
 
   // TODO: improve layout code for better flexing, especially with <> 4 steps
   return <div id={anchorRef} className="py-5" style={getSectionStyle(config)}>
-    <h1 className="fs-1 fw-normal lh-sm mb-3 text-center">
-      <ReactMarkdown>{title ? title : ''}</ReactMarkdown>
-    </h1>
+    {!!title && (
+      <h2 className="fs-1 fw-normal lh-sm mb-3 text-center">
+        <ReactMarkdown>{title}</ReactMarkdown>
+      </h2>
+    )}
     <div className="row mx-0">
       {
         _.map(steps, ({ image, duration, blurb }: StepConfig, i: number) => {


### PR DESCRIPTION
We have a tendency to use h1-h6 elements based on their default styles. But h1-h6 elements serve as an outline for the page, defining its structure. Heading levels should increase one at a time without skipping levels.

https://webaim.org/techniques/semanticstructure/#headings
https://dequeuniversity.com/rules/axe/4.4/heading-order

This updates cases where heading levels were out of order.

It also updates all section headings to h2 instead of h1, laying the groundwork to have only one h1 per page.
https://dequeuniversity.com/rules/axe/4.6/page-has-heading-one