### PR TITLE
[JN-378] Add controls for changing input type for text questions

### DIFF
--- a/ui-admin/src/components/forms/NumberInput.test.tsx
+++ b/ui-admin/src/components/forms/NumberInput.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+
+import { NumberInput } from './NumberInput'
+
+describe('NumberInput', () => {
+  it('renders a number input with label', () => {
+    // Act
+    render(<NumberInput label="Value" />)
+
+    // Assert
+    const input = screen.getByLabelText('Value')
+    expect(input).toBeInstanceOf(HTMLInputElement)
+    expect(input).toHaveAttribute('type', 'number')
+  })
+
+  it('calls onChange with input value', () => {
+    // Arrange
+    const onChange = jest.fn()
+    render(<NumberInput label="Test input" value={1} onChange={onChange} />)
+
+    // Act
+    const input = screen.getByLabelText('Test input')
+    fireEvent.change(input, { target: { value: '2' } })
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith(2)
+  })
+})

--- a/ui-admin/src/components/forms/NumberInput.tsx
+++ b/ui-admin/src/components/forms/NumberInput.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+
+import { TextInput, TextInputProps } from './TextInput'
+
+export type NumberInputProps = Omit<TextInputProps, 'value' | 'onChange'> & {
+  value?: number
+  onChange?: (newValue: number | undefined) => void
+}
+
+/**
+ * A number input with label and description.
+ */
+export const NumberInput = (props: NumberInputProps) => {
+  const { onChange, value } = props
+  return (
+    <TextInput
+      {...props}
+      type="number"
+      value={value === undefined ? '' : `${value}`}
+      onChange={newValue => {
+        onChange?.(newValue === '' ? undefined : parseInt(newValue))
+      }}
+    />
+  )
+}

--- a/ui-admin/src/components/forms/NumberInput.tsx
+++ b/ui-admin/src/components/forms/NumberInput.tsx
@@ -11,12 +11,11 @@ export type NumberInputProps = Omit<TextInputProps, 'value' | 'onChange'> & {
  * A number input with label and description.
  */
 export const NumberInput = (props: NumberInputProps) => {
-  const { onChange, value } = props
+  const { onChange } = props
   return (
     <TextInput
       {...props}
       type="number"
-      value={value === undefined ? '' : `${value}`}
       onChange={newValue => {
         onChange?.(newValue === '' ? undefined : parseInt(newValue))
       }}

--- a/ui-admin/src/components/forms/TextInput.tsx
+++ b/ui-admin/src/components/forms/TextInput.tsx
@@ -34,7 +34,7 @@ export const TextInput = (props: TextInputProps) => {
         disabled={undefined}
         id={inputId}
         // Allow value to be undefined without triggering a React warning about uncontrolled input.
-        value={value || ''}
+        value={value ?? ''}
         onChange={
           disabled
             // Noop because providing a value without an onChange handler causes a React warning

--- a/ui-admin/src/components/forms/TextInput.tsx
+++ b/ui-admin/src/components/forms/TextInput.tsx
@@ -11,7 +11,7 @@ export type TextInputProps = Omit<JSX.IntrinsicElements['input'], 'onChange'> & 
 /** A text input with label and description. */
 export const TextInput = (props: TextInputProps) => {
   const { description, label, labelClassname, ...inputProps } = props
-  const { className, disabled, id, onChange } = inputProps
+  const { className, disabled, id, value, onChange } = inputProps
 
   const generatedId = useId()
   const inputId = id || generatedId
@@ -26,13 +26,15 @@ export const TextInput = (props: TextInputProps) => {
         {label}
       </label>
       <input
+        type="text"
         {...inputProps}
         aria-describedby={description ? descriptionId : undefined}
         aria-disabled={disabled}
         className={classNames('form-control', { disabled }, className)}
         disabled={undefined}
         id={inputId}
-        type="text"
+        // Allow value to be undefined without triggering a React warning about uncontrolled input.
+        value={value || ''}
         onChange={
           disabled
             // Noop because providing a value without an onChange handler causes a React warning

--- a/ui-admin/src/forms/designer/QuestionDesigner.tsx
+++ b/ui-admin/src/forms/designer/QuestionDesigner.tsx
@@ -77,10 +77,10 @@ export const QuestionDesigner = (props: QuestionDesignerProps) => {
             )
           }
           {
-            value.type === 'text' && (
+            question.type === 'text' && (
               <TextFields
                 disabled={readOnly}
-                question={value}
+                question={question}
                 onChange={onChange}
               />
             )

--- a/ui-admin/src/forms/designer/QuestionDesigner.tsx
+++ b/ui-admin/src/forms/designer/QuestionDesigner.tsx
@@ -7,6 +7,7 @@ import { CheckboxFields } from './questions/CheckboxFields'
 import { ChoicesList } from './questions/ChoicesList'
 import { OtherOptionFields } from './questions/OtherOptionFields'
 import { questionTypeDescriptions, questionTypeLabels } from './questions/questionTypes'
+import { TextFields } from './questions/TextFields'
 import { VisibilityFields } from './questions/VisibilityFields'
 
 export type QuestionDesignerProps = {
@@ -71,6 +72,15 @@ export const QuestionDesigner = (props: QuestionDesignerProps) => {
               <CheckboxFields
                 disabled={readOnly}
                 question={question}
+                onChange={onChange}
+              />
+            )
+          }
+          {
+            value.type === 'text' && (
+              <TextFields
+                disabled={readOnly}
+                question={value}
                 onChange={onChange}
               />
             )

--- a/ui-admin/src/forms/designer/questions/TextFields.test.tsx
+++ b/ui-admin/src/forms/designer/questions/TextFields.test.tsx
@@ -1,0 +1,135 @@
+import { unset } from 'lodash/fp'
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+
+import { TextQuestion } from '@juniper/ui-core'
+
+import { TextFields } from './TextFields'
+
+describe('TextFields', () => {
+  it('has menu to choose input type', () => {
+    // Arrange
+    const question: TextQuestion = {
+      name: 'test_question',
+      title: 'What?',
+      type: 'text'
+    }
+
+    // Act
+    render(<TextFields disabled={false} question={question} onChange={jest.fn()} />)
+
+    // Assert
+    const inputTypeMenu = screen.getByLabelText('Input type')
+    expect((inputTypeMenu as HTMLSelectElement).value).toBe('text')
+  })
+
+  it('sets input type', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const question: TextQuestion = {
+      name: 'test_question',
+      title: 'What?',
+      type: 'text'
+    }
+
+    const onChange = jest.fn()
+    render(<TextFields disabled={false} question={question} onChange={onChange} />)
+
+    // Act
+    const inputTypeMenu = screen.getByLabelText('Input type')
+    await user.selectOptions(inputTypeMenu, 'number')
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith({
+      ...question,
+      inputType: 'number'
+    })
+  })
+
+  describe('number input type', () => {
+    const question: TextQuestion = {
+      name: 'test_question',
+      title: 'How mamy?',
+      type: 'text',
+      inputType: 'number',
+      min: 0,
+      max: 10
+    }
+
+    it('has inputs for min and max values', () => {
+      // Arrange
+      const onChange = jest.fn()
+
+      // Act
+      render(<TextFields disabled={false} question={question} onChange={onChange} />)
+      const minInput = screen.getByLabelText('Minimum')
+      const maxInput = screen.getByLabelText('Maximum')
+
+      // Assert
+      expect((minInput as HTMLInputElement).value).toBe('0')
+      expect((maxInput as HTMLInputElement).value).toBe('10')
+
+      // Act
+      fireEvent.change(minInput, { target: { value: '2' } })
+
+      // Assert
+      expect(onChange).toHaveBeenCalledWith({ ...question, min: 2 })
+
+      // Act
+      fireEvent.change(maxInput, { target: { value: '50' } })
+
+      // Assert
+      expect(onChange).toHaveBeenCalledWith({ ...question, max: 50 })
+    })
+
+    it('renders undefined min and max values', () => {
+      // Arrange
+      const question: TextQuestion = {
+        name: 'test_question',
+        title: 'How mamy?',
+        type: 'text',
+        inputType: 'number'
+      }
+
+      // Act
+      render(<TextFields disabled={false} question={question} onChange={jest.fn()} />)
+
+      // Assert
+      const minInput = screen.getByLabelText('Minimum')
+      const maxInput = screen.getByLabelText('Maximum')
+      expect((minInput as HTMLInputElement).value).toBe('')
+      expect((maxInput as HTMLInputElement).value).toBe('')
+    })
+
+    it('sets undefined min and max values', () => {
+      // Arrange
+      const question: TextQuestion = {
+        name: 'test_question',
+        title: 'How mamy?',
+        type: 'text',
+        inputType: 'number',
+        min: 0,
+        max: 10
+      }
+
+      const onChange = jest.fn()
+      render(<TextFields disabled={false} question={question} onChange={onChange} />)
+      const minInput = screen.getByLabelText('Minimum')
+      const maxInput = screen.getByLabelText('Maximum')
+
+      // Act
+      fireEvent.change(minInput, { target: { value: '' } })
+
+      // Assert
+      expect(onChange).toHaveBeenCalledWith(unset('min', question))
+
+      // Act
+      fireEvent.change(maxInput, { target: { value: '' } })
+
+      // Assert
+      expect(onChange).toHaveBeenCalledWith(unset('max', question))
+    })
+  })
+})

--- a/ui-admin/src/forms/designer/questions/TextFields.tsx
+++ b/ui-admin/src/forms/designer/questions/TextFields.tsx
@@ -1,0 +1,72 @@
+import { set, unset } from 'lodash/fp'
+import React from 'react'
+
+import { TextQuestion } from '@juniper/ui-core'
+
+import { NumberInput } from 'components/forms/NumberInput'
+
+type TextFieldsProps = {
+  disabled: boolean
+  question: TextQuestion
+  onChange: (newValue: TextQuestion) => void
+}
+
+/** Controls for editing fields specific to text questions. */
+export const TextFields = (props: TextFieldsProps) => {
+  const { disabled, question, onChange } = props
+
+  return (
+    <>
+      <div className="mb-3">
+        <label className="form-label" htmlFor="text-question-input-type">Input type</label>
+        <select
+          className="form-select"
+          id="text-question-input-type"
+          value={question.inputType || 'text'}
+          onChange={e => {
+            const newType = e.target.value
+            const update = newType === 'text' ? unset('inputType') : set('inputType', newType)
+            onChange(update(question))
+          }}
+        >
+          <option value="text">Text</option>
+          <option value="number">Number</option>
+        </select>
+      </div>
+
+      {question.inputType === 'number' && (
+        <fieldset>
+          <legend className="form-label fs-5">Number input validation</legend>
+
+          <div className="mb-3">
+            <NumberInput
+              description="Minimum value accepted for this question."
+              disabled={disabled}
+              label="Minimum"
+              placeholder="Undefined"
+              value={question.min}
+              onChange={value => {
+                const update = value === undefined ? unset('min') : set('min', value)
+                onChange(update(question))
+              }}
+            />
+          </div>
+
+          <div className="mb-3">
+            <NumberInput
+              description="Maximum value accepted for this question."
+              disabled={disabled}
+              label="Maximum"
+              placeholder="Undefined"
+              value={question.max}
+              onChange={value => {
+                const update = value === undefined ? unset('max') : set('max', value)
+                onChange(update(question))
+              }}
+            />
+          </div>
+        </fieldset>
+      )}
+    </>
+  )
+}

--- a/ui-core/src/types/forms.ts
+++ b/ui-core/src/types/forms.ts
@@ -137,6 +137,10 @@ export type TemplatedQuestion = Omit<BaseQuestion, 'title'> & {
 
 export type TextQuestion = BaseQuestion & {
   type: 'text'
+  inputType?: 'text' | 'number'
+  size?: number
+  min?: number
+  max?: number
 }
 
 export type SignatureQuestion = BaseQuestion & {


### PR DESCRIPTION
Stacked on #444.

This adds controls for selecting input type for text questions and adding min/max validation for number inputs.

![Screenshot 2023-06-27 at 11 17 59 AM](https://github.com/broadinstitute/juniper/assets/1156625/40748be1-a846-4cf1-bf31-44f7c6725de7)
