### PR TITLE
JN-251: fixing bug in admin question text display

### DIFF
--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/enrollees/jsalk.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/enrollees/jsalk.json
@@ -17,7 +17,7 @@
           "fullDataJson": {
             "items": [
               {
-                "stableId": "oh_medHx_worriedHeartHealth",
+                "stableId": "oh_oh_cardioHx_worriedHeartHealth",
                 "simpleValue": "yesSpecificallyAboutMyHeart",
                 "displayValue": "Yes, specifically about my heart"
               }
@@ -25,7 +25,7 @@
           },
           "resumeDataJson": {
             "data": {
-              "oh_oh_medHx_worriedHeartHealth": "yesSpecificallyAboutMyHeart"
+              "oh_oh_cardioHx_worriedHeartHealth": "yesSpecificallyAboutMyHeart"
             },
             "currentPageNo": 1
           }

--- a/ui-admin/src/study/participants/EnrolleeView.tsx
+++ b/ui-admin/src/study/participants/EnrolleeView.tsx
@@ -17,6 +17,7 @@ import EnrolleeNotifications from './EnrolleeNotifications'
 import DataChangeRecords from './DataChangeRecords'
 import EnrolleeProfile from './EnrolleeProfile'
 import ParticipantTaskView from './tasks/ParticipantTaskView'
+import ErrorBoundary from '../../util/ErrorBoundary'
 
 export type SurveyWithResponsesT = {
   survey: StudyEnvironmentSurvey,
@@ -76,6 +77,10 @@ export default function EnrolleeView({ enrollee, studyEnvContext }:
               <li className="list-group-item">
                 <NavLink to="profile" className={getLinkCssClasses}>Profile</NavLink>
               </li>
+              <li className="list-group-item subgroup">
+                <NavLink to="tasks" className={getLinkCssClasses}>Tasks</NavLink>
+                <TaskSummary tasks={enrollee.participantTasks}/>
+              </li>
               <li className="list-group-item">
                 <NavLink to="preRegistration" className={getLinkCssClasses}>PreEnrollment</NavLink>
               </li>
@@ -114,10 +119,6 @@ export default function EnrolleeView({ enrollee, studyEnvContext }:
                 </ul>
               </li>
               <li className="list-group-item subgroup">
-                <NavLink to="tasks" className={getLinkCssClasses}>Tasks</NavLink>
-                <TaskSummary tasks={enrollee.participantTasks}/>
-              </li>
-              <li className="list-group-item subgroup">
                 <NavLink to="notifications" className={getLinkCssClasses}>Notifications</NavLink>
               </li>
               <li className="list-group-item subgroup">
@@ -126,33 +127,35 @@ export default function EnrolleeView({ enrollee, studyEnvContext }:
             </ul>
           </div>
           <div className="participantTabContent flex-grow-1 bg-white p-3">
-            <Routes>
-              <Route path="profile" element={<EnrolleeProfile enrollee={enrollee}/>}/>
-              <Route path="consents" element={<div>consents</div>}/>
-              <Route path="preRegistration" element={
-                <PreEnrollmentView preEnrollSurvey={currentEnv.preEnrollSurvey}
-                  preEnrollResponse={enrollee.preEnrollmentResponse}/>
-              }/>
-              <Route path="surveys">
-                <Route path=":surveyStableId" element={<EnrolleeSurveyView enrollee={enrollee}
-                  responseMap={responseMap}/>}/>
-                <Route path="*" element={<div>Unknown participant survey page</div>}/>
-              </Route>
-              <Route path="tasks" element={<ParticipantTaskView enrollee={enrollee}/>}/>
-              <Route path="consents">
-                <Route path=":consentStableId" element={<EnrolleeConsentView enrollee={enrollee}
-                  responseMap={consentMap}/>}/>
-                <Route path="*" element={<div>Unknown participant survey page</div>}/>
-              </Route>
-              <Route path="notifications" element={
-                <EnrolleeNotifications enrollee={enrollee} studyEnvContext={studyEnvContext}/>
-              }/>
-              <Route path="changeRecords" element={
-                <DataChangeRecords enrollee={enrollee} studyEnvContext={studyEnvContext}/>
-              }/>
-              <Route index element={<EnrolleeProfile enrollee={enrollee}/>}/>
-              <Route path="*" element={<div>unknown enrollee route</div>}/>
-            </Routes>
+            <ErrorBoundary>
+              <Routes>
+                <Route path="profile" element={<EnrolleeProfile enrollee={enrollee}/>}/>
+                <Route path="consents" element={<div>consents</div>}/>
+                <Route path="preRegistration" element={
+                  <PreEnrollmentView preEnrollSurvey={currentEnv.preEnrollSurvey}
+                    preEnrollResponse={enrollee.preEnrollmentResponse}/>
+                }/>
+                <Route path="surveys">
+                  <Route path=":surveyStableId" element={<EnrolleeSurveyView enrollee={enrollee}
+                    responseMap={responseMap}/>}/>
+                  <Route path="*" element={<div>Unknown participant survey page</div>}/>
+                </Route>
+                <Route path="tasks" element={<ParticipantTaskView enrollee={enrollee}/>}/>
+                <Route path="consents">
+                  <Route path=":consentStableId" element={<EnrolleeConsentView enrollee={enrollee}
+                    responseMap={consentMap}/>}/>
+                  <Route path="*" element={<div>Unknown participant survey page</div>}/>
+                </Route>
+                <Route path="notifications" element={
+                  <EnrolleeNotifications enrollee={enrollee} studyEnvContext={studyEnvContext}/>
+                }/>
+                <Route path="changeRecords" element={
+                  <DataChangeRecords enrollee={enrollee} studyEnvContext={studyEnvContext}/>
+                }/>
+                <Route index element={<EnrolleeProfile enrollee={enrollee}/>}/>
+                <Route path="*" element={<div>unknown enrollee route</div>}/>
+              </Routes>
+            </ErrorBoundary>
           </div>
         </div>
       </div>

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -25,7 +25,7 @@ const ItemDisplay = ({ dataItem, surveyJsModel }: {dataItem: DenormalizedRespons
   </>
 }
 
-const getDisplayValue = (dataItem: DenormalizedResponseItem) => {
+export const getDisplayValue = (dataItem: DenormalizedResponseItem) => {
   let displayValue: React.ReactNode = dataItem.displayValue
   if (!displayValue) {
     displayValue = dataItem.simpleValue
@@ -39,8 +39,8 @@ const getDisplayValue = (dataItem: DenormalizedResponseItem) => {
 }
 
 /** gets the question text -- truncates it at 100 chars */
-const renderQuestionText = (dataItem: DenormalizedResponseItem, surveyJsModel: SurveyModel) => {
-  const questionText = surveyJsModel.getQuestionByName(dataItem.stableId).title
+export const renderQuestionText = (dataItem: DenormalizedResponseItem, surveyJsModel: SurveyModel) => {
+  const questionText = surveyJsModel.getQuestionByName(dataItem.stableId)?.title
   if (questionText && questionText.length > 100) {
     const truncatedText = `${questionText.substring(0, 100)  }...`
     return <span title={questionText}>{truncatedText}</span>

--- a/ui-admin/src/util/ErrorBoundary.tsx
+++ b/ui-admin/src/util/ErrorBoundary.tsx
@@ -1,0 +1,64 @@
+import React, { ErrorInfo } from 'react'
+
+type ErrorState = {
+  error: Error | null,
+  info: ErrorInfo | null
+}
+
+type ErrorProps = {
+  children: React.ReactNode
+}
+
+/**
+ * See https://reactjs.org/docs/error-boundaries.html
+ * note that this must be a class component as hooks do not support componentDidCatch yet.
+ *
+ * adapted from
+ * https://github.com/broadinstitute/single_cell_portal_core/blob/development/app/javascript/lib/ErrorBoundary.jsx
+ */
+export default class ErrorBoundary extends React.Component<ErrorProps, ErrorState> {
+  /** initialize to a non-error state */
+  constructor(props: ErrorProps) {
+    super(props)
+    this.state = { error: null, info: null }
+  }
+
+  /** log an error, and then update the display to show the error */
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // TODO log error to Mixpanel
+    // TODO log error to Sentry
+    this.setState({ error, info })
+  }
+
+  /** show an error if one exists, otherwise show the component */
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="alert-danger text-center error-boundary">
+          <span className="font-italic ">Something went wrong.</span><br/>
+          <span>
+            Please try reloading the page. If this error persists, or you require assistance, please
+            contact support and include the error text below.
+          </span>
+          <pre>
+            {this.state.error.message}
+            {this.state.info?.componentStack}
+          </pre>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+/** HOC for wrapping arbitrary components in error boundaries */
+export function withErrorBoundary<Props extends object>(Component: React.ComponentType<Props>) {
+  return function SafeWrappedComponent(props: Props) {
+    return (
+      <ErrorBoundary>
+        <Component {...props} />
+      </ErrorBoundary>
+    )
+  }
+}


### PR DESCRIPTION
Fixes a bug where trying to look at Jonas Salk's cardio history survey broke the UI.  This was fixed in three different ways:

1. The rendering of question titles is null-safed (until we have robust version-handling in the admin enrollee view, it's possible questions from prior versions won't be found)
2. ErrorBoundary was brought over from participant UI, and wrapped around the enrolle views
3. Jonas Salk's populate data was fixed to reflect the new stableId of the question.

This also moves the task list up in the enrollee sidebar following up on the demo feedback

TO TEST:
1. do not repopulate
2. go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants/OHSALK/surveys/oh_oh_cardioHx, confirm the page renders, even though there is no question text
3. repopulate ourhealth
5. reload the page
6. confirm the question text "I am worried about my heart health." appears