### PR TITLE
[JN-199] Minor updates and fixes to participant idle timeout

### DIFF
--- a/ui-participant/src/login/IdleStatusMonitor.tsx
+++ b/ui-participant/src/login/IdleStatusMonitor.tsx
@@ -128,7 +128,7 @@ const InactivityTimer = ({ maxIdleSessionDuration, idleWarningDuration, doSignOu
       doSignOut()
       setSignOutTriggered(true)
     }
-  }, [doSignOut, setSignOutTriggered, signOutTriggered, timedOut])
+  }, [doSignOut, signOutTriggered, timedOut])
 
   if (idleModalVisible != showCountdown) {
     setIdleModalVisible(showCountdown)
@@ -157,7 +157,7 @@ export const useCurrentTime = (initialDelay = 250) => {
       }
     }
     poll()
-  }, [setCurrentTime])
+  }, [])
   return [currentTime, (delay: number) => { delayRef.current = delay }] as const
 }
 


### PR DESCRIPTION
I noticed this morning that `InactivityTimer` was hitting an infinite re-render loop when auto sign-out was triggered. This fixes that problem, as well as a little clean-up of `useEffect` dependencies.