### PR TITLE
JN-132 handling surveyJS other comments

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/survey/Answer.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/Answer.java
@@ -69,12 +69,14 @@ public class Answer extends BaseEntity {
         numberValue = answer.numberValue;
         objectValue = answer.objectValue;
         answerType = answer.answerType;
+        otherDescription = answer.otherDescription;
     }
 
     public boolean valuesEqual(Answer answer) {
         return Objects.equals(booleanValue, answer.booleanValue) &&
                 Objects.equals(stringValue, answer.stringValue) &&
                 Objects.equals(numberValue, answer.numberValue) &&
-                Objects.equals(objectValue, answer.objectValue);
+                Objects.equals(objectValue, answer.objectValue) &&
+                Objects.equals(otherDescription, answer.otherDescription);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -169,7 +169,9 @@ public class SurveyResponseService extends ImmutableEntityService<SurveyResponse
 
     protected ParticipantTask updateTaskToResponse(ParticipantTask task, SurveyResponse response) {
         task.setSurveyResponseId(response.getId());
-        task.setStatus(response.isComplete() ? TaskStatus.COMPLETE : TaskStatus.IN_PROGRESS);
+        if (task.getStatus() != TaskStatus.COMPLETE) { // task statuses shouldn't ever change from complete to not
+            task.setStatus(response.isComplete() ? TaskStatus.COMPLETE : TaskStatus.IN_PROGRESS);
+        }
         return participantTaskService.update(task);
     }
 

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -254,7 +254,8 @@ export type Answer = {
   numberValue?: number,
   booleanValue?: boolean,
   objectValue?: string,
-  questionStableId: string
+  questionStableId: string,
+  otherDescription?: string
 }
 
 export type HubResponse = {

--- a/ui-participant/src/util/surveyJsUtils.test.tsx
+++ b/ui-participant/src/util/surveyJsUtils.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 
-import {act, render, screen} from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import {setupRouterTest} from 'test-utils/router-testing-utils'
-import {Profile, SurveyJSForm} from 'api/api'
+import { setupRouterTest } from 'test-utils/router-testing-utils'
+import { Profile, SurveyJSForm } from 'api/api'
 
 import {
   extractSurveyContent,
@@ -12,18 +12,18 @@ import {
   useRoutablePageNumber,
   useSurveyJSModel
 } from './surveyJsUtils'
-import {Survey as SurveyComponent} from 'survey-react-ui'
+import { Survey as SurveyComponent } from 'survey-react-ui'
 import {
   generateSurvey,
   generateTemplatedQuestionSurvey,
   generateThreePageSurvey
 } from '../test-utils/test-survey-factory'
-import {Model} from 'survey-core'
+import { Model } from 'survey-core'
 
 /** does nothing except render a survey using the hooks from surveyJSUtils */
-function PlainSurveyComponent({formModel, profile}: { formModel: SurveyJSForm, profile?: Profile }) {
+function PlainSurveyComponent({ formModel, profile }: { formModel: SurveyJSForm, profile?: Profile }) {
   const pager = useRoutablePageNumber()
-  const {surveyModel} = useSurveyJSModel(formModel, null, () => 1, pager, profile)
+  const { surveyModel } = useSurveyJSModel(formModel, null, () => 1, pager, profile)
 
   return <div>
     {surveyModel && <SurveyComponent model={surveyModel}/>}
@@ -31,20 +31,20 @@ function PlainSurveyComponent({formModel, profile}: { formModel: SurveyJSForm, p
 }
 
 test('it starts on the first page', () => {
-  const {RoutedComponent} = setupRouterTest(<PlainSurveyComponent formModel={generateThreePageSurvey()}/>)
+  const { RoutedComponent } = setupRouterTest(<PlainSurveyComponent formModel={generateThreePageSurvey()}/>)
   render(RoutedComponent)
   expect(screen.getByText('You are on page1')).toBeInTheDocument()
 })
 
 test('handles page numbers in initial url', () => {
-  const {RoutedComponent} = setupRouterTest(<PlainSurveyComponent formModel={generateThreePageSurvey()}/>,
+  const { RoutedComponent } = setupRouterTest(<PlainSurveyComponent formModel={generateThreePageSurvey()}/>,
     ['/foo?page=2'])
   render(RoutedComponent)
   expect(screen.getByText('You are on page2')).toBeInTheDocument()
 })
 
 test('updates urls on page navigation', async () => {
-  const {RoutedComponent, router} = setupRouterTest(<PlainSurveyComponent formModel={generateThreePageSurvey()}/>)
+  const { RoutedComponent, router } = setupRouterTest(<PlainSurveyComponent formModel={generateThreePageSurvey()}/>)
   render(RoutedComponent)
   expect(screen.getByText('You are on page1')).toBeInTheDocument()
   userEvent.click(screen.getByText('Next'))
@@ -70,7 +70,7 @@ const dynamicSurvey = generateSurvey({
     pages: [
       {
         elements: [
-          {type: 'html', html: '<span>You are on page1</span>'},
+          { type: 'html', html: '<span>You are on page1</span>' },
           {
             type: 'html',
             visibleIf: '{profile.sexAtBirth} = female',
@@ -83,9 +83,9 @@ const dynamicSurvey = generateSurvey({
 })
 
 test('enables hide on profile attributes', () => {
-  const maleProfile: Profile = {sexAtBirth: 'male'}
-  const {RoutedComponent} = setupRouterTest(<PlainSurveyComponent formModel={dynamicSurvey}
-                                                                  profile={maleProfile}/>)
+  const maleProfile: Profile = { sexAtBirth: 'male' }
+  const { RoutedComponent } = setupRouterTest(<PlainSurveyComponent formModel={dynamicSurvey}
+    profile={maleProfile}/>)
   render(RoutedComponent)
   expect(screen.getByText('You are on page1')).toBeInTheDocument()
   const dynamicText = screen.queryByText('You have a sex of female')
@@ -93,9 +93,9 @@ test('enables hide on profile attributes', () => {
 })
 
 test('enables show on profile attributes', () => {
-  const femaleProfile: Profile = {sexAtBirth: 'female'}
-  const {RoutedComponent} = setupRouterTest(<PlainSurveyComponent formModel={dynamicSurvey}
-                                                                  profile={femaleProfile}/>)
+  const femaleProfile: Profile = { sexAtBirth: 'female' }
+  const { RoutedComponent } = setupRouterTest(<PlainSurveyComponent formModel={dynamicSurvey}
+    profile={femaleProfile}/>)
   render(RoutedComponent)
   expect(screen.getByText('You are on page1')).toBeInTheDocument()
   expect(screen.getByText('You have a sex of female')).toBeInTheDocument()
@@ -119,18 +119,18 @@ const sampleSurvey = {
     elements: [{
       name: 'radioQ',
       type: 'radiogroup',
-      choices: [{text: 'A', value: 'a'}, {text: 'B', value: 'b'}]
+      choices: [{ text: 'A', value: 'a' }, { text: 'B', value: 'b' }]
     }, {
       name: 'textQ',
       type: 'text'
     }, {
       name: 'numberQ',
       type: 'dropdown',
-      choices: [{text: '35', value: 35}, {text: '40', value: 40}]
+      choices: [{ text: '35', value: 35 }, { text: '40', value: 40 }]
     }, {
       name: 'checkboxQ',
       type: 'checkbox',
-      choices: [{text: 'X', value: 'x'}, {text: 'Y', value: 'y'}]
+      choices: [{ text: 'X', value: 'x' }, { text: 'Y', value: 'y' }]
     }]
   }],
   calculatedValues: [
@@ -144,32 +144,32 @@ const sampleSurvey = {
 
 test('gets text answers from survey model', () => {
   const model = new Model(sampleSurvey)
-  model.data = {'textQ': 'some text'}
+  model.data = { 'textQ': 'some text' }
   const answers = getSurveyJsAnswerList(model)
   expect(answers).toHaveLength(2)
-  expect(answers).toContainEqual({questionStableId: 'textQ', stringValue: 'some text'})
-  expect(answers).toContainEqual({questionStableId: 'qualified', booleanValue: false})
+  expect(answers).toContainEqual({ questionStableId: 'textQ', stringValue: 'some text' })
+  expect(answers).toContainEqual({ questionStableId: 'qualified', booleanValue: false })
 })
 
 test('gets choice answers from survey model', () => {
   const model = new Model(sampleSurvey)
-  model.data = {'radioQ': 'b'}
+  model.data = { 'radioQ': 'b' }
   const answers = getSurveyJsAnswerList(model)
   expect(answers).toHaveLength(2)
-  expect(answers).toContainEqual({questionStableId: 'radioQ', stringValue: 'b'})
-  expect(answers).toContainEqual({questionStableId: 'qualified', booleanValue: true})
+  expect(answers).toContainEqual({ questionStableId: 'radioQ', stringValue: 'b' })
+  expect(answers).toContainEqual({ questionStableId: 'qualified', booleanValue: true })
 })
 
 test('gets numeric answers from survey model', () => {
   const model = new Model(sampleSurvey)
-  model.data = {'numberQ': 40}
+  model.data = { 'numberQ': 40 }
   const answers = getSurveyJsAnswerList(model)
-  expect(answers).toContainEqual({questionStableId: 'numberQ', numberValue: 40})
+  expect(answers).toContainEqual({ questionStableId: 'numberQ', numberValue: 40 })
 })
 
 test('gets checkbox answers from survey model', () => {
   const model = new Model(sampleSurvey)
-  model.data = {'checkboxQ': ['x', 'y']}
+  model.data = { 'checkboxQ': ['x', 'y'] }
   const answers = getSurveyJsAnswerList(model)
   expect(answers).toContainEqual({
     questionStableId: 'checkboxQ',
@@ -182,74 +182,90 @@ test('testGetUpdatedAnswersEmpty', () => {
 })
 
 test('testGetUpdatedAnswersRemovedValue', () => {
-  const updatedAnswers = getUpdatedAnswers({'foo': 'bar'}, {})
-  expect(updatedAnswers).toEqual([{questionStableId: 'foo'}])
+  const updatedAnswers = getUpdatedAnswers({ 'foo': 'bar' }, {})
+  expect(updatedAnswers).toEqual([{ questionStableId: 'foo' }])
 })
 
 test('testGetUpdatedAnswersStringNew', () => {
-  const updatedAnswers = getUpdatedAnswers({}, {'foo': 'bar'})
-  expect(updatedAnswers).toEqual([{questionStableId: 'foo', stringValue: 'bar'}])
+  const updatedAnswers = getUpdatedAnswers({}, { 'foo': 'bar' })
+  expect(updatedAnswers).toEqual([{ questionStableId: 'foo', stringValue: 'bar' }])
 })
 
 
 test('testGetUpdatedAnswersStringUnchanged', () => {
-  const updatedAnswers = getUpdatedAnswers({'foo': 'bar'}, {'foo': 'bar'})
+  const updatedAnswers = getUpdatedAnswers({ 'foo': 'bar' }, { 'foo': 'bar' })
   expect(updatedAnswers).toEqual([])
 })
 
 
 test('testGetUpdatedAnswersStringUpdated', () => {
-  const updatedAnswers = getUpdatedAnswers({'foo': 'bar'}, {'foo': 'baz'})
-  expect(updatedAnswers).toEqual([{questionStableId: 'foo', stringValue: 'baz'}])
+  const updatedAnswers = getUpdatedAnswers({ 'foo': 'bar' }, { 'foo': 'baz' })
+  expect(updatedAnswers).toEqual([{ questionStableId: 'foo', stringValue: 'baz' }])
+})
+
+test('testGetUpdatedAnswersOtherAdded', () => {
+  const updatedAnswers = getUpdatedAnswers({ 'foo': 'bar' }, { 'foo': 'baz', 'foo-Comment': 'blah' })
+  expect(updatedAnswers).toEqual([{ questionStableId: 'foo', stringValue: 'baz', otherDescription: 'blah' }])
+})
+
+test('testGetUpdatedAnswersOtherRemoved', () => {
+  const updatedAnswers = getUpdatedAnswers({ 'foo': 'bar', 'foo-Comment': 'blah' }, { 'foo': 'baz' })
+  expect(updatedAnswers).toEqual([{ questionStableId: 'foo', stringValue: 'baz' }])
+})
+
+test('testGetUpdatedAnswersOtherChanged', () => {
+  const updatedAnswers = getUpdatedAnswers({ 'foo': 'bar', 'foo-Comment': 'blah' },
+    { 'foo': 'baz', 'foo-Comment': 'blah2' })
+  expect(updatedAnswers).toEqual([{ questionStableId: 'foo', stringValue: 'baz', otherDescription: 'blah2' }])
 })
 
 test('testGetUpdatedAnswersBooleanNew', () => {
-  const updatedAnswers = getUpdatedAnswers({}, {'foo': false})
-  expect(updatedAnswers).toEqual([{questionStableId: 'foo', booleanValue: false}])
+  const updatedAnswers = getUpdatedAnswers({}, { 'foo': false })
+  expect(updatedAnswers).toEqual([{ questionStableId: 'foo', booleanValue: false }])
 })
 
 test('testGetUpdatedAnswersBooleanUnchanged', () => {
-  const updatedAnswers = getUpdatedAnswers({'foo': false}, {'foo': false})
+  const updatedAnswers = getUpdatedAnswers({ 'foo': false }, { 'foo': false })
   expect(updatedAnswers).toEqual([])
 })
 
 test('testGetUpdatedAnswersBooleanChanged', () => {
-  const updatedAnswers = getUpdatedAnswers({'foo': true}, {'foo': false})
-  expect(updatedAnswers).toEqual([{questionStableId: 'foo', booleanValue: false}])
+  const updatedAnswers = getUpdatedAnswers({ 'foo': true }, { 'foo': false })
+  expect(updatedAnswers).toEqual([{ questionStableId: 'foo', booleanValue: false }])
 })
 
 test('testGetUpdatedAnswersObjectNew', () => {
-  const updatedAnswers = getUpdatedAnswers({}, {'foo': ['bleck']})
-  expect(updatedAnswers).toEqual([{questionStableId: 'foo', objectValue: JSON.stringify(['bleck'])}])
+  const updatedAnswers = getUpdatedAnswers({}, { 'foo': ['bleck'] })
+  expect(updatedAnswers).toEqual([{ questionStableId: 'foo', objectValue: JSON.stringify(['bleck']) }])
 })
 
 test('testGetUpdatedAnswersObjectChanged', () => {
-  const updatedAnswers = getUpdatedAnswers({'foo': ['blah']}, {'foo': ['bleck']})
-  expect(updatedAnswers).toEqual([{questionStableId: 'foo', objectValue: JSON.stringify(['bleck'])}])
+  const updatedAnswers = getUpdatedAnswers({ 'foo': ['blah'] }, { 'foo': ['bleck'] })
+  expect(updatedAnswers).toEqual([{ questionStableId: 'foo', objectValue: JSON.stringify(['bleck']) }])
 })
 
 test('testGetUpdatedAnswersObjectUnchanged', () => {
-  const updatedAnswers = getUpdatedAnswers({'foo': ['blah']}, {'foo': ['blah']})
+  const updatedAnswers = getUpdatedAnswers({ 'foo': ['blah'] }, { 'foo': ['blah'] })
   expect(updatedAnswers).toEqual([])
 })
 
 test('testGetUpdatedAnswersNumberNew', () => {
-  const updatedAnswers = getUpdatedAnswers({}, {'foo': 2})
-  expect(updatedAnswers).toEqual([{questionStableId: 'foo', numberValue: 2}])
+  const updatedAnswers = getUpdatedAnswers({}, { 'foo': 2 })
+  expect(updatedAnswers).toEqual([{ questionStableId: 'foo', numberValue: 2 }])
 })
 
 test('testGetUpdatedAnswersNumberNewZero', () => {
-  const updatedAnswers = getUpdatedAnswers({}, {'foo': 0})
-  expect(updatedAnswers).toEqual([{questionStableId: 'foo', numberValue: 0}])
+  const updatedAnswers = getUpdatedAnswers({}, { 'foo': 0 })
+  expect(updatedAnswers).toEqual([{ questionStableId: 'foo', numberValue: 0 }])
 })
 
 test('testGetUpdatedAnswersNumberChanged', () => {
-  const updatedAnswers = getUpdatedAnswers({'foo': 2}, {'foo': 3})
-  expect(updatedAnswers).toEqual([{questionStableId: 'foo', numberValue: 3}])
+  const updatedAnswers = getUpdatedAnswers({ 'foo': 2 }, { 'foo': 3 })
+  expect(updatedAnswers).toEqual([{ questionStableId: 'foo', numberValue: 3 }])
 })
 
 test('testGetUpdatedAnswersNumberUnchanged', () => {
-  const updatedAnswers = getUpdatedAnswers({'foo': 4}, {'foo': 4})
+  const updatedAnswers = getUpdatedAnswers({ 'foo': 4 }, { 'foo': 4 })
   expect(updatedAnswers).toEqual([])
 })
 

--- a/ui-participant/src/util/surveyJsUtils.tsx
+++ b/ui-participant/src/util/surveyJsUtils.tsx
@@ -26,6 +26,7 @@ import _union from 'lodash/union'
 import _keys from 'lodash/keys'
 import _isEqual from 'lodash/isEqual'
 
+const SURVEY_JS_OTHER_SUFFIX = '-Comment'
 
 // See https://surveyjs.io/form-library/examples/control-data-entry-formats-with-input-masks/reactjs#content-code
 widgets.inputmask(SurveyCore)
@@ -232,9 +233,9 @@ export function getSurveyJsAnswerList(surveyJSModel: SurveyModel): Answer[] {
   return Object.entries(surveyJSModel.data)
     // don't make answers for the descriptive sections
     .filter(([key]) => {
-      return surveyJSModel.getQuestionByName(key)?.getType() !== 'html'
+      return !key.endsWith(SURVEY_JS_OTHER_SUFFIX) && surveyJSModel.getQuestionByName(key)?.getType() !== 'html'
     })
-    .map(([key, value]) => makeAnswer(value as SurveyJsValueType, key))
+    .map(([key, value]) => makeAnswer(value as SurveyJsValueType, key, surveyJSModel.data))
 }
 
 /** convert a list of answers and resumeData into the resume data format surveyJs expects */
@@ -247,6 +248,9 @@ export function makeSurveyJsData(resumeData: string | undefined, answers: Answer
         hash[answer.questionStableId] = JSON.parse(answer.objectValue)
       } else {
         hash[answer.questionStableId] = answer.stringValue ?? answer.numberValue ?? null
+      }
+      if (answer.otherDescription) {
+        hash[answer.questionStableId + SURVEY_JS_OTHER_SUFFIX] = answer.otherDescription
       }
       return hash
     }, {})
@@ -263,7 +267,8 @@ export function makeSurveyJsData(resumeData: string | undefined, answers: Answer
 }
 
 /** return an Answer for the given value.  This should be updated to take some sort of questionType/dataType param */
-export function makeAnswer(value: SurveyJsValueType, questionStableId: string): Answer {
+export function makeAnswer(value: SurveyJsValueType, questionStableId: string,
+  surveyJsData: Record<string, SurveyJsValueType>): Answer {
   const answer: Answer = { questionStableId }
   if (typeof value === 'string') {
     answer.stringValue = value
@@ -273,6 +278,13 @@ export function makeAnswer(value: SurveyJsValueType, questionStableId: string): 
     answer.booleanValue = value
   } else if (value) {
     answer.objectValue = JSON.stringify(value)
+  }
+  if (surveyJsData[questionStableId + SURVEY_JS_OTHER_SUFFIX]) {
+    // surveyJS "other" descriptions are always strings
+    answer.otherDescription = surveyJsData[questionStableId + SURVEY_JS_OTHER_SUFFIX] as string
+  } else if (questionStableId.endsWith(SURVEY_JS_OTHER_SUFFIX)) {
+    const baseStableId = questionStableId.substring(0, questionStableId.lastIndexOf('-'))
+    return makeAnswer(surveyJsData[baseStableId], baseStableId, surveyJsData)
   }
   return answer
 }
@@ -330,7 +342,9 @@ type PearlQuestion = Question & {
 export function getUpdatedAnswers(original: Record<string, SurveyJsValueType>,
   updated: Record<string, SurveyJsValueType>): Answer[] {
   const allKeys = _union(_keys(original), _keys(updated))
-  const updatedAnswers = allKeys.filter(key => !_isEqual(original[key], updated[key]))
-    .map(key => makeAnswer(updated[key], key))
-  return updatedAnswers
+  const updatedKeys = allKeys.filter(key => !_isEqual(original[key], updated[key]))
+    .map(key => key.endsWith(SURVEY_JS_OTHER_SUFFIX) ? key.substring(0, key.lastIndexOf(SURVEY_JS_OTHER_SUFFIX)) : key)
+  const dedupedKeys = Array.from(new Set(updatedKeys).values())
+
+  return dedupedKeys.map(key => makeAnswer(updated[key], key, updated))
 }


### PR DESCRIPTION
SurveyJS maps free-text other entries as entirely separate answers with the magic-string "-Comment" suffixed to the question name.  Needless to say, we don't want to mimic that model in our backend.  So this adds mapping in the frontend between that format, and our Answer data structure, with has an explicit "otherDescription" field.

This also contains a minor fix to address the response status bug that Brian might have found earlier today in team testing where a completed survey got spontaneously set to not complete-- now we have an explicit check to make sure that a response status can't be reverted once it's complete.  The check isn't thread-safe, so there still might be rare race conditions, but this should significantly reduce the frequency.

TO TEST:
1. restart participantAPIApp
2. sign https://sandbox.ourhealth.localhost:3001/ as consented@test.com
3. go to the basics survey
4. scroll down to "Which term best describes your gender identity? (Check all that apply) *".  Select "None of these describe me" and enter some free text.  
5. Reload the page, and confirm your answer is persisted