### PR TITLE
[JN-384] Save datasets immediately upon creation

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/datarepo/DatasetDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/datarepo/DatasetDao.java
@@ -29,6 +29,10 @@ public class DatasetDao extends BaseMutableJdbiDao<Dataset> {
         return findByProperty("dataset_id", dataRepoId);
     }
 
+    public Optional<Dataset> findByDatasetName(String datasetName) {
+        return findByProperty("dataset_name", datasetName);
+    }
+
     public void updateLastExported(UUID id, Instant lastExported) {
         updateProperty(id, "last_exported", lastExported);
     }

--- a/core/src/main/java/bio/terra/pearl/core/model/datarepo/Dataset.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/datarepo/Dataset.java
@@ -18,6 +18,6 @@ public class Dataset extends BaseEntity {
     private UUID datasetId;
     private String datasetName;
     private String description;
-    private String status;
+    private DatasetStatus status;
     private Instant lastExported;
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/datarepo/Dataset.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/datarepo/Dataset.java
@@ -18,5 +18,6 @@ public class Dataset extends BaseEntity {
     private UUID datasetId;
     private String datasetName;
     private String description;
+    private String status;
     private Instant lastExported;
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/datarepo/DatasetStatus.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/datarepo/DatasetStatus.java
@@ -1,0 +1,7 @@
+package bio.terra.pearl.core.model.datarepo;
+
+public enum DatasetStatus {
+    CREATED,
+    FAILED,
+    CREATING
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoExportService.java
@@ -3,7 +3,6 @@ package bio.terra.pearl.core.service.datarepo;
 import bio.terra.datarepo.client.ApiException;
 import bio.terra.datarepo.model.JobModel;
 import bio.terra.datarepo.model.JobModel.JobStatusEnum;
-import bio.terra.datarepo.model.TableDataType;
 import bio.terra.pearl.core.dao.datarepo.DataRepoJobDao;
 import bio.terra.pearl.core.dao.datarepo.DatasetDao;
 import bio.terra.pearl.core.dao.participant.EnrolleeDao;
@@ -13,6 +12,7 @@ import bio.terra.pearl.core.dao.study.StudyEnvironmentDao;
 import bio.terra.pearl.core.dao.survey.AnswerDao;
 import bio.terra.pearl.core.model.datarepo.DataRepoJob;
 import bio.terra.pearl.core.model.datarepo.Dataset;
+import bio.terra.pearl.core.model.datarepo.DatasetStatus;
 import bio.terra.pearl.core.model.datarepo.JobType;
 import bio.terra.pearl.core.model.study.PortalStudy;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
@@ -104,7 +104,7 @@ public class DataRepoExportService {
         }
 
         Dataset dataset = Dataset.builder()
-                .status(response.getJobStatus().getValue())
+                .status(DatasetStatus.CREATING)
                 .datasetName(datasetName)
                 .lastExported(Instant.ofEpochSecond(0))
                 .studyEnvironmentId(studyEnv.getId())
@@ -225,7 +225,7 @@ public class DataRepoExportService {
                             .datasetId(UUID.fromString(jobResult.get("id").toString()))
                             .description(jobResult.get("description").toString())
                             .datasetName(job.getDatasetName())
-                            .status(jobStatus.getValue())
+                            .status(DatasetStatus.CREATED)
                             .lastExported(Instant.ofEpochSecond(0))
                             .build();
 
@@ -251,7 +251,7 @@ public class DataRepoExportService {
                             .id(existingDataset.getId())
                             .studyEnvironmentId(job.getStudyEnvironmentId())
                             .datasetName(job.getDatasetName())
-                            .status(jobStatus.getValue())
+                            .status(DatasetStatus.FAILED)
                             .lastExported(Instant.ofEpochSecond(0))
                             .build();
 

--- a/core/src/main/resources/db/changelog/changesets/2023_05_15_dataset_creation.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2023_05_15_dataset_creation.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: "dataset_creation"
+      author: mbemis
+      changes:
+        - dropNotNullConstraint:
+            columnName:  dataset_id
+            tableName:  dataset
+        - addColumn:
+            tableName: dataset
+            columns:
+              - column: { name: status, type: text, constraints: { nullable: false }, defaultValue: "succeeded" }

--- a/core/src/main/resources/db/changelog/changesets/2023_05_15_dataset_creation.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2023_05_15_dataset_creation.yaml
@@ -9,4 +9,4 @@ databaseChangeLog:
         - addColumn:
             tableName: dataset
             columns:
-              - column: { name: status, type: text, constraints: { nullable: false }, defaultValue: "succeeded" }
+              - column: { name: status, type: text, constraints: { nullable: false }, defaultValue: "CREATED" }

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -98,6 +98,9 @@ databaseChangeLog:
   - include:
       file: changesets/2023_05_15_dataset_description.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2023_05_15_dataset_creation.yaml
+      relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -214,6 +214,7 @@ export type DatasetDetails = {
   datasetId: string,
   datasetName: string,
   description: string,
+  status: string,
   lastExported: number
 }
 

--- a/ui-admin/src/study/participants/datarepo/CreateDatasetModal.tsx
+++ b/ui-admin/src/study/participants/datarepo/CreateDatasetModal.tsx
@@ -6,8 +6,8 @@ import Api from 'api/api'
 import { failureNotification, successNotification } from 'util/notifications'
 import { Store } from 'react-notifications-component'
 
-const CreateDatasetModal = ({ studyEnvContext, show, setShow }: {studyEnvContext: StudyEnvContextT, show: boolean,
-    setShow:  React.Dispatch<React.SetStateAction<boolean>>}) => {
+const CreateDatasetModal = ({ studyEnvContext, show, setShow, loadDatasets }: {studyEnvContext: StudyEnvContextT,
+  show: boolean, setShow:  React.Dispatch<React.SetStateAction<boolean>>, loadDatasets: () => void }) => {
   const [isLoading, setIsLoading] = useState(false)
   const [datasetName, setDatasetName] = useState('')
   const [datasetDescription, setDatasetDescription] = useState('')
@@ -21,6 +21,7 @@ const CreateDatasetModal = ({ studyEnvContext, show, setShow }: {studyEnvContext
     } else {
       Store.addNotification(failureNotification(`${datasetName} creation failed`))
     }
+    loadDatasets()
     setShow(false)
     setIsLoading(false)
     clearFields()

--- a/ui-admin/src/study/participants/datarepo/DatasetDashboard.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetDashboard.tsx
@@ -117,14 +117,16 @@ const DatasetDashboard = ({ studyEnvContext }: {studyEnvContext: StudyEnvContext
                   <br/>
                   <label>Dataset ID:</label> { datasetDetails?.datasetId }
                   <br/>
-                  <label>Date Created:</label> { instantToDefaultString(datasetDetails?.createdAt) }
-                  <br/>
                   <label>Description:</label> { datasetDetails?.description ?
                     datasetDetails?.description : <span className="fst-italic">N/A</span> }
+                  <br/>
+                  <label>Date Created:</label> { instantToDefaultString(datasetDetails?.createdAt) }
                 </div>
                 <br/>
-                <a href={`https://jade.datarepo-dev.broadinstitute.org/datasets/${datasetDetails?.datasetId}`}
-                  target="_blank">View dataset in Terra Data Repo <FontAwesomeIcon icon={faExternalLink}/></a>
+                { datasetDetails?.status == 'succeeded' &&
+                  <a href={`https://jade.datarepo-dev.broadinstitute.org/datasets/${datasetDetails?.datasetId}`}
+                    target="_blank">View dataset in Terra Data Repo <FontAwesomeIcon icon={faExternalLink}/></a>
+                }
               </div>
             </div>
           </li>

--- a/ui-admin/src/study/participants/datarepo/DatasetDashboard.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetDashboard.tsx
@@ -115,8 +115,6 @@ const DatasetDashboard = ({ studyEnvContext }: {studyEnvContext: StudyEnvContext
                 <div className="form-group-item">
                   <label>Dataset Name:</label> { datasetDetails?.datasetName }
                   <br/>
-                  <label>Dataset ID:</label> { datasetDetails?.datasetId }
-                  <br/>
                   <label>Description:</label> { datasetDetails?.description ?
                     datasetDetails?.description : <span className="fst-italic">N/A</span> }
                   <br/>

--- a/ui-admin/src/study/participants/datarepo/DatasetList.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetList.tsx
@@ -5,7 +5,6 @@ import LoadingSpinner from 'util/LoadingSpinner'
 import { Store } from 'react-notifications-component'
 import { failureNotification } from 'util/notifications'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faExternalLink } from '@fortawesome/free-solid-svg-icons/faExternalLink'
 import { instantToDefaultString } from '../../../util/timeUtils'
 import {
   ColumnDef,
@@ -37,11 +36,9 @@ const datasetColumns = (currentEnvPath: string): ColumnDef<DatasetDetails>[] => 
   accessorKey: 'createdAt',
   cell: info => instantToDefaultString(info.getValue() as unknown as number)
 }, {
-  header: 'Terra Data Repo',
-  accessorKey: 'datasetId',
-  cell: info => <a href={
-      `https://jade.datarepo-dev.broadinstitute.org/datasets/${info.getValue()}`} target="_blank"
-  >View in Terra Data Repo <FontAwesomeIcon icon={faExternalLink}/></a>
+  id: 'status',
+  header: 'Status',
+  accessorKey: 'status'
 }]
 
 const DatasetList = ({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) => {
@@ -96,7 +93,8 @@ const DatasetList = ({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) =
     }
     <CreateDatasetModal studyEnvContext={studyEnvContext}
       show={showCreateDatasetModal}
-      setShow={setShowCreateDatasetModal}/>
+      setShow={setShowCreateDatasetModal}
+      loadDatasets={loadData}/>
     <LoadingSpinner isLoading={isLoading}>
       <div className="col-12 p-3">
         <ul className="list-unstyled">


### PR DESCRIPTION
Previously Juniper would wait for the TDR job to succeed before creating a `dataset` row in the DB. This was an artifact of the old scheduled dataset creation. For on-demand dataset creation, we want to save a record immediately with a null dataset ID and a status field.

![Screenshot 2023-05-18 at 3 07 57 PM](https://github.com/broadinstitute/pearl/assets/7257391/0f0971d8-8d23-4f8b-82dc-c0164e2cd859)

TO TEST:

Launch Juniper admin UI
Launch Juniper admin API

Navigate to study environment TDR dashboard, i.e. https://localhost:3000/ourhealth/studies/ourheart/env/live/export/dataRepo/datasets

Create a new dataset, and note that you see it show up immediately. The "View in TDR" link is hidden in the dataset details page unless it has successfully been created.