### PR TITLE
[JN-304] Remove date picker from consent form

### DIFF
--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/ourHealthConsent.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/ourHealthConsent.json
@@ -7,6 +7,17 @@
   "logoPosition": "right",
   "showQuestionNumbers": "off",
   "showProgressBar": "bottom",
+  "calculatedValues": [
+    {
+      "name": "oh_oh_consent_signatureDate",
+      "expression": "currentDate()",
+      "includeIntoResult": true
+    },
+    {
+      "name": "formattedSignatureDate",
+      "expression": "formatDate({oh_oh_consent_signatureDate})"
+    }
+  ],
   "pages": [
     {
       "name": "infoPage",
@@ -165,13 +176,14 @@
           "title": "Full legal name"
         },
         {
-          "type": "text",
-          "isRequired": true,
-          "name": "oh_oh_consent_signatureDate",
-          "title": "Date/Time",
-          "inputType": "date",
-          "minValueExpression": "today()",
-          "maxValueExpression": "today()"
+          "type": "panel",
+          "elements": [
+            {
+              "type": "html",
+              "name": "signatureDateDisplay",
+              "html": "<p style='padding-top:2rem;margin:0;'><span style='font-weight:600;'>Today's date</span>: {formattedSignatureDate}.</p>"
+            }
+          ]
         },
         {
           "type": "signaturepad",

--- a/ui-participant/src/util/formatDate.ts
+++ b/ui-participant/src/util/formatDate.ts
@@ -1,0 +1,16 @@
+import { FunctionFactory } from 'survey-core'
+
+const formatDate = (params: unknown[]) => {
+  if (params.length !== 1) {
+    return null
+  }
+
+  const date = params[0]
+  if (!(date instanceof Date)) {
+    return null
+  }
+
+  return date.toLocaleDateString()
+}
+
+FunctionFactory.Instance.register('formatDate', formatDate)

--- a/ui-participant/src/util/surveyJsUtils.tsx
+++ b/ui-participant/src/util/surveyJsUtils.tsx
@@ -26,6 +26,7 @@ import _union from 'lodash/union'
 import _keys from 'lodash/keys'
 import _isEqual from 'lodash/isEqual'
 import { usePortalEnv } from 'providers/PortalProvider'
+import './formatDate'
 
 const SURVEY_JS_OTHER_SUFFIX = '-Comment'
 


### PR DESCRIPTION
Currently, the consent form displays a date picker but only allows selecting the current date. It's pointless to make the user select that date, so this replaces the date picker with an HTML element that displays the current date.

My original plan was to set the date input's default value and make it read only. However, default values don't seem to be working and I couldn't figure out why. So this uses a [calculated value](https://surveyjs.io/form-library/examples/survey-calculatedvalues/reactjs) to store the signature date in the survey record and it uses a [custom expression function](https://surveyjs.io/form-library/documentation/design-survey/conditional-logic#implement-a-custom-function) to format the date for display. The formatted date has to be stored in another calculated value because HTML elements do not support expressions.

![Screenshot 2023-05-02 at 11 50 22 AM](https://user-images.githubusercontent.com/1156625/235719941-bec97279-19d2-49df-bd85-de66268cbaeb.png)


