### PR TITLE
[JN-89] Implement dashboard design (part 2)

### DIFF
--- a/ui-participant/src/hub/HubPage.tsx
+++ b/ui-participant/src/hub/HubPage.tsx
@@ -85,6 +85,12 @@ const taskTypeDisplayMap: Record<string, string> = {
   SURVEY: 'Survey'
 }
 
+const enrolleeHasStartedTaskType = (enrollee: Enrollee, taskType: string): boolean => {
+  return enrollee.participantTasks
+    .filter(task => task.taskType === taskType && (task.status === 'COMPLETE' || task.status === 'IN_PROGRESS'))
+    .length > 0
+}
+
 type StudyTasksProps = {
   enrollee: Enrollee
   study: Study
@@ -124,10 +130,10 @@ function StudyTasks(props: StudyTasksProps) {
             to={getTaskPath(nextTask, enrollee.shortcode, study.shortcode)}
             className="btn rounded-pill ps-4 pe-4 fw-bold btn-primary"
           >
-            {enrollee.participantTasks
-              .filter(task => task.taskType === nextTask.taskType && task.status === 'COMPLETE')
-              .length > 0
-              ? 'Continue' : 'Start'} {taskTypeDisplayMap[nextTask.taskType]}s
+            {enrolleeHasStartedTaskType(enrollee, nextTask.taskType)
+              ? 'Continue'
+              : 'Start'}
+            {' '}{taskTypeDisplayMap[nextTask.taskType]}s
           </Link>
         </div>
       )}


### PR DESCRIPTION
Lots of formatting and name changes here to make things easier to read.

The major visual changes are to the next task section. Updated the background to match the brand color and changed the button text from "Continue" to "Start" if the next task is the first consent/survey task.

![Screenshot 2023-04-11 at 2 51 55 PM](https://user-images.githubusercontent.com/1156625/231261128-04da23e8-7001-4489-9ce9-9e312ea7e1c4.png)
