### PR TITLE
JN-301 fixing notification config bugs

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/publishing/PortalUpdateService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/publishing/PortalUpdateService.java
@@ -72,7 +72,7 @@ public class PortalUpdateService {
         applyChangesToNotificationConfigs(destEnv, envChanges.notificationConfigChanges());
         for(StudyEnvironmentChange studyEnvChange : envChanges.studyEnvChanges()) {
             StudyEnvironment studyEnv = portalDiffService.loadStudyEnvForProcessing(studyEnvChange.studyShortcode(), destEnv.getEnvironmentName());
-            studyUpdateService.applyChanges(studyEnv, studyEnvChange);
+            studyUpdateService.applyChanges(studyEnv, studyEnvChange, destEnv.getId());
         }
 
         var changeRecord = PortalEnvironmentChangeRecord.builder()

--- a/core/src/main/java/bio/terra/pearl/core/service/publishing/StudyUpdateService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/publishing/StudyUpdateService.java
@@ -53,12 +53,13 @@ public class StudyUpdateService {
 
     /** the study environment must be fully hydrated by a call to loadStudyEnvForProcessing prior to passing in */
     @Transactional
-    public StudyEnvironment applyChanges(StudyEnvironment destEnv, StudyEnvironmentChange envChange) throws Exception {
+    public StudyEnvironment applyChanges(StudyEnvironment destEnv, StudyEnvironmentChange envChange,
+                                         UUID destPortalEnvId) throws Exception {
         applyChangesToStudyEnvConfig(destEnv, envChange.configChanges());
         applyChangesToPreEnrollSurvey(destEnv, envChange.preEnrollSurveyChanges());
         applyChangesToConsents(destEnv, envChange.consentChanges());
         applyChangesToSurveys(destEnv, envChange.surveyChanges());
-        applyChangesToNotificationConfigs(destEnv, envChange.notificationConfigChanges());
+        applyChangesToNotificationConfigs(destEnv, envChange.notificationConfigChanges(), destPortalEnvId);
         return destEnv;
     }
 
@@ -119,9 +120,10 @@ public class StudyUpdateService {
     }
 
     protected void applyChangesToNotificationConfigs(StudyEnvironment destEnv, ListChange<NotificationConfig,
-            VersionedConfigChange> listChange) throws Exception {
+            VersionedConfigChange> listChange, UUID destPortalEnvId) throws Exception {
         for(NotificationConfig config : listChange.addedItems()) {
             config.setStudyEnvironmentId(destEnv.getId());
+            config.setPortalEnvironmentId(destPortalEnvId);
             notificationConfigService.create(config.cleanForCopying());
             destEnv.getNotificationConfigs().add(config);
         }

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/study.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/study.json
@@ -53,11 +53,11 @@
         "populateFileName": "emails/studyEnroll.json"
       },{
         "notificationType": "TASK_REMINDER",
-        "taskType": "SURVEY",
+        "taskType": "CONSENT",
         "populateFileName": "emails/consentReminder.json"
       },{
         "notificationType": "TASK_REMINDER",
-        "taskType": "CONSENT",
+        "taskType": "SURVEY",
         "reminderIntervalMinutes": 10080,
         "maxNumReminders": 2,
         "populateFileName": "emails/surveyReminder.json"


### PR DESCRIPTION
This fixes a bug where we weren't updating the portal environment of notifications appropriately when they were populated or copied.  So emails from the 'live' environment were linking back to the sandbox hub.  This also fixes a bug where the Consent and Survey reminders were swapped.  

TO TEST:
1. restart apiAdminApp
2. run `./scripts/populate_portal.sh ourhealth`
3. go to `https://localhost:3000/ourhealth`
4. click "copy from irb" to copy the environment over
5. reload the page
6. go into the "content" of the IRB site 
![image](https://user-images.githubusercontent.com/2800795/233175898-29b638be-898b-40a9-b942-5ee010ceaa63.png)
7. select a notification config at the bottom of the page, and then send a test email
8. confirm that the link in the test email goes to irb.ourhealth.localhost, and not sandbox.ourhealth.localhost