### PR TITLE
[JN-405] Fail PR checks on ESLint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "typescript": "^4.8.3"
   },
   "scripts": {
-    "lint": "eslint ui-admin/src ui-core/src ui-participant/src"
+    "lint": "eslint --max-warnings=0 ui-admin/src ui-core/src ui-participant/src"
   }
 }

--- a/ui-admin/src/study/participants/datarepo/DatasetDashboard.test.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetDashboard.test.tsx
@@ -5,7 +5,7 @@ import DatasetDashboard from './DatasetDashboard'
 import { DatasetDetails, DatasetJobHistory } from 'api/api'
 import { setupRouterTest } from 'test-utils/router-testing-utils'
 import { mockDatasetDetails, mockStudyEnvContext } from 'test-utils/mocking-utils'
-import Router from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 
 jest.mock('api/api', () => ({
   listDatasetsForStudyEnvironment: () => {
@@ -32,7 +32,7 @@ test('renders a link to TDR if the dataset successful created', async () => {
   const studyEnvContext = mockStudyEnvContext()
 
   const { RoutedComponent } = setupRouterTest(<DatasetDashboard studyEnvContext={studyEnvContext}/>)
-  jest.spyOn(Router, 'useParams').mockReturnValue({ datasetName: 'successful_dataset' })
+  ;(useParams as jest.Mock).mockReturnValue({ datasetName: 'successful_dataset' })
   render(RoutedComponent)
   await waitFor(() => {
     expect(screen.getByText('successful_dataset', { exact: false })).toBeInTheDocument()
@@ -48,7 +48,7 @@ test('does not render a link to TDR if the dataset failed to create', async () =
   const studyEnvContext = mockStudyEnvContext()
 
   const { RoutedComponent } = setupRouterTest(<DatasetDashboard studyEnvContext={studyEnvContext}/>)
-  jest.spyOn(Router, 'useParams').mockReturnValue({ datasetName: 'failed_dataset' })
+  ;(useParams as jest.Mock).mockReturnValue({ datasetName: 'failed_dataset' })
   render(RoutedComponent)
   await waitFor(() => {
     expect(screen.getByText('failed_dataset', { exact: false })).toBeInTheDocument()


### PR DESCRIPTION
When building one of the UIs, ESLint is run via a webpack plugin. In CI environments (when the CI environment variable is set), create-react-app treats webpack warnings as errors. Thus, an ESLint warning will cause the publish workflow to fail.

Since #395, ESLint is run differently in PR checks. There, we run ESLint directly (in order to cover ui-core) and disable the webpack plugin. Thus, PR checks can pass on code with an ESLint warning.

This changes the `lint` script to fail on warnings so that PR checks are consistent with the publish workflow.