### PR TITLE
JN-345 pre-enroll fixes

### DIFF
--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/registration/PreregistrationController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/registration/PreregistrationController.java
@@ -33,10 +33,9 @@ public class PreregistrationController implements PreregistrationApi {
     ParsedPreRegResponse response = objectMapper.convertValue(body, ParsedPreRegResponse.class);
     EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
     try {
-      String responseData = objectMapper.writeValueAsString(response.getParsedData());
       PreregistrationResponse createdResponse =
           registrationService.createAnonymousPreregistration(
-              portalShortcode, environmentName, surveyStableId, surveyVersion, responseData);
+              portalShortcode, environmentName, surveyStableId, surveyVersion, response);
       return ResponseEntity.ok(createdResponse);
     } catch (JsonProcessingException e) {
       throw new IllegalArgumentException("malformatted response data", e);

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/ParsedPreRegResponse.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/ParsedPreRegResponse.java
@@ -11,5 +11,5 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @SuperBuilder
 public class ParsedPreRegResponse extends PreregistrationResponse {
-    private List<Answer> parsedData;
+    private List<Answer> answers;
 }

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -240,6 +240,7 @@ export type Answer = {
   stringValue: string,
   numberValue: number,
   objectValue: object,
+  booleanValue: boolean,
   questionStableId: string
 }
 

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -26,10 +26,10 @@ const ItemDisplay = ({ answer, surveyJsModel }: {answer: Answer, surveyJsModel: 
 }
 
 export const getDisplayValue = (answer: Answer, question: Question | QuestionWithChoices) => {
-  const answerValue = answer.stringValue ?? answer.numberValue ?? answer.objectValue
+  const answerValue = answer.stringValue ?? answer.numberValue ?? answer.objectValue ?? answer.booleanValue
   if (!question) {
     // if the answer represents a computedValue, we won't have a question for it
-    return answerValue
+    return answerValue?.toString()
   }
   let displayValue: React.ReactNode = answerValue
   if (question.choices) {

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -192,14 +192,14 @@ export type SurveyResponse = FormResponse & {
 export type PreregistrationResponse = FormResponse & {
   qualified: false,
   surveyId: string,
-  fullData: string
+  answers: Answer[]
 }
 
 export type PreEnrollmentResponse = FormResponse & {
   qualified: false,
   surveyId: string,
   studyEnvironmentId: string,
-  fullData: string
+  answers: Answer[]
 }
 
 export type Enrollee = {

--- a/ui-participant/src/landing/registration/Preregistration.tsx
+++ b/ui-participant/src/landing/registration/Preregistration.tsx
@@ -21,7 +21,7 @@ export default function PreRegistration({ registrationContext }: { registrationC
     }
     const responseDto = {
       resumeData: getResumeData(surveyModel, null),
-      fullData: JSON.stringify(getSurveyJsAnswerList(surveyModel)),
+      answers: getSurveyJsAnswerList(surveyModel),
       creatingParticipantId: null,
       surveyId: survey.id,
       qualified: surveyModel.getCalculatedValueByName('qualified').value

--- a/ui-participant/src/studies/enroll/PreEnroll.tsx
+++ b/ui-participant/src/studies/enroll/PreEnroll.tsx
@@ -34,7 +34,7 @@ export default function PreEnrollView({ enrollContext }: { enrollContext: StudyE
     const qualified = surveyModel.getCalculatedValueByName(ENROLLMENT_QUALIFIED_VARIABLE).value
     const responseDto = {
       resumeData: getResumeData(surveyModel, null),
-      fullData: JSON.stringify(getSurveyJsAnswerList(surveyModel)),
+      answers: getSurveyJsAnswerList(surveyModel),
       creatingParticipantId: null,
       surveyId: survey.id,
       studyEnvironmentId: studyEnv.id,


### PR DESCRIPTION
This fixes a couple of pre-enroll issues caused by the switchover to saving answer lists instead of JSON blobs.  It also updates the admin tool to handle showing boolean responses to computed values.

TO TEST:
1. restart adminApiApp
2. enroll a participant in OurHealth
3. go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants
4. clikc on the new participant you enrolled, and confirm their pre-enrollment response appears in the tool