### PR TITLE
[JN-316] Set widthMode for all surveys

### DIFF
--- a/ui-participant/src/util/surveyJsUtils.tsx
+++ b/ui-participant/src/util/surveyJsUtils.tsx
@@ -168,6 +168,7 @@ export function useSurveyJSModel(
     newSurveyModel.setVariable('profile', profile)
 
     newSurveyModel.showTitle = false
+    newSurveyModel.widthMode = 'static'
     setSurveyModel(newSurveyModel)
   }
 


### PR DESCRIPTION
If not set, SurveyJS automatically determines [widthMode](https://surveyjs.io/form-library/documentation/api-reference/survey-data-model#widthMode) based on the elements in the survey.

For some reason, the medication survey is currently getting set to "responsive", so it fills the page width, while all other surveys are "static" and a fixed width. We want all surveys to be consistent, so this sets widthMode to static in `useSurveyJSModel`.