### PR TITLE
[JN-378] Add designer tab and table of contents to form editor

### DIFF
--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -3,6 +3,7 @@ import { Tab, Tabs } from 'react-bootstrap'
 
 import { FormContent } from '@juniper/ui-core'
 
+import { FormDesigner } from './FormDesigner'
 import { OnChangeFormContent } from './formEditorTypes'
 import { FormContentJsonEditor } from './FormContentJsonEditor'
 import { FormPreview } from './FormPreview'
@@ -16,7 +17,7 @@ type FormContentEditorProps = {
 export const FormContentEditor = (props: FormContentEditorProps) => {
   const { initialContent, readOnly, onChange } = props
 
-  const [activeTab, setActiveTab] = useState<string | null>('json')
+  const [activeTab, setActiveTab] = useState<string | null>('designer')
   const [tabsEnabled, setTabsEnabled] = useState(true)
 
   const [editedContent, setEditedContent] = useState(() => JSON.parse(initialContent) as FormContent)
@@ -30,6 +31,16 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
         unmountOnExit
         onSelect={setActiveTab}
       >
+        <Tab
+          disabled={activeTab !== 'designer' && !tabsEnabled}
+          eventKey="designer"
+          title="Designer"
+        >
+          <FormDesigner
+            value={editedContent}
+            onChange={setEditedContent}
+          />
+        </Tab>
         <Tab
           disabled={activeTab !== 'json' && !tabsEnabled}
           eventKey="json"

--- a/ui-admin/src/forms/FormDesigner.tsx
+++ b/ui-admin/src/forms/FormDesigner.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react'
+
+import { FormContent } from '@juniper/ui-core'
+
+import { FormTableOfContents } from './FormTableOfContents'
+
+type FormDesignerProps = {
+  readOnly?: boolean
+  value: FormContent
+  onChange: (editedContent: FormContent) => void
+}
+
+export const FormDesigner = (props: FormDesignerProps) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { readOnly = false, value, onChange } = props
+
+  const [selectedElementName, setSelectedElementName] = useState<string>()
+
+  return (
+    <div className="overflow-hidden flex-grow-1 d-flex flex-row mh-100" style={{ flexBasis: 0 }}>
+      <div className="flex-shrink-0 border-end" style={{ width: 400, overflowY: 'scroll' }}>
+        <FormTableOfContents
+          formContent={value}
+          selectedElementName={selectedElementName}
+          onSelectElement={setSelectedElementName}
+        />
+      </div>
+      <div className="flex-grow-1 overflow-scroll">
+      </div>
+    </div>
+  )
+}

--- a/ui-admin/src/forms/FormTableOfContents.test.tsx
+++ b/ui-admin/src/forms/FormTableOfContents.test.tsx
@@ -1,0 +1,125 @@
+/* eslint-disable jest/expect-expect */
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+
+import { FormContent } from '@juniper/ui-core'
+
+import { FormTableOfContents } from './FormTableOfContents'
+
+const formContent: FormContent = {
+  title: 'Test Survey',
+  pages: [
+    {
+      elements: [
+        {
+          type: 'html',
+          name: 'page1_intro',
+          html: '<h1>Name</h1>'
+        },
+        {
+          type: 'panel',
+          elements: [
+            {
+              name: 'first_name',
+              type: 'text',
+              title: 'First name?'
+            },
+            {
+              name: 'last_name',
+              type: 'text',
+              title: 'Last name?'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      elements: [
+        {
+          name: 'address',
+          questionTemplateName: 'address_template'
+        }
+      ]
+    }
+  ],
+  questionTemplates: [
+    {
+      name: 'address_template',
+      type: 'text',
+      title: 'Address?'
+    }
+  ]
+}
+
+describe('FormTableOfContents', () => {
+  it('renders table of contents as a tree', () => {
+    // Act
+    render(
+      <FormTableOfContents
+        formContent={formContent}
+        selectedElementName={undefined}
+        onSelectElement={jest.fn()}
+      />
+    )
+
+    // Assert
+    ;['page1_intro', 'first_name', 'last_name', 'address', 'address_template'].forEach(questionName => {
+      screen.getByText(questionName)
+    })
+
+    const getTreeItemChildren = (name: string) => {
+      const treeItem = screen.getByText(name)
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const childListItems = Array.from(treeItem.parentElement!.querySelector('ul')!.children)
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return childListItems.map(el => el.querySelector('a')!.textContent)
+    }
+
+    expect(getTreeItemChildren('Form')).toEqual(['Pages', 'Question templates'])
+    expect(getTreeItemChildren('Pages')).toEqual(['Page 1', 'Page 2'])
+    expect(getTreeItemChildren('Page 1')).toEqual(['page1_intro', 'Panel (2 elements)'])
+    expect(getTreeItemChildren('Page 2')).toEqual(['address'])
+    expect(getTreeItemChildren('Question templates')).toEqual(['address_template'])
+  })
+
+  it.each(['page1_intro', 'first_name'])('allows selecting html elements and questions', async elementName => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const onSelectElement = jest.fn()
+    render(
+      <FormTableOfContents
+        formContent={formContent}
+        selectedElementName={undefined}
+        onSelectElement={onSelectElement}
+      />
+    )
+
+    // Act
+    await user.click(screen.getByText(elementName))
+
+    // Assert
+    expect(onSelectElement).toHaveBeenCalledWith(elementName)
+  })
+
+  it.each(['Page 1', 'Panel (2 elements)'])('it does not allow selecting other elements', async elementName => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const onSelectElement = jest.fn()
+    render(
+      <FormTableOfContents
+        formContent={formContent}
+        selectedElementName={undefined}
+        onSelectElement={onSelectElement}
+      />
+    )
+
+    // Act
+    await user.click(screen.getByText(elementName))
+
+    // Assert
+    expect(onSelectElement).not.toHaveBeenCalled()
+  })
+})

--- a/ui-admin/src/forms/FormTableOfContents.tsx
+++ b/ui-admin/src/forms/FormTableOfContents.tsx
@@ -18,6 +18,7 @@ type TableOfContentsEntry = {
   children: TableOfContentsEntry[]
 }
 
+/** Recursive helper for getTableOfContents. */
 const getTableOfContentsHelper = (formElement: FormElement): TableOfContentsEntry => {
   if ('type' in formElement && formElement.type === 'panel') {
     return {
@@ -34,6 +35,7 @@ const getTableOfContentsHelper = (formElement: FormElement): TableOfContentsEntr
   }
 }
 
+/** Convert a FormContent object into a TableOfContentsEntry. */
 const getTableOfContents = (formContent: FormContent): TableOfContentsEntry => {
   return {
     type: 'form',
@@ -61,10 +63,12 @@ const getTableOfContents = (formContent: FormContent): TableOfContentsEntry => {
   }
 }
 
+/** Should a table of contents entry be expandable? */
 const isEntryTypeExpandable = (entryType: string): boolean => {
   return entryType !== 'questionOrHtml'
 }
 
+/** Should a table of contents entry be selectable? */
 const isEntryTypeSelectable = (entryType: string): boolean => {
   return entryType === 'questionOrHtml'
 }
@@ -79,6 +83,7 @@ type EntryContentsProps = {
   onSelectEntry: (name: string) => void
 }
 
+/** Render the contents/children of a table of contents entry. */
 export const EntryContents = (props: EntryContentsProps) => {
   const {
     activeDescendant,
@@ -128,6 +133,7 @@ type EntryProps = {
   onSelectEntry: (name: string) => void
 }
 
+/** Render a table of contents entry. */
 export const Entry = (props: EntryProps) => {
   const {
     activeDescendant,
@@ -238,6 +244,7 @@ type FormTableOfContentsProps = {
   onSelectElement: (name: string) => void
 }
 
+/** Render a table of contents for a form. */
 export const FormTableOfContents = (props: FormTableOfContentsProps) => {
   const { formContent, selectedElementName, onSelectElement } = props
 

--- a/ui-admin/src/forms/FormTableOfContents.tsx
+++ b/ui-admin/src/forms/FormTableOfContents.tsx
@@ -1,0 +1,346 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons'
+import React, { Dispatch, SetStateAction, useRef, useState } from 'react'
+
+import { FormContent, FormElement } from '@juniper/ui-core'
+
+type TableOfContentsEntryType =
+  | 'form'
+  | 'pages'
+  | 'questionTemplates'
+  | 'page'
+  | 'panel'
+  | 'questionOrHtml'
+
+type TableOfContentsEntry = {
+  name: string
+  type: TableOfContentsEntryType
+  children: TableOfContentsEntry[]
+}
+
+const getTableOfContentsHelper = (formElement: FormElement): TableOfContentsEntry => {
+  if ('type' in formElement && formElement.type === 'panel') {
+    return {
+      name: `Panel (${formElement.elements.length} elements)`,
+      type: 'panel',
+      children: formElement.elements.map(getTableOfContentsHelper)
+    }
+  } else {
+    return {
+      name: formElement.name,
+      type: 'questionOrHtml',
+      children: []
+    }
+  }
+}
+
+const getTableOfContents = (formContent: FormContent): TableOfContentsEntry => {
+  return {
+    type: 'form',
+    name: 'Form',
+    children: [
+      {
+        name: 'Pages',
+        type: 'pages',
+        children: (formContent.pages || []).map((page, pageIndex) => ({
+          name: `Page ${pageIndex + 1}`,
+          type: 'page',
+          children: page.elements.map(getTableOfContentsHelper)
+        }))
+      },
+      {
+        name: 'Question templates',
+        type: 'questionTemplates',
+        children: (formContent.questionTemplates || []).map(question => ({
+          name: question.name,
+          type: 'questionOrHtml',
+          children: []
+        }))
+      }
+    ]
+  }
+}
+
+const isEntryTypeExpandable = (entryType: string): boolean => {
+  return entryType !== 'questionOrHtml'
+}
+
+const isEntryTypeSelectable = (entryType: string): boolean => {
+  return entryType === 'questionOrHtml'
+}
+
+type EntryContentsProps = {
+  activeDescendant: string
+  entry: TableOfContentsEntry
+  level: number
+  parentId: string
+  selectedEntryName: string | undefined
+  setActiveDescendant: Dispatch<SetStateAction<string>>
+  onSelectEntry: (name: string) => void
+}
+
+export const EntryContents = (props: EntryContentsProps) => {
+  const {
+    activeDescendant,
+    entry,
+    level,
+    parentId,
+    selectedEntryName,
+    setActiveDescendant,
+    onSelectEntry
+  } = props
+
+  return (
+    <ul
+      aria-label={`${entry.name} children`}
+      role="group"
+      style={{
+        padding: 0,
+        margin: 0,
+        listStyleType: 'none'
+      }}
+    >
+      {entry.children.map((childEntry, index) => {
+        return (
+          <Entry
+            key={index}
+            activeDescendant={activeDescendant}
+            entry={childEntry}
+            id={`${parentId}-${index}`}
+            level={level + 1}
+            selectedEntryName={selectedEntryName}
+            setActiveDescendant={setActiveDescendant}
+            onSelectEntry={onSelectEntry}
+          />
+        )
+      })}
+    </ul>
+  )
+}
+
+type EntryProps = {
+  activeDescendant: string
+  entry: TableOfContentsEntry
+  id: string
+  level: number
+  selectedEntryName: string | undefined
+  setActiveDescendant: Dispatch<SetStateAction<string>>
+  onSelectEntry: (name: string) => void
+}
+
+export const Entry = (props: EntryProps) => {
+  const {
+    activeDescendant,
+    entry,
+    id,
+    level,
+    selectedEntryName,
+    setActiveDescendant,
+    onSelectEntry
+  } = props
+
+  const hasChildren = entry.children.length > 0
+  const isExpandable = isEntryTypeExpandable(entry.type) && hasChildren
+  const [isExpanded, setIsExpanded] = useState(true)
+
+  const isSelected = selectedEntryName && selectedEntryName === entry.name
+
+  return (
+    <li
+      aria-expanded={isExpandable ? isExpanded : undefined}
+      // Label with the link to read only the entry name instead of both the entry name and the children list label.
+      aria-labelledby={`${id}-link`}
+      // aria-level starts at 1, level starts at 0.
+      aria-level={level + 1}
+      // aria-selected: false results in every tree item being read as "selected".
+      aria-selected={isSelected ? true : undefined}
+      // Data attribute allows getting the entry from the activedescendant element ID.
+      data-name={entry.name}
+      data-type={entry.type}
+      id={id}
+      role="treeitem"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        position: 'relative'
+      }}
+    >
+      {/* Wrapper span provides a larger click target than just the icon. */}
+      <span
+        aria-hidden
+        style={{
+          position: 'absolute',
+          top: '1px',
+          left: `${level - 1}rem`,
+          display: 'flex',
+          justifyContent: 'flex-end',
+          alignItems: 'center',
+          width: '2rem',
+          height: '2rem'
+        }}
+        onClick={() => {
+          setIsExpanded(!isExpanded)
+          // If the active descendant is a child of this entry and thus will be removed,
+          // set the active descendant to this entry.
+          if (isExpanded && activeDescendant.startsWith(`${id}-`)) {
+            setActiveDescendant(id)
+          }
+        }}
+      >
+        {isExpandable && <FontAwesomeIcon icon={isExpanded ? faChevronDown : faChevronRight} />}
+      </span>
+      <a
+        id={`${id}-link`}
+        role="presentation"
+        tabIndex={-1}
+        style={{
+          display: 'inline-block',
+          overflow: 'hidden',
+          maxWidth: '100%',
+          padding: `0.25rem 0.5rem 0.25rem ${level + 1.25}rem`,
+          borderColor: id === activeDescendant ? 'var(--bs-primary)' : 'transparent',
+          borderStyle: 'solid',
+          borderWidth: '1px 0',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          ...(isSelected && {
+            background: 'var(--bs-primary)',
+            color: 'white'
+          })
+        }}
+        onClick={() => {
+          setIsExpanded(true)
+          if (isEntryTypeSelectable(entry.type)) {
+            onSelectEntry(entry.name)
+          }
+        }}
+      >
+        {entry.name}
+      </a>
+      {isExpanded && (
+        <EntryContents
+          activeDescendant={activeDescendant}
+          entry={entry}
+          level={level}
+          parentId={id}
+          selectedEntryName={selectedEntryName}
+          setActiveDescendant={setActiveDescendant}
+          onSelectEntry={onSelectEntry}
+        />
+      )}
+    </li>
+  )
+}
+
+type FormTableOfContentsProps = {
+  formContent: FormContent
+  selectedElementName: string | undefined
+  onSelectElement: (name: string) => void
+}
+
+export const FormTableOfContents = (props: FormTableOfContentsProps) => {
+  const { formContent, selectedElementName, onSelectElement } = props
+
+  const treeElementRef = useRef<HTMLUListElement | null>(null)
+
+  const [activeDescendant, setActiveDescendant] = useState('node-0')
+
+  return (
+    <ul
+      ref={treeElementRef}
+      // aria-activedescendant tells which tree item is "focused", while actual focus stays on the tree itself.
+      aria-activedescendant={activeDescendant}
+      aria-label="Table of contents"
+      role="tree"
+      tabIndex={0}
+      style={{
+        padding: 0,
+        border: '2px solid transparent',
+        margin: 0,
+        listStyleType: 'none'
+      }}
+      onKeyDown={e => {
+        // If the key isn't relevant to tree navigation, do nothing.
+        if (!(e.key === 'Enter' || e.key.startsWith('Arrow'))) {
+          return
+        }
+
+        e.preventDefault()
+        e.stopPropagation()
+
+        /* eslint-disable @typescript-eslint/no-non-null-assertion */
+        const currentTreeItem = document.getElementById(activeDescendant)
+
+        if (!currentTreeItem) {
+          // If the active descendant isn't found (for example, if it was in a group that has been collapsed),
+          // then reset the active descendant to the first item in the tree.
+          setActiveDescendant('node-0')
+        } else if (e.key === 'Enter') {
+          // Otherwise, select the question for the current tree item if it is a question.
+          const name = currentTreeItem.dataset.name!
+          const type = currentTreeItem.dataset.type!
+          if (isEntryTypeSelectable(type)) {
+            onSelectElement(name)
+          }
+          // onSelectElement(name)
+        } else if (e.key === 'ArrowLeft') {
+          const isExpanded = currentTreeItem.getAttribute('aria-expanded') === 'true'
+          if (isExpanded) {
+            // Close the tree item if it is open.
+            (currentTreeItem.firstElementChild as HTMLElement)!.click()
+          } else {
+            // If the tree item is closed, move to the parent tree item (if there is one).
+            const parentGroup = currentTreeItem.parentElement!
+            if (parentGroup.getAttribute('role') === 'group') {
+              // If the parent group is a group within the tree, move up the tree.
+              // Else if the parent group is the tree itself, do nothing.
+              const parentTreeItem = parentGroup.parentElement!
+              setActiveDescendant(parentTreeItem.id)
+            }
+          }
+        } else if (e.key === 'ArrowRight') {
+          const expanded = currentTreeItem.getAttribute('aria-expanded')
+          if (expanded === 'false') {
+            // Open the tree item if it is currently closed.
+            (currentTreeItem.firstElementChild as HTMLElement)!.click()
+          } else if (expanded === 'true') {
+            // Move to the first child node.
+            // If the current tree item has no children, then do nothing.
+            const firstChildTreeItem = currentTreeItem.lastElementChild!.firstElementChild
+            if (firstChildTreeItem) {
+              setActiveDescendant(firstChildTreeItem.id)
+            }
+          }
+        } else if (e.key === 'ArrowDown') {
+          // Move to the next tree item without opening/closing any tree items.
+          const allTreeItemIds = Array.from(treeElementRef.current!.querySelectorAll('[role="treeitem"]')).map(
+            el => el.id
+          )
+          const indexOfCurrentTreeItem = allTreeItemIds.findIndex(id => id === activeDescendant)
+          if (indexOfCurrentTreeItem < allTreeItemIds.length - 1) {
+            setActiveDescendant(allTreeItemIds[indexOfCurrentTreeItem + 1])
+          }
+        } else if (e.key === 'ArrowUp') {
+          // Move to the previous tree item without opening/closing any tree items.
+          const allTreeItemIds = Array.from(treeElementRef.current!.querySelectorAll('[role="treeitem"]')).map(
+            el => el.id
+          )
+          const indexOfCurrentTreeItem = allTreeItemIds.findIndex(id => id === activeDescendant)
+          if (indexOfCurrentTreeItem > 0) {
+            setActiveDescendant(allTreeItemIds[indexOfCurrentTreeItem - 1])
+          }
+        }
+      }}
+    >
+      <Entry
+        activeDescendant={activeDescendant}
+        entry={getTableOfContents(formContent)}
+        id="node-0"
+        level={0}
+        selectedEntryName={selectedElementName}
+        setActiveDescendant={setActiveDescendant}
+        onSelectEntry={onSelectElement}
+      />
+    </ul>
+  )
+}

--- a/ui-core/src/surveyUtils.test.ts
+++ b/ui-core/src/surveyUtils.test.ts
@@ -15,13 +15,13 @@ describe('surveyJSModelFromFormContent', () => {
       pages: [
         {
           elements: [
-            { type: 'html', html: '<span>Talk about your brother</span>' },
+            { type: 'html', name: 'brotherIntro', html: '<span>Talk about your brother</span>' },
             { name: 'brotherFavoriteColor', questionTemplateName: 'colorPicker' }
           ]
         },
         {
           elements: [
-            { type: 'html', html: '<span>Talk about your sister</span>' },
+            { type: 'html', name: 'sisterIntro', html: '<span>Talk about your sister</span>' },
             { name: 'sisterFavoriteColor', questionTemplateName: 'colorPicker' }
           ]
         }

--- a/ui-core/src/types/forms.ts
+++ b/ui-core/src/types/forms.ts
@@ -87,6 +87,7 @@ export type FormPanel = BaseElement & {
 }
 
 export type HtmlElement = {
+  name: string
   type: 'html'
   html: string
 }


### PR DESCRIPTION
This adds a "Designer" tab to the form editor. For now, this tab contains a table of contents for all elements in the form. The intent is that when a user selects one of the elements in the table of contents, the right panel will show a form for editing that element.

![Screenshot 2023-06-13 at 12 21 52 PM](https://github.com/broadinstitute/juniper/assets/1156625/1744335b-d366-4cad-bc46-9d7424236745)
