### PR TITLE
[JN-242] Use silently refreshed access tokens (participant)

### DIFF
--- a/ui-participant/src/authConfig.ts
+++ b/ui-participant/src/authConfig.ts
@@ -29,9 +29,7 @@ export const getOidcConfig = (b2cTenantName: string, b2cClientId: string, b2cPol
     stateStore: new WebStorageStateStore({ store: window.localStorage }),
     userStore: new WebStorageStateStore({ store: window.localStorage }),
     automaticSilentRenew: true,
-    // Leo's setCookie interval is currently 5 min, set refresh auth then 5 min 30 seconds to gurantee that setCookie's
-    // token won't expire between 2 setCookie api calls
-    accessTokenExpiringNotificationTimeInSeconds: 330,
+    accessTokenExpiringNotificationTimeInSeconds: 300,
     includeIdTokenInSilentRenew: true,
     extraQueryParams: { access_type: 'offline' },
     // from https://github.com/authts/react-oidc-context/blob/f175dcba6ab09871b027d6a2f2224a17712b67c5/src/AuthProvider.tsx#L20-L30

--- a/ui-participant/src/providers/UserProvider.tsx
+++ b/ui-participant/src/providers/UserProvider.tsx
@@ -109,6 +109,10 @@ export default function UserProvider({ children }: { children: React.ReactNode }
   }
 
   useEffect(() => {
+    auth.events.addUserLoaded(user => {
+      localStorage.setItem(OAUTH_ACCRESS_TOKEN_KEY, user.access_token)
+    })
+
     // Recover state for a signed-in user (internal) that we might have lost due to a full page load
     const oauthAccessToken = localStorage.getItem(OAUTH_ACCRESS_TOKEN_KEY)
     const internalLogintoken = localStorage.getItem(INTERNAL_LOGIN_TOKEN_KEY)


### PR DESCRIPTION
We currently keep our own copy of the user's access token. This is somewhat of a holdover from the original un-authed sign-in, but it also allows us to keep un-authed sign-in as an option. Ideally, I'd like to just use the token that oidc-client-ts manages, but this works for now.