### PR TITLE
Fix spacing of logos on mobile

### DIFF
--- a/ui-participant/src/landing/sections/HeroWithImageTemplate.tsx
+++ b/ui-participant/src/landing/sections/HeroWithImageTemplate.tsx
@@ -148,8 +148,14 @@ function HeroWithImageTemplate(props: HeroWithImageTemplateProps) {
                 'flex-sm-row align-items-sm-start flex-sm-wrap'
               )}
             >
-              {_.map(logos, logo => {
-                return <ConfiguredImage key={logo.cleanFileName} image={logo} className="me-sm-4" />
+              {_.map(logos, (logo, i) => {
+                return (
+                  <ConfiguredImage
+                    key={logo.cleanFileName}
+                    image={logo}
+                    className={classNames({ 'mt-4': i !== 0 }, 'mt-sm-0', 'me-sm-4')}
+                  />
+                )
               })}
             </div>
           )}


### PR DESCRIPTION
## Before
<img width="343" alt="Screenshot 2023-04-19 at 2 47 24 PM" src="https://user-images.githubusercontent.com/1156625/233171854-02553824-b3ee-4587-99b4-db0cb8daa61a.png">

## After
<img width="344" alt="Screenshot 2023-04-19 at 2 49 25 PM" src="https://user-images.githubusercontent.com/1156625/233171856-03b02010-a623-4d53-8f1a-02c3e9f0047c.png">
