### PR TITLE
Fix navbar dropdown

### DIFF
--- a/ui-participant/src/index.tsx
+++ b/ui-participant/src/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import 'bootstrap/dist/js/bootstrap.bundle.min'
+import 'bootstrap'
 import 'survey-core/defaultV2.min.css'
 import './index.scss'
 import './surveyJsStyle.css'

--- a/ui-participant/src/landing/LandingNavbar.tsx
+++ b/ui-participant/src/landing/LandingNavbar.tsx
@@ -1,5 +1,4 @@
-// @ts-expect-error No types for this Bootstrap file
-import { Collapse } from 'bootstrap/dist/js/bootstrap.bundle.min'
+import { Collapse } from 'bootstrap'
 import classNames from 'classnames'
 import React, { useEffect, useId, useRef } from 'react'
 import { NavLink, useLocation } from 'react-router-dom'


### PR DESCRIPTION
#175 broke the user dropdown in the navbar by importing multiple versions of Collapse from Bootstrap. This fixes it by importing from the same copy of Bootstrap in both index and LandingNavbar.