### PR TITLE
Add empty alt text for decorative image

### DIFF
--- a/populate/src/main/resources/seed/portals/ourhealth/siteContent/siteContent.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/siteContent/siteContent.json
@@ -163,7 +163,8 @@
         "sectionConfigJson": {
           "image": {
             "cleanFileName": "globe_and_hearts.png",
-            "version": 1
+            "version": 1,
+            "alt": ""
           },
           "background": "linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%)",
           "paddingBottom": 0


### PR DESCRIPTION
Forgot to add alt text when adding this image in #212. Since it's a decorative image, alt text can be empty.