### PR TITLE
Add a key to icons in social media template

### DIFF
--- a/ui-participant/src/landing/sections/SocialMediaTemplate.tsx
+++ b/ui-participant/src/landing/sections/SocialMediaTemplate.tsx
@@ -94,6 +94,7 @@ function SocialMediaTemplate(props: SocialMediaTemplateProps) {
           } else {
             return (
               <SocialMediaLink
+                key={site.label}
                 icon={site.icon}
                 label={site.label}
                 url={site.renderUrl({ domain: site.domain, handle })}


### PR DESCRIPTION
Avoid a React warning by adding keys to icons rendered in an array.