### PR TITLE
[JN-433] Add name for element in OurHealth consent form

### DIFF
--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/ourHealthConsent.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/ourHealthConsent.json
@@ -62,7 +62,7 @@
             },
             {
               "type": "html",
-              "name": "",
+              "name": "whatAreTheBenefits",
               "html": "<h2 class='my-4'>What are the benefits to me?</h2><p>You will likely <strong style='font-weight:normal;text-decoration:underline;'>not receive any direct personal health benefits</strong> from research conducted on your information in this study.</p>"
             },
             {


### PR DESCRIPTION
Discovered this while working on the table of contents for the form editor. One element in the OurHealth consent form is missing a name / stable ID. The name field is how elements are labeled in the table of contents.