### PR TITLE
JN-303 required surveys take precedence

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/workflow/ParticipantTask.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/workflow/ParticipantTask.java
@@ -29,7 +29,7 @@ public class ParticipantTask extends BaseEntity {
     private String targetStableId;
     private int targetAssignedVersion;
     private int taskOrder;
-    private boolean blocksHub;
+    private boolean blocksHub; // whether this task blocks the participant from doing optional tasks in the hub
     private UUID studyEnvironmentId;
     private UUID enrolleeId;
     private UUID portalParticipantUserId;

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
@@ -85,7 +85,7 @@ public class SurveyTaskDispatcher {
                 .enrolleeId(enrollee.getId())
                 .portalParticipantUserId(portalParticipantUser.getId())
                 .studyEnvironmentId(enrollee.getStudyEnvironmentId())
-                .blocksHub(false) // for now, no surveys block the hub
+                .blocksHub(studySurvey.isRequired())
                 .taskOrder(studySurvey.getSurveyOrder())
                 .targetStableId(survey.getStableId())
                 .targetAssignedVersion(survey.getVersion())

--- a/ui-participant/src/hub/TaskLink.tsx
+++ b/ui-participant/src/hub/TaskLink.tsx
@@ -12,19 +12,19 @@ export type StatusDisplayInfo = {
 
 const statusDisplayMap: Record<string, StatusDisplayInfo> = {
   'COMPLETE': {
-    icon: <FontAwesomeIcon icon={faCheck} className="fa-lg" style={{ color: 'rgb(122, 152, 188)' }} />,
+    icon: <FontAwesomeIcon icon={faCheck} className="fa-lg" style={{ color: 'rgb(122, 152, 188)' }}/>,
     statusDisplay: 'Complete'
   },
   'IN_PROGRESS': {
-    icon: <FontAwesomeIcon icon={faCircleHalfStroke} style={{ color: 'rgb(129, 172, 82)' }} />,
+    icon: <FontAwesomeIcon icon={faCircleHalfStroke} style={{ color: 'rgb(129, 172, 82)' }}/>,
     statusDisplay: 'In Progress'
   },
   'NEW': {
-    icon: <FontAwesomeIcon icon={faCircle} style={{ color: '#777' }} />,
+    icon: <FontAwesomeIcon icon={faCircle} style={{ color: '#777' }}/>,
     statusDisplay: 'Not Started'
   },
   'REJECTED': {
-    icon: <FontAwesomeIcon icon={faCircleXmark} style={{ color: '#777' }} />,
+    icon: <FontAwesomeIcon icon={faCircleXmark} style={{ color: '#777' }}/>,
     statusDisplay: 'Declined'
   }
 }
@@ -50,7 +50,7 @@ export default function TaskLink({ task, studyShortcode, enrollee }:
       <div className="detail">
         {isAccessible
           ? statusDisplayMap[task.status].icon
-          : <FontAwesomeIcon icon={faLock} style={{ color: 'rgb(203, 203, 203)' }} />}
+          : <FontAwesomeIcon icon={faLock} style={{ color: 'rgb(203, 203, 203)' }}/>}
       </div>
       <div className="flex-grow-1 ms-3">
         {isAccessible
@@ -78,9 +78,16 @@ export function getTaskPath(task: ParticipantTask, enrolleeShortcode: string, st
   return ''
 }
 
-/** is the task actionable by the user? for now, just looks at whether they've consented */
+/** is the task actionable by the user? the rules are:
+ * consent forms are always actionable.
+ * nothing else is actionable until consent
+ * non-required tasks are not actionable until all required tasks are cleared */
 export function isTaskAccessible(task: ParticipantTask, enrollee: Enrollee) {
-  return task.taskType === 'CONSENT' || enrollee.consented
+  const hasRequiredTasks = enrollee.participantTasks.some(task => task.blocksHub && task.status !== 'COMPLETE')
+  return task.taskType === 'CONSENT' || (
+    enrollee.consented &&
+    (!hasRequiredTasks || task.blocksHub)
+  )
 }
 
 /** is the task ready to be worked on (not done or rejected) */


### PR DESCRIPTION
This updates display logic so that a user cannot complete optional surveys until all required surveys are complete.  this is only enforced on the frontend, it's just a user-encouragement method, not a research requirement.  

TO TEST:
1. restart adminApiApp, and repopulate ourhealth
2. go to participant UI, sign in as jsalk@test.com
3. observe that since the required surveys aren't complete yet, the others are inaccessible
![image](https://user-images.githubusercontent.com/2800795/233725280-9f59e92d-d842-4186-83ab-f25b108dce46.png)
4. Take the Heart health survey
5. observe that now all optional surveys are available
![image](https://user-images.githubusercontent.com/2800795/233725358-c6554fea-00a7-472c-8388-2c8941cc1b36.png)
