### PR TITLE
[JN-378] Update types for survey configuration

### DIFF
--- a/ui-admin/src/study/surveys/editor/SurveyEditor.tsx
+++ b/ui-admin/src/study/surveys/editor/SurveyEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Tab, Tabs } from 'react-bootstrap'
 
-import { JuniperSurvey } from '@juniper/ui-core'
+import { FormContent } from '@juniper/ui-core'
 
 import { OnChangeSurvey } from './surveyEditorTypes'
 import { SurveyJsonEditor } from './SurveyJsonEditor'
@@ -19,7 +19,7 @@ export const SurveyEditor = (props: SurveyEditorProps) => {
   const [activeTab, setActiveTab] = useState<string | null>('json')
   const [tabsEnabled, setTabsEnabled] = useState(true)
 
-  const [editedSurvey, setEditedSurvey] = useState(() => JSON.parse(initialContent) as JuniperSurvey)
+  const [editedSurvey, setEditedSurvey] = useState(() => JSON.parse(initialContent) as FormContent)
 
   return (
     <div className="SurveyEditor d-flex flex-column flex-grow-1">

--- a/ui-admin/src/study/surveys/editor/SurveyJsonEditor.test.tsx
+++ b/ui-admin/src/study/surveys/editor/SurveyJsonEditor.test.tsx
@@ -3,11 +3,11 @@ import userEvent from '@testing-library/user-event'
 import { cloneDeep } from 'lodash'
 import React from 'react'
 
+import { FormContent } from '@juniper/ui-core'
+
 import { SurveyJsonEditor } from './SurveyJsonEditor'
 
-// TODO: Types for survey config
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const survey: any = {
+const survey: FormContent = {
   title: 'Test survey',
   pages: [
     {

--- a/ui-admin/src/study/surveys/editor/SurveyJsonEditor.test.tsx
+++ b/ui-admin/src/study/surveys/editor/SurveyJsonEditor.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { cloneDeep } from 'lodash'
 import React from 'react'
 
-import { FormContent } from '@juniper/ui-core'
+import { FormContent, Question } from '@juniper/ui-core'
 
 import { SurveyJsonEditor } from './SurveyJsonEditor'
 
@@ -62,7 +62,7 @@ describe('SurveyJsonEditor', () => {
 
     // Assert
     const expectedEditedSurvey = cloneDeep(survey)
-    expectedEditedSurvey.pages[0].elements[0].title = 'Given name'
+    ;(expectedEditedSurvey.pages[0].elements[0] as Question).title = 'Given name'
 
     expect(onChange).toHaveBeenCalledWith(true, expectedEditedSurvey)
   })

--- a/ui-admin/src/study/surveys/editor/SurveyJsonEditor.tsx
+++ b/ui-admin/src/study/surveys/editor/SurveyJsonEditor.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useState } from 'react'
 
-import { JuniperSurvey } from '@juniper/ui-core'
+import { FormContent } from '@juniper/ui-core'
 
 import { OnChangeSurvey } from './surveyEditorTypes'
 
 type SurveyJsonEditorProps = {
-  initialValue: JuniperSurvey
+  initialValue: FormContent
   readOnly?: boolean
   onChange: OnChangeSurvey
 }

--- a/ui-admin/src/study/surveys/editor/SurveyPreview.test.tsx
+++ b/ui-admin/src/study/surveys/editor/SurveyPreview.test.tsx
@@ -1,11 +1,11 @@
 import { render, screen } from '@testing-library/react'
 import React from 'react'
 
+import { FormContent } from '@juniper/ui-core'
+
 import { SurveyPreview } from './SurveyPreview'
 
-// TODO: Types for survey config
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const survey: any = {
+const survey: FormContent = {
   title: 'Test survey',
   pages: [
     {

--- a/ui-admin/src/study/surveys/editor/SurveyPreview.tsx
+++ b/ui-admin/src/study/surveys/editor/SurveyPreview.tsx
@@ -2,10 +2,10 @@ import React, { useState } from 'react'
 import { SurveyModel } from 'survey-core'
 import { Survey as SurveyJSComponent } from 'survey-react-ui'
 
-import { extractSurveyContent, JuniperSurvey, Survey } from '@juniper/ui-core'
+import { extractSurveyContent, FormContent, Survey } from '@juniper/ui-core'
 
 type SurveyPreviewProps = {
-  survey: JuniperSurvey
+  survey: FormContent
 }
 
 export const SurveyPreview = (props: SurveyPreviewProps) => {

--- a/ui-admin/src/study/surveys/editor/surveyEditorTypes.ts
+++ b/ui-admin/src/study/surveys/editor/surveyEditorTypes.ts
@@ -1,3 +1,3 @@
-import { JuniperSurvey } from '@juniper/ui-core'
+import { FormContent } from '@juniper/ui-core'
 
-export type OnChangeSurvey = (...args: [valid: true, newValue: JuniperSurvey] | [false, undefined]) => void
+export type OnChangeSurvey = (...args: [valid: true, newValue: FormContent] | [false, undefined]) => void

--- a/ui-core/src/surveyUtils.test.ts
+++ b/ui-core/src/surveyUtils.test.ts
@@ -1,5 +1,5 @@
 import { extractSurveyContent } from './surveyUtils'
-import { VersionedForm } from './types/forms'
+import { RadiogroupQuestion, VersionedForm } from './types/forms'
 
 describe('extractSurveyContent', () => {
   it('transforms models with question templates', () => {
@@ -32,11 +32,11 @@ describe('extractSurveyContent', () => {
 
     const surveyModel = extractSurveyContent(survey as VersionedForm)
     expect(surveyModel.pages).toHaveLength(2)
-    const firstTemplatedQuestion = surveyModel.pages[0].elements[1]
+    const firstTemplatedQuestion = surveyModel.pages[0].elements[1] as RadiogroupQuestion
     expect(firstTemplatedQuestion.name).toEqual('brotherFavoriteColor')
     expect(firstTemplatedQuestion.title).toEqual('what is their favorite color?')
     expect(firstTemplatedQuestion.choices).toHaveLength(2)
-    const secondTemplatedQuestion = surveyModel.pages[1].elements[1]
+    const secondTemplatedQuestion = surveyModel.pages[1].elements[1] as RadiogroupQuestion
     expect(secondTemplatedQuestion.name).toEqual('sisterFavoriteColor')
   })
 })

--- a/ui-core/src/types/forms.ts
+++ b/ui-core/src/types/forms.ts
@@ -1,5 +1,3 @@
-import { IPage, Question } from 'survey-core'
-
 export type VersionedForm = {
   id: string
   stableId: string
@@ -66,32 +64,85 @@ export type PreEnrollmentResponse = FormResponse & {
 
 // Survey configuration
 
-/** these types are vague as we're still deciding how much custom stuff we need on top of SurveyJS */
-export type JuniperSurvey = {
-  pages: IPage[]
-  questionTemplates: JuniperQuestion[]
-}
-
-/** things that we need from SurveyJS elements to render the sheet view */
-export type ElementBase = {
-  name: string
-  type: string
+/** Configuration passed to SurveyModel constructor. */
+export type FormContent = {
   title: string
+  pages: FormContentPage[]
+  questionTemplates?: Question[]
 }
 
-/** Encompasses SurveyJS pages and panels. */
-export type ElementContainer = {
+type BaseElement = {
+  visibleIf?: string
+}
+
+export type FormContentPage = BaseElement & {
+  elements: FormElement[]
+}
+
+export type FormElement = FormPanel | HtmlElement | Question
+
+export type FormPanel = BaseElement & {
+  type: 'panel'
+  elements: FormElement[]
+}
+
+export type HtmlElement = {
+  type: 'html'
+  html: string
+}
+
+type BaseQuestion = BaseElement & {
   name: string
-  elements: ElementBase[]
+  title: string
+  description?: string
+  isRequired?: boolean
 }
 
-/**
- * We're extending SurveyJS to support templates -- the idea that a common question format may recur many times
- * in a survey, and so should only be coded once
- */
-export type JuniperQuestion = Question & {
-  questionTemplateName?: string
-  type: string
+type QuestionChoice = {
+  text: string
+  value: string
 }
+
+type WithOtherOption<T> = T & {
+  showOtherItem?: boolean
+  otherText?: string
+  otherPlaceholder?: string
+  otherErrorText?: string
+}
+
+export type CheckboxQuestion = WithOtherOption<BaseQuestion & {
+  type: 'checkbox'
+  choices: QuestionChoice[]
+  showNoneItem?: boolean
+  noneText?: string
+  noneValue?: string
+}>
+
+export type DropdownQuestion = WithOtherOption<BaseQuestion & {
+  type: 'dropdown'
+  choices: QuestionChoice[]
+}>
+
+export type RadiogroupQuestion = WithOtherOption<BaseQuestion & {
+  type: 'radiogroup'
+  choices: QuestionChoice[]
+}>
+
+export type TemplatedQuestion = BaseQuestion & {
+  name: string
+  title?: string
+  questionTemplateName: string
+}
+
+export type TextQuestion = BaseQuestion & {
+  type: 'text'
+}
+
+export type Question =
+  | CheckboxQuestion
+  | DropdownQuestion
+  | RadiogroupQuestion
+  | TemplatedQuestion
+  | TextQuestion
 
 export {}


### PR DESCRIPTION
Stacked on #419.

Currently, we use some types from SurveyJS for survey configuration (Question, etc). However, these are types for model classes and we're using them for the config object passed to SurveyModel's constructor.

Thus, attempting to do something like this in a test does not work because TS expects objects in the pages array to have a bunch of methods from SurveyJS' model object for pages.
```ts
const survey: JuniperSurvey = {
  pages: [ ... ]
}
```

SurveyJS does not provide types for the configuration object. The type of SurveyModel's constructor's parameter is `any`.
https://github.com/surveyjs/survey-library/blob/e5c5bf69001af854430d224d1362a96b84134884/src/survey.ts#L784

So this adds our own types for survey configuration. These are incomplete and certainly don't cover everything available from SurveyJS, but should cover a decent percentage of our current surveys. Also note that currently nothing validates that configured content is actually valid.