### PR TITLE
[JN-248] Use finalized email templates

### DIFF
--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/emails/consentReminder.html
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/emails/consentReminder.html
@@ -159,7 +159,7 @@
 
                                             <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
                                                 <p style="line-height: 140%;">Thank you for participating in OurHealth. It's very important to complete each of the study activities in order to provide as much information to our researchers as possible.</p>
-                                                <p style="line-height: 140%;"> </p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
                                                 <p style="line-height: 140%;">Please return to the study at your earliest convenience to finish your activities.</p>
                                             </div>
 

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/emails/studyEnroll.html
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/emails/studyEnroll.html
@@ -244,7 +244,7 @@
 
                                             <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
                                                 <p style="line-height: 140%;">We are so grateful for your participation - thank you again!</p>
-                                                <p style="line-height: 140%;"> </p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
                                                 <p style="line-height: 140%;">Best regards,</p>
                                                 <p style="line-height: 140%;"><em>The OurHealth Study Staff</em></p>
                                             </div>

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/emails/surveyReminder.html
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/emails/surveyReminder.html
@@ -244,7 +244,7 @@
 
                                             <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
                                                 <p style="line-height: 140%;">We are so grateful for your participation - thank you again!</p>
-                                                <p style="line-height: 140%;"> </p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
                                                 <p style="line-height: 140%;">Best regards,</p>
                                                 <p style="line-height: 140%;"><em>The OurHealth Study Staff</em></p>
                                             </div>


### PR DESCRIPTION
I basically copied the HTML attached to the ticket: https://broadworkbench.atlassian.net/browse/JN-248

There's a lot of duplicated HTML here, especially since it looks like the designs have us merging the consent and survey reminder emails into one generically worded email template (although they'll still have different email subjects). Not sure how much it's worth the effort to de-duplicate things at this moment in time.