### PR TITLE
[JN-373] Add change password

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Open the root folder in IntelliJ.
         * set environment variable: `B2C_TENANT_NAME=ddpdevb2c`
         * set environment variable: `B2C_CLIENT_ID=<<vault read -field value secret/dsp/ddp/b2c/dev/application_id>>`
         * set environment variable: `B2C_POLICY_NAME=B2C_1A_ddp_participant_signup_signin_dev`
+        * set environment variable: `B2C_CHANGE_PASSWORD_POLICY_NAME=B2C_1A_ddp_participant_change_password_dev`
         * disable launch optimization
         
          

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/config/B2CConfiguration.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/config/B2CConfiguration.java
@@ -3,4 +3,5 @@ package bio.terra.pearl.api.participant.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "b2c")
-public record B2CConfiguration(String tenantName, String clientId, String policyName) {}
+public record B2CConfiguration(
+    String tenantName, String clientId, String policyName, String changePasswordPolicyName) {}

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PublicApiController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PublicApiController.java
@@ -144,7 +144,8 @@ public class PublicApiController implements PublicApi {
     return Map.of(
         "b2cTenantName", b2CConfiguration.tenantName(),
         "b2cClientId", b2CConfiguration.clientId(),
-        "b2cPolicyName", b2CConfiguration.policyName());
+        "b2cPolicyName", b2CConfiguration.policyName(),
+        "b2cChangePasswordPolicyName", b2CConfiguration.changePasswordPolicyName());
   }
 
   private Optional<PortalEnvironmentDescriptor> getPortalDescriptorForRequest(

--- a/api-participant/src/main/resources/application.yml
+++ b/api-participant/src/main/resources/application.yml
@@ -19,6 +19,7 @@ env:
     tenantName: ${B2C_TENANT_NAME:missing_tenant_name}
     clientId: ${B2C_CLIENT_ID:missing_client_id}
     policyName: ${B2C_POLICY_NAME:missing_policy_name}
+    changePasswordPolicyName: ${B2C_CHANGE_PASSWORD_POLICY_NAME:missing_policy_name}
   email:
     sendgridApiKey: ${SENDGRID_API_KEY:}
     supportEmailAddress: ${SUPPORT_EMAIL_ADDRESS:support@juniper.terra.bio}
@@ -87,6 +88,7 @@ b2c:
   tenantName: ${env.b2c.tenantName}
   clientId: ${env.b2c.clientId}
   policyName: ${env.b2c.policyName}
+  changePasswordPolicyName: ${env.b2c.changePasswordPolicyName}
 
 javatemplate:
   ingress:

--- a/ui-participant/src/App.tsx
+++ b/ui-participant/src/App.tsx
@@ -8,7 +8,7 @@ import { isInternalLink, NavbarItemInternal } from 'api/api'
 import HtmlPageView from 'landing/sections/HtmlPageView'
 import PortalRegistrationRouter from 'landing/registration/PortalRegistrationRouter'
 import { AuthProvider } from 'react-oidc-context'
-import { getOidcConfig } from 'authConfig'
+import { getAuthProviderProps } from 'authConfig'
 import UserProvider from 'providers/UserProvider'
 import { ProtectedRoute } from 'login/ProtectedRoute'
 import { RedirectFromOAuth } from 'login/RedirectFromOAuth'
@@ -105,7 +105,9 @@ function App() {
             <ConfigProvider>
               <ConfigConsumer>
                 {config =>
-                  <AuthProvider {...getOidcConfig(config.b2cTenantName, config.b2cClientId, config.b2cPolicyName)}>
+                  <AuthProvider {
+                    ...getAuthProviderProps(config.b2cTenantName, config.b2cClientId, config.b2cPolicyName)
+                  }>
                     <UserProvider>
                       <Suspense fallback={<PageLoadingIndicator />}>
                         <IdleStatusMonitor maxIdleSessionDuration={30 * 60 * 1000} idleWarningDuration={5 * 60 * 1000}/>

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -271,6 +271,7 @@ export type Config = {
   b2cTenantName: string,
   b2cClientId: string,
   b2cPolicyName: string,
+  b2cChangePasswordPolicyName: string,
 }
 
 export type LogEvent = {

--- a/ui-participant/src/authConfig.ts
+++ b/ui-participant/src/authConfig.ts
@@ -1,4 +1,4 @@
-import { WebStorageStateStore } from 'oidc-client-ts'
+import { UserManagerSettings, WebStorageStateStore } from 'oidc-client-ts'
 import { AuthProviderProps } from 'react-oidc-context'
 
 /**
@@ -7,9 +7,32 @@ import { AuthProviderProps } from 'react-oidc-context'
  *    visit: https://docs.microsoft.com/en-us/azure/active-directory-b2c/custom-policy-overview
  */
 
+export const getAuthProviderProps = (
+  b2cTenantName: string,
+  b2cClientId: string,
+  b2cPolicyName: string): AuthProviderProps => {
+  const oidcConfig = getOidcConfig(b2cTenantName, b2cClientId, b2cPolicyName)
+
+  // eslint-disable-next-line max-len
+  // from https://github.com/authts/react-oidc-context/blob/f175dcba6ab09871b027d6a2f2224a17712b67c5/src/AuthProvider.tsx#L20-L30
+  const onSigninCallback = () => {
+    window.history.replaceState(
+      {},
+      document.title,
+      window.location.pathname
+    )
+  }
+
+  return {
+    ...oidcConfig,
+    prompt: 'login',
+    onSigninCallback
+  }
+}
+
 // TODO: This is a modified copy of code from Terra UI. It could use some clean-up.
 /* eslint-disable camelcase, max-len */
-export const getOidcConfig = (b2cTenantName: string, b2cClientId: string, b2cPolicyName: string): AuthProviderProps => {
+export const getOidcConfig = (b2cTenantName: string, b2cClientId: string, b2cPolicyName: string): UserManagerSettings => {
   return {
     /*
      * oidc-client-ts uses `authority` to fetch `metadata`. For some reason providing `metadata` manually results in not
@@ -23,7 +46,6 @@ export const getOidcConfig = (b2cTenantName: string, b2cClientId: string, b2cPol
     redirect_uri: `${window.origin}/redirect-from-oauth`,
     popup_redirect_uri: `${window.origin}/redirect-from-oauth`,
     silent_redirect_uri: `${window.origin}/redirect-from-oauth-silent`,
-    prompt: 'login',
     scope: `openid email ${b2cClientId}`,
     loadUserInfo: false,
     stateStore: new WebStorageStateStore({ store: window.localStorage }),
@@ -31,15 +53,7 @@ export const getOidcConfig = (b2cTenantName: string, b2cClientId: string, b2cPol
     automaticSilentRenew: true,
     accessTokenExpiringNotificationTimeInSeconds: 300,
     includeIdTokenInSilentRenew: true,
-    extraQueryParams: { access_type: 'offline' },
-    // from https://github.com/authts/react-oidc-context/blob/f175dcba6ab09871b027d6a2f2224a17712b67c5/src/AuthProvider.tsx#L20-L30
-    onSigninCallback: () => {
-      window.history.replaceState(
-        {},
-        document.title,
-        window.location.pathname
-      )
-    }
+    extraQueryParams: { access_type: 'offline' }
   }
 }
 /* eslint-enable camelcase, max-len */

--- a/ui-participant/src/authConfig.ts
+++ b/ui-participant/src/authConfig.ts
@@ -7,6 +7,7 @@ import { AuthProviderProps } from 'react-oidc-context'
  *    visit: https://docs.microsoft.com/en-us/azure/active-directory-b2c/custom-policy-overview
  */
 
+/** Creates and returns props for an AuthProvider component based on B2C configuration values. */
 export const getAuthProviderProps = (
   b2cTenantName: string,
   b2cClientId: string,
@@ -30,7 +31,7 @@ export const getAuthProviderProps = (
   }
 }
 
-// TODO: This is a modified copy of code from Terra UI. It could use some clean-up.
+/** Creates and returns UserManagerSettings based on B2C configuration values. */
 /* eslint-disable camelcase, max-len */
 export const getOidcConfig = (b2cTenantName: string, b2cClientId: string, b2cPolicyName: string): UserManagerSettings => {
   return {

--- a/ui-participant/src/providers/ConfigProvider.tsx
+++ b/ui-participant/src/providers/ConfigProvider.tsx
@@ -5,7 +5,8 @@ import { PageLoadingIndicator } from 'util/LoadingSpinner'
 const uninitializedConfig = {
   b2cTenantName: 'uninitialized',
   b2cClientId: 'uninitialized',
-  b2cPolicyName: 'uninitialized'
+  b2cPolicyName: 'uninitialized',
+  b2cChangePasswordPolicyName: 'uninitialized'
 }
 
 const ConfigContext = React.createContext<Config>(uninitializedConfig)


### PR DESCRIPTION
Change password is currently implemented with a separate policy. The policy name comes from config fetched from the API, so this PR also contains those config plumbing changes.

![Screen Shot 2023-05-15 at 9 09 46 PM](https://github.com/broadinstitute/pearl/assets/19228696/0913864d-7a73-466a-8991-24840a12b45e)

The conditions under which the user is prompted to sign in when trying to change their password may be a little different than what I explained in https://github.com/broadinstitute/terraform-ap-deployments/pull/1066. I'm not 100% sure what the conditions are. I'm not terribly satisfied with my level of understanding of this -- I fully expect to get bug reports that will take a lot of fiddling to iron out -- but change password is there and generally works.

To test:
1. Restart participant API and UI
2. Sign in to https://sandbox.ourhealth.localhost:3001/
3. Open the profile menu and click "Change Password"
4. Change your password and make sure you end up back at the OurHealth portal
5. Sign out and make sure you are required to use your new password to sign back in
