### PR TITLE
[JN-46] Use date input for consent form

### DIFF
--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/ourHealthConsent.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/ourHealthConsent.json
@@ -98,7 +98,10 @@
           "type": "text",
           "isRequired": true,
           "name": "oh_oh_consent_signatureDate",
-          "title": "Date/Time"
+          "title": "Date/Time",
+          "inputType": "date",
+          "minValueExpression": "today()",
+          "maxValueExpression": "today()"
         },
         {
           "type": "signaturepad",


### PR DESCRIPTION
Currently, the OurHealth consent survey uses a free text input for the date on the consent form.

This changes it to a date input that only accepts the current date.

## Before
![Screenshot 2023-03-31 at 2 59 55 PM](https://user-images.githubusercontent.com/1156625/229207233-7e5243ea-ab1d-48fc-b62d-c2bdf034c918.png)

## After
![Screenshot 2023-03-31 at 3 00 27 PM](https://user-images.githubusercontent.com/1156625/229207253-4aa0ee12-8766-4921-b819-461afb398454.png)
![Screenshot 2023-03-31 at 3 00 35 PM](https://user-images.githubusercontent.com/1156625/229207255-7dab809b-e2d8-4961-80e5-be1c884cc478.png)

