### PR TITLE
[JN-307, JN-308] Admin dashboard functionality (list, view, create datasets)

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/datarepo/DataRepoExportController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/datarepo/DataRepoExportController.java
@@ -1,0 +1,69 @@
+package bio.terra.pearl.api.admin.controller.datarepo;
+
+import bio.terra.pearl.api.admin.api.DatarepoApi;
+import bio.terra.pearl.api.admin.model.DatasetName;
+import bio.terra.pearl.api.admin.service.AuthUtilService;
+import bio.terra.pearl.api.admin.service.DataRepoExportExtService;
+import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.model.datarepo.DataRepoJob;
+import bio.terra.pearl.core.model.datarepo.Dataset;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class DataRepoExportController implements DatarepoApi {
+
+  private AuthUtilService authUtilService;
+  private DataRepoExportExtService dataRepoExportExtService;
+  private HttpServletRequest request;
+
+  public DataRepoExportController(
+      AuthUtilService authUtilService,
+      DataRepoExportExtService dataRepoExportExtService,
+      HttpServletRequest request) {
+    this.authUtilService = authUtilService;
+    this.dataRepoExportExtService = dataRepoExportExtService;
+    this.request = request;
+  }
+
+  @Override
+  public ResponseEntity<Object> listDatasetsForStudyEnvironment(
+      String portalShortcode, String studyShortcode, String envName) {
+    AdminUser user = authUtilService.requireAdminUser(request);
+    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
+
+    List<Dataset> datasets =
+        dataRepoExportExtService.listDatasetsForStudyEnvironment(
+            portalShortcode, studyShortcode, environmentName, user);
+
+    return ResponseEntity.ok().body(datasets);
+  }
+
+  @Override
+  public ResponseEntity<Object> getJobHistoryForDataset(
+      String portalShortcode, String studyShortcode, String envName, String datasetName) {
+    AdminUser user = authUtilService.requireAdminUser(request);
+    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
+
+    List<DataRepoJob> jobHistory =
+        dataRepoExportExtService.getJobHistoryForDataset(
+            portalShortcode, studyShortcode, environmentName, datasetName, user);
+
+    return ResponseEntity.ok().body(jobHistory);
+  }
+
+  @Override
+  public ResponseEntity<Void> createDatasetForStudyEnvironment(
+      String portalShortcode, String studyShortcode, String envName, DatasetName datasetName) {
+    AdminUser user = authUtilService.requireAdminUser(request);
+    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
+
+    dataRepoExportExtService.createDataset(
+        portalShortcode, studyShortcode, environmentName, datasetName, user);
+
+    return ResponseEntity.accepted().build();
+  }
+}

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/DataRepoExportExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/DataRepoExportExtService.java
@@ -1,0 +1,78 @@
+package bio.terra.pearl.api.admin.service;
+
+import bio.terra.pearl.api.admin.model.DatasetName;
+import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.model.datarepo.DataRepoJob;
+import bio.terra.pearl.core.model.datarepo.Dataset;
+import bio.terra.pearl.core.model.portal.Portal;
+import bio.terra.pearl.core.model.study.StudyEnvironment;
+import bio.terra.pearl.core.service.datarepo.DataRepoExportService;
+import bio.terra.pearl.core.service.exception.PermissionDeniedException;
+import bio.terra.pearl.core.service.study.StudyEnvironmentService;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DataRepoExportExtService {
+
+  private AuthUtilService authUtilService;
+  private DataRepoExportService dataRepoExportService;
+  private StudyEnvironmentService studyEnvironmentService;
+
+  public DataRepoExportExtService(
+      AuthUtilService authUtilService,
+      DataRepoExportService dataRepoExportService,
+      StudyEnvironmentService studyEnvironmentService) {
+    this.authUtilService = authUtilService;
+    this.dataRepoExportService = dataRepoExportService;
+    this.studyEnvironmentService = studyEnvironmentService;
+  }
+
+  public List<Dataset> listDatasetsForStudyEnvironment(
+      String portalShortcode,
+      String studyShortcode,
+      EnvironmentName environmentName,
+      AdminUser user) {
+    Portal portal = authUtilService.authUserToPortal(user, portalShortcode);
+    authUtilService.authUserToStudy(user, portalShortcode, studyShortcode);
+
+    StudyEnvironment studyEnv =
+        studyEnvironmentService.findByStudy(studyShortcode, environmentName).get();
+
+    return dataRepoExportService.listDatasetsForStudyEnvironment(studyEnv.getId());
+  }
+
+  public List<DataRepoJob> getJobHistoryForDataset(
+      String portalShortcode,
+      String studyShortcode,
+      EnvironmentName environmentName,
+      String datasetName,
+      AdminUser user) {
+    Portal portal = authUtilService.authUserToPortal(user, portalShortcode);
+    authUtilService.authUserToStudy(user, portalShortcode, studyShortcode);
+
+    StudyEnvironment studyEnv =
+        studyEnvironmentService.findByStudy(studyShortcode, environmentName).get();
+
+    return dataRepoExportService.getJobHistoryForDataset(studyEnv.getId(), datasetName);
+  }
+
+  public void createDataset(
+      String portalShortcode,
+      String studyShortcode,
+      EnvironmentName environmentName,
+      DatasetName datasetName,
+      AdminUser user) {
+    if (!user.isSuperuser()) {
+      throw new PermissionDeniedException("You do not have permissions to perform this operation");
+    }
+    Portal portal = authUtilService.authUserToPortal(user, portalShortcode);
+    authUtilService.authUserToStudy(user, portalShortcode, studyShortcode);
+
+    StudyEnvironment studyEnv =
+        studyEnvironmentService.findByStudy(studyShortcode, environmentName).get();
+
+    dataRepoExportService.createDataset(studyEnv, datasetName.getName());
+  }
+}

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: Pearl Admin API
+  title: Juniper Admin API
   description: API for portal and study management
   version: 0.0.1
 paths:
@@ -609,6 +609,53 @@ paths:
                 type: object
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/datarepo/datasets:
+    get:
+      summary: Gets the list of datasets for the study environment
+      tags: [ datarepo ]
+      operationId: listDatasetsForStudyEnvironment
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: studyShortcode, in: path, required: true, schema: { type: string } }
+        - { name: envName, in: path, required: true, schema: { type: string } }
+      responses:
+        '200':
+          description: dataset
+          content: { application/json: { schema: { type: object } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
+    post:
+      summary: Creates a new TDR dataset for the study environment
+      tags: [ datarepo ]
+      operationId: createDatasetForStudyEnvironment
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: studyShortcode, in: path, required: true, schema: { type: string } }
+        - { name: envName, in: path, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content: { application/json: { schema: { $ref: '#/components/schemas/DatasetName' } } }
+      responses:
+        '202':
+          description: Accepted
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/datarepo/datasets/{datasetName}/jobs:
+    get:
+      summary: Gets the job history for a study environment TDR dataset
+      tags: [ datarepo ]
+      operationId: getJobHistoryForDataset
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: studyShortcode, in: path, required: true, schema: { type: string } }
+        - { name: envName, in: path, required: true, schema: { type: string } }
+        - { name: datasetName, in: path, required: true, schema: { type: string } }
+      responses:
+        '200':
+          description: dataset job history
+          content: { application/json: { schema: { type: object } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
 components:
   responses:
     SystemStatusResponse:
@@ -705,6 +752,10 @@ components:
       required: [ roles ]
     PortalDto:
       type: object
+    DatasetName:
+      properties:
+        name:
+          type: string
     SystemStatus:
       required: [ ok, systems ]
       type: object

--- a/api-admin/src/main/resources/templates/swagger-ui.html
+++ b/api-admin/src/main/resources/templates/swagger-ui.html
@@ -7,9 +7,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta
     name="description"
-    content="Terra Java Project Template SwaggerUI"
+    content="Juniper Admin SwaggerUI"
   />
-  <title>Terra Java Project Template SwaggerUI</title>
+  <title>Juniper Admin SwaggerUI</title>
   <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css" >
   <style>
     html

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/DataRepoExportExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/DataRepoExportExtServiceTests.java
@@ -1,0 +1,49 @@
+package bio.terra.pearl.api.admin.service;
+
+import bio.terra.pearl.api.admin.MockAuthServiceAlwaysRejects;
+import bio.terra.pearl.api.admin.model.DatasetName;
+import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.service.exception.PermissionDeniedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DataRepoExportExtServiceTests {
+
+  private DataRepoExportExtService emptyService =
+      new DataRepoExportExtService(new MockAuthServiceAlwaysRejects(), null, null);
+
+  @Test
+  public void listDatasetsForStudyEnvironmentRequiresAuth() {
+    AdminUser user = new AdminUser();
+    Assertions.assertThrows(
+        PermissionDeniedException.class,
+        () ->
+            emptyService.listDatasetsForStudyEnvironment(
+                "someportal", "somestudy", EnvironmentName.sandbox, user));
+  }
+
+  @Test
+  public void getJobHistoryForDatasetRequiresAuth() {
+    AdminUser user = new AdminUser();
+    Assertions.assertThrows(
+        PermissionDeniedException.class,
+        () ->
+            emptyService.getJobHistoryForDataset(
+                "someportal", "somestudy", EnvironmentName.sandbox, "somedataset", user));
+  }
+
+  @Test
+  public void createDatasetRequiresSuperUser() {
+    AdminUser user = new AdminUser();
+    Assertions.assertThrows(
+        PermissionDeniedException.class,
+        () ->
+            emptyService.createDataset(
+                "someportal",
+                "somestudy",
+                EnvironmentName.sandbox,
+                new DatasetName().name("somedataset"),
+                user));
+  }
+}

--- a/api-participant/src/main/resources/api/openapi.yml
+++ b/api-participant/src/main/resources/api/openapi.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: Pearl Admin API
+  title: Juniper Admin API
   description: API for portal and study management
   version: 0.0.1
 paths:

--- a/api-participant/src/main/resources/templates/swagger-ui.html
+++ b/api-participant/src/main/resources/templates/swagger-ui.html
@@ -7,9 +7,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta
     name="description"
-    content="Terra Java Project Template SwaggerUI"
+    content="Juniper Participant SwaggerUI"
   />
-  <title>Terra Java Project Template SwaggerUI</title>
+  <title>Juniper Participant SwaggerUI</title>
   <link rel="stylesheet" type="text/css" href="/webjars/swagger-ui-dist/swagger-ui.css" >
   <style>
     html

--- a/core/src/main/java/bio/terra/pearl/core/dao/datarepo/DataRepoJobDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/datarepo/DataRepoJobDao.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.core.dao.datarepo;
 
 import bio.terra.pearl.core.dao.BaseMutableJdbiDao;
 import bio.terra.pearl.core.model.datarepo.DataRepoJob;
+import bio.terra.pearl.core.model.datarepo.Dataset;
 import org.jdbi.v3.core.Jdbi;
 import org.springframework.stereotype.Component;
 
@@ -21,6 +22,10 @@ public class DataRepoJobDao extends BaseMutableJdbiDao<DataRepoJob> {
 
     public List<DataRepoJob> findAllByStatus(String status) {
         return findAllByProperty("status", status);
+    }
+
+    public List<DataRepoJob> findByStudyEnvironmentIdAndName(UUID studyEnvId, String datasetName) {
+        return findAllByTwoProperties("study_environment_id", studyEnvId, "dataset_name", datasetName);
     }
 
     public void updateJobStatus(UUID id, String newJobStatus) {

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -395,6 +395,27 @@ export type StudyEnvStats = {
   withdrawnCount: number
 }
 
+export type DatasetDetails = {
+  id: string,
+  createdAt: number,
+  lastUpdatedAt: number,
+  studyEnvironmentId: string,
+  datasetId: string,
+  datasetName: string,
+  lastExported: number
+}
+
+export type DatasetJobHistory = {
+  id: string,
+  createdAt: number,
+  lastUpdatedAt: number,
+  studyEnvironmentId: string,
+  tdrJobId: string,
+  datasetName: string,
+  status: string
+  jobType: string
+}
+
 let bearerToken: string | null = null
 export const API_ROOT = '/api'
 
@@ -648,6 +669,31 @@ export default {
     }
     url += searchParams.toString()
     return fetch(url,  this.getGetInit())
+  },
+
+  listDatasetsForStudyEnvironment(portalShortcode: string, studyShortcode: string,
+    envName: string):
+      Promise<Response> {
+    const url =`${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/datarepo/datasets`
+    return fetch(url,  this.getGetInit())
+  },
+
+  getJobHistoryForDataset(portalShortcode: string, studyShortcode: string,
+    envName: string, datasetName: string):
+      Promise<Response> {
+    const url =`${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/datarepo/datasets/${datasetName}/jobs`
+    return fetch(url,  this.getGetInit())
+  },
+
+  async createDatasetForStudyEnvironment(portalShortcode: string, studyShortcode: string,
+    envName: string, datasetName: { name: string }):
+      Promise<Response> {
+    const url =`${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/datarepo/datasets`
+    return await fetch(url, {
+      method: 'POST',
+      headers: this.getInitHeaders(),
+      body: JSON.stringify(datasetName)
+    })
   },
 
   async fetchMailingList(portalShortcode: string, envName: string): Promise<MailingListContact[]> {

--- a/ui-admin/src/study/StudyEnvironmentRouter.tsx
+++ b/ui-admin/src/study/StudyEnvironmentRouter.tsx
@@ -15,6 +15,8 @@ import NotificationConfigView from './notifications/NotificationConfigView'
 import QuestionScratchbox from './surveys/editor/QuestionScratchbox'
 import ExportDataBrowser from './participants/export/ExportDataBrowser'
 import StudyEnvStatsView from './StudyEnvStatsView'
+import DatasetDashboard from './participants/datarepo/DatasetDashboard'
+import DatasetList from './participants/datarepo/DatasetList'
 
 
 export type StudyEnvContextT = { study: Study, currentEnv: StudyEnvironment, currentEnvPath: string, portal: Portal }
@@ -70,6 +72,9 @@ function StudyEnvironmentRouter({ study }: {study: Study}) {
       <Route path="participants/*" element={<ParticipantsRouter studyEnvContext={studyEnvContext}/>}/>
       <Route path="stats" element={<StudyEnvStatsView studyEnvContext={studyEnvContext}/>}/>
       <Route path="export/dataBrowser" element={<ExportDataBrowser studyEnvContext={studyEnvContext}/>}/>
+      <Route path="export/dataRepo/datasets" element={<DatasetList studyEnvContext={studyEnvContext}/>}/>
+      <Route path="export/dataRepo/datasets/:datasetName"
+        element={<DatasetDashboard studyEnvContext={studyEnvContext}/>}/>
       <Route index element={<StudyContent studyEnvContext={studyEnvContext}/>}/>
       <Route path="*" element={<div>Unknown study environment page</div>}/>
     </Routes>
@@ -88,4 +93,12 @@ export const notificationConfigPath = (config: NotificationConfig, currentEnvPat
 
 export const getExportDataBrowserPath = (currentEnvPath: string) => {
   return `${currentEnvPath}/export/dataBrowser`
+}
+
+export const getDatasetListViewPath = (currentEnvPath: string) => {
+  return `${currentEnvPath}/export/dataRepo/datasets`
+}
+
+export const getDatasetDashboardPath = (datasetName: string, currentEnvPath: string) => {
+  return `${currentEnvPath}/export/dataRepo/datasets/${datasetName}`
 }

--- a/ui-admin/src/study/participants/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/ParticipantList.tsx
@@ -4,7 +4,7 @@ import LoadingSpinner from 'util/LoadingSpinner'
 import { Store } from 'react-notifications-component'
 import { failureNotification } from 'util/notifications'
 import { Link } from 'react-router-dom'
-import { getExportDataBrowserPath, StudyEnvContextT } from '../StudyEnvironmentRouter'
+import { getDatasetListViewPath, getExportDataBrowserPath, StudyEnvContextT } from '../StudyEnvironmentRouter'
 import {
   ColumnDef,
   flexRender,
@@ -109,6 +109,8 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
                 aria-label="show or hide export modal">
                 Download
               </button>
+              <span className="px-1">|</span>
+              <Link to={getDatasetListViewPath(currentEnvPath)} className="mx-2">Terra Data Repo</Link>
               <ExportDataControl studyEnvContext={studyEnvContext} show={showExportModal} setShow={setShowExportModal}/>
             </div>
             <ColumnVisibilityControl table={table}/>

--- a/ui-admin/src/study/participants/datarepo/CreateDatasetModal.tsx
+++ b/ui-admin/src/study/participants/datarepo/CreateDatasetModal.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react'
+import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
+import Modal from 'react-bootstrap/Modal'
+import LoadingSpinner from 'util/LoadingSpinner'
+import Api from 'api/api'
+import { failureNotification, successNotification } from 'util/notifications'
+import { Store } from 'react-notifications-component'
+
+const CreateDatasetModal = ({ studyEnvContext, show, setShow }: {studyEnvContext: StudyEnvContextT, show: boolean,
+    setShow:  React.Dispatch<React.SetStateAction<boolean>>}) => {
+  const [isLoading, setIsLoading] = useState(false)
+  const [datasetName, setDatasetName] = useState('')
+  const createDataset = async () => {
+    setIsLoading(true)
+    const response = await Api.createDatasetForStudyEnvironment(studyEnvContext.portal.shortcode,
+      studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName, { name: datasetName })
+    if (response.ok) {
+      Store.addNotification(successNotification(`${datasetName} created`))
+    } else {
+      Store.addNotification(failureNotification(`${datasetName} creation failed`))
+    }
+    setShow(false)
+    setIsLoading(false)
+    setDatasetName('')
+  }
+
+  return <Modal show={show} onHide={() => setShow(false)}>
+    <Modal.Header closeButton>
+      <Modal.Title>Create Dataset</Modal.Title>
+      <div className="ms-4">
+        {studyEnvContext.study.name}: {studyEnvContext.currentEnv.environmentName}
+      </div>
+    </Modal.Header>
+    <Modal.Body>
+      <form onSubmit={e => e.preventDefault()}>
+        <label className="form-label"> Dataset Name
+          <input type="text" size={50} className="form-control" id="inputDatasetName" value={datasetName}
+            onChange={event => setDatasetName(event.target.value)}/>
+        </label>
+      </form>
+    </Modal.Body>
+    <Modal.Footer>
+      <LoadingSpinner isLoading={isLoading}>
+        <button className="btn btn-primary" onClick={createDataset}>Create</button>
+        <button className="btn btn-secondary" onClick={() => {
+          setShow(false)
+          setDatasetName('')
+        }}>Cancel</button>
+      </LoadingSpinner>
+    </Modal.Footer>
+  </Modal>
+}
+
+export default CreateDatasetModal

--- a/ui-admin/src/study/participants/datarepo/DatasetDashboard.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetDashboard.tsx
@@ -1,0 +1,142 @@
+import React, { useEffect, useState } from 'react'
+import { getDatasetListViewPath, StudyEnvContextT } from 'study/StudyEnvironmentRouter'
+import Api, { DatasetDetails, DatasetJobHistory } from 'api/api'
+import LoadingSpinner from 'util/LoadingSpinner'
+import { Store } from 'react-notifications-component'
+import { failureNotification } from 'util/notifications'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faExternalLink, faArrowLeft } from '@fortawesome/free-solid-svg-icons'
+import { instantToDefaultString } from '../../../util/timeUtils'
+import {
+  ColumnDef,
+  getCoreRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable
+} from '@tanstack/react-table'
+import { basicTableLayout } from '../../../util/tableUtils'
+import { Link, useParams } from 'react-router-dom'
+
+const columns: ColumnDef<DatasetJobHistory>[] = [{
+  id: 'jobType',
+  header: 'Action',
+  accessorKey: 'jobType'
+}, {
+  id: 'status',
+  header: 'Status',
+  accessorKey: 'status'
+}, {
+  id: 'created',
+  header: 'Created',
+  accessorKey: 'createdAt',
+  cell: info => instantToDefaultString(info.getValue() as unknown as number)
+}, {
+  id: 'lastUpdated',
+  header: 'Last Updated',
+  accessorKey: 'lastUpdatedAt',
+  cell: info => instantToDefaultString(info.getValue() as unknown as number)
+}, {
+  id: 'jobDetails',
+  header: 'Job Details',
+  accessorKey: 'tdrJobId',
+  cell: info => <a href={
+    `https://jade.datarepo-dev.broadinstitute.org/activity?expandedJob=${info.getValue()}`} target="_blank"
+  >View job in Terra Data Repo <FontAwesomeIcon icon={faExternalLink}/></a>
+}]
+
+const DatasetDashboard = ({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) => {
+  const { currentEnvPath } = studyEnvContext
+  const [datasetDetails, setDatasetDetails] = useState<DatasetDetails | null>(null)
+  const [datasetJobHistory, setDatasetJobHistory] = useState<DatasetJobHistory[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [sorting, setSorting] = React.useState<SortingState>([])
+  const datasetName = useParams().datasetName as string
+
+  const table = useReactTable({
+    data: datasetJobHistory,
+    columns,
+    state: {
+      sorting
+    },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    debugTable: true
+  })
+
+  const contentHeaderStyle = {
+    padding: '1em 0 0 1em',
+    borderBottom: '1px solid #f6f6f6'
+  }
+
+  const loadData = async () => {
+    try {
+      //Fetch dataset details
+      const datasetDetails = await Api.listDatasetsForStudyEnvironment(
+        studyEnvContext.portal.shortcode,
+        studyEnvContext.study.shortcode,
+        studyEnvContext.currentEnv.environmentName)
+      const datasetDetailsResponse = await datasetDetails.json()
+      setDatasetDetails(datasetDetailsResponse.find((dataset: { datasetName: string }) =>
+        dataset.datasetName === datasetName))
+
+      //Fetch dataset job history
+      const datasetJobHistory = await Api.getJobHistoryForDataset(
+        studyEnvContext.portal.shortcode,
+        studyEnvContext.study.shortcode,
+        studyEnvContext.currentEnv.environmentName,
+        datasetName)
+      const datasetJobHistoryResponse = await datasetJobHistory.json()
+      setDatasetJobHistory(datasetJobHistoryResponse)
+
+      setIsLoading(false)
+    } catch (e) {
+      Store.addNotification(failureNotification(`Error loading dataset information`))
+    }
+  }
+
+  useEffect(() => {
+    loadData()
+  }, [])
+  return <div className="container-fluid py-3">
+    <h1 className="h3">Terra Data Repo</h1>
+    <Link to={getDatasetListViewPath(currentEnvPath)} className="mx-2">
+      <FontAwesomeIcon icon={faArrowLeft}/> Back to dataset list
+    </Link>
+    <LoadingSpinner isLoading={isLoading}>
+      <div className="col-12 p-3">
+        <ul className="list-unstyled">
+          <li className="bg-white my-3">
+            <div style={contentHeaderStyle}>
+              <h6>Dataset Details</h6>
+            </div>
+            <div className="flex-grow-1 p-3">
+              <div className="form-group">
+                <div className="form-group-item">
+                  <label>Dataset Name:</label> { datasetDetails?.datasetName }
+                  <br/>
+                  <label>Dataset ID:</label> { datasetDetails?.datasetId }
+                  <br/>
+                  <label>Created Date:</label> { instantToDefaultString(datasetDetails?.createdAt) }
+                  <br/>
+                  <label>Last Successful Export:</label> { instantToDefaultString(datasetDetails?.lastExported) }
+                </div>
+                <br/>
+                <a href={`https://jade.datarepo-dev.broadinstitute.org/datasets/${datasetDetails?.datasetId}`}
+                  target="_blank">View dataset in Terra Data Repo <FontAwesomeIcon icon={faExternalLink}/></a>
+              </div>
+            </div>
+          </li>
+          <li className="bg-white my-3">
+            <div style={contentHeaderStyle}>
+              <h6>Export History</h6>
+            </div>
+            {basicTableLayout(table)}
+          </li>
+        </ul>
+      </div>
+    </LoadingSpinner>
+  </div>
+}
+
+export default DatasetDashboard

--- a/ui-admin/src/study/participants/datarepo/DatasetList.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetList.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useState } from 'react'
+import { getDatasetDashboardPath, StudyEnvContextT } from 'study/StudyEnvironmentRouter'
+import Api, { DatasetDetails } from 'api/api'
+import LoadingSpinner from 'util/LoadingSpinner'
+import { Store } from 'react-notifications-component'
+import { failureNotification } from 'util/notifications'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faExternalLink } from '@fortawesome/free-solid-svg-icons/faExternalLink'
+import { instantToDefaultString } from '../../../util/timeUtils'
+import {
+  ColumnDef,
+  getCoreRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable
+} from '@tanstack/react-table'
+import { basicTableLayout } from '../../../util/tableUtils'
+import { Link } from 'react-router-dom'
+import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus'
+import { useUser } from '../../../user/UserProvider'
+import CreateDatasetModal from './CreateDatasetModal'
+
+const datasetColumns = (currentEnvPath: string): ColumnDef<DatasetDetails>[] => [{
+  id: 'datasetName',
+  header: 'Dataset Name',
+  accessorKey: 'datasetName',
+  cell: info => <Link to={getDatasetDashboardPath(info.getValue() as unknown as string, currentEnvPath)}
+    className="mx-2">{info.getValue() as unknown as string}</Link>
+}, {
+  id: 'datasetUuid',
+  header: 'Dataset ID',
+  accessorKey: 'datasetId'
+}, {
+  id: 'created',
+  header: 'Created Date',
+  accessorKey: 'createdAt',
+  cell: info => instantToDefaultString(info.getValue() as unknown as number)
+}, {
+  id: 'lastUpdated',
+  header: 'Last Export',
+  accessorKey: 'lastExported',
+  cell: info => instantToDefaultString(info.getValue() as unknown as number)
+}, {
+  header: 'Terra Data Repo',
+  accessorKey: 'datasetId',
+  cell: info => <a href={
+      `https://jade.datarepo-dev.broadinstitute.org/datasets/${info.getValue()}`} target="_blank"
+  >View in Terra Data Repo <FontAwesomeIcon icon={faExternalLink}/></a>
+}]
+
+const DatasetList = ({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) => {
+  const { currentEnvPath } = studyEnvContext
+  const [showCreateDatasetModal, setShowCreateDatasetModal] = useState(false)
+  const [datasets, setDatasets] = useState<DatasetDetails[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [datasetsSorting, setDatasetsSorting] = React.useState<SortingState>([])
+  const { user } = useUser()
+
+  const datasetTable = useReactTable({
+    data: datasets,
+    columns: datasetColumns(currentEnvPath),
+    state: {
+      sorting: datasetsSorting
+    },
+    onSortingChange: setDatasetsSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel()
+  })
+
+  const contentHeaderStyle = {
+    padding: '1em 0 0 1em',
+    borderBottom: '1px solid #f6f6f6'
+  }
+
+  const loadData = async () => {
+    try {
+      //Fetch datasets
+      const datasets = await Api.listDatasetsForStudyEnvironment(
+        studyEnvContext.portal.shortcode,
+        studyEnvContext.study.shortcode,
+        studyEnvContext.currentEnv.environmentName)
+      const datasetsResponse = await datasets.json()
+      setDatasets(datasetsResponse)
+      setIsLoading(false)
+    } catch (e) {
+      Store.addNotification(failureNotification(`Error loading datasets`))
+    }
+  }
+
+  useEffect(() => {
+    loadData()
+  }, [])
+  return <div className="container-fluid py-3">
+    <h1 className="h3">Study Environment Datasets</h1>
+    { user.superuser &&
+        <button className="btn btn-secondary" onClick={() => setShowCreateDatasetModal(!showCreateDatasetModal)}
+          aria-label="show or hide export modal">
+          <FontAwesomeIcon icon={faPlus}/> Create new dataset
+        </button>
+    }
+    <CreateDatasetModal studyEnvContext={studyEnvContext}
+      show={showCreateDatasetModal}
+      setShow={setShowCreateDatasetModal}/>
+    <LoadingSpinner isLoading={isLoading}>
+      <div className="col-12 p-3">
+        <ul className="list-unstyled">
+          <li className="bg-white my-3">
+            <div style={contentHeaderStyle}>
+              <h6>Datasets</h6>
+            </div>
+            {basicTableLayout(datasetTable)}
+          </li>
+        </ul>
+      </div>
+    </LoadingSpinner>
+  </div>
+}
+
+export default DatasetList


### PR DESCRIPTION
This introduces some functionality into the admin UI for managing TDR datasets. The goal is to make it easier for developers and study admins to see and manage datasets for their study environments.

Other functionality I'd like to add in the future:
* Delete dataset
* View and cleanup orphaned TDR datasets (might make this a developer script since it shouldn't really happen in persistent environments. But it's common if you clear your local DB, which leaves dangling TDR datasets that conflict with new dataset creations from your local Juniper)

Screenshots:

Study environment dataset list
![Screenshot 2023-05-09 at 9 43 02 AM](https://github.com/broadinstitute/pearl/assets/7257391/b1ae0380-216a-4c01-883c-19bb6e3d58b5)

Dataset summary/job history
![Screenshot 2023-05-09 at 9 43 15 AM](https://github.com/broadinstitute/pearl/assets/7257391/45b91cd3-a50e-409c-8513-b5f9d56be0f2)


Create dataset modal (limited to superusers)
![Screenshot 2023-05-09 at 9 42 44 AM](https://github.com/broadinstitute/pearl/assets/7257391/8fee68f6-1fa4-41f9-a220-1eddec30fe85)


**TO TEST:**

Make sure you have all of your local environment variables set, [per these instructions](https://broadworkbench.atlassian.net/wiki/spaces/PEARL/pages/2708471863/TDR+Export#Setting-up-TDR-export-locally%3A).

1. Boot ApiAdminApp
2. Boot admin UI
3. Make sure OurHealth portal is populated
4. Navigate to the participants list, i.e. https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants
5. Click "Terra Data Repo" and verify that you can view existing datasets, create new datasets, and view the details for a dataset.

There is a bit of a quirk to this UX that I'll iron out in a followup PR: you won't immediately see the dataset in the dataset list after creation, but it should show up within 10 mins (I may tighten the poll time in a future PR since 10 mins is a bit too slow). I'd like to display some information to the user that shows in progress or failed dataset creations. This will likely involve pre-populating a partial row in our `dataset` DB table with some information to return in the `listDatasetsForStudyEnvironment` call.