### PR TITLE
[JN-376] Update user state after auto saving survey progress

### DIFF
--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -108,8 +108,13 @@ function RawSurveyView({ form, enrollee, resumableData, pager, studyShortcode, t
         Api.submitSurveyResponse({
           studyShortcode, stableId: form.stableId, enrolleeShortcode: enrollee.shortcode,
           version: form.version, response: responseDto, taskId
-        }).then(() => {
-          // no-op for now.  When we implement live-sync, it will be here.
+        }).then(response => {
+          const updatedEnrollee = {
+            ...response.enrollee,
+            participantTasks: response.tasks,
+            profile: response.profile
+          }
+          updateEnrollee(updatedEnrollee)
         }).catch(() => {
           // if the operation fails, restore the state from before so the next diff operation will capture the changes
           // that failed to save this time


### PR DESCRIPTION
Currently, if you start a survey and then return to the dashboard via the Dashboard link in the navbar, the survey still shows as "Not started". After refreshing the page, the survey shows as "In progress".

This updates the user state after auto saving survey progress so that the dashboard is accurate.