### PR TITLE
[JN-406] search DAO upgrades

### DIFF
--- a/.github/workflows/require-ticket.yml
+++ b/.github/workflows/require-ticket.yml
@@ -15,7 +15,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const title = context.payload.pull_request.title;
-            const regex = /JN|DDO-\d+/;
+            const regex = /JN-\d+/;
             if (!regex.test(title)) {
               core.setFailed("PR title must contain a Jira ticket");
             }

--- a/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
@@ -8,6 +8,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
+import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.mapper.RowMapper;
@@ -27,7 +28,7 @@ public abstract class BaseJdbiDao<T extends BaseEntity> {
     protected List<String> getQueryFieldSymbols;
     protected List<String> getQueryColumns;
     protected String createQuerySql;
-
+    @Getter
     protected String tableName;
     protected Class<T> clazz;
 
@@ -85,7 +86,7 @@ public abstract class BaseJdbiDao<T extends BaseEntity> {
                 .collect(Collectors.toList());
     }
 
-    protected String getTableName() {
+    protected String generateTableName() {
         return toSnakeCase(getClazz().getSimpleName());
     };
 
@@ -98,7 +99,7 @@ public abstract class BaseJdbiDao<T extends BaseEntity> {
         getQueryFields = generateGetFields(clazz);
         getQueryFieldSymbols = getQueryFields.stream().map(field -> ":" + field).collect(Collectors.toList());
         getQueryColumns = generateGetColumns(getQueryFields);
-        tableName = getTableName();
+        tableName = generateTableName();
         createQuerySql = getCreateQuerySql();
         initializeRowMapper(jdbi);
     }
@@ -331,4 +332,12 @@ public abstract class BaseJdbiDao<T extends BaseEntity> {
     public static String toSnakeCase(String camelCased) {
         return camelCased.replaceAll("(.)(\\p{Upper})", "$1_$2").toLowerCase();
     }
+
+    /** returns a cloned list of the get query columns (the actual list should never be modified) */
+    public List<String> getGetQueryColumns() {
+        List<String> copy = new ArrayList<>();
+        copy.addAll(getQueryColumns);
+        return copy;
+    }
+
 }

--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeDao.java
@@ -8,11 +8,9 @@ import bio.terra.pearl.core.dao.survey.PreEnrollmentResponseDao;
 import bio.terra.pearl.core.dao.survey.SurveyResponseDao;
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.participant.Enrollee;
-import bio.terra.pearl.core.model.participant.EnrolleeSearchResult;
-import bio.terra.pearl.core.model.participant.Profile;
-
-import java.util.*;
-
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import org.jdbi.v3.core.Jdbi;
 import org.springframework.stereotype.Component;
 
@@ -102,23 +100,6 @@ public class EnrolleeDao extends BaseMutableJdbiDao<Enrollee> {
             kitRequest.setKitType(kitType);
         }
         return enrollee;
-    }
-
-    public List<EnrolleeSearchResult> searchByStudyEnvironment(UUID studyEnvironmentId) {
-        List<Enrollee> enrollees = findByStudyEnvironmentId(studyEnvironmentId);
-        Map<UUID, Boolean> hasKit = new HashMap<>();
-        for (Enrollee enrollee : enrollees) {
-            var kitRequests = kitRequestDao.findByEnrollee(enrollee.getId());
-            hasKit.put(enrollee.getId(), !kitRequests.isEmpty());
-        }
-        List<UUID> profileIds = enrollees.stream().map(enrollee -> enrollee.getProfileId()).toList();
-        List<Profile> profiles = profileDao.findAll(profileIds);
-        return enrollees.stream().map(enrollee -> EnrolleeSearchResult.builder()
-                .enrollee(enrollee)
-                .profile(profiles.stream().filter(profile -> profile.getId().equals(enrollee.getProfileId()))
-                        .findFirst().orElse(null))
-                .hasKit(hasKit.get(enrollee.getId()))
-                .build()).toList();
     }
 
     public int countByStudyEnvironment(UUID studyEnvironmentId) {

--- a/core/src/main/java/bio/terra/pearl/core/model/participant/EnrolleeSearchResult.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/participant/EnrolleeSearchResult.java
@@ -1,13 +1,15 @@
 package bio.terra.pearl.core.model.participant;
 
-import lombok.Builder;
+import bio.terra.pearl.core.model.kit.KitRequestStatus;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 
 /** holder class to include an enrolle and their profile */
-@Getter @Setter @Builder
+@Getter @Setter @SuperBuilder
 public class EnrolleeSearchResult {
+    public EnrolleeSearchResult() {}
     private Enrollee enrollee;
     private Profile profile;
-    private boolean hasKit;
+    private KitRequestStatus mostRecentKitStatus;
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
@@ -97,13 +97,13 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
         var enrollee1a = enrolleeFactory.buildPersisted("testSyncAllKitStatusesFromPepper", studyEnvironment);
         var enrollee1b = enrolleeFactory.buildPersisted("testSyncAllKitStatusesFromPepper", studyEnvironment);
         var kitRequest1a = kitRequestFactory.buildPersisted("testSyncAllKitStatusesFromPepper",
-            kitType.getId(), enrollee1a.getId(), adminUser.getId());
+            enrollee1a.getId(), kitType.getId(), adminUser.getId());
         var kitRequest1b = kitRequestFactory.buildPersisted("testSyncAllKitStatusesFromPepper",
-            kitType.getId(), enrollee1b.getId(), adminUser.getId());
+            enrollee1b.getId(), kitType.getId(), adminUser.getId());
         var studyEnvironment2 = studyEnvironmentFactory.buildPersisted("testSyncAllKitStatusesFromPepper2");
         var enrollee2 = enrolleeFactory.buildPersisted("testSyncAllKitStatusesFromPepper", studyEnvironment2);
         var kitRequest2 = kitRequestFactory.buildPersisted("testSyncAllKitStatusesFromPepper",
-            kitType.getId(), enrollee2.getId(), adminUser.getId());
+            enrollee2.getId(), kitType.getId(), adminUser.getId());
 
         /*
          * Mock DSM to return kits by study:

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
@@ -67,7 +67,7 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
         var enrollee = enrolleeFactory.buildPersisted("testUpdateKitStatus");
         var kitType = kitTypeFactory.buildPersisted("testUpdateKitStatus");
         var kitRequest = kitRequestFactory.buildPersisted("testUpdateKitStatus",
-                adminUser.getId(), enrollee.getId(), kitType.getId());
+            enrollee.getId(), kitType.getId(), adminUser.getId());
 
         var response = PepperDSMKitStatus.builder()
                 .kitId(kitRequest.getId().toString())
@@ -97,13 +97,13 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
         var enrollee1a = enrolleeFactory.buildPersisted("testSyncAllKitStatusesFromPepper", studyEnvironment);
         var enrollee1b = enrolleeFactory.buildPersisted("testSyncAllKitStatusesFromPepper", studyEnvironment);
         var kitRequest1a = kitRequestFactory.buildPersisted("testSyncAllKitStatusesFromPepper",
-                adminUser.getId(), enrollee1a.getId(), kitType.getId());
+            kitType.getId(), enrollee1a.getId(), adminUser.getId());
         var kitRequest1b = kitRequestFactory.buildPersisted("testSyncAllKitStatusesFromPepper",
-                adminUser.getId(), enrollee1b.getId(), kitType.getId());
+            kitType.getId(), enrollee1b.getId(), adminUser.getId());
         var studyEnvironment2 = studyEnvironmentFactory.buildPersisted("testSyncAllKitStatusesFromPepper2");
         var enrollee2 = enrolleeFactory.buildPersisted("testSyncAllKitStatusesFromPepper", studyEnvironment2);
         var kitRequest2 = kitRequestFactory.buildPersisted("testSyncAllKitStatusesFromPepper",
-                adminUser.getId(), enrollee2.getId(), kitType.getId());
+            kitType.getId(), enrollee2.getId(), adminUser.getId());
 
         /*
          * Mock DSM to return kits by study:

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/kit/KitRequestFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/kit/KitRequestFactory.java
@@ -1,27 +1,31 @@
 package bio.terra.pearl.core.factory.kit;
 
 import bio.terra.pearl.core.dao.kit.KitRequestDao;
+import bio.terra.pearl.core.factory.admin.AdminUserFactory;
+import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.kit.KitRequestStatus;
+import bio.terra.pearl.core.model.kit.KitType;
 import bio.terra.pearl.core.service.kit.PepperDSMKitStatus;
 import bio.terra.pearl.core.service.kit.PepperKitAddress;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.stereotype.Component;
-
 import java.time.Instant;
 import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 @Component
 public class KitRequestFactory {
-    private final KitRequestDao kitRequestDao;
-    private final ObjectMapper objectMapper;
+    @Autowired
+    private KitRequestDao kitRequestDao;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private KitTypeFactory kitTypeFactory;
+    @Autowired
+    private AdminUserFactory adminUserFactory;
 
-    public KitRequestFactory(KitRequestDao kitRequestDao,
-                             ObjectMapper objectMapper) {
-        this.kitRequestDao = kitRequestDao;
-        this.objectMapper = objectMapper;
-    }
 
     public KitRequest.KitRequestBuilder builder(String testName) throws JsonProcessingException {
         var address = PepperKitAddress.builder()
@@ -32,7 +36,17 @@ public class KitRequestFactory {
                 .status(KitRequestStatus.CREATED);
     }
 
-    public KitRequest buildPersisted(String testName, UUID adminUserId, UUID enrolleeId, UUID kitTypeId)
+    public KitRequest buildPersisted(String testName, UUID enrolleeId) throws JsonProcessingException {
+        KitType kitType = kitTypeFactory.buildPersisted(testName);
+        return buildPersisted(testName, enrolleeId, kitType.getId());
+    }
+
+    public KitRequest buildPersisted(String testName, UUID enrolleeId, UUID kitTypeId) throws JsonProcessingException {
+        AdminUser adminUser = adminUserFactory.buildPersisted(testName);
+        return buildPersisted(testName, enrolleeId, kitTypeId, adminUser.getId());
+    }
+
+    public KitRequest buildPersisted(String testName, UUID enrolleeId, UUID kitTypeId, UUID adminUserId)
             throws JsonProcessingException {
         var kitRequest = builder(testName)
                 .creatingAdminUserId(adminUserId)

--- a/scripts/sql_connect
+++ b/scripts/sql_connect
@@ -12,12 +12,12 @@ set -o pipefail
 # DEBUG = 2
 declare -i desired_log_level=2
 declare -a valid_environment_targets=( dev prod )
-
+/
 function usage() {
     local -r usage="
     $0: connect to an Azure managed database instance with private networking through AKS cluster
 
-    Usage: $0 <environment> -d <Database> -s <Subscription> -c <AKS Cluster> -r <Resource Group>
+    Usage: $0 <Enviornment> -d <Database> -s <Subscription> -c <AKS Cluster> -r <Resource Group>
     Where:  <Environment> is one of: ${valid_environment_targets[*]} (required and positional - must be first argument)
             <Database> is an exisiting Azure managed database instance (optional)
             <Subscription> is the Azure subscription which contains the AKS Cluster where the pod will be spun up (optional)
@@ -41,14 +41,9 @@ declare -a required_tools=( az kubectl vault sleep jq )
 declare -r proj_name="d2p"
 declare -r target_environment="${1:?An environment must be specified as first argument}"
 
-# azure vars
-declare user=""
-declare username=""
-declare subscription=""
-
 # k8s vars
-declare k8s_namespace="${proj_name}-postgres-${target_environment}"
-declare k8s_pod_name="postgres"
+declare -r k8s_namespace="${proj_name}-postgres-${target_environment}"
+declare -r k8s_pod_name="postgres"
 declare -r docker_image="postgres:12"
 # password is required but not important. can be anything
 declare postgres_password=$(openssl rand -base64 12)
@@ -57,6 +52,10 @@ declare postgres_password=$(openssl rand -base64 12)
 declare database_name=""
 declare database_user=""
 declare database_pw=""
+
+# azure vars
+declare user=""
+declare subscription=""
 
 # Default azure vars - used if other values are not given on the command line
 declare -r subscription_default_dev="385ed569-ca04-4b97-97b4-677c8479585e"
@@ -205,16 +204,6 @@ function change_namespace(){
 }
 
 function create_namespace() {
-    # First check if namespace already exists
-    local -r -a get_namespace_cmd=(kubectl get namespace "${k8s_namespace}")
-    if ! "${get_namespace_cmd[@]}" > /dev/null 2>&1 ;
-    then
-        log_info "namespace ${k8s_namespace} does not exist, creating"
-    else
-        log_info "namespace ${k8s_namespace} already exists, skipping creation"
-        change_namespace
-        return 0
-    fi
     local -r -a create_cmd=(kubectl create namespace "${k8s_namespace}")
     log_info "creating kubernetes namespace: ${k8s_namespace}"
     if ! "${create_cmd[@]}" ;
@@ -260,7 +249,7 @@ function delete_postgres_pod() {
     log_info "successfully deleted pod"
 }
 
-function setup_k8s_environment() {
+function setup_k8s_enviornment() {
     set_subscription
     set_cluster
     # Create a temporary namespace with kubectl to spin up the postgres jump pod in
@@ -270,7 +259,7 @@ function setup_k8s_environment() {
 
 }
 
-function cleanup_k8s_environment() {
+function cleanup_k8s_enviornment() {
     # Once they are done cleanup - cleanup order matters, delete the jump pod first then the namespace
     delete_postgres_pod
     cleanup_namespace
@@ -279,15 +268,7 @@ function cleanup_k8s_environment() {
 function read_user() {
     local -r -a read_user_cmd=(az ad signed-in-user show)
     local -r -a jq_cmd=(jq .displayName -r)
-    local -r -a jq_read_username_cmd=(jq .mail -r
-    )
     user=$( "${read_user_cmd[@]}" | "${jq_cmd[@]}" )
-    email=$( "${read_user_cmd[@]}" | "${jq_read_username_cmd[@]}" )
-    username=${email%%@*}
-    # update relevant k8s vars to include the username to avoid conflicts
-    k8s_pod_name="${k8s_pod_name}-${username}"
-    k8s_namespace="${k8s_namespace}-${username}"
-    
     if ! ("${read_user_cmd[@]}" | "${jq_cmd[@]}") > /dev/null 2>&1 ;
     then
         log_err "unable to read azure username...exiting"
@@ -300,7 +281,7 @@ function exec_into_pod() {
     #let pod spin up
     sleep 5
     log_info "$user connected to database $database_name"
-    local -r -a connect_cmd=(kubectl exec -it -n "${k8s_namespace}" "${k8s_pod_name}" -- psql "host=$database_name.postgres.database.azure.com port=5432 dbname=postgres user=$database_user password=$database_pw sslmode=require")
+    local -r -a connect_cmd=(kubectl exec -it -n "${k8s_namespace}" postgres -- psql "host=$database_name.postgres.database.azure.com port=5432 dbname=postgres user=$database_user password=$database_pw sslmode=require")
  
     log_info "running kubernetes pod ${k8s_pod_name} in ${k8s_namespace} namespace"
     if ! "${connect_cmd[@]}" ;
@@ -319,12 +300,12 @@ function init() {
 
 function main() {
     init "$@"
-    read_user
-    setup_k8s_environment || exit 1
+    setup_k8s_enviornment || exit 1
     # ( If any thing from this point forward fails script must cleanup )
-    trap cleanup_k8s_environment SIGHUP SIGINT SIGQUIT
+    trap cleanup_k8s_enviornment SIGHUP SIGINT SIGQUIT
+    read_user
     exec_into_pod
-    cleanup_k8s_environment
+    cleanup_k8s_enviornment
 }
 
 main "$@"

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -74,7 +74,7 @@ export type StudyEnvironmentUpdate = {
 export type EnrolleeSearchResult = {
   enrollee: Enrollee,
   profile: Profile,
-  hasKit: boolean
+  mostRecentKitStatus: string
 }
 
 export type Enrollee = {

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -74,7 +74,7 @@ export type StudyEnvironmentUpdate = {
 export type EnrolleeSearchResult = {
   enrollee: Enrollee,
   profile: Profile,
-  mostRecentKitStatus: string
+  mostRecentKitStatus: string | null
 }
 
 export type Enrollee = {

--- a/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
@@ -12,7 +12,7 @@ jest.mock('api/api', () => ({
     const enrolleeSearchResults: EnrolleeSearchResult[] = [{
       enrollee: fakeEnrollee,
       profile: fakeEnrollee.profile,
-      hasKit: false
+      mostRecentKitStatus: null
     }]
     return Promise.resolve(enrolleeSearchResults)
   }

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -73,9 +73,8 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     accessorKey: 'enrollee.consented',
     cell: info => info.getValue() ? <FontAwesomeIcon icon={faCheck}/> : ''
   }, {
-    header: 'Kit requested',
-    accessorKey: 'kitRequested',
-    cell: data => data.row.original.hasKit ? <FontAwesomeIcon icon={faCheck}/> : ''
+    header: 'Kit status',
+    accessorKey: 'mostRecentKitStatus'
   }], [study.shortcode])
 
 


### PR DESCRIPTION
This significantly improves the search query building and processing by leveraging the already-existing DAOs to identify the fields to query, and how to map them to their respective classes.  this also fixes a bug I introduced where kit request status wasn't being returned with search results

TO TEST:
1. go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants
2. note the "kit status" column, which should show "created" for jsalk, and nothing for everyone else.