### PR TITLE
JN-372 sonar-scanner

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -53,8 +53,8 @@ jobs:
         with:
           arguments: build --info # if you need to see test failure full stacktraces, change this to `build --info`
       - name: SonarCloud Scan
-        working-directory: /home/runner/pearl
         uses: SonarSource/sonarcloud-github-action@master
+        working-directory: ${{ github.workspace }}/pearl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -52,12 +52,6 @@ jobs:
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
           arguments: build --info # if you need to see test failure full stacktraces, change this to `build --info`
-
-  sonarcloud:
-    name: SonarCloud
-    needs: [ build ]
-    runs-on: ubuntu-latest
-    steps:
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         with:
-          projectBaseDir: pearl
+          projectBaseDir: /home/runner/work/pearl/pearl
           args: -Dsonar.verbose=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -41,6 +41,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of SonarQube analysis
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -54,6 +56,8 @@ jobs:
           arguments: build --info # if you need to see test failure full stacktraces, change this to `build --info`
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
+        with:
+          projectBaseDir: pearl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -53,6 +53,17 @@ jobs:
         with:
           arguments: build --info # if you need to see test failure full stacktraces, change this to `build --info`
 
+  sonarcloud:
+    name: SonarCloud
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
   # Need to uncomment these in follow up PR, The new Trivy and Tag workflows need to exist on the development branch
   # before the following steps will work
 
@@ -70,7 +81,7 @@ jobs:
           workflow: Trivy
           token: ${{ secrets.BROADBOT_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
-  
+
   dispatch-tag:
     needs: [ build ]
     runs-on: ubuntu-latest

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -58,6 +58,7 @@ jobs:
         uses: SonarSource/sonarcloud-github-action@master
         with:
           projectBaseDir: pearl
+          -Dsonar.verbose=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -58,7 +58,7 @@ jobs:
         uses: SonarSource/sonarcloud-github-action@master
         with:
           projectBaseDir: /home/runner/work/pearl/pearl
-          args: -Dsonar.verbose=true
+          args: -X
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -58,7 +58,7 @@ jobs:
         uses: SonarSource/sonarcloud-github-action@master
         with:
           projectBaseDir: pearl
-          -Dsonar.verbose=true
+          args: -Dsonar.verbose=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -54,14 +54,6 @@ jobs:
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
           arguments: build --info # if you need to see test failure full stacktraces, change this to `build --info`
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        with:
-          projectBaseDir: /home/runner/work/pearl/pearl
-          args: -X
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   # Need to uncomment these in follow up PR, The new Trivy and Tag workflows need to exist on the development branch
   # before the following steps will work

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           arguments: build --info # if you need to see test failure full stacktraces, change this to `build --info`
       - name: SonarCloud Scan
+        working-directory: /home/runner/pearl
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -54,7 +54,6 @@ jobs:
           arguments: build --info # if you need to see test failure full stacktraces, change this to `build --info`
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
-        working-directory: ${{ github.workspace }}/pearl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -1,0 +1,24 @@
+name: Trivy
+on: workflow_dispatch
+
+jobs:
+  trivy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Build all projects without running tests
+        run: ./gradlew --build-cache compileJava
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -1,8 +1,8 @@
-name: Trivy
+name: Sonar
 on: workflow_dispatch
 
 jobs:
-  trivy:
+  sonar:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ bin/
 # Sonar
 .scannerwork
 .sonar-token
+tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ bin/
 
 # PyEnv environment files
 .env/
+
+# Sonar
+.scannerwork
+.sonar-token

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+sonar.projectKey=broadinstitute_pearl
+sonar.organization=dsp-appsec
+sonar.projectName=pearl
+sonar.sources=api-admin,api-participant,core,ui-admin,ui-participant
+sonar.sourceEncoding=UTF-8
+sonar.java.binaries=api-admin/build/classes,api-participant/build/classes,core/build/classes
+
+# TODO sonar.coverage.jacoco.xmlReportPaths

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=broadinstitute_pearl
 sonar.organization=dsp-appsec
 sonar.projectName=pearl
-sonar.sources=api-admin,api-participant,core,ui-admin,ui-participant
+sonar.sources=api-admin,api-participant,core,populate,ui-admin,ui-participant
 sonar.sourceEncoding=UTF-8
 sonar.java.binaries=api-admin/build/classes,api-participant/build/classes,core/build/classes
 


### PR DESCRIPTION
Run SonarCloud across api-admin, api-participant, core, ui-admin, ui-participant. Using sonar-scanner rather than gradle because this repo contains both Java and TypeScript.