### PR TITLE
[JN-378] Add site images to admin API

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/SiteImageController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/SiteImageController.java
@@ -1,0 +1,44 @@
+package bio.terra.pearl.api.admin.controller;
+
+import bio.terra.pearl.api.admin.api.SiteImageApi;
+import bio.terra.pearl.core.model.site.SiteImage;
+import bio.terra.pearl.core.service.site.SiteImageService;
+import java.net.URLConnection;
+import java.util.Optional;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class SiteImageController implements SiteImageApi {
+  private SiteImageService siteImageService;
+
+  public SiteImageController(SiteImageService siteImageService) {
+    this.siteImageService = siteImageService;
+  }
+
+  @Override
+  public ResponseEntity<Resource> get(
+      String portalShortcode, String envName, String cleanFileName, Integer version) {
+    Optional<SiteImage> siteImageOpt;
+
+    siteImageOpt = siteImageService.findOne(portalShortcode, cleanFileName, version);
+    return convertToResourceResponse(siteImageOpt);
+  }
+
+  private ResponseEntity<Resource> convertToResourceResponse(Optional<SiteImage> imageOpt) {
+    if (imageOpt.isPresent()) {
+      SiteImage image = imageOpt.get();
+      MediaType contentType =
+          MediaType.parseMediaType(
+              URLConnection.guessContentTypeFromName(image.getCleanFileName()));
+      return ResponseEntity.ok()
+          .contentType(contentType)
+          .body(new ByteArrayResource(image.getData()));
+    } else {
+      return ResponseEntity.notFound().build();
+    }
+  }
+}

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -814,6 +814,26 @@ paths:
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/public/portals/v1/{portalShortcode}/env/{envName}/siteImages/{version}/{cleanFileName}:
+    get:
+      summary: Returns the binary image data for the image of the given shortcode
+      tags: [ siteImage ]
+      operationId: get
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: envName, in: path, required: true, schema: { type: string } }
+        - { name: cleanFileName, in: path, required: true, schema: { type: string } }
+        - { name: version, in: path, required: true, schema: { type: integer } }
+      responses:
+        '200':
+          description: image data
+          content:
+            image/*: # see https://superuser.com/questions/979135/is-there-a-generic-mime-type-for-all-image-files
+              schema:
+                type: string
+                format: binary
+        '500':
+          $ref: '#/components/responses/ServerError'
 components:
   responses:
     SystemStatusResponse:

--- a/ui-admin/src/forms/FormPreview.tsx
+++ b/ui-admin/src/forms/FormPreview.tsx
@@ -10,7 +10,11 @@ type FormPreviewProps = {
 export const FormPreview = (props: FormPreviewProps) => {
   const { formContent } = props
 
-  const [surveyModel] = useState(() => surveyJSModelFromFormContent(formContent))
+  const [surveyModel] = useState(() => {
+    const model = surveyJSModelFromFormContent(formContent)
+    model.setVariable('portalEnvironmentName', 'sandbox')
+    return model
+  })
 
   return (
     <SurveyJSComponent model={surveyModel} />


### PR DESCRIPTION
Currently, images are broken in the form editor preview. This is because the images are requested from a site images API which does not exist in the admin API.

This copies the site images controller from the participant API to the admin API. Note that the site images API is not authenticated/authorized. This is acceptable because any uploaded images are immediately available through the public participant API anyway. It would also be a challenge to add authentication to the images API since the images are loaded by the browser, which does not send a token header with those requests.