### PR TITLE
[JN-378] Update shared survey styles to apply to editor preview

### DIFF
--- a/ui-core/src/surveyjs/surveyJsStyle.scss
+++ b/ui-core/src/surveyjs/surveyJsStyle.scss
@@ -14,19 +14,17 @@
   padding: 1em;
 }
 
-.survey-js-survey h2 {
+.sd-html h2 {
   padding-top: 1em;
   margin-bottom: 0.5em;
   font-weight: 600;
+
+  &:last-child {
+    margin-bottom: 0em;
+  }
 }
 
-.survey-js-survey h2:last-child {
-  padding-top: 1em;
-  margin-bottom: 0em;
-  font-weight: 600;
-}
-
-.survey-js-survey .sd-html p:only-child {
+.sd-html p:only-child {
   padding-top: 2em;
   margin-bottom: 0;
 }

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -143,7 +143,7 @@ function RawSurveyView({ form, enrollee, resumableData, pager, studyShortcode, t
     <>
       <DocumentTitle title={form.name} />
       {/* f3f3f3 background is to match surveyJs "modern" theme */}
-      <div style={{ background: '#f3f3f3' }} className="flex-grow-1 survey-js-survey">
+      <div style={{ background: '#f3f3f3' }} className="flex-grow-1">
         <SurveyReviewModeButton surveyModel={surveyModel}/>
         <h1 className="text-center mt-5 mb-0 pb-0 fw-bold">{form.name}</h1>
         {surveyModel && <SurveyComponent model={surveyModel}/>}


### PR DESCRIPTION
#422 moved some custom styles for SurveyJS surveys to ui-core so that they could be used in the form editor preview as well. However, some of those styles relied on a custom CSS class `survey-js-survey` applied in the participant UI. Since this class was not applied in the admin UI, the related styles did not apply to the form editor preview.

This removes the custom CSS class and bases the custom styles only on SurveyJS classes. This way, the styles apply in both participant and admin UIs without having to worry about adding the same class in both places.

## Before
![Screenshot 2023-06-12 at 10 45 40 AM](https://github.com/broadinstitute/juniper/assets/1156625/5e2e1abc-673e-4871-bdf7-aeb244e86f38)

## After
![Screenshot 2023-06-12 at 10 45 50 AM](https://github.com/broadinstitute/juniper/assets/1156625/63035f21-185f-4c54-ad7e-91730e4372b7)
