### PR TITLE
JN-258 replace arbor/juniper text

### DIFF
--- a/ui-admin/public/index.html
+++ b/ui-admin/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Pearl</title>
+    <title>Juniper</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/ui-admin/src/navbar/AdminNavbar.tsx
+++ b/ui-admin/src/navbar/AdminNavbar.tsx
@@ -43,7 +43,7 @@ function AdminNavbar({ breadCrumbs, sidebarContent, showSidebar, setShowSidebar 
             <FontAwesomeIcon icon={faBars}/>
           </button>
           <Link className="navbar-brand ms-2 fw-bold text-white" to="/">
-          Pearl
+          Juniper
           </Link>
         </div>
         <div className="collapse navbar-collapse" id="navbarNavDropdown">

--- a/ui-admin/src/portal/PortalList.tsx
+++ b/ui-admin/src/portal/PortalList.tsx
@@ -21,7 +21,7 @@ function PortalList() {
   }, [])
   return <div>
     <div className="App-study-list position-absolute top-50 start-50 translate-middle">
-      <h4 className="text-center">Arbor</h4>
+      <h4 className="text-center">Juniper</h4>
 
       <h6 className="mt-3">Select a portal</h6>
       <LoadingSpinner isLoading={isLoading}>

--- a/ui-participant/src/hub/HubPage.tsx
+++ b/ui-participant/src/hub/HubPage.tsx
@@ -76,7 +76,6 @@ function StudyTaskBox({ enrollee, portal }: { enrollee: Enrollee, portal: Portal
   const hasCompletedForms = completedForms.length > 0
 
   return <div className="p-3">
-    <h4 className="mb-3">{matchedStudy.name}</h4>
     {hasStudyTasks && <div>
       {nextTask && <div className="row">
         <div className="col-md-12 text-center p-4" style={{ background: '#eef' }}>


### PR DESCRIPTION
For the demo today, I pulled out some Arbor/Pearl refs.  There are probably more lurking, but this is a start.  This also takes out the superfluous "OurHealth" at the top of the participant hub.  We'll need something like that for HeartHive, but in the meantime it's good to keep it simple and leave it out.

![image](https://user-images.githubusercontent.com/2800795/229928132-fc39036c-f67e-4bd0-97ef-2356397d7283.png)

TO TEST:
1. go to admin tool, and login
2. confirm you see juniper in the screen, navbar, and html page title


