### PR TITLE
[JN-378] Move SurveyModel creation into shared code

### DIFF
--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import { Model, Question, SurveyModel } from 'survey-core'
+import { Question, SurveyModel } from 'survey-core'
 
-import { extractSurveyContent } from '@juniper/ui-core'
+import { surveyJSModelFromForm } from '@juniper/ui-core'
 
 import { Answer, ConsentForm, Survey } from 'api/api'
 
 /** renders every item in a survey response */
 export default function SurveyFullDataView({ answers, survey }: {answers: Answer[], survey: Survey | ConsentForm}) {
-  const surveyJsModel = new Model(extractSurveyContent(survey))
+  const surveyJsModel = surveyJSModelFromForm(survey)
   console.log(`rendering data for survey ${survey.stableId} -- question text not yet implemented`)
   return <dl>
     {answers.map((answer, index) => <ItemDisplay key={index}

--- a/ui-admin/src/study/surveys/editor/SurveyPreview.tsx
+++ b/ui-admin/src/study/surveys/editor/SurveyPreview.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react'
-import { SurveyModel } from 'survey-core'
 import { Survey as SurveyJSComponent } from 'survey-react-ui'
 
-import { extractSurveyContent, FormContent, Survey } from '@juniper/ui-core'
+import { FormContent, surveyJSModelFromFormContent } from '@juniper/ui-core'
 
 type SurveyPreviewProps = {
   survey: FormContent
@@ -11,16 +10,7 @@ type SurveyPreviewProps = {
 export const SurveyPreview = (props: SurveyPreviewProps) => {
   const { survey } = props
 
-  const [surveyModel] = useState(() => {
-    const fakeForm = { content: JSON.stringify(survey) } as Survey
-
-    const model = new SurveyModel(extractSurveyContent(fakeForm))
-    model.focusFirstQuestionAutomatic = false
-    model.showTitle = false
-    model.widthMode = 'static'
-
-    return model
-  })
+  const [surveyModel] = useState(() => surveyJSModelFromFormContent(survey))
 
   return (
     <SurveyJSComponent model={surveyModel} />

--- a/ui-core/src/surveyUtils.ts
+++ b/ui-core/src/surveyUtils.ts
@@ -1,5 +1,8 @@
 import './surveyjs'
 
+import { cloneDeep } from 'lodash'
+import { SurveyModel } from 'survey-core'
+
 import { FormContent, FormElement, VersionedForm } from './types/forms'
 
 /** Gets a flattened list of the survey elements */
@@ -14,22 +17,18 @@ function getFormQuestionsHelper(element: FormElement): FormElement[] {
     : [element]
 }
 
-/** transform the stored survey representation into what SurveyJS expects */
-export function extractSurveyContent(form: VersionedForm) {
-  const parsedSurvey = JSON.parse(form.content) as FormContent
-  const questionTemplates = parsedSurvey.questionTemplates
+/** Create a SurveyJS SurveyModel from a Juniper FormContent object. */
+export const surveyJSModelFromFormContent = (formContent: FormContent): SurveyModel => {
+  const formContentClone = cloneDeep(formContent)
+  const questionTemplates = formContentClone.questionTemplates
   if (questionTemplates) {
-    const elementList = getFormElements(parsedSurvey)
+    const elementList = getFormElements(formContentClone)
     elementList.forEach(q => {
       if ('questionTemplateName' in q) {
         const templateName = q.questionTemplateName
         const matchedTemplate = questionTemplates.find(qt => qt.name === templateName)
         if (!matchedTemplate) {
-          // TODO this is an error we'd want to log in prod systems
-          if (process.env.NODE_ENV === 'development') {
-            alert(`unmatched template ${templateName}`)
-          }
-          return
+          throw new Error(`Unknown question template: ${templateName}`)
         }
         // create a new question object by merging the existing question into the template.
         // any properties explicitly specified on the question will override those from the template
@@ -38,5 +37,22 @@ export function extractSurveyContent(form: VersionedForm) {
       }
     })
   }
-  return parsedSurvey
+
+  const model = new SurveyModel(formContentClone)
+
+  model.focusFirstQuestionAutomatic = false
+  model.showTitle = false
+  model.widthMode = 'static'
+
+  return model
+}
+
+/** Get a VersionedForm's form content. */
+const getFormContent = (form: VersionedForm): FormContent => {
+  return JSON.parse(form.content) as FormContent
+}
+
+/** Create a SurveyJS SurveyModel from a Juniper VersionedForm object. */
+export const surveyJSModelFromForm = (form: VersionedForm): SurveyModel => {
+  return surveyJSModelFromFormContent(getFormContent(form))
 }

--- a/ui-core/src/surveyUtils.ts
+++ b/ui-core/src/surveyUtils.ts
@@ -17,6 +17,12 @@ function getFormQuestionsHelper(element: FormElement): FormElement[] {
     : [element]
 }
 
+const applyDefaultSurveyConfig = (surveyModel: SurveyModel): void => {
+  surveyModel.focusFirstQuestionAutomatic = false
+  surveyModel.showTitle = false
+  surveyModel.widthMode = 'static'
+}
+
 /** Create a SurveyJS SurveyModel from a Juniper FormContent object. */
 export const surveyJSModelFromFormContent = (formContent: FormContent): SurveyModel => {
   const formContentClone = cloneDeep(formContent)
@@ -39,11 +45,7 @@ export const surveyJSModelFromFormContent = (formContent: FormContent): SurveyMo
   }
 
   const model = new SurveyModel(formContentClone)
-
-  model.focusFirstQuestionAutomatic = false
-  model.showTitle = false
-  model.widthMode = 'static'
-
+  applyDefaultSurveyConfig(model)
   return model
 }
 

--- a/ui-core/src/types/forms.ts
+++ b/ui-core/src/types/forms.ts
@@ -128,7 +128,7 @@ export type RadiogroupQuestion = WithOtherOption<BaseQuestion & {
   choices: QuestionChoice[]
 }>
 
-export type TemplatedQuestion = BaseQuestion & {
+export type TemplatedQuestion = Omit<BaseQuestion, 'title'> & {
   name: string
   title?: string
   questionTemplateName: string

--- a/ui-participant/src/hub/consent/PrintConsentView.tsx
+++ b/ui-participant/src/hub/consent/PrintConsentView.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom'
 import { Model } from 'survey-core'
 import { Survey as SurveyComponent } from 'survey-react-ui'
 
-import { extractSurveyContent } from '@juniper/ui-core'
+import { surveyJSModelFromForm } from '@juniper/ui-core'
 
 import Api, { Answer, Enrollee } from 'api/api'
 import { usePortalEnv } from 'providers/PortalProvider'
@@ -74,19 +74,13 @@ const usePrintableConsent = (args: UsePrintableConsentArgs) => {
       }
       const resumableData = makeSurveyJsData(response?.resumeData, answers, enrollee.participantUserId)
 
-      const surveyContent = extractSurveyContent(form)
-
-      const surveyModel = new Model(surveyContent)
+      const surveyModel = surveyJSModelFromForm(form)
       surveyModel.title = form.name
       surveyModel.data = resumableData?.data
 
       surveyModel.mode = 'display'
       surveyModel.questionsOnPageMode = 'singlePage'
-
-      surveyModel.focusFirstQuestionAutomatic = false
       surveyModel.showProgressBar = 'off'
-      surveyModel.showTitle = false
-      surveyModel.widthMode = 'static'
       surveyModel.setVariable('portalEnvironmentName', portalEnv.environmentName)
 
       return surveyModel

--- a/ui-participant/src/util/surveyJsUtils.tsx
+++ b/ui-participant/src/util/surveyJsUtils.tsx
@@ -6,10 +6,10 @@ import _isEqual from 'lodash/isEqual'
 import { micromark } from 'micromark'
 import React, { useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { Model, SurveyModel } from 'survey-core'
+import { SurveyModel } from 'survey-core'
 import { Survey as SurveyJSComponent } from 'survey-react-ui'
 
-import { extractSurveyContent } from '@juniper/ui-core'
+import { surveyJSModelFromForm } from '@juniper/ui-core'
 
 import { Answer, ConsentForm, Profile, Survey, SurveyJsResumeData, UserResumeData } from 'api/api'
 import { usePortalEnv } from 'providers/PortalProvider'
@@ -94,7 +94,7 @@ export function useSurveyJSModel(
 
   /** syncs the surveyJS survey model with the given data/pageNumber */
   function refreshSurvey(refreshData: SurveyJsResumeData | null, pagerPageNumber: number | null) {
-    const newSurveyModel = new Model(extractSurveyContent(form))
+    const newSurveyModel = surveyJSModelFromForm(form)
 
     Object.entries(extraCssClasses).forEach(([elementPath, className]) => {
       set(newSurveyModel.css, elementPath, classNames(get(newSurveyModel.css, elementPath), className))
@@ -116,10 +116,6 @@ export function useSurveyJSModel(
     }
     newSurveyModel.currentPageNo = pageNumber
     newSurveyModel.setVariable('profile', profile)
-
-    newSurveyModel.focusFirstQuestionAutomatic = false
-    newSurveyModel.showTitle = false
-    newSurveyModel.widthMode = 'static'
     newSurveyModel.setVariable('portalEnvironmentName', portalEnv.environmentName)
     setSurveyModel(newSurveyModel)
   }


### PR DESCRIPTION
Addresses https://github.com/broadinstitute/juniper/pull/419#discussion_r1220332120.

Currently, ui-core contains a function `extractSurveyContent` that takes a Juniper VersionedForm and returns a configuration object to be passed to the SurveyJS SurveyModel constructor.

However, there are additional settings that we always apply to the SurveyModel after it's created (`focusFirstQuestionAutomatic = false`, etc). This moves the SurveyModel creation into ui-core so that we can avoid duplicating that configuration every time we create a SurveyModel.