### PR TITLE
[JN-378] Allow reordering elements on form pages and panels

### DIFF
--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -40,7 +40,10 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
         >
           <FormDesigner
             value={editedContent}
-            onChange={setEditedContent}
+            onChange={newContent => {
+              setEditedContent(newContent)
+              onChange(true, newContent)
+            }}
           />
         </Tab>
         <Tab

--- a/ui-admin/src/forms/FormDesigner.tsx
+++ b/ui-admin/src/forms/FormDesigner.tsx
@@ -1,7 +1,10 @@
+import { get, set } from 'lodash/fp'
 import React, { useState } from 'react'
 
-import { FormContent } from '@juniper/ui-core'
+import { FormContent, FormContentPage, FormElement } from '@juniper/ui-core'
 
+import { PageDesigner } from './designer/PageDesigner'
+import { PanelDesigner } from './designer/PanelDesigner'
 import { FormTableOfContents } from './FormTableOfContents'
 
 type FormDesignerProps = {
@@ -12,7 +15,6 @@ type FormDesignerProps = {
 
 /** UI for editing forms. */
 export const FormDesigner = (props: FormDesignerProps) => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { readOnly = false, value, onChange } = props
 
   const [selectedElementPath, setSelectedElementPath] = useState<string>()
@@ -26,11 +28,37 @@ export const FormDesigner = (props: FormDesignerProps) => {
           onSelectElement={setSelectedElementPath}
         />
       </div>
-      <div className="flex-grow-1 overflow-scroll">
+      <div className="flex-grow-1 overflow-scroll py-2 px-3">
         {(() => {
           if (selectedElementPath === undefined) {
             return (
               <p className="mt-5 text-center">Select an element to edit</p>
+            )
+          }
+
+          const selectedElement = get(selectedElementPath, value) as FormContentPage | FormElement
+
+          if (!('type' in selectedElement) && !('questionTemplateName' in selectedElement)) {
+            return (
+              <PageDesigner
+                readOnly={readOnly}
+                value={selectedElement}
+                onChange={updatedElement => {
+                  onChange(set(selectedElementPath, updatedElement, value))
+                }}
+              />
+            )
+          }
+
+          if ('type' in selectedElement && selectedElement.type === 'panel') {
+            return (
+              <PanelDesigner
+                readOnly={readOnly}
+                value={selectedElement}
+                onChange={updatedElement => {
+                  onChange(set(selectedElementPath, updatedElement, value))
+                }}
+              />
             )
           }
 

--- a/ui-admin/src/forms/designer/ElementList.test.tsx
+++ b/ui-admin/src/forms/designer/ElementList.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+
+import { FormElement } from '@juniper/ui-core'
+
+import { ElementList } from './ElementList'
+
+describe('ElementList', () => {
+  const elements: FormElement[] = [
+    {
+      name: 'foo',
+      type: 'html',
+      html: '<p>foo</p>'
+    },
+    {
+      name: 'bar',
+      type: 'html',
+      html: '<p>bar</p>'
+    },
+    {
+      name: 'baz',
+      type: 'html',
+      html: '<p>baz</p>'
+    }
+  ]
+
+  it('renders elements', () => {
+    // Act
+    render(<ElementList readOnly={false} value={elements} onChange={jest.fn()} />)
+
+    // Assert
+    const listItems = screen.getAllByRole('listitem')
+    expect(listItems.map(el => el.textContent)).toEqual(['foo', 'bar', 'baz'])
+  })
+
+  it('allows reodering elements', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const onChange = jest.fn()
+    render(<ElementList readOnly={false} value={elements} onChange={onChange} />)
+
+    // Act
+    const moveBarUpButton = screen.getAllByLabelText('Move this element before the previous one')[1]
+    await user.click(moveBarUpButton)
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith([
+      {
+        name: 'bar',
+        type: 'html',
+        html: '<p>bar</p>'
+      },
+      {
+        name: 'foo',
+        type: 'html',
+        html: '<p>foo</p>'
+      },
+      {
+        name: 'baz',
+        type: 'html',
+        html: '<p>baz</p>'
+      }
+    ])
+
+    const moveBarDownButton = screen.getAllByLabelText('Move this element after the next one')[1]
+    await user.click(moveBarDownButton)
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith([
+      {
+        name: 'foo',
+        type: 'html',
+        html: '<p>foo</p>'
+      },
+      {
+        name: 'baz',
+        type: 'html',
+        html: '<p>baz</p>'
+      },
+      {
+        name: 'bar',
+        type: 'html',
+        html: '<p>bar</p>'
+      }
+    ])
+  })
+})

--- a/ui-admin/src/forms/designer/ElementList.tsx
+++ b/ui-admin/src/forms/designer/ElementList.tsx
@@ -1,0 +1,73 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons'
+import React from 'react'
+
+import { FormElement } from '@juniper/ui-core'
+
+import { getElementLabel } from './designer-utils'
+
+type ElementListProps = {
+  readOnly: boolean
+  value: FormElement[]
+  onChange: (newValue: FormElement[]) => void
+}
+
+/** UI for re-ordering a list of form elements. */
+export const ElementList = (props: ElementListProps) => {
+  const { readOnly, value, onChange } = props
+
+  return (
+    <ol className="list-group list-group-numbered">
+      {value.map((element, i) => {
+        return (
+          <li
+            key={i}
+            className="list-group-item d-flex align-items-center"
+          >
+            <div className="flex-grow-1 text-truncate ms-2">
+              {getElementLabel(element)}
+            </div>
+            <div className="flex-shrink-0">
+              <button
+                aria-disabled={readOnly}
+                aria-label="Move this element before the previous one"
+                className="btn btn-light ms-2"
+                disabled={i === 0}
+                onClick={() => {
+                  if (!readOnly) {
+                    onChange([
+                      ...value.slice(0, i - 1),
+                      value[i],
+                      value[i - 1],
+                      ...value.slice(i + 1)
+                    ])
+                  }
+                }}
+              >
+                <FontAwesomeIcon icon={faChevronUp} />
+              </button>
+              <button
+                aria-disabled={readOnly}
+                aria-label="Move this element after the next one"
+                className="btn btn-light ms-2"
+                disabled={i === value.length - 1}
+                onClick={() => {
+                  if (!readOnly) {
+                    onChange([
+                      ...value.slice(0, i),
+                      value[i + 1],
+                      value[i],
+                      ...value.slice(i + 2)
+                    ])
+                  }
+                }}
+              >
+                <FontAwesomeIcon icon={faChevronDown} />
+              </button>
+            </div>
+          </li>
+        )
+      })}
+    </ol>
+  )
+}

--- a/ui-admin/src/forms/designer/PageDesigner.tsx
+++ b/ui-admin/src/forms/designer/PageDesigner.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+import { FormContentPage } from '@juniper/ui-core'
+
+import { ElementList } from './ElementList'
+
+export type PageDesignerProps = {
+  readOnly: boolean
+  value: FormContentPage
+  onChange: (newValue: FormContentPage) => void
+}
+
+/** UI for editing a page of a form. */
+export const PageDesigner = (props: PageDesignerProps) => {
+  const { readOnly, value, onChange } = props
+
+  return (
+    <div>
+      <h2>Page</h2>
+      <ElementList
+        readOnly={readOnly}
+        value={value.elements}
+        onChange={newValue => {
+          onChange({ ...value, elements: newValue })
+        }}
+      />
+    </div>
+  )
+}

--- a/ui-admin/src/forms/designer/PanelDesigner.tsx
+++ b/ui-admin/src/forms/designer/PanelDesigner.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+import { FormPanel } from '@juniper/ui-core'
+
+import { ElementList } from './ElementList'
+
+export type PanelDesignerProps = {
+  readOnly: boolean
+  value: FormPanel
+  onChange: (newValue: FormPanel) => void
+}
+
+/** UI for editing a panel in a form. */
+export const PanelDesigner = (props: PanelDesignerProps) => {
+  const { readOnly, value, onChange } = props
+
+  return (
+    <div>
+      <h2>Panel</h2>
+      <ElementList
+        readOnly={readOnly}
+        value={value.elements}
+        onChange={newValue => {
+          onChange({ ...value, elements: newValue })
+        }}
+      />
+    </div>
+  )
+}

--- a/ui-admin/src/forms/designer/designer-utils.tsx
+++ b/ui-admin/src/forms/designer/designer-utils.tsx
@@ -1,0 +1,9 @@
+import { FormElement } from '@juniper/ui-core'
+
+/** Get the user-facing label for a form element. */
+export const getElementLabel = (element: FormElement): string => {
+  if ('type' in element && element.type === 'panel') {
+    return `Panel (${element.elements.length} elements)`
+  }
+  return element.name
+}


### PR DESCRIPTION
This adds the ability to reorder questions/elements in forms, both at the page level and panel level. In the future, this could be improved to add drag and drop reordering.

![Screenshot 2023-06-21 at 2 21 16 PM](https://github.com/broadinstitute/juniper/assets/1156625/20f4a370-27b1-43cc-a174-0c3925b0e222)
