### PR TITLE
[JN-293] Update how survey is skipped for no family history knowledge

### DIFF
--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/familyHistory.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/familyHistory.json
@@ -5,12 +5,6 @@
   "jsonContent": {
     "showQuestionNumbers": "off",
     "showProgressBar": "bottom",
-    "triggers": [
-      {
-        "type": "complete",
-        "expression": "{oh_oh_famHx_famKnowledge} = 'none'"
-      }
-    ],
     "questionTemplates": [
       {
         "name": "oh_oh_famHx_ageAtHeartAttack",
@@ -166,6 +160,7 @@
         ]
       },
       {
+        "visibleIf": "{oh_oh_famHx_famKnowledge} != 'none'",
         "elements": [
           {
             "type": "panel",
@@ -539,6 +534,7 @@
           }
         ]
       },{
+        "visibleIf": "{oh_oh_famHx_famKnowledge} != 'none'",
         "elements": [
           {
             "type": "panel",
@@ -723,6 +719,7 @@
           ]
         }]
       },{
+        "visibleIf": "{oh_oh_famHx_famKnowledge} != 'none'",
         "elements": [
           {
             "type": "panel",
@@ -904,6 +901,7 @@
           ]
         }]
       },{
+        "visibleIf": "{oh_oh_famHx_famKnowledge} != 'none'",
         "elements": [
           {
             "type": "panel",
@@ -1089,6 +1087,7 @@
           ]
         }]
       },{
+        "visibleIf": "{oh_oh_famHx_famKnowledge} != 'none'",
         "elements": [{
           "type": "panel",
           "elements": [
@@ -1272,6 +1271,7 @@
           ]
         }]
       },{
+        "visibleIf": "{oh_oh_famHx_famKnowledge} != 'none'",
         "elements": [{
           "type": "panel",
           "elements": [
@@ -1452,6 +1452,7 @@
           ]
         }]
       },{
+        "visibleIf": "{oh_oh_famHx_famKnowledge} != 'none'",
         "elements": [{
           "type": "panel",
           "elements": [


### PR DESCRIPTION
The first question of the family history survey asks:
> How much do you know about illnesses or health problems of your parents, grandparents, brothers, sisters, and/or children?

If the user answers "None at all", then the rest of the survey is skipped.

Currently, this is implemented using a trigger. This works fine when initially filling out the survey. However, when returning to a previous completed survey, the survey shows the full 8 pages and a "Next" button. Clicking "Next" returns to the dashboard.

This replaces the trigger with `visibleIf` conditions on all following pages. This way, when returning to a completed survey, the survey says it only has one page and shows a "Complete" button.

## Before
https://user-images.githubusercontent.com/1156625/234676952-71a01c64-242f-45dc-92b1-02c9c50ef448.mov

## After
https://user-images.githubusercontent.com/1156625/234676822-9ac91332-9fbe-4c0b-9efb-97fbdcb769d9.mov


