### PR TITLE
[JN-378] Add option to ignore validation in form preview

### DIFF
--- a/ui-admin/src/forms/FormPreview.tsx
+++ b/ui-admin/src/forms/FormPreview.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react'
 import { Survey as SurveyJSComponent } from 'survey-react-ui'
 
-import { FormContent, surveyJSModelFromFormContent } from '@juniper/ui-core'
+import { FormContent, surveyJSModelFromFormContent, useForceUpdate } from '@juniper/ui-core'
+
+import { FormPreviewOptions } from './FormPreviewOptions'
 
 type FormPreviewProps = {
   formContent: FormContent
@@ -13,10 +15,27 @@ export const FormPreview = (props: FormPreviewProps) => {
   const [surveyModel] = useState(() => {
     const model = surveyJSModelFromFormContent(formContent)
     model.setVariable('portalEnvironmentName', 'sandbox')
+    model.ignoreValidation = true
     return model
   })
+  const forceUpdate = useForceUpdate()
 
   return (
-    <SurveyJSComponent model={surveyModel} />
+    <div className="overflow-hidden flex-grow-1 d-flex flex-row mh-100" style={{ flexBasis: 0 }}>
+      <div className="flex-grow-1 overflow-scroll">
+        <SurveyJSComponent model={surveyModel} />
+      </div>
+      <div className="flex-shrink-0 p-3" style={{ width: 300 }}>
+        <FormPreviewOptions
+          value={{
+            ignoreValidation: surveyModel.ignoreValidation
+          }}
+          onChange={({ ignoreValidation }) => {
+            surveyModel.ignoreValidation = ignoreValidation
+            forceUpdate()
+          }}
+        />
+      </div>
+    </div>
   )
 }

--- a/ui-admin/src/forms/FormPreviewOptions.tsx
+++ b/ui-admin/src/forms/FormPreviewOptions.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+
+type FormPreviewOptions = {
+  ignoreValidation: boolean
+}
+
+type FormPreviewOptionsProps = {
+  value: FormPreviewOptions
+  onChange: (newValue: FormPreviewOptions) => void
+}
+
+export const FormPreviewOptions = (props: FormPreviewOptionsProps) => {
+  const { value, onChange } = props
+  return (
+    <div>
+      <div className="form-check">
+        <label className="form-check-label" htmlFor="form-preview-ignore-validation">
+          <input
+            checked={value.ignoreValidation}
+            className="form-check-input"
+            id="form-preview-ignore-validation"
+            type="checkbox"
+            onChange={e => {
+              onChange({ ...value, ignoreValidation: e.target.checked })
+            }}
+          />
+          Ignore validation
+        </label>
+      </div>
+      <p className="form-text">
+        Ignore validation to preview all pages of a form without enforcing required fields.
+        Enable validation to simulate a participant&apos;s experience.
+      </p>
+    </div>
+  )
+}

--- a/ui-admin/src/forms/FormPreviewOptions.tsx
+++ b/ui-admin/src/forms/FormPreviewOptions.tsx
@@ -9,6 +9,7 @@ type FormPreviewOptionsProps = {
   onChange: (newValue: FormPreviewOptions) => void
 }
 
+/** Controls for configuring the form editor's preview tab. */
 export const FormPreviewOptions = (props: FormPreviewOptionsProps) => {
   const { value, onChange } = props
   return (

--- a/ui-core/src/index.ts
+++ b/ui-core/src/index.ts
@@ -8,4 +8,5 @@ export * from './types/portal'
 export * from './types/study'
 export * from './types/task'
 
+export * from './reactUtils'
 export * from './surveyUtils'

--- a/ui-core/src/reactUtils.ts
+++ b/ui-core/src/reactUtils.ts
@@ -1,5 +1,9 @@
 import { useCallback, useState } from 'react'
 
+/**
+ * Force a component to re-render.
+ * @returns A function that forces the component to re-render.
+ * */
 export const useForceUpdate = (): () => void => {
   const [, setKey] = useState(0)
   return useCallback(() => { setKey(k => k + 1) }, [])

--- a/ui-core/src/reactUtils.ts
+++ b/ui-core/src/reactUtils.ts
@@ -1,0 +1,6 @@
+import { useCallback, useState } from 'react'
+
+export const useForceUpdate = (): () => void => {
+  const [, setKey] = useState(0)
+  return useCallback(() => { setKey(k => k + 1) }, [])
+}


### PR DESCRIPTION
This adds an options panel to the form editor preview tab. Currently, the only option is to ignore validation, which is useful for quickly paging through a survey without having to enter required fields.