### PR TITLE
[JN-374] Support dataset descriptions

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/datarepo/DataRepoExportController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/datarepo/DataRepoExportController.java
@@ -1,7 +1,7 @@
 package bio.terra.pearl.api.admin.controller.datarepo;
 
 import bio.terra.pearl.api.admin.api.DatarepoApi;
-import bio.terra.pearl.api.admin.model.DatasetName;
+import bio.terra.pearl.api.admin.model.CreateDataset;
 import bio.terra.pearl.api.admin.service.AuthUtilService;
 import bio.terra.pearl.api.admin.service.DataRepoExportExtService;
 import bio.terra.pearl.core.model.EnvironmentName;
@@ -57,12 +57,12 @@ public class DataRepoExportController implements DatarepoApi {
 
   @Override
   public ResponseEntity<Void> createDatasetForStudyEnvironment(
-      String portalShortcode, String studyShortcode, String envName, DatasetName datasetName) {
+      String portalShortcode, String studyShortcode, String envName, CreateDataset createDataset) {
     AdminUser user = authUtilService.requireAdminUser(request);
     EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
 
     dataRepoExportExtService.createDataset(
-        portalShortcode, studyShortcode, environmentName, datasetName, user);
+        portalShortcode, studyShortcode, environmentName, createDataset, user);
 
     return ResponseEntity.accepted().build();
   }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/DataRepoExportExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/DataRepoExportExtService.java
@@ -1,6 +1,6 @@
 package bio.terra.pearl.api.admin.service;
 
-import bio.terra.pearl.api.admin.model.DatasetName;
+import bio.terra.pearl.api.admin.model.CreateDataset;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.datarepo.DataRepoJob;
@@ -62,7 +62,7 @@ public class DataRepoExportExtService {
       String portalShortcode,
       String studyShortcode,
       EnvironmentName environmentName,
-      DatasetName datasetName,
+      CreateDataset createDataset,
       AdminUser user) {
     if (!user.isSuperuser()) {
       throw new PermissionDeniedException("You do not have permissions to perform this operation");
@@ -73,6 +73,7 @@ public class DataRepoExportExtService {
     StudyEnvironment studyEnv =
         studyEnvironmentService.findByStudy(studyShortcode, environmentName).get();
 
-    dataRepoExportService.createDataset(studyEnv, datasetName.getName());
+    dataRepoExportService.createDataset(
+        studyEnv, createDataset.getName(), createDataset.getDescription());
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledDataRepoExportService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledDataRepoExportService.java
@@ -37,11 +37,11 @@ public class ScheduledDataRepoExportService {
     }
   }
 
-  @Scheduled(timeUnit = TimeUnit.MINUTES, fixedDelay = 5, initialDelay = 0)
+  @Scheduled(timeUnit = TimeUnit.SECONDS, fixedDelay = 5, initialDelay = 0)
   @SchedulerLock(
       name = "DataRepoExportService.pollRunningJobs",
-      lockAtMostFor = "5m",
-      lockAtLeastFor = "1m")
+      lockAtMostFor = "5s",
+      lockAtLeastFor = "1s")
   public void pollRunningJobs() {
     if (isTdrConfigured()) {
       logger.info("Polling running TDR jobs...");

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledDataRepoExportService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledDataRepoExportService.java
@@ -37,11 +37,11 @@ public class ScheduledDataRepoExportService {
     }
   }
 
-  @Scheduled(timeUnit = TimeUnit.SECONDS, fixedDelay = 5, initialDelay = 0)
+  @Scheduled(timeUnit = TimeUnit.MINUTES, fixedDelay = 5, initialDelay = 0)
   @SchedulerLock(
       name = "DataRepoExportService.pollRunningJobs",
-      lockAtMostFor = "5s",
-      lockAtLeastFor = "1s")
+      lockAtMostFor = "5m",
+      lockAtLeastFor = "1m")
   public void pollRunningJobs() {
     if (isTdrConfigured()) {
       logger.info("Polling running TDR jobs...");

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -634,7 +634,7 @@ paths:
         - { name: envName, in: path, required: true, schema: { type: string } }
       requestBody:
         required: true
-        content: { application/json: { schema: { $ref: '#/components/schemas/DatasetName' } } }
+        content: { application/json: { schema: { $ref: '#/components/schemas/CreateDataset' } } }
       responses:
         '202':
           description: Accepted
@@ -752,9 +752,11 @@ components:
       required: [ roles ]
     PortalDto:
       type: object
-    DatasetName:
+    CreateDataset:
       properties:
         name:
+          type: string
+        description:
           type: string
     SystemStatus:
       required: [ ok, systems ]

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/DataRepoExportExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/DataRepoExportExtServiceTests.java
@@ -1,7 +1,7 @@
 package bio.terra.pearl.api.admin.service;
 
 import bio.terra.pearl.api.admin.MockAuthServiceAlwaysRejects;
-import bio.terra.pearl.api.admin.model.DatasetName;
+import bio.terra.pearl.api.admin.model.CreateDataset;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.service.exception.PermissionDeniedException;
@@ -43,7 +43,7 @@ public class DataRepoExportExtServiceTests {
                 "someportal",
                 "somestudy",
                 EnvironmentName.sandbox,
-                new DatasetName().name("somedataset"),
+                new CreateDataset().name("somedataset").description("a dataset"),
                 user));
   }
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/datarepo/Dataset.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/datarepo/Dataset.java
@@ -17,5 +17,6 @@ public class Dataset extends BaseEntity {
     private UUID studyEnvironmentId;
     private UUID datasetId;
     private String datasetName;
+    private String description;
     private Instant lastExported;
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoClient.java
@@ -5,7 +5,6 @@ import bio.terra.datarepo.api.JobsApi;
 import bio.terra.datarepo.api.UnauthenticatedApi;
 import bio.terra.datarepo.client.ApiException;
 import bio.terra.datarepo.model.*;
-import bio.terra.pearl.core.service.export.formatters.DataValueExportType;
 import bio.terra.pearl.core.shared.GoogleServiceAccountUtils;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -28,9 +27,8 @@ public class DataRepoClient {
     }
 
     //Dataset APIs
-    public JobModel createDataset(UUID spendProfileId, String datasetName, List<String> columnKeys) throws ApiException {
+    public JobModel createDataset(UUID spendProfileId, String datasetName, String description, List<String> columnKeys) throws ApiException {
         DatasetsApi datasetsApi = getDatasetsApi();
-
 
         //TODO: Temporarily setting all column types of STRING. There seems to be an issue converting our DATETIME format
         //into a TDR DATETIME. This will be resolved in JN-381.
@@ -41,6 +39,7 @@ public class DataRepoClient {
 
         DatasetRequestModel dataset = new DatasetRequestModel()
                 .name(datasetName)
+                .description(description)
                 .cloudPlatform(CloudPlatform.AZURE)
                 .defaultProfileId(spendProfileId)
                 .schema(schema);

--- a/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoExportService.java
@@ -21,7 +21,8 @@ import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.exception.datarepo.DatasetCreationException;
 import bio.terra.pearl.core.service.exception.datarepo.DatasetNotFoundException;
 import bio.terra.pearl.core.service.export.*;
-import bio.terra.pearl.core.service.export.formatters.DataValueExportType;
+import bio.terra.pearl.core.service.export.EnrolleeExportService;
+import bio.terra.pearl.core.service.export.ExportFileFormat;
 import bio.terra.pearl.core.service.export.instance.ExportOptions;
 import bio.terra.pearl.core.service.export.instance.ModuleExportInfo;
 import org.slf4j.Logger;
@@ -88,7 +89,7 @@ public class DataRepoExportService {
         return dataRepoJobDao.findByStudyEnvironmentIdAndName(studyEnvironmentId, datasetName);
     }
 
-    public void createDataset(StudyEnvironment studyEnv, String datasetName) {
+    public void createDataset(StudyEnvironment studyEnv, String datasetName, String description) {
         //TODO: JN-125: This default spend profile is temporary. Eventually, we will want to configure spend profiles
         // on a per-study basis and store those in the Juniper DB.
         UUID defaultSpendProfileId = UUID.fromString(Objects.requireNonNull(env.getProperty("env.tdr.billingProfileId")));
@@ -97,7 +98,7 @@ public class DataRepoExportService {
 
         JobModel response;
         try {
-            response = dataRepoClient.createDataset(defaultSpendProfileId, datasetName, columnKeys);
+            response = dataRepoClient.createDataset(defaultSpendProfileId, datasetName, description, columnKeys);
         } catch (ApiException e) {
             throw new DatasetCreationException(String.format("Unable to create TDR dataset for study environment %s. Error: %s", studyEnv.getStudyId(), e.getMessage()));
         }
@@ -212,6 +213,7 @@ public class DataRepoExportService {
                     Dataset dataset = Dataset.builder()
                             .studyEnvironmentId(job.getStudyEnvironmentId())
                             .datasetId(UUID.fromString(jobResult.get("id").toString()))
+                            .description(jobResult.get("description").toString())
                             .datasetName(job.getDatasetName())
                             .lastExported(Instant.ofEpochSecond(0))
                             .build();

--- a/core/src/main/resources/db/changelog/changesets/2023_05_15_dataset_description.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2023_05_15_dataset_description.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: "dataset_description"
+      author: mbemis
+      changes:
+        - addColumn:
+            tableName: dataset
+            columns:
+              - column: { name: description, type: text }

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -92,6 +92,9 @@ databaseChangeLog:
   - include:
       file: changesets/2023_05_09_enrollee_withdraw.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2023_05_15_dataset_description.yaml
+      relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -402,6 +402,7 @@ export type DatasetDetails = {
   studyEnvironmentId: string,
   datasetId: string,
   datasetName: string,
+  description: string,
   lastExported: number
 }
 
@@ -686,13 +687,13 @@ export default {
   },
 
   async createDatasetForStudyEnvironment(portalShortcode: string, studyShortcode: string,
-    envName: string, datasetName: { name: string }):
+    envName: string, createDataset: { name: string, description: string }):
       Promise<Response> {
     const url =`${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/datarepo/datasets`
     return await fetch(url, {
       method: 'POST',
       headers: this.getInitHeaders(),
-      body: JSON.stringify(datasetName)
+      body: JSON.stringify(createDataset)
     })
   },
 

--- a/ui-admin/src/study/participants/datarepo/CreateDatasetModal.tsx
+++ b/ui-admin/src/study/participants/datarepo/CreateDatasetModal.tsx
@@ -10,10 +10,12 @@ const CreateDatasetModal = ({ studyEnvContext, show, setShow }: {studyEnvContext
     setShow:  React.Dispatch<React.SetStateAction<boolean>>}) => {
   const [isLoading, setIsLoading] = useState(false)
   const [datasetName, setDatasetName] = useState('')
+  const [datasetDescription, setDatasetDescription] = useState('')
   const createDataset = async () => {
     setIsLoading(true)
     const response = await Api.createDatasetForStudyEnvironment(studyEnvContext.portal.shortcode,
-      studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName, { name: datasetName })
+      studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName,
+      { name: datasetName, description: datasetDescription })
     if (response.ok) {
       Store.addNotification(successNotification(`${datasetName} created`))
     } else {
@@ -21,7 +23,11 @@ const CreateDatasetModal = ({ studyEnvContext, show, setShow }: {studyEnvContext
     }
     setShow(false)
     setIsLoading(false)
+    clearFields()
+  }
+  const clearFields = () => {
     setDatasetName('')
+    setDatasetDescription('')
   }
 
   return <Modal show={show} onHide={() => setShow(false)}>
@@ -37,6 +43,10 @@ const CreateDatasetModal = ({ studyEnvContext, show, setShow }: {studyEnvContext
           <input type="text" size={50} className="form-control" id="inputDatasetName" value={datasetName}
             onChange={event => setDatasetName(event.target.value)}/>
         </label>
+        <label className="form-label"> Description
+          <textarea rows={3} cols={50} value={datasetDescription}
+            onChange={event => setDatasetDescription(event.target.value)}/>
+        </label>
       </form>
     </Modal.Body>
     <Modal.Footer>
@@ -44,7 +54,7 @@ const CreateDatasetModal = ({ studyEnvContext, show, setShow }: {studyEnvContext
         <button className="btn btn-primary" onClick={createDataset}>Create</button>
         <button className="btn btn-secondary" onClick={() => {
           setShow(false)
-          setDatasetName('')
+          clearFields()
         }}>Cancel</button>
       </LoadingSpinner>
     </Modal.Footer>

--- a/ui-admin/src/study/participants/datarepo/DatasetDashboard.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetDashboard.tsx
@@ -120,7 +120,7 @@ const DatasetDashboard = ({ studyEnvContext }: {studyEnvContext: StudyEnvContext
                   <label>Date Created:</label> { instantToDefaultString(datasetDetails?.createdAt) }
                   <br/>
                   <label>Description:</label> { datasetDetails?.description ?
-                    datasetDetails?.description : <em>N/A</em> }
+                    datasetDetails?.description : <span className="fst-italic">N/A</span> }
                 </div>
                 <br/>
                 <a href={`https://jade.datarepo-dev.broadinstitute.org/datasets/${datasetDetails?.datasetId}`}

--- a/ui-admin/src/study/participants/datarepo/DatasetDashboard.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetDashboard.tsx
@@ -117,9 +117,10 @@ const DatasetDashboard = ({ studyEnvContext }: {studyEnvContext: StudyEnvContext
                   <br/>
                   <label>Dataset ID:</label> { datasetDetails?.datasetId }
                   <br/>
-                  <label>Created Date:</label> { instantToDefaultString(datasetDetails?.createdAt) }
+                  <label>Date Created:</label> { instantToDefaultString(datasetDetails?.createdAt) }
                   <br/>
-                  <label>Last Successful Export:</label> { instantToDefaultString(datasetDetails?.lastExported) }
+                  <label>Description:</label> { datasetDetails?.description ?
+                    datasetDetails?.description : <em>N/A</em> }
                 </div>
                 <br/>
                 <a href={`https://jade.datarepo-dev.broadinstitute.org/datasets/${datasetDetails?.datasetId}`}

--- a/ui-admin/src/study/participants/datarepo/DatasetList.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetList.tsx
@@ -27,18 +27,14 @@ const datasetColumns = (currentEnvPath: string): ColumnDef<DatasetDetails>[] => 
   cell: info => <Link to={getDatasetDashboardPath(info.getValue() as unknown as string, currentEnvPath)}
     className="mx-2">{info.getValue() as unknown as string}</Link>
 }, {
-  id: 'datasetUuid',
-  header: 'Dataset ID',
-  accessorKey: 'datasetId'
+  id: 'description',
+  header: 'Description',
+  accessorKey: 'description',
+  cell: info => info.getValue() ? info.getValue() : <em>N/A</em>
 }, {
   id: 'created',
-  header: 'Created Date',
+  header: 'Date Created',
   accessorKey: 'createdAt',
-  cell: info => instantToDefaultString(info.getValue() as unknown as number)
-}, {
-  id: 'lastUpdated',
-  header: 'Last Export',
-  accessorKey: 'lastExported',
   cell: info => instantToDefaultString(info.getValue() as unknown as number)
 }, {
   header: 'Terra Data Repo',

--- a/ui-admin/src/study/participants/datarepo/DatasetList.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetList.tsx
@@ -30,7 +30,7 @@ const datasetColumns = (currentEnvPath: string): ColumnDef<DatasetDetails>[] => 
   id: 'description',
   header: 'Description',
   accessorKey: 'description',
-  cell: info => info.getValue() ? info.getValue() : <em>N/A</em>
+  cell: info => info.getValue() ? info.getValue() : <span className="fst-italic">N/A</span>
 }, {
   id: 'created',
   header: 'Date Created',


### PR DESCRIPTION
It was mentioned by a few folks during demo last week that setting a description for a dataset would be a nice UX. This also weaves the supplied description through to TDR and sets it directly on the TDR dataset. 

Also in this PR:
* Removed the dataset ID from the Juniper UI (it can still be retrieved by going to the TDR UI). 
* Removed the Last Exported field, because with on-demand dataset creation, dataset export happens once at the time of creation.