### PR TITLE
[JN-89] Update next task button text

### DIFF
--- a/ui-participant/src/hub/HubPage.tsx
+++ b/ui-participant/src/hub/HubPage.tsx
@@ -113,6 +113,9 @@ function StudyTasks(props: StudyTasksProps) {
   const hasSurveyTasks = sortedSurveyTasks.length > 0
 
   const nextTask = getNextTask(enrollee, [...sortedActiveConsentTasks, ...sortedSurveyTasks])
+  const numTasksOfNextTaskType = nextTask
+    ? enrollee.participantTasks.filter(task => task.taskType === nextTask.taskType).length
+    : 0
 
   const completedConsentTasks = enrollee.participantTasks
     .filter(task => task.status === 'COMPLETE' && task.taskType === 'CONSENT')
@@ -134,7 +137,7 @@ function StudyTasks(props: StudyTasksProps) {
               ? 'Continue'
               : 'Start'}
             {' '}{taskTypeDisplayMap[nextTask.taskType]}
-            {enrollee.participantTasks.filter(task => task.taskType === nextTask.taskType).length > 1 && 's'}
+            {numTasksOfNextTaskType > 1 && 's'}
           </Link>
         </div>
       )}


### PR DESCRIPTION
If there is only one consent/survey for a study, show "Start Consent/Survey" instead of "Start Consents/Surveys".

## Before
<img width="802" alt="Screenshot 2023-04-13 at 12 14 13 PM" src="https://user-images.githubusercontent.com/1156625/231821447-94a97593-0430-4e31-bdb9-30ff30acf412.png">

## After
<img width="803" alt="Screenshot 2023-04-13 at 12 14 02 PM" src="https://user-images.githubusercontent.com/1156625/231821475-48ab6534-b57a-4c68-9f25-774a146c4597.png">
