### PR TITLE
[JN-259] Adjust spacing between sections (part 2)

### DIFF
--- a/ui-participant/src/landing/sections/FrequentlyAskedQuestionsTemplate.tsx
+++ b/ui-participant/src/landing/sections/FrequentlyAskedQuestionsTemplate.tsx
@@ -165,7 +165,7 @@ function FrequentlyAskedQuestionsTemplate(props: FrequentlyAskedQuestionsProps) 
           </button>
         </div>
       )}
-      <ul ref={questionsListRef} className="mx-0 px-0 border-top" style={{ listStyle: 'none' }}>
+      <ul ref={questionsListRef} className="list-unstyled mb-0 border-top">
         {
           questions.map(({ question, answer }, i) => {
             return (

--- a/ui-participant/src/landing/sections/HeroWithImageTemplate.tsx
+++ b/ui-participant/src/landing/sections/HeroWithImageTemplate.tsx
@@ -77,9 +77,11 @@ function HeroWithImageTemplate(props: HeroWithImageTemplateProps) {
     : (fullWidth ? 50 : 33)
   const imageCols = Math.max(Math.floor(imageWidthPercentage / 100 * 12), 1)
 
+  const hasBlurb = !!blurb
   const hasButtons = (buttons || []).length > 0
   const hasLogos = (logos || []).length > 0
 
+  const hasContentFollowingTitle = hasBlurb || hasButtons || hasLogos
   const hasContentFollowingBlurb = hasButtons || hasLogos
   const hasContentFollowingButtons = hasLogos
 
@@ -115,11 +117,11 @@ function HeroWithImageTemplate(props: HeroWithImageTemplateProps) {
           )}
         >
           {!!title && (
-            <h2 className="fs-1 fw-normal lh-sm">
+            <h2 className={classNames('fs-1 fw-normal lh-sm', hasContentFollowingTitle ? 'mb-4' : 'mb-0')}>
               <InlineMarkdown>{title}</InlineMarkdown>
             </h2>
           )}
-          {!!blurb && (
+          {hasBlurb && (
             <Markdown className={classNames('fs-4', { 'mb-4': hasContentFollowingBlurb })}>
               {blurb}
             </Markdown>

--- a/ui-participant/src/landing/sections/ParticipationDetailTemplate.tsx
+++ b/ui-participant/src/landing/sections/ParticipationDetailTemplate.tsx
@@ -87,7 +87,7 @@ function ParticipationDetailTemplate(props: ParticipationDetailTemplateProps) {
           {title}
         </h2>
         <p><FontAwesomeIcon icon={faClock}/> {timeIndication}</p>
-        <p className="fs-4">
+        <p className={classNames('fs-4', actionButton ? 'mb-4' : 'mb-0')}>
           {blurb}
         </p>
         {actionButton && <ConfiguredButton config={actionButton} />}

--- a/ui-participant/src/landing/sections/StepOverviewTemplate.tsx
+++ b/ui-participant/src/landing/sections/StepOverviewTemplate.tsx
@@ -51,22 +51,24 @@ function StepOverviewTemplate(props: StepOverviewTemplateProps) {
   const { anchorRef, config } = props
   const { buttons, steps, title } = config
 
+  const hasButtons = (buttons || []).length > 0
+
   // TODO: improve layout code for better flexing, especially with <> 4 steps
   return <div id={anchorRef} className="py-5" style={getSectionStyle(config)}>
     {!!title && (
-      <h2 className="fs-1 fw-normal lh-sm mb-3 text-center">
+      <h2 className="fs-1 fw-normal lh-sm text-center">
         <InlineMarkdown>{title}</InlineMarkdown>
       </h2>
     )}
     <div className="row mx-0">
       {
         _.map(steps, ({ image, duration, blurb }: StepConfig, i: number) => {
-          return <div key={i} className="col-12 col-lg-3 d-flex flex-column align-items-center">
+          return <div key={i} className="col-12 col-lg-3 d-flex flex-column align-items-center mt-4">
             <div className="w-75 d-flex flex-column align-items-center align-items-lg-start">
               <PearlImage image={image} className="img-fluid p-3" style={{ maxWidth: '200px' }}/>
               <p className="text-uppercase fs-5 fw-semibold mb-0">Step {i + 1}</p>
               <p className="text-uppercase fs-6">{duration}</p>
-              <p className="fs-4">
+              <p className="fs-4 mb-0">
                 {blurb}
               </p>
             </div>
@@ -74,13 +76,15 @@ function StepOverviewTemplate(props: StepOverviewTemplateProps) {
         })
       }
     </div>
-    <div className="d-grid gap-2 d-md-flex pt-4 justify-content-center">
-      {
-        _.map(buttons, (button, i) => {
-          return <ConfiguredButton key={i} config={button} className="px-4 me-md-2" />
-        })
-      }
-    </div>
+    {hasButtons && (
+      <div className="d-grid gap-2 d-md-flex justify-content-center mt-4">
+        {
+          _.map(buttons, (button, i) => {
+            return <ConfiguredButton key={i} config={button} className="px-4 me-md-2" />
+          })
+        }
+      </div>
+    )}
   </div>
 }
 


### PR DESCRIPTION
Stacked on #235

The goal here is to make sure that the last element in a landing page section does not have any bottom margin/padding. That way, all padding on the section will come from the section wrapper, and we can make that padding configurable to adjust the spacing between sections.