### PR TITLE
[JN-363] Added nightly fetch of kit status from DSM

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledKitStatusService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledKitStatusService.java
@@ -16,7 +16,7 @@ public class ScheduledKitStatusService {
     this.kitRequestService = kitRequestService;
   }
   /**
-   * Update kit statuses from DSM at 12:30am every day. We're _very_ generous with lockAtMostFor
+   * Update kit statuses from Pepper at 12:30am every day. We're _very_ generous with lockAtMostFor
    * because this only runs once per day.
    */
   @Scheduled(cron = "0 30 0 * * *")
@@ -25,8 +25,8 @@ public class ScheduledKitStatusService {
       lockAtLeastFor = "1m",
       lockAtMostFor = "360m")
   public void fetchUpdatedKitStatuses() {
-    logger.info("Updating kit status from DSM...");
-    kitRequestService.updateAllKitStatuses();
+    logger.info("Updating kit status from Pepper...");
+    kitRequestService.syncAllKitStatusesFromPepper();
     logger.info("Finished updating kit status.");
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledKitStatusService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledKitStatusService.java
@@ -1,0 +1,32 @@
+package bio.terra.pearl.api.admin.service;
+
+import bio.terra.pearl.core.service.kit.KitRequestService;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ScheduledKitStatusService {
+  private static final Logger logger = LoggerFactory.getLogger(ScheduledKitStatusService.class);
+  private final KitRequestService kitRequestService;
+
+  public ScheduledKitStatusService(KitRequestService kitRequestService) {
+    this.kitRequestService = kitRequestService;
+  }
+  /**
+   * Update kit statuses from DSM at 12:30am every day. We're _very_ generous with lockAtMostFor
+   * because this only runs once per day.
+   */
+  @Scheduled(cron = "0 30 0 * * *")
+  @SchedulerLock(
+      name = "KitRequestService.updateAllKitStatuses",
+      lockAtLeastFor = "1m",
+      lockAtMostFor = "360m")
+  public void fetchUpdatedKitStatuses() {
+    logger.info("Updating kit status from DSM...");
+    kitRequestService.updateAllKitStatuses();
+    logger.info("Finished updating kit status.");
+  }
+}

--- a/core/src/main/java/bio/terra/pearl/core/dao/kit/KitRequestDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/kit/KitRequestDao.java
@@ -15,12 +15,6 @@ public class KitRequestDao extends BaseMutableJdbiDao<KitRequest> {
         super(jdbi);
     }
 
-    private final String BASE_QUERY_BY_STUDY =
-            " select " + prefixedGetQueryColumns("kit") + " from " + tableName + " kit " +
-            " join enrollee on kit.enrollee_id = enrollee.id " +
-            " join study_environment on enrollee.study_environment_id = study_environment.id " +
-            " where study_environment.id = :studyEnvironmentId ";
-
     @Override
     protected Class<KitRequest> getClazz() { return KitRequest.class; }
 

--- a/core/src/main/java/bio/terra/pearl/core/dao/kit/KitRequestDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/kit/KitRequestDao.java
@@ -24,7 +24,7 @@ public class KitRequestDao extends BaseMutableJdbiDao<KitRequest> {
 
     /**
      * Find all kits that are not complete (or errored) for a study.
-     * This represents the set of in-flight kits that we want to keep an eye on in DSM.
+     * This represents the set of in-flight kits that we want to keep an eye on in Pepper.
      */
     public List<KitRequest> findIncompleteKits(UUID studyEnvironmentId) {
         return jdbi.withHandle(handle ->

--- a/core/src/main/java/bio/terra/pearl/core/model/kit/KitRequestStatus.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/kit/KitRequestStatus.java
@@ -1,6 +1,28 @@
 package bio.terra.pearl.core.model.kit;
 
-// TODO: We'll see what other status values we might need. It's also possible that we won't end up needing this status.
+import java.util.Set;
+
+/**
+ * High-level, Juniper-centric kit status. Only needs to be specific enough for Juniper to decide how to interact with
+ * DSM. This is not intended to mirror all possible states in DSM. For that, see
+ * {@link bio.terra.pearl.core.service.kit.PepperDSMKitStatus#currentStatus}.
+ *
+ * CREATED --> IN_PROGRESS --> COMPLETE
+ *                         \-> ERRORED
+ *
+ * ERRORED kits should always have some error detail associated with them. However, the presence of error details does
+ * not necessarily imply ERRORED. There may be transient errors while a kit is IN_PROGRESS that are resolved on the way
+ * to being COMPLETE.
+ *
+ * We may add additional states in the future if needed to facilitate more complicated workflows involving intervention
+ * by study staff.
+ */
 public enum KitRequestStatus {
-    CREATED
+    CREATED, // record created in Juniper database, usually followed almost immediately by IN_PROGRESS
+    IN_PROGRESS, // request sent to DSM
+    COMPLETE, // DSM returned a successful end state
+    ERRORED; // DSM returned a terminal error state
+
+    public static final Set<KitRequestStatus> NON_TERMINAL_STATES = Set.of(CREATED, IN_PROGRESS);
+    public static final Set<KitRequestStatus> TERMINAL_STATES = Set.of(COMPLETE, ERRORED);
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/kit/KitRequestStatus.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/kit/KitRequestStatus.java
@@ -4,7 +4,7 @@ import java.util.Set;
 
 /**
  * High-level, Juniper-centric kit status. Only needs to be specific enough for Juniper to decide how to interact with
- * DSM. This is not intended to mirror all possible states in DSM. For that, see
+ * Pepper. This is not intended to mirror all possible states in Pepper. For that, see
  * {@link bio.terra.pearl.core.service.kit.PepperDSMKitStatus#currentStatus}.
  *
  * CREATED --> IN_PROGRESS --> COMPLETE
@@ -19,10 +19,10 @@ import java.util.Set;
  */
 public enum KitRequestStatus {
     CREATED, // record created in Juniper database, usually followed almost immediately by IN_PROGRESS
-    IN_PROGRESS, // request sent to DSM
-    COMPLETE, // DSM returned a successful end state
-    ERRORED; // DSM returned a terminal error state
+    IN_PROGRESS, // request sent to Pepper
+    COMPLETE, // Pepper returned a successful end state
+    FAILED; // Pepper returned a terminal error state
 
     public static final Set<KitRequestStatus> NON_TERMINAL_STATES = Set.of(CREATED, IN_PROGRESS);
-    public static final Set<KitRequestStatus> TERMINAL_STATES = Set.of(COMPLETE, ERRORED);
+    public static final Set<KitRequestStatus> TERMINAL_STATES = Set.of(COMPLETE, FAILED);
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.core.service.kit;
 
 import bio.terra.pearl.core.dao.kit.KitRequestDao;
 import bio.terra.pearl.core.dao.kit.KitTypeDao;
+import bio.terra.pearl.core.dao.study.StudyDao;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.kit.KitRequestStatus;
@@ -9,35 +10,52 @@ import bio.terra.pearl.core.model.kit.KitType;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.MailingAddress;
 import bio.terra.pearl.core.model.participant.Profile;
+import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.service.CascadeProperty;
 import bio.terra.pearl.core.service.CrudService;
+import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.participant.ProfileService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collection;
-import java.util.Set;
-import java.util.UUID;
+import java.time.Instant;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
-    private final PepperDSMClient pepperDSMClient;
-    private final KitTypeDao kitTypeDao;
+    private static final Logger logger = LoggerFactory.getLogger(KitRequestService.class);
+
+    // NOTE: These are completely made up for now, until we get further with the DSM integration and know what the real
+    // possible statuses are.
+    private static final Set<String> DSM_COMPLETED_STATUSES = Set.of("PROCESSED", "CANCELLED");
+    private static final Set<String> DSM_ERRORED_STATUSES = Set.of("CONTAMINATED");
 
     public KitRequestService(KitRequestDao dao,
-                             PepperDSMClient pepperDSMClient,
                              KitTypeDao kitTypeDao,
+                             PepperDSMClient pepperDSMClient,
                              ProfileService profileService,
+                             StudyDao studyDao,
                              ObjectMapper objectMapper) {
         super(dao);
-        this.pepperDSMClient = pepperDSMClient;
         this.kitTypeDao = kitTypeDao;
+        this.pepperDSMClient = pepperDSMClient;
         this.profileService = profileService;
+        this.studyDao = studyDao;
         this.objectMapper = objectMapper;
     }
 
-    public KitRequest requestKit(AdminUser adminUser, Enrollee enrollee, String kitTypeName) throws JsonProcessingException {
+    /**
+     * Send a request for a sample kit to DSM.
+     */
+    @Transactional
+    public KitRequest requestKit(AdminUser adminUser, Enrollee enrollee, String kitTypeName)
+            throws JsonProcessingException {
         // create and save kit request
         Profile profile = profileService.loadWithMailingAddress(enrollee.getProfileId())
                 .orElseThrow(() -> new RuntimeException("Missing profile for enrollee: " + enrollee.getShortcode()));
@@ -54,10 +72,90 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
         return kitRequest;
     }
 
+    /**
+     * Collect the address fields sent to DSM with a kit request. This is not the full DSM request, just the address
+     * information captured at the time of, and stored with, the kit request.
+     */
+    public static PepperKitAddress makePepperKitAddress(Profile profile) {
+        MailingAddress mailingAddress = profile.getMailingAddress();
+        return PepperKitAddress.builder()
+                .firstName(profile.getGivenName())
+                .lastName(profile.getFamilyName())
+                .street1(mailingAddress.getStreet1())
+                .street2(mailingAddress.getStreet2())
+                .city(mailingAddress.getCity())
+                .state(mailingAddress.getState())
+                .postalCode(mailingAddress.getPostalCode())
+                .country(mailingAddress.getCountry())
+                .phoneNumber(profile.getPhoneNumber())
+                .build();
+    }
+
+    /**
+     * Fetch all kits for an enrollee.
+     */
     public Collection<KitRequest> getKitRequests(AdminUser adminUser, Enrollee enrollee) {
         return dao.findByEnrollee(enrollee.getId());
     }
 
+    /**
+     * Query DSM for the status of a single kit and update the cached status in Juniper.
+     * This is intended for the special case of needing the absolute most up-to-date information for a single kit.
+     * Do _NOT_ call this repeatedly for a collection of kits. Use a bulk operation instead to avoid overwhelming DSM.
+     */
+    @Transactional
+    public PepperDSMKitStatus updateKitStatus(UUID kitId) {
+        // auth admin user
+        // find kit request
+        var kitRequest = dao.find(kitId).orElseThrow(() -> new NotFoundException("Kit request not found"));
+        // fetch latest status
+        var pepperDSMKitStatus = pepperDSMClient.fetchKitStatus(kitId);
+        // save latest status
+        try {
+            kitRequest.setDsmStatus(objectMapper.writeValueAsString(pepperDSMKitStatus));
+            kitRequest.setDsmStatusFetchedAt(Instant.now());
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Could not parse JSON response from DSM", e);
+        }
+        dao.update(kitRequest);
+        return pepperDSMKitStatus;
+    }
+
+    /**
+     * Query DSM for all in-progress kits and update the cached status in Juniper. This is intended to be called as a
+     * scheduled job during expected non-busy times for DSM. If on-demand updates are needed outside the scheduled job,
+     * use {@link KitRequestService#updateKitStatus(AdminUser, UUID)} for a single kit or a batch operation that queries
+     * DSM for less than all open kits.
+     */
+    @Transactional
+    public void updateAllKitStatuses() {
+        var studies = studyDao.findAll();
+        for (Study study : studies) {
+            // find all in-flight kits
+            var incompleteKits = dao.findIncompleteKits(study.getId());
+
+            // fetch statuses from DSM
+            if (!incompleteKits.isEmpty()) {
+                var dsmKitStatuses = pepperDSMClient.fetchKitStatusByStudy(study.getId());
+                var dsmStatusFetchedAt = Instant.now();
+                var dsmKitStatusByKitId = dsmKitStatuses.stream().collect(
+                        Collectors.toMap(PepperDSMKitStatus::getKitId, Function.identity()));
+                // The set of kits returned from DSM may be different from the set of incomplete kits in Juniper, but
+                // we want to update the records in Juniper so those are the ones we want to iterate here.
+                for (KitRequest kit : incompleteKits) {
+                    // update each kit
+                    var dsmKitStatus = dsmKitStatusByKitId.get(kit.getId().toString());
+                    if (dsmKitStatus != null) {
+                        saveKitStatus(kit, dsmKitStatus, dsmStatusFetchedAt);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Delete kits for an enrollee. Only for use by populate functions.
+     */
     public void deleteByEnrolleeId(UUID enrolleeId, Set<CascadeProperty> cascade) {
         for (KitRequest kitRequest : dao.findByEnrollee(enrolleeId)) {
             dao.delete(kitRequest.getId());
@@ -82,21 +180,36 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
         return savedKitRequest;
     }
 
-    public static PepperKitAddress makePepperKitAddress(Profile profile) {
-        MailingAddress mailingAddress = profile.getMailingAddress();
-        return PepperKitAddress.builder()
-                .firstName(profile.getGivenName())
-                .lastName(profile.getFamilyName())
-                .street1(mailingAddress.getStreet1())
-                .street2(mailingAddress.getStreet2())
-                .city(mailingAddress.getCity())
-                .state(mailingAddress.getState())
-                .postalCode(mailingAddress.getPostalCode())
-                .country(mailingAddress.getCountry())
-                .phoneNumber(profile.getPhoneNumber())
-                .build();
+    /**
+     * Saves updated kit status. This is called from a batch job, so exceptions are caught and logged instead of thrown
+     * to allow the rest of the batch to be processed.
+     */
+    private void saveKitStatus(KitRequest kit, PepperDSMKitStatus dsmKitStatus, Instant dsmStatusFetchedAt) {
+        try {
+            kit.setDsmStatus(objectMapper.writeValueAsString(dsmKitStatus));
+            kit.setDsmStatusFetchedAt(dsmStatusFetchedAt);
+            kit.setStatus(statusFromDSMStatus(dsmKitStatus.getCurrentStatus()));
+            dao.update(kit);
+        } catch (JsonProcessingException e) {
+            logger.warn(
+                    "Unable to serialize status JSON for kit %s: %s".formatted(kit.getId(), dsmKitStatus.toString()),
+                    e);
+        }
     }
 
+    private KitRequestStatus statusFromDSMStatus(String currentStatus) {
+        if (DSM_COMPLETED_STATUSES.contains(currentStatus)) {
+            return KitRequestStatus.COMPLETE;
+        } else if (DSM_ERRORED_STATUSES.contains(currentStatus)) {
+            return KitRequestStatus.ERRORED;
+        } else {
+            return KitRequestStatus.IN_PROGRESS;
+        }
+    }
+
+    private final KitTypeDao kitTypeDao;
+    private final PepperDSMClient pepperDSMClient;
     private final ProfileService profileService;
+    private final StudyDao studyDao;
     private final ObjectMapper objectMapper;
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/LivePepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/LivePepperDSMClient.java
@@ -1,0 +1,88 @@
+package bio.terra.pearl.core.service.kit;
+
+import bio.terra.pearl.core.model.kit.KitRequest;
+import bio.terra.pearl.core.model.participant.Enrollee;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.UUID;
+
+@Component
+public class LivePepperDSMClient implements PepperDSMClient {
+    private final PepperDSMConfig pepperDSMConfig;
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+
+    public LivePepperDSMClient(PepperDSMConfig pepperDSMConfig,
+                               WebClient.Builder webClientBuilder,
+                               ObjectMapper objectMapper) {
+        this.pepperDSMConfig = pepperDSMConfig;
+        this.webClient = webClientBuilder
+                .baseUrl(this.pepperDSMConfig.getBasePath())
+                .build();
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public String sendKitRequest(Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address)
+            throws JsonProcessingException {
+        var juniperKitRequest = PepperDSMKitRequest.JuniperKitRequest.builderWithAddress(address)
+                .juniperKitId(kitRequest.getId().toString())
+                .juniperParticipantId(enrollee.getShortcode())
+                .build();
+        var pepperDSMKitRequest = PepperDSMKitRequest.builder()
+                .juniperKitRequest(juniperKitRequest)
+                .kitType("SALIVA")
+                .juniperStudyId("Juniper-mock-guid")
+                .build();
+
+        var body = objectMapper.writeValueAsString(pepperDSMKitRequest);
+        Mono<String> stringMono = webClient
+                .post().uri("/shipKit")
+                .header("Authorization", "Bearer " + generateDsmJwt())
+                .bodyValue(body)
+                .retrieve().bodyToMono(String.class);
+        return stringMono.block();
+    }
+
+    @Override
+    public PepperDSMKitStatus fetchKitStatus(UUID kitRequestId) {
+        return null;
+    }
+
+    @Override
+    public Collection<PepperDSMKitStatus> fetchKitStatusByStudy(UUID studyId) {
+        return null;
+    }
+
+    private String generateDsmJwt() {
+        var fifteenMinutes = 15 * 60 * 1000;
+        var now = System.currentTimeMillis();
+        return JWT.create()
+                .withExpiresAt(Instant.ofEpochMilli(now + fifteenMinutes))
+                .sign(Algorithm.HMAC256(pepperDSMConfig.getSecret()));
+    }
+}
+
+@Component
+@Getter
+@Setter
+class PepperDSMConfig {
+    private String basePath;
+    private String secret;
+
+    public PepperDSMConfig(Environment environment) {
+        this.basePath = environment.getProperty("env.dsm.basePath");
+        this.secret = environment.getProperty("env.dsm.secret");
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/PepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/PepperDSMClient.java
@@ -2,63 +2,14 @@ package bio.terra.pearl.core.service.kit;
 
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.participant.Enrollee;
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.algorithms.Algorithm;
-import lombok.Getter;
-import lombok.Setter;
-import org.springframework.core.env.Environment;
-import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
-import java.time.Instant;
+import java.util.Collection;
+import java.util.UUID;
 
-@Component
-public class PepperDSMClient {
-    private final PepperDSMConfig pepperDSMConfig;
-    private final WebClient webClient;
-
-    public PepperDSMClient(PepperDSMConfig pepperDSMConfig,
-                           WebClient.Builder webClientBuilder) {
-        this.pepperDSMConfig = pepperDSMConfig;
-        this.webClient = webClientBuilder
-                .baseUrl(this.pepperDSMConfig.getBasePath())
-                .build();
-    }
-
-    public String sendKitRequest(Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address) {
-        var pepperDSMKitRequest = PepperDSMKitRequest.builderWithAddress(address)
-                .juniperKitId(kitRequest.getId().toString())
-                .juniperParticipantId(enrollee.getShortcode())
-                .build();
-
-        // TODO: call the correct endpoint; this is just a placeholder until the correct endpoint is available on dev
-        Mono<String> stringMono = webClient
-                .get().uri("/Kits/{kitId}", "12345678900301")
-                .header("Authorization", "Bearer " + generateDsmJwt())
-                .retrieve().bodyToMono(String.class);
-
-        return stringMono.block();
-    }
-
-    private String generateDsmJwt() {
-        var fifteenMinutes = 15 * 60 * 1000;
-        var now = System.currentTimeMillis();
-        return JWT.create()
-                .withExpiresAt(Instant.ofEpochMilli(now + fifteenMinutes))
-                .sign(Algorithm.HMAC256(pepperDSMConfig.getSecret()));
-    }
-}
-
-@Component
-@Getter
-@Setter
-class PepperDSMConfig {
-    private String basePath;
-    private String secret;
-
-    public PepperDSMConfig(Environment environment) {
-        this.basePath = environment.getProperty("env.dsm.basePath");
-        this.secret = environment.getProperty("env.dsm.secret");
-    }
+public interface PepperDSMClient {
+    String sendKitRequest(Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address)
+            throws JsonProcessingException;
+    PepperDSMKitStatus fetchKitStatus(UUID kitRequestId);
+    Collection<PepperDSMKitStatus> fetchKitStatusByStudy(UUID studyId);
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/PepperDSMClientProvider.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/PepperDSMClientProvider.java
@@ -1,0 +1,35 @@
+package bio.terra.pearl.core.service.kit;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class PepperDSMClientProvider {
+    private final LivePepperDSMClient livePepperDSMClient;
+    private final StubPepperDSMClient stubPepperDSMClient;
+
+    public PepperDSMClientProvider(LivePepperDSMClient livePepperDSMClient, StubPepperDSMClient stubPepperDSMClient) {
+        this.livePepperDSMClient = livePepperDSMClient;
+        this.stubPepperDSMClient = stubPepperDSMClient;
+    }
+
+    /**
+     * Resolves the PepperDSMClient implementation to use in the deployed application.
+     */
+    @Primary
+    @Bean
+    public PepperDSMClient getPepperDSMClient() {
+        return getStubPepperDSMClient();
+    }
+
+    @Bean
+    public LivePepperDSMClient getLivePepperDSMClient() {
+        return livePepperDSMClient;
+    }
+
+    @Bean
+    public StubPepperDSMClient getStubPepperDSMClient() {
+        return stubPepperDSMClient;
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/PepperDSMKitRequest.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/PepperDSMKitRequest.java
@@ -1,34 +1,44 @@
 package bio.terra.pearl.core.service.kit;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter @Builder
 public class PepperDSMKitRequest {
-    private String firstName;
-    private String lastName;
-    private String street1;
-    private String street2;
-    private String city;
-    private String state;
-    private String postalCode;
-    private String country;
-    private String phoneNumber;
-    private String juniperKitId;
-    private String juniperParticipantId;
+    @JsonProperty("JuniperKitRequest")
+    private JuniperKitRequest juniperKitRequest;
+    @JsonProperty("juniperStudyGUID")
     private String juniperStudyId;
-    private boolean skipAddressValidation;
+    private String kitType;
     private boolean uploadAnyway;
 
-    public static PepperDSMKitRequestBuilder builderWithAddress(PepperKitAddress address) {
-        return PepperDSMKitRequest.builder()
-                .firstName(address.getFirstName())
-                .lastName(address.getLastName())
-                .street1(address.getStreet1())
-                .street2(address.getStreet2())
-                .city(address.getCity())
-                .state(address.getState())
-                .postalCode(address.getPostalCode())
-                .phoneNumber(address.getPhoneNumber());
+    @Getter @Builder
+    public static class JuniperKitRequest {
+        private String firstName;
+        private String lastName;
+        private String street1;
+        private String street2;
+        private String city;
+        private String state;
+        private String postalCode;
+        private String country;
+        private String phoneNumber;
+        private String juniperKitId;
+        @JsonProperty("juniperParticipantID")
+        private String juniperParticipantId;
+        private boolean skipAddressValidation;
+
+        public static JuniperKitRequestBuilder builderWithAddress(PepperKitAddress address) {
+            return JuniperKitRequest.builder()
+                    .firstName(address.getFirstName())
+                    .lastName(address.getLastName())
+                    .street1(address.getStreet1())
+                    .street2(address.getStreet2())
+                    .city(address.getCity())
+                    .state(address.getState())
+                    .postalCode(address.getPostalCode())
+                    .phoneNumber(address.getPhoneNumber());
+        }
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/PepperDSMKitStatus.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/PepperDSMKitStatus.java
@@ -1,0 +1,17 @@
+package bio.terra.pearl.core.service.kit;
+
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.time.Instant;
+
+@Getter @Setter
+@SuperBuilder @NoArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class PepperDSMKitStatus {
+    private String kitId;
+    private String currentStatus;
+    private String errorMessage;
+    private Instant errorDate;
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/PepperKitAddress.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/PepperKitAddress.java
@@ -1,12 +1,18 @@
 package bio.terra.pearl.core.service.kit;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 /**
  * Address fields included in the request to DSM when requesting a kit.
  */
-@Getter @SuperBuilder
+@Getter
+@SuperBuilder @NoArgsConstructor
+@EqualsAndHashCode
+@ToString
 public class PepperKitAddress {
     private String firstName;
     private String lastName;

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/StubPepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/StubPepperDSMClient.java
@@ -34,8 +34,8 @@ public class StubPepperDSMClient implements PepperDSMClient {
     }
 
     @Override
-    public Collection<PepperDSMKitStatus> fetchKitStatusByStudy(UUID studyId) {
-        return kitRequestDao.findIncompleteKits(studyId).stream().map(kit -> {
+    public Collection<PepperDSMKitStatus> fetchKitStatusByStudy(UUID studyEnvironmentId) {
+        return kitRequestDao.findIncompleteKits(studyEnvironmentId).stream().map(kit -> {
             PepperDSMKitStatus status = PepperDSMKitStatus.builder()
                     .kitId(kit.getId().toString())
                     .currentStatus("SHIPPED")

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/StubPepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/StubPepperDSMClient.java
@@ -1,0 +1,46 @@
+package bio.terra.pearl.core.service.kit;
+
+import bio.terra.pearl.core.dao.kit.KitRequestDao;
+import bio.terra.pearl.core.model.kit.KitRequest;
+import bio.terra.pearl.core.model.participant.Enrollee;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.UUID;
+
+@Component
+public class StubPepperDSMClient implements PepperDSMClient {
+    private final KitRequestDao kitRequestDao;
+    private final ObjectMapper objectMapper;
+
+    public StubPepperDSMClient(KitRequestDao kitRequestDao,
+                               ObjectMapper objectMapper) {
+        this.kitRequestDao = kitRequestDao;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public String sendKitRequest(Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address) {
+        return "{}";
+    }
+
+    @Override
+    public PepperDSMKitStatus fetchKitStatus(UUID kitRequestId) {
+        return PepperDSMKitStatus.builder()
+                .kitId(kitRequestId.toString())
+                .currentStatus("SHIPPED")
+                .build();
+    }
+
+    @Override
+    public Collection<PepperDSMKitStatus> fetchKitStatusByStudy(UUID studyId) {
+        return kitRequestDao.findIncompleteKits(studyId).stream().map(kit -> {
+            PepperDSMKitStatus status = PepperDSMKitStatus.builder()
+                    .kitId(kit.getId().toString())
+                    .currentStatus("SHIPPED")
+                    .build();
+            return status;
+        }).toList();
+    }
+}

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
@@ -75,14 +75,14 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
                 .build();
         when(mockPepperDSMClient.fetchKitStatus(kitRequest.getId())).thenReturn(response);
 
-        var sampleKitStatus = kitRequestService.updateKitStatus(kitRequest.getId());
+        var sampleKitStatus = kitRequestService.syncKitStatusFromPepper(kitRequest.getId());
 
         assertThat(sampleKitStatus.getCurrentStatus(), equalTo("SENT"));
     }
 
     @Transactional
     @Test
-    public void testUpdateAllKitStatuses() throws Exception {
+    public void testSyncAllKitStatusesFromPepper() throws Exception {
         /*
          * Arrange:
          *  - an admin user
@@ -91,18 +91,18 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
          *  - two enrollees, 1a and 1b, in the study environment, each with a sample kit
          *  - another enrollee in another study, also with a sample kit
          */
-        var adminUser = adminUserFactory.buildPersisted("testUpdateAllKitStatuses");
-        var studyEnvironment = studyEnvironmentFactory.buildPersisted("testUpdateAllKitStatuses");
-        var kitType = kitTypeFactory.buildPersisted("testUpdateAllKitStatuses");
-        var enrollee1a = enrolleeFactory.buildPersisted("testUpdateAllKitStatuses", studyEnvironment);
-        var enrollee1b = enrolleeFactory.buildPersisted("testUpdateAllKitStatuses", studyEnvironment);
-        var kitRequest1a = kitRequestFactory.buildPersisted("testUpdateAllKitStatuses",
+        var adminUser = adminUserFactory.buildPersisted("testSyncAllKitStatusesFromPepper");
+        var studyEnvironment = studyEnvironmentFactory.buildPersisted("testSyncAllKitStatusesFromPepper");
+        var kitType = kitTypeFactory.buildPersisted("testSyncAllKitStatusesFromPepper");
+        var enrollee1a = enrolleeFactory.buildPersisted("testSyncAllKitStatusesFromPepper", studyEnvironment);
+        var enrollee1b = enrolleeFactory.buildPersisted("testSyncAllKitStatusesFromPepper", studyEnvironment);
+        var kitRequest1a = kitRequestFactory.buildPersisted("testSyncAllKitStatusesFromPepper",
                 adminUser.getId(), enrollee1a.getId(), kitType.getId());
-        var kitRequest1b = kitRequestFactory.buildPersisted("testUpdateAllKitStatuses",
+        var kitRequest1b = kitRequestFactory.buildPersisted("testSyncAllKitStatusesFromPepper",
                 adminUser.getId(), enrollee1b.getId(), kitType.getId());
-        var studyEnvironment2 = studyEnvironmentFactory.buildPersisted("testUpdateAllKitStatuses2");
-        var enrollee2 = enrolleeFactory.buildPersisted("testUpdateAllKitStatuses", studyEnvironment2);
-        var kitRequest2 = kitRequestFactory.buildPersisted("testUpdateAllKitStatuses",
+        var studyEnvironment2 = studyEnvironmentFactory.buildPersisted("testSyncAllKitStatusesFromPepper2");
+        var enrollee2 = enrolleeFactory.buildPersisted("testSyncAllKitStatusesFromPepper", studyEnvironment2);
+        var kitRequest2 = kitRequestFactory.buildPersisted("testSyncAllKitStatusesFromPepper",
                 adminUser.getId(), enrollee2.getId(), kitType.getId());
 
         /*
@@ -130,12 +130,12 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
                 .thenReturn(List.of(kitStatus2));
 
         /* Finally, exercise the unit under test! */
-        kitRequestService.updateAllKitStatuses();
+        kitRequestService.syncAllKitStatusesFromPepper();
 
         /* Load and verify each kit */
         verifyKit(kitRequest1a, kitStatus1a, KitRequestStatus.IN_PROGRESS);
         verifyKit(kitRequest1b, kitStatus1b, KitRequestStatus.COMPLETE);
-        verifyKit(kitRequest2, kitStatus2, KitRequestStatus.ERRORED);
+        verifyKit(kitRequest2, kitStatus2, KitRequestStatus.FAILED);
     }
 
     private void verifyKit(KitRequest kit, PepperDSMKitStatus expectedDSMStatus, KitRequestStatus expectedStatus)

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
@@ -1,22 +1,31 @@
 package bio.terra.pearl.core.service.kit;
 
 import bio.terra.pearl.core.BaseSpringBootTest;
+import bio.terra.pearl.core.dao.kit.KitRequestDao;
+import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
 import bio.terra.pearl.core.factory.admin.AdminUserFactory;
+import bio.terra.pearl.core.factory.kit.KitRequestFactory;
 import bio.terra.pearl.core.factory.kit.KitTypeFactory;
 import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.kit.KitRequestStatus;
 import bio.terra.pearl.core.service.participant.ProfileService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.util.List;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 public class KitRequestServiceTest extends BaseSpringBootTest {
 
@@ -31,8 +40,14 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
         profile.setGivenName("Alex");
         profile.setFamilyName("Tester");
         profile.setPhoneNumber("111-222-3333");
-        profileService.update(profile);
-        var expectedSentToAddress = "{\"firstName\":\"Alex\",\"lastName\":\"Tester\",\"street1\":null,\"street2\":null,\"city\":null,\"state\":null,\"postalCode\":null,\"country\":null,\"phoneNumber\":\"111-222-3333\"}";
+        profile.getMailingAddress().setStreet1("123 Fake Street");
+        profileService.updateWithMailingAddress(profile);
+        var expectedSentToAddress = PepperKitAddress.builder()
+                .firstName("Alex")
+                .lastName("Tester")
+                .street1("123 Fake Street")
+                .phoneNumber("111-222-3333")
+                .build();
 
         var sampleKit = kitRequestService.requestKit(adminUser, enrollee, "testRequestKit");
 
@@ -40,9 +55,97 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
                 .sendKitRequest(eq(enrollee), any(KitRequest.class), any(PepperKitAddress.class));
         assertThat(sampleKit.getCreatingAdminUserId(), equalTo(adminUser.getId()));
         assertThat(sampleKit.getEnrolleeId(), equalTo(enrollee.getId()));
-        assertThat(sampleKit.getSentToAddress(), equalTo(expectedSentToAddress));
+        assertThat(objectMapper.readValue(sampleKit.getSentToAddress(), PepperKitAddress.class),
+                equalTo(expectedSentToAddress));
         assertThat(sampleKit.getStatus(), equalTo(KitRequestStatus.CREATED));
     }
+
+    @Transactional
+    @Test
+    public void testUpdateKitStatus() throws Exception {
+        var adminUser = adminUserFactory.buildPersisted("testUpdateKitStatus");
+        var enrollee = enrolleeFactory.buildPersisted("testUpdateKitStatus");
+        var kitType = kitTypeFactory.buildPersisted("testUpdateKitStatus");
+        var kitRequest = kitRequestFactory.buildPersisted("testUpdateKitStatus",
+                adminUser.getId(), enrollee.getId(), kitType.getId());
+
+        var response = PepperDSMKitStatus.builder()
+                .kitId(kitRequest.getId().toString())
+                .currentStatus("SENT")
+                .build();
+        when(mockPepperDSMClient.fetchKitStatus(kitRequest.getId())).thenReturn(response);
+
+        var sampleKitStatus = kitRequestService.updateKitStatus(kitRequest.getId());
+
+        assertThat(sampleKitStatus.getCurrentStatus(), equalTo("SENT"));
+    }
+
+    @Transactional
+    @Test
+    public void testUpdateAllKitStatuses() throws Exception {
+        /*
+         * Arrange:
+         *  - an admin user
+         *  - a study environment
+         *  - a kit type
+         *  - two enrollees, 1a and 1b, in the study environment, each with a sample kit
+         *  - another enrollee in another study, also with a sample kit
+         */
+        var adminUser = adminUserFactory.buildPersisted("testUpdateAllKitStatuses");
+        var studyEnvironment = studyEnvironmentFactory.buildPersisted("testUpdateAllKitStatuses");
+        var kitType = kitTypeFactory.buildPersisted("testUpdateAllKitStatuses");
+        var enrollee1a = enrolleeFactory.buildPersisted("testUpdateAllKitStatuses", studyEnvironment);
+        var enrollee1b = enrolleeFactory.buildPersisted("testUpdateAllKitStatuses", studyEnvironment);
+        var kitRequest1a = kitRequestFactory.buildPersisted("testUpdateAllKitStatuses",
+                adminUser.getId(), enrollee1a.getId(), kitType.getId());
+        var kitRequest1b = kitRequestFactory.buildPersisted("testUpdateAllKitStatuses",
+                adminUser.getId(), enrollee1b.getId(), kitType.getId());
+        var studyEnvironment2 = studyEnvironmentFactory.buildPersisted("testUpdateAllKitStatuses2");
+        var enrollee2 = enrolleeFactory.buildPersisted("testUpdateAllKitStatuses", studyEnvironment2);
+        var kitRequest2 = kitRequestFactory.buildPersisted("testUpdateAllKitStatuses",
+                adminUser.getId(), enrollee2.getId(), kitType.getId());
+
+        /*
+         * Mock DSM to return kits by study:
+         *  - the first study has two kits, one in flight and one complete
+         *  - the second study has one kit with an error
+         */
+        var kitStatus1a = PepperDSMKitStatus.builder()
+                .kitId(kitRequest1a.getId().toString())
+                .currentStatus("SENT")
+                .build();
+        var kitStatus1b = PepperDSMKitStatus.builder()
+                .kitId(kitRequest1b.getId().toString())
+                .currentStatus("PROCESSED")
+                .build();
+        var kitStatus2 = PepperDSMKitStatus.builder()
+                .kitId(kitRequest2.getId().toString())
+                .currentStatus("CONTAMINATED")
+                .errorMessage("Something went wrong")
+                .errorDate(Instant.now())
+                .build();
+        when(mockPepperDSMClient.fetchKitStatusByStudy(studyEnvironment.getStudyId()))
+                .thenReturn(List.of(kitStatus1a, kitStatus1b));
+        when(mockPepperDSMClient.fetchKitStatusByStudy(studyEnvironment2.getStudyId()))
+                .thenReturn(List.of(kitStatus2));
+
+        /* Finally, exercise the unit under test! */
+        kitRequestService.updateAllKitStatuses();
+
+        /* Load and verify each kit */
+        verifyKit(kitRequest1a, kitStatus1a, KitRequestStatus.IN_PROGRESS);
+        verifyKit(kitRequest1b, kitStatus1b, KitRequestStatus.COMPLETE);
+        verifyKit(kitRequest2, kitStatus2, KitRequestStatus.ERRORED);
+    }
+
+    private void verifyKit(KitRequest kit, PepperDSMKitStatus expectedDSMStatus, KitRequestStatus expectedStatus)
+            throws JsonProcessingException {
+        var savedKit = kitRequestDao.find(kit.getId()).get();
+        assertThat(savedKit.getStatus(), equalTo(expectedStatus));
+        assertThat(objectMapper.readValue(savedKit.getDsmStatus(), PepperDSMKitStatus.class),
+                equalTo(expectedDSMStatus));
+    }
+
 
     @MockBean
     private PepperDSMClient mockPepperDSMClient;
@@ -52,10 +155,17 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
     @Autowired
     private EnrolleeFactory enrolleeFactory;
     @Autowired
+    private KitRequestDao kitRequestDao;
+    @Autowired
+    private KitRequestFactory kitRequestFactory;
+    @Autowired
     private KitRequestService kitRequestService;
     @Autowired
     private KitTypeFactory kitTypeFactory;
     @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
     private ProfileService profileService;
-
+    @Autowired
+    private StudyEnvironmentFactory studyEnvironmentFactory;
 }

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/kit/KitRequestFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/kit/KitRequestFactory.java
@@ -1,0 +1,51 @@
+package bio.terra.pearl.core.factory.kit;
+
+import bio.terra.pearl.core.dao.kit.KitRequestDao;
+import bio.terra.pearl.core.model.kit.KitRequest;
+import bio.terra.pearl.core.model.kit.KitRequestStatus;
+import bio.terra.pearl.core.service.kit.PepperDSMKitStatus;
+import bio.terra.pearl.core.service.kit.PepperKitAddress;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Component
+public class KitRequestFactory {
+    private final KitRequestDao kitRequestDao;
+    private final ObjectMapper objectMapper;
+
+    public KitRequestFactory(KitRequestDao kitRequestDao,
+                             ObjectMapper objectMapper) {
+        this.kitRequestDao = kitRequestDao;
+        this.objectMapper = objectMapper;
+    }
+
+    public KitRequest.KitRequestBuilder builder(String testName) throws JsonProcessingException {
+        var address = PepperKitAddress.builder()
+                .lastName(testName + "last name")
+                .build();
+        return KitRequest.builder()
+                .sentToAddress(objectMapper.writeValueAsString(address))
+                .status(KitRequestStatus.CREATED);
+    }
+
+    public KitRequest buildPersisted(String testName, UUID adminUserId, UUID enrolleeId, UUID kitTypeId)
+            throws JsonProcessingException {
+        var kitRequest = builder(testName)
+                .creatingAdminUserId(adminUserId)
+                .enrolleeId(enrolleeId)
+                .kitTypeId(kitTypeId)
+                .build();
+        var savedKitRequest = kitRequestDao.create(kitRequest);
+        var dsmStatus = PepperDSMKitStatus.builder()
+                .currentStatus("CREATED")
+                .kitId(savedKitRequest.getId().toString())
+                .build();
+        savedKitRequest.setDsmStatus(objectMapper.writeValueAsString(dsmStatus));
+        savedKitRequest.setDsmStatusFetchedAt(Instant.now());
+        return kitRequestDao.update(savedKitRequest);
+    }
+}


### PR DESCRIPTION
No UI in this PR, so no screenshots. There is a service function for fetching the status of a single kit, but that's not hooked in yet.

Primarily, there's a scheduled service that runs nightly that updates the status of all in-progress kits.

To test:
1. Run the tests; verify that they pass.
2. Modify the timing in `ScheduledKitStatusService` so that it will run in the next couple of minutes.
3. Start the admin API and UI and open https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants/OHSALK/kitRequests. You'll see the seeded kit with its fake status.
4. Wait for `ScheduledKitStatusService` to run; it will log start and finish.
5. Reload OHSALK's kit requests and see that the DSM status has updated.

There's also some iteration on the integration with DSM for sending kits. However, I haven't been able to make a successful request to DSM dev yet, so that's still work-in-progress.