### PR TITLE
Adjust spacing in FAQ answers

### DIFF
--- a/ui-participant/src/landing/sections/FrequentlyAskedQuestionsTemplate.tsx
+++ b/ui-participant/src/landing/sections/FrequentlyAskedQuestionsTemplate.tsx
@@ -99,7 +99,7 @@ const FrequentlyAskedQuestion = (props: FrequentlyAskedQuestionProps) => {
         {question}
       </button>
       <div ref={collapseRef} className="collapse px-0 px-sm-2 ms-2" id={idFor(question)}>
-        <Markdown className="fs-5" style={{ marginLeft: 20 }}>
+        <Markdown className="mb-3 fs-5" style={{ marginLeft: 20 }}>
           {answer}
         </Markdown>
       </div>


### PR DESCRIPTION
Currently, there is no space between FAQ answer text and the border separating FAQ entries. This adds some.

## Before
![Screenshot 2023-05-02 at 1 37 28 PM](https://user-images.githubusercontent.com/1156625/235742271-0dffeec9-30a7-40b0-a9fa-85c542106b70.png)


## After
![Screenshot 2023-05-02 at 1 35 17 PM](https://user-images.githubusercontent.com/1156625/235742093-4bbc082d-92db-41ef-b628-9aef4220cf36.png)
