### PR TITLE
[JN-378] Navigate to study environment content page when cancelling form edits

### DIFF
--- a/ui-admin/src/study/surveys/ConsentView.tsx
+++ b/ui-admin/src/study/surveys/ConsentView.tsx
@@ -6,9 +6,6 @@ import {  StudyParams } from 'study/StudyRouter'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
 import Api, {
   ConsentForm,
-  Portal,
-  Study,
-  StudyEnvironment,
   StudyEnvironmentConsent
 } from 'api/api'
 
@@ -17,9 +14,10 @@ import SurveyEditorView from './SurveyEditorView'
 import { useUser } from 'user/UserProvider'
 
 /** Handles logic for updating study environment surveys */
-function RawConsentView({ portal, study, currentEnv, consent, readOnly = false }:
-                         {portal: Portal, study: Study, currentEnv: StudyEnvironment,
+function RawConsentView({ studyEnvContext, consent, readOnly = false }:
+                         {studyEnvContext: StudyEnvContextT,
                            consent: ConsentForm, readOnly?: boolean}) {
+  const { portal, study, currentEnv, currentEnvPath } = studyEnvContext
   const { user } = useUser()
   const navigate = useNavigate()
 
@@ -62,7 +60,7 @@ function RawConsentView({ portal, study, currentEnv, consent, readOnly = false }
     <SurveyEditorView
       currentForm={currentForm}
       readOnly={readOnly}
-      onCancel={() => navigate('../..')}
+      onCancel={() => navigate(currentEnvPath)}
       onSave={createNewVersion}
     />
   )
@@ -77,7 +75,7 @@ function ConsentView({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
   const params = useParams<ConsentParamsT>()
   const consentStableId: string | undefined = params.consentStableId
 
-  const { portal, currentEnv, study } = studyEnvContext
+  const { currentEnv } = studyEnvContext
   const [searchParams] = useSearchParams()
   const isReadOnly = searchParams.get('readOnly') === 'true'
 
@@ -89,7 +87,7 @@ function ConsentView({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
   if (!consent) {
     return <span>The consent {consentStableId} does not exist in this environment</span>
   }
-  return <RawConsentView portal={portal} study={study} currentEnv={currentEnv} consent={consent} readOnly={isReadOnly}/>
+  return <RawConsentView studyEnvContext={studyEnvContext} consent={consent} readOnly={isReadOnly}/>
 }
 
 export default ConsentView

--- a/ui-admin/src/study/surveys/ConsentView.tsx
+++ b/ui-admin/src/study/surveys/ConsentView.tsx
@@ -62,7 +62,7 @@ function RawConsentView({ portal, study, currentEnv, consent, readOnly = false }
     <SurveyEditorView
       currentForm={currentForm}
       readOnly={readOnly}
-      onCancel={() => navigate('../../..')}
+      onCancel={() => navigate('../..')}
       onSave={createNewVersion}
     />
   )

--- a/ui-admin/src/study/surveys/PreEnrollView.tsx
+++ b/ui-admin/src/study/surveys/PreEnrollView.tsx
@@ -50,7 +50,7 @@ function RawPreRegView({ portalShortcode, currentEnv, survey, studyShortcode, re
     <SurveyEditorView
       currentForm={currentSurvey}
       readOnly={readOnly}
-      onCancel={() => navigate('../../..')}
+      onCancel={() => navigate('../..')}
       onSave={createNewVersion}
     />
   )

--- a/ui-admin/src/study/surveys/PreEnrollView.tsx
+++ b/ui-admin/src/study/surveys/PreEnrollView.tsx
@@ -4,7 +4,7 @@ import { Store } from 'react-notifications-component'
 
 import {  StudyParams } from 'study/StudyRouter'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
-import Api, { StudyEnvironment, Survey } from 'api/api'
+import Api, { Survey } from 'api/api'
 
 import { failureNotification, successNotification } from 'util/notifications'
 import SurveyEditorView from './SurveyEditorView'
@@ -16,9 +16,10 @@ export type SurveyParamsT = StudyParams & {
 }
 
 /** Preregistration editor.  This shares a LOT in common with SurveyView */
-function RawPreRegView({ portalShortcode, currentEnv, survey, studyShortcode, readOnly }:
-                      {portalShortcode: string, currentEnv: StudyEnvironment, readOnly: boolean
-                        survey: Survey, studyShortcode: string}) {
+function RawPreRegView({ studyEnvContext, survey, readOnly }:
+                      { studyEnvContext: StudyEnvContextT, readOnly: boolean
+                        survey: Survey}) {
+  const { portal, study, currentEnv, currentEnvPath } = studyEnvContext
   const { user } = useUser()
   const navigate = useNavigate()
 
@@ -33,10 +34,10 @@ function RawPreRegView({ portalShortcode, currentEnv, survey, studyShortcode, re
 
     survey.content = updatedContent
     try {
-      const updatedSurvey = await Api.createNewSurveyVersion(portalShortcode, currentSurvey)
+      const updatedSurvey = await Api.createNewSurveyVersion(portal.shortcode, currentSurvey)
       setCurrentSurvey(updatedSurvey)
       const updatedEnv = { ...currentEnv, preEnrollSurveyId: updatedSurvey.id }
-      const updatedStudyEnv = await Api.updateStudyEnvironment(portalShortcode, studyShortcode,
+      const updatedStudyEnv = await Api.updateStudyEnvironment(portal.shortcode, study.shortcode,
         currentEnv.environmentName, updatedEnv)
       currentEnv.preEnrollSurveyId = updatedStudyEnv.preEnrollSurveyId
       currentEnv.preEnrollSurvey = updatedSurvey
@@ -50,7 +51,7 @@ function RawPreRegView({ portalShortcode, currentEnv, survey, studyShortcode, re
     <SurveyEditorView
       currentForm={currentSurvey}
       readOnly={readOnly}
-      onCancel={() => navigate('../..')}
+      onCancel={() => navigate(currentEnvPath)}
       onSave={createNewVersion}
     />
   )
@@ -61,7 +62,7 @@ function PreEnrollView({ studyEnvContext }: {studyEnvContext: StudyEnvContextT})
   const params = useParams<SurveyParamsT>()
   const surveyStableId: string | undefined = params.surveyStableId
 
-  const { portal, currentEnv, study } = studyEnvContext
+  const { currentEnv } = studyEnvContext
   const [searchParams] = useSearchParams()
   const readOnly = searchParams.get('readOnly') === 'true'
 
@@ -72,8 +73,7 @@ function PreEnrollView({ studyEnvContext }: {studyEnvContext: StudyEnvContextT})
   if (survey?.stableId != surveyStableId) {
     return <span>The survey {surveyStableId} does not exist on this study</span>
   }
-  return <RawPreRegView portalShortcode={portal.shortcode} currentEnv={currentEnv}
-    survey={survey} studyShortcode={study.shortcode} readOnly={readOnly}/>
+  return <RawPreRegView studyEnvContext={studyEnvContext} survey={survey} readOnly={readOnly}/>
 }
 
 export default PreEnrollView

--- a/ui-admin/src/study/surveys/SurveyView.tsx
+++ b/ui-admin/src/study/surveys/SurveyView.tsx
@@ -4,7 +4,7 @@ import { Store } from 'react-notifications-component'
 
 import {  StudyParams } from 'study/StudyRouter'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
-import Api, { Portal, Study, StudyEnvironment, StudyEnvironmentSurvey, Survey } from 'api/api'
+import Api, { StudyEnvironmentSurvey, Survey } from 'api/api'
 
 import { failureNotification, successNotification } from 'util/notifications'
 import SurveyEditorView from './SurveyEditorView'
@@ -15,9 +15,9 @@ export type SurveyParamsT = StudyParams & {
 }
 
 /** Handles logic for updating study environment surveys */
-function RawSurveyView({ portal, currentEnv, study, survey, readOnly = false }:
-                      {portal: Portal, currentEnv: StudyEnvironment, study: Study,
-                        survey: Survey, readOnly?: boolean}) {
+function RawSurveyView({ studyEnvContext, survey, readOnly = false }:
+                      {studyEnvContext: StudyEnvContextT, survey: Survey, readOnly?: boolean}) {
+  const { portal, study, currentEnv, currentEnvPath } = studyEnvContext
   const navigate = useNavigate()
   const { user } = useUser()
 
@@ -60,7 +60,7 @@ function RawSurveyView({ portal, currentEnv, study, survey, readOnly = false }:
     <SurveyEditorView
       currentForm={currentSurvey}
       readOnly={readOnly}
-      onCancel={() => navigate('../..')}
+      onCancel={() => navigate(currentEnvPath)}
       onSave={createNewVersion}
     />
   )
@@ -71,7 +71,7 @@ function SurveyView({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
   const params = useParams<SurveyParamsT>()
   const surveyStableId: string | undefined = params.surveyStableId
 
-  const { portal, currentEnv, study } = studyEnvContext
+  const { currentEnv } = studyEnvContext
   const [searchParams] = useSearchParams()
   const isReadOnly = searchParams.get('readOnly') === 'true'
 
@@ -83,7 +83,7 @@ function SurveyView({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
   if (!survey) {
     return <span>The survey {surveyStableId} does not exist in this environment</span>
   }
-  return <RawSurveyView portal={portal} study={study} currentEnv={currentEnv} survey={survey} readOnly={isReadOnly}/>
+  return <RawSurveyView studyEnvContext={studyEnvContext} survey={survey} readOnly={isReadOnly}/>
 }
 
 export default SurveyView

--- a/ui-admin/src/study/surveys/SurveyView.tsx
+++ b/ui-admin/src/study/surveys/SurveyView.tsx
@@ -60,7 +60,7 @@ function RawSurveyView({ portal, currentEnv, study, survey, readOnly = false }:
     <SurveyEditorView
       currentForm={currentSurvey}
       readOnly={readOnly}
-      onCancel={() => navigate('../../..')}
+      onCancel={() => navigate('../..')}
       onSave={createNewVersion}
     />
   )


### PR DESCRIPTION
Currently, clicking the "Cancel" button while editing a form navigates all the way back to the study page. This changes it to navigate to the study environment page, which is the page where you see the various forms in the study environment.