### PR TITLE
[JN-353] Automatically check for ticket in PR title

### DIFF
--- a/.github/workflows/require-ticket.yml
+++ b/.github/workflows/require-ticket.yml
@@ -1,0 +1,21 @@
+name: Require ticket
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  require_ticket:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for ticket in PR title
+        id: validate
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const title = context.payload.pull_request.title;
+            const regex = /JN-\d+/;
+            if (!regex.test(title)) {
+              core.setFailed("PR title must contain a Jira ticket");
+            }


### PR DESCRIPTION
If we want all PRs linked to tickets, let's automatically check and enforce that. 

This check can be configured to be required to merge a PR.