### PR TITLE
[JN-436] Resolve ESLint configuration warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -125,6 +125,9 @@ module.exports = {
           'ui-participant/tsconfig.json'
         ]
       }
+    },
+    react: {
+      version: 'detect'
     }
   }
 }


### PR DESCRIPTION
Currently, running ESLint with `npm run lint` shows this warning
> Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration.

Adding this configuration resolves that warning.