### PR TITLE
[JN-380] Automatically share dev datasets with dev team

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoClient.java
@@ -73,6 +73,17 @@ public class DataRepoClient {
         return datasetsApi.deleteDataset(datasetId);
     }
 
+    //TODO: This is to be replaced by JN-133. This code should only ever be executed in dev.
+    public void shareWithJuniperDevs(UUID datasetId) {
+        DatasetsApi datasetsApi = getDatasetsApi();
+
+        try {
+            datasetsApi.addDatasetPolicyMember(datasetId, "steward", new PolicyMemberRequest().email("juniper-dev@dev.test.firecloud.org"));
+        } catch (ApiException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     //Job APIs
     public JobModel getJobStatus(String jobId) throws ApiException {
         JobsApi jobsApi = getJobsApi();

--- a/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoExportService.java
@@ -220,6 +220,16 @@ public class DataRepoExportService {
 
                     datasetService.create(dataset);
                     dataRepoJobService.updateJobStatus(job.getId(), jobStatus.getValue());
+
+                    //TODO: This is to be replaced by JN-133. This code should only ever be executed in dev.
+                    // The ultimate safeguard here is in Terra, where this would fail in production because
+                    // the juniper-dev managed group does not exist in Terra Prod. But this is an extra layer
+                    // of safety to be totally safe.
+                    String DEPLOYMENT_ZONE = env.getProperty("env.tdr.deploymentZone");
+                    if(!DEPLOYMENT_ZONE.equalsIgnoreCase("prod")) {
+                        logger.info("Sharing dataset with Juniper dev team. If you're seeing this in prod, panic!");
+                        dataRepoClient.shareWithJuniperDevs(dataset.getDatasetId());
+                    }
                 }
                 case FAILED -> {
                     logger.warn("createDataset job ID {} has failed. Dataset {} failed to create.", job.getId(), job.getDatasetName());


### PR DESCRIPTION
Previously, only the Juniper service account would have access to the datasets created through Juniper. This has been a huge pain point in testing, and makes it so you have to backdoor yourself onto the datasets in order to demo this functionality or test it out. I've created a [juniper-dev](https://bvdp-saturn-dev.appspot.com/#groups/juniper-dev) managed group in Terra with all of the devs on it (we're all admins so feel free to add other folks). This code will only be executed in non-prod environments. Should it somehow execute in production, it will still fail because the juniper-dev group does not exist in prod (and the group can't possibly be duplicated in production due to how Sam namespaces managed groups). 

Ultimately, this will be replaced by JN-133, which will provision a Terra managed group with all of the study admins in it, and add that as a steward to the TDR dataset. This is a stopgap to make things easier to test until that is ready.

I chose to go this route instead of automatically sharing the datasets with the super admins in our DB because for most of us, the emails we use in Terra dev are different than the emails we have as super admins. We could of course align those, but this felt easier for a stop-gap solution.

This will also make testing all of my other pending PRs a lot easier.

TO TEST:

1) Create a dataset in the Juniper admin UI.
2) Verify that your dev Terra account has access by clicking the "View in Terra Data Repo" link. (currently you can expect this to take 5mins unless you tweak the `pollRunningJobs` poll time in `ScheduledDataRepoExportService.java`)

Also note that the code on `development` is way behind what I've been demoing lately, so don't expect it to be as smooth :)
