### PR TITLE
[JN-443] Fix a bug causing numeric fields to not be written to the database

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
@@ -48,7 +48,7 @@ public abstract class BaseJdbiDao<T extends BaseEntity> {
     protected boolean isSimpleFieldType(Class fieldType) {
         return Enum.class.isAssignableFrom(fieldType) ||
                 Arrays.asList(String.class, Instant.class, LocalDate.class, Boolean.class, boolean.class,
-                                Integer.class, int.class, UUID.class, byte[].class)
+                                Integer.class, Double.class, int.class, UUID.class, byte[].class)
                         .contains(fieldType);
     }
 
@@ -150,7 +150,7 @@ public abstract class BaseJdbiDao<T extends BaseEntity> {
         return "insert into " + tableName + " (" + StringUtils.join(insertColumns, ", ") +") " +
                 "values (" + StringUtils.join(insertFieldSymbols, ", ") + ");";
     }
-    
+
     /** basic get-by-id */
     public Optional<T> find(UUID id) {
         return jdbi.withHandle(handle ->

--- a/core/src/test/java/bio/terra/pearl/core/dao/BaseJdbiDaoTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/BaseJdbiDaoTests.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
@@ -32,17 +33,16 @@ public class BaseJdbiDaoTests extends BaseSpringBootTest {
     public void testGenerateInsertFields() {
         SimpleModelDao testDao = new SimpleModelDao(null);
         List<String> fields = testDao.insertFields;
-        List<String> expectedFields = Arrays.asList("createdAt", "lastUpdatedAt", "boolField",
-                "intField", "stringField", "uuidField", "instantField");
-        Assertions.assertTrue(fields.size() == expectedFields.size() &&
-                expectedFields.containsAll(fields) &&
-                fields.containsAll(expectedFields));
+        var expectedFields = new String[]{"createdAt", "lastUpdatedAt", "boolField",
+                "intField", "doubleField", "stringField", "uuidField", "instantField"};
+        assertThat(fields.toString(), fields, containsInAnyOrder(expectedFields));
     }
 
     @Getter @Setter
     private class SimpleModel extends BaseEntity {
         private boolean boolField;
         private int intField;
+        private Double doubleField;
         private String stringField;
         private UUID uuidField;
         private Instant instantField;

--- a/core/src/test/java/bio/terra/pearl/core/dao/survey/AnswerDaoTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/survey/AnswerDaoTests.java
@@ -1,0 +1,83 @@
+package bio.terra.pearl.core.dao.survey;
+
+import bio.terra.pearl.core.BaseSpringBootTest;
+import bio.terra.pearl.core.factory.DaoTestUtils;
+import bio.terra.pearl.core.factory.survey.SurveyResponseFactory;
+import bio.terra.pearl.core.model.survey.Answer;
+import bio.terra.pearl.core.model.survey.Survey;
+import bio.terra.pearl.core.model.survey.SurveyResponse;
+import bio.terra.pearl.core.service.survey.SurveyService;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+public class AnswerDaoTests extends BaseSpringBootTest {
+  @Autowired
+  private AnswerDao answerDao;
+  @Autowired
+  private SurveyResponseFactory surveyResponseFactory;
+  @Autowired
+  private SurveyService surveyService;
+
+  @Test
+  @Transactional
+  public void testEmptyAnswerSaves() {
+    SurveyResponse response = surveyResponseFactory.buildPersisted("testAnswerValuesSave");
+    Answer stringAnswer = Answer.builder()
+        .enrolleeId(response.getEnrolleeId())
+        .questionStableId("whatevs")
+        .surveyResponseId(response.getId())
+        .creatingParticipantUserId(response.getCreatingParticipantUserId())
+        .surveyStableId("something")
+        .surveyVersion(1)
+        .build();
+    Answer savedAnswer = answerDao.create(stringAnswer);
+    DaoTestUtils.assertGeneratedProperties(savedAnswer);
+    assertThat(savedAnswer, samePropertyValuesAs(stringAnswer, "id", "createdAt", "lastUpdatedAt",
+        "valueAndType"));
+  }
+
+  @Test
+  @Transactional
+  public void testAnswerValuesSave() {
+    SurveyResponse response = surveyResponseFactory.buildPersisted("testAnswerValuesSave");
+    Answer stringAnswer = answerForResponse(response, "q1")
+        .stringValue("test1234")
+        .build();
+    Answer savedAnswer = answerDao.create(stringAnswer);
+    assertThat(savedAnswer.getStringValue(), equalTo(stringAnswer.getStringValue()));
+
+    Answer objectAnswer = answerForResponse(response, "q2")
+        .objectValue("[\"foo\", \"bar\"]")
+        .build();
+    savedAnswer = answerDao.create(objectAnswer);
+    assertThat(savedAnswer.getObjectValue(), equalTo(objectAnswer.getObjectValue()));
+
+    Answer booleanAnswer = answerForResponse(response, "q3")
+        .booleanValue(true)
+        .build();
+    savedAnswer = answerDao.create(booleanAnswer);
+    assertThat(savedAnswer.getBooleanValue(), equalTo(booleanAnswer.getBooleanValue()));
+
+    Answer numberAnswer = answerForResponse(response, "q4")
+        .numberValue(45.6)
+        .build();
+    savedAnswer = answerDao.create(numberAnswer);
+    assertThat(savedAnswer.getNumberValue(), equalTo(numberAnswer.getNumberValue()));
+  }
+
+
+  private Answer.AnswerBuilder answerForResponse(SurveyResponse response, String questionStableId) {
+    Survey survey = surveyService.find(response.getSurveyId()).get();
+    return Answer.builder()
+        .enrolleeId(response.getEnrolleeId())
+        .questionStableId(questionStableId)
+        .surveyResponseId(response.getId())
+        .creatingParticipantUserId(response.getCreatingParticipantUserId())
+        .surveyStableId(survey.getStableId())
+        .surveyVersion(survey.getVersion());
+  }
+}

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/survey/SurveyResponseFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/survey/SurveyResponseFactory.java
@@ -4,6 +4,7 @@ import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
+import bio.terra.pearl.core.service.survey.SurveyResponseService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -13,6 +14,8 @@ public class SurveyResponseFactory {
     private EnrolleeFactory enrolleeFactory;
     @Autowired
     private SurveyFactory surveyFactory;
+    @Autowired
+    private SurveyResponseService surveyResponseService;
 
     public SurveyResponse.SurveyResponseBuilder builder(String testName) {
         return SurveyResponse.builder().complete(false);
@@ -25,5 +28,9 @@ public class SurveyResponseFactory {
                 .enrolleeId(enrollee.getId())
                 .creatingParticipantUserId(enrollee.getParticipantUserId())
                 .surveyId(survey.getId());
+    }
+
+    public SurveyResponse buildPersisted(String testName) {
+        return surveyResponseService.create(builderWithDependencies(testName).build());
     }
 }


### PR DESCRIPTION
To test, enter a number in a numeric field and make sure it is saved. For example:
1. In the participant UI, fill out enough surveys to unlock the "Family History" survey.
2. In the Family History survey, select "Mother" for the first question of the second page.
3. In the field asking for age, enter a number (less than 50).
4. Unfocus the field and wait a few seconds for autosave (opening the network tool window helps here) or click through the remaining pages and complete the survey.
5. Open the Family History survey again and check that the value you entered is re-populated in the form (or check in the admin).