### PR TITLE
[JN-378] Add UI for editing questions in forms

### DIFF
--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -39,6 +39,7 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
           title="Designer"
         >
           <FormDesigner
+            readOnly={readOnly}
             value={editedContent}
             onChange={newContent => {
               setEditedContent(newContent)

--- a/ui-admin/src/forms/FormDesigner.tsx
+++ b/ui-admin/src/forms/FormDesigner.tsx
@@ -78,8 +78,8 @@ export const FormDesigner = (props: FormDesignerProps) => {
 
           return (
             <QuestionDesigner
+              question={selectedElement}
               readOnly={readOnly}
-              value={selectedElement}
               onChange={updatedElement => {
                 onChange(set(selectedElementPath, updatedElement, value))
               }}

--- a/ui-admin/src/forms/FormDesigner.tsx
+++ b/ui-admin/src/forms/FormDesigner.tsx
@@ -6,6 +6,7 @@ import { FormContent, FormContentPage, FormElement } from '@juniper/ui-core'
 import { HtmlDesigner } from './designer/HtmlDesigner'
 import { PageDesigner } from './designer/PageDesigner'
 import { PanelDesigner } from './designer/PanelDesigner'
+import { QuestionDesigner } from './designer/QuestionDesigner'
 import { FormTableOfContents } from './FormTableOfContents'
 
 type FormDesignerProps = {
@@ -75,7 +76,15 @@ export const FormDesigner = (props: FormDesignerProps) => {
             )
           }
 
-          return null
+          return (
+            <QuestionDesigner
+              readOnly={readOnly}
+              value={selectedElement}
+              onChange={updatedElement => {
+                onChange(set(selectedElementPath, updatedElement, value))
+              }}
+            />
+          )
         })()}
       </div>
     </div>

--- a/ui-admin/src/forms/designer/QuestionDesigner.tsx
+++ b/ui-admin/src/forms/designer/QuestionDesigner.tsx
@@ -10,25 +10,25 @@ import { questionTypeDescriptions, questionTypeLabels } from './questions/questi
 import { VisibilityFields } from './questions/VisibilityFields'
 
 export type QuestionDesignerProps = {
+  question: Question
   readOnly: boolean
-  value: Question
   onChange: (newValue: Question) => void
 }
 
 /** UI for editing a question in a form. */
 export const QuestionDesigner = (props: QuestionDesignerProps) => {
-  const { readOnly, value, onChange } = props
+  const { question, readOnly, onChange } = props
 
-  const isTemplated = 'questionTemplateName' in value
+  const isTemplated = 'questionTemplateName' in question
 
   return (
     <div>
-      <h2>{value.name}</h2>
+      <h2>{question.name}</h2>
 
       {!isTemplated && (
         <>
-          <p className="fs-4 mb-0">{questionTypeLabels[value.type]} question</p>
-          <p>{questionTypeDescriptions[value.type]}</p>
+          <p className="fs-4 mb-0">{questionTypeLabels[question.type]} question</p>
+          <p>{questionTypeDescriptions[question.type]}</p>
         </>
       )}
 
@@ -36,7 +36,7 @@ export const QuestionDesigner = (props: QuestionDesignerProps) => {
         <>
           <p className="fs-4 mb-0">Templated question</p>
           <p>
-            This question uses <span className="fw-bold">{value.questionTemplateName}</span> as a template.
+            This question uses <span className="fw-bold">{question.questionTemplateName}</span> as a template.
             Question settings entered here override settings from the template.
           </p>
         </>
@@ -44,33 +44,33 @@ export const QuestionDesigner = (props: QuestionDesignerProps) => {
 
       <BaseFields
         disabled={readOnly}
-        question={value}
+        question={question}
         onChange={onChange}
       />
 
       {!isTemplated && (
         <>
           {
-            (value.type === 'checkbox' || value.type === 'dropdown' || value.type === 'radiogroup') && (
+            (question.type === 'checkbox' || question.type === 'dropdown' || question.type === 'radiogroup') && (
               <>
                 <ChoicesList
-                  question={value}
+                  question={question}
                   readOnly={readOnly}
                   onChange={onChange}
                 />
                 <OtherOptionFields
                   disabled={readOnly}
-                  question={value}
+                  question={question}
                   onChange={onChange}
                 />
               </>
             )
           }
           {
-            value.type === 'checkbox' && (
+            question.type === 'checkbox' && (
               <CheckboxFields
                 disabled={readOnly}
-                question={value}
+                question={question}
                 onChange={onChange}
               />
             )
@@ -80,7 +80,7 @@ export const QuestionDesigner = (props: QuestionDesignerProps) => {
 
       <VisibilityFields
         disabled={readOnly}
-        question={value}
+        question={question}
         onChange={onChange}
       />
     </div>

--- a/ui-admin/src/forms/designer/QuestionDesigner.tsx
+++ b/ui-admin/src/forms/designer/QuestionDesigner.tsx
@@ -1,0 +1,88 @@
+import React from 'react'
+
+import { Question } from '@juniper/ui-core'
+
+import { BaseFields } from './questions/BaseFields'
+import { CheckboxFields } from './questions/CheckboxFields'
+import { ChoicesList } from './questions/ChoicesList'
+import { OtherOptionFields } from './questions/OtherOptionFields'
+import { questionTypeDescriptions, questionTypeLabels } from './questions/questionTypes'
+import { VisibilityFields } from './questions/VisibilityFields'
+
+export type QuestionDesignerProps = {
+  readOnly: boolean
+  value: Question
+  onChange: (newValue: Question) => void
+}
+
+/** UI for editing a question in a form. */
+export const QuestionDesigner = (props: QuestionDesignerProps) => {
+  const { readOnly, value, onChange } = props
+
+  const isTemplated = 'questionTemplateName' in value
+
+  return (
+    <div>
+      <h2>{value.name}</h2>
+
+      {!isTemplated && (
+        <>
+          <p className="fs-4 mb-0">{questionTypeLabels[value.type]} question</p>
+          <p>{questionTypeDescriptions[value.type]}</p>
+        </>
+      )}
+
+      {isTemplated && (
+        <>
+          <p className="fs-4 mb-0">Templated question</p>
+          <p>
+            This question uses <span className="fw-bold">{value.questionTemplateName}</span> as a template.
+            Question settings entered here override settings from the template.
+          </p>
+        </>
+      )}
+
+      <BaseFields
+        disabled={readOnly}
+        question={value}
+        onChange={onChange}
+      />
+
+      {!isTemplated && (
+        <>
+          {
+            (value.type === 'checkbox' || value.type === 'dropdown' || value.type === 'radiogroup') && (
+              <>
+                <ChoicesList
+                  question={value}
+                  readOnly={readOnly}
+                  onChange={onChange}
+                />
+                <OtherOptionFields
+                  disabled={readOnly}
+                  question={value}
+                  onChange={onChange}
+                />
+              </>
+            )
+          }
+          {
+            value.type === 'checkbox' && (
+              <CheckboxFields
+                disabled={readOnly}
+                question={value}
+                onChange={onChange}
+              />
+            )
+          }
+        </>
+      )}
+
+      <VisibilityFields
+        disabled={readOnly}
+        question={value}
+        onChange={onChange}
+      />
+    </div>
+  )
+}

--- a/ui-admin/src/forms/designer/questions/BaseFields.test.tsx
+++ b/ui-admin/src/forms/designer/questions/BaseFields.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+
+import { Question } from '@juniper/ui-core'
+
+import { BaseFields } from './BaseFields'
+
+describe('BaseFields', () => {
+  const question: Question = {
+    name: 'test_question',
+    title: 'What?',
+    description: 'This is a test question',
+    isRequired: true,
+    type: 'text'
+  }
+
+  it('shows question title', () => {
+    // Act
+    render(<BaseFields disabled={false} question={question} onChange={jest.fn()} />)
+
+    // Assert
+    const input = screen.getByLabelText('Question text')
+    expect((input as HTMLInputElement).value).toBe('What?')
+  })
+
+  it('updates question title', () => {
+    // Arrange
+    const onChange = jest.fn()
+    render(<BaseFields disabled={false} question={question} onChange={onChange} />)
+
+    // Act
+    const input = screen.getByLabelText('Question text')
+    fireEvent.change(input, { target: { value: 'Why?' } })
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith({
+      ...question,
+      title: 'Why?'
+    })
+  })
+
+  it('shows question description', () => {
+    // Act
+    render(<BaseFields disabled={false} question={question} onChange={jest.fn()} />)
+
+    // Assert
+    const input = screen.getByLabelText('Description')
+    expect((input as HTMLInputElement).value).toBe('This is a test question')
+  })
+
+  it('updates question description', () => {
+    // Arrange
+    const onChange = jest.fn()
+    render(<BaseFields disabled={false} question={question} onChange={onChange} />)
+
+    // Act
+    const input = screen.getByLabelText('Description')
+    fireEvent.change(input, { target: { value: 'More information' } })
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith({
+      ...question,
+      description: 'More information'
+    })
+  })
+
+  it('shows required flag', () => {
+    // Act
+    render(<BaseFields disabled={false} question={question} onChange={jest.fn()} />)
+
+    // Assert
+    const input = screen.getByLabelText('Require response')
+    expect((input as HTMLInputElement).checked).toBe(true)
+  })
+
+  it('updates required flag', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const onChange = jest.fn()
+    render(<BaseFields disabled={false} question={question} onChange={onChange} />)
+
+    // Act
+    const input = screen.getByLabelText('Require response')
+    await user.click(input)
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith({
+      ...question,
+      isRequired: false
+    })
+  })
+})

--- a/ui-admin/src/forms/designer/questions/BaseFields.tsx
+++ b/ui-admin/src/forms/designer/questions/BaseFields.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+
+import { Question } from '@juniper/ui-core'
+
+import { Checkbox } from 'components/forms/Checkbox'
+import { Textarea } from 'components/forms/Textarea'
+
+type BaseFieldsProps = {
+  disabled: boolean
+  question: Question
+  onChange: (newValue: Question) => void
+}
+
+/** Controls for editing base question fields. */
+export const BaseFields = (props: BaseFieldsProps) => {
+  const { disabled, question, onChange } = props
+
+  return (
+    <>
+      <div className="mb-3">
+        <Textarea
+          disabled={disabled}
+          label="Question text"
+          rows={2}
+          value={question.title}
+          onChange={value => {
+            onChange({
+              ...question,
+              title: value
+            })
+          }}
+        />
+      </div>
+
+      <div className="mb-3">
+        <Textarea
+          description="Additional context for the question."
+          disabled={disabled}
+          label="Description"
+          rows={2}
+          value={question.description}
+          onChange={value => {
+            onChange({
+              ...question,
+              description: value
+            })
+          }}
+        />
+      </div>
+
+      <div className="mb-3">
+        <Checkbox
+          checked={!!question.isRequired}
+          // eslint-disable-next-line max-len
+          description="If checked, participants will be required to enter a response before they can continue to the next page of the form."
+          disabled={disabled}
+          label="Require response"
+          onChange={checked => {
+            onChange({
+              ...question,
+              isRequired: checked
+            })
+          }}
+        />
+      </div>
+    </>
+  )
+}

--- a/ui-admin/src/forms/designer/questions/CheckboxFields.test.tsx
+++ b/ui-admin/src/forms/designer/questions/CheckboxFields.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+
+import { CheckboxQuestion } from '@juniper/ui-core'
+
+import { CheckboxFields } from './CheckboxFields'
+
+describe('CheckboxFields', () => {
+  it('has option to show "None" option', () => {
+    // Arrange
+    const question: CheckboxQuestion = {
+      name: 'test_question',
+      title: 'Pick some',
+      type: 'checkbox',
+      choices: [
+        { value: 'foo', text: 'foo' },
+        { value: 'bar', text: 'bar' },
+        { value: 'baz', text: 'baz' }
+      ]
+    }
+
+    // Act
+    render(<CheckboxFields disabled={false} question={question} onChange={jest.fn()} />)
+
+    // Assert
+    const input = screen.getByLabelText('Show "None" option')
+    expect((input as HTMLInputElement).checked).toBe(false)
+  })
+
+  it('sets default values for "None" option config', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const question: CheckboxQuestion = {
+      name: 'test_question',
+      title: 'Pick some',
+      type: 'checkbox',
+      choices: [
+        { value: 'foo', text: 'foo' },
+        { value: 'bar', text: 'bar' },
+        { value: 'baz', text: 'baz' }
+      ]
+    }
+
+    const onChange = jest.fn()
+
+    render(<CheckboxFields disabled={false} question={question} onChange={onChange} />)
+
+    // Act
+    const input = screen.getByLabelText('Show "None" option')
+    await user.click(input)
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith({
+      ...question,
+      showNoneItem: true,
+      noneText: 'None of the above',
+      noneValue: 'noneOfAbove'
+    })
+  })
+
+  describe('when "None" option is shown', () => {
+    const question: CheckboxQuestion = {
+      name: 'test_question',
+      title: 'Pick some',
+      type: 'checkbox',
+      choices: [
+        { value: 'foo', text: 'foo' },
+        { value: 'bar', text: 'bar' },
+        { value: 'baz', text: 'baz' }
+      ],
+      showNoneItem: true,
+      noneText: 'None of the above',
+      noneValue: 'noneOfAbove'
+    }
+
+    it('shows "None" option text', () => {
+      // Act
+      render(<CheckboxFields disabled={false} question={question} onChange={jest.fn()} />)
+
+      // Assert
+      const input = screen.getByLabelText('Label')
+      expect((input as HTMLInputElement).value).toBe('None of the above')
+    })
+
+    it('updates "None" option text', () => {
+      // Arrange
+      const onChange = jest.fn()
+      render(<CheckboxFields disabled={false} question={question} onChange={onChange} />)
+
+      // Act
+      const input = screen.getByLabelText('Label')
+      fireEvent.change(input, { target: { value: 'None of these' } })
+
+      // Assert
+      expect(onChange).toHaveBeenCalledWith({
+        ...question,
+        noneText: 'None of these'
+      })
+    })
+
+    it('shows "None" option value', () => {
+      // Act
+      render(<CheckboxFields disabled={false} question={question} onChange={jest.fn()} />)
+
+      // Assert
+      const input = screen.getByLabelText('Value')
+      expect((input as HTMLInputElement).value).toBe('noneOfAbove')
+    })
+
+    it('updates "None" option value', () => {
+      // Arrange
+      const onChange = jest.fn()
+      render(<CheckboxFields disabled={false} question={question} onChange={onChange} />)
+
+      // Act
+      const input = screen.getByLabelText('Value')
+      fireEvent.change(input, { target: { value: 'noneOfThese' } })
+
+      // Assert
+      expect(onChange).toHaveBeenCalledWith({
+        ...question,
+        noneValue: 'noneOfThese'
+      })
+    })
+  })
+})

--- a/ui-admin/src/forms/designer/questions/CheckboxFields.tsx
+++ b/ui-admin/src/forms/designer/questions/CheckboxFields.tsx
@@ -11,7 +11,7 @@ type CheckboxFieldsProps = {
   onChange: (newValue: CheckboxQuestion) => void
 }
 
-/** Controls for editing other option for questions. */
+/** Controls for editing fields specific to checkbox questions. */
 export const CheckboxFields = (props: CheckboxFieldsProps) => {
   const { disabled, question, onChange } = props
 

--- a/ui-admin/src/forms/designer/questions/CheckboxFields.tsx
+++ b/ui-admin/src/forms/designer/questions/CheckboxFields.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+
+import { CheckboxQuestion } from '@juniper/ui-core'
+
+import { Checkbox } from 'components/forms/Checkbox'
+import { TextInput } from 'components/forms/TextInput'
+
+type CheckboxFieldsProps = {
+  disabled: boolean
+  question: CheckboxQuestion
+  onChange: (newValue: CheckboxQuestion) => void
+}
+
+/** Controls for editing other option for questions. */
+export const CheckboxFields = (props: CheckboxFieldsProps) => {
+  const { disabled, question, onChange } = props
+
+  return (
+    <>
+      <div className="mb-3">
+        <Checkbox
+          checked={!!question.showNoneItem}
+          description={'Show a "None" option that, when selected, clears all other selections for this question.'}
+          disabled={disabled}
+          label={'Show "None" option'}
+          onChange={checked => {
+            if (checked) {
+              const { noneText, noneValue } = question
+              onChange({
+                ...question,
+                showNoneItem: true,
+                noneText: noneText || 'None of the above',
+                noneValue: noneValue || 'noneOfAbove'
+              })
+            } else {
+              onChange({
+                ...question,
+                showNoneItem: false
+              })
+            }
+          }}
+        />
+      </div>
+
+      {!!question.showNoneItem && (
+        <fieldset>
+          <legend className="form-label fs-5">&ldquo;None&rdquo; option</legend>
+
+          <div className="mb-3">
+            <TextInput
+              description={'Label for the "None" option.'}
+              disabled={disabled}
+              label="Label"
+              value={question.noneText || ''}
+              onChange={value => {
+                onChange({
+                  ...question,
+                  noneText: value
+                })
+              }}
+            />
+          </div>
+
+          <div className="mb-3">
+            <TextInput
+              description={'Value for the "None" option.'}
+              disabled={disabled}
+              label="Value"
+              value={question.noneValue || ''}
+              onChange={value => {
+                onChange({
+                  ...question,
+                  noneValue: value
+                })
+              }}
+            />
+          </div>
+        </fieldset>
+      )}
+    </>
+  )
+}

--- a/ui-admin/src/forms/designer/questions/ChoicesList.test.tsx
+++ b/ui-admin/src/forms/designer/questions/ChoicesList.test.tsx
@@ -1,0 +1,141 @@
+import { act, fireEvent, getByLabelText, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+
+import { CheckboxQuestion } from '@juniper/ui-core'
+
+import { ChoicesList } from './ChoicesList'
+
+describe('ChoicesList', () => {
+  const question: CheckboxQuestion = {
+    name: 'test_question',
+    title: 'Pick some',
+    type: 'checkbox',
+    choices: [
+      { value: 'foo', text: 'Foo' },
+      { value: 'bar', text: 'Bar' },
+      { value: 'baz', text: 'Baz' }
+    ]
+  }
+
+  it('renders list of choices with inputs for text and value', () => {
+    // Act
+    render(<ChoicesList question={question} readOnly={false} onChange={jest.fn()} />)
+
+    // Assert
+    const choiceListItems = screen.getAllByRole('listitem')
+
+    ;['Foo', 'Bar', 'Baz'].forEach((label, index) => {
+      const labelInput = getByLabelText(choiceListItems[index], 'Text')
+      expect((labelInput as HTMLInputElement).value).toBe(label)
+
+      const valueInput = getByLabelText(choiceListItems[index], 'Value')
+      expect((valueInput as HTMLInputElement).value).toBe(label.toLowerCase())
+    })
+  })
+
+  it('allows changing choice labels', () => {
+    // Arrange
+    const onChange = jest.fn()
+    render(<ChoicesList question={question} readOnly={false} onChange={onChange} />)
+
+    const barChoice = screen.getAllByRole('listitem')[1]
+
+    // Act
+    const barLabelInput = getByLabelText(barChoice, 'Text')
+    fireEvent.change(barLabelInput, { target: { value: 'BAR' } })
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith({
+      ...question,
+      choices: [
+        { value: 'foo', text: 'Foo' },
+        { value: 'bar', text: 'BAR' },
+        { value: 'baz', text: 'Baz' }
+      ]
+    })
+  })
+
+  it('allows changing choice values', () => {
+    // Arrange
+    const onChange = jest.fn()
+    render(<ChoicesList question={question} readOnly={false} onChange={onChange} />)
+
+    const barChoice = screen.getAllByRole('listitem')[1]
+
+    // Act
+    const barLabelInput = getByLabelText(barChoice, 'Value')
+    fireEvent.change(barLabelInput, { target: { value: 'BAR' } })
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith({
+      ...question,
+      choices: [
+        { value: 'foo', text: 'Foo' },
+        { value: 'BAR', text: 'Bar' },
+        { value: 'baz', text: 'Baz' }
+      ]
+    })
+  })
+
+  it('allows reordering choices', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const onChange = jest.fn()
+    render(<ChoicesList question={question} readOnly={false} onChange={onChange} />)
+
+    const barChoice = screen.getAllByRole('listitem')[1]
+    const moveUpButton = getByLabelText(barChoice, 'Move this choice before the previous one')
+    const moveDownButton = getByLabelText(barChoice, 'Move this choice after the next one')
+
+    // Act
+    await act(() => user.click(moveUpButton))
+
+    // Assert
+    expect(onChange).toBeCalledWith({
+      ...question,
+      choices: [
+        { value: 'bar', text: 'Bar' },
+        { value: 'foo', text: 'Foo' },
+        { value: 'baz', text: 'Baz' }
+      ]
+    })
+
+    // Act
+    await act(() => user.click(moveDownButton))
+
+    // Assert
+    expect(onChange).toBeCalledWith({
+      ...question,
+      choices: [
+        { value: 'foo', text: 'Foo' },
+        { value: 'baz', text: 'Baz' },
+        { value: 'bar', text: 'Bar' }
+      ]
+    })
+  })
+
+  it('allows deleting choices', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const onChange = jest.fn()
+    render(<ChoicesList question={question} readOnly={false} onChange={onChange} />)
+
+    const barChoice = screen.getAllByRole('listitem')[1]
+    const deleteButton = getByLabelText(barChoice, 'Delete this choice')
+
+    // Act
+    await act(() => user.click(deleteButton))
+
+    // Assert
+    expect(onChange).toBeCalledWith({
+      ...question,
+      choices: [
+        { value: 'foo', text: 'Foo' },
+        { value: 'baz', text: 'Baz' }
+      ]
+    })
+  })
+})

--- a/ui-admin/src/forms/designer/questions/ChoicesList.tsx
+++ b/ui-admin/src/forms/designer/questions/ChoicesList.tsx
@@ -24,7 +24,7 @@ export const ChoicesList = (props: ChoicesListProps) => {
   return (
     <div className="mb-3">
       <p className="mb-2" id={labelId}>Choices</p>
-      <ol aria-labelledby={labelId} className="list-group list-group-numbered mb-1">
+      <ol aria-labelledby={labelId} className="list-group mb-1">
         {question.choices.map((choice, i) => {
           return (
             <li
@@ -32,7 +32,7 @@ export const ChoicesList = (props: ChoicesListProps) => {
               className="list-group-item d-flex"
             >
               <div
-                className="flex-grow-1 ms-3"
+                className="flex-grow-1"
                 style={{
                   display: 'grid',
                   grid: 'auto-flow / max-content auto',

--- a/ui-admin/src/forms/designer/questions/ChoicesList.tsx
+++ b/ui-admin/src/forms/designer/questions/ChoicesList.tsx
@@ -1,0 +1,158 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faChevronDown, faChevronUp, faPlus, faTimes } from '@fortawesome/free-solid-svg-icons'
+import React, { useId } from 'react'
+
+import { CheckboxQuestion, DropdownQuestion, RadiogroupQuestion } from '@juniper/ui-core'
+
+import { Button, IconButton } from 'components/forms/Button'
+import { TextInput } from 'components/forms/TextInput'
+
+type QuestionWithChoices = CheckboxQuestion | DropdownQuestion | RadiogroupQuestion
+
+type ChoicesListProps = {
+  question: QuestionWithChoices
+  readOnly: boolean
+  onChange: (newValue: QuestionWithChoices) => void
+}
+
+/** UI for editing the list of choices for a question. */
+export const ChoicesList = (props: ChoicesListProps) => {
+  const { question, readOnly, onChange } = props
+
+  const labelId = useId()
+
+  return (
+    <div className="mb-3">
+      <p className="mb-2" id={labelId}>Choices</p>
+      <ol aria-labelledby={labelId} className="list-group list-group-numbered mb-1">
+        {question.choices.map((choice, i) => {
+          return (
+            <li
+              key={i}
+              className="list-group-item d-flex"
+            >
+              <div
+                className="flex-grow-1 ms-3"
+                style={{
+                  display: 'grid',
+                  grid: 'auto-flow / max-content auto',
+                  gridColumnGap: '0.5rem',
+                  gridRowGap: '1rem',
+                  alignItems: 'center',
+                  height: 'fit-content'
+                }}
+              >
+                <TextInput
+                  className="form-control"
+                  disabled={readOnly}
+                  label="Text"
+                  labelClassname="mb-0"
+                  value={choice.text}
+                  onChange={value => {
+                    onChange({
+                      ...question,
+                      choices: [
+                        ...question.choices.slice(0, i),
+                        { ...question.choices[i], text: value },
+                        ...question.choices.slice(i + 1)
+                      ]
+                    })
+                  }}
+                />
+                <TextInput
+                  disabled={readOnly}
+                  label="Value"
+                  labelClassname="mb-0"
+                  value={choice.value}
+                  onChange={value => {
+                    onChange({
+                      ...question,
+                      choices: [
+                        ...question.choices.slice(0, i),
+                        { ...question.choices[i], value },
+                        ...question.choices.slice(i + 1)
+                      ]
+                    })
+                  }}
+                />
+              </div>
+
+              <div className="d-flex flex-column justify-content-between ms-2">
+                <IconButton
+                  aria-label="Move this choice before the previous one"
+                  disabled={readOnly || i === 0}
+                  icon={faChevronUp}
+                  variant="light"
+                  onClick={() => {
+                    onChange({
+                      ...question,
+                      choices: [
+                        ...question.choices.slice(0, i - 1),
+                        question.choices[i],
+                        question.choices[i - 1],
+                        ...question.choices.slice(i + 1)
+                      ]
+                    })
+                  }}
+                />
+
+                <IconButton
+                  aria-label="Move this choice after the next one"
+                  disabled={readOnly || i === question.choices.length - 1}
+                  icon={faChevronDown}
+                  variant="light"
+                  className="btn btn-light"
+                  onClick={() => {
+                    onChange({
+                      ...question,
+                      choices: [
+                        ...question.choices.slice(0, i),
+                        question.choices[i + 1],
+                        question.choices[i],
+                        ...question.choices.slice(i + 2)
+                      ]
+                    })
+                  }}
+                />
+              </div>
+
+              <div className="d-flex flex-column justify-content-between flex-shrink-0 ms-2">
+                <IconButton
+                  aria-label="Delete this choice"
+                  disabled={readOnly}
+                  icon={faTimes}
+                  variant="light"
+                  onClick={() => {
+                    onChange({
+                      ...question,
+                      choices: [
+                        ...question.choices.slice(0, i),
+                        ...question.choices.slice(i + 1)
+                      ]
+                    })
+                  }}
+                />
+              </div>
+            </li>
+          )
+        })}
+      </ol>
+
+      <Button
+        disabled={readOnly}
+        variant="secondary"
+        onClick={() => {
+          onChange({
+            ...question,
+            choices: [
+              ...question.choices,
+              { text: '', value: '' }
+            ]
+          })
+        }}
+      >
+        <FontAwesomeIcon icon={faPlus} /> Add a choice
+      </Button>
+    </div>
+  )
+}

--- a/ui-admin/src/forms/designer/questions/OtherOptionFields.test.tsx
+++ b/ui-admin/src/forms/designer/questions/OtherOptionFields.test.tsx
@@ -1,0 +1,155 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+
+import { CheckboxQuestion } from '@juniper/ui-core'
+
+import { OtherOptionFields } from './OtherOptionFields'
+
+describe('OtherOptionFields', () => {
+  it('has option to show "Other" option', () => {
+    // Arrange
+    const question: CheckboxQuestion = {
+      name: 'test_question',
+      title: 'Pick some',
+      type: 'checkbox',
+      choices: [
+        { value: 'foo', text: 'foo' },
+        { value: 'bar', text: 'bar' },
+        { value: 'baz', text: 'baz' }
+      ]
+    }
+
+    // Act
+    render(<OtherOptionFields disabled={false} question={question} onChange={jest.fn()} />)
+
+    // Assert
+    const input = screen.getByLabelText('Show "Other" option')
+    expect((input as HTMLInputElement).checked).toBe(false)
+  })
+
+  it('sets default values for "Other" option config', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const question: CheckboxQuestion = {
+      name: 'test_question',
+      title: 'Pick some',
+      type: 'checkbox',
+      choices: [
+        { value: 'foo', text: 'foo' },
+        { value: 'bar', text: 'bar' },
+        { value: 'baz', text: 'baz' }
+      ]
+    }
+
+    const onChange = jest.fn()
+
+    render(<OtherOptionFields disabled={false} question={question} onChange={onChange} />)
+
+    // Act
+    const input = screen.getByLabelText('Show "Other" option')
+    await user.click(input)
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith({
+      ...question,
+      showOtherItem: true,
+      otherText: 'Other',
+      otherPlaceholder: 'Please specify',
+      otherErrorText: 'A description is required for choices of "other".'
+    })
+  })
+
+  describe('when "Other" option is shown', () => {
+    const question: CheckboxQuestion = {
+      name: 'test_question',
+      title: 'Pick some',
+      type: 'checkbox',
+      choices: [
+        { value: 'foo', text: 'foo' },
+        { value: 'bar', text: 'bar' },
+        { value: 'baz', text: 'baz' }
+      ],
+      showOtherItem: true,
+      otherText: 'Other',
+      otherPlaceholder: 'Please specify',
+      otherErrorText: 'A description is required for choices of "other".'
+    }
+
+    it('shows "Other" option text', () => {
+      // Act
+      render(<OtherOptionFields disabled={false} question={question} onChange={jest.fn()} />)
+
+      // Assert
+      const input = screen.getByLabelText('Label')
+      expect((input as HTMLInputElement).value).toBe('Other')
+    })
+
+    it('updates "Other" option text', () => {
+      // Arrange
+      const onChange = jest.fn()
+      render(<OtherOptionFields disabled={false} question={question} onChange={onChange} />)
+
+      // Act
+      const input = screen.getByLabelText('Label')
+      fireEvent.change(input, { target: { value: 'Something else' } })
+
+      // Assert
+      expect(onChange).toHaveBeenCalledWith({
+        ...question,
+        otherText: 'Something else'
+      })
+    })
+
+    it('shows "Other" description placeholder', () => {
+      // Act
+      render(<OtherOptionFields disabled={false} question={question} onChange={jest.fn()} />)
+
+      // Assert
+      const input = screen.getByLabelText('Placeholder')
+      expect((input as HTMLInputElement).value).toBe('Please specify')
+    })
+
+    it('updates "Other" description placeholder', () => {
+      // Arrange
+      const onChange = jest.fn()
+      render(<OtherOptionFields disabled={false} question={question} onChange={onChange} />)
+
+      // Act
+      const input = screen.getByLabelText('Placeholder')
+      fireEvent.change(input, { target: { value: 'Please describe' } })
+
+      // Assert
+      expect(onChange).toHaveBeenCalledWith({
+        ...question,
+        otherPlaceholder: 'Please describe'
+      })
+    })
+
+    it('shows "Other" description error message', () => {
+      // Act
+      render(<OtherOptionFields disabled={false} question={question} onChange={jest.fn()} />)
+
+      // Assert
+      const input = screen.getByLabelText('Error message')
+      expect((input as HTMLInputElement).value).toBe('A description is required for choices of "other".')
+    })
+
+    it('updates "Other" description error message', () => {
+      // Arrange
+      const onChange = jest.fn()
+      render(<OtherOptionFields disabled={false} question={question} onChange={onChange} />)
+
+      // Act
+      const input = screen.getByLabelText('Error message')
+      fireEvent.change(input, { target: { value: 'A description is required' } })
+
+      // Assert
+      expect(onChange).toHaveBeenCalledWith({
+        ...question,
+        otherErrorText: 'A description is required'
+      })
+    })
+  })
+})

--- a/ui-admin/src/forms/designer/questions/OtherOptionFields.tsx
+++ b/ui-admin/src/forms/designer/questions/OtherOptionFields.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+
+import { CheckboxQuestion, DropdownQuestion, RadiogroupQuestion } from '@juniper/ui-core'
+
+import { Checkbox } from 'components/forms/Checkbox'
+import { TextInput } from 'components/forms/TextInput'
+
+type QuestionWithOtherOption = CheckboxQuestion | DropdownQuestion | RadiogroupQuestion
+
+type OtherOptionFieldsProps = {
+  disabled: boolean
+  question: QuestionWithOtherOption
+  onChange: (newValue: QuestionWithOtherOption) => void
+}
+
+/** Controls for editing other option for questions. */
+export const OtherOptionFields = (props: OtherOptionFieldsProps) => {
+  const { disabled, question, onChange } = props
+
+  return (
+    <>
+      <div className="mb-3">
+        <Checkbox
+          checked={!!question.showOtherItem}
+          description={'Show an "Other" option that, when selected, prompts the participant to enter a text response.'}
+          disabled={disabled}
+          label={'Show "Other" option'}
+          onChange={checked => {
+            if (checked) {
+              const { otherText, otherPlaceholder, otherErrorText } = question
+              onChange({
+                ...question,
+                showOtherItem: true,
+                otherText: otherText || 'Other',
+                otherPlaceholder: otherPlaceholder || 'Please specify',
+                otherErrorText: otherErrorText || 'A description is required for choices of "other".'
+              })
+            } else {
+              onChange({
+                ...question,
+                showOtherItem: false
+              })
+            }
+          }}
+        />
+      </div>
+
+      {!!question.showOtherItem && (
+        <fieldset>
+          <legend className="form-label fs-5">&ldquo;Other&rdquo; option</legend>
+
+          <div className="mb-3">
+            <TextInput
+              description={'Label for the "Other" option.'}
+              disabled={disabled}
+              label="Label"
+              value={question.otherText || ''}
+              onChange={value => {
+                onChange({
+                  ...question,
+                  otherText: value
+                })
+              }}
+            />
+          </div>
+
+          <div className="mb-3">
+            <TextInput
+              description={'Placeholder text for the text response input.'}
+              disabled={disabled}
+              label="Placeholder"
+              value={question.otherPlaceholder || ''}
+              onChange={value => {
+                onChange({
+                  ...question,
+                  otherPlaceholder: value
+                })
+              }}
+            />
+          </div>
+
+          <div className="mb-3">
+            <TextInput
+              // eslint-disable-next-line max-len
+              description={'Error message shown if the participant selects the "Other" option but does not provide a text response'}
+              disabled={disabled}
+              label="Error message"
+              value={question.otherErrorText || ''}
+              onChange={value => {
+                onChange({
+                  ...question,
+                  otherErrorText: value
+                })
+              }}
+            />
+          </div>
+        </fieldset>
+      )}
+    </>
+  )
+}

--- a/ui-admin/src/forms/designer/questions/VisibilityFields.test.tsx
+++ b/ui-admin/src/forms/designer/questions/VisibilityFields.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+
+import { Question } from '@juniper/ui-core'
+
+import { VisibilityFields } from './VisibilityFields'
+
+describe('VisibilityFields', () => {
+  it('has option to conditionally show question', () => {
+    // Arrange
+    const question: Question = {
+      name: 'test_question',
+      title: 'What?',
+      type: 'text'
+    }
+
+    // Act
+    render(<VisibilityFields disabled={false} question={question} onChange={jest.fn()} />)
+
+    // Assert
+    const input = screen.getByLabelText('Conditionally show this question')
+    expect((input as HTMLInputElement).checked).toBe(false)
+  })
+
+  it('adds visibleIf field when checked', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const question: Question = {
+      name: 'test_question',
+      title: 'What?',
+      type: 'text'
+    }
+
+    const onChange = jest.fn()
+
+    render(<VisibilityFields disabled={false} question={question} onChange={onChange} />)
+
+    // Act
+    const input = screen.getByLabelText('Conditionally show this question')
+    await user.click(input)
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith({
+      ...question,
+      visibleIf: ''
+    })
+  })
+
+  it('removes visibleIf field when unchecked', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const question: Question = {
+      name: 'test_question',
+      title: 'What?',
+      type: 'text',
+      visibleIf: '{other_question} = "Yes"'
+    }
+
+    const onChange = jest.fn()
+
+    render(<VisibilityFields disabled={false} question={question} onChange={onChange} />)
+
+    // Act
+    const input = screen.getByLabelText('Conditionally show this question')
+    await user.click(input)
+
+    // Assert
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { visibleIf, ...otherQuestionFields } = question
+    expect(onChange).toHaveBeenCalledWith(otherQuestionFields)
+  })
+
+  describe('when "Conditionally show this question" option is selected', () => {
+    const question: Question = {
+      name: 'test_question',
+      title: 'What?',
+      type: 'text',
+      visibleIf: '{other_question} = "Yes"'
+    }
+
+    it('shows visibility express', () => {
+      // Act
+      render(<VisibilityFields disabled={false} question={question} onChange={jest.fn()} />)
+
+      // Assert
+      const input = screen.getByLabelText('Visibility expression')
+      expect((input as HTMLInputElement).value).toBe('{other_question} = "Yes"')
+    })
+
+    it('updates visibility expression', () => {
+      // Arrange
+      const onChange = jest.fn()
+      render(<VisibilityFields disabled={false} question={question} onChange={onChange} />)
+
+      // Act
+      const input = screen.getByLabelText('Visibility expression')
+      fireEvent.change(input, { target: { value: 'true' } })
+
+      // Assert
+      expect(onChange).toHaveBeenCalledWith({
+        ...question,
+        visibleIf: 'true'
+      })
+    })
+  })
+})

--- a/ui-admin/src/forms/designer/questions/VisibilityFields.tsx
+++ b/ui-admin/src/forms/designer/questions/VisibilityFields.tsx
@@ -12,7 +12,7 @@ type VisibilityFieldsProps = {
   onChange: (newValue: Question) => void
 }
 
-/** Controls for editing other option for questions. */
+/** Controls for making a question conditionally visible. */
 export const VisibilityFields = (props: VisibilityFieldsProps) => {
   const { disabled, question, onChange } = props
 

--- a/ui-admin/src/forms/designer/questions/VisibilityFields.tsx
+++ b/ui-admin/src/forms/designer/questions/VisibilityFields.tsx
@@ -1,0 +1,61 @@
+import { unset } from 'lodash/fp'
+import React from 'react'
+
+import { Question } from '@juniper/ui-core'
+
+import { Checkbox } from 'components/forms/Checkbox'
+import { TextInput } from 'components/forms/TextInput'
+
+type VisibilityFieldsProps = {
+  disabled: boolean
+  question: Question
+  onChange: (newValue: Question) => void
+}
+
+/** Controls for editing other option for questions. */
+export const VisibilityFields = (props: VisibilityFieldsProps) => {
+  const { disabled, question, onChange } = props
+
+  const hasVisibleIfExpression = Object.hasOwnProperty.call(question, 'visibleIf')
+
+  return (
+    <>
+      <div className="mb-3">
+        <Checkbox
+          checked={hasVisibleIfExpression}
+          description="Show or hide this question based on responses to other questions."
+          disabled={disabled}
+          label="Conditionally show this question"
+          onChange={checked => {
+            if (checked) {
+              onChange({
+                ...question,
+                visibleIf: ''
+              })
+            } else {
+              onChange(unset('visibleIf', question))
+            }
+          }}
+        />
+      </div>
+
+      {hasVisibleIfExpression && (
+        <div className="mb-3">
+          <TextInput
+            // eslint-disable-next-line max-len
+            description={'Expression for this question\'s visibility. If this expression evaluates to true, the question will be shown.'}
+            disabled={disabled}
+            label="Visibility expression"
+            value={question.visibleIf}
+            onChange={value => {
+              onChange({
+                ...question,
+                visibleIf: value
+              })
+            }}
+          />
+        </div>
+      )}
+    </>
+  )
+}

--- a/ui-admin/src/forms/designer/questions/questionTypes.tsx
+++ b/ui-admin/src/forms/designer/questions/questionTypes.tsx
@@ -1,0 +1,19 @@
+import { QuestionType } from '@juniper/ui-core'
+
+export const questionTypeLabels: Record<QuestionType, string> = {
+  text: 'Text',
+  checkbox: 'Checkbox',
+  dropdown: 'Dropdown',
+  radiogroup: 'Radio group',
+  signaturepad: 'Signature',
+  medications: 'Medications'
+}
+
+export const questionTypeDescriptions: Record<QuestionType, string> = {
+  text: 'Prompts the participant to enter a text response.',
+  checkbox: 'Shows choices as checkboxes and prompts the participant to select one or more responses.',
+  dropdown: 'Prompts the participant to choose a response from a menu of choices.',
+  radiogroup: 'Shows choices as radio buttons and prompts the participant to select a response.',
+  signaturepad: 'Prompts the participant to sign a form.',
+  medications: 'Prompts the participant to choose medications from a list.'
+}

--- a/ui-core/src/types/forms.ts
+++ b/ui-core/src/types/forms.ts
@@ -139,11 +139,24 @@ export type TextQuestion = BaseQuestion & {
   type: 'text'
 }
 
+export type SignatureQuestion = BaseQuestion & {
+  type: 'signaturepad'
+}
+
+export type MedicationsQuestion = BaseQuestion & {
+  type: 'medications'
+}
+
 export type Question =
   | CheckboxQuestion
   | DropdownQuestion
+  | MedicationsQuestion
   | RadiogroupQuestion
+  | SignatureQuestion
   | TemplatedQuestion
   | TextQuestion
+
+/** Possible values for the 'type' field of a Question. */
+export type QuestionType = Exclude<Question, TemplatedQuestion>['type']
 
 export {}


### PR DESCRIPTION
This adds the UI to edit questions in surveys and other forms.

This supports most (but not all) of the SurveyJS question options that we use. In particular, this is still missing the ability to make a text question use a number input and add validation.

Some example screenshots...
<img width="1624" alt="Screenshot 2023-06-26 at 3 47 08 PM" src="https://github.com/broadinstitute/juniper/assets/1156625/7e061506-68fd-4ae5-9f0d-4f45e2c623e5">
<img width="1624" alt="Screenshot 2023-06-26 at 3 47 18 PM" src="https://github.com/broadinstitute/juniper/assets/1156625/b5c22524-5ffe-4bba-954b-8c152bbfb3e6">

