### PR TITLE
[JN-378] Show feedback when form content JSON is invalid

### DIFF
--- a/ui-admin/src/forms/FormContentJsonEditor.test.tsx
+++ b/ui-admin/src/forms/FormContentJsonEditor.test.tsx
@@ -39,7 +39,7 @@ describe('FormContentJsonEditor', () => {
     expect(container).toHaveTextContent(expectedContent)
   })
 
-  it('sets readonly attribute on textatrea', () => {
+  it('sets readonly attribute on textarea', () => {
     // Act
     render(<FormContentJsonEditor initialValue={formContent} readOnly onChange={jest.fn()} />)
 
@@ -81,5 +81,21 @@ describe('FormContentJsonEditor', () => {
 
     // Assert
     expect(onChange).toHaveBeenCalledWith(false, undefined)
+  })
+
+  it('shows feedback when edited with invalid JSON', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const onChange = jest.fn()
+    render(<FormContentJsonEditor initialValue={formContent} onChange={onChange} />)
+
+    // Act
+    const textArea = screen.getByRole('textbox')
+    // Removes quotes around "First name"
+    await act(() => user.type(textArea, 'First name', { initialSelectionStart: 158, initialSelectionEnd: 170 }))
+
+    // Assert
+    expect(textArea).toHaveClass('is-invalid')
   })
 })

--- a/ui-admin/src/forms/FormContentJsonEditor.tsx
+++ b/ui-admin/src/forms/FormContentJsonEditor.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import React, { useCallback, useState } from 'react'
 
 import { FormContent } from '@juniper/ui-core'
@@ -15,7 +16,7 @@ type FormContentJsonEditorProps = {
 export const FormContentJsonEditor = (props: FormContentJsonEditorProps) => {
   const { initialValue, readOnly = false, onChange } = props
   const [editorValue, _setEditorValue] = useState(() => JSON.stringify(initialValue, null, 2))
-  const [, setIsValid] = useState(true)
+  const [isValid, setIsValid] = useState(true)
   const setEditorValue = useCallback((newEditorValue: string) => {
     _setEditorValue(newEditorValue)
     try {
@@ -31,7 +32,7 @@ export const FormContentJsonEditor = (props: FormContentJsonEditorProps) => {
   return (
     <div className="d-flex flex-column flex-grow-1">
       <textarea
-        className="w-100 flex-grow-1 font-monospace"
+        className={classNames('w-100 flex-grow-1 form-control font-monospace', { 'is-invalid': !isValid })}
         readOnly={readOnly}
         style={{
           overflowX: 'auto',

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -1,8 +1,8 @@
-import classNames from 'classnames'
 import React, { useState } from 'react'
 
 import { VersionedForm } from 'api/api'
 
+import { Button } from 'components/forms/Button'
 import { FormContentEditor } from 'forms/FormContentEditor'
 
 type SurveyEditorViewProps = {
@@ -48,17 +48,23 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
           </h5>
         </div>
         {!readOnly && (
-          <button
-            aria-disabled={isSaveEnabled ? 'true' : 'false'}
-            className={classNames(
-              'btn btn-primary me-md-2',
-              { disabled: !isSaveEnabled }
-            )}
-            type="button"
+          <Button
+            disabled={!isSaveEnabled}
+            className="me-md-2"
+            tooltip={(() => {
+              if (!editedContent) {
+                return 'Form is unchanged. Make changes to save.'
+              }
+              if (!isEditorValid) {
+                return 'Form is invalid. Correct to save.'
+              }
+              return 'Save changes'
+            })()}
+            variant="primary"
             onClick={onClickSave}
           >
             Save
-          </button>
+          </Button>
         )}
         <button className="btn btn-secondary" type="button" onClick={onCancel}>Cancel</button>
       </div>


### PR DESCRIPTION
Currently, when invalid JSON is entered in the form editor, there is no feedback other than the disabled save button. This adds a red outline around the textarea and adds a tooltip to the save button explaining why it is disabled. It's not intended to be a final design for feedback, just an improvement on what's there now.