### PR TITLE
[JN-404] Implement mailing list navbar item

### DIFF
--- a/ui-participant/src/Navbar.test.tsx
+++ b/ui-participant/src/Navbar.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import React from 'react'
 
 import {
@@ -70,25 +69,18 @@ describe('CustomNavLink', () => {
 
   it('renders mailing list links', async () => {
     // Arrange
-    const user = userEvent.setup()
-
     const navbarItem: NavbarItemMailingList = {
       itemType: 'MAILING_LIST',
       text: 'Mailing list link'
     }
-
-    jest.spyOn(window, 'alert').mockImplementation(() => { /* noop */ })
 
     // Act
     render(<CustomNavLink navLink={navbarItem} />)
 
     // Assert
     const link = screen.getByText('Mailing list link')
-
-    // Act
-    await user.click(link)
-
-    // Assert
-    expect(window.alert).toHaveBeenCalled()
+    const modal = document.querySelector('.modal') as HTMLElement
+    expect(link).toHaveAttribute('data-bs-toggle', 'modal')
+    expect(link).toHaveAttribute('data-bs-target', `#${CSS.escape(modal.getAttribute('id') as string)}`)
   })
 })

--- a/ui-participant/src/Navbar.tsx
+++ b/ui-participant/src/Navbar.tsx
@@ -7,6 +7,7 @@ import { Link, NavLink, useLocation } from 'react-router-dom'
 import { HashLink } from 'react-router-hash-link'
 
 import Api, { getEnvSpec, getImageUrl, NavbarItem } from 'api/api'
+import { MailingListModal } from 'landing/MailingListModal'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { useUser } from 'providers/UserProvider'
 import { useConfig } from 'providers/ConfigProvider'
@@ -166,22 +167,34 @@ export default function Navbar(props: NavbarProps) {
   </nav>
 }
 
+type MailingListNavLinkProps = JSX.IntrinsicElements['a']
+
+const MailingListNavLink = (props: MailingListNavLinkProps) => {
+  const modalId = useId()
+
+  return (
+    <>
+      <a
+        {...props}
+        data-bs-toggle="modal"
+        data-bs-target={`#${CSS.escape(modalId)}`}
+      />
+      <MailingListModal id={modalId} />
+    </>
+  )
+}
+
 /** renders a single navBarItem. This will likely get split out into subcomponents for each type as they are
  * implemented
  */
 export function CustomNavLink({ navLink }: { navLink: NavbarItem }) {
-  /** will eventually popup a modal allowing email address entry */
-  function mailingList(navLinkObj: NavbarItem) {
-    alert(`mailing list ${navLinkObj.text}`)
-  }
-
   if (navLink.itemType === 'INTERNAL') {
     // we require navbar links to be absolute rather than relative links
     return <NavLink to={`/${navLink.htmlPage.path}`} className={navLinkClasses}>{navLink.text}</NavLink>
   } else if (navLink.itemType === 'INTERNAL_ANCHOR') {
     return <HashLink to={navLink.href} className={navLinkClasses}>{navLink.text}</HashLink>
   } else if (navLink.itemType === 'MAILING_LIST') {
-    return <a role="button" className={navLinkClasses} onClick={() => mailingList(navLink)}>{navLink.text}</a>
+    return <MailingListNavLink role="button" className={navLinkClasses}>{navLink.text}</MailingListNavLink>
   } else if (navLink.itemType === 'EXTERNAL') {
     return <a href={navLink.href} className={navLinkClasses} target="_blank">{navLink.text}</a>
   }


### PR DESCRIPTION
One available type of navbar item is a link to join the mailing list.
https://github.com/broadinstitute/juniper/blob/9495654e63330f22c7bfd750d173e039e33df405/ui-core/src/types/landingPageConfig.ts#L65-L68

Currently, this is not implemented. Clicking a navbar item configured this way shows an alert that says "mailing list".
https://github.com/broadinstitute/juniper/blob/9495654e63330f22c7bfd750d173e039e33df405/ui-participant/src/Navbar.tsx#L173-L176

This implements this type of navbar item to show the usual join mailing list modal.