### PR TITLE
[JN-378] Allow reordering pages of forms

### DIFF
--- a/ui-admin/src/forms/FormDesigner.tsx
+++ b/ui-admin/src/forms/FormDesigner.tsx
@@ -5,6 +5,7 @@ import { FormContent, FormContentPage, FormElement } from '@juniper/ui-core'
 
 import { HtmlDesigner } from './designer/HtmlDesigner'
 import { PageDesigner } from './designer/PageDesigner'
+import { PagesList } from './designer/PagesList'
 import { PanelDesigner } from './designer/PanelDesigner'
 import { QuestionDesigner } from './designer/QuestionDesigner'
 import { QuestionTemplateList } from './designer/QuestionTemplateList'
@@ -36,6 +37,16 @@ export const FormDesigner = (props: FormDesignerProps) => {
           if (selectedElementPath === undefined) {
             return (
               <p className="mt-5 text-center">Select an element to edit</p>
+            )
+          }
+
+          if (selectedElementPath === 'pages') {
+            return (
+              <PagesList
+                formContent={value}
+                readOnly={readOnly}
+                onChange={onChange}
+              />
             )
           }
 

--- a/ui-admin/src/forms/FormTableOfContents.test.tsx
+++ b/ui-admin/src/forms/FormTableOfContents.test.tsx
@@ -63,7 +63,7 @@ describe('getTableOfContentsTree', () => {
         {
           label: 'Pages',
           data: {
-            isSelectable: false,
+            isSelectable: true,
             path: 'pages'
           },
           children: [

--- a/ui-admin/src/forms/FormTableOfContents.tsx
+++ b/ui-admin/src/forms/FormTableOfContents.tsx
@@ -48,7 +48,7 @@ export const getTableOfContentsTree = (formContent: FormContent): FormContentTab
       {
         label: 'Pages',
         data: {
-          isSelectable: false,
+          isSelectable: true,
           path: 'pages'
         },
         children: (formContent.pages || []).map((page, pageIndex) => ({

--- a/ui-admin/src/forms/designer/PagesList.test.tsx
+++ b/ui-admin/src/forms/designer/PagesList.test.tsx
@@ -1,0 +1,135 @@
+import { act, getByLabelText, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+
+import { FormContent } from '@juniper/ui-core'
+
+import { PagesList } from './PagesList'
+
+describe('PagesList', () => {
+  const formContent: FormContent = {
+    title: 'Test form',
+    pages: [
+      {
+        elements: [
+          {
+            name: 'page1Intro',
+            type: 'html',
+            html: '<p>This is page 1</p>'
+          }
+        ]
+      },
+      {
+        elements: [
+          {
+            name: 'page2Intro',
+            type: 'html',
+            html: '<p>This is page 2</p>'
+          }
+        ]
+      },
+      {
+        elements: [
+          {
+            name: 'page3Intro',
+            type: 'html',
+            html: '<p>This is page 3</p>'
+          }
+        ]
+      }
+    ]
+  }
+
+  it('renders list of pages', () => {
+    // Act
+    render(<PagesList formContent={formContent} readOnly={false} onChange={jest.fn()} />)
+
+    // Assert
+    const listItems = screen.getAllByRole('listitem')
+    expect(listItems.map(el => el.textContent)).toEqual(['Page 1', 'Page 2', 'Page 3'])
+  })
+
+  it('allows reordering pages', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const onChange = jest.fn()
+    render(<PagesList formContent={formContent} readOnly={false} onChange={onChange} />)
+
+    // Act
+    const listItems = screen.getAllByRole('listitem')
+    const movePage2UpButton = getByLabelText(listItems[1], 'Move this page before the previous one')
+    await act(() => user.click(movePage2UpButton))
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith({
+      ...formContent,
+      pages: [
+        {
+          elements: [
+            {
+              name: 'page2Intro',
+              type: 'html',
+              html: '<p>This is page 2</p>'
+            }
+          ]
+        },
+        {
+          elements: [
+            {
+              name: 'page1Intro',
+              type: 'html',
+              html: '<p>This is page 1</p>'
+            }
+          ]
+        },
+        {
+          elements: [
+            {
+              name: 'page3Intro',
+              type: 'html',
+              html: '<p>This is page 3</p>'
+            }
+          ]
+        }
+      ]
+    })
+
+    const movePage2DownButton = getByLabelText(listItems[1], 'Move this page after the next one')
+    await act(() => user.click(movePage2DownButton))
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith({
+      ...formContent,
+      pages: [
+        {
+          elements: [
+            {
+              name: 'page1Intro',
+              type: 'html',
+              html: '<p>This is page 1</p>'
+            }
+          ]
+        },
+        {
+          elements: [
+            {
+              name: 'page3Intro',
+              type: 'html',
+              html: '<p>This is page 3</p>'
+            }
+          ]
+        },
+        {
+          elements: [
+            {
+              name: 'page2Intro',
+              type: 'html',
+              html: '<p>This is page 2</p>'
+            }
+          ]
+        }
+      ]
+    })
+  })
+})

--- a/ui-admin/src/forms/designer/PagesList.tsx
+++ b/ui-admin/src/forms/designer/PagesList.tsx
@@ -1,0 +1,77 @@
+import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons'
+import React from 'react'
+
+import { FormContent } from '@juniper/ui-core'
+
+import { IconButton } from 'components/forms/Button'
+
+type PagesListProps = {
+  formContent: FormContent
+  readOnly: boolean
+  onChange: (newValue: FormContent) => void
+}
+
+/** UI for re-ordering pages in a form. */
+export const PagesList = (props: PagesListProps) => {
+  const { formContent, readOnly, onChange } = props
+  const { pages } = formContent
+
+  return (
+    <ol className="list-group list-group-numbered">
+      {pages.map((page, i) => {
+        return (
+          <li
+            key={i}
+            className="list-group-item d-flex align-items-center"
+          >
+            <div className="flex-grow-1 text-truncate ms-2">
+              Page {i + 1}
+            </div>
+            <div className="flex-shrink-0">
+              <IconButton
+                aria-label="Move this page before the previous one"
+                className="ms-2"
+                disabled={readOnly || i === 0}
+                icon={faChevronUp}
+                variant="light"
+                onClick={() => {
+                  if (!readOnly) {
+                    onChange({
+                      ...formContent,
+                      pages: [
+                        ...pages.slice(0, i - 1),
+                        pages[i],
+                        pages[i - 1],
+                        ...pages.slice(i + 1)
+                      ]
+                    })
+                  }
+                }}
+              />
+              <IconButton
+                aria-label="Move this page after the next one"
+                className="ms-2"
+                disabled={readOnly || i === pages.length - 1}
+                icon={faChevronDown}
+                variant="light"
+                onClick={() => {
+                  if (!readOnly) {
+                    onChange({
+                      ...formContent,
+                      pages: [
+                        ...pages.slice(0, i),
+                        pages[i + 1],
+                        pages[i],
+                        ...pages.slice(i + 2)
+                      ]
+                    })
+                  }
+                }}
+              />
+            </div>
+          </li>
+        )
+      })}
+    </ol>
+  )
+}


### PR DESCRIPTION
This allows selecting "Pages" in the form designer table of contents and reordering pages in the form.

![Screenshot 2023-06-26 at 5 53 54 PM](https://github.com/broadinstitute/juniper/assets/1156625/a110fed4-6e18-4d7f-a517-0813750c38b3)
