### PR TITLE
Link to study for join links

### DIFF
--- a/populate/src/main/resources/seed/portals/ourhealth/siteContent/aboutUs.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/siteContent/aboutUs.json
@@ -54,7 +54,7 @@
       "sectionType": "HERO_CENTERED",
       "sectionConfigJson": {
         "blurbAlign": "left",
-        "blurb": "The OurHealth investigators, led by Co-Principal Investigators Dr. Pradeep Natarajan and Dr. Amit V. Khera, have extensive experience in studying the genetic basis of cardiovascular and cardiometabolic disease. By closely studying the contribution of genetics towards heart and metabolic disease in individuals of South Asian ancestry living outside the United States, they have helped develop a new genotyping array optimized for South Asians. Unfortunately, South Asian datasets remain limited in size, cultural diversity, and diasporic representation.\n\nHelp us close this gap! [Join the OurHealth study](/join) and contribute to improving South Asian heart health."
+        "blurb": "The OurHealth investigators, led by Co-Principal Investigators Dr. Pradeep Natarajan and Dr. Amit V. Khera, have extensive experience in studying the genetic basis of cardiovascular and cardiometabolic disease. By closely studying the contribution of genetics towards heart and metabolic disease in individuals of South Asian ancestry living outside the United States, they have helped develop a new genotyping array optimized for South Asians. Unfortunately, South Asian datasets remain limited in size, cultural diversity, and diasporic representation.\n\nHelp us close this gap! [Join the OurHealth study](/studies/ourheart/join) and contribute to improving South Asian heart health."
       }
     },
     {

--- a/populate/src/main/resources/seed/portals/ourhealth/siteContent/faq.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/siteContent/faq.json
@@ -28,7 +28,7 @@
             },
             {
               "question": "How can I participate?",
-              "answer": "If you are over 18 years of age, live in the United States, and identify as South Asian, you can sign up by clicking [“Join”](/join)."
+              "answer": "If you are over 18 years of age, live in the United States, and identify as South Asian, you can sign up by clicking [“Join”](/studies/ourheart/join)."
             },
             {
               "question": "What does OurHealth do with the data?",

--- a/populate/src/main/resources/seed/portals/ourhealth/siteContent/siteContent.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/siteContent/siteContent.json
@@ -123,7 +123,7 @@
           },
           {
             "question": "How can I participate?",
-            "answer": "If you are over 18 years of age, live in the United States, and identify as South Asian, you can sign up by clicking [“Join”](/join)."
+            "answer": "If you are over 18 years of age, live in the United States, and identify as South Asian, you can sign up by clicking [“Join”](/studies/ourheart/join)."
           },
           {
             "question": "What does OurHealth do with the data?",


### PR DESCRIPTION
Fixup for #230.

For inline "Join" links in Markdown content, link to the join OurHeart study page (the pre-enroll survey) instead of the join portal page (a login prompt). This matches the behavior of Join buttons throughout the site.