### PR TITLE
JN-412 refreshing seed populate

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/config/InitialPopulate.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/config/InitialPopulate.java
@@ -17,12 +17,8 @@ public class InitialPopulate {
   @Autowired private BaseSeedPopulator baseSeedPopulator;
 
   @EventListener(ApplicationReadyEvent.class)
-  public void populateSeedIfNeeded() throws IOException {
-    if (adminUserService.count() == 0) {
-      log.info("No admin users found, populating base");
-      baseSeedPopulator.populate("seed");
-    } else {
-      log.info("Existing admin users found, skipping seed populate");
-    }
+  public void populateSeed() throws IOException {
+    log.info("Refreshing base seed populate data");
+    baseSeedPopulator.populate();
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/PopulateExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/PopulateExtService.java
@@ -42,7 +42,7 @@ public class PopulateExtService {
   public BaseSeedPopulator.SetupStats populateBaseSeed(AdminUser user) {
     authorizeUser(user);
     try {
-      return baseSeedPopulator.populate("");
+      return baseSeedPopulator.populate();
     } catch (IOException e) {
       throw new IllegalArgumentException("populate failed", e);
     }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/BaseSeedPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/BaseSeedPopulator.java
@@ -13,8 +13,11 @@ import lombok.experimental.SuperBuilder;
 import org.springframework.stereotype.Service;
 
 /**
- * Populates entities configs needed for a new server instance, including environments and admin users.
- * If those users/items exist, the will be updated, rather than duplicated.
+ * Populates entities configs needed for a server instance, including environments and admin users.
+ * If those users/items exist, they will be updated, rather than duplicated.
+ *
+ * this is intended to capture essential populate data -- it will be checked every time a server starts
+ * so avoid putting things in this file unless they are essential to server operations, and not customizable by users
  * */
 @Service
 public class BaseSeedPopulator {
@@ -47,7 +50,12 @@ public class BaseSeedPopulator {
         this.kitTypePopulator = kitTypePopulator;
     }
 
-    public SetupStats populate(String filePathName) throws IOException {
+    /**
+     * BE CAREFUL!!!
+     * This method runs every time a server instance starts.  So avoid things that might take a long time,
+     * or that might overwrite user-entered data
+     */
+    public SetupStats populate() throws IOException {
         // for now, we ignore the pathname
         for (String file : ADMIN_USERS_TO_POPULATE) {
             adminUserPopulator.populate(new FilePopulateContext(file), false);
@@ -58,6 +66,8 @@ public class BaseSeedPopulator {
         for (String file : KIT_TYPES_TO_POPULATE) {
             kitTypePopulator.populate(new FilePopulateContext(file), false);
         }
+        // overwrite is ok here -- we're not versioning admin emails (currently just the "here's the link to
+        // the admin tool" welcome email to ne study staff
         var configStats = adminConfigPopulator.populate(true);
         return SetupStats.builder()
                 .numAdminUsers(adminUserService.count())

--- a/populate/src/test/java/bio/terra/pearl/populate/SetupPopulateTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/SetupPopulateTest.java
@@ -34,7 +34,7 @@ public class SetupPopulateTest extends BaseSpringBootTest {
     @Test
     @Transactional
     public void testSetup() throws IOException {
-        BaseSeedPopulator.SetupStats setupStats = baseSeedPopulator.populate("");
+        BaseSeedPopulator.SetupStats setupStats = baseSeedPopulator.populate();
         Assertions.assertEquals(BaseSeedPopulator.ADMIN_USERS_TO_POPULATE.size(), setupStats.getNumAdminUsers());
         Assertions.assertEquals(BaseSeedPopulator.ENVIRONMENTS_TO_POPULATE.size(), setupStats.getNumEnvironments());
     }


### PR DESCRIPTION
This changes our approach to BaseSeedPopulator.  Previously, it was only run on fresh DBs.  Now, we will run BaseSeedPopulator on every server startup.  BaseSeedPopulator takes the role of ensuring that any essential data for server operation is in place.  This will solve a lot of configuration errors, at the cost of us having to be more careful about what we include in the base seed, and remembering that the seeded entities will always be set to their source-controlled values on server startup. 

For example, if I go rogue, and someone needs to revoke my superuser permissions in production, then setting superuser=false in the DB for my account will not be enough -- that change would get reverted next time a pod starts.  You'd need to do a release removing my superuser permission from the seed files -- those seed files are now the 'source of truth'.   

I think this cost is worth it in the short term rather than manually shepherding migration scripts, but I could be convinced otherwise.  If so, then Brian will just need to write a liquibase migration script adding the kit request types he needs.


TO TEST:
1. restart ApiAdminApp
2. confirm base seed populator runs, despite  an existing database