### PR TITLE
[JN-346] Improve "You are already enrolled in this study" message

### DIFF
--- a/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
+++ b/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
@@ -84,8 +84,13 @@ function StudyEnrollOutletMatched(props: StudyEnrollOutletMatchedProps) {
   useEffect(() => {
     const isAlreadyEnrolled = !!enrollees.find(rollee => rollee.studyEnvironmentId === studyEnv.id)
     if (isAlreadyEnrolled) {
-      alert('you are already enrolled in this study')
-      navigate('/hub', { replace: true })
+      const hubUpdate: HubUpdate = {
+        message: {
+          title: 'You are already enrolled in this study.',
+          type: 'info'
+        }
+      }
+      navigate('/hub', { replace: true, state: hubUpdate })
       return
     }
     if (mustProvidePassword) {


### PR DESCRIPTION
Currently, if you are logged in and have enrolled in OurHealth, clicking one of the "Join" buttons on a landing page shows an alert "you are already enrolled in this study" before redirecting to the dashboard.

The alert isn't great UX, so this replaces it with the banner pattern used when first joining a study.

## Before
https://user-images.githubusercontent.com/1156625/236011649-2af3d732-c5ac-43c5-8a02-5f125f1fd86b.mov

## After
https://user-images.githubusercontent.com/1156625/236011712-b7466d96-7177-4eb5-b5c4-78294ec4f715.mov