### PR TITLE
[JN-386] Run ESLint on ui-core in CI

### DIFF
--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -21,7 +21,9 @@ jobs:
           node-version: '16.x'
       - name: Install dependencies
         run: npm ci
+      - name: Lint
+        run: npm run lint
       - name: Build
-        run: npm --workspaces run build
+        run: DISABLE_ESLINT_PLUGIN=true npm --workspace=ui-core --workspace=ui-admin --workspace=ui-participant run build
       - name: Run tests
-        run: npm --workspace=ui-core --workspace=ui-admin --workspace=ui-participant test --if-present
+        run: npm --workspace=ui-core --workspace=ui-admin --workspace=ui-participant test

--- a/ui-core/src/types/task.ts
+++ b/ui-core/src/types/task.ts
@@ -11,7 +11,7 @@ export type ParticipantTask = {
   createdAt: number
 }
 
-export type ParticipantTaskStatus = 
+export type ParticipantTaskStatus =
   | 'NEW'
   | 'IN_PROGRESS'
   | 'COMPLETE'


### PR DESCRIPTION
Currently, ESLint is not run on the ui-core package in CI. It is run on ui-admin and ui-participant as part of their build steps.

This adds a step to CI that runs ESLint on all 3 UI packages and disables it in ui-admin/ui-participant builds.