### PR TITLE
[JN-277] Set 'from' name on emails

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/notification/EmailService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/EmailService.java
@@ -49,7 +49,7 @@ public class EmailService implements NotificationSender {
         this.emailTemplateService = emailTemplateService;
         this.routingPaths = routingPaths;
     }
-    
+
     @Async
     @Override
     public void processNotificationAsync(Notification notification, NotificationConfig config, EnrolleeRuleData ruleData) {
@@ -143,6 +143,9 @@ public class EmailService implements NotificationSender {
     public Mail buildEmail(NotificationContextInfo contextInfo, EnrolleeRuleData ruleData) {
         Email from = new Email(contextInfo.portalEnv().getPortalEnvironmentConfig().getEmailSourceAddress());
         Email to = new Email(ruleData.profile().getContactEmail());
+
+        //Set the 'from' name on the email to the portal name
+        from.setName(contextInfo.portal().getName());
 
         StringSubstitutor stringSubstitutor = EnrolleeEmailSubstitutor
                 .newSubstitutor(ruleData, contextInfo, routingPaths);


### PR DESCRIPTION
Do we want to do this? Makes things look more professional in the inbox IMO. I'll make a ticket if we want to keep this.

Before:
<img width="385" alt="Screenshot 2023-04-12 at 11 41 07 AM" src="https://user-images.githubusercontent.com/7257391/231510080-20cc9a4e-a9a6-4881-bfd4-cfc7d827b90c.png">


After:
<img width="452" alt="Screenshot 2023-04-12 at 11 40 22 AM" src="https://user-images.githubusercontent.com/7257391/231509851-9cbdc6bc-d148-4550-bb59-fd67f28765a6.png">
