### PR TITLE
Improve back button behavior after clicking "Log In" button

### DIFF
--- a/ui-participant/src/login/Login.tsx
+++ b/ui-participant/src/login/Login.tsx
@@ -9,7 +9,7 @@ function Login() {
 
   const signIn = () => {
     auth.signinRedirect(
-      { extraQueryParams: { portalShortcode: envSpec.shortcode, portalHomeLink: window.location.origin } })
+      { redirectMethod: 'replace', extraQueryParams: { portalShortcode: envSpec.shortcode } })
   }
 
   useEffect(() => {


### PR DESCRIPTION
The "Log In" button navigates to `/hub` which is a protected route that causes a redirect to B2C. Previously, clicking the browser back button after clicking "Log In" would return to `/hub` which would again redirect to B2C. Clicking the back button yet again... skips over the hub _and_ the landing page and goes back to wherever you were before that? Anyway, definitely a bad experience. This simple change fixes all that.

We'll need to do something similar to `Register` but that logic is a bit more complicated due to the layers of pre-reg/pre-enroll survey handling.