### PR TITLE
[JN-414 pt2] Improve UX of Consent column filter

### DIFF
--- a/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
@@ -36,9 +36,9 @@ test('renders filters for participant columns', async () => {
   const { RoutedComponent } = setupRouterTest(<ParticipantList studyEnvContext={studyEnvContext}/>)
   render(RoutedComponent)
 
-  //Assert that all 3 default columns have filter inputs
+  //There are 3 default columns shown, 2 of which allow text search
   const searchInputs = await screen.findAllByPlaceholderText('Search...')
-  expect(searchInputs).toHaveLength(3)
+  expect(searchInputs).toHaveLength(2)
 })
 
 test('filters participants based on shortcode', async () => {

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -101,7 +101,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     cell: info => info.getValue() ? <FontAwesomeIcon icon={faCheck}/> : ''
   }, {
     header: 'Kit status',
-    // filterFn: 'includesString', //an undefined value in a cell seems to switch the filter table away from the default
+    filterFn: 'includesString', //an undefined value in a cell seems to switch the filter table away from the default
     accessorKey: 'mostRecentKitStatus',
     meta: {
       columnType: 'string'

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -92,7 +92,6 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     meta: {
       columnType: 'boolean',
       filterOptions: [
-        { value: undefined, label: 'Any' },
         { value: true, label: 'Consented' },
         { value: false, label: 'Not Consented' }
       ]

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -61,27 +61,51 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
   }, {
     header: 'Shortcode',
     accessorKey: 'enrollee.shortcode',
+    meta: {
+      columnType: 'string'
+    },
     cell: info => <Link to={`${currentEnvPath}/participants/${info.getValue()}`}>{info.getValue()}</Link>
   }, {
     id: 'familyName',
     header: 'Family name',
-    accessorKey: 'profile.familyName'
+    accessorKey: 'profile.familyName',
+    meta: {
+      columnType: 'string'
+    }
   }, {
     id: 'givenName',
     header: 'Given name',
-    accessorKey: 'profile.givenName'
+    accessorKey: 'profile.givenName',
+    meta: {
+      columnType: 'string'
+    }
   }, {
     id: 'contactEmail',
     header: 'Contact email',
-    accessorKey: 'profile.contactEmail'
+    accessorKey: 'profile.contactEmail',
+    meta: {
+      columnType: 'string'
+    }
   }, {
     header: 'Consented',
-    accessorFn: data => data.enrollee.consented.toString(),
-    cell: info => info.getValue() === 'true' ? <FontAwesomeIcon icon={faCheck}/> : ''
+    accessorKey: 'enrollee.consented',
+    meta: {
+      columnType: 'boolean',
+      filterOptions: [
+        { value: undefined, label: 'Any' },
+        { value: true, label: 'Consented' },
+        { value: false, label: 'Not Consented' }
+      ]
+    },
+    filterFn: 'equals',
+    cell: info => info.getValue() ? <FontAwesomeIcon icon={faCheck}/> : ''
   }, {
     header: 'Kit status',
-    filterFn: 'includesString', //an undefined value in a cell seems to switch the filter table away from the default
-    accessorKey: 'mostRecentKitStatus'
+    // filterFn: 'includesString', //an undefined value in a cell seems to switch the filter table away from the default
+    accessorKey: 'mostRecentKitStatus',
+    meta: {
+      columnType: 'string'
+    }
   }], [study.shortcode])
 
 

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -39,6 +39,7 @@ function DebouncedInput({
 
 declare module '@tanstack/table-core' {
   //Extra column metadata for extending the built-in filter functionality of react-table
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface ColumnMeta<TData extends RowData, TValue> {
     //Specifies the type of the column data. By default, columns will be treated as strings
     columnType?: string

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -37,17 +37,6 @@ function DebouncedInput({
   )
 }
 
-declare module '@tanstack/table-core' {
-  //Extra column metadata for extending the built-in filter functionality of react-table
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface ColumnMeta<TData extends RowData, TValue> {
-    //Specifies the type of the column data. By default, columns will be treated as strings
-    columnType?: string
-    //Specifies the Select options if using a dropdown filter (i.e. for booleans)
-    filterOptions?: object[]
-  }
-}
-
 /**
  * returns a Filter to handle text fields
  * adapted from https://tanstack.com/table/v8/docs/examples/react/filters
@@ -261,4 +250,15 @@ export function basicTableLayout<T>(table: Table<T>) {
       })}
     </tbody>
   </table>
+}
+
+declare module '@tanstack/table-core' {
+  //Extra column metadata for extending the built-in filter functionality of react-table
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData extends RowData, TValue> {
+    //Specifies the type of the column data. By default, columns will be treated as strings
+    columnType?: string
+    //Specifies the Select options if using a dropdown filter (i.e. for booleans)
+    filterOptions?: object[]
+  }
 }

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -231,7 +231,7 @@ export function basicTableLayout<T>(table: Table<T>) {
   return <table className="table table-striped">
     <thead>
       <tr>
-        {table.getFlatHeaders().map(header => sortableTableHeader(header))}
+        {table.getFlatHeaders().map(header => tableHeader(header, { sortable: true, filterable: false }))}
       </tr>
     </thead>
     <tbody>

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -62,11 +62,12 @@ function SelectFilter<A>({
 }: {
   column: Column<A>
 }) {
-  const [selectedValue, setSelectedValue] = useState({})
+  const [selectedValue, setSelectedValue] = useState<{ value: boolean, label: string }>()
 
   return <div>
     <Select
       options={column.columnDef.meta?.filterOptions || []}
+      isClearable={true}
       styles={{
         control: baseStyles => ({
           ...baseStyles,
@@ -85,7 +86,9 @@ function SelectFilter<A>({
         //so we need to manage the filter value used by the column separately
         //from the selected value used by the Select component
         setSelectedValue(newValue)
-        column.setFilterValue(newValue.value)
+        newValue !== null ?
+          column.setFilterValue(newValue.value) :
+          column.setFilterValue(undefined)
       }}
     />
     <div className="h-1" />
@@ -259,6 +262,6 @@ declare module '@tanstack/table-core' {
     //Specifies the type of the column data. By default, columns will be treated as strings
     columnType?: string
     //Specifies the Select options if using a dropdown filter (i.e. for booleans)
-    filterOptions?: object[]
+    filterOptions?: { value: boolean, label: string }[]
   }
 }

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -11,7 +11,7 @@ import Select from 'react-select'
 function DebouncedInput({
   value: initialValue,
   onChange,
-  debounce = 200,
+  debounce = 500,
   ...props
 }: {
   value: string
@@ -59,6 +59,7 @@ function Filter<A>({
   return column.columnDef.meta?.columnType === 'boolean' ? (
     SelectFilter({ column })
   ) : (
+    //Defaults to the text search filter
     SearchFilter({ column })
   )
 }

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -112,7 +112,6 @@ function SearchFilter<A>({
       value={(column.getFilterValue() ?? '') as string}
       onChange={value => column.setFilterValue(value)}
       placeholder={`Search...`}
-      list={`${column.id} list`}
     />
     <div className="h-1" />
   </div>


### PR DESCRIPTION
I got feedback from Erin that it would be a much better UX to have the consented column be a dropdown of possible options. This required extending some of the react-table functionality because it doesn't support this type of filtering natively. I've PR'd this into `mb-jn-414-search` so this particular change would be easier to review.

I also have a couple of TS/React questions within the PR.

![Screenshot 2023-06-27 at 10 51 01 AM](https://github.com/broadinstitute/juniper/assets/7257391/e78e0a4c-8a3d-4f0a-937e-c6af13968ec7)

