### PR TITLE
Add link to OurHealth Facebook page

### DIFF
--- a/populate/src/main/resources/seed/portals/ourhealth/siteContent/siteContent.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/siteContent/siteContent.json
@@ -143,7 +143,8 @@
         "sectionType": "SOCIAL_MEDIA",
         "sectionConfigJson": {
           "twitterHandle": "ourhealthstudy",
-          "instagramHandle": "ourhealthstudy"
+          "instagramHandle": "ourhealthstudy",
+          "facebookHandle": "ourhealthstudy"
         }
       },{
         "sectionType": "HERO_CENTERED",

--- a/ui-participant/src/landing/sections/SocialMediaTemplate.tsx
+++ b/ui-participant/src/landing/sections/SocialMediaTemplate.tsx
@@ -60,7 +60,7 @@ function SocialMediaTemplate(props: SocialMediaTemplateProps) {
   } = config
 
   return (
-    <div id={anchorRef} className="row py-5" style={getSectionStyle(config)}>
+    <div id={anchorRef} className="row mx-0 py-5" style={getSectionStyle(config)}>
       <div className="hstack justify-content-center gap-2">
         {twitterHandle && (
           <SocialMediaLink


### PR DESCRIPTION
When initially adding social media links, I didn't find a Facebook link on https://ourhealthstudy.org/. However, there is one in the footer. This adds it to the social media section on the home page.

![Screenshot 2023-04-03 at 2 44 12 PM](https://user-images.githubusercontent.com/1156625/229598747-9b93a3f9-0702-49da-9de4-00bed039f5df.png)
