### PR TITLE
AR-243 fixing name field width for ourhealth

### DIFF
--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/basic.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/basic.json
@@ -32,23 +32,26 @@
       {
         "elements": [
           {
-            "name": "oh_oh_basic_firstName",
-            "type": "text",
-            "title": "First name",
-            "isRequired": true
-          }, {
-            "name": "oh_oh_basic_lastName",
-            "type": "text",
-            "title": "Last name",
-            "isRequired": true,
-            "startWithNewLine": false
-          }, {
-            "name": "oh_oh_basic_middleInitial",
-            "type": "text",
-            "title": "Middle initial",
-            "maxLength": 1,
-            "size": 1,
-            "startWithNewLine": false
+            "type": "panel",
+            "elements": [
+              {
+                "name": "oh_oh_basic_firstName",
+                "type": "text",
+                "title": "First name",
+                "isRequired": true
+              }, {
+                "name": "oh_oh_basic_lastName",
+                "type": "text",
+                "title": "Last name",
+                "isRequired": true
+              }, {
+                "name": "oh_oh_basic_middleInitial",
+                "type": "text",
+                "title": "Middle initial",
+                "maxLength": 1,
+                "size": 1
+              }
+            ]
           }, {
             "name": "oh_oh_basic_mghPatient",
             "type": "radiogroup",


### PR DESCRIPTION
The name fields are now on separate lines to match other survey styles
![image](https://user-images.githubusercontent.com/2800795/228330257-2439259f-bf48-49ec-a429-c15155c0cdb2.png)

TO TEST:
1. repopulate ourhealth
2. sign in to participant UX as "consented@test.com"
3. click the "basics" survey
4. confirm the page looks as above