### PR TITLE
[JN-378] Rename SurveyEditor => FormContentEditor

### DIFF
--- a/ui-admin/src/App.css
+++ b/ui-admin/src/App.css
@@ -85,9 +85,9 @@ a {
   max-height: 90vh;
 }
 
-/* Have survey editor tabs fill page height */
-.SurveyEditor .tab-content,
-.SurveyEditor .tab-pane.active {
+/* Have form content editor tabs fill page height */
+.FormContentEditor .tab-content,
+.FormContentEditor .tab-pane.active {
   display: flex;
   flex-direction: column;
   flex-grow: 1;

--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -3,26 +3,26 @@ import { Tab, Tabs } from 'react-bootstrap'
 
 import { FormContent } from '@juniper/ui-core'
 
-import { OnChangeSurvey } from './surveyEditorTypes'
-import { SurveyJsonEditor } from './SurveyJsonEditor'
-import { SurveyPreview } from './SurveyPreview'
+import { OnChangeFormContent } from './formEditorTypes'
+import { FormContentJsonEditor } from './FormContentJsonEditor'
+import { FormPreview } from './FormPreview'
 
-type SurveyEditorProps = {
+type FormContentEditorProps = {
   initialContent: string
   readOnly: boolean
-  onChange: OnChangeSurvey
+  onChange: OnChangeFormContent
 }
 
-export const SurveyEditor = (props: SurveyEditorProps) => {
+export const FormContentEditor = (props: FormContentEditorProps) => {
   const { initialContent, readOnly, onChange } = props
 
   const [activeTab, setActiveTab] = useState<string | null>('json')
   const [tabsEnabled, setTabsEnabled] = useState(true)
 
-  const [editedSurvey, setEditedSurvey] = useState(() => JSON.parse(initialContent) as FormContent)
+  const [editedContent, setEditedContent] = useState(() => JSON.parse(initialContent) as FormContent)
 
   return (
-    <div className="SurveyEditor d-flex flex-column flex-grow-1">
+    <div className="FormContentEditor d-flex flex-column flex-grow-1">
       <Tabs
         activeKey={activeTab ?? undefined}
         className="mb-1"
@@ -35,12 +35,12 @@ export const SurveyEditor = (props: SurveyEditorProps) => {
           eventKey="json"
           title="JSON Editor"
         >
-          <SurveyJsonEditor
-            initialValue={editedSurvey}
+          <FormContentJsonEditor
+            initialValue={editedContent}
             readOnly={readOnly}
             onChange={(isValid, newSurvey) => {
               if (isValid) {
-                setEditedSurvey(newSurvey)
+                setEditedContent(newSurvey)
                 onChange(true, newSurvey)
               } else {
                 onChange(false, undefined)
@@ -54,7 +54,7 @@ export const SurveyEditor = (props: SurveyEditorProps) => {
           eventKey="preview"
           title="Preview"
         >
-          <SurveyPreview survey={editedSurvey} />
+          <FormPreview formContent={editedContent} />
         </Tab>
       </Tabs>
     </div>

--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -38,10 +38,10 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
           <FormContentJsonEditor
             initialValue={editedContent}
             readOnly={readOnly}
-            onChange={(isValid, newSurvey) => {
+            onChange={(isValid, newContent) => {
               if (isValid) {
-                setEditedContent(newSurvey)
-                onChange(true, newSurvey)
+                setEditedContent(newContent)
+                onChange(true, newContent)
               } else {
                 onChange(false, undefined)
               }

--- a/ui-admin/src/forms/FormContentJsonEditor.test.tsx
+++ b/ui-admin/src/forms/FormContentJsonEditor.test.tsx
@@ -5,9 +5,9 @@ import React from 'react'
 
 import { FormContent, Question } from '@juniper/ui-core'
 
-import { SurveyJsonEditor } from './SurveyJsonEditor'
+import { FormContentJsonEditor } from './FormContentJsonEditor'
 
-const survey: FormContent = {
+const formContent: FormContent = {
   title: 'Test survey',
   pages: [
     {
@@ -29,19 +29,19 @@ const survey: FormContent = {
   ]
 }
 
-describe('SurveyJsonEditor', () => {
+describe('FormContentJsonEditor', () => {
   it('renders survey as JSON', () => {
     // Act
-    const { container } = render(<SurveyJsonEditor initialValue={survey} onChange={jest.fn()} />)
+    const { container } = render(<FormContentJsonEditor initialValue={formContent} onChange={jest.fn()} />)
 
     // Assert
-    const expectedContent = JSON.stringify(survey, null, 2).replace(/\s+/g, ' ') // Collapse whitespace
+    const expectedContent = JSON.stringify(formContent, null, 2).replace(/\s+/g, ' ') // Collapse whitespace
     expect(container).toHaveTextContent(expectedContent)
   })
 
   it('sets readonly attribute on textatrea', () => {
     // Act
-    render(<SurveyJsonEditor initialValue={survey} readOnly onChange={jest.fn()} />)
+    render(<FormContentJsonEditor initialValue={formContent} readOnly onChange={jest.fn()} />)
 
     // Assert
     const textArea = screen.getByRole('textbox')
@@ -53,7 +53,7 @@ describe('SurveyJsonEditor', () => {
     const user = userEvent.setup()
 
     const onChange = jest.fn()
-    render(<SurveyJsonEditor initialValue={survey} onChange={onChange} />)
+    render(<FormContentJsonEditor initialValue={formContent} onChange={onChange} />)
 
     // Act
     const textArea = screen.getByRole('textbox')
@@ -61,10 +61,10 @@ describe('SurveyJsonEditor', () => {
     await act(() => user.type(textArea, 'Given', { initialSelectionStart: 159, initialSelectionEnd: 164 }))
 
     // Assert
-    const expectedEditedSurvey = cloneDeep(survey)
-    ;(expectedEditedSurvey.pages[0].elements[0] as Question).title = 'Given name'
+    const expectedEditedContent = cloneDeep(formContent)
+    ;(expectedEditedContent.pages[0].elements[0] as Question).title = 'Given name'
 
-    expect(onChange).toHaveBeenCalledWith(true, expectedEditedSurvey)
+    expect(onChange).toHaveBeenCalledWith(true, expectedEditedContent)
   })
 
   it('calls onChange when edited with invalid JSON', async () => {
@@ -72,7 +72,7 @@ describe('SurveyJsonEditor', () => {
     const user = userEvent.setup()
 
     const onChange = jest.fn()
-    render(<SurveyJsonEditor initialValue={survey} onChange={onChange} />)
+    render(<FormContentJsonEditor initialValue={formContent} onChange={onChange} />)
 
     // Act
     const textArea = screen.getByRole('textbox')

--- a/ui-admin/src/forms/FormContentJsonEditor.test.tsx
+++ b/ui-admin/src/forms/FormContentJsonEditor.test.tsx
@@ -30,7 +30,7 @@ const formContent: FormContent = {
 }
 
 describe('FormContentJsonEditor', () => {
-  it('renders survey as JSON', () => {
+  it('renders form content as JSON', () => {
     // Act
     const { container } = render(<FormContentJsonEditor initialValue={formContent} onChange={jest.fn()} />)
 

--- a/ui-admin/src/forms/FormContentJsonEditor.tsx
+++ b/ui-admin/src/forms/FormContentJsonEditor.tsx
@@ -17,9 +17,9 @@ export const FormContentJsonEditor = (props: FormContentJsonEditorProps) => {
   const setEditorValue = useCallback((newEditorValue: string) => {
     _setEditorValue(newEditorValue)
     try {
-      const survey = JSON.parse(newEditorValue)
+      const formContent = JSON.parse(newEditorValue)
       setIsValid(true)
-      onChange(true, survey)
+      onChange(true, formContent)
     } catch (e) {
       setIsValid(false)
       onChange(false, undefined)

--- a/ui-admin/src/forms/FormContentJsonEditor.tsx
+++ b/ui-admin/src/forms/FormContentJsonEditor.tsx
@@ -2,15 +2,15 @@ import React, { useCallback, useState } from 'react'
 
 import { FormContent } from '@juniper/ui-core'
 
-import { OnChangeSurvey } from './surveyEditorTypes'
+import { OnChangeFormContent } from './formEditorTypes'
 
-type SurveyJsonEditorProps = {
+type FormContentJsonEditorProps = {
   initialValue: FormContent
   readOnly?: boolean
-  onChange: OnChangeSurvey
+  onChange: OnChangeFormContent
 }
 
-export const SurveyJsonEditor = (props: SurveyJsonEditorProps) => {
+export const FormContentJsonEditor = (props: FormContentJsonEditorProps) => {
   const { initialValue, readOnly = false, onChange } = props
   const [editorValue, _setEditorValue] = useState(() => JSON.stringify(initialValue, null, 2))
   const [, setIsValid] = useState(true)

--- a/ui-admin/src/forms/FormPreview.test.tsx
+++ b/ui-admin/src/forms/FormPreview.test.tsx
@@ -3,9 +3,9 @@ import React from 'react'
 
 import { FormContent } from '@juniper/ui-core'
 
-import { SurveyPreview } from './SurveyPreview'
+import { FormPreview } from './FormPreview'
 
-const survey: FormContent = {
+const formContent: FormContent = {
   title: 'Test survey',
   pages: [
     {
@@ -27,11 +27,11 @@ const survey: FormContent = {
   ]
 }
 
-describe('SurveyPreview', () => {
+describe('FormPreview', () => {
   // eslint-disable-next-line jest/expect-expect
-  it('renders survey', () => {
+  it('renders form', () => {
     // Act
-    render(<SurveyPreview survey={survey} />)
+    render(<FormPreview formContent={formContent} />)
 
     // Assert
     screen.getAllByLabelText('First name')

--- a/ui-admin/src/forms/FormPreview.tsx
+++ b/ui-admin/src/forms/FormPreview.tsx
@@ -3,14 +3,14 @@ import { Survey as SurveyJSComponent } from 'survey-react-ui'
 
 import { FormContent, surveyJSModelFromFormContent } from '@juniper/ui-core'
 
-type SurveyPreviewProps = {
-  survey: FormContent
+type FormPreviewProps = {
+  formContent: FormContent
 }
 
-export const SurveyPreview = (props: SurveyPreviewProps) => {
-  const { survey } = props
+export const FormPreview = (props: FormPreviewProps) => {
+  const { formContent } = props
 
-  const [surveyModel] = useState(() => surveyJSModelFromFormContent(survey))
+  const [surveyModel] = useState(() => surveyJSModelFromFormContent(formContent))
 
   return (
     <SurveyJSComponent model={surveyModel} />

--- a/ui-admin/src/forms/formEditorTypes.ts
+++ b/ui-admin/src/forms/formEditorTypes.ts
@@ -1,0 +1,3 @@
+import { FormContent } from '@juniper/ui-core'
+
+export type OnChangeFormContent = (...args: [valid: true, newValue: FormContent] | [false, undefined]) => void

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react'
 
 import { VersionedForm } from 'api/api'
 
-import { SurveyEditor } from './editor/SurveyEditor'
+import { FormContentEditor } from 'forms/FormContentEditor'
 
 type SurveyEditorViewProps = {
   currentForm: VersionedForm
@@ -62,12 +62,12 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
         )}
         <button className="btn btn-secondary" type="button" onClick={onCancel}>Cancel</button>
       </div>
-      <SurveyEditor
+      <FormContentEditor
         initialContent={currentForm.content}
         readOnly={readOnly}
-        onChange={(isValid, editedSurvey) => {
+        onChange={(isValid, newContent) => {
           if (isValid) {
-            setEditedContent(JSON.stringify(editedSurvey))
+            setEditedContent(JSON.stringify(newContent))
           }
           setIsEditorValid(isValid)
         }}

--- a/ui-admin/src/study/surveys/editor/surveyEditorTypes.ts
+++ b/ui-admin/src/study/surveys/editor/surveyEditorTypes.ts
@@ -1,3 +1,0 @@
-import { FormContent } from '@juniper/ui-core'
-
-export type OnChangeSurvey = (...args: [valid: true, newValue: FormContent] | [false, undefined]) => void


### PR DESCRIPTION
The admin UI distinguishes "surveys" from "consent forms" and "pre-enrollment questionnaires". However, the editor code refers to all of these things as "surveys". To avoid confusion, this renames those components (along with some props and variables) to use the more generic "form" instead of "survey".

It also moves the editor components from "study/surveys" to a top level "forms" directory since the editor will also apply to portal pre-registration forms whenever those are added to the admin UI.