### PR TITLE
[JN-260] Align navbar item and button/link config

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/site/NavbarItem.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/site/NavbarItem.java
@@ -12,13 +12,11 @@ import java.util.UUID;
 public class NavbarItem extends BaseEntity {
     private UUID localizedSiteContentId;
     private NavbarItemType itemType;
-    private String label;
+    private String text;
     private int itemOrder;
 
     private UUID htmlPageId; // for NavbarItemType INTERNAL
     private HtmlPage htmlPage; // for NavBarItemType INTERNAL
 
-    private String externalLinkUrl; // for NavBarItemType EXTERNAL
-
-    private String anchorLinkPath; // for NavBarItemType INTERNAL_ANCHOR
+    private String href; // for NavBarItemType EXTERNAL and INTERNAL_ANCHOR
 }

--- a/core/src/main/resources/db/changelog/changesets/2023_05_24_navbar_item.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2023_05_24_navbar_item.yaml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  - changeSet:
+      id: navbar_item
+      author: nwatts
+      changes:
+        - renameColumn:
+            tableName: navbar_item
+            oldColumnName: label
+            newColumnName: text
+        - dropColumn:
+            tableName: navbar_item
+            columns:
+              - column:
+                  name: external_link_url
+              - column:
+                  name: anchor_link_path
+        - addColumn:
+            tableName: navbar_item
+            columns:
+              - column:
+                  name: href
+                  type: text

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -101,6 +101,9 @@ databaseChangeLog:
   - include:
       file: changesets/2023_05_15_dataset_creation.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2023_05_24_navbar_item.yaml
+      relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/core/src/test/java/bio/terra/pearl/core/dao/site/SiteContentDaoTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/site/SiteContentDaoTests.java
@@ -57,7 +57,7 @@ public class SiteContentDaoTests extends BaseSpringBootTest {
         LocalizedSiteContent loadedLocal = loadedContent.getLocalizedSiteContents().stream().findFirst().get();
         Assertions.assertEquals(1, loadedLocal.getNavbarItems().size());
         NavbarItem loadedItem = loadedLocal.getNavbarItems().get(0);
-        Assertions.assertEquals("About Us", loadedItem.getLabel());
+        Assertions.assertEquals("About Us", loadedItem.getText());
         HtmlPage loadedAboutUs = loadedItem.getHtmlPage();
         Assertions.assertEquals("About Us Title", loadedAboutUs.getTitle());
         Assertions.assertEquals("a great team", loadedAboutUs.getSections().get(0).getRawContent());

--- a/core/src/test/java/bio/terra/pearl/core/dao/site/SiteContentDaoTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/site/SiteContentDaoTests.java
@@ -38,7 +38,7 @@ public class SiteContentDaoTests extends BaseSpringBootTest {
                 .sections(Arrays.asList(aboutUsSection)).build();
         NavbarItem navbarItem = NavbarItem.builder()
                 .htmlPage(aboutUsPage)
-                .label("About Us").build();
+                .text("About Us").build();
 
         LocalizedSiteContent lsc = LocalizedSiteContent.builder()
                 .language("en")

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent.json
@@ -26,7 +26,7 @@
     },
     "navbarItemDtos": [{
       "itemType": "INTERNAL",
-      "label": "Current research",
+      "text": "Current research",
       "htmlPageDto": {
         "path": "research",
         "title": "Heart Hive -- Current Research",

--- a/populate/src/main/resources/seed/portals/ourhealth/siteContent/aboutUs.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/siteContent/aboutUs.json
@@ -1,6 +1,6 @@
 {
   "itemType": "INTERNAL",
-  "label": "About Us",
+  "text": "About Us",
   "htmlPageDto": {
     "title": "About Us",
     "path": "aboutUs",

--- a/populate/src/main/resources/seed/portals/ourhealth/siteContent/faq.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/siteContent/faq.json
@@ -1,6 +1,6 @@
 {
   "itemType": "INTERNAL",
-  "label": "FAQ",
+  "text": "FAQ",
   "htmlPageDto": {
     "title": "FAQ",
     "path": "faq",

--- a/populate/src/main/resources/seed/portals/ourhealth/siteContent/participation.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/siteContent/participation.json
@@ -1,6 +1,6 @@
 {
   "itemType": "INTERNAL",
-  "label": "Participation",
+  "text": "Participation",
   "htmlPageDto": {
     "title": "Participation",
     "path": "participation",

--- a/populate/src/main/resources/seed/portals/ourhealth/siteContent/scientificBackground.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/siteContent/scientificBackground.json
@@ -1,6 +1,6 @@
 {
   "itemType": "INTERNAL",
-  "label": "Scientific Background",
+  "text": "Scientific Background",
   "htmlPageDto": {
     "title": "Scientific Background",
     "path": "background",

--- a/ui-admin/src/portal/siteContent/SiteContentView.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentView.tsx
@@ -12,7 +12,7 @@ const SiteContentView = ({ portalEnv }: {portalEnv: PortalEnvironment}) => {
   if (!localContent) {
     return <div>no content for language {selectedLanguage}</div>
   }
-  const renderedTitle = selectedNavItem ? selectedNavItem.label : 'Landing page'
+  const renderedTitle = selectedNavItem ? selectedNavItem.text : 'Landing page'
   const pageToRender = selectedNavItem ? selectedNavItem.htmlPage : localContent.landingPage
 
   return <div className="container d-flex bg-white p-3">
@@ -20,9 +20,9 @@ const SiteContentView = ({ portalEnv }: {portalEnv: PortalEnvironment}) => {
       <li className="list-group-item" onClick={() => setSelectedNavItem(null)}>Landing page</li>
       {localContent.navbarItems
         .filter((navItem): navItem is NavbarItemInternal => navItem.itemType === 'INTERNAL')
-        .map(navItem => <li key={navItem.label} className="list-group-item" role="button"
+        .map(navItem => <li key={navItem.text} className="list-group-item" role="button"
           onClick={() => setSelectedNavItem(navItem)}>
-          {navItem.label}
+          {navItem.text}
         </li>
         )}
     </ul>

--- a/ui-core/src/types/landingPageConfig.ts
+++ b/ui-core/src/types/landingPageConfig.ts
@@ -52,23 +52,23 @@ export type NavbarItem =
 
 export type NavbarItemInternal = {
   itemType: 'INTERNAL'
-  label: string
+  text: string
   htmlPage: HtmlPage
 }
 
 export type NavbarItemInternalAnchor = {
   itemType: 'INTERNAL_ANCHOR'
-  label: string
-  anchorLinkPath: string
+  text: string
+  href: string
 }
 
 export type NavbarItemMailingList = {
   itemType: 'MAILING_LIST'
-  label: string
+  text: string
 }
 
 export type NavbarItemExternal = {
   itemType: 'EXTERNAL'
-  label: string
-  externalLink: string
+  text: string
+  href: string
 }

--- a/ui-participant/src/Navbar.test.tsx
+++ b/ui-participant/src/Navbar.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+
+import {
+  HtmlPage,
+  NavbarItemExternal,
+  NavbarItemInternal,
+  NavbarItemInternalAnchor,
+  NavbarItemMailingList
+} from 'api/api'
+import { setupRouterTest } from 'test-utils/router-testing-utils'
+
+import { CustomNavLink } from './Navbar'
+
+describe('CustomNavLink', () => {
+  it('renders internal links', () => {
+    // Arrange
+    const navbarItem: NavbarItemInternal = {
+      itemType: 'INTERNAL',
+      text: 'Internal link',
+      htmlPage: {
+        path: 'testPage'
+      } as HtmlPage
+    }
+
+    const { RoutedComponent } = setupRouterTest(<CustomNavLink navLink={navbarItem} />)
+
+    // Act
+    render(RoutedComponent)
+
+    // Assert
+    const link = screen.getByText('Internal link')
+    expect(link).toHaveAttribute('href', '/testPage')
+  })
+
+  it('renders internal anchor links', () => {
+    // Arrange
+    const navbarItem: NavbarItemInternalAnchor = {
+      itemType: 'INTERNAL_ANCHOR',
+      text: 'Internal anchor link',
+      href: '/testPage#anchor'
+    }
+
+    const { RoutedComponent } = setupRouterTest(<CustomNavLink navLink={navbarItem} />)
+
+    // Act
+    render(RoutedComponent)
+
+    // Assert
+    const link = screen.getByText('Internal anchor link')
+    expect(link).toHaveAttribute('href', '/testPage#anchor')
+  })
+
+  it('renders external links', () => {
+    // Arrange
+    const navbarItem: NavbarItemExternal = {
+      itemType: 'EXTERNAL',
+      text: 'External link',
+      href: 'https://example.com'
+    }
+
+    // Act
+    render(<CustomNavLink navLink={navbarItem} />)
+
+    // Assert
+    const link = screen.getByText('External link')
+    expect(link).toHaveAttribute('href', 'https://example.com')
+  })
+
+  it('renders mailing list links', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const navbarItem: NavbarItemMailingList = {
+      itemType: 'MAILING_LIST',
+      text: 'Mailing list link'
+    }
+
+    jest.spyOn(window, 'alert').mockImplementation(() => { /* noop */ })
+
+    // Act
+    render(<CustomNavLink navLink={navbarItem} />)
+
+    // Assert
+    const link = screen.getByText('Mailing list link')
+
+    // Act
+    await user.click(link)
+
+    // Assert
+    expect(window.alert).toHaveBeenCalled()
+  })
+})

--- a/ui-participant/src/Navbar.tsx
+++ b/ui-participant/src/Navbar.tsx
@@ -172,18 +172,18 @@ export default function Navbar(props: NavbarProps) {
 export function CustomNavLink({ navLink }: { navLink: NavbarItem }) {
   /** will eventually popup a modal allowing email address entry */
   function mailingList(navLinkObj: NavbarItem) {
-    alert(`mailing list ${navLinkObj.label}`)
+    alert(`mailing list ${navLinkObj.text}`)
   }
 
   if (navLink.itemType === 'INTERNAL') {
     // we require navbar links to be absolute rather than relative links
-    return <NavLink to={`/${navLink.htmlPage.path}`} className={navLinkClasses}>{navLink.label}</NavLink>
+    return <NavLink to={`/${navLink.htmlPage.path}`} className={navLinkClasses}>{navLink.text}</NavLink>
   } else if (navLink.itemType === 'INTERNAL_ANCHOR') {
-    return <HashLink to={`/${navLink.anchorLinkPath}`} className={navLinkClasses}>{navLink.label}</HashLink>
+    return <HashLink to={navLink.href} className={navLinkClasses}>{navLink.text}</HashLink>
   } else if (navLink.itemType === 'MAILING_LIST') {
-    return <a role="button" className={navLinkClasses} onClick={() => mailingList(navLink)}>{navLink.label}</a>
+    return <a role="button" className={navLinkClasses} onClick={() => mailingList(navLink)}>{navLink.text}</a>
   } else if (navLink.itemType === 'EXTERNAL') {
-    return <a href={navLink.externalLink} className={navLinkClasses} target="_blank">{navLink.label}</a>
+    return <a href={navLink.href} className={navLinkClasses} target="_blank">{navLink.text}</a>
   }
   return <></>
 }


### PR DESCRIPTION
Navbar items and buttons/links in landing pages have similar options: internal links, external links, join mailing list buttons. However, their configuration schemas are different.

https://github.com/broadinstitute/pearl/blob/95e5d0f337532b574c9e706ea34853f90129be08/ui-core/src/types/landingPageConfig.ts#L47-L74

https://github.com/broadinstitute/pearl/blob/95e5d0f337532b574c9e706ea34853f90129be08/ui-participant/src/landing/ConfiguredButton.tsx#L7-L34

This makes configuration more difficult since you have to remember which fields to use in which case instead of always using the same fields.

This more closely aligns the two by modifying navbar item and renaming `label` to `text` and combining `anchorLinkPath` and `externalLink` into `href`.
