### PR TITLE
[JN-378] Add question templates list

### DIFF
--- a/ui-admin/src/forms/FormDesigner.tsx
+++ b/ui-admin/src/forms/FormDesigner.tsx
@@ -7,6 +7,7 @@ import { HtmlDesigner } from './designer/HtmlDesigner'
 import { PageDesigner } from './designer/PageDesigner'
 import { PanelDesigner } from './designer/PanelDesigner'
 import { QuestionDesigner } from './designer/QuestionDesigner'
+import { QuestionTemplateList } from './designer/QuestionTemplateList'
 import { FormTableOfContents } from './FormTableOfContents'
 
 type FormDesignerProps = {
@@ -35,6 +36,16 @@ export const FormDesigner = (props: FormDesignerProps) => {
           if (selectedElementPath === undefined) {
             return (
               <p className="mt-5 text-center">Select an element to edit</p>
+            )
+          }
+
+          if (selectedElementPath === 'questionTemplates') {
+            return (
+              <QuestionTemplateList
+                formContent={value}
+                readOnly={readOnly}
+                onChange={onChange}
+              />
             )
           }
 

--- a/ui-admin/src/forms/FormTableOfContents.test.tsx
+++ b/ui-admin/src/forms/FormTableOfContents.test.tsx
@@ -127,7 +127,7 @@ describe('getTableOfContentsTree', () => {
         {
           label: 'Question templates',
           data: {
-            isSelectable: false,
+            isSelectable: true,
             path: 'questionTemplates'
           },
           children: [

--- a/ui-admin/src/forms/FormTableOfContents.tsx
+++ b/ui-admin/src/forms/FormTableOfContents.tsx
@@ -63,7 +63,7 @@ export const getTableOfContentsTree = (formContent: FormContent): FormContentTab
       {
         label: 'Question templates',
         data: {
-          isSelectable: false,
+          isSelectable: true,
           path: 'questionTemplates'
         },
         children: (formContent.questionTemplates || []).map((question, questionIndex) => ({

--- a/ui-admin/src/forms/designer/QuestionTemplateList.test.tsx
+++ b/ui-admin/src/forms/designer/QuestionTemplateList.test.tsx
@@ -1,0 +1,85 @@
+import { act, getByRole, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+
+import { FormContent } from '@juniper/ui-core'
+
+import { QuestionTemplateList } from './QuestionTemplateList'
+
+describe('QuestionTemplateList', () => {
+  const formContent: FormContent = {
+    title: 'Test form',
+    pages: [
+      {
+        elements: [
+          {
+            name: 'question1',
+            questionTemplateName: 'templateA'
+          }
+        ]
+      }
+    ],
+    questionTemplates: [
+      {
+        name: 'templateA',
+        type: 'text',
+        title: 'A?'
+      },
+      {
+        name: 'templateB',
+        type: 'text',
+        title: 'B?'
+      }
+    ]
+  }
+
+  it('renders list of question templates in form', () => {
+    // Act
+    render(<QuestionTemplateList formContent={formContent} readOnly={false} onChange={jest.fn()} />)
+
+    // Assert
+    const listItems = screen.getAllByRole('listitem')
+    expect(listItems.map(el => el.textContent)).toEqual(['templateA', 'templateB'])
+  })
+
+  it('allows deleting question templates that are not referenced by a question', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const onChange = jest.fn()
+    render(<QuestionTemplateList formContent={formContent} readOnly={false} onChange={onChange} />)
+
+    // Act
+    const listItems = screen.getAllByRole('listitem')
+    await act(() => user.click(getByRole(listItems[1], 'button')))
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith({
+      ...formContent,
+      questionTemplates: [
+        {
+          name: 'templateA',
+          type: 'text',
+          title: 'A?'
+        }
+      ]
+    })
+  })
+
+  it('does not allow deleting question templates that are referenced by a question', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const onChange = jest.fn()
+    render(<QuestionTemplateList formContent={formContent} readOnly={false} onChange={onChange} />)
+
+    // Act
+    const listItems = screen.getAllByRole('listitem')
+    const deleteTemplateAButton = getByRole(listItems[0], 'button')
+    await act(() => user.click(deleteTemplateAButton))
+
+    // Assert
+    expect(deleteTemplateAButton).toHaveAttribute('aria-disabled', 'true')
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/ui-admin/src/forms/designer/QuestionTemplateList.tsx
+++ b/ui-admin/src/forms/designer/QuestionTemplateList.tsx
@@ -1,0 +1,72 @@
+import { faTimes } from '@fortawesome/free-solid-svg-icons'
+import { compact, flow, uniq, map } from 'lodash/fp'
+import React from 'react'
+
+import { FormContent, getFormElements, Question } from '@juniper/ui-core'
+
+import { IconButton } from 'components/forms/Button'
+
+const isQuestionTemplateReferencedInFormContent =
+  (formContent: FormContent, questionTemplate: Question): boolean => {
+    const allReferencedQuestionTemplates: string[] = flow(
+      getFormElements,
+      map('questionTemplateName'),
+      compact,
+      uniq
+    )(formContent)
+    return allReferencedQuestionTemplates.includes(questionTemplate.name)
+  }
+
+type QuestionTemplateListProps = {
+  formContent: FormContent
+  readOnly: boolean
+  onChange: (newValue: FormContent) => void
+}
+
+/** UI for viewing a list of question templates in a form. */
+export const QuestionTemplateList = (props: QuestionTemplateListProps) => {
+  const { formContent, readOnly, onChange } = props
+  const { questionTemplates = [] } = formContent
+
+  return (
+    <>
+      <h2>Question Templates</h2>
+      <ul className="list-group">
+        {questionTemplates.map((question, i) => {
+          const isReferenced = isQuestionTemplateReferencedInFormContent(formContent, question)
+          return (
+            <li
+              key={i}
+              className="list-group-item d-flex align-items-center"
+            >
+              <div className="flex-grow-1 text-truncate ms-2">
+                {question.name}
+              </div>
+              <div className="flex-shrink-0">
+                <IconButton
+                  aria-label={isReferenced
+                    ? 'This question template cannot be deleted while a question references it'
+                    : 'Delete this question template'
+                  }
+                  className="ms-2"
+                  disabled={readOnly || isReferenced}
+                  icon={faTimes}
+                  variant="light"
+                  onClick={() => {
+                    onChange({
+                      ...formContent,
+                      questionTemplates: [
+                        ...questionTemplates.slice(0, i),
+                        ...questionTemplates.slice(i + 1)
+                      ]
+                    })
+                  }}
+                />
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </>
+  )
+}

--- a/ui-core/src/surveyUtils.ts
+++ b/ui-core/src/surveyUtils.ts
@@ -6,7 +6,7 @@ import { SurveyModel } from 'survey-core'
 import { FormContent, FormElement, VersionedForm } from './types/forms'
 
 /** Gets a flattened list of the survey elements */
-function getFormElements(formContent: FormContent): FormElement[] {
+export function getFormElements(formContent: FormContent): FormElement[] {
   return formContent.pages.flatMap(page => page.elements.flatMap(getFormQuestionsHelper))
 }
 


### PR DESCRIPTION
This adds the ability to select the "Question templates" list in the form designer's table of contents and delete question templates (if they are not referenced by a question).

![Screenshot 2023-06-26 at 5 35 53 PM](https://github.com/broadinstitute/juniper/assets/1156625/bdd3608c-2eb5-4699-8883-0528c4c43937)
