### PR TITLE
[JN-378] Revise form editor table of contents

### DIFF
--- a/ui-admin/src/components/Tree.test.tsx
+++ b/ui-admin/src/components/Tree.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+import { Tree, TreeItemT } from './Tree'
+
+describe('Tree', () => {
+  const rootItem: TreeItemT<string> = {
+    label: 'root',
+    data: '',
+    children: [
+      {
+        label: 'a',
+        data: 'a',
+        children: [
+          {
+            label: 'a1',
+            data: 'a1'
+          },
+          {
+            label: 'a2',
+            data: 'a2'
+          }
+        ]
+      },
+      {
+        label: 'b',
+        data: 'b'
+      }
+    ]
+  }
+
+  it('renders tree', () => {
+    // Act
+    render(
+      <Tree
+        id="test-tree"
+        label="Test tree"
+        isItemSelected={() => false}
+        rootItem={rootItem}
+        onClickItem={() => { /* noop */ }}
+      />
+    )
+
+    // Assert
+    ;['root', 'a', 'a1', 'a2', 'b'].forEach(itemName => {
+      screen.getByText(itemName)
+    })
+
+    const getTreeItemChildren = (name: string) => {
+      const treeItem = screen.getByText(name)
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const childListItems = Array.from(treeItem.parentElement!.querySelector('ul')!.children)
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return childListItems.map(el => el.querySelector('a')!.textContent)
+    }
+
+    expect(getTreeItemChildren('root')).toEqual(['a', 'b'])
+    expect(getTreeItemChildren('a')).toEqual(['a1', 'a2'])
+  })
+})

--- a/ui-admin/src/components/Tree.tsx
+++ b/ui-admin/src/components/Tree.tsx
@@ -4,19 +4,39 @@ import { get } from 'lodash'
 import React, { Dispatch, SetStateAction, useRef, useState } from 'react'
 
 export type TreeItemT<T> = {
+  /** User facing label. */
   label: string
+
+  /** Data associated with this tree item. */
   data: T
+
+  /** Child tree items. */
   children?: TreeItemT<T>[]
 }
 
 type TreeItemProps<T> = {
+  /** ID of the tree's current active descendant element. */
   activeDescendant: string
+
+  /** ID for this tree item element. */
   id: string
+
+  /** Should the given tree item be rendered as selected? */
   isItemSelected: (item: TreeItemT<T>) => boolean
+
+  /** This tree item's data model. */
   item: TreeItemT<T>
+
+  /** Level within the tree (root is level 0, its children are level 1, etc). */
   level: number
+
+  /** Path to this item from the tree root in object notation. For example, 'children[0].children[1]'. */
   path: string
+
+  /** Update the tree's active descendant. */
   setActiveDescendant: Dispatch<SetStateAction<string>>
+
+  /** Callback when a tree item is clicked. */
   onClickItem: (item: TreeItemT<T>) => void
 }
 
@@ -140,10 +160,19 @@ export const TreeItem = <T, >(props: TreeItemProps<T>) => {
 }
 
 type TreeProps<T> = {
+  /** ID for the tree element. */
   id: string
+
+  /** Should the given tree item be rendered as selected? */
   isItemSelected: (item: TreeItemT<T>) => boolean
+
+  /** ARIA label for the tree element. */
   label: string
+
+  /** Data model for the tree. */
   rootItem: TreeItemT<T>
+
+  /** Callback when a tree item is clicked. */
   onClickItem: (item: TreeItemT<T>) => void
 }
 

--- a/ui-admin/src/components/Tree.tsx
+++ b/ui-admin/src/components/Tree.tsx
@@ -1,0 +1,256 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons'
+import { get } from 'lodash'
+import React, { Dispatch, SetStateAction, useRef, useState } from 'react'
+
+export type TreeItemT<T> = {
+  label: string
+  data: T
+  children?: TreeItemT<T>[]
+}
+
+type TreeItemProps<T> = {
+  activeDescendant: string
+  id: string
+  isItemSelected: (item: TreeItemT<T>) => boolean
+  item: TreeItemT<T>
+  level: number
+  path: string
+  setActiveDescendant: Dispatch<SetStateAction<string>>
+  onClickItem: (item: TreeItemT<T>) => void
+}
+
+/** Render a tree item. */
+export const TreeItem = <T, >(props: TreeItemProps<T>) => {
+  const {
+    activeDescendant,
+    id,
+    isItemSelected,
+    item,
+    level,
+    path,
+    setActiveDescendant,
+    onClickItem
+  } = props
+
+  const isExpandable = item.children !== undefined
+  const [isExpanded, setIsExpanded] = useState(isExpandable)
+
+  const isSelected = isItemSelected(item)
+
+  return (
+    <li
+      aria-expanded={isExpandable ? isExpanded : undefined}
+      // Label with the link to read only the item label instead of both the item label and the children list label.
+      aria-labelledby={`${id}-link`}
+      // aria-level starts at 1, level starts at 0.
+      aria-level={level + 1}
+      // aria-selected: false results in every tree item being read as "selected".
+      aria-selected={isSelected ? true : undefined}
+      // Data attribute allows getting the item from the activedescendant element ID.
+      data-path={path}
+      id={id}
+      role="treeitem"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        position: 'relative'
+      }}
+    >
+      {/* Wrapper span provides a larger click target than just the icon. */}
+      <span
+        aria-hidden
+        style={{
+          position: 'absolute',
+          top: '1px',
+          left: `${level - 1}rem`,
+          display: 'flex',
+          justifyContent: 'flex-end',
+          alignItems: 'center',
+          width: '2rem',
+          height: '2rem'
+        }}
+        onClick={() => {
+          setIsExpanded(!isExpanded)
+          // If the active descendant is a child of this item and thus will be removed,
+          // set the active descendant to this item.
+          if (isExpanded && activeDescendant.startsWith(`${id}-`)) {
+            setActiveDescendant(id)
+          }
+        }}
+      >
+        {isExpandable && <FontAwesomeIcon icon={isExpanded ? faChevronDown : faChevronRight} />}
+      </span>
+      <a
+        id={`${id}-link`}
+        role="presentation"
+        tabIndex={-1}
+        style={{
+          display: 'inline-block',
+          overflow: 'hidden',
+          maxWidth: '100%',
+          padding: `0.25rem 0.5rem 0.25rem ${level + 1.25}rem`,
+          borderColor: id === activeDescendant ? 'var(--bs-primary)' : 'transparent',
+          borderStyle: 'solid',
+          borderWidth: '1px 0',
+          cursor: 'default',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          ...(isSelected && {
+            background: 'var(--bs-primary)',
+            color: 'white'
+          })
+        }}
+        onClick={() => {
+          setIsExpanded(true)
+          onClickItem(item)
+        }}
+      >
+        {item.label}
+      </a>
+      {isExpanded && (
+        <ul
+          aria-label={`${item.label} children`}
+          role="group"
+          style={{
+            padding: 0,
+            margin: 0,
+            listStyleType: 'none'
+          }}
+        >
+          {item.children?.map((childItem, index) => {
+            return (
+              <TreeItem<T>
+                key={index}
+                activeDescendant={activeDescendant}
+                id={`${id}-${index}`}
+                isItemSelected={isItemSelected}
+                item={childItem}
+                level={level + 1}
+                path={`${path}${path === '' ? '' : '.'}children[${index}]`}
+                setActiveDescendant={setActiveDescendant}
+                onClickItem={onClickItem}
+              />
+            )
+          })}
+        </ul>
+      )}
+    </li>
+  )
+}
+
+type TreeProps<T> = {
+  id: string
+  isItemSelected: (item: TreeItemT<T>) => boolean
+  label: string
+  rootItem: TreeItemT<T>
+  onClickItem: (item: TreeItemT<T>) => void
+}
+
+/** Render a tree. */
+export const Tree = <T, >(props: TreeProps<T>) => {
+  const { id, isItemSelected, label, rootItem, onClickItem } = props
+
+  const treeElementRef = useRef<HTMLUListElement | null>(null)
+
+  const [activeDescendant, setActiveDescendant] = useState(`${id}-node-0`)
+
+  return (
+    <ul
+      ref={treeElementRef}
+      // aria-activedescendant tells which tree item is "focused", while actual focus stays on the tree itself.
+      aria-activedescendant={activeDescendant}
+      aria-label={label}
+      role="tree"
+      tabIndex={0}
+      style={{
+        padding: 0,
+        border: '2px solid transparent',
+        margin: 0,
+        listStyleType: 'none'
+      }}
+      onKeyDown={e => {
+        // If the key isn't relevant to tree navigation, do nothing.
+        if (!(e.key === 'Enter' || e.key.startsWith('Arrow'))) {
+          return
+        }
+
+        e.preventDefault()
+        e.stopPropagation()
+
+        /* eslint-disable @typescript-eslint/no-non-null-assertion */
+        const currentTreeItem = document.getElementById(activeDescendant)
+
+        if (!currentTreeItem) {
+          // If the active descendant isn't found (for example, if it was in a group that has been collapsed),
+          // then reset the active descendant to the first item in the tree.
+          setActiveDescendant('node-0')
+        } else if (e.key === 'Enter') {
+          // Otherwise, call click callback for the current tree item.
+          const currentTreeItemPath = currentTreeItem.dataset.path!
+          const treeItem: TreeItemT<T> = currentTreeItemPath === ''
+            ? rootItem
+            : get(rootItem, currentTreeItemPath)
+          onClickItem(treeItem)
+        } else if (e.key === 'ArrowLeft') {
+          const isExpanded = currentTreeItem.getAttribute('aria-expanded') === 'true'
+          if (isExpanded) {
+            // Close the tree item if it is open.
+            (currentTreeItem.firstElementChild as HTMLElement)!.click()
+          } else {
+            // If the tree item is closed, move to the parent tree item (if there is one).
+            const parentGroup = currentTreeItem.parentElement!
+            if (parentGroup.getAttribute('role') === 'group') {
+              // If the parent group is a group within the tree, move up the tree.
+              // Else if the parent group is the tree itself, do nothing.
+              const parentTreeItem = parentGroup.parentElement!
+              setActiveDescendant(parentTreeItem.id)
+            }
+          }
+        } else if (e.key === 'ArrowRight') {
+          const expanded = currentTreeItem.getAttribute('aria-expanded')
+          if (expanded === 'false') {
+            // Open the tree item if it is currently closed.
+            (currentTreeItem.firstElementChild as HTMLElement)!.click()
+          } else if (expanded === 'true') {
+            // Move to the first child node.
+            // If the current tree item has no children, then do nothing.
+            const firstChildTreeItem = currentTreeItem.lastElementChild!.firstElementChild
+            if (firstChildTreeItem) {
+              setActiveDescendant(firstChildTreeItem.id)
+            }
+          }
+        } else if (e.key === 'ArrowDown') {
+          // Move to the next tree item without opening/closing any tree items.
+          const allTreeItemIds = Array.from(treeElementRef.current!.querySelectorAll('[role="treeitem"]')).map(
+            el => el.id
+          )
+          const indexOfCurrentTreeItem = allTreeItemIds.findIndex(id => id === activeDescendant)
+          if (indexOfCurrentTreeItem < allTreeItemIds.length - 1) {
+            setActiveDescendant(allTreeItemIds[indexOfCurrentTreeItem + 1])
+          }
+        } else if (e.key === 'ArrowUp') {
+          // Move to the previous tree item without opening/closing any tree items.
+          const allTreeItemIds = Array.from(treeElementRef.current!.querySelectorAll('[role="treeitem"]')).map(
+            el => el.id
+          )
+          const indexOfCurrentTreeItem = allTreeItemIds.findIndex(id => id === activeDescendant)
+          if (indexOfCurrentTreeItem > 0) {
+            setActiveDescendant(allTreeItemIds[indexOfCurrentTreeItem - 1])
+          }
+        }
+      }}
+    >
+      <TreeItem<T>
+        activeDescendant={activeDescendant}
+        id={`${id}-node-0`}
+        isItemSelected={isItemSelected}
+        item={rootItem}
+        level={0}
+        path=""
+        setActiveDescendant={setActiveDescendant}
+        onClickItem={onClickItem}
+      />
+    </ul>
+  )
+}

--- a/ui-admin/src/forms/FormDesigner.tsx
+++ b/ui-admin/src/forms/FormDesigner.tsx
@@ -15,18 +15,27 @@ export const FormDesigner = (props: FormDesignerProps) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { readOnly = false, value, onChange } = props
 
-  const [selectedElementName, setSelectedElementName] = useState<string>()
+  const [selectedElementPath, setSelectedElementPath] = useState<string>()
 
   return (
     <div className="overflow-hidden flex-grow-1 d-flex flex-row mh-100" style={{ flexBasis: 0 }}>
       <div className="flex-shrink-0 border-end" style={{ width: 400, overflowY: 'scroll' }}>
         <FormTableOfContents
           formContent={value}
-          selectedElementName={selectedElementName}
-          onSelectElement={setSelectedElementName}
+          selectedElementPath={selectedElementPath}
+          onSelectElement={setSelectedElementPath}
         />
       </div>
       <div className="flex-grow-1 overflow-scroll">
+        {(() => {
+          if (selectedElementPath === undefined) {
+            return (
+              <p className="mt-5 text-center">Select an element to edit</p>
+            )
+          }
+
+          return null
+        })()}
       </div>
     </div>
   )

--- a/ui-admin/src/forms/FormTableOfContents.test.tsx
+++ b/ui-admin/src/forms/FormTableOfContents.test.tsx
@@ -1,11 +1,6 @@
-/* eslint-disable jest/expect-expect */
-import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import React from 'react'
-
 import { FormContent } from '@juniper/ui-core'
 
-import { FormTableOfContents } from './FormTableOfContents'
+import { getTableOfContentsTree } from './FormTableOfContents'
 
 const formContent: FormContent = {
   title: 'Test Survey',
@@ -52,74 +47,100 @@ const formContent: FormContent = {
   ]
 }
 
-describe('FormTableOfContents', () => {
-  it('renders table of contents as a tree', () => {
+describe('getTableOfContentsTree', () => {
+  it('returns a table of contents tree', () => {
     // Act
-    render(
-      <FormTableOfContents
-        formContent={formContent}
-        selectedElementName={undefined}
-        onSelectElement={jest.fn()}
-      />
-    )
+    const tableOfContentsTree = getTableOfContentsTree(formContent)
 
     // Assert
-    ;['page1_intro', 'first_name', 'last_name', 'address', 'address_template'].forEach(questionName => {
-      screen.getByText(questionName)
+    expect(tableOfContentsTree).toEqual({
+      label: 'Form',
+      data: {
+        isSelectable: false,
+        path: ''
+      },
+      children: [
+        {
+          label: 'Pages',
+          data: {
+            isSelectable: false,
+            path: 'pages'
+          },
+          children: [
+            {
+              label: 'Page 1',
+              data: {
+                isSelectable: true,
+                path: 'pages[0]'
+              },
+              children: [
+                {
+                  label: 'page1_intro',
+                  data: {
+                    isSelectable: true,
+                    path: 'pages[0].elements[0]'
+                  }
+                },
+                {
+                  label: 'Panel (2 elements)',
+                  data: {
+                    isSelectable: true,
+                    path: 'pages[0].elements[1]'
+                  },
+                  children: [
+                    {
+                      label: 'first_name',
+                      data: {
+                        isSelectable: true,
+                        path: 'pages[0].elements[1].elements[0]'
+                      }
+                    },
+                    {
+                      label: 'last_name',
+                      data: {
+                        isSelectable: true,
+                        path: 'pages[0].elements[1].elements[1]'
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              label: 'Page 2',
+              data: {
+                isSelectable: true,
+                path: 'pages[1]'
+              },
+              children: [
+                {
+                  label: 'address',
+                  data: {
+                    isSelectable: true,
+                    path: 'pages[1].elements[0]'
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          label: 'Question templates',
+          data: {
+            isSelectable: false,
+            path: 'questionTemplates'
+          },
+          children: [
+            {
+              label: 'address_template',
+              data: {
+                isSelectable: true,
+                path: 'questionTemplates[0]'
+              }
+            }
+          ]
+        }
+      ]
     })
-
-    const getTreeItemChildren = (name: string) => {
-      const treeItem = screen.getByText(name)
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const childListItems = Array.from(treeItem.parentElement!.querySelector('ul')!.children)
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      return childListItems.map(el => el.querySelector('a')!.textContent)
-    }
-
-    expect(getTreeItemChildren('Form')).toEqual(['Pages', 'Question templates'])
-    expect(getTreeItemChildren('Pages')).toEqual(['Page 1', 'Page 2'])
-    expect(getTreeItemChildren('Page 1')).toEqual(['page1_intro', 'Panel (2 elements)'])
-    expect(getTreeItemChildren('Page 2')).toEqual(['address'])
-    expect(getTreeItemChildren('Question templates')).toEqual(['address_template'])
-  })
-
-  it.each(['page1_intro', 'first_name'])('allows selecting html elements and questions', async elementName => {
-    // Arrange
-    const user = userEvent.setup()
-
-    const onSelectElement = jest.fn()
-    render(
-      <FormTableOfContents
-        formContent={formContent}
-        selectedElementName={undefined}
-        onSelectElement={onSelectElement}
-      />
-    )
-
-    // Act
-    await user.click(screen.getByText(elementName))
-
-    // Assert
-    expect(onSelectElement).toHaveBeenCalledWith(elementName)
-  })
-
-  it.each(['Page 1', 'Panel (2 elements)'])('it does not allow selecting other elements', async elementName => {
-    // Arrange
-    const user = userEvent.setup()
-
-    const onSelectElement = jest.fn()
-    render(
-      <FormTableOfContents
-        formContent={formContent}
-        selectedElementName={undefined}
-        onSelectElement={onSelectElement}
-      />
-    )
-
-    // Act
-    await user.click(screen.getByText(elementName))
-
-    // Assert
-    expect(onSelectElement).not.toHaveBeenCalled()
   })
 })

--- a/ui-admin/src/forms/FormTableOfContents.tsx
+++ b/ui-admin/src/forms/FormTableOfContents.tsx
@@ -5,7 +5,10 @@ import { FormContent, FormElement } from '@juniper/ui-core'
 import { Tree, TreeItemT } from 'components/Tree'
 
 type FormContentTableOfContentsTreeItem = TreeItemT<{
+  /** If this item can be selected. */
   isSelectable: boolean
+
+  /** Path to the form element associated with this tree item in object notation. For example, 'pages[0].elements[1]' */
   path: string
 }>
 

--- a/ui-admin/src/forms/FormTableOfContents.tsx
+++ b/ui-admin/src/forms/FormTableOfContents.tsx
@@ -1,353 +1,102 @@
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons'
-import React, { Dispatch, SetStateAction, useRef, useState } from 'react'
+import React from 'react'
 
 import { FormContent, FormElement } from '@juniper/ui-core'
 
-type TableOfContentsEntryType =
-  | 'form'
-  | 'pages'
-  | 'questionTemplates'
-  | 'page'
-  | 'panel'
-  | 'questionOrHtml'
+import { Tree, TreeItemT } from 'components/Tree'
 
-type TableOfContentsEntry = {
-  name: string
-  type: TableOfContentsEntryType
-  children: TableOfContentsEntry[]
-}
+type FormContentTableOfContentsTreeItem = TreeItemT<{
+  isSelectable: boolean
+  path: string
+}>
 
-/** Recursive helper for getTableOfContents. */
-const getTableOfContentsHelper = (formElement: FormElement): TableOfContentsEntry => {
-  if ('type' in formElement && formElement.type === 'panel') {
-    return {
-      name: `Panel (${formElement.elements.length} elements)`,
-      type: 'panel',
-      children: formElement.elements.map(getTableOfContentsHelper)
-    }
-  } else {
-    return {
-      name: formElement.name,
-      type: 'questionOrHtml',
-      children: []
+/** Recursive helper for getTableOfContentsTree. */
+const getTableOfContentsTreeHelper = (parentPath: string) => {
+  return (formElement: FormElement, elementIndex: number): FormContentTableOfContentsTreeItem => {
+    if ('type' in formElement && formElement.type === 'panel') {
+      return {
+        label: `Panel (${formElement.elements.length} elements)`,
+        data: {
+          isSelectable: true,
+          path: `${parentPath}[${elementIndex}]`
+        },
+        children: formElement.elements.map(getTableOfContentsTreeHelper(`${parentPath}[${elementIndex}].elements`))
+      }
+    } else {
+      return {
+        label: formElement.name,
+        data: {
+          isSelectable: true,
+          path: `${parentPath}[${elementIndex}]`
+        }
+      }
     }
   }
 }
 
-/** Convert a FormContent object into a TableOfContentsEntry. */
-const getTableOfContents = (formContent: FormContent): TableOfContentsEntry => {
+/** Convert a FormContent object into a TreeItemT to render the table of contents as a string. */
+export const getTableOfContentsTree = (formContent: FormContent): FormContentTableOfContentsTreeItem => {
   return {
-    type: 'form',
-    name: 'Form',
+    label: 'Form',
+    data: {
+      isSelectable: false,
+      path: ''
+    },
     children: [
       {
-        name: 'Pages',
-        type: 'pages',
+        label: 'Pages',
+        data: {
+          isSelectable: false,
+          path: 'pages'
+        },
         children: (formContent.pages || []).map((page, pageIndex) => ({
-          name: `Page ${pageIndex + 1}`,
-          type: 'page',
-          children: page.elements.map(getTableOfContentsHelper)
+          label: `Page ${pageIndex + 1}`,
+          data: {
+            isSelectable: true,
+            path: `pages[${pageIndex}]`
+          },
+          children: page.elements.map(getTableOfContentsTreeHelper(`pages[${pageIndex}].elements`))
         }))
       },
       {
-        name: 'Question templates',
-        type: 'questionTemplates',
-        children: (formContent.questionTemplates || []).map(question => ({
-          name: question.name,
-          type: 'questionOrHtml',
-          children: []
+        label: 'Question templates',
+        data: {
+          isSelectable: false,
+          path: 'questionTemplates'
+        },
+        children: (formContent.questionTemplates || []).map((question, questionIndex) => ({
+          label: question.name,
+          data: {
+            isSelectable: true,
+            path: `questionTemplates[${questionIndex}]`
+          }
         }))
       }
     ]
   }
 }
 
-/** Should a table of contents entry be expandable? */
-const isEntryTypeExpandable = (entryType: string): boolean => {
-  return entryType !== 'questionOrHtml'
-}
-
-/** Should a table of contents entry be selectable? */
-const isEntryTypeSelectable = (entryType: string): boolean => {
-  return entryType === 'questionOrHtml'
-}
-
-type EntryContentsProps = {
-  activeDescendant: string
-  entry: TableOfContentsEntry
-  level: number
-  parentId: string
-  selectedEntryName: string | undefined
-  setActiveDescendant: Dispatch<SetStateAction<string>>
-  onSelectEntry: (name: string) => void
-}
-
-/** Render the contents/children of a table of contents entry. */
-export const EntryContents = (props: EntryContentsProps) => {
-  const {
-    activeDescendant,
-    entry,
-    level,
-    parentId,
-    selectedEntryName,
-    setActiveDescendant,
-    onSelectEntry
-  } = props
-
-  return (
-    <ul
-      aria-label={`${entry.name} children`}
-      role="group"
-      style={{
-        padding: 0,
-        margin: 0,
-        listStyleType: 'none'
-      }}
-    >
-      {entry.children.map((childEntry, index) => {
-        return (
-          <Entry
-            key={index}
-            activeDescendant={activeDescendant}
-            entry={childEntry}
-            id={`${parentId}-${index}`}
-            level={level + 1}
-            selectedEntryName={selectedEntryName}
-            setActiveDescendant={setActiveDescendant}
-            onSelectEntry={onSelectEntry}
-          />
-        )
-      })}
-    </ul>
-  )
-}
-
-type EntryProps = {
-  activeDescendant: string
-  entry: TableOfContentsEntry
-  id: string
-  level: number
-  selectedEntryName: string | undefined
-  setActiveDescendant: Dispatch<SetStateAction<string>>
-  onSelectEntry: (name: string) => void
-}
-
-/** Render a table of contents entry. */
-export const Entry = (props: EntryProps) => {
-  const {
-    activeDescendant,
-    entry,
-    id,
-    level,
-    selectedEntryName,
-    setActiveDescendant,
-    onSelectEntry
-  } = props
-
-  const hasChildren = entry.children.length > 0
-  const isExpandable = isEntryTypeExpandable(entry.type) && hasChildren
-  const [isExpanded, setIsExpanded] = useState(true)
-
-  const isSelected = selectedEntryName && selectedEntryName === entry.name
-
-  return (
-    <li
-      aria-expanded={isExpandable ? isExpanded : undefined}
-      // Label with the link to read only the entry name instead of both the entry name and the children list label.
-      aria-labelledby={`${id}-link`}
-      // aria-level starts at 1, level starts at 0.
-      aria-level={level + 1}
-      // aria-selected: false results in every tree item being read as "selected".
-      aria-selected={isSelected ? true : undefined}
-      // Data attribute allows getting the entry from the activedescendant element ID.
-      data-name={entry.name}
-      data-type={entry.type}
-      id={id}
-      role="treeitem"
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        position: 'relative'
-      }}
-    >
-      {/* Wrapper span provides a larger click target than just the icon. */}
-      <span
-        aria-hidden
-        style={{
-          position: 'absolute',
-          top: '1px',
-          left: `${level - 1}rem`,
-          display: 'flex',
-          justifyContent: 'flex-end',
-          alignItems: 'center',
-          width: '2rem',
-          height: '2rem'
-        }}
-        onClick={() => {
-          setIsExpanded(!isExpanded)
-          // If the active descendant is a child of this entry and thus will be removed,
-          // set the active descendant to this entry.
-          if (isExpanded && activeDescendant.startsWith(`${id}-`)) {
-            setActiveDescendant(id)
-          }
-        }}
-      >
-        {isExpandable && <FontAwesomeIcon icon={isExpanded ? faChevronDown : faChevronRight} />}
-      </span>
-      <a
-        id={`${id}-link`}
-        role="presentation"
-        tabIndex={-1}
-        style={{
-          display: 'inline-block',
-          overflow: 'hidden',
-          maxWidth: '100%',
-          padding: `0.25rem 0.5rem 0.25rem ${level + 1.25}rem`,
-          borderColor: id === activeDescendant ? 'var(--bs-primary)' : 'transparent',
-          borderStyle: 'solid',
-          borderWidth: '1px 0',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-          ...(isSelected && {
-            background: 'var(--bs-primary)',
-            color: 'white'
-          })
-        }}
-        onClick={() => {
-          setIsExpanded(true)
-          if (isEntryTypeSelectable(entry.type)) {
-            onSelectEntry(entry.name)
-          }
-        }}
-      >
-        {entry.name}
-      </a>
-      {isExpanded && (
-        <EntryContents
-          activeDescendant={activeDescendant}
-          entry={entry}
-          level={level}
-          parentId={id}
-          selectedEntryName={selectedEntryName}
-          setActiveDescendant={setActiveDescendant}
-          onSelectEntry={onSelectEntry}
-        />
-      )}
-    </li>
-  )
-}
-
 type FormTableOfContentsProps = {
   formContent: FormContent
-  selectedElementName: string | undefined
-  onSelectElement: (name: string) => void
+  selectedElementPath: string | undefined
+  onSelectElement: (path: string) => void
 }
 
 /** Render a table of contents for a form. */
 export const FormTableOfContents = (props: FormTableOfContentsProps) => {
-  const { formContent, selectedElementName, onSelectElement } = props
-
-  const treeElementRef = useRef<HTMLUListElement | null>(null)
-
-  const [activeDescendant, setActiveDescendant] = useState('node-0')
+  const { formContent, selectedElementPath, onSelectElement } = props
 
   return (
-    <ul
-      ref={treeElementRef}
-      // aria-activedescendant tells which tree item is "focused", while actual focus stays on the tree itself.
-      aria-activedescendant={activeDescendant}
-      aria-label="Table of contents"
-      role="tree"
-      tabIndex={0}
-      style={{
-        padding: 0,
-        border: '2px solid transparent',
-        margin: 0,
-        listStyleType: 'none'
-      }}
-      onKeyDown={e => {
-        // If the key isn't relevant to tree navigation, do nothing.
-        if (!(e.key === 'Enter' || e.key.startsWith('Arrow'))) {
-          return
-        }
-
-        e.preventDefault()
-        e.stopPropagation()
-
-        /* eslint-disable @typescript-eslint/no-non-null-assertion */
-        const currentTreeItem = document.getElementById(activeDescendant)
-
-        if (!currentTreeItem) {
-          // If the active descendant isn't found (for example, if it was in a group that has been collapsed),
-          // then reset the active descendant to the first item in the tree.
-          setActiveDescendant('node-0')
-        } else if (e.key === 'Enter') {
-          // Otherwise, select the question for the current tree item if it is a question.
-          const name = currentTreeItem.dataset.name!
-          const type = currentTreeItem.dataset.type!
-          if (isEntryTypeSelectable(type)) {
-            onSelectElement(name)
-          }
-          // onSelectElement(name)
-        } else if (e.key === 'ArrowLeft') {
-          const isExpanded = currentTreeItem.getAttribute('aria-expanded') === 'true'
-          if (isExpanded) {
-            // Close the tree item if it is open.
-            (currentTreeItem.firstElementChild as HTMLElement)!.click()
-          } else {
-            // If the tree item is closed, move to the parent tree item (if there is one).
-            const parentGroup = currentTreeItem.parentElement!
-            if (parentGroup.getAttribute('role') === 'group') {
-              // If the parent group is a group within the tree, move up the tree.
-              // Else if the parent group is the tree itself, do nothing.
-              const parentTreeItem = parentGroup.parentElement!
-              setActiveDescendant(parentTreeItem.id)
-            }
-          }
-        } else if (e.key === 'ArrowRight') {
-          const expanded = currentTreeItem.getAttribute('aria-expanded')
-          if (expanded === 'false') {
-            // Open the tree item if it is currently closed.
-            (currentTreeItem.firstElementChild as HTMLElement)!.click()
-          } else if (expanded === 'true') {
-            // Move to the first child node.
-            // If the current tree item has no children, then do nothing.
-            const firstChildTreeItem = currentTreeItem.lastElementChild!.firstElementChild
-            if (firstChildTreeItem) {
-              setActiveDescendant(firstChildTreeItem.id)
-            }
-          }
-        } else if (e.key === 'ArrowDown') {
-          // Move to the next tree item without opening/closing any tree items.
-          const allTreeItemIds = Array.from(treeElementRef.current!.querySelectorAll('[role="treeitem"]')).map(
-            el => el.id
-          )
-          const indexOfCurrentTreeItem = allTreeItemIds.findIndex(id => id === activeDescendant)
-          if (indexOfCurrentTreeItem < allTreeItemIds.length - 1) {
-            setActiveDescendant(allTreeItemIds[indexOfCurrentTreeItem + 1])
-          }
-        } else if (e.key === 'ArrowUp') {
-          // Move to the previous tree item without opening/closing any tree items.
-          const allTreeItemIds = Array.from(treeElementRef.current!.querySelectorAll('[role="treeitem"]')).map(
-            el => el.id
-          )
-          const indexOfCurrentTreeItem = allTreeItemIds.findIndex(id => id === activeDescendant)
-          if (indexOfCurrentTreeItem > 0) {
-            setActiveDescendant(allTreeItemIds[indexOfCurrentTreeItem - 1])
-          }
+    <Tree
+      id="form-table-of-contents"
+      isItemSelected={item => item.data.path === selectedElementPath}
+      label="Table of contents"
+      rootItem={getTableOfContentsTree(formContent)}
+      onClickItem={item => {
+        const { isSelectable, path } = item.data
+        if (isSelectable) {
+          onSelectElement(path)
         }
       }}
-    >
-      <Entry
-        activeDescendant={activeDescendant}
-        entry={getTableOfContents(formContent)}
-        id="node-0"
-        level={0}
-        selectedEntryName={selectedElementName}
-        setActiveDescendant={setActiveDescendant}
-        onSelectEntry={onSelectElement}
-      />
-    </ul>
+    />
   )
 }


### PR DESCRIPTION
Currently, the form editor stores the selected element by name. This proved to not work very well since we'll want to edit pages and panels which don't have names and updating a question by name required iterating over the form content object to find the question to update.

This changes the editor to store the path to the selected element, which we can use to easily get the selected element (`_.get(formContent, path)`) and update it (`_.set(formContent, path, newQuestion)`). It also extracts the Tree into a generic component.