### PR TITLE
JN-349 fixing reminder duration wiring

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/notification/ParticipantTaskQueryService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/ParticipantTaskQueryService.java
@@ -22,8 +22,8 @@ public class ParticipantTaskQueryService {
     public List<ParticipantTaskDao.EnrolleeWithTasks> findByStatusAndTime(UUID studyEnvironmentId,
                                                                           TaskType taskType,
                                                                           Duration timeSinceCreation,
-                                                                          Duration timeSinceLastNotification,
                                                                           Duration maxTimeSinceCreation,
+                                                                          Duration timeSinceLastNotification,
                                                                           List<TaskStatus> statuses) {
         return participantTaskDao.findByStatusAndTime(studyEnvironmentId, taskType, timeSinceCreation, maxTimeSinceCreation,
                 timeSinceLastNotification, statuses);

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/EnrolleeReminderServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/EnrolleeReminderServiceTests.java
@@ -1,0 +1,68 @@
+package bio.terra.pearl.core.service.notification;
+
+import bio.terra.pearl.core.BaseSpringBootTest;
+import bio.terra.pearl.core.dao.notification.NotificationDao;
+import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
+import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
+import bio.terra.pearl.core.factory.participant.ParticipantTaskFactory;
+import bio.terra.pearl.core.factory.portal.PortalEnvironmentFactory;
+import bio.terra.pearl.core.model.notification.Notification;
+import bio.terra.pearl.core.model.notification.NotificationConfig;
+import bio.terra.pearl.core.model.notification.NotificationDeliveryType;
+import bio.terra.pearl.core.model.notification.NotificationType;
+import bio.terra.pearl.core.model.portal.PortalEnvironment;
+import bio.terra.pearl.core.model.study.StudyEnvironment;
+import bio.terra.pearl.core.model.workflow.ParticipantTask;
+import bio.terra.pearl.core.model.workflow.TaskStatus;
+import bio.terra.pearl.core.model.workflow.TaskType;
+import java.util.List;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * See ParticipantTaskDaoTests for detailed tests of the reminder timing logic.  This is a high-level test
+ * to confirm everything works together.
+ */
+public class EnrolleeReminderServiceTests extends BaseSpringBootTest {
+  @Test
+  @Transactional
+  public void testConsentReminders() {
+    PortalEnvironment portalEnv = portalEnvironmentFactory.buildPersisted("testConsentReminders");
+    StudyEnvironment studyEnv = studyEnvironmentFactory.buildPersisted(portalEnv, "testConsentReminders");
+    var enrolleeBundle = enrolleeFactory.buildWithPortalUser("testConsentReminders", portalEnv, studyEnv);
+    ParticipantTask newTask1 = participantTaskFactory.buildPersisted(enrolleeBundle, TaskStatus.NEW, TaskType.CONSENT);
+
+    NotificationConfig config = NotificationConfig.builder()
+        .notificationType(NotificationType.TASK_REMINDER)
+        .taskType(TaskType.CONSENT)
+        .afterMinutesIncomplete(0)
+        .deliveryType(NotificationDeliveryType.EMAIL)
+        .studyEnvironmentId(studyEnv.getId())
+        .portalEnvironmentId(portalEnv.getId())
+        .build();
+    NotificationConfig savedConfig = notificationConfigService.create(config);
+    enrolleeReminderService.sendTaskReminders(studyEnv);
+
+    List<Notification> notificationList = notificationDao.findByEnrolleeId(enrolleeBundle.enrollee().getId());
+    assertThat(notificationList, hasSize(1));
+    assertThat(notificationList.get(0).getNotificationConfigId(), equalTo(savedConfig.getId()));
+  }
+  @Autowired
+  private ParticipantTaskFactory participantTaskFactory;
+  @Autowired
+  private EnrolleeReminderService enrolleeReminderService;
+  @Autowired
+  private StudyEnvironmentFactory studyEnvironmentFactory;
+  @Autowired
+  private PortalEnvironmentFactory portalEnvironmentFactory;
+  @Autowired
+  private NotificationDao notificationDao;
+  @Autowired
+  private NotificationConfigService notificationConfigService;
+  @Autowired
+  private EnrolleeFactory enrolleeFactory;
+}

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/participant/ParticipantTaskFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/participant/ParticipantTaskFactory.java
@@ -1,0 +1,28 @@
+package bio.terra.pearl.core.factory.participant;
+
+import bio.terra.pearl.core.model.workflow.ParticipantTask;
+import bio.terra.pearl.core.model.workflow.TaskStatus;
+import bio.terra.pearl.core.model.workflow.TaskType;
+import bio.terra.pearl.core.service.participant.ParticipantTaskService;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ParticipantTaskFactory {
+  @Autowired
+  ParticipantTaskService participantTaskService;
+
+  public ParticipantTask buildPersisted(EnrolleeFactory.EnrolleeBundle enrolleeBundle,
+                                                             TaskStatus status, TaskType type) {
+    ParticipantTask task = ParticipantTask.builder()
+        .status(status)
+        .enrolleeId(enrolleeBundle.enrollee().getId())
+        .taskType(type)
+        .studyEnvironmentId(enrolleeBundle.enrollee().getStudyEnvironmentId())
+        .targetName(RandomStringUtils.randomAlphabetic(6))
+        .portalParticipantUserId(enrolleeBundle.portalParticipantUser().getId())
+        .build();
+    return participantTaskService.create(task);
+  }
+}


### PR DESCRIPTION
A couple of arguments got transposed, so no reminders were ever being sent.  This adds a higher-level integration test to hopefully avoid that happening in the future

TO TEST:
1. repopulate ourhealth
2. run `update notification_config set after_minutes_incomplete = 1;` in your database
4. wiat a minute, then restart AdminApiApp
5. observe a reminder email to newbie@test.com about their consent