### PR TITLE
[JN-378] Add "Show invisible questions" option to form editor preview

### DIFF
--- a/ui-admin/src/forms/FormPreview.test.tsx
+++ b/ui-admin/src/forms/FormPreview.test.tsx
@@ -104,5 +104,51 @@ describe('FormPreview', () => {
         screen.getByText('Response required.')
       })
     })
+
+    describe('show invisible questions', () => {
+      const formContent: FormContent = {
+        title: 'Test survey',
+        pages: [
+          {
+            elements: [
+              {
+                name: 'visible_question',
+                title: 'Visible question',
+                type: 'text'
+              },
+              {
+                name: 'hidden_question',
+                title: 'Hidden question',
+                type: 'text',
+                visibleIf: 'false'
+              }
+            ]
+          }
+        ]
+      }
+
+      it('hides invisible questions by default', () => {
+        // Act
+        render(<FormPreview formContent={formContent} />)
+
+        // Assert
+        expect(screen.queryAllByLabelText('Hidden question')).toHaveLength(0)
+      })
+
+      it('can show invisible questions', async () => {
+        // Arrange
+        const user = userEvent.setup()
+
+        render(<FormPreview formContent={formContent} />)
+
+        // Act
+        // Show invisible questions
+        const showInvisibleElementsCheckbox = screen.getByLabelText('Show invisible questions')
+        await act(() => user.click(showInvisibleElementsCheckbox))
+
+        // Assert
+        screen.getAllByLabelText('Hidden question')
+      })
+    })
   })
 })

--- a/ui-admin/src/forms/FormPreview.tsx
+++ b/ui-admin/src/forms/FormPreview.tsx
@@ -28,10 +28,12 @@ export const FormPreview = (props: FormPreviewProps) => {
       <div className="flex-shrink-0 p-3" style={{ width: 300 }}>
         <FormPreviewOptions
           value={{
-            ignoreValidation: surveyModel.ignoreValidation
+            ignoreValidation: surveyModel.ignoreValidation,
+            showInvisibleElements: surveyModel.showInvisibleElements
           }}
-          onChange={({ ignoreValidation }) => {
+          onChange={({ ignoreValidation, showInvisibleElements }) => {
             surveyModel.ignoreValidation = ignoreValidation
+            surveyModel.showInvisibleElements = showInvisibleElements
             forceUpdate()
           }}
         />

--- a/ui-admin/src/forms/FormPreviewOptions.tsx
+++ b/ui-admin/src/forms/FormPreviewOptions.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 type FormPreviewOptions = {
   ignoreValidation: boolean
+  showInvisibleElements: boolean
 }
 
 type FormPreviewOptionsProps = {
@@ -31,6 +32,24 @@ export const FormPreviewOptions = (props: FormPreviewOptionsProps) => {
       <p className="form-text">
         Ignore validation to preview all pages of a form without enforcing required fields.
         Enable validation to simulate a participant&apos;s experience.
+      </p>
+      <div className="form-check">
+        <label className="form-check-label" htmlFor="form-preview-show-invisible-elements">
+          <input
+            checked={value.showInvisibleElements}
+            className="form-check-input"
+            id="form-preview-show-invisible-elements"
+            type="checkbox"
+            onChange={e => {
+              onChange({ ...value, showInvisibleElements: e.target.checked })
+            }}
+          />
+          Show invisible questions
+        </label>
+      </div>
+      <p className="form-text">
+        Show all questions, regardless of their visibility. Use this to review questions that
+        would be hidden by survey branching logic.
       </p>
     </div>
   )


### PR DESCRIPTION
Bringing over another feature of "Review mode" in the participant UI.

This adds an option to show invisible questions in the form editor preview. This ignores questions' `visibleIf` expressions and shows all questions in the preview.

![Screenshot 2023-06-12 at 10 20 30 AM](https://github.com/broadinstitute/juniper/assets/1156625/161b862d-e767-45aa-8fe8-25216e0abf16)