### PR TITLE
[JN-341] Replace "Completed" with "Last updated" for in progress surveys

### DIFF
--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -228,6 +228,7 @@ export type ResponseSnapshot = {
 }
 
 export type SurveyResponse = {
+  complete: boolean,
   createdAt: number, // this is a java instant, so number of seconds since epoch start
   lastUpdatedAt: string,
   surveyId: string,

--- a/ui-admin/src/study/participants/survey/EnrolleeSurveyView.tsx
+++ b/ui-admin/src/study/participants/survey/EnrolleeSurveyView.tsx
@@ -43,7 +43,9 @@ export function RawEnrolleeSurveyView({ enrollee, configSurvey, responses }:
   return <div>
     <h6>{configSurvey.survey.name}</h6>
     <div>
-      <span className="fst-italic">completed {instantToDefaultString(lastResponse.createdAt)}</span>
+      <span className="fst-italic">
+        {lastResponse.complete ? 'Completed' : 'Last updated'} {instantToDefaultString(lastResponse.createdAt)}
+      </span>
       <button className="ms-5 btn btn-secondary" onClick={() => setIsEditing(!isEditing)}>
         {isEditing ? 'cancel' : 'update / edit'}
       </button>


### PR DESCRIPTION
When viewing a participant's response for a survey in the admin tool, "Completed <date/time>" is shown if there is any response. This was fine when surveys had to completed all at once, but since we started allowing saving partial responses and added a concept of "in progress" surveys ([JN-190](https://broadworkbench.atlassian.net/browse/JN-190)), this can be misleading.

This replaces "Completed" with "Last updated" if the last saved response did not complete the survey.

[JN-190]: https://broadworkbench.atlassian.net/browse/JN-190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ