### PR TITLE
[JN-44] Add terms of use privacy policy to admin site

### DIFF
--- a/ui-admin/src/App.tsx
+++ b/ui-admin/src/App.tsx
@@ -20,6 +20,8 @@ import { getOidcConfig } from 'authConfig'
 import { AuthProvider } from 'react-oidc-context'
 import PortalRouter from './portal/PortalRouter'
 import UserList from './user/UserList'
+import InvestigatorTermsOfUsePage from './terms/InvestigatorTermsOfUsePage'
+import PrivacyPolicyPage from 'terms/PrivacyPolicyPage'
 
 
 /** container for the app including the router  */
@@ -35,12 +37,14 @@ function App() {
                 <NavbarProvider>
                   <BrowserRouter>
                     <Routes>
-                      <Route element={<ProtectedRoute/>}>
-                        <Route path="/" element={<PageFrame/>}>
+                      <Route path="/" element={<PageFrame/>}>
+                        <Route element={<ProtectedRoute/>}>
                           <Route path="users" element={<UserList/>}/>
                           <Route path=":portalShortcode/*" element={<PortalProvider><PortalRouter/></PortalProvider>}/>
                           <Route index element={<PortalList/>}/>
                         </Route>
+                        <Route path="privacy" element={<PrivacyPolicyPage />} />
+                        <Route path="terms" element={<InvestigatorTermsOfUsePage />} />
                         <Route path="*" element={<div>Unknown page</div>}/>
                       </Route>
                       <Route path='redirect-from-oauth' element={<RedirectFromOAuth/>}/>

--- a/ui-admin/src/login/Login.tsx
+++ b/ui-admin/src/login/Login.tsx
@@ -4,6 +4,7 @@ import googleLogo from 'images/googleLogo.png'
 import Api, { AdminUser } from 'api/api'
 import { useUser } from 'user/UserProvider'
 import { useAuth } from 'react-oidc-context'
+import { Link } from 'react-router-dom'
 
 /** component for showing a login dialog that hides other content on the page */
 function Login() {
@@ -66,6 +67,11 @@ function Login() {
         </div> }
         { isError && <div className="text-danger text-center">Login failed</div> }
       </form>
+      <hr className="mt-2"/>
+      <div className="text-center">
+        <Link className="link-light" to="/terms">Terms of Use</Link> |{' '}
+        <Link className="link-light" to="/privacy">Privacy Policy</Link>
+      </div>
     </div>
   </div>
 }

--- a/ui-admin/src/navbar/AdminNavbar.tsx
+++ b/ui-admin/src/navbar/AdminNavbar.tsx
@@ -3,7 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { UserContextT, useUser } from 'user/UserProvider'
 import { faBars } from '@fortawesome/free-solid-svg-icons/faBars'
 
-import { Link, NavLink } from 'react-router-dom'
+import { Link, NavLink, NavLinkProps } from 'react-router-dom'
 import { NavbarContext, NavbarContextT } from './NavbarProvider'
 
 /** note we name this adminNavbar to avoid naming conflicts with bootstrap navbar */
@@ -69,21 +69,36 @@ function AdminNavbar({ breadCrumbs, sidebarContent, showSidebar, setShowSidebar 
         </div>
       </div>
     </nav>
-    {(showSidebar && sidebarContent) && <div style={{
-      position: 'absolute',
-      top: '56px',
-      backgroundColor: 'rgb(92, 101, 117)',
-      maxWidth: '280px',
-      minWidth: '280px',
-      height: 'calc(100% - 56px)',
-      color: '#f0f0f0',
-      zIndex: 80
-    }} ref={sidebarRef}>
-      { sidebarContent.map((content, index) => <div key={index}>
-        {content}
-        <hr/>
-      </div>)}
-    </div>}
+    {showSidebar && (
+      <div
+        ref={sidebarRef}
+        style={{
+          position: 'absolute',
+          top: '56px',
+          backgroundColor: 'rgb(92, 101, 117)',
+          maxWidth: '280px',
+          minWidth: '280px',
+          height: 'calc(100% - 56px)',
+          display: 'flex',
+          flexDirection: 'column',
+          color: '#f0f0f0',
+          zIndex: 80
+        }}
+      >
+        <div className="flex-grow-1">
+          {sidebarContent && sidebarContent.map((content, index) => (
+            <div key={index}>
+              {content}
+              <hr/>
+            </div>
+          ))}
+        </div>
+        <div className="p-3">
+          <SidebarNavLink to="/terms" style={{ display: 'inline' }}>Terms of Use</SidebarNavLink> |{' '}
+          <SidebarNavLink to="/privacy" style={{ display: 'inline' }}>Privacy Policy</SidebarNavLink>
+        </div>
+      </div>
+    )}
   </>
 }
 
@@ -111,12 +126,16 @@ export function SidebarContent({ children }: {children: React.ReactNode}) {
 }
 
 /** renders a link in the sidebar with appropriate style and onClick handler to close the sidebar when clicked */
-export function SidebarNavLink({ to, children }: {to: string, children: React.ReactNode}) {
+export function SidebarNavLink(props: NavLinkProps) {
   const { setShowSidebar } = useContext(NavbarContext)
-  return <NavLink to={to} className="nav-link" onClick={() => setShowSidebar(false)}
-    style={{ color: '#fff' }}>
-    {children}
-  </NavLink>
+  return (
+    <NavLink
+      {...props}
+      className="nav-link"
+      onClick={() => setShowSidebar(false)}
+      style={{ ...props.style, color: '#fff' }}
+    />
+  )
 }
 
 /**

--- a/ui-admin/src/terms/InvestigatorTermsOfUsePage.tsx
+++ b/ui-admin/src/terms/InvestigatorTermsOfUsePage.tsx
@@ -1,0 +1,349 @@
+import classNames from 'classnames'
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+type SectionHeadingProps = JSX.IntrinsicElements['h2']
+
+const SectionHeading = (props: SectionHeadingProps) => {
+  const { className, ...otherProps } = props
+  return <h2 {...otherProps} className={classNames('h3', className)} />
+}
+
+const InvestigatorTermsOfUse = () => {
+  return (
+    <>
+      <h1 className="h2 text-center mb-5">
+        Broad Institute
+        <br />
+        Juniper Platform
+        <br />
+        Investigator Terms of Use
+      </h1>
+      <p>Effective Date: April 28, 2023</p>
+
+      <p>
+        Please read these Terms of Use (these <strong>“Terms”</strong>)
+        carefully, as they constitute a binding contract between you, an
+        investigator or other researcher (<strong>“you”</strong> or{' '}
+        <strong>“your”</strong>) and The Broad Institute, Inc. (
+        <strong>“Broad,”</strong> <strong>“we,”</strong> <strong>“us,”</strong>{' '}
+        or <strong>“our”</strong>).
+      </p>
+      <p>
+        These Terms of Use (<strong>“Terms”</strong>) apply to your use of the
+        Juniper Platform, which can be accessed by our website{' '}
+        <a href="https://juniper.terra.bio">juniper.terra.bio</a> (collectively,
+        the <strong>“Platform”</strong>). By clicking “I accept” or by using or
+        accessing the Platform, you agree to be bound by these Terms. If you do
+        not agree to these Terms, you may not access or use the Platform.{' '}
+      </p>
+      <p>
+        We reserve the right to change or otherwise modify these Terms at any
+        time. All changes are effective immediately when we post them, and apply
+        to all access to and use of the Platform thereafter. We may also notify
+        you by sending an email notification to the address associated with your
+        Account (as defined below) or providing notice through our Platform.
+        Your continued access or use of the Platform after receiving notice of
+        any update, modification or other change to these Terms signifies your
+        acceptance thereof.
+      </p>
+
+      <SectionHeading>1. General Overview of the Platform</SectionHeading>
+      <p>
+        We have developed the Platform to enable you to connect with users
+        participating in certain research projects (each, a{' '}
+        <strong>“Research Project”</strong>), and provide tools to help you,
+        your staff and your collaborators analyze data.
+      </p>
+
+      <SectionHeading>
+        2. Creating an Account; Accessing the Platform
+      </SectionHeading>
+      <p>
+        To access and use certain features of the Platform, you might need to
+        register for an account (<strong>“Account”</strong>) by creating a
+        password and providing your name, email address, phone number and other
+        information. If you register for an Account, you must provide accurate
+        information and promptly update this information if it changes. You may
+        not permit any other person to access the Platform using your user name
+        and password, and the use of your Account is your responsibility. If you
+        learn or suspect that your user name or password has been wrongfully
+        used or disclosed, you should promptly notify us and immediately reset
+        your password. To help ensure the security of your password or Account,
+        please sign out of your Account at the end of each session.
+      </p>
+
+      <SectionHeading>3. Privacy</SectionHeading>
+      <p>
+        Broad understands the importance of confidentiality and privacy
+        regarding your information. Please see our{' '}
+        <Link to="/privacy">Privacy Policy</Link> for a description of how we
+        collect, use and disclose your personal information when you access or
+        use the Platform. By using the Platform or by clicking to accept or
+        agree to these Terms when this option is made available to you, you
+        consent to our use of your information and our contacting you, in each
+        case, in compliance with our Privacy Policy.
+      </p>
+
+      <SectionHeading>4. Communication Preferences</SectionHeading>
+      <p>
+        By creating an Account, you also consent to receive electronic
+        communications from Broad (e.g., via email, text message, or by posting
+        notices to the Platform). These communications may include operational
+        notices about your Account (e.g., password changes and other
+        transactional information) and are part of your relationship with us.
+        You agree that any communications that we send to you electronically
+        will satisfy any legal communication requirements, including that such
+        communications be in writing.
+      </p>
+
+      <SectionHeading>5. Relationship Between You and Broad</SectionHeading>
+      <p>
+        You acknowledge that you are an independent contractor, and that no
+        agency, partnership, joint venture or employee-employer relationship is
+        intended or created by these Terms or any relationship between you and
+        Broad.
+      </p>
+      <p>
+        You agree to provide complete and accurate information when registering
+        to use the Platform and to keep that information updated; this ensures
+        that we can properly identify and contact you.
+      </p>
+      <p>
+        As a user of the Platform, you represent to us that you meet these
+        eligibility requirements and that you have the right to provide the
+        information and User Content (as defined in Section 7 below), and that
+        such information and User Content does not violate these Terms or any
+        other person’s rights or any law.
+      </p>
+
+      <SectionHeading>6. Proprietary Rights</SectionHeading>
+      <p>
+        All original content, materials, features and functionality (including
+        text, information, images, photos, graphics, artworks, logos, videos,
+        audios, directories, listings, databases, and search engines) available
+        via the Platform (the “Content”) are owned by Broad and/or its licensors
+        (including, when applicable, investigators) and may be protected by U.S.
+        and foreign copyright, trademark and other intellectual property laws.
+        Subject to your compliance with these Terms, we grant you a limited,
+        non-exclusive, non-transferable right and license to access and use the
+        Platform and Content; provided, however, that such license does not
+        include any right to (a) sell or resell our Platform or the Content; (b)
+        copy, reproduce, distribute, publicly perform or publicly display
+        Content, except as expressly permitted by us or our licensors; (c)
+        modify the Content, remove any proprietary rights notices or markings,
+        or otherwise make any derivative uses of our Platform and the Content;
+        (d) use any data mining, medical robots or similar data gathering or
+        extraction methods; and (e) use our Platform or the Content other than
+        for their intended purposes. Except for this limited license granted to
+        you, we reserve all other rights. This license may be revoked and
+        terminated by us at any time and for any reason. Any unauthorized use,
+        reproduction or distribution of the Platform or Content is strictly
+        prohibited and may result in termination of the license granted herein,
+        as well as civil and/or criminal penalties.
+      </p>
+      <p>
+        All trademarks, trade names and logos appearing on or through the
+        Platform are owned or licensed by us. The “Broad Institute” name and
+        logo and all other Broad names, marks, logos and other identifiers are
+        trademarks and service marks of Broad. You may not use or display any
+        Broad trademarks, trade names, or logos without our prior written
+        permission. We reserve all rights.
+      </p>
+      <p>
+        If you choose to provide us with any comments, suggestions, ideas or
+        other feedback, you agree that we have an unrestricted right to use
+        them, and you are not entitled to receive any compensation.
+      </p>
+
+      <SectionHeading>7. Uploaded Information and User Content</SectionHeading>
+      <p>
+        The Platform may contain medical and other information about
+        participants in the Research Projects (
+        <strong>“Participant Information”</strong>). This Participant
+        Information is uploaded by authorized persons in the Research Projects
+        only if the participant has signed an informed consent to participate in
+        one or more Research Projects or the release of such Participant
+        Information is otherwise authorized under applicable law. Each
+        participant grants us the right to upload, reproduce, display, perform,
+        transmit and distribute the Participant Information, including to
+        investigators. This enables the collaboration that is the goal of the
+        Platform. As a user, you should only use the Participant Information in
+        connection with the Platform, and in connection with the applicable
+        Research Project in which you are an investigator or researcher.
+        Furthermore, you are required to maintain Collaborative IRB Training
+        Initiative (CITI) training and documentation of institutional review
+        board approval, as required by your institution.
+      </p>
+      <p>
+        The Platform may contain features that allow you to post or provide
+        information, comments and other content; we refer to this as “User
+        Content”. You retain the right to your User Content. However, you grant
+        to Broad the worldwide, perpetual, irrevocable, fully transferable and
+        royalty-free right and license to use the User Content for any purposes,
+        including without limitation, to reproduce, distribute, publish, modify,
+        display, perform, make derivative works, and for any and all commercial
+        purposes, and in any and all media and formats, whether now known or
+        hereafter created. This means we can use the User Content you submit in
+        order to provide the Platform and use information you submit for the
+        Research Projects.
+      </p>
+
+      <SectionHeading>8. Prohibited Uses</SectionHeading>
+      <p>
+        We want to make sure the Platform is a safe place for us and our users.
+        For this reason, we need to have certain rules about the use of the
+        Platform, including certain conduct that is prohibited. You agree not to
+        use the Platform in any way, provide User Content or engage in any
+        conduct that:
+      </p>
+      <ul>
+        <li>is unlawful, illegal, or unauthorized;</li>
+        <li>is defamatory of any other person;</li>
+        <li>is obscene, sexually explicit, or offensive;</li>
+        <li>advertises or promotes any other product or business;</li>
+        <li>
+          is likely to harass, upset, embarrass, alarm, or annoy any other
+          person;
+        </li>
+        <li>is likely to disrupt our service in any way; or</li>
+        <li>
+          promotes discrimination based on race, sex, religion, nationality,
+          disability, sexual orientation, or age;
+        </li>
+        <li>
+          infringes any copyright, trademark, trade secret, or other proprietary
+          right of any other person; or
+        </li>
+        <li>
+          advocates, promotes or assists any violence or any unlawful act.
+        </li>
+      </ul>
+      <p>
+        We reserve the right, but do not have the obligation, at our sole
+        discretion to edit, delete, remove or block any User Content that
+        violates these Terms. In addition, we reserve the right at our sole
+        discretion to terminate any user’s access to Platform if they violate
+        this Section 8 or any other provision of these Terms.
+      </p>
+
+      <SectionHeading>
+        9. Broad is Not Responsible for Third-Party Content
+      </SectionHeading>
+      <p>
+        The Platform may contain links to third-party web sites, products, and
+        services, and it may redirect you to third party applications on your
+        mobile device (each, a <strong>“Linked Third-Party Service”</strong>).
+        Broad is not responsible for the content of Linked Third-Party Services,
+        and does not make any representations or warranties regarding the
+        content or accuracy of any such content. When you access and use a
+        Linked Third-Party Service, you are subject to that third party’s terms
+        and conditions of use and privacy policy and you agree that Broad is not
+        responsible for and has made no representations or warranties, express
+        or implied, regarding any Linked Third-Party Service and that Broad
+        shall have no liability relating to such Linked Third-Party Service.
+        Your use of any Linked Third-Party Service is at your own risk and
+        subject to the terms and conditions of use for such offerings.
+      </p>
+
+      <SectionHeading>10. Disclaimer of Warranties</SectionHeading>
+      <p>
+        We provide the Platform on an ‘as is’ and ‘as available’ basis without
+        any promises or representations, expressed or implied. For example, we
+        make no promises about how the Platform will work, that they will be
+        error-free, uninterrupted or have no defects, or that the information
+        you provide will result in any particular treatment, cure or other
+        results in any Research Project. The law also provides certain implied
+        warranties, such as warranties of merchantability and fitness for a
+        particular use; we disclaim those warranties, meaning they do not apply
+        to the Platform.
+      </p>
+
+      <SectionHeading>11. Limitation of Liability</SectionHeading>
+      <p>THIS SECTION LIMITS THE DAMAGE YOU CAN RECOVER FROM US.</p>
+      <p>
+        NOTWITHSTANDING THE FAILURE OF ESSENTIAL PURPOSE OF ANY LIMITED REMEDY
+        OF ANY KIND, TO THE MAXIMUM EXTENT PERMITTED BY LAW, WE ARE NOT
+        RESPONSIBLE OR LIABLE FOR ANY INDIRECT, INCIDENTAL, CONSEQUENTIAL,
+        SPECIAL, EXEMPLARY, PUNITIVE, OR OTHER DAMAGES (INCLUDING WITHOUT
+        LIMITATION ANY LOSS OF PROFITS, LOST SAVINGS, OR LOSS OF DATA) OR
+        LIABILITIES UNDER ANY CONTRACT, STRICT LIABILITY, OR OTHER THEORY
+        ARISING OUT OF OR RELATING IN ANY MANNER TO THE PLATFORM, WHETHER OR NOT
+        WE HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES OR LIABILITIES.
+        YOUR SOLE REMEDY WITH RESPECT TO THE PLATFORM IS TO STOP USING THE
+        PLATFORM.
+      </p>
+      <p>
+        SOME STATES DO NOT ALLOW THE EXCLUSION OR LIMITATION OF CERTAIN
+        WARRANTIES AND/OR LIABILITIES, SO CERTAIN OF THE ABOVE LIMITATIONS OR
+        EXCLUSIONS MAY NOT APPLY TO YOU.
+      </p>
+      <p>
+        In the event that applicable law does not allow the disclaimer of
+        certain warranties and/or the limitation of liability for direct,
+        indirect, consequential or other damages, in no event shall Indemnitees’
+        liability arising under or in connection with these Terms and your use
+        of the Platform exceed $100.
+      </p>
+
+      <SectionHeading>12. Termination</SectionHeading>
+      <p>
+        These Terms are effective unless and until terminated by either you or
+        Broad. You may terminate these Terms at any time, provided that you
+        discontinue any further use of the Platform. We also may terminate or
+        suspend these Terms, at any time, without notice and accordingly deny
+        you access to the Platform, for any reason, including without
+        limitation, if at our sole discretion you fail to comply with any
+        provision of these Terms or your use is harmful to the interests of
+        another user of the Platform. Upon any termination of the Terms by
+        either you or us, you must promptly cease using the Platform.
+      </p>
+      <p>
+        Termination will not limit any of our other rights and remedies. Any
+        provision that must survive in order to give proper effect to the intent
+        and purpose of these Terms shall survive termination.
+      </p>
+
+      <SectionHeading>13. General</SectionHeading>
+      <p>
+        These Terms, including the Privacy Policy and other policies
+        incorporated herein, constitute the entire and only agreement between
+        you and Broad with respect to the subject matter of these Terms, and
+        supersede any and all prior or contemporaneous agreements,
+        representations, warranties and understandings, written or oral, with
+        respect to the subject matter of these Terms. If any provision of these
+        Terms is found to be unlawful, void or for any reason unenforceable,
+        then that provision shall be deemed severable from these Terms and shall
+        not affect the validity and enforceability of any remaining provisions.
+        Neither these Terms nor any right, obligation or remedy hereunder is
+        assignable, transferable, delegable or sub-licensable by you except with
+        Broad’s prior written consent, and any attempted assignment, transfer,
+        delegation or sublicense shall be null and void. Broad may assign,
+        transfer or delegate this or any right or obligation or remedy hereunder
+        in its sole discretion. No waiver by either party of any breach or
+        default hereunder shall be deemed to be a waiver of any preceding or
+        subsequent breach or default. Any heading, caption, or section title
+        contained in these Terms is inserted only as a matter of convenience and
+        in no way defines or explains any section or provision hereof.
+      </p>
+
+      <SectionHeading>14. Contact Us</SectionHeading>
+      <p>
+        If you have any questions regarding our Platform or these Terms, you can
+        contact us at{' '}
+        <a href="mailto:support@juniper.terra.bio">support@juniper.terra.bio</a>
+        .
+      </p>
+    </>
+  )
+}
+
+const InvestigatorTermsOfUsePage = () => {
+  return (
+    <div className="container p-3">
+      <InvestigatorTermsOfUse />
+    </div>
+  )
+}
+
+export default InvestigatorTermsOfUsePage

--- a/ui-admin/src/terms/PrivacyPolicyPage.tsx
+++ b/ui-admin/src/terms/PrivacyPolicyPage.tsx
@@ -1,0 +1,451 @@
+import classNames from 'classnames'
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+type SectionHeadingProps = JSX.IntrinsicElements['h2']
+
+const SectionHeading = (props: SectionHeadingProps) => {
+  const { className, ...otherProps } = props
+  return <h2 {...otherProps} className={classNames('h3', className)} />
+}
+
+const PrivacyPolicy = () => {
+  return (
+    <>
+      <h1 className="h2 text-center mb-5">
+        The Broad Institute, Inc.
+        <br />
+        Juniper Platform
+        <br />
+        Privacy Policy
+      </h1>
+      <p>Last Updated: April 28, 2023</p>
+
+      <p>
+        The Broad Institute, Inc. (<strong>“Broad,”</strong>{' '}
+        <strong>“we,”</strong> <strong>“us,”</strong> or <strong>“our”</strong>)
+        values your privacy. This Privacy Policy (<strong>“Policy”</strong>)
+        provides important information about how Broad collects and uses your
+        Personal Information when you access or use the Juniper Platform (the{' '}
+        <strong>“Platform”</strong>). Please review this Policy, which is
+        incorporated into and made part of the Terms of Use that apply to you:{' '}
+        <Link to="/terms/participant">Participant Terms of Use</Link> or{' '}
+        <Link to="/terms/investigator">Investigator Terms of Use</Link>. By
+        accessing or using the Platform, you consent to our collection, use, and
+        disclosure of your information in accordance with this Policy and our
+        Terms of Use. If you do not agree to our Policy or Terms of Use, you may
+        not use the Platform.
+      </p>
+      <p>
+        If you are a participant in a research project (
+        <strong>“Participant User”</strong>) supported by the Platform (each, a{' '}
+        <strong>“Research Project”</strong>), the Research Project will collect
+        health-related information from you regarding your medical and health
+        conditions, treatments, and diagnosis (
+        <strong>“Participant User Information”</strong>). Some Participant User
+        Information may be gathered from you prior to the Research Project
+        commencing to determine if you qualify to participate in the Research
+        Project, and other information is collected after you have qualified to
+        participate and, where applicable to the Research Project, have signed a
+        written consent form to participate. Participant User Information may be
+        uploaded to the Platform by you or by persons conducting the Research
+        Project.
+      </p>
+      <p>
+        This Privacy Policy also describes how Broad collects, uses, and
+        discloses personal information of users who are investigators and or
+        other researchers (each, an <strong>“Investigator User”</strong>).
+      </p>
+      <p>
+        <strong>Important Note to Participant Users</strong>: By participating
+        in a Research Project, you may be subject to additional policies,
+        including a privacy policy from that Research Project’s sponsor or the
+        institution at which the research is conducted. That privacy policy may
+        be presented to you in the Platform or through alternate means. You may
+        also need to complete an informed consent process before participating
+        in research on the Platform. If you are participating in a Research
+        Project, you may be asked to provide Participant User Information,
+        blood, saliva, and other types of samples to assist in research and
+        development activities. The Investigator Users will obtain your
+        separate, written consent to use these samples, and our research
+        partners’ use of these samples and your Participant User Information
+        will be governed by the terms of the consent that you sign and not this
+        Policy.
+      </p>
+
+      <SectionHeading>Information We Collect</SectionHeading>
+      <p>
+        We collect information (including Personal Information) about you in two
+        ways. The first is information you voluntarily provide to us when you
+        choose to do any of the following, none of which is required:
+      </p>
+      <ul>
+        <li>
+          Register to use the Platform, such as when you create an account.
+        </li>
+        <li>
+          Use the Platform to provide us information about you, such as your
+          experiences in connection with Research Projects in which you
+          participate.
+        </li>
+        <li>Use the Platform as an Investigator User.</li>
+        <li>Respond to surveys we or the researchers may send to you.</li>
+        <li>Communicate with us (e.g., by email).</li>
+      </ul>
+
+      <p>
+        The second way we collect information is through certain automated
+        technologies that are used when you access our Platform. An example is a
+        “cookie,” which is a small piece of computer code that is placed on your
+        computer or other device that can be used for various purposes, such as
+        to recognize a user or to track their activities on a website. We
+        describe automated technologies in more detail below. We may collect
+        various information through these automated technologies, including your
+        Device Information as described below, along with how you use our
+        Platform, such as the web pages you view, the links you click, the
+        length of time you spend visiting our Platform, and the web page or web
+        site that led you to our Platform.
+      </p>
+
+      <SectionHeading>What kind of information do we collect?</SectionHeading>
+      <p>We collect various types of information:</p>
+      <ul>
+        <li>
+          <strong>“Personal Information”</strong> is information that alone or
+          in combination with other information may be used to readily identify,
+          contact, or locate you. For example, your name, age, address, phone
+          number, email address, clinical data, medical history, and treatment
+          type are Personal Information we may collect through your use of the
+          Platform once a user has consented to participate in a study.
+        </li>
+        <li>
+          <strong>“Device Information”</strong> is information that relates to a
+          particular computer, mobile device, or other device (e.g., iPad) that
+          you use to access the Platform. Device Information includes such
+          things as an IP address (which is a number assigned by an internet
+          service provider to the computer you use to access the Internet), a
+          device ID (which is a number assigned to a mobile phone by the device
+          manufacturer), or the type of operating system or web browser used to
+          access the Platform.
+        </li>
+        <li>
+          <strong>Other information you choose to provide</strong>, such as when
+          you participate in a survey or when you request technical or customer
+          support.
+        </li>
+      </ul>
+
+      <SectionHeading>
+        Do we use cookies and other tracking technologies?
+      </SectionHeading>
+      <p>
+        Yes. We use cookies for various purposes, such as to make it easier for
+        you to navigate our Platform, to enable a faster log-in process, or to
+        allow us to track your activities on our Platform. There are two types
+        of cookies: session and persistent cookies.
+      </p>
+
+      <ul>
+        <li>
+          <strong className="text-decoration-underline">Session Cookies</strong>
+          . Session Cookies exist only during a session. They disappear from
+          your computer or device when you close your browser or turn off your
+          computer or device. We use Session Cookies to allow our systems to
+          uniquely identify you during a session or while you are logged in to
+          the Platform. This allows us to process your communications and
+          requests and verify your identity after you have logged in and as you
+          move through our Platform, and to optimize your experience in using
+          the Platform.
+        </li>
+        <li>
+          <strong className="text-decoration-underline">
+            Persistent Cookies
+          </strong>
+          . Persistent Cookies remain on your computer or device after you have
+          closed your browser or turned off your computer or mobile device. We
+          use Persistent Cookies to track aggregate and statistical information
+          about user activity on our Platform (see{' '}
+          <strong>“Tracking Technologies”</strong> below).
+        </li>
+      </ul>
+      <p>
+        <strong>Disabling Cookies</strong>. Most web browsers automatically
+        accept cookies, but if you prefer, you can edit your browser options to
+        block them in the future. The Help portion of the toolbar on most
+        browsers will tell you how to prevent your computer from accepting new
+        cookies, how to have the browser notify you when you receive a new
+        cookie, or how to disable cookies altogether. Visitors to our Platform
+        who disable cookies may not be able to use the Platform.
+      </p>
+      <p>
+        <strong>Tracking Technologies</strong>. We use analytics tools to
+        evaluate our Platform. We use these tools to help us improve our
+        Platform, performance, and user experiences. We may also use third-party
+        tracking technologies to detect malicious code or attacks on our
+        Platform. These entities may use cookies and other tracking technologies
+        to perform their services.
+      </p>
+      <SectionHeading>Do you respond to Do Not Track signals?</SectionHeading>
+      <p>
+        Do Not Track (<strong>“DNT”</strong>) is a privacy preference that users
+        can set in their web browsers. When users turn on DNT, their browser
+        sends a message to websites requesting that they do not track the user.
+        However, our Platform does not change its information collection in
+        response to DNT browser settings or signals. For information about DNT,
+        visit <a href="https://www.allaboutdnt.org">www.allaboutdnt.org</a>.
+      </p>
+
+      <SectionHeading>How do we use your information?</SectionHeading>
+      <p>
+        We use your information, including your Personal Information, for
+        various purposes:
+      </p>
+      <ul>
+        <li>
+          <strong className="text-decoration-underline">
+            Conduct Research
+          </strong>
+          . We, and the research partners to whom we provide the Platform and
+          also those with whom we collaborate, use the information you provide
+          about yourself, your medical condition, and experiences to conduct
+          research, but only if you are a Participant User that has enrolled in
+          a Research Project in which case you may need to execute a separate
+          written consent with the applicable Research Project.
+        </li>
+        <li>
+          <strong className="text-decoration-underline">
+            Provide the Platform
+          </strong>
+          . We, and our vendors and service providers, use your information
+          (e.g., your profile information, user identification, and password) to
+          provide the Platform, respond to your inquiries, and troubleshoot
+          issues with the Platform, and for other customer service purposes.
+        </li>
+        <li>
+          <strong className="text-decoration-underline">
+            Personalize Your Experience
+          </strong>
+          . We use your information to tailor the content and information that
+          we may send or display to you, to offer location customization, and
+          personalized help and instructions, and to otherwise personalize your
+          experiences while you are using the Platform.
+        </li>
+        <li>
+          <strong className="text-decoration-underline">
+            Improve and Develop Our Platform
+          </strong>
+          . We use your information to ensure our Platform is working as
+          intended, to better understand how users access and use our Platform,
+          both on an aggregated and individualized basis, to make improvements
+          to our Platform, to develop new features and applications, and for
+          other research and analytical purposes.
+        </li>
+      </ul>
+      <p>
+        We may share aggregate data from our cohorts to encourage participation
+        in our Research Projects. This aggregate data does not identify you
+        personally.
+      </p>
+
+      <SectionHeading>With whom do we share your information?</SectionHeading>
+      <p>
+        We may need to share your information, including your Personal
+        Information, with third parties. The following are the categories of
+        third parties with whom we may share your Personal Information:
+      </p>
+      <ul>
+        <li>
+          <strong className="text-decoration-underline">
+            Research Partners
+          </strong>
+          . The purpose of the Platform is to facilitate the collection and
+          analysis of information for research purposes. For example, the
+          information you provide through the Platform may be used by various
+          persons involved in a Research Project such as the principal
+          investigator and other clinicians and Investigator Users involved in
+          conducting research in a particular Research Project. If you are asked
+          to sign an informed consent to participate in a Research Project, we
+          may also share your information with the third parties listed on the
+          consent that you sign and for the purposes listed on the consent.
+        </li>
+        <li>
+          <strong className="text-decoration-underline">
+            Vendors and Service Providers
+          </strong>
+          . We use various third-party vendors and service providers that assist
+          us in providing the Platform. For example, we may use third-party
+          vendors to store and authenticate account credentials, send email
+          communications, ship test kits, and for hosting and storing
+          information collected through our Platform. We may share your
+          information with these vendors and service providers to enable them to
+          provide these services to us. These service providers and vendors are
+          required to only use your information to provide their services to us
+          and in a manner consistent with this Policy.
+        </li>
+        <li>
+          <strong className="text-decoration-underline">
+            As Required By Law
+          </strong>
+          . We may be required, by law, to disclose your Personal Information to
+          third parties, such as in the following situations:
+          <ul>
+            <li>In response to a request by law enforcement;</li>
+            <li>
+              In response to legal process, such as a subpoena, a request for
+              discovery in a civil proceeding, or in response to a court order.
+            </li>
+          </ul>
+        </li>
+        <li>
+          <strong className="text-decoration-underline">
+            Enforce Our Terms and Protect You, Us, and Others
+          </strong>
+          . We may access, preserve, and disclose your Personal Information to
+          enforce the Terms of Use for the Platform and protect your, our, or
+          others’ rights, property, or safety.
+        </li>
+        <li>
+          <strong className="text-decoration-underline">
+            Merger, Sale, or Other Corporate Transactions
+          </strong>
+          . A legal entity, such as Broad, may be involved in a business
+          transaction where its ownership or assets are sold or transferred to
+          another legal entity. This can happen in a merger with another legal
+          entity, an acquisition by another legal entity, a corporate
+          reorganization, or a legal proceeding (e.g., bankruptcy or
+          receivership) where a trustee or other takes over control of the
+          entity. In each of these situations, your information, including your
+          Personal Information, may be sold or transferred as part of such a
+          transaction as permitted by law and/or contract.
+        </li>
+        <li>
+          <strong className="text-decoration-underline">
+            With Your Consent
+          </strong>
+          . We may ask you from time to time to give us permission to share your
+          information with other third parties not described in this section. In
+          each case, we will describe that third party and the purpose for
+          sharing your information.
+        </li>
+        <li>
+          <strong className="text-decoration-underline">
+            Aggregate and De-Identified Information
+          </strong>
+          . We may share aggregate or de-identified information about users and
+          their use of the Platform with third parties and publicly for
+          marketing, advertising, research, or similar purposes. This
+          information will not identify you personally.
+        </li>
+      </ul>
+
+      <SectionHeading>
+        What rights do I have with respect to my information?
+      </SectionHeading>
+      <p>
+        You can update your account at any time during the active period of the
+        Research Study.
+      </p>
+      <p>
+        We will respond to any user request as soon as we reasonably can, and
+        within the time and in the manner required by law. We may request
+        additional information from you to verify the request. We may not be
+        able to accommodate all requests; for example, we may be unable to
+        accommodate a deletion request if we are required to maintain
+        information under law or a legal obligation or if information is used as
+        part of a study.
+      </p>
+
+      <SectionHeading>
+        What kind of security does the Platform use to protect my information?
+      </SectionHeading>
+      <p>
+        We seek to use reasonable physical, technical, and administrative
+        measures designed to protect personal information within our
+        organization. Unfortunately, no data transmission, processing, or
+        storage system can be guaranteed to be 100% secure. If you have reason
+        to believe that your use of the Platform is no longer secure (for
+        example, if you feel that the security of your account has been
+        compromised), please immediately notify us in accordance with the
+        “Contacting Us” section below.
+      </p>
+
+      <SectionHeading>Do you collect information from children?</SectionHeading>
+      <p>
+        Minors can join and participate in a Research Project with the consent
+        of their parent or legal guardian as required by applicable law. If you
+        are a parent or legal guardian providing personal information regarding
+        your child, you represent and warrant that you have the right and
+        authority to provide us such information.
+      </p>
+
+      <SectionHeading>
+        Is there any transfer of Personal Information from one country to
+        another?
+      </SectionHeading>
+      <p>
+        We store the information you provide on servers in the United States. If
+        you are a user of the Platform, you agree to the transfer of your
+        Personal Information to the United States and acknowledge that the laws
+        in the United States may offer less protection to your Personal
+        Information than the laws where you live.
+      </p>
+
+      <SectionHeading>Links to Third-Party Websites</SectionHeading>
+      <p>
+        Our Platform may reference or provide links to third-party websites.
+        Other websites may also reference or link to our Platform. Because these
+        websites are not controlled by Broad, we are not responsible for the
+        third-party websites. We encourage our users to be aware when they leave
+        our Platform to review the privacy policies posted on each and every
+        website that collects personally identifiable information. Please be
+        aware that Broad does not control, endorse, screen or approve, nor are
+        we responsible for, the privacy policies or information practices of
+        third parties or their websites or mobile applications. Visiting these
+        other websites is at your own risk.
+      </p>
+
+      <SectionHeading>
+        Whom do I contact if I have a question or a complaint?
+      </SectionHeading>
+      <p>
+        You may contact us at the address below if you have any questions or
+        complaints about information practices or this Policy:
+      </p>
+      <p>
+        By email to:{' '}
+        <a href="mailto:support@juniper.terra.bio">support@juniper.terra.bio</a>
+      </p>
+
+      <SectionHeading>Will you update or change this Policy?</SectionHeading>
+      <p>
+        Yes, we may need to update or change this Policy for various reasons,
+        such as to comply with changes in the law or to cover new features,
+        services, or Research Projects provided through the Platform. If we
+        update or change this Policy we will:
+      </p>
+      <ul>
+        <li>Post the changes to the Policy on the Platform; and</li>
+        <li>
+          Endeavor to notify you of any material changes to the Policy through
+          the email address in your profile.
+        </li>
+      </ul>
+      <p>
+        To make sure you are aware of any updates or changes, you should review
+        this Policy periodically and make sure you have your most current email
+        address in your account. We will post the effective date of any new
+        policy.
+      </p>
+    </>
+  )
+}
+
+const PrivacyPolicyPage = () => {
+  return (
+    <div className="container p-3">
+      <PrivacyPolicy />
+    </div>
+  )
+}
+
+export default PrivacyPolicyPage


### PR DESCRIPTION
Adds terms of use and privacy policy pages to the admin site.

Adds links to those pages to the login page and at the bottom of the sidebar.

![Screenshot 2023-05-03 at 1 43 09 PM](https://user-images.githubusercontent.com/1156625/236001160-c55d5223-3df1-407e-939e-8e4583961b43.png)
![Screenshot 2023-05-03 at 1 43 27 PM](https://user-images.githubusercontent.com/1156625/236001162-3f210e23-82f5-4371-b690-263b67bbb335.png)
