### PR TITLE
[JN-105] Do not scroll to first question on page

### DIFF
--- a/ui-participant/src/util/surveyJsUtils.tsx
+++ b/ui-participant/src/util/surveyJsUtils.tsx
@@ -167,6 +167,7 @@ export function useSurveyJSModel(
     newSurveyModel.currentPageNo = pageNumber
     newSurveyModel.setVariable('profile', profile)
 
+    newSurveyModel.focusFirstQuestionAutomatic = false
     newSurveyModel.showTitle = false
     newSurveyModel.widthMode = 'static'
     setSurveyModel(newSurveyModel)


### PR DESCRIPTION
Currently, when going to the next page in a survey, SurveyJS automatically focuses the first input and scrolls so that the input is visible. If a survey has a large amount of content before the first question (such as in the consent survey) some of that content may be scrolled past.

This prevents that behavior by setting the survey's [focusFirstQuestionAutomatic](https://surveyjs.io/form-library/documentation/api-reference/survey-data-model#focusFirstQuestionAutomatic) setting to false.

## Before
https://user-images.githubusercontent.com/1156625/234671657-6fe5154c-81be-42f9-8a95-d24caafb5ae0.mov

## After
https://user-images.githubusercontent.com/1156625/234671696-2b84349a-c1ba-4477-ac46-d0a48e6d5bbe.mov


