### PR TITLE
[JN-378] Update HTML designer component

### DIFF
--- a/ui-admin/src/forms/FormDesigner.tsx
+++ b/ui-admin/src/forms/FormDesigner.tsx
@@ -89,8 +89,8 @@ export const FormDesigner = (props: FormDesignerProps) => {
           if ('type' in selectedElement && selectedElement.type === 'html') {
             return (
               <HtmlDesigner
+                element={selectedElement}
                 readOnly={readOnly}
-                value={selectedElement}
                 onChange={updatedElement => {
                   onChange(set(selectedElementPath, updatedElement, value))
                 }}

--- a/ui-admin/src/forms/designer/HtmlDesigner.test.tsx
+++ b/ui-admin/src/forms/designer/HtmlDesigner.test.tsx
@@ -14,21 +14,21 @@ describe('HtmlDesigner', () => {
 
   it('renders HTML', () => {
     // Act
-    render(<HtmlDesigner readOnly={false} value={element} onChange={jest.fn()} />)
+    render(<HtmlDesigner element={element} readOnly={false} onChange={jest.fn()} />)
 
     // Assert
-    const textArea = screen.getByRole('textbox')
-    expect(textArea.textContent).toBe('<h2>Section heading</h2><p>This is a section.</p>')
+    const htmlTextarea = screen.getByLabelText('HTML')
+    expect(htmlTextarea.textContent).toBe('<h2>Section heading</h2><p>This is a section.</p>')
   })
 
   it('allows editing HTML', () => {
     // Arrange
     const onChange = jest.fn()
-    render(<HtmlDesigner readOnly={false} value={element} onChange={onChange} />)
+    render(<HtmlDesigner element={element} readOnly={false} onChange={onChange} />)
 
     // Act
-    const textArea = screen.getByRole('textbox')
-    fireEvent.change(textArea, {
+    const htmlTextarea = screen.getByLabelText('HTML')
+    fireEvent.change(htmlTextarea, {
       target: {
         value: '<h2>New section heading</h2><p>This is a section.</p>'
       }

--- a/ui-admin/src/forms/designer/HtmlDesigner.tsx
+++ b/ui-admin/src/forms/designer/HtmlDesigner.tsx
@@ -2,33 +2,37 @@ import React from 'react'
 
 import { HtmlElement } from '@juniper/ui-core'
 
+import { Textarea } from 'components/forms/Textarea'
+
 export type HtmlDesignerProps = {
+  element: HtmlElement
   readOnly: boolean
-  value: HtmlElement
   onChange: (newValue: HtmlElement) => void
 }
 
 /** UI for editing an HTML element in a form. */
 export const HtmlDesigner = (props: HtmlDesignerProps) => {
-  const { readOnly, value, onChange } = props
+  const { element, readOnly, onChange } = props
 
   return (
     <div className="d-flex flex-column h-100">
-      <h2>{value.name}</h2>
-      <textarea
+      <h2>{element.name}</h2>
+      <label className="form-label fs-4 mb-0" htmlFor="html-element-html">HTML</label>
+      <Textarea
         className="w-100 flex-grow-1 font-monospace"
-        readOnly={readOnly}
+        disabled={readOnly}
+        id="html-element-html"
         style={{
           overflowX: 'auto',
           resize: 'none',
           // @ts-ignore TS thinks this isn't a valid style property
           textWrap: 'nowrap'
         }}
-        value={value.html}
-        onChange={e => {
+        value={element.html}
+        onChange={newHtml => {
           onChange({
-            ...value,
-            html: e.target.value
+            ...element,
+            html: newHtml
           })
         }}
       />


### PR DESCRIPTION
Updating the HTML designer component to fix an a11y issue (form element missing a label) and adopt some of the conventions that have been more established in the question designer components (rename `value` prop to `element`, use Textarea component).