### PR TITLE
[AR-237] Resize signaturepad to fill available width

### DIFF
--- a/ui-participant/src/surveyJsStyle.css
+++ b/ui-participant/src/surveyJsStyle.css
@@ -1,3 +1,11 @@
 .sd-btn--action {
   background-color: #4D72AA;
 }
+
+.sjs_sp_container {
+  border: none
+}
+
+.sjs_sp_container canvas {
+  border: 1px dashed var(--border, #d6d6d6);
+}

--- a/ui-participant/src/util/surveyJsUtils.tsx
+++ b/ui-participant/src/util/surveyJsUtils.tsx
@@ -1,9 +1,18 @@
 import classNames from 'classnames'
-import { get, set } from 'lodash'
+import { get, set, throttle } from 'lodash'
 import React, { useEffect, useState } from 'react'
 
 import * as SurveyCore from 'survey-core'
-import { Model, Question, Serializer, StylesManager, SurveyModel } from 'survey-core'
+import {
+  QuestionCustomWidget,
+  IQuestion,
+  Model,
+  Question,
+  QuestionSignaturePadModel,
+  Serializer,
+  StylesManager,
+  SurveyModel
+} from 'survey-core'
 import { micromark } from 'micromark'
 import 'inputmask/dist/inputmask/phone-codes/phone'
 // eslint-disable-next-line
@@ -18,6 +27,42 @@ import { getSurveyElementList } from './pearlSurveyUtils'
 // See https://surveyjs.io/form-library/examples/control-data-entry-formats-with-input-masks/reactjs#content-code
 widgets.inputmask(SurveyCore)
 
+// eslint-disable-next-line max-len
+// https://surveyjs.io/survey-creator/documentation/customize-question-types/create-custom-widgets#add-functionality-into-existing-question
+const autosizedSignaturePadWidget: Partial<QuestionCustomWidget> = {
+  name: 'autosized_signaturepad',
+  // SurveyJS calls this for every question to check if this widget should apply.
+  isFit: (question: IQuestion) => question.getType() === 'signaturepad',
+  // Extend default render, do not replace.
+  isDefaultRender: true,
+  afterRender: (question: QuestionSignaturePadModel, el: HTMLElement) => {
+    const resizeSignaturePad = throttle(() => {
+      const { width } = el.getBoundingClientRect()
+      question.signatureWidth = width
+    }, 150)
+
+    window.addEventListener('resize', resizeSignaturePad)
+    question.autosizedSignaturePadRemoveResizeListener = () => {
+      window.removeEventListener('resize', resizeSignaturePad)
+    }
+
+    const { width } = el.getBoundingClientRect()
+    question.signatureWidth = width
+
+    // If no signature has been entered, re-center "Sign here" placeholder.
+    if (!question.value) {
+      setTimeout(() => {
+        question.value = ''
+        question.clearValue()
+      }, 0)
+    }
+  },
+  willUnmount: (question: QuestionSignaturePadModel) => {
+    question.autosizedSignaturePadRemoveResizeListener?.()
+  }
+}
+
+SurveyCore.CustomWidgetCollection.Instance.add(autosizedSignaturePadWidget)
 
 const PAGE_NUMBER_PARAM_NAME = 'page'
 


### PR DESCRIPTION
Use a [custom widget](https://surveyjs.io/survey-creator/documentation/customize-question-types/create-custom-widgets#add-functionality-into-existing-question) to extend the existing signaturepad question to automatically resize to fill available width.

Also fix the border to prevent the bottom and right borders from getting cut off.

## Before
![Screenshot 2023-03-30 at 4 01 54 PM](https://user-images.githubusercontent.com/1156625/228951495-9852b7c4-5111-4f65-a25c-61401e234301.png)

## After
![Screenshot 2023-03-30 at 4 01 43 PM](https://user-images.githubusercontent.com/1156625/228951503-1a23f6cc-0e10-4a9f-81cf-0313ba41f7f6.png)
