### PR TITLE
[JN-378] Allow editing HTML elements

### DIFF
--- a/ui-admin/src/forms/FormDesigner.tsx
+++ b/ui-admin/src/forms/FormDesigner.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react'
 
 import { FormContent, FormContentPage, FormElement } from '@juniper/ui-core'
 
+import { HtmlDesigner } from './designer/HtmlDesigner'
 import { PageDesigner } from './designer/PageDesigner'
 import { PanelDesigner } from './designer/PanelDesigner'
 import { FormTableOfContents } from './FormTableOfContents'
@@ -53,6 +54,18 @@ export const FormDesigner = (props: FormDesignerProps) => {
           if ('type' in selectedElement && selectedElement.type === 'panel') {
             return (
               <PanelDesigner
+                readOnly={readOnly}
+                value={selectedElement}
+                onChange={updatedElement => {
+                  onChange(set(selectedElementPath, updatedElement, value))
+                }}
+              />
+            )
+          }
+
+          if ('type' in selectedElement && selectedElement.type === 'html') {
+            return (
+              <HtmlDesigner
                 readOnly={readOnly}
                 value={selectedElement}
                 onChange={updatedElement => {

--- a/ui-admin/src/forms/designer/HtmlDesigner.test.tsx
+++ b/ui-admin/src/forms/designer/HtmlDesigner.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+
+import { HtmlElement } from '@juniper/ui-core'
+
+import { HtmlDesigner } from './HtmlDesigner'
+
+describe('HtmlDesigner', () => {
+  const element: HtmlElement = {
+    name: 'testElement',
+    type: 'html',
+    html: '<h2>Section heading</h2><p>This is a section.</p>'
+  }
+
+  it('renders HTML', () => {
+    // Act
+    render(<HtmlDesigner readOnly={false} value={element} onChange={jest.fn()} />)
+
+    // Assert
+    const textArea = screen.getByRole('textbox')
+    expect(textArea.textContent).toBe('<h2>Section heading</h2><p>This is a section.</p>')
+  })
+
+  it('allows editing HTML', () => {
+    // Arrange
+    const onChange = jest.fn()
+    render(<HtmlDesigner readOnly={false} value={element} onChange={onChange} />)
+
+    // Act
+    const textArea = screen.getByRole('textbox')
+    fireEvent.change(textArea, {
+      target: {
+        value: '<h2>New section heading</h2><p>This is a section.</p>'
+      }
+    })
+
+    // Assert
+    expect(onChange).toHaveBeenLastCalledWith({
+      name: 'testElement',
+      type: 'html',
+      html: '<h2>New section heading</h2><p>This is a section.</p>'
+    })
+  })
+})

--- a/ui-admin/src/forms/designer/HtmlDesigner.tsx
+++ b/ui-admin/src/forms/designer/HtmlDesigner.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+
+import { HtmlElement } from '@juniper/ui-core'
+
+export type HtmlDesignerProps = {
+  readOnly: boolean
+  value: HtmlElement
+  onChange: (newValue: HtmlElement) => void
+}
+
+/** UI for editing an HTML element in a form. */
+export const HtmlDesigner = (props: HtmlDesignerProps) => {
+  const { readOnly, value, onChange } = props
+
+  return (
+    <div className="d-flex flex-column h-100">
+      <h2>{value.name}</h2>
+      <textarea
+        className="w-100 flex-grow-1 font-monospace"
+        readOnly={readOnly}
+        style={{
+          overflowX: 'auto',
+          resize: 'none',
+          // @ts-ignore TS thinks this isn't a valid style property
+          textWrap: 'nowrap'
+        }}
+        value={value.html}
+        onChange={e => {
+          onChange({
+            ...value,
+            html: e.target.value
+          })
+        }}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
Stacked on #434. This adds basic editing for HTML elements in forms. In the future, this could be improved to add syntax highlighting, etc.

![Screenshot 2023-06-21 at 3 01 40 PM](https://github.com/broadinstitute/juniper/assets/1156625/3d6e5de9-33a6-4307-8fd9-e61dd5a70fa2)
