### PR TITLE
Add document titles to hub pages

### DIFF
--- a/ui-participant/src/hub/HubPage.tsx
+++ b/ui-participant/src/hub/HubPage.tsx
@@ -5,6 +5,7 @@ import { useUser } from '../providers/UserProvider'
 import { Enrollee, ParticipantTask, Portal, Study } from '../api/api'
 import TaskLink, { getTaskPath, isTaskAccessible, isTaskActive } from './TaskLink'
 import { Link, NavLink } from 'react-router-dom'
+import { DocumentTitle } from 'util/DocumentTitle'
 import { userHasJoinedPortalStudy } from 'util/enrolleeUtils'
 
 import { HubMessageAlert, useHubUpdate } from './hubUpdates'
@@ -21,41 +22,44 @@ export default function HubPage() {
   const unjoinedStudies = portal.portalStudies.filter(pStudy => !userHasJoinedPortalStudy(pStudy, enrollees))
   const hasUnjoinedStudies = unjoinedStudies.length > 0
   return (
-    <div
-      className="hub-dashboard-background flex-grow-1"
-      style={{ background: 'linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%' }}
-    >
-      {!!displayedHubMessage && (
-        <HubMessageAlert
-          message={displayedHubMessage}
-          className="mx-1 mx-md-auto my-1 my-md-5 shadow-sm"
-          role="alert"
-          style={{ maxWidth: 768 }}
-          onDismiss={() => {
-            setDisplayedHubMessage(undefined)
-          }}
-        />
-      )}
-
+    <>
+      <DocumentTitle title="Dashboard" />
       <div
-        className="hub-dashboard py-4 px-2 px-md-5 my-md-5 mx-auto shadow-sm"
-        style={{ background: '#fff', maxWidth: 768 }}
+        className="hub-dashboard-background flex-grow-1"
+        style={{ background: 'linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%' }}
       >
-        {enrollees.map(enrollee => <StudySection key={enrollee.id} enrollee={enrollee} portal={portal} />)}
-
-        {hasUnjoinedStudies && (
-          <>
-            <h2 className="text-center">Studies you can join</h2>
-            <ul className="list-group">
-              {unjoinedStudies.map(portalStudy => <li key={portalStudy.study.shortcode} className="list-group-item">
-                <h6>{portalStudy.study.name}</h6>
-                <NavLink to={`/studies/${portalStudy.study.shortcode}/join`}>Join</NavLink>
-              </li>)}
-            </ul>
-          </>
+        {!!displayedHubMessage && (
+          <HubMessageAlert
+            message={displayedHubMessage}
+            className="mx-1 mx-md-auto my-1 my-md-5 shadow-sm"
+            role="alert"
+            style={{ maxWidth: 768 }}
+            onDismiss={() => {
+              setDisplayedHubMessage(undefined)
+            }}
+          />
         )}
+
+        <div
+          className="hub-dashboard py-4 px-2 px-md-5 my-md-5 mx-auto shadow-sm"
+          style={{ background: '#fff', maxWidth: 768 }}
+        >
+          {enrollees.map(enrollee => <StudySection key={enrollee.id} enrollee={enrollee} portal={portal} />)}
+
+          {hasUnjoinedStudies && (
+            <>
+              <h2 className="text-center">Studies you can join</h2>
+              <ul className="list-group">
+                {unjoinedStudies.map(portalStudy => <li key={portalStudy.study.shortcode} className="list-group-item">
+                  <h6>{portalStudy.study.name}</h6>
+                  <NavLink to={`/studies/${portalStudy.study.shortcode}/join`}>Join</NavLink>
+                </li>)}
+              </ul>
+            </>
+          )}
+        </div>
       </div>
-    </div>
+    </>
   )
 }
 

--- a/ui-participant/src/hub/consent/ConsentView.tsx
+++ b/ui-participant/src/hub/consent/ConsentView.tsx
@@ -23,6 +23,7 @@ import {
 import { HubUpdate } from 'hub/hubUpdates'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { useUser } from 'providers/UserProvider'
+import { DocumentTitle } from 'util/DocumentTitle'
 import { PageLoadingIndicator } from 'util/LoadingSpinner'
 
 /**
@@ -79,7 +80,12 @@ function RawConsentView({ form, enrollee, resumableData, pager, studyShortcode, 
   }
 
 
-  return surveyModel ? <SurveyComponent model={surveyModel} /> : null
+  return (
+    <>
+      <DocumentTitle title={form.name} />
+      {surveyModel ? <SurveyComponent model={surveyModel} /> : null}
+    </>
+  )
 }
 
 /** handles paging the form */

--- a/ui-participant/src/hub/consent/PrintConsentView.tsx
+++ b/ui-participant/src/hub/consent/PrintConsentView.tsx
@@ -6,6 +6,7 @@ import { Survey as SurveyComponent } from 'survey-react-ui'
 import Api, { Answer, Enrollee } from 'api/api'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { useUser } from 'providers/UserProvider'
+import { DocumentTitle } from 'util/DocumentTitle'
 import { PageLoadingIndicator } from 'util/LoadingSpinner'
 import { extractSurveyContent, makeSurveyJsData } from 'util/surveyJsUtils'
 
@@ -74,6 +75,7 @@ const usePrintableConsent = (args: UsePrintableConsentArgs) => {
       const surveyContent = extractSurveyContent(form)
 
       const surveyModel = new Model(surveyContent)
+      surveyModel.title = form.name
       surveyModel.data = resumableData?.data
 
       surveyModel.mode = 'display'
@@ -127,7 +129,12 @@ const PrintConsentView = () => {
   } else if (!surveyModel) {
     return null
   } else {
-    return <SurveyComponent model={surveyModel} />
+    return (
+      <>
+        <DocumentTitle title={surveyModel.title} />
+        <SurveyComponent model={surveyModel} />
+      </>
+    )
   }
 }
 

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -29,6 +29,7 @@ import { withErrorBoundary } from '../../util/ErrorBoundary'
 import SurveyReviewModeButton from './ReviewModeButton'
 import { Markdown } from '../../landing/Markdown'
 import { SurveyModel } from 'survey-core'
+import { DocumentTitle } from 'util/DocumentTitle'
 
 const TASK_ID_PARAM = 'taskId'
 const AUTO_SAVE_INTERVAL = 3 * 1000  // auto-save every 3 seconds if there are changes
@@ -133,13 +134,18 @@ function RawSurveyView({ form, enrollee, resumableData, pager, studyShortcode, t
     }
   }, [])
 
-  // f3f3f3 background is to match surveyJs "modern" theme
-  return <div style={{ background: '#f3f3f3' }} className="flex-grow-1 survey-js-survey">
-    <SurveyReviewModeButton surveyModel={surveyModel}/>
-    <h1 className="text-center mt-5 mb-0 pb-0 fw-bold">{form.name}</h1>
-    {surveyModel && <SurveyComponent model={surveyModel}/>}
-    <SurveyFooter survey={form} surveyModel={surveyModel}/>
-  </div>
+  return (
+    <>
+      <DocumentTitle title={form.name} />
+      {/* f3f3f3 background is to match surveyJs "modern" theme */}
+      <div style={{ background: '#f3f3f3' }} className="flex-grow-1 survey-js-survey">
+        <SurveyReviewModeButton surveyModel={surveyModel}/>
+        <h1 className="text-center mt-5 mb-0 pb-0 fw-bold">{form.name}</h1>
+        {surveyModel && <SurveyComponent model={surveyModel}/>}
+        <SurveyFooter survey={form} surveyModel={surveyModel}/>
+      </div>
+    </>
+  )
 }
 
 /** renders the foot for the survey, if it exists and we are on the last page */


### PR DESCRIPTION
Add document titles to hub pages so that the browser tab shows the name of the survey/consent form.

Suggest reviewing with [whitespace ignored](https://github.com/broadinstitute/pearl/pull/351/files?w=1).