### PR TITLE
[JN-378] Cleanup SurveyEditorView

### DIFF
--- a/ui-admin/src/study/surveys/PreEnrollView.tsx
+++ b/ui-admin/src/study/surveys/PreEnrollView.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useParams, useSearchParams } from 'react-router-dom'
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { Store } from 'react-notifications-component'
 
 import {  StudyParams } from 'study/StudyRouter'
@@ -8,6 +8,7 @@ import Api, { StudyEnvironment, Survey } from 'api/api'
 
 import { failureNotification, successNotification } from 'util/notifications'
 import SurveyEditorView from './SurveyEditorView'
+import { useUser } from 'user/UserProvider'
 
 export type SurveyParamsT = StudyParams & {
   surveyStableId: string,
@@ -18,16 +19,18 @@ export type SurveyParamsT = StudyParams & {
 function RawPreRegView({ portalShortcode, currentEnv, survey, studyShortcode, readOnly }:
                       {portalShortcode: string, currentEnv: StudyEnvironment, readOnly: boolean
                         survey: Survey, studyShortcode: string}) {
+  const { user } = useUser()
+  const navigate = useNavigate()
+
   const [currentSurvey, setCurrentSurvey] = useState(survey)
 
-  /** update the version */
-  async function changeVersion(version: number): Promise<string> {
-    throw `Not implemented ${version}`
-  }
-
-
   /** saves as a new version and updates the study environment accordingly */
-  async function createNewVersion(updatedContent: string): Promise<string> {
+  async function createNewVersion({ content: updatedContent }: { content: string }): Promise<void> {
+    if (!user.superuser) {
+      Store.addNotification(failureNotification('you do not have permissions to save surveys'))
+      return
+    }
+
     survey.content = updatedContent
     try {
       const updatedSurvey = await Api.createNewSurveyVersion(portalShortcode, currentSurvey)
@@ -41,11 +44,16 @@ function RawPreRegView({ portalShortcode, currentEnv, survey, studyShortcode, re
     } catch (e) {
       Store.addNotification(failureNotification(`Save failed`))
     }
-    return updatedContent
   }
 
-  return <SurveyEditorView portalShortcode={portalShortcode} currentForm={currentSurvey}
-    createNewVersion={createNewVersion} changeVersion={changeVersion} readOnly={readOnly}/>
+  return (
+    <SurveyEditorView
+      currentForm={currentSurvey}
+      readOnly={readOnly}
+      onCancel={() => navigate('../../..')}
+      onSave={createNewVersion}
+    />
+  )
 }
 
 /** Routable component that delegates rendering to the raw view */

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -1,36 +1,29 @@
-import React, { useCallback, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import React, { useState } from 'react'
 
 import { VersionedForm } from 'api/api'
-import VersionSelector from './VersionSelector'
 
 import { SurveyCreatorComponent } from 'survey-creator-react'
 import { useSurveyJSCreator } from '../../util/surveyJsUtils'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCaretDown } from '@fortawesome/free-solid-svg-icons/faCaretDown'
-import { useUser } from '../../user/UserProvider'
-import { failureNotification } from '../../util/notifications'
-import { Store } from 'react-notifications-component'
+
+type SurveyEditorViewProps<T extends VersionedForm> = {
+  currentForm: T
+  readOnly?: boolean
+  onCancel: () => void
+  onSave: (update: { content: string }) => Promise<void>
+}
 
 /** renders a survey for editing/viewing using the surveyJS editor */
-export default function SurveyEditorView({
-  portalShortcode, currentForm, readOnly = false,
-  createNewVersion, changeVersion
-}:
-                         {portalShortcode: string, currentForm: VersionedForm, readOnly?: boolean,
-                           createNewVersion: (updatedContent: string) => Promise<string>,
-                           changeVersion: (version: number) => void}) {
-  const navigate = useNavigate()
-  const [isDirty, setIsDirty] = useState(false)
-  const [showVersionSelector, setShowVersionSelector] = useState(false)
-  const { user } = useUser()
+const SurveyEditorView = <T extends VersionedForm>(props: SurveyEditorViewProps<T>) => {
+  const {
+    currentForm,
+    readOnly = false,
+    onCancel,
+    onSave
+  } = props
 
-  /** indicate the survey has been modified */
-  const handleSurveyModification = useCallback(() => {
-    //setIsDirty(true)
-  }, [])
+  const [saving, setSaving] = useState(false)
 
-  const { surveyJSCreator } = useSurveyJSCreator(currentForm, handleSurveyModification)
+  const { surveyJSCreator } = useSurveyJSCreator(currentForm, () => { /* noop */ })
   if (surveyJSCreator) {
     surveyJSCreator.readOnly = readOnly
   }
@@ -38,44 +31,35 @@ export default function SurveyEditorView({
 
   /** when save is pressed, call the handling function, and then update the survey with the response */
   async function handleSave() {
-    if (!surveyJSCreator) {
+    if (!surveyJSCreator || saving) {
       return
     }
-    if (!user.superuser) {
-      Store.addNotification(failureNotification('you do not have permissions to save surveys'))
-      return
+    setSaving(true)
+    try {
+      await onSave({ content: surveyJSCreator.text })
+    } finally {
+      setSaving(false)
     }
-    surveyJSCreator.text = await createNewVersion(surveyJSCreator.text)
-    setIsDirty(false)
   }
 
-  /** handles the "cancel" button press */
-  function handleCancel() {
-    navigate('../../..')
-  }
-
-  return <div className="SurveyView">
-    <div className="d-flex p-2 align-items-center">
-      <div className="d-flex flex-grow-1">
-        <h5>{currentForm.name}
-          <span className="detail me-2 ms-2">version {currentForm.version}</span>
-          { isDirty && <span className="badge" style={{ backgroundColor: 'rgb(51, 136, 0)' }} >
-            <em>modified</em>
-          </span> }
-          <button className="btn-secondary btn" onClick={() => setShowVersionSelector(true)}>
-            all versions <FontAwesomeIcon icon={faCaretDown}/>
+  return (
+    <div className="SurveyView">
+      <div className="d-flex p-2 align-items-center">
+        <div className="d-flex flex-grow-1">
+          <h5>{currentForm.name}
+            <span className="detail me-2 ms-2">version {currentForm.version}</span>
+          </h5>
+        </div>
+        {!readOnly && (
+          <button className="btn btn-primary me-md-2" type="button" onClick={handleSave}>
+            Save
           </button>
-          { showVersionSelector && <VersionSelector studyShortname={portalShortcode}
-            stableId={currentForm.stableId}
-            show={showVersionSelector} setShow={setShowVersionSelector}
-            updateVersion={changeVersion}/> }
-        </h5>
+        )}
+        <button className="btn btn-secondary" type="button" onClick={onCancel}>Cancel</button>
       </div>
-      {!readOnly && <button className="btn btn-primary me-md-2" type="button" onClick={handleSave}>
-        Save
-      </button> }
-      <button className="btn btn-secondary" type="button" onClick={handleCancel}>Cancel</button>
+      {surveyJSCreator && <SurveyCreatorComponent creator={surveyJSCreator} /> }
     </div>
-    {surveyJSCreator && <SurveyCreatorComponent creator={surveyJSCreator} /> }
-  </div>
+  )
 }
+
+export default SurveyEditorView


### PR DESCRIPTION
Groundwork for survey editor.

This removes navigation and permission concerns from SurveyEditorView, moving them up to its parent views. This will make SurveyEditorView easier to test.

It also removes the broken version selection from SurveyEditorView. Currently, the version selector attempts to load versions from an endpoint that doesn't exist. It looks like the commented out code automatically "publishes" the old version when its selected. I'm thinking we may want to allow loading an old version in the editor, but only publishing it when a user clicks "Save".