### PR TITLE
JN-280 upgrading enrollee table to use react-table for show/hide columns

### DIFF
--- a/ui-admin/src/study/participants/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/ParticipantList.tsx
@@ -1,16 +1,86 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useMemo } from 'react'
 import Api, { EnrolleeSearchResult } from 'api/api'
 import LoadingSpinner from 'util/LoadingSpinner'
 import { Store } from 'react-notifications-component'
 import { failureNotification } from 'util/notifications'
 import { Link } from 'react-router-dom'
 import { StudyEnvContextT } from '../StudyEnvironmentRouter'
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable, VisibilityState
+} from '@tanstack/react-table'
+import { ColumnVisibilityControl, IndeterminateCheckbox, sortableTableHeader } from '../../util/tableUtils'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faCheck, faTimes } from '@fortawesome/free-solid-svg-icons'
+
 
 /** Shows a list of (for now) enrollees */
 function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
   const { portal, study, currentEnv, currentEnvPath } = studyEnvContext
   const [participantList, setParticipantList] = useState<EnrolleeSearchResult[]>([])
   const [isLoading, setIsLoading] = useState(true)
+  const [sorting, setSorting] = React.useState<SortingState>([])
+  const [rowSelection, setRowSelection] = React.useState<Record<string, boolean>>({})
+  const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({
+    'givenName': false,
+    'familyName': false
+  })
+
+
+  const columns = useMemo<ColumnDef<EnrolleeSearchResult, string>[]>(() => [{
+    id: 'select',
+    header: ({ table }) => <IndeterminateCheckbox
+      checked={table.getIsAllRowsSelected()} indeterminate={table.getIsSomeRowsSelected()}
+      onChange={table.getToggleAllRowsSelectedHandler()}/>,
+    cell: ({ row }) => (
+      <div className="px-1">
+        <IndeterminateCheckbox
+          checked={row.getIsSelected()} indeterminate={row.getIsSomeSelected()}
+          onChange={row.getToggleSelectedHandler()} disabled={!row.getCanSelect()}/>
+      </div>
+    )
+  }, {
+    header: 'Shortcode',
+    accessorKey: 'enrollee.shortcode',
+    cell: info => <Link to={`${currentEnvPath}/participants/${info.getValue()}`}>{info.getValue()}</Link>
+  }, {
+    id: 'familyName',
+    header: 'Family name',
+    accessorKey: 'profile.familyName'
+  }, {
+    id: 'givenName',
+    header: 'Given name',
+    accessorKey: 'profile.givenName'
+  }, {
+    header: 'Consented',
+    accessorKey: 'enrollee.consented',
+    cell: info => info.getValue() ? <FontAwesomeIcon icon={faCheck}/> : ''
+  }, {
+    header: 'Withdrawn',
+    accessorKey: 'enrollee.withdrawn',
+    cell: info => info.getValue() ? <FontAwesomeIcon icon={faTimes}/> : ''
+  }], [study.shortcode])
+
+
+  const table = useReactTable({
+    data: participantList,
+    columns,
+    state: {
+      sorting,
+      rowSelection,
+      columnVisibility
+    },
+    onColumnVisibilityChange: setColumnVisibility,
+    enableRowSelection: true,
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    onRowSelectionChange: setRowSelection
+  })
 
   useEffect(() => {
     Api.getEnrollees(portal.shortcode, study.shortcode, currentEnv.environmentName).then(result => {
@@ -25,27 +95,32 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
       <div className="col-12">
         <h5>Participants</h5>
         <LoadingSpinner isLoading={isLoading}>
+          <div className="d-flex align-items-center justify-content-between">
+            <div>
+              {Object.keys(rowSelection).length} of{' '}
+              {table.getPreFilteredRowModel().rows.length} selected
+            </div>
+            <ColumnVisibilityControl table={table}/>
+          </div>
           <table className="table table-striped">
             <thead>
               <tr>
-                <th>Shortcode</th>
-                <th>Family name</th>
-                <th>Given name</th>
-                <th>Consented</th>
-                <th>Forms complete</th>
+                {table.getFlatHeaders().map(header => sortableTableHeader(header))}
               </tr>
             </thead>
             <tbody>
-              { participantList.map(participant => {
-                return <tr key={participant.enrollee.shortcode}>
-                  <td><Link to={`${currentEnvPath}/participants/${participant.enrollee.shortcode}`}>
-                    {participant.enrollee.shortcode}
-                  </Link></td>
-                  <td>{participant.profile.givenName}</td>
-                  <td>{participant.profile.familyName}</td>
-                  <td>{participant.enrollee.consented ? 'Yes' : 'No'}</td>
-                  <td>No</td>
-                </tr>
+              {table.getRowModel().rows.map(row => {
+                return (
+                  <tr key={row.id}>
+                    {row.getVisibleCells().map(cell => {
+                      return (
+                        <td key={cell.id}>
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </td>
+                      )
+                    })}
+                  </tr>
+                )
               })}
             </tbody>
           </table>
@@ -54,5 +129,6 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     </div>
   </div>
 }
+
 
 export default ParticipantList

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -1,7 +1,7 @@
-import React, { HTMLProps } from 'react'
-import { flexRender, Header } from '@tanstack/react-table'
+import React, { HTMLProps, useState } from 'react'
+import { flexRender, Header, Table } from '@tanstack/react-table'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCaretDown, faCaretUp } from '@fortawesome/free-solid-svg-icons'
+import { faCaretDown, faCaretUp, faColumns } from '@fortawesome/free-solid-svg-icons'
 
 /**
  * returns a clickable header column with up/down icons indicating sort direction
@@ -46,3 +46,49 @@ export function IndeterminateCheckbox({
     />
   )
 }
+
+/**
+ * adapted from https://tanstack.com/table/v8/docs/examples/react/column-visibility
+ * For now, this control assumes that all the headers are simple strings.
+ * */
+export function ColumnVisibilityControl<T>({ table }: {table: Table<T>}) {
+  const [show, setShow] = useState(false)
+  return <div className="position-relative">
+    <button className="btn btn-secondary" onClick={() => setShow(!show)} aria-label="show or hide columns">
+      <FontAwesomeIcon icon={faColumns} className="fa-lg"/>
+    </button>
+    { show && <div className="position-absolute border border-gray rounded bg-white p-3"
+      style={{ width: '300px', zIndex: 100, right: 0 }}>
+      <div className="border-b border-black">
+        <label>
+          <input
+            {...{
+              type: 'checkbox',
+              checked: table.getIsAllColumnsVisible(),
+              onChange: table.getToggleAllColumnsVisibilityHandler()
+            }}
+          />
+          <span className="ps-2">Toggle All</span>
+        </label>
+      </div>
+      <hr/>
+      {table.getAllLeafColumns().map(column => {
+        return (
+          <div key={column.id} className="pb-1">
+            <label>
+              <input
+                {...{
+                  type: 'checkbox',
+                  checked: column.getIsVisible(),
+                  onChange: column.getToggleVisibilityHandler()
+                }}
+              />
+              <span className="ps-2">{ column.columnDef.header as string ?? column.columnDef.id }</span>
+            </label>
+          </div>
+        )
+      })}
+    </div> }
+  </div>
+}
+


### PR DESCRIPTION
  So this updates the table to react-table and adds the show/hide column functionality.  As was discussed, by default, the view hides columns including PHI.  This adds a "withdrawn" column in preparation for JN-36.  Eventually, the enrollee table will hide both the withdrawn column and withdrawn enrollees by default, but for now while we're building out withdrawn functionality, it's easier to just show it as a column by default so we can quickly spot errors 

TO TEST:
1. go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants
2. observe 
![image](https://user-images.githubusercontent.com/2800795/231871702-36283623-586e-4e31-aefd-38adb9dee505.png)
3. Futz with the show/hide column control