### PR TITLE
[JN-306] Only support on-demand dataset creation

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledDataRepoExportService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledDataRepoExportService.java
@@ -33,44 +33,7 @@ public class ScheduledDataRepoExportService {
     }
   }
 
-  /* Create any missing datasets every hour or so. There is one dataset per study
-    environment. By decoupling dataset creation from ingest, we don't have to worry
-    about handling large async saga transactions. If a dataset has not yet been created, ingest
-    will simply be skipped until the dataset is ready. These operations happen frequently enough
-    that it shouldn't be a problem if the first round of ingest is delayed due to a missing
-    dataset: by the next round, it should be ready.
-  */
-  @Scheduled(timeUnit = TimeUnit.MINUTES, fixedDelay = 60, initialDelay = 1)
-  @SchedulerLock(
-      name = "DataRepoExportService.createDatasetsForStudyEnvironments",
-      lockAtMostFor = "10m",
-      lockAtLeastFor = "5m")
-  public void createStudyEnvironmentDatasets() {
-    if (isTdrConfigured()) {
-      logger.info("Creating datasets...");
-      dataRepoExportService.createDatasetsForStudyEnvironments();
-    } else {
-      logger.error(
-          "Error: Skipping TDR dataset creation, as TDR has not been configured for this environment.");
-    }
-  }
-
-  @Scheduled(timeUnit = TimeUnit.MINUTES, fixedDelay = 240, initialDelay = 1)
-  @SchedulerLock(
-      name = "DataRepoExportService.ingestStudyEnvironmentDatasets",
-      lockAtMostFor = "10m",
-      lockAtLeastFor = "5m")
-  public void ingestStudyEnvironmentDatasets() {
-    if (isTdrConfigured()) {
-      logger.info("Ingesting datasets...");
-      dataRepoExportService.ingestDatasets();
-    } else {
-      logger.error(
-          "Error: Skipping TDR dataset ingest, as TDR has not been configured for this environment.");
-    }
-  }
-
-  @Scheduled(timeUnit = TimeUnit.MINUTES, fixedDelay = 10, initialDelay = 0)
+  @Scheduled(timeUnit = TimeUnit.MINUTES, fixedDelay = 5, initialDelay = 0)
   @SchedulerLock(
       name = "DataRepoExportService.pollRunningJobs",
       lockAtMostFor = "5m",

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledDataRepoExportService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledDataRepoExportService.java
@@ -18,8 +18,8 @@ public class ScheduledDataRepoExportService {
   private Environment env;
 
   /* NOTE: Scheduled dataset creation and ingest was removed in https://github.com/broadinstitute/pearl/pull/367
-     If you'd like to restore that functionality, reference that PR so you don't have to re-write the code.
-   */
+    If you'd like to restore that functionality, reference that PR so you don't have to re-write the code.
+  */
 
   public ScheduledDataRepoExportService(
       Environment env, DataRepoExportService dataRepoExportService) {

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledDataRepoExportService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledDataRepoExportService.java
@@ -17,6 +17,10 @@ public class ScheduledDataRepoExportService {
   private DataRepoExportService dataRepoExportService;
   private Environment env;
 
+  /* NOTE: Scheduled dataset creation and ingest was removed in https://github.com/broadinstitute/pearl/pull/367
+     If you'd like to restore that functionality, reference that PR so you don't have to re-write the code.
+   */
+
   public ScheduledDataRepoExportService(
       Environment env, DataRepoExportService dataRepoExportService) {
     this.env = env;


### PR DESCRIPTION
Until we have a better plan for dataset schema migration _and_ until TDR on Azure supports row upserts, we're better off removing the scheduled process that periodically creates datasets and ingests data. It's just cluttering things at the moment.

In the short-term, the higher value and simpler approach is to embrace on-demand dataset creation. This was introduced in #359, and will be fully hooked up to the TSV ingest code (introduced in #326) shortly once I wrap up schema creation. Once that's complete, study staff will be able to click a button in the admin tool and have their current data be exported to TDR.

Note that this is only one small part of JN-306.