### PR TITLE
[JN-403] Rename some TDR settings, add global on/off switch for TDR export

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledDataRepoExportService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledDataRepoExportService.java
@@ -61,7 +61,7 @@ public class ScheduledDataRepoExportService {
             "storageAccountKey",
             "storageContainerName");
 
-    //Kill-switch for TDR export
+    // Kill-switch for TDR export
     boolean tdrExportEnabled = env.getProperty("env.tdr.tdrExportEnabled", Boolean.class, false);
 
     return tdrExportEnabled

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledDataRepoExportService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledDataRepoExportService.java
@@ -61,8 +61,13 @@ public class ScheduledDataRepoExportService {
             "storageAccountKey",
             "storageContainerName");
 
-    return REQUIRED_TDR_ENV_VARS.stream()
-        .allMatch(
-            envVar -> StringUtils.isNotBlank(env.getProperty(String.format("env.tdr.%s", envVar))));
+    //Kill-switch for TDR export
+    boolean tdrExportEnabled = env.getProperty("env.tdr.tdrExportEnabled", Boolean.class, false);
+
+    return tdrExportEnabled
+        && REQUIRED_TDR_ENV_VARS.stream()
+            .allMatch(
+                envVar ->
+                    StringUtils.isNotBlank(env.getProperty(String.format("env.tdr.%s", envVar))));
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledDataRepoExportService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledDataRepoExportService.java
@@ -61,7 +61,7 @@ public class ScheduledDataRepoExportService {
             "storageAccountKey",
             "storageContainerName");
 
-    // Kill-switch for TDR export
+    // Global on/off switch for TDR export
     boolean tdrExportEnabled = env.getProperty("env.tdr.tdrExportEnabled", Boolean.class, false);
 
     return tdrExportEnabled

--- a/api-admin/src/main/resources/application.yml
+++ b/api-admin/src/main/resources/application.yml
@@ -15,11 +15,12 @@ env:
   tdr:
     basePath: ${TDR_ADDRESS:https://jade.datarepo-dev.broadinstitute.org}
     serviceAccountCreds: ${TDR_SA_CREDS:}
-    storageAccountName: ${STORAGE_ACCOUNT_NAME:}
-    storageAccountKey: ${STORAGE_ACCOUNT_KEY:}
-    storageContainerName: ${STORAGE_CONTAINER_NAME:}
+    storageAccountName: ${TDR_EXPORT_STORAGE_ACCOUNT_NAME:}
+    storageAccountKey: ${TDR_EXPORT_STORAGE_ACCOUNT_KEY:}
+    storageContainerName: ${TDR_EXPORT_STORAGE_CONTAINER_NAME:}
     billingProfileId: ${BILLING_PROFILE_ID:550212cf-45dc-478f-9fe6-9b3290e2a1fe}
     deploymentZone: ${DEPLOYMENT_ZONE:}
+    tdrExportEnabled: ${TDR_EXPORT_ENABLED:false}
   populate:
     populate-from-classpath: true
   b2c:


### PR DESCRIPTION
Companion PR: https://github.com/broadinstitute/terra-helmfile/pull/4227

Two objectives in this pair of PRs:

1) Get things properly set up in dev so AppSec can start evaluating the TDR integration
2) Add a global toggle for TDR export. Even though this won't work in prod because some credentials haven't been provisioned yet, I don't like the implicit nature of the toggle. At some point we should expose whether or not TDR integration is enabled and use that to disable/hide parts of the admin UI.