### PR TITLE
JN-176: config lookups work across version updates

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/study/StudyEnvironmentConsentDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/study/StudyEnvironmentConsentDao.java
@@ -40,6 +40,19 @@ public class StudyEnvironmentConsentDao extends BaseMutableJdbiDao<StudyEnvironm
         return studyEnvConsents;
     }
 
+    public List<StudyEnvironmentConsent> findByConsentForm(UUID studyEnvId, String consentStableId) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("select " + prefixedGetQueryColumns("a") + " from " + tableName +
+                        " a join consent_form on consent_form.id = a.consent_form_id " +
+                        " where consent_form.stable_id = :stableId " +
+                        " and a.study_environment_id = :studyEnvId;")
+                        .bind("stableId", consentStableId)
+                        .bind("studyEnvId", studyEnvId)
+                        .mapTo(clazz)
+                        .list()
+        );
+    }
+
     public Optional<StudyEnvironmentConsent> findByConsentForm(UUID studyEnvId, UUID consentFormId) {
         return findByTwoProperties("study_environment_id",studyEnvId,
                 "consent_form_id", consentFormId);

--- a/core/src/main/java/bio/terra/pearl/core/dao/study/StudyEnvironmentSurveyDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/study/StudyEnvironmentSurveyDao.java
@@ -46,8 +46,21 @@ public class StudyEnvironmentSurveyDao extends BaseMutableJdbiDao<StudyEnvironme
     }
 
     /** finds by a surveyId and studyEnvironment */
-    public Optional<StudyEnvironmentSurvey> findBySurvey(UUID studyEnvId, UUID consentFormId) {
+    public Optional<StudyEnvironmentSurvey> findBySurvey(UUID studyEnvId, UUID surveyId) {
         return findByTwoProperties("study_environment_id",studyEnvId,
-                "survey_id", consentFormId);
+                "survey_id", surveyId);
+    }
+
+    public List<StudyEnvironmentSurvey> findBySurvey(UUID studyEnvId, String surveyStableId) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("select " + prefixedGetQueryColumns("a") + " from " + tableName +
+                                " a join survey on survey.id = a.survey_id" +
+                                " where survey.stable_id = :stableId " +
+                                " and a.study_environment_id = :studyEnvId;")
+                        .bind("stableId", surveyStableId)
+                        .bind("studyEnvId", studyEnvId)
+                        .mapTo(clazz)
+                        .list()
+        );
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/consent/ConsentResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/consent/ConsentResponseService.java
@@ -47,12 +47,11 @@ public class ConsentResponseService extends ImmutableEntityService<ConsentRespon
     public ConsentWithResponses findWithResponses(UUID studyEnvId, String stableId, Integer version,
                                                   Enrollee enrollee, UUID participantUserId) {
         ConsentForm form = consentFormService.findByStableId(stableId, version).get();
-        // TODO we should only get the most recent response, and we should search by stableId, not form id, in
-        // case they have a previous response to a different version of the form.
+        // this searches by form id -- we don't carry forward responses from one version of a consent to the next
         List<ConsentResponse> responses = dao.findByEnrolleeId(enrollee.getId(), form.getId());
-        // TODO this lookup should be by stableId -- it will fail if the version has been updated
+
         StudyEnvironmentConsent configConsent = studyEnvironmentConsentService
-                .findByConsentForm(studyEnvId, form.getId()).get();
+                .findByConsentForm(studyEnvId, stableId).get();
         configConsent.setConsentForm(form);
         return new ConsentWithResponses(
             configConsent, responses

--- a/core/src/main/java/bio/terra/pearl/core/service/study/StudyEnvironmentConsentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/study/StudyEnvironmentConsentService.java
@@ -21,4 +21,11 @@ public class StudyEnvironmentConsentService extends CrudService<StudyEnvironment
     public Optional<StudyEnvironmentConsent> findByConsentForm(UUID studyEnvId, UUID consentFormId) {
         return dao.findByConsentForm(studyEnvId, consentFormId);
     }
+
+    public Optional<StudyEnvironmentConsent> findByConsentForm(UUID studyEnvId, String stableId) {
+        var configs = dao.findByConsentForm(studyEnvId, stableId);
+        // we don't yet have robust support for having multiple consents with the same stableId configured for an
+        // environment.  For now, just pick one
+        return configs.stream().findFirst();
+    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/study/StudyEnvironmentSurveyService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/study/StudyEnvironmentSurveyService.java
@@ -22,7 +22,10 @@ public class StudyEnvironmentSurveyService extends CrudService<StudyEnvironmentS
         return dao.findBySurvey(studyEnvId, surveyId);
     }
 
-    public Optional<StudyEnvironmentSurvey> findBySurveyOrUpdate(UUID studyEnvId, UUID surveyId) {
-        return dao.findBySurvey(studyEnvId, surveyId);
+    public Optional<StudyEnvironmentSurvey> findBySurvey(UUID studyEnvId, String stableId) {
+        var configs = dao.findBySurvey(studyEnvId, stableId);
+        // we don't yet have robust support for having multiple surveys with the same stableId configured for an
+        // environment.  For now, just pick one
+        return configs.stream().findFirst();
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -101,9 +101,8 @@ public class SurveyResponseService extends ImmutableEntityService<SurveyResponse
                         .orElse(null));
             }
         }
-        // TODO -- this lookup should be by stableId, not formId
         StudyEnvironmentSurvey configSurvey = studyEnvironmentSurveyService
-                .findBySurvey(studyEnvId, form.getId()).get();
+                .findBySurvey(studyEnvId, stableId).get();
         configSurvey.setSurvey(form);
         return new SurveyWithResponse(
                 configSurvey, lastResponse


### PR DESCRIPTION
Previously, if a user was assigned a task with a given version, and then the study environment config was updated to use a different version, the user would be unable to complete the task due to the lookup for the form config failing.  This updates the lookups to be based on stableId of the form.  Two implications of this are:
1. if a study environment has the same form configured twice, this randomly picks one of the configs
2. if a study environment has totally removed the form from the environment, the lookup will fail.  This is correct -- removing the form should stop people from completing it.  We will just need better participant error handling for that case (and/or have removing the form also delete outstanding tasks for that form). That's outside the scope of this PR

TO TEST:
1. restart participantApiApp
2. repopulate ourhealth
3. make an edit to the Heart Health survey, and save the new version (don't try to save a change to the basic survey, there is a bug in surveyParseUtils that will prevent that)
4. sign in as consented@test.com
5. click the Heart Health survey to take it. 
6. Confirm the survey loads.  Note that the original version will load, not the updated one, since consented was assigned the task for the prior version.  We haven't yet implemented always getting participants the latest version