### PR TITLE
[JN-260] Update types for navbar configuration

### DIFF
--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -23,6 +23,8 @@ export type {
   NavbarItem,
   NavbarItemInternal,
   NavbarItemInternalAnchor,
+  NavbarItemMailingList,
+  NavbarItemExternal,
   NotificationConfig,
   ParticipantTask,
   Portal,

--- a/ui-admin/src/portal/siteContent/SiteContentView.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentView.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react'
-import { HtmlPage, NavbarItem, PortalEnvironment } from '../../api/api'
+import { HtmlPage, NavbarItemInternal, PortalEnvironment } from '../../api/api'
 
 const SiteContentView = ({ portalEnv }: {portalEnv: PortalEnvironment}) => {
   const selectedLanguage = 'en'
-  const [selectedNavItem, setSelectedNavItem] = useState<NavbarItem | null>(null)
+  const [selectedNavItem, setSelectedNavItem] = useState<NavbarItemInternal | null>(null)
 
   if (!portalEnv.siteContent) {
     return <div>no site content configured yet</div>
@@ -18,11 +18,13 @@ const SiteContentView = ({ portalEnv }: {portalEnv: PortalEnvironment}) => {
   return <div className="container d-flex bg-white p-3">
     <ul className="list-group">
       <li className="list-group-item" onClick={() => setSelectedNavItem(null)}>Landing page</li>
-      {localContent.navbarItems.map(navItem => <li key={navItem.label} className="list-group-item" role="button"
-        onClick={() => setSelectedNavItem(navItem)}>
-        {navItem.label}
-      </li>
-      )}
+      {localContent.navbarItems
+        .filter((navItem): navItem is NavbarItemInternal => navItem.itemType === 'INTERNAL')
+        .map(navItem => <li key={navItem.label} className="list-group-item" role="button"
+          onClick={() => setSelectedNavItem(navItem)}>
+          {navItem.label}
+        </li>
+        )}
     </ul>
     <div className="ps-3">
       <h2 className="h5">{renderedTitle}</h2>

--- a/ui-core/src/types/landingPageConfig.ts
+++ b/ui-core/src/types/landingPageConfig.ts
@@ -44,20 +44,33 @@ export type SectionType =
   | 'SOCIAL_MEDIA'
   | 'STEP_OVERVIEW'
 
-export type NavbarItem = {
-  label: string
-  externalLink?: string
-  anchorLinkPath?: string
-  itemType: string
-  htmlPage?: HtmlPage
-}
+export type NavbarItem =
+  | NavbarItemInternal
+  | NavbarItemInternalAnchor
+  | NavbarItemMailingList
+  | NavbarItemExternal
 
-export type NavbarItemInternal = NavbarItem & {
+export type NavbarItemInternal = {
+  itemType: 'INTERNAL'
+  label: string
   htmlPage: HtmlPage
 }
 
-export type NavbarItemInternalAnchor = NavbarItem & {
+export type NavbarItemInternalAnchor = {
+  itemType: 'INTERNAL_ANCHOR'
+  label: string
   anchorLinkPath: string
+}
+
+export type NavbarItemMailingList = {
+  itemType: 'MAILING_LIST'
+  label: string
+}
+
+export type NavbarItemExternal = {
+  itemType: 'EXTERNAL'
+  label: string
+  externalLink: string
 }
 
 /** type predicate for handling internal links */

--- a/ui-core/src/types/landingPageConfig.ts
+++ b/ui-core/src/types/landingPageConfig.ts
@@ -72,13 +72,3 @@ export type NavbarItemExternal = {
   label: string
   externalLink: string
 }
-
-/** type predicate for handling internal links */
-export const isInternalLink = (navItem: NavbarItem): navItem is NavbarItemInternal => {
-  return navItem.itemType === 'INTERNAL'
-}
-
-/** type predicate for handling internal anchor links */
-export const isInternalAnchorLink = (navItem: NavbarItem): navItem is NavbarItemInternalAnchor => {
-  return navItem.itemType === 'INTERNAL_ANCHOR'
-}

--- a/ui-participant/src/App.tsx
+++ b/ui-participant/src/App.tsx
@@ -4,7 +4,7 @@ import React, { CSSProperties, Suspense, lazy, useEffect } from 'react'
 import LandingPage from 'landing/LandingPage'
 import { BrowserRouter, Route, Routes, useLocation } from 'react-router-dom'
 import { usePortalEnv } from 'providers/PortalProvider'
-import { isInternalLink, NavbarItemInternal } from 'api/api'
+import { NavbarItem, NavbarItemInternal } from 'api/api'
 import HtmlPageView from 'landing/sections/HtmlPageView'
 import PortalRegistrationRouter from 'landing/registration/PortalRegistrationRouter'
 import { AuthProvider } from 'react-oidc-context'
@@ -79,9 +79,14 @@ function App() {
   let landingRoutes: JSX.Element[] = []
   if (localContent.navbarItems) {
     landingRoutes = localContent.navbarItems
-      .filter(isInternalLink)
-      .map((navItem: NavbarItemInternal, index: number) => <Route key={index} path={navItem.htmlPage.path}
-        element={<HtmlPageView page={navItem.htmlPage}/>}/>)
+      .filter((navItem: NavbarItem): navItem is NavbarItemInternal => navItem.itemType === 'INTERNAL')
+      .map((navItem: NavbarItemInternal, index: number) => (
+        <Route
+          key={index}
+          path={navItem.htmlPage.path}
+          element={<HtmlPageView page={navItem.htmlPage}/>}
+        />
+      ))
     landingRoutes.push(
       <Route index key="main" element={<HtmlPageView page={localContent.landingPage}/>}/>
     )

--- a/ui-participant/src/Navbar.tsx
+++ b/ui-participant/src/Navbar.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useId, useRef } from 'react'
 import { Link, NavLink, useLocation } from 'react-router-dom'
 import { HashLink } from 'react-router-hash-link'
 
-import Api, { getEnvSpec, getImageUrl, isInternalAnchorLink, isInternalLink, NavbarItem } from 'api/api'
+import Api, { getEnvSpec, getImageUrl, NavbarItem } from 'api/api'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { useUser } from 'providers/UserProvider'
 import { useConfig } from 'providers/ConfigProvider'
@@ -175,10 +175,10 @@ export function CustomNavLink({ navLink }: { navLink: NavbarItem }) {
     alert(`mailing list ${navLinkObj.label}`)
   }
 
-  if (isInternalLink(navLink)) {
+  if (navLink.itemType === 'INTERNAL') {
     // we require navbar links to be absolute rather than relative links
     return <NavLink to={`/${navLink.htmlPage.path}`} className={navLinkClasses}>{navLink.label}</NavLink>
-  } else if (isInternalAnchorLink(navLink)) {
+  } else if (navLink.itemType === 'INTERNAL_ANCHOR') {
     return <HashLink to={`/${navLink.anchorLinkPath}`} className={navLinkClasses}>{navLink.label}</HashLink>
   } else if (navLink.itemType === 'MAILING_LIST') {
     return <a role="button" className={navLinkClasses} onClick={() => mailingList(navLink)}>{navLink.label}</a>

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -19,6 +19,8 @@ export type {
   NavbarItem,
   NavbarItemInternal,
   NavbarItemInternalAnchor,
+  NavbarItemMailingList,
+  NavbarItemExternal,
   ParticipantTask,
   ParticipantTaskStatus,
   ParticipantTaskType,

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -41,10 +41,6 @@ export type {
   Survey,
   SurveyResponse
 } from '@juniper/ui-core'
-export {
-  isInternalLink,
-  isInternalAnchorLink
-} from '@juniper/ui-core'
 
 export type ParticipantUser = {
   username: string,


### PR DESCRIPTION
This defines a separate type for each type of navbar item (internal, internal anchor, mailing list, external) and redefines the `NavbarItem` type as a union of those individual types. This way, TypeScript can automatically narrow the type by looking at the `itemType` field, removing the need for the `isInternalLink` and `isInternalAnchorLink` helpers.