### PR TITLE
Update navbar design

### DIFF
--- a/ui-participant/src/Navbar.tsx
+++ b/ui-participant/src/Navbar.tsx
@@ -1,3 +1,5 @@
+import { faUser } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Collapse } from 'bootstrap'
 import classNames from 'classnames'
 import React, { useEffect, useId, useRef } from 'react'
@@ -92,17 +94,54 @@ export default function Navbar(props: NavbarProps) {
               </li>
             </>
           )}
-          {!user.isAnonymous && <li className="nav-item dropdown">
-            <a className={classNames(navLinkClasses, 'dropdown-toggle')} href="#"
-              role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              {user.username}
-            </a>
-            <ul className="dropdown-menu">
-              <li><Link className="dropdown-item" to="/hub">Dashboard</Link></li>
-              <li><hr className="dropdown-divider" /></li>
-              <li><a className="dropdown-item" onClick={doLogout}>Log Out</a></li>
-            </ul>
-          </li>}
+          {!user.isAnonymous && (
+            <>
+              <li className="nav-item">
+                <Link
+                  className={classNames(
+                    'btn btn-lg btn-outline-primary',
+                    'd-flex justify-content-center',
+                    'ms-lg-3'
+                  )}
+                  to="/hub"
+                >
+                  Dashboard
+                </Link>
+              </li>
+              <li className="nav-item dropdown d-flex flex-column">
+                <button
+                  aria-expanded="false"
+                  aria-label={user.username}
+                  className={classNames(
+                    navLinkClasses,
+                    'btn btn-text dropdown-toggle text-start'
+                  )}
+                  data-bs-toggle="dropdown"
+                >
+                  <FontAwesomeIcon className="d-none d-lg-inline" icon={faUser} />
+                  <span className="d-lg-none">{user.username}</span>
+                </button>
+                <div className="dropdown-menu dropdown-menu-end">
+                  <p
+                    className="d-none d-lg-block"
+                    style={{
+                      padding: 'var(--bs-dropdown-item-padding-y) var(--bs-dropdown-item-padding-x)',
+                      margin: 0,
+                      fontWeight: 400,
+                      color: 'var(--bs-dropdown-link-color)',
+                      whiteSpace: 'nowrap'
+                    }}
+                  >
+                    {user.username}
+                  </p>
+                  <hr className="dropdown-divider d-none d-lg-block" />
+                  <button className="dropdown-item" onClick={doLogout}>
+                    Log Out
+                  </button>
+                </div>
+              </li>
+            </>
+          )}
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Currently, when logged in, it's not obvious how to get back to the dashboard. You have to click on the dropdown with your email address to find the link. On mobile, it takes 3 clicks: expand the navbar, expand the email address dropdown, and then click the link.

This updates the design of the navbar to include a link to the dashboard.

To save space, it moves the user's email address into the dropdown and uses an icon button to toggle the dropdown. On mobile, that icon is replaced with the user's email address.

## Before
![Screenshot 2023-04-28 at 3 55 25 PM](https://user-images.githubusercontent.com/1156625/235242636-561e0880-c116-4bc7-a1b6-dc4636ff8d95.png)
![Screenshot 2023-04-28 at 3 58 18 PM](https://user-images.githubusercontent.com/1156625/235242638-70610850-32e5-4c58-930f-c31a00d50b87.png)
![Screenshot 2023-04-28 at 3 58 31 PM](https://user-images.githubusercontent.com/1156625/235242639-923ae81d-da43-4be3-965b-2485d508f737.png)

## After
![Screenshot 2023-04-28 at 3 57 35 PM](https://user-images.githubusercontent.com/1156625/235242926-2a3d3625-714c-484c-9081-2ea0f50b3985.png)
![Screenshot 2023-04-28 at 3 57 39 PM](https://user-images.githubusercontent.com/1156625/235242927-9464d211-af2c-4367-9b9b-3332c4971936.png)
![Screenshot 2023-04-28 at 3 58 45 PM](https://user-images.githubusercontent.com/1156625/235242928-c6053b71-7226-427b-bed7-cb9708b3b78e.png)

