### PR TITLE
[AR-220] Add labels to navbars to make them unique landmarks

### DIFF
--- a/ui-participant/src/landing/LandingNavbar.tsx
+++ b/ui-participant/src/landing/LandingNavbar.tsx
@@ -10,8 +10,10 @@ import { useUser } from 'providers/UserProvider'
 
 const navLinkClasses = 'nav-link fs-5 ms-lg-3'
 
+type LandingNavbarProps = JSX.IntrinsicElements['nav']
+
 /** renders the navbar for participant landing page (for not-logged-in participants) */
-export default function LandingNavbar() {
+export default function LandingNavbar(props: LandingNavbarProps) {
   const portalEnv = usePortalEnv()
   const { localContent } = portalEnv
   const { user, logoutUser } = useUser()
@@ -41,7 +43,7 @@ export default function LandingNavbar() {
 
   const dropdownId = useId()
 
-  return <nav className="LandingNavbar navbar navbar-expand-lg navbar-light">
+  return <nav {...props} className={classNames('LandingNavbar navbar navbar-expand-lg navbar-light', props.className)}>
     <div className="container-fluid">
       <NavLink to="/" className="navbar-brand">
         <img className="Navbar-logo" style={{ maxHeight: '30px' }}

--- a/ui-participant/src/landing/LandingPage.tsx
+++ b/ui-participant/src/landing/LandingPage.tsx
@@ -9,7 +9,7 @@ function LandingPageView({ localContent }: { localContent: LocalSiteContent }) {
   return <div className="LandingPage">
     <div className="container-fluid bg-white min-vh-100 d-flex flex-column p-0">
       <div>
-        <LandingNavbar/>
+        <LandingNavbar aria-label="Primary" />
       </div>
       <div className="flex-grow-1">
         <Outlet/>

--- a/ui-participant/src/landing/sections/NavAndLinkSectionsFooter.tsx
+++ b/ui-participant/src/landing/sections/NavAndLinkSectionsFooter.tsx
@@ -72,7 +72,7 @@ export function NavAndLinkSectionsFooter(props: NavAndLinkSectionsFooterProps) {
   const { config } = props
 
   return <>
-    {config.includeNavbar && <LandingNavbar/>}
+    {config.includeNavbar && <LandingNavbar aria-label="Secondary" />}
     <div className="d-flex justify-content-center py-3">
       <div className="col-lg-8">
         {_.map(config.itemSections, (section, index) =>


### PR DESCRIPTION
Since the landing page navbar (and it's `nav` element) appear twice on the page (once at the top and once in the footer), each instance needs a unique label.

https://dequeuniversity.com/rules/axe/4.6/landmark-unique