### PR TITLE
[JN-414] Client-side participant filtering

### DIFF
--- a/ui-admin/src/study/participants/enrolleeView/ParticipantTaskView.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/ParticipantTaskView.tsx
@@ -9,7 +9,7 @@ import {
   SortingState,
   useReactTable
 } from '@tanstack/react-table'
-import { sortableTableHeader } from 'util/tableUtils'
+import { tableHeader } from 'util/tableUtils'
 import { instantToDefaultString } from 'util/timeUtils'
 
 const columns: ColumnDef<ParticipantTask>[] = [{
@@ -56,7 +56,7 @@ const ParticipantTaskView = ({ enrollee }: {enrollee: Enrollee}) => {
     <table className="table table-striped">
       <thead>
         <tr>
-          {table.getFlatHeaders().map(header => sortableTableHeader(header))}
+          {table.getFlatHeaders().map(header => tableHeader(header, { sortable: true, filterable: false }))}
         </tr>
       </thead>
       <tbody>

--- a/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
@@ -10,7 +10,7 @@ import {
   useReactTable,
   VisibilityState
 } from '@tanstack/react-table'
-import { sortableTableHeader } from 'util/tableUtils'
+import { tableHeader } from 'util/tableUtils'
 import { Store } from 'react-notifications-component'
 import { failureNotification } from 'util/notifications'
 import ExportDataControl from './ExportDataControl'
@@ -96,7 +96,7 @@ const ExportDataBrowser = ({ studyEnvContext }: {studyEnvContext: StudyEnvContex
     {!isLoading && <table className="table table-striped">
       <thead>
         <tr>
-          {table.getFlatHeaders().map(header => sortableTableHeader(header))}
+          {table.getFlatHeaders().map(header => tableHeader(header, { sortable: true, filterable: false }))}
         </tr>
       </thead>
       <tbody>

--- a/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
@@ -5,6 +5,8 @@ import ParticipantList from './ParticipantList'
 import { EnrolleeSearchResult } from 'api/api'
 import { mockEnrollee, mockStudyEnvContext } from 'test-utils/mocking-utils'
 import { setupRouterTest } from 'test-utils/router-testing-utils'
+import userEvent from "@testing-library/user-event";
+import { act } from "react-dom/test-utils";
 
 jest.mock('api/api', () => ({
   searchEnrollees: () => {
@@ -27,6 +29,40 @@ test('renders a participant with link', async () => {
   })
   const participantLink = screen.getByText('JOSALK')
   expect(participantLink).toHaveAttribute('href', `/${studyEnvContext.currentEnvPath}/participants/JOSALK`)
+})
+
+test('renders filters for participant columns', async () => {
+  const studyEnvContext = mockStudyEnvContext()
+  const { RoutedComponent } = setupRouterTest(<ParticipantList studyEnvContext={studyEnvContext}/>)
+  render(RoutedComponent)
+
+  //Assert that all 3 default columns have filter inputs
+  await waitFor(() => {
+    expect(screen.getAllByPlaceholderText('Search...').length).toBe(3)
+  })
+
+})
+
+test('filters participants based on shortcode', async () => {
+  const studyEnvContext = mockStudyEnvContext()
+  const { RoutedComponent } = setupRouterTest(<ParticipantList studyEnvContext={studyEnvContext}/>)
+  render(RoutedComponent)
+
+  //Assert that JOSALK is visible in the table
+  await waitFor(() => {
+    expect(screen.getByText('JOSALK')).toBeInTheDocument()
+  })
+
+  //Search for some unknown shortcode
+  await act(() =>
+    userEvent.type(screen.getAllByPlaceholderText('Search...')[0], 'UNKNOWN SHORTCODE')
+  )
+
+  //Assert that JOSALK is no longer visible in the table
+  await waitFor(() => {
+    expect(screen.queryByText('JOSALK')).not.toBeInTheDocument()
+  })
+
 })
 
 test('send email is toggled depending on participants selected', async () => {

--- a/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
@@ -36,9 +36,9 @@ test('renders filters for participant columns', async () => {
   const { RoutedComponent } = setupRouterTest(<ParticipantList studyEnvContext={studyEnvContext}/>)
   render(RoutedComponent)
 
-  //Assert that all 3 default columns have filter inputs
+  //There are 3 default columns shown, 2 of which allow text search
   const searchInputs = await screen.findAllByPlaceholderText('Search...')
-  expect(searchInputs).toHaveLength(3)
+  expect(searchInputs).toHaveLength(2)
 })
 
 test('filters participants based on shortcode', async () => {

--- a/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
@@ -5,8 +5,8 @@ import ParticipantList from './ParticipantList'
 import { EnrolleeSearchResult } from 'api/api'
 import { mockEnrollee, mockStudyEnvContext } from 'test-utils/mocking-utils'
 import { setupRouterTest } from 'test-utils/router-testing-utils'
-import userEvent from "@testing-library/user-event";
-import { act } from "react-dom/test-utils";
+import userEvent from '@testing-library/user-event'
+import { act } from 'react-dom/test-utils'
 
 jest.mock('api/api', () => ({
   searchEnrollees: () => {
@@ -38,9 +38,8 @@ test('renders filters for participant columns', async () => {
 
   //Assert that all 3 default columns have filter inputs
   await waitFor(() => {
-    expect(screen.getAllByPlaceholderText('Search...').length).toBe(3)
+    expect(screen.getAllByPlaceholderText('Search...')).toHaveLength(3)
   })
-
 })
 
 test('filters participants based on shortcode', async () => {
@@ -62,7 +61,6 @@ test('filters participants based on shortcode', async () => {
   await waitFor(() => {
     expect(screen.queryByText('JOSALK')).not.toBeInTheDocument()
   })
-
 })
 
 test('send email is toggled depending on participants selected', async () => {

--- a/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
@@ -37,9 +37,8 @@ test('renders filters for participant columns', async () => {
   render(RoutedComponent)
 
   //Assert that all 3 default columns have filter inputs
-  await waitFor(() => {
-    expect(screen.getAllByPlaceholderText('Search...')).toHaveLength(3)
-  })
+  const searchInputs = await screen.findAllByPlaceholderText('Search...')
+  expect(searchInputs).toHaveLength(3)
 })
 
 test('filters participants based on shortcode', async () => {
@@ -48,9 +47,7 @@ test('filters participants based on shortcode', async () => {
   render(RoutedComponent)
 
   //Assert that JOSALK is visible in the table
-  await waitFor(() => {
-    expect(screen.getByText('JOSALK')).toBeInTheDocument()
-  })
+  await screen.findByText('JOSALK')
 
   //Search for some unknown shortcode
   await act(() =>

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -61,27 +61,50 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
   }, {
     header: 'Shortcode',
     accessorKey: 'enrollee.shortcode',
+    meta: {
+      columnType: 'string'
+    },
     cell: info => <Link to={`${currentEnvPath}/participants/${info.getValue()}`}>{info.getValue()}</Link>
   }, {
     id: 'familyName',
     header: 'Family name',
-    accessorKey: 'profile.familyName'
+    accessorKey: 'profile.familyName',
+    meta: {
+      columnType: 'string'
+    }
   }, {
     id: 'givenName',
     header: 'Given name',
-    accessorKey: 'profile.givenName'
+    accessorKey: 'profile.givenName',
+    meta: {
+      columnType: 'string'
+    }
   }, {
     id: 'contactEmail',
     header: 'Contact email',
-    accessorKey: 'profile.contactEmail'
+    accessorKey: 'profile.contactEmail',
+    meta: {
+      columnType: 'string'
+    }
   }, {
     header: 'Consented',
-    accessorFn: data => data.enrollee.consented.toString(),
-    cell: info => info.getValue() === 'true' ? <FontAwesomeIcon icon={faCheck}/> : ''
+    accessorKey: 'enrollee.consented',
+    meta: {
+      columnType: 'boolean',
+      filterOptions: [
+        { value: true, label: 'Consented' },
+        { value: false, label: 'Not Consented' }
+      ]
+    },
+    filterFn: 'equals',
+    cell: info => info.getValue() ? <FontAwesomeIcon icon={faCheck}/> : ''
   }, {
     header: 'Kit status',
     filterFn: 'includesString', //an undefined value in a cell seems to switch the filter table away from the default
-    accessorKey: 'mostRecentKitStatus'
+    accessorKey: 'mostRecentKitStatus',
+    meta: {
+      columnType: 'string'
+    }
   }], [study.shortcode])
 
 

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -18,7 +18,7 @@ import {
   SortingState,
   useReactTable, VisibilityState
 } from '@tanstack/react-table'
-import { ColumnVisibilityControl, IndeterminateCheckbox, filterableTableHeader } from 'util/tableUtils'
+import { ColumnVisibilityControl, IndeterminateCheckbox, tableHeader } from 'util/tableUtils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheck } from '@fortawesome/free-solid-svg-icons'
 import ExportDataControl from '../export/ExportDataControl'
@@ -177,7 +177,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
           <table className="table table-striped">
             <thead>
               <tr>
-                {table.getFlatHeaders().map(header => filterableTableHeader(header))}
+                {table.getFlatHeaders().map(header => tableHeader(header, { sortable: true, filterable: true }))}
               </tr>
             </thead>
             <tbody>

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -182,7 +182,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
             <div className="d-flex align-items-center">
               <span className="me-2">
                 {numSelected} of{' '}
-                {table.getPreFilteredRowModel().rows.length} selected
+                {table.getPreFilteredRowModel().rows.length} selected ({table.getFilteredRowModel().rows.length} shown)
               </span>
               <span className="me-2">
                 <button onClick={() => setShowEmailModal(allowSendEmail)}

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -80,7 +80,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     cell: info => info.getValue() === 'true' ? <FontAwesomeIcon icon={faCheck}/> : ''
   }, {
     header: 'Kit status',
-    filterFn: 'includesString', //the occasional presence of undefined values seems to require a filter type to be set
+    filterFn: 'includesString', //the occasional presence of an undefined value seems to require a filter type to be set
     accessorKey: 'mostRecentKitStatus'
   }], [study.shortcode])
 

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -80,7 +80,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     cell: info => info.getValue() === 'true' ? <FontAwesomeIcon icon={faCheck}/> : ''
   }, {
     header: 'Kit status',
-    filterFn: 'includesString', //the occasional presence of an undefined value seems to require a filter type to be set
+    filterFn: 'includesString', //an undefined value in a cell seems to switch the filter table away from the default
     accessorKey: 'mostRecentKitStatus'
   }], [study.shortcode])
 

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -13,11 +13,12 @@ import {
   ColumnDef,
   flexRender,
   getCoreRowModel,
+  getFilteredRowModel,
   getSortedRowModel,
   SortingState,
   useReactTable, VisibilityState
 } from '@tanstack/react-table'
-import { ColumnVisibilityControl, IndeterminateCheckbox, sortableTableHeader } from 'util/tableUtils'
+import { ColumnVisibilityControl, IndeterminateCheckbox, filterableTableHeader } from 'util/tableUtils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheck } from '@fortawesome/free-solid-svg-icons'
 import ExportDataControl from '../export/ExportDataControl'
@@ -37,7 +38,8 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
   const [rowSelection, setRowSelection] = React.useState<Record<string, boolean>>({})
   const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({
     'givenName': false,
-    'familyName': false
+    'familyName': false,
+    'contactEmail': false
   })
   const [searchParams, setSearchParams] = useSearchParams()
 
@@ -69,11 +71,16 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     header: 'Given name',
     accessorKey: 'profile.givenName'
   }, {
+    id: 'contactEmail',
+    header: 'Contact email',
+    accessorKey: 'profile.contactEmail'
+  }, {
     header: 'Consented',
-    accessorKey: 'enrollee.consented',
-    cell: info => info.getValue() ? <FontAwesomeIcon icon={faCheck}/> : ''
+    accessorFn: data => data.enrollee.consented.toString(),
+    cell: info => info.getValue() === 'true' ? <FontAwesomeIcon icon={faCheck}/> : ''
   }, {
     header: 'Kit status',
+    filterFn: 'includesString', //the occasional presence of undefined values seems to require a filter type to be set
     accessorKey: 'mostRecentKitStatus'
   }], [study.shortcode])
 
@@ -91,6 +98,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
     onRowSelectionChange: setRowSelection
   })
 
@@ -169,7 +177,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
           <table className="table table-striped">
             <thead>
               <tr>
-                {table.getFlatHeaders().map(header => sortableTableHeader(header))}
+                {table.getFlatHeaders().map(header => filterableTableHeader(header))}
               </tr>
             </thead>
             <tbody>

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -1,7 +1,8 @@
 import React, { HTMLProps, useEffect, useState } from 'react'
-import { Column, flexRender, Header, Table } from '@tanstack/react-table'
+import { Column, flexRender, Header, RowData, Table } from '@tanstack/react-table'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCaretDown, faCaretUp, faColumns } from '@fortawesome/free-solid-svg-icons'
+import Select from 'react-select'
 
 /**
  * Returns a debounced input react component
@@ -10,7 +11,7 @@ import { faCaretDown, faCaretUp, faColumns } from '@fortawesome/free-solid-svg-i
 function DebouncedInput({
   value: initialValue,
   onChange,
-  debounce = 200,
+  debounce = 500,
   ...props
 }: {
   value: string
@@ -45,12 +46,64 @@ function Filter<A>({
 }: {
   column: Column<A>
 }) {
-  const columnFilterValue = column.getFilterValue()
+  return column.columnDef.meta?.columnType === 'boolean' ? (
+    SelectFilter({ column })
+  ) : (
+    //Defaults to the text search filter
+    SearchFilter({ column })
+  )
+}
 
+/**
+ * returns a SelectFilter to handle fields filtered by dropdown
+ * */
+function SelectFilter<A>({
+  column
+}: {
+  column: Column<A>
+}) {
+  const [selectedValue, setSelectedValue] = useState<{ value: boolean, label: string }>()
+
+  return <div>
+    <Select
+      options={column.columnDef.meta?.filterOptions || []}
+      isClearable={true}
+      styles={{
+        control: baseStyles => ({
+          ...baseStyles,
+          width: 200,
+          fontWeight: 'normal'
+        }),
+        menu: baseStyles => ({
+          ...baseStyles,
+          fontWeight: 'normal'
+        })
+      }}
+      value={selectedValue}
+      // @ts-ignore
+      onChange={(newValue: { value: boolean, label: string }) => {
+        //setFilterValue on Column cannot natively handle dropdown options,
+        //so we need to manage the filter value used by the column separately
+        //from the selected value used by the Select component
+        setSelectedValue(newValue)
+        newValue !== null ?
+          column.setFilterValue(newValue.value) :
+          column.setFilterValue(undefined)
+      }}
+    />
+    <div className="h-1" />
+  </div>
+}
+
+function SearchFilter<A>({
+  column
+}: {
+  column: Column<A>
+}) {
   return <div>
     <DebouncedInput
       type="text"
-      value={(columnFilterValue ?? '') as string}
+      value={(column.getFilterValue() ?? '') as string}
       onChange={value => column.setFilterValue(value)}
       placeholder={`Search...`}
     />
@@ -58,12 +111,14 @@ function Filter<A>({
   </div>
 }
 
-
 /**
  * returns a table header with optional sorting and filtering
  * adapted from https://tanstack.com/table/v8/docs/examples/react/sorting
  * */
-export function tableHeader<A, B>(header: Header<A, B>, options: { sortable: boolean, filterable: boolean }) {
+export function tableHeader<A, B>(
+  header: Header<A, B>,
+  options: { sortable: boolean, filterable: boolean }
+) {
   const sortDirection = options.sortable && header.column.getIsSorted()
   const ariaSort = options.sortable ?
     sortDirection ? (sortDirection === 'desc' ? 'descending' : 'ascending') : 'none' : undefined
@@ -179,7 +234,7 @@ export function basicTableLayout<T>(table: Table<T>) {
   return <table className="table table-striped">
     <thead>
       <tr>
-        {table.getFlatHeaders().map(header => sortableTableHeader(header))}
+        {table.getFlatHeaders().map(header => tableHeader(header, { sortable: true, filterable: false }))}
       </tr>
     </thead>
     <tbody>
@@ -198,4 +253,15 @@ export function basicTableLayout<T>(table: Table<T>) {
       })}
     </tbody>
   </table>
+}
+
+declare module '@tanstack/table-core' {
+  //Extra column metadata for extending the built-in filter functionality of react-table
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData extends RowData, TValue> {
+    //Specifies the type of the column data. By default, columns will be treated as strings
+    columnType?: string
+    //Specifies the Select options if using a dropdown filter (i.e. for booleans)
+    filterOptions?: { value: boolean, label: string }[]
+  }
 }

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -59,21 +59,31 @@ function Filter<A>({
   </div>
 }
 
+
+/**
+ * returns a table header with optional sorting and filtering
+ * adapted from https://tanstack.com/table/v8/docs/examples/react/sorting
+ * */
+export function tableHeader<A, B>(header: Header<A, B>, options: { sortable: boolean, filterable: boolean }) {
+  return <th key={header.id}>
+    { options.sortable ? sortableTableHeader(header) : null }
+    { options.filterable ? filterableTableHeader(header) : null }
+  </th>
+}
+
 /**
  * returns a clickable header column with up/down icons indicating sort direction
  * adapted from https://tanstack.com/table/v8/docs/examples/react/sorting
  * */
 export function sortableTableHeader<A, B>(header: Header<A, B>) {
-  return <th key={header.id}>
-    <div className={header.column.getCanSort() ? 'cursor-pointer select-none' : ''}
-      onClick={header.column.getToggleSortingHandler()} role="button">
-      {flexRender(header.column.columnDef.header, header.getContext())}
-      {{
-        asc: <FontAwesomeIcon icon={faCaretUp}/>,
-        desc: <FontAwesomeIcon icon={faCaretDown}/>
-      }[header.column.getIsSorted() as string] ?? null}
-    </div>
-  </th>
+  return <div className={header.column.getCanSort() ? 'cursor-pointer select-none' : ''}
+    onClick={header.column.getToggleSortingHandler()} role="button">
+    {flexRender(header.column.columnDef.header, header.getContext())}
+    {{
+      asc: <FontAwesomeIcon icon={faCaretUp}/>,
+      desc: <FontAwesomeIcon icon={faCaretDown}/>
+    }[header.column.getIsSorted() as string] ?? null}
+  </div>
 }
 
 /**
@@ -81,14 +91,11 @@ export function sortableTableHeader<A, B>(header: Header<A, B>) {
  * adapted from https://tanstack.com/table/v8/docs/examples/react/filters
  * */
 export function filterableTableHeader<A, B>(header: Header<A, B>) {
-  return <th key={header.id}>
-    { sortableTableHeader(header) }
-    {header.column.getCanFilter() ? (
-      <div>
-        <Filter column={header.column}/>
-      </div>
-    ) : null}
-  </th>
+  return header.column.getCanFilter() ? (
+    <div>
+      <Filter column={header.column}/>
+    </div>
+  ) : null
 }
 
 /**

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -53,7 +53,6 @@ function Filter<A>({
       value={(columnFilterValue ?? '') as string}
       onChange={value => column.setFilterValue(value)}
       placeholder={`Search...`}
-      list={`${column.id} list`}
     />
     <div className="h-1" />
   </div>

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps, useState } from 'react'
+import React, { HTMLProps, useEffect, useState } from 'react'
 import { Column, flexRender, Header, Table } from '@tanstack/react-table'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCaretDown, faCaretUp, faColumns } from '@fortawesome/free-solid-svg-icons'
@@ -19,11 +19,11 @@ function DebouncedInput({
 } & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'>) {
   const [value, setValue] = React.useState(initialValue)
 
-  React.useEffect(() => {
+  useEffect(() => {
     setValue(initialValue)
   }, [initialValue])
 
-  React.useEffect(() => {
+  useEffect(() => {
     const timeout = setTimeout(() => {
       onChange(value)
     }, debounce)

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -16,7 +16,7 @@ function DebouncedInput({
   value: string
   onChange: (value: string) => void
   debounce?: number
-} & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'>) {
+} & Omit<JSX.IntrinsicElements['input'], 'onChange'>) {
   const [value, setValue] = React.useState(initialValue)
 
   useEffect(() => {

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -33,7 +33,7 @@ function DebouncedInput({
   }, [value])
 
   return (
-    <input {...props} value={value} onChange={e => setValue(e.target.value)} />
+    <input {...props} value={value} style={{ height: 32 }} onChange={e => setValue(e.target.value)} />
   )
 }
 
@@ -72,11 +72,17 @@ function SelectFilter<A>({
         control: baseStyles => ({
           ...baseStyles,
           width: 200,
+          height: 32,
+          minHeight: 32,
           fontWeight: 'normal'
         }),
         menu: baseStyles => ({
           ...baseStyles,
           fontWeight: 'normal'
+        }),
+        valueContainer: baseStyles => ({
+          ...baseStyles,
+          padding: '0 0.25rem'
         })
       }}
       value={selectedValue}

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -3,7 +3,10 @@ import { Column, flexRender, Header, Table } from '@tanstack/react-table'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCaretDown, faCaretUp, faColumns } from '@fortawesome/free-solid-svg-icons'
 
-// A debounced input react component
+/**
+ * Returns a debounced input react component
+ * Adapted from https://tanstack.com/table/v8/docs/examples/react/filters
+ */
 function DebouncedInput({
   value: initialValue,
   onChange,
@@ -40,7 +43,7 @@ function DebouncedInput({
 function Filter<A>({
   column
 }: {
-  column: Column<A, unknown>
+  column: Column<A>
 }) {
   const columnFilterValue = column.getFilterValue()
 
@@ -77,7 +80,7 @@ export function sortableTableHeader<A, B>(header: Header<A, B>) {
  * returns a filterable and sortable header column
  * adapted from https://tanstack.com/table/v8/docs/examples/react/filters
  * */
-export function filterableTableHeader<A, B, C>(header: Header<A, B>) {
+export function filterableTableHeader<A, B>(header: Header<A, B>) {
   return <th key={header.id}>
     { sortableTableHeader(header) }
     {header.column.getCanFilter() ? (

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -37,7 +37,7 @@ function DebouncedInput({
 }
 
 /**
- * returns a Filter to handle text and boolean fields
+ * returns a Filter to handle text fields
  * adapted from https://tanstack.com/table/v8/docs/examples/react/filters
  * */
 function Filter<A>({

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -66,7 +66,7 @@ function Filter<A>({
 export function tableHeader<A, B>(header: Header<A, B>, options: { sortable: boolean, filterable: boolean }) {
   const sortDirection = options.sortable && header.column.getIsSorted()
   const ariaSort = options.sortable ?
-      sortDirection ? (sortDirection === 'desc' ? 'descending' : 'ascending') : 'none' : undefined
+    sortDirection ? (sortDirection === 'desc' ? 'descending' : 'ascending') : 'none' : undefined
 
   return <th key={header.id}
     aria-sort={ariaSort}>

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -17,7 +17,7 @@ function DebouncedInput({
   onChange: (value: string) => void
   debounce?: number
 } & Omit<JSX.IntrinsicElements['input'], 'onChange'>) {
-  const [value, setValue] = React.useState(initialValue)
+  const [value, setValue] = useState(initialValue)
 
   useEffect(() => {
     setValue(initialValue)
@@ -64,7 +64,12 @@ function Filter<A>({
  * adapted from https://tanstack.com/table/v8/docs/examples/react/sorting
  * */
 export function tableHeader<A, B>(header: Header<A, B>, options: { sortable: boolean, filterable: boolean }) {
-  return <th key={header.id}>
+  const sortDirection = options.sortable && header.column.getIsSorted()
+  const ariaSort = options.sortable ?
+      sortDirection ? (sortDirection === 'desc' ? 'descending' : 'ascending') : 'none' : undefined
+
+  return <th key={header.id}
+    aria-sort={ariaSort}>
     { options.sortable ? sortableTableHeader(header) : null }
     { options.filterable ? filterableTableHeader(header) : null }
   </th>


### PR DESCRIPTION
This enables the client-side filtering available in react-table. It also adds the contactEmail field to the participant view (hidden by default).

![Screenshot 2023-06-26 at 2 50 15 PM](https://github.com/broadinstitute/juniper/assets/7257391/7ee579d1-eba0-46cb-a9a5-2451b2622f34)


TO TEST:
1. Go to https://localhost:3000/ourhealth/env/sandbox/participants
2. Play around with the filters