### PR TITLE
JN-434 fix login tracking

### DIFF
--- a/ui-admin/src/user/UserProvider.tsx
+++ b/ui-admin/src/user/UserProvider.tsx
@@ -81,7 +81,7 @@ export default function UserProvider({ children }: { children: React.ReactNode }
     auth.events.addUserLoaded(user => {
       const token = user.access_token as string
       Api.setBearerToken(token)
-      Api.refreshLogin(token).then(user => {
+      Api.tokenLogin(token).then(user => {
         user.token = token
         loginUser(user)
         setIsLoading(false)


### PR DESCRIPTION
Some logins weren't resulting in the "last_login" field being updated for the user.  I suspect tis is a timing issue where the call to "Api.tokenLogin" from RedirectFromOAuth.tsx gets cancelled or doesn't happen since the popup is closing.  So I'm updating the event in the main window to use the tokenLogin path instead of the refresh path.  This might result in some double-logins, but currently the only difference between login and refreshLogin is whether or not we update the `last_login` property, so I'd just as soon error on the side of tracking it.  When Brian gets back we can sort out a more robust solution.

TO TEST:
1. login to the admin tool using regular login (not developer login)
2. go to   https://localhost:3000/users -- confirm your last login is the current time