### PR TITLE
Restyle loading indicator on OAuth landing page

### DIFF
--- a/ui-participant/src/App.tsx
+++ b/ui-participant/src/App.tsx
@@ -113,8 +113,8 @@ function App() {
                           </Route>
                           <Route path="/" element={<LandingPage localContent={localContent}/>}>
                             {landingRoutes}
-                            <Route path='redirect-from-oauth' element={<RedirectFromOAuth/>}/>
                           </Route>
+                          <Route path="/redirect-from-oauth" element={<RedirectFromOAuth/>}/>
                           <Route path="/privacy" element={<PrivacyPolicyPage />} />
                           <Route path="/terms/investigator" element={<InvestigatorTermsOfUsePage />} />
                           <Route path="/terms/participant" element={<ParticipantTermsOfUsePage />} />

--- a/ui-participant/src/login/RedirectFromOAuth.tsx
+++ b/ui-participant/src/login/RedirectFromOAuth.tsx
@@ -7,6 +7,7 @@ import Api from 'api/api'
 import { HubUpdate } from 'hub/hubUpdates'
 import { usePreEnrollResponseId, usePreRegResponseId, useReturnToStudy } from 'browserPersistentState'
 import { userHasJoinedPortalStudy } from 'util/enrolleeUtils'
+import { PageLoadingIndicator } from 'util/LoadingSpinner'
 
 export const RedirectFromOAuth = () => {
   const auth = useAuth()
@@ -87,5 +88,5 @@ export const RedirectFromOAuth = () => {
     handleRedirectFromOauth()
   })
 
-  return <div>Loading...</div>
+  return <PageLoadingIndicator />
 }


### PR DESCRIPTION
Currently, when returning from B2C after signing up or signing in, you see a flash of the landing page footer and a "Loading..." message in the top left of the page while some API requests are made.

This restyles that to show our usual page loading indicator.

The screen recordings below have an artificial 3 second delay added.

## Before
https://user-images.githubusercontent.com/1156625/233199710-870ff5e1-29e7-4cb6-9ba6-ad76b0dc482d.mov

## After
https://user-images.githubusercontent.com/1156625/233199717-049a5a95-4459-4752-a4b7-765a15ed279d.mov




