### PR TITLE
[JN-424] Require JSDoc for function expressions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,7 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module'
   },
-  plugins: ['react', 'jsx-a11y', 'import', 'jest'],
+  plugins: ['react', 'jsx-a11y', 'import', 'jest', 'jsdoc'],
   rules: {
     'array-bracket-newline': ['warn', 'consistent'],
     'array-bracket-spacing': 'warn',
@@ -65,7 +65,6 @@ module.exports = {
     'one-var': ['warn', 'never'],
     'padded-blocks': ['warn', 'never'],
     quotes: ['warn', 'single', { allowTemplateLiterals: true }],
-    'require-jsdoc': 'warn',
     semi: ['warn', 'never'],
     'space-before-blocks': 'warn',
     'space-before-function-paren': [
@@ -104,7 +103,17 @@ module.exports = {
     'jest/prefer-to-have-length': 'warn',
 
     // TypeScript
-    '@typescript-eslint/ban-ts-comment': 'off'
+    '@typescript-eslint/ban-ts-comment': 'off',
+
+    // JSDoc
+    'jsdoc/require-jsdoc': ['warn', {
+      publicOnly: true,
+      require: {
+        FunctionDeclaration: true,
+        FunctionExpression: true,
+        ArrowFunctionExpression: true
+      }
+    }]
   },
   settings: {
     'import/resolver': {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "eslint": "^8.23.0",
         "eslint-import-resolver-typescript": "^3.5.5",
         "eslint-plugin-import": "^2.27.5",
+        "eslint-plugin-jsdoc": "^46.2.6",
         "prettier": "^1.19.1",
         "prettier-eslint": "^11.0.0",
         "react-scripts": "5.0.1",
@@ -2443,6 +2444,20 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.10"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.39.4",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.39.4.tgz",
+      "integrity": "sha512-Jvw915fjqQct445+yron7Dufix9A+m9j1fCJYlCo1FWlRvTxa3pjJelxdSTdaLWcTwRU6vbL+NYjO4YuNIS5Qg==",
+      "dev": true,
+      "dependencies": {
+        "comment-parser": "1.3.1",
+        "esquery": "^1.5.0",
+        "jsdoc-type-pratt-parser": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -5026,6 +5041,15 @@
       "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
       "dev": true
     },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/are-we-there-yet": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
@@ -6608,6 +6632,15 @@
       "dev": true,
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/common-path-prefix": {
@@ -8866,6 +8899,29 @@
         "jest": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "46.2.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.2.6.tgz",
+      "integrity": "sha512-zIaK3zbSrKuH12bP+SPybPgcHSM6MFzh3HFeaODzmsF1N8C1l8dzJ22cW1aq4g0+nayU1VMjmNf7hg0dpShLrA==",
+      "dev": true,
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.39.4",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.5.0",
+        "is-builtin-module": "^3.2.1",
+        "semver": "^7.5.1",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {
@@ -11325,6 +11381,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "dependencies": {
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -12816,6 +12887,15 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/jsdom": {
@@ -17893,9 +17973,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -18325,6 +18405,28 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
+      "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
       "dev": true
     },
     "node_modules/spdy": {
@@ -24859,6 +24961,17 @@
       "dev": true,
       "requires": {}
     },
+    "@es-joy/jsdoccomment": {
+      "version": "0.39.4",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.39.4.tgz",
+      "integrity": "sha512-Jvw915fjqQct445+yron7Dufix9A+m9j1fCJYlCo1FWlRvTxa3pjJelxdSTdaLWcTwRU6vbL+NYjO4YuNIS5Qg==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "1.3.1",
+        "esquery": "^1.5.0",
+        "jsdoc-type-pratt-parser": "~4.0.0"
+      }
+    },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -27979,6 +28092,12 @@
       "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
       "dev": true
     },
+    "are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true
+    },
     "are-we-there-yet": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
@@ -29226,6 +29345,12 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true
+    },
+    "comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
       "dev": true
     },
     "common-path-prefix": {
@@ -30994,6 +31119,23 @@
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^5.0.0"
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "46.2.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.2.6.tgz",
+      "integrity": "sha512-zIaK3zbSrKuH12bP+SPybPgcHSM6MFzh3HFeaODzmsF1N8C1l8dzJ22cW1aq4g0+nayU1VMjmNf7hg0dpShLrA==",
+      "dev": true,
+      "requires": {
+        "@es-joy/jsdoccomment": "~0.39.4",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.5.0",
+        "is-builtin-module": "^3.2.1",
+        "semver": "^7.5.1",
+        "spdx-expression-parse": "^3.0.1"
       }
     },
     "eslint-plugin-jsx-a11y": {
@@ -32908,6 +33050,15 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
       "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
     },
+    "is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^3.3.0"
+      }
+    },
     "is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -34020,6 +34171,12 @@
       "requires": {
         "argparse": "^2.0.1"
       }
+    },
+    "jsdoc-type-pratt-parser": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
+      "dev": true
     },
     "jsdom": {
       "version": "16.7.0",
@@ -37670,9 +37827,9 @@
       }
     },
     "semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -38029,6 +38186,28 @@
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
+      "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
       "dev": true
     },
     "spdy": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "eslint": "^8.23.0",
     "eslint-import-resolver-typescript": "^3.5.5",
     "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-jsdoc": "^46.2.6",
     "prettier": "^1.19.1",
     "prettier-eslint": "^11.0.0",
     "react-scripts": "5.0.1",

--- a/ui-admin/src/authConfig.ts
+++ b/ui-admin/src/authConfig.ts
@@ -11,6 +11,8 @@ const aadb2cPolicyName = process.env.REACT_APP_B2C_POLICY_NAME ? process.env.REA
 
 // TODO: This is a modified copy of code from Terra UI. It could use some clean-up.
 /* eslint-disable camelcase, max-len */
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const getOidcConfig = (
   b2cTenantName: string = aadB2cName,
   b2cClientId: string = aadb2cClientId,

--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -14,6 +14,8 @@ type FormContentEditorProps = {
   onChange: OnChangeFormContent
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const FormContentEditor = (props: FormContentEditorProps) => {
   const { initialContent, readOnly, onChange } = props
 

--- a/ui-admin/src/forms/FormContentJsonEditor.tsx
+++ b/ui-admin/src/forms/FormContentJsonEditor.tsx
@@ -10,6 +10,8 @@ type FormContentJsonEditorProps = {
   onChange: OnChangeFormContent
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const FormContentJsonEditor = (props: FormContentJsonEditorProps) => {
   const { initialValue, readOnly = false, onChange } = props
   const [editorValue, _setEditorValue] = useState(() => JSON.stringify(initialValue, null, 2))

--- a/ui-admin/src/forms/FormDesigner.tsx
+++ b/ui-admin/src/forms/FormDesigner.tsx
@@ -10,6 +10,7 @@ type FormDesignerProps = {
   onChange: (editedContent: FormContent) => void
 }
 
+/** UI for editing forms. */
 export const FormDesigner = (props: FormDesignerProps) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { readOnly = false, value, onChange } = props

--- a/ui-admin/src/forms/FormPreview.tsx
+++ b/ui-admin/src/forms/FormPreview.tsx
@@ -9,6 +9,8 @@ type FormPreviewProps = {
   formContent: FormContent
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const FormPreview = (props: FormPreviewProps) => {
   const { formContent } = props
 

--- a/ui-admin/src/login/IdleStatusMonitor.tsx
+++ b/ui-admin/src/login/IdleStatusMonitor.tsx
@@ -69,6 +69,8 @@ export const calculateIdleData = ({ currentTime, lastRecordedActivity, maxIdleSe
   return { timedOut, showCountdown, secondsUntilTimedOut: displaySecondsUntilTimeout, millisecondsUntilNextUpdate }
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const IdleStatusMonitor = ({ maxIdleSessionDuration, idleWarningDuration }: {
   maxIdleSessionDuration: number,
   idleWarningDuration: number
@@ -149,6 +151,8 @@ const InactivityTimer = ({ maxIdleSessionDuration, idleWarningDuration, doSignOu
 
 // Copied from Terra UI
 // Modified to yield execution before looping and starting the next delay
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const useCurrentTime = (initialDelay = 250) => {
   const [currentTime, setCurrentTime] = useState(Date.now())
   const signal = useCancellation()
@@ -168,6 +172,8 @@ export const useCurrentTime = (initialDelay = 250) => {
 }
 
 // Copied from Terra UI without modification for use by useCurrentTime
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const useCancellation = (): AbortSignal => {
   const controller = useRef<AbortController>()
   useEffect(() => {
@@ -181,6 +187,8 @@ export const useCancellation = (): AbortSignal => {
 }
 
 // Copied from Terra UI without modification for use by useCurrentTime
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const delay = (ms: number) => {
   return new Promise(resolve => setTimeout(resolve, ms))
 }

--- a/ui-admin/src/login/ProtectedRoute.tsx
+++ b/ui-admin/src/login/ProtectedRoute.tsx
@@ -4,6 +4,8 @@ import { useUser } from 'user/UserProvider'
 import Login from 'login/Login'
 
 /* Inspired by https://www.robinwieruch.de/react-router-private-routes/ */
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const ProtectedRoute = ({ children }: { children?: ReactNode }) => {
   const { user } = useUser()
 

--- a/ui-admin/src/login/RedirectFromOAuth.tsx
+++ b/ui-admin/src/login/RedirectFromOAuth.tsx
@@ -3,6 +3,8 @@ import { useAuth } from 'react-oidc-context'
 import { useUser } from 'user/UserProvider'
 import Api from 'api/api'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const RedirectFromOAuth = () => {
   const auth = useAuth()
   const { user } = useUser()

--- a/ui-admin/src/navbar/BaseSidebar.tsx
+++ b/ui-admin/src/navbar/BaseSidebar.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { useUser } from '../user/UserProvider'
 import { SidebarNavLink } from './AdminNavbar'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const BaseSidebar = () => {
   const { user } = useUser()
   return <ul className="nav nav-pills flex-column mb-auto">

--- a/ui-admin/src/portal/PortalEnvConfigView.tsx
+++ b/ui-admin/src/portal/PortalEnvConfigView.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { PortalEnvironment } from 'api/api'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const PortalEnvConfigView = ({ portalEnv }: {portalEnv: PortalEnvironment}) => {
   const config = portalEnv.portalEnvironmentConfig
 

--- a/ui-admin/src/portal/PortalRouter.tsx
+++ b/ui-admin/src/portal/PortalRouter.tsx
@@ -60,6 +60,8 @@ function PortalEnvRouter({ portalContext }: {portalContext: LoadedPortalContextT
   </>
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const usersPath = (portalShortcode: string) => {
   return `/${portalShortcode}/users`
 }
@@ -74,22 +76,32 @@ export const portalEnvDiffPath = (portalShortcode: string, destEnvName: string, 
   return `/${portalShortcode}/env/${destEnvName}/diff/${sourceEnvName}`
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const siteContentPath = (portalShortcode: string, envName: string) => {
   return `/${portalShortcode}/env/${envName}/siteContent`
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const portalConfigPath = (portalShortcode: string, envName: string) => {
   return `/${portalShortcode}/env/${envName}/config`
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const studyParticipantsPath = (portalShortcode: string, envName: string, studyShortcode: string) => {
   return `/${portalShortcode}/studies/${studyShortcode}/env/${envName}/participants`
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const studyContentPath = (portalShortcode: string, envName: string, studyShortcode: string) => {
   return `/${portalShortcode}/studies/${studyShortcode}/env/${envName}`
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const portalParticipantsPath = (portalShortcode: string, envName: string) => {
   return `/${portalShortcode}/env/${envName}/participants`
 }

--- a/ui-admin/src/portal/PortalSidebar.tsx
+++ b/ui-admin/src/portal/PortalSidebar.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { usersPath } from './PortalRouter'
 import { SidebarNavLink } from '../navbar/AdminNavbar'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const PortalSidebar = ({ portalShortcode }: {portalShortcode: string}) => {
   return <ul className="nav nav-pills flex-column mb-auto">
     <li>

--- a/ui-admin/src/portal/publish/StudyEnvDiff.tsx
+++ b/ui-admin/src/portal/publish/StudyEnvDiff.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { StudyEnvironmentChange } from 'api/api'
 import { ConfigChangeListView, ConfigChanges, VersionChangeView } from './diffComponents'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const StudyEnvDiff = ({ studyEnvChange }: {studyEnvChange: StudyEnvironmentChange}) => {
   return <div className="px-3">
     <div className="my-1">

--- a/ui-admin/src/portal/publish/diffComponents.tsx
+++ b/ui-admin/src/portal/publish/diffComponents.tsx
@@ -50,6 +50,8 @@ export const ConfigChangeView = ({ configChange }: {configChange: ConfigChange})
   </div>
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const valuePresent = (val: object) => {
   return val !== null && typeof val !== 'undefined'
 }

--- a/ui-admin/src/portal/siteContent/SiteContentView.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentView.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react'
 import { HtmlPage, NavbarItemInternal, PortalEnvironment } from '../../api/api'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const SiteContentView = ({ portalEnv }: {portalEnv: PortalEnvironment}) => {
   const selectedLanguage = 'en'
   const [selectedNavItem, setSelectedNavItem] = useState<NavbarItemInternal | null>(null)

--- a/ui-admin/src/providers/ConfigProvider.tsx
+++ b/ui-admin/src/providers/ConfigProvider.tsx
@@ -14,6 +14,8 @@ const uninitializedConfig = {
 
 const ConfigContext = React.createContext<Config>(uninitializedConfig)
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const useConfig = () => useContext(ConfigContext)
 
 export const ConfigConsumer = ConfigContext.Consumer

--- a/ui-admin/src/reportWebVitals.ts
+++ b/ui-admin/src/reportWebVitals.ts
@@ -1,5 +1,7 @@
 import { ReportHandler } from 'web-vitals'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
     import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {

--- a/ui-admin/src/study/StudyEnvironmentRouter.tsx
+++ b/ui-admin/src/study/StudyEnvironmentRouter.tsx
@@ -83,26 +83,38 @@ function StudyEnvironmentRouter({ study }: {study: Study}) {
 
 export default StudyEnvironmentRouter
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const studyEnvPath = (portalShortcode: string, studyShortcode: string, envName: string) => {
   return `/${portalShortcode}/studies/${studyShortcode}/env/${envName}`
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const notificationConfigPath = (config: NotificationConfig, currentEnvPath: string) => {
   return `${currentEnvPath}/notificationConfigs/${config.id}`
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const getExportDataBrowserPath = (currentEnvPath: string) => {
   return `${currentEnvPath}/export/dataBrowser`
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const studyEnvMetricsPath = (portalShortcode: string, envName: string, studyShortcode: string) => {
   return `${studyEnvPath(portalShortcode, studyShortcode, envName)}/metrics`
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const getDatasetListViewPath = (currentEnvPath: string) => {
   return `${currentEnvPath}/export/dataRepo/datasets`
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const getDatasetDashboardPath = (datasetName: string, currentEnvPath: string) => {
   return `${currentEnvPath}/export/dataRepo/datasets/${datasetName}`
 }

--- a/ui-admin/src/study/participants/datarepo/CreateDatasetModal.tsx
+++ b/ui-admin/src/study/participants/datarepo/CreateDatasetModal.tsx
@@ -6,6 +6,8 @@ import Api from 'api/api'
 import { failureNotification, successNotification } from 'util/notifications'
 import { Store } from 'react-notifications-component'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const CreateDatasetModal = ({ studyEnvContext, show, setShow, loadDatasets }: {studyEnvContext: StudyEnvContextT,
   show: boolean, setShow:  React.Dispatch<React.SetStateAction<boolean>>, loadDatasets: () => void }) => {
   const [isLoading, setIsLoading] = useState(false)

--- a/ui-admin/src/study/participants/datarepo/DatasetDashboard.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetDashboard.tsx
@@ -46,6 +46,8 @@ const columns: ColumnDef<DatasetJobHistory>[] = [{
   >View job in Terra Data Repo <FontAwesomeIcon icon={faExternalLink}/></a>
 }]
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const DatasetDashboard = ({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) => {
   const { currentEnvPath } = studyEnvContext
   const [showDeleteDatasetModal, setShowDeleteDatasetModal] = useState(false)

--- a/ui-admin/src/study/participants/datarepo/DatasetList.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetList.tsx
@@ -45,6 +45,8 @@ const datasetColumns = (currentEnvPath: string): ColumnDef<DatasetDetails>[] => 
   accessorKey: 'status'
 }]
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const DatasetList = ({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) => {
   const { currentEnvPath } = studyEnvContext
   const [showCreateDatasetModal, setShowCreateDatasetModal] = useState(false)

--- a/ui-admin/src/study/participants/datarepo/DeleteDatasetModal.tsx
+++ b/ui-admin/src/study/participants/datarepo/DeleteDatasetModal.tsx
@@ -7,6 +7,8 @@ import Api from 'api/api'
 import { failureNotification, successNotification } from 'util/notifications'
 import { Store } from 'react-notifications-component'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const DeleteDatasetModal = ({ studyEnvContext, datasetName, show, setShow, loadDatasets }: {
     studyEnvContext: StudyEnvContextT, datasetName: string, show: boolean,
     setShow:  React.Dispatch<React.SetStateAction<boolean>>, loadDatasets: () => void }) => {

--- a/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
@@ -17,6 +17,8 @@ import ExportDataControl from './ExportDataControl'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faDownload } from '@fortawesome/free-solid-svg-icons'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const ExportDataBrowser = ({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) => {
   const [data, setData] = useState<ExportData | null>(null)
   const [isLoading, setIsLoading] = useState(true)

--- a/ui-admin/src/study/participants/export/ExportDataControl.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataControl.tsx
@@ -7,6 +7,8 @@ import { currentIsoDate } from 'util/timeUtils'
 import { failureNotification } from 'util/notifications'
 import { Store } from 'react-notifications-component'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const ExportDataControl = ({ studyEnvContext, show, setShow }: {studyEnvContext: StudyEnvContextT, show: boolean,
                            setShow:  React.Dispatch<React.SetStateAction<boolean>>}) => {
   const [humanReadable, setHumanReadable] = useState(true)

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -32,6 +32,8 @@ const ItemDisplay = ({ answer, surveyJsModel, surveyVersion }: {answer: Answer,
   </>
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const getDisplayValue = (answer: Answer, question: Question | QuestionWithChoices) => {
   const answerValue = answer.stringValue ?? answer.numberValue ?? answer.objectValue ?? answer.booleanValue
   if (!question) {
@@ -55,6 +57,8 @@ export const getDisplayValue = (answer: Answer, question: Question | QuestionWit
   return displayValue
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const getTextForChoice = (value: string | number | boolean | undefined, question: Question) => {
   return question.choices.find((choice: ItemValue)  => choice.value === value)?.text ?? value
 }

--- a/ui-admin/src/terms/InvestigatorTermsOfUsePage.tsx
+++ b/ui-admin/src/terms/InvestigatorTermsOfUsePage.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 
 import { InvestigatorTermsOfUse } from '@juniper/ui-core'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const InvestigatorTermsOfUsePage = () => {
   return (
     <div className="container p-3">

--- a/ui-admin/src/terms/PrivacyPolicyPage.tsx
+++ b/ui-admin/src/terms/PrivacyPolicyPage.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 
 import { PrivacyPolicy } from '@juniper/ui-core'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const PrivacyPolicyPage = () => {
   return (
     <div className="container p-3">

--- a/ui-admin/src/test-utils/mocking-utils.ts
+++ b/ui-admin/src/test-utils/mocking-utils.ts
@@ -7,6 +7,8 @@ import _times from 'lodash/times'
 import _random from 'lodash/random'
 
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const mockSurvey: () => Survey = () => ({
   id: 'surveyId1',
   stableId: 'survey1',
@@ -18,6 +20,8 @@ export const mockSurvey: () => Survey = () => ({
 })
 
 // as we add more tests, we'll want to parameterize this and turn it into a proper factory
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const mockStudyEnvContext: () => StudyEnvContextT = () => ({
   study: { name: 'Fake study', studyEnvironments: [], shortcode: 'fakeStudy' },
   portal: { shortcode: 'portalCode', id: 'portalId', portalStudies: [], portalEnvironments: [], name: 'Fake portal' },
@@ -49,6 +53,8 @@ export const mockStudyEnvContext: () => StudyEnvContextT = () => ({
 })
 
 export const mockDatasetDetails: (datasetName: string, status: string) => DatasetDetails =
+    // TODO: Add JSDoc
+    // eslint-disable-next-line jsdoc/require-jsdoc
     (datasetName: string, status: string) => ({
       createdAt: 1685557140,
       createdBy: '0b9ade05-f7e3-483e-b85a-43deac7505c0',
@@ -63,6 +69,8 @@ export const mockDatasetDetails: (datasetName: string, status: string) => Datase
     })
 
 // as we add more tests, we'll want to parameterize this and turn it into a proper factory
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const mockEnrollee: () => Enrollee = () => {
   const enrolleeId = randomString(10)
   return {
@@ -114,6 +122,8 @@ export const mockEnrollee: () => Enrollee = () => {
   }
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const taskForSurvey = (survey: Survey, enrolleeId: string): ParticipantTask => {
   return {
     id: randomString(10),

--- a/ui-admin/src/user/CreateUserModal.tsx
+++ b/ui-admin/src/user/CreateUserModal.tsx
@@ -7,6 +7,8 @@ import { failureNotification, successNotification } from 'util/notifications'
 import { Store } from 'react-notifications-component'
 import Select from 'react-select'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const CreateUserModal = ({ onDismiss, portals, userCreated }:
                            { onDismiss: () => void,
                              portals: Portal[], userCreated: () => void

--- a/ui-admin/src/user/PortalUserList.tsx
+++ b/ui-admin/src/user/PortalUserList.tsx
@@ -16,6 +16,8 @@ import CreateUserModal from './CreateUserModal'
 import { failureNotification } from '../util/notifications'
 import { Store } from 'react-notifications-component'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const PortalUserList = ({ portal }: {portal: Portal}) => {
   const [users, setUsers] = useState<AdminUser[]>([])
   const [isLoading, setIsLoading] = useState(true)

--- a/ui-admin/src/user/UserList.tsx
+++ b/ui-admin/src/user/UserList.tsx
@@ -14,6 +14,8 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheck, faPlus } from '@fortawesome/free-solid-svg-icons'
 import CreateUserModal from './CreateUserModal'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const UserList = () => {
   const [users, setUsers] = useState<AdminUser[]>([])
   const [isLoading, setIsLoading] = useState(true)

--- a/ui-admin/src/user/UserProvider.tsx
+++ b/ui-admin/src/user/UserProvider.tsx
@@ -28,6 +28,8 @@ const UserContext = React.createContext<UserContextT>({
 const INTERNAL_LOGIN_TOKEN_KEY = 'internalLoginToken'
 const OAUTH_ACCRESS_TOKEN_KEY = 'oauthAccessToken'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const useUser = () => useContext(UserContext)
 
 /** Provider for the current logged-in user. */

--- a/ui-core/src/components/MultipleCombobox.tsx
+++ b/ui-core/src/components/MultipleCombobox.tsx
@@ -14,6 +14,8 @@ type MultipleComboboxProps<ComboboxItem> = {
   onChange?: (value: ComboboxItem[]) => void
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const MultipleComboBox = <ComboboxItem, >(props: MultipleComboboxProps<ComboboxItem>) => {
   const { id, initialValue, itemToString, options, placeholder, onChange } = props
 

--- a/ui-core/src/terms/InvestigatorTermsOfUse.tsx
+++ b/ui-core/src/terms/InvestigatorTermsOfUse.tsx
@@ -9,6 +9,8 @@ const SectionHeading = (props: SectionHeadingProps) => {
   return <h2 {...otherProps} className={classNames('h3', className)} />
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const InvestigatorTermsOfUse = () => {
   return (
     <>

--- a/ui-core/src/terms/ParticipantTermsOfUse.tsx
+++ b/ui-core/src/terms/ParticipantTermsOfUse.tsx
@@ -9,6 +9,8 @@ const SectionHeading = (props: SectionHeadingProps) => {
   return <h2 {...otherProps} className={classNames('h3', className)} />
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const ParticipantTermsOfUse = () => {
   return (
     <>

--- a/ui-core/src/terms/PrivacyPolicy.tsx
+++ b/ui-core/src/terms/PrivacyPolicy.tsx
@@ -9,6 +9,8 @@ const SectionHeading = (props: SectionHeadingProps) => {
   return <h2 {...otherProps} className={classNames('h3', className)} />
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const PrivacyPolicy = () => {
   return (
     <>

--- a/ui-participant/src/Alert.tsx
+++ b/ui-participant/src/Alert.tsx
@@ -28,6 +28,8 @@ export type AlertProps = {
   onDismiss?: () => void
 } & JSX.IntrinsicElements['div']
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const Alert = (props: AlertProps) => {
   const { children, className, icon, level = 'info', title, onDismiss, ...otherProps } = props
   const renderedIcon = icon ? icon : getDefaultIcon(level)

--- a/ui-participant/src/CookieAlert.tsx
+++ b/ui-participant/src/CookieAlert.tsx
@@ -8,6 +8,8 @@ type CookieAlertProps = {
   onDismiss: () => void
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const CookieAlert = (props: CookieAlertProps) => {
   const { onDismiss } = props
   return (

--- a/ui-participant/src/authConfig.ts
+++ b/ui-participant/src/authConfig.ts
@@ -31,8 +31,8 @@ export const getAuthProviderProps = (
   }
 }
 
-/** Creates and returns UserManagerSettings based on B2C configuration values. */
 /* eslint-disable camelcase, max-len */
+/** Creates and returns UserManagerSettings based on B2C configuration values. */
 export const getOidcConfig = (b2cTenantName: string, b2cClientId: string, b2cPolicyName: string): UserManagerSettings => {
   return {
     /*

--- a/ui-participant/src/browserPersistentState.tsx
+++ b/ui-participant/src/browserPersistentState.tsx
@@ -21,6 +21,8 @@ export const useHasProvidedStudyPassword = (studyShortcode: string): [boolean, (
   return [value === 'true', setHasProvidedStudyPassword]
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const useCookiesAcknowledged = (): [boolean, () => void] => {
   const [value, setValue] = useLocalStorage('cookiesAcknowledged')
   return [!!value, () => setValue('true')]

--- a/ui-participant/src/hub/consent/PrintConsentView.tsx
+++ b/ui-participant/src/hub/consent/PrintConsentView.tsx
@@ -100,6 +100,8 @@ const usePrintableConsent = (args: UsePrintableConsentArgs) => {
   return { loading, surveyModel }
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const PrintConsentView = () => {
   const { portal } = usePortalEnv()
   const { enrollees } = useUser()

--- a/ui-participant/src/hub/hubUpdates.tsx
+++ b/ui-participant/src/hub/hubUpdates.tsx
@@ -25,6 +25,8 @@ export const useHubUpdate = (): HubUpdate | undefined => {
 
 type HubMessageAlertProps = { message: HubUpdateMessage } & Omit<AlertProps, 'children' | 'level' | 'title'>
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const HubMessageAlert = (props: HubMessageAlertProps) => {
   const { message, ...otherProps } = props
   return (

--- a/ui-participant/src/landing/ConfiguredButton.tsx
+++ b/ui-participant/src/landing/ConfiguredButton.tsx
@@ -33,6 +33,8 @@ export type ButtonConfig =
   | InternalLinkButtonConfig
   | ExternalLinkButtonConfig
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const validateButtonConfig = (buttonConfig: unknown): ButtonConfig => {
   const message = 'Invalid button config'
   const config = requirePlainObject(buttonConfig, message)
@@ -58,6 +60,8 @@ type ConfiguredButtonProps = {
   className?: string;
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const ConfiguredLink = (props: ConfiguredButtonProps) => {
   const { className, config } = props
   if (config.type === 'join') {

--- a/ui-participant/src/landing/ConfiguredImage.tsx
+++ b/ui-participant/src/landing/ConfiguredImage.tsx
@@ -12,6 +12,8 @@ export type ImageConfig = {
   style?: CSSProperties
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const validateImageConfig = (imageConfig: unknown): ImageConfig => {
   const message = 'Invalid image config'
   const config = requirePlainObject(imageConfig, message)

--- a/ui-participant/src/landing/MailingListModal.tsx
+++ b/ui-participant/src/landing/MailingListModal.tsx
@@ -6,6 +6,8 @@ type MailingListModalProps = {
   id: string
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const MailingListModal = (props: MailingListModalProps) => {
   const { id } = props
   const closeButtonRef = useRef<HTMLButtonElement>(null)

--- a/ui-participant/src/login/IdleStatusMonitor.tsx
+++ b/ui-participant/src/login/IdleStatusMonitor.tsx
@@ -69,6 +69,8 @@ export const calculateIdleData = ({ currentTime, lastRecordedActivity, maxIdleSe
   return { timedOut, showCountdown, secondsUntilTimedOut: displaySecondsUntilTimeout, millisecondsUntilNextUpdate }
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const IdleStatusMonitor = ({ maxIdleSessionDuration, idleWarningDuration }: {
   maxIdleSessionDuration: number,
   idleWarningDuration: number
@@ -149,6 +151,8 @@ const InactivityTimer = ({ maxIdleSessionDuration, idleWarningDuration, doSignOu
 
 // Copied from Terra UI
 // Modified to yield execution before looping and starting the next delay
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const useCurrentTime = (initialDelay = 250) => {
   const [currentTime, setCurrentTime] = useState(Date.now())
   const signal = useCancellation()
@@ -168,6 +172,8 @@ export const useCurrentTime = (initialDelay = 250) => {
 }
 
 // Copied from Terra UI without modification for use by useCurrentTime
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const useCancellation = (): AbortSignal => {
   const controller = useRef<AbortController>()
   useEffect(() => {
@@ -181,6 +187,8 @@ export const useCancellation = (): AbortSignal => {
 }
 
 // Copied from Terra UI without modification for use by useCurrentTime
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const delay = (ms: number) => {
   return new Promise(resolve => setTimeout(resolve, ms))
 }

--- a/ui-participant/src/login/ProtectedRoute.tsx
+++ b/ui-participant/src/login/ProtectedRoute.tsx
@@ -5,6 +5,8 @@ import Login from 'login/Login'
 import LoginUnauthed from './LoginUnauthed'
 
 /* Inspired by https://www.robinwieruch.de/react-router-private-routes/ */
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const ProtectedRoute = ({ children }: { children?: ReactNode }) => {
   const { user } = useUser()
 

--- a/ui-participant/src/login/RedirectFromOAuth.tsx
+++ b/ui-participant/src/login/RedirectFromOAuth.tsx
@@ -9,6 +9,8 @@ import { usePreEnrollResponseId, usePreRegResponseId, useReturnToStudy } from 'b
 import { userHasJoinedPortalStudy } from 'util/enrolleeUtils'
 import { PageLoadingIndicator } from 'util/LoadingSpinner'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const RedirectFromOAuth = () => {
   const auth = useAuth()
   const { loginUser, updateEnrollee, user } = useUser()

--- a/ui-participant/src/providers/ConfigProvider.tsx
+++ b/ui-participant/src/providers/ConfigProvider.tsx
@@ -11,6 +11,8 @@ const uninitializedConfig = {
 
 const ConfigContext = React.createContext<Config>(uninitializedConfig)
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const useConfig = () => useContext(ConfigContext)
 
 export const ConfigConsumer = ConfigContext.Consumer

--- a/ui-participant/src/providers/UserProvider.tsx
+++ b/ui-participant/src/providers/UserProvider.tsx
@@ -43,6 +43,8 @@ const UserContext = React.createContext<UserContextT>({
 const INTERNAL_LOGIN_TOKEN_KEY = 'internalLoginToken'
 const OAUTH_ACCRESS_TOKEN_KEY = 'oauthAccessToken'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const useUser = () => useContext(UserContext)
 
 /** Provider for the current logged-in user. */

--- a/ui-participant/src/reportWebVitals.ts
+++ b/ui-participant/src/reportWebVitals.ts
@@ -1,5 +1,7 @@
 import { ReportHandler } from 'web-vitals'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
     import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {

--- a/ui-participant/src/setupProxy.js
+++ b/ui-participant/src/setupProxy.js
@@ -1,6 +1,7 @@
 /* eslint-disable-next-line */
 const {createProxyMiddleware} = require('http-proxy-middleware')
 
+/** Configure Create React App's proxy. */
 module.exports = function(app) {
   app.use(
     ['/api', '/config', '/favicon.ico'],

--- a/ui-participant/src/studies/enroll/StudyEnrollPasswordGate.tsx
+++ b/ui-participant/src/studies/enroll/StudyEnrollPasswordGate.tsx
@@ -11,6 +11,8 @@ type StudyEnrollPasswordGateProps = {
   onSubmitCorrectPassword: () => void
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const StudyEnrollPasswordGate = (props: StudyEnrollPasswordGateProps) => {
   const { studyEnv, studyName, onSubmitCorrectPassword } = props
   const { password: studyPassword } = studyEnv.studyEnvironmentConfig

--- a/ui-participant/src/terms/InvestigatorTermsOfUsePage.tsx
+++ b/ui-participant/src/terms/InvestigatorTermsOfUsePage.tsx
@@ -4,6 +4,8 @@ import { InvestigatorTermsOfUse } from '@juniper/ui-core'
 
 import Navbar from '../Navbar'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const InvestigatorTermsOfUsePage = () => {
   return (
     <div className="container-fluid bg-white min-vh-100 d-flex flex-column p-0">

--- a/ui-participant/src/terms/ParticipantTermsOfUsePage.tsx
+++ b/ui-participant/src/terms/ParticipantTermsOfUsePage.tsx
@@ -4,6 +4,8 @@ import { ParticipantTermsOfUse } from '@juniper/ui-core'
 
 import Navbar from '../Navbar'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const ParticipantTermsOfUsePage = () => {
   return (
     <div className="container-fluid bg-white min-vh-100 d-flex flex-column p-0">

--- a/ui-participant/src/terms/PrivacyPolicyPage.tsx
+++ b/ui-participant/src/terms/PrivacyPolicyPage.tsx
@@ -4,6 +4,8 @@ import { PrivacyPolicy } from '@juniper/ui-core'
 
 import Navbar from '../Navbar'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 const PrivacyPolicyPage = () => {
   return (
     <div className="container-fluid bg-white min-vh-100 d-flex flex-column p-0">

--- a/ui-participant/src/util/DocumentTitle.tsx
+++ b/ui-participant/src/util/DocumentTitle.tsx
@@ -6,6 +6,8 @@ type DocumentTitleProps = {
   title?: string
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const DocumentTitle = (props: DocumentTitleProps) => {
   const { title } = props
   const { portal } = usePortalEnv()

--- a/ui-participant/src/util/surveyJsUtils.tsx
+++ b/ui-participant/src/util/surveyJsUtils.tsx
@@ -146,6 +146,8 @@ export function useSurveyJSModel(
   return { surveyModel, refreshSurvey, pageNumber, SurveyComponent, setSurveyModel }
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const applyMarkdown = (survey: object, options: { text: string, html: string }) => {
   const markdownText = micromark(options.text)
   // chop off <p> tags.

--- a/ui-participant/src/util/validationUtils.ts
+++ b/ui-participant/src/util/validationUtils.ts
@@ -1,9 +1,13 @@
 import { isPlainObject as _isPlainObject } from 'lodash'
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const isPlainObject = (config: unknown): config is Record<string, unknown> => {
   return _isPlainObject(config)
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const requirePlainObject = (value: unknown, prefix = ''): Record<string, unknown> => {
   if (!isPlainObject(value)) {
     const messagePrefix = prefix ? `${prefix}: ` : ''
@@ -12,6 +16,8 @@ export const requirePlainObject = (value: unknown, prefix = ''): Record<string, 
   return value
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const requireString = (
   config: Record<string, unknown>,
   key: string,
@@ -26,6 +32,8 @@ export const requireString = (
   return value
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const requireOptionalString = (
   config: Record<string, unknown>,
   key: string,
@@ -40,6 +48,8 @@ export const requireOptionalString = (
   return value
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const requireNumber = (
   config: Record<string, unknown>,
   key: string,
@@ -54,6 +64,8 @@ export const requireNumber = (
   return value
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const requireOptionalNumber = (
   config: Record<string, unknown>,
   key: string,
@@ -68,6 +80,8 @@ export const requireOptionalNumber = (
   return value
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const requireOptionalBoolean = (
   config: Record<string, unknown>,
   key: string,
@@ -81,6 +95,8 @@ export const requireOptionalBoolean = (
   return value
 }
 
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
 export const requireOptionalArray = <ElementType>(
   config: Record<string, unknown>,
   key: string,


### PR DESCRIPTION
Currently, JSDoc is only required for function declarations (`function foo() { ... }`). This also requires it for function expressions (`const foo = function() { ... }` and arrow function expressions (`const foo = () => { ... }`). It only requires JSDoc for functions exported from the module.

Since [ESLint's built in require-jsdoc rule is deprecated](https://eslint.org/blog/2018/11/jsdoc-end-of-life/), this also switches to [eslint-plugin-jsdoc](https://github.com/gajus/eslint-plugin-jsdoc).