### PR TITLE
Remove custom btn-secondary styles

### DIFF
--- a/ui-admin/src/App.css
+++ b/ui-admin/src/App.css
@@ -7,25 +7,6 @@
   background-color: #4D72AA;
 }
 
-.btn-secondary {
-  background-color: transparent;
-  color:#4D72AA;
-  border: none;
-}
-
-.btn-secondary[aria-disabled="true"] {
-  color: #666;
-  font-style: italic;
-}
-
-.btn-secondary:focus, .btn-secondary:hover {
-  background-color: transparent;
-  color:#4D72AA;
-  font-weight: bold;
-  border: none;
-  box-shadow: none;
-}
-
 a {
   color: #4D72AA;
   text-decoration: none;


### PR DESCRIPTION
Possibly controversial...

The current custom btn-secondary styles aren't great. The `font-weight: bold` on hover causes the button to grow wider, which shifts other content around.

https://github.com/broadinstitute/juniper/assets/1156625/b4398aae-bcb5-47c2-bf5d-221d71fddd9b

Bootstrap's "light" or "link" variants look better suited to providing a style like the current secondary button override.
https://getbootstrap.com/docs/5.3/components/buttons/#variants