### PR TITLE
[JN-382] Move types for landing page config to ui-core

### DIFF
--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -1,3 +1,17 @@
+import { SiteContent } from '@juniper/ui-core'
+
+export type {
+  SiteContent,
+  LocalSiteContent,
+  HtmlPage,
+  HtmlSection,
+  SectionConfig,
+  SectionType,
+  NavbarItem,
+  NavbarItemInternal,
+  NavbarItemInternalAnchor
+} from '@juniper/ui-core'
+
 export type AdminUser = {
   username: string,
   token: string,
@@ -100,75 +114,6 @@ export type PortalEnvironment = {
   environmentName: string,
   portalEnvironmentConfig: PortalEnvironmentConfig,
   siteContent?: SiteContent
-}
-
-export type SiteContent = {
-  defaultLanguage: string,
-  localizedSiteContents: LocalSiteContent[],
-  stableId: string,
-  version: number
-}
-
-export type LocalSiteContent = {
-  language: string,
-  navbarItems: NavbarItem[],
-  landingPage: HtmlPage,
-  navLogoCleanFileName: string,
-  navLogoVersion: number,
-  footerSection?: HtmlSection
-  primaryBrandColor?: string
-}
-
-export type HtmlPage = {
-  title: string,
-  path: string,
-  sections: HtmlSection[]
-}
-
-export type NavbarItem = {
-  label: string,
-  externalLink?: string,
-  anchorLinkPath?: string,
-  itemType: string
-  htmlPage?: HtmlPage
-}
-
-export type NavbarItemInternal = NavbarItem & {
-  htmlPage: HtmlPage
-}
-
-export type NavbarItemInternalAnchor = NavbarItem & {
-  anchorLinkPath: string
-}
-
-/** type predicate for handling internal links */
-export function isInternalLink(navItem: NavbarItem): navItem is NavbarItemInternal {
-  return navItem.itemType === 'INTERNAL'
-}
-
-/** type predicate for handling internal anchor links */
-export function isInternalAnchorLink(navItem: NavbarItem): navItem is NavbarItemInternalAnchor {
-  return navItem.itemType === 'INTERNAL_ANCHOR'
-}
-
-export type SectionType =
-  | 'BANNER_IMAGE'
-  | 'FAQ'
-  | 'HERO_CENTERED'
-  | 'HERO_WITH_IMAGE'
-  | 'LINK_SECTIONS_FOOTER'
-  | 'PARTICIPATION_DETAIL'
-  | 'PHOTO_BLURB_GRID'
-  | 'RAW_HTML'
-  | 'SOCIAL_MEDIA'
-  | 'STEP_OVERVIEW'
-
-export type HtmlSection = {
-  id: string,
-  sectionType: SectionType,
-  anchorRef?: string,
-  rawContent?: string | null,
-  sectionConfig?: string | null
 }
 
 export type PortalEnvironmentConfig = {

--- a/ui-core/src/index.ts
+++ b/ui-core/src/index.ts
@@ -1,3 +1,5 @@
 export { InvestigatorTermsOfUse } from './terms/InvestigatorTermsOfUse'
 export { ParticipantTermsOfUse } from './terms/ParticipantTermsOfUse'
 export { PrivacyPolicy } from './terms/PrivacyPolicy'
+
+export * from './types/landingPageConfig'

--- a/ui-core/src/types/landingPageConfig.ts
+++ b/ui-core/src/types/landingPageConfig.ts
@@ -1,0 +1,71 @@
+export type SiteContent = {
+  defaultLanguage: string
+  localizedSiteContents: LocalSiteContent[]
+  stableId: string
+  version: number
+}
+
+export type LocalSiteContent = {
+  language: string
+  navbarItems: NavbarItem[]
+  landingPage: HtmlPage
+  navLogoCleanFileName: string
+  navLogoVersion: number
+  footerSection?: HtmlSection
+  primaryBrandColor?: string
+}
+
+export type HtmlPage = {
+  title: string
+  path: string
+  sections: HtmlSection[]
+}
+
+export type HtmlSection = {
+  id: string
+  sectionType: SectionType
+  anchorRef?: string
+  rawContent?: string | null
+  sectionConfig?: string | null
+}
+
+// Type for JSON decoded HtmlSection sectionConfig.
+export type SectionConfig = Record<string, unknown>
+
+export type SectionType =
+  | 'BANNER_IMAGE'
+  | 'FAQ'
+  | 'HERO_CENTERED'
+  | 'HERO_WITH_IMAGE'
+  | 'LINK_SECTIONS_FOOTER'
+  | 'PARTICIPATION_DETAIL'
+  | 'PHOTO_BLURB_GRID'
+  | 'RAW_HTML'
+  | 'SOCIAL_MEDIA'
+  | 'STEP_OVERVIEW'
+
+export type NavbarItem = {
+  label: string
+  externalLink?: string
+  anchorLinkPath?: string
+  itemType: string
+  htmlPage?: HtmlPage
+}
+
+export type NavbarItemInternal = NavbarItem & {
+  htmlPage: HtmlPage
+}
+
+export type NavbarItemInternalAnchor = NavbarItem & {
+  anchorLinkPath: string
+}
+
+/** type predicate for handling internal links */
+export const isInternalLink = (navItem: NavbarItem): navItem is NavbarItemInternal => {
+  return navItem.itemType === 'INTERNAL'
+}
+
+/** type predicate for handling internal anchor links */
+export const isInternalAnchorLink = (navItem: NavbarItem): navItem is NavbarItemInternalAnchor => {
+  return navItem.itemType === 'INTERNAL_ANCHOR'
+}

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -1,3 +1,21 @@
+import { SiteContent } from '@juniper/ui-core'
+
+export type {
+  SiteContent,
+  LocalSiteContent,
+  HtmlPage,
+  HtmlSection,
+  SectionConfig,
+  SectionType,
+  NavbarItem,
+  NavbarItemInternal,
+  NavbarItemInternalAnchor
+} from '@juniper/ui-core'
+export {
+  isInternalLink,
+  isInternalAnchorLink
+} from '@juniper/ui-core'
+
 export type ParticipantUser = {
   username: string,
   token: string
@@ -41,73 +59,6 @@ export type Study = {
   name: string,
   shortcode: string,
   studyEnvironments: StudyEnvironment[]
-}
-
-export type SiteContent = {
-  defaultLanguage: string,
-  localizedSiteContents: LocalSiteContent[],
-}
-
-export type LocalSiteContent = {
-  language: string,
-  navbarItems: NavbarItem[],
-  landingPage: HtmlPage,
-  navLogoCleanFileName: string,
-  navLogoVersion: number,
-  footerSection?: HtmlSection
-  primaryBrandColor?: string
-}
-
-export type HtmlPage = {
-  title: string,
-  path: string,
-  sections: HtmlSection[]
-}
-
-export type NavbarItem = {
-  label: string,
-  externalLink?: string,
-  anchorLinkPath?: string,
-  itemType: string
-  htmlPage?: HtmlPage
-}
-
-export type NavbarItemInternal = NavbarItem & {
-  htmlPage: HtmlPage
-}
-
-export type NavbarItemInternalAnchor = NavbarItem & {
-  anchorLinkPath: string
-}
-
-/** type predicate for handling internal links */
-export function isInternalLink(navItem: NavbarItem): navItem is NavbarItemInternal {
-  return navItem.itemType === 'INTERNAL'
-}
-
-/** type predicate for handling internal anchor links */
-export function isInternalAnchorLink(navItem: NavbarItem): navItem is NavbarItemInternalAnchor {
-  return navItem.itemType === 'INTERNAL_ANCHOR'
-}
-
-export type SectionType =
-  | 'BANNER_IMAGE'
-  | 'FAQ'
-  | 'HERO_CENTERED'
-  | 'HERO_WITH_IMAGE'
-  | 'LINK_SECTIONS_FOOTER'
-  | 'PARTICIPATION_DETAIL'
-  | 'PHOTO_BLURB_GRID'
-  | 'RAW_HTML'
-  | 'SOCIAL_MEDIA'
-  | 'STEP_OVERVIEW'
-
-export type HtmlSection = {
-  id: string,
-  sectionType: SectionType,
-  anchorRef?: string,
-  rawContent?: string | null,
-  sectionConfig?: string | null
 }
 
 export type SurveyJSForm = {
@@ -286,8 +237,6 @@ export type LogEvent = {
   enrolleeShortcode?: string,
   operatorId?: string,
 }
-
-export type SectionConfig = Record<string, unknown>
 
 let bearerToken: string | null = null
 const API_ROOT = `${process.env.REACT_APP_API_ROOT}`


### PR DESCRIPTION
Many type definitions are duplicated between ui-admin/api and ui-participant/api. This moves some of those type definitions into ui-core, starting with the types for landing page configuration. Started with those because they are the same in both places and thus easiest to understand.

Types are re-exported from ui-admin/api and ui-participant/api instead of imported directly from ui-core to leave open the ability to tailor them for the admin/participant UI (for example, if the participant API doesn't return all the fields of a certain type that the admin API does).