### PR TITLE
[JN-26] Fully sign-out of admin UI

### DIFF
--- a/ui-admin/src/authConfig.ts
+++ b/ui-admin/src/authConfig.ts
@@ -17,7 +17,8 @@ export const getOidcConfig = (
   b2cPolicyName: string = aadb2cPolicyName) => {
   const metadata = {
     authorization_endpoint: `https://${b2cTenantName}.b2clogin.com/${b2cTenantName}.onmicrosoft.com/${b2cPolicyName}/oauth2/v2.0/authorize`,
-    token_endpoint: `https://${b2cTenantName}.b2clogin.com/${b2cTenantName}.onmicrosoft.com/${b2cPolicyName}/oauth2/v2.0/token`
+    token_endpoint: `https://${b2cTenantName}.b2clogin.com/${b2cTenantName}.onmicrosoft.com/${b2cPolicyName}/oauth2/v2.0/token`,
+    end_session_endpoint: `https://${b2cTenantName}.b2clogin.com/${b2cTenantName}.onmicrosoft.com/${b2cPolicyName}/oauth2/v2.0/logout`
   }
 
   return {
@@ -25,6 +26,7 @@ export const getOidcConfig = (
     client_id: b2cClientId,
     popup_redirect_uri: `${window.origin}/redirect-from-oauth`,
     silent_redirect_uri: `${window.origin}/redirect-from-oauth-silent`,
+    post_logout_redirect_uri: window.origin,
     metadata,
     prompt: 'login',
     scope: `openid email ${b2cClientId}`,

--- a/ui-admin/src/user/UserProvider.tsx
+++ b/ui-admin/src/user/UserProvider.tsx
@@ -58,9 +58,14 @@ export default function UserProvider({ children }: { children: React.ReactNode }
   const logoutUser = () => {
     setUserState(anonymousUser)
     Api.setBearerToken(null)
+    const oauthAccessToken = localStorage.getItem(OAUTH_ACCRESS_TOKEN_KEY)
     localStorage.removeItem(OAUTH_ACCRESS_TOKEN_KEY)
     localStorage.removeItem(INTERNAL_LOGIN_TOKEN_KEY)
-    window.location.href = '/'
+    if (oauthAccessToken) {
+      auth.signoutRedirect()
+    } else {
+      window.location.href = '/'
+    }
   }
 
   const userContext: UserContextT = {


### PR DESCRIPTION
Addresses an issue I discovered while working on token refresh. Prior to this, when signing out, the access token managed by the oidc-client-ts library was still in local storage. When that token got close to expiration, it would fetch a new access token and the user would be automatically signed back in. This makes sure we let oidc-client-ts know about the sign-out so it clears its local storage. (Since B2C gets invoked as well, it may invalidate the existing token; I didn't test that part.)