### PR TITLE
[JN-300] Fix bugs with token state

### DIFF
--- a/ui-participant/src/authConfig.ts
+++ b/ui-participant/src/authConfig.ts
@@ -23,13 +23,13 @@ export const getOidcConfig = (
      */
     // oidc-client-ts appends /v2.0/.well-known/openid-configuration, so can't use ?p={policy} here
     authority:
-      `https://${b2cTenantName}.b2clogin.com/${b2cTenantName}.onmicrosoft.com/${b2cPolicyName}`,
+      `https://${b2cTenantName}.b2clogin.com/${b2cTenantName}.onmicrosoft.com/${b2cPolicyName}/v2.0`,
     client_id: b2cClientId,
     redirect_uri: `${window.origin}/redirect-from-oauth`,
     popup_redirect_uri: `${window.origin}/redirect-from-oauth`,
     silent_redirect_uri: `${window.origin}/redirect-from-oauth-silent`,
     prompt: 'login',
-    scope: 'openid',
+    scope: `openid email ${b2cClientId}`,
     loadUserInfo: false,
     stateStore: new WebStorageStateStore({ store: window.localStorage }),
     userStore: new WebStorageStateStore({ store: window.localStorage }),

--- a/ui-participant/src/providers/UserProvider.tsx
+++ b/ui-participant/src/providers/UserProvider.tsx
@@ -114,7 +114,7 @@ export default function UserProvider({ children }: { children: React.ReactNode }
     const internalLogintoken = localStorage.getItem(INTERNAL_LOGIN_TOKEN_KEY)
     if (oauthAccessToken) {
       Api.refreshLogin(oauthAccessToken).then(loginResult => {
-        loginUser(loginResult, loginResult.user.token)
+        loginUser(loginResult, oauthAccessToken)
         setIsLoading(false)
       }).catch(() => {
         setIsLoading(false)


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/JN-300

To test:
1. Join or sign in with any account.
2. Reload the page and confirm that you're still signed in.
3. Reload the page _again_ and confirm that you're _still_ signed in. (The bug was that the token in local storage was being wiped out on the first reload which didn't affect sign-in state until the 2nd reload.)
4. Wait 60 minutes and confirm that there's a successful call to the `https://ddpdevb2c.b2clogin.com/ddpdevb2c.onmicrosoft.com/b2c_1a_ddp_participant_signup_signin_dev_breilly/oauth2/v2.0/token` endpoint.

I don't actually expect you to do step #4. I'd rather get this merged quickly; I trust that we'll test this organically. Also, we rely on the apache proxy to validate the token and the app currently doesn't double-check expiration, so you won't see errors from an expired token when running locally without the apache proxy.