### PR TITLE
[JN-378] Better handle forms with no question templates

### DIFF
--- a/ui-admin/src/forms/FormDesigner.tsx
+++ b/ui-admin/src/forms/FormDesigner.tsx
@@ -8,7 +8,7 @@ import { PageDesigner } from './designer/PageDesigner'
 import { PagesList } from './designer/PagesList'
 import { PanelDesigner } from './designer/PanelDesigner'
 import { QuestionDesigner } from './designer/QuestionDesigner'
-import { QuestionTemplateList } from './designer/QuestionTemplateList'
+import { QuestionTemplatesDesigner } from './designer/QuestionTemplatesDesigner'
 import { FormTableOfContents } from './FormTableOfContents'
 
 type FormDesignerProps = {
@@ -52,7 +52,7 @@ export const FormDesigner = (props: FormDesignerProps) => {
 
           if (selectedElementPath === 'questionTemplates') {
             return (
-              <QuestionTemplateList
+              <QuestionTemplatesDesigner
                 formContent={value}
                 readOnly={readOnly}
                 onChange={onChange}

--- a/ui-admin/src/forms/designer/QuestionTemplateList.tsx
+++ b/ui-admin/src/forms/designer/QuestionTemplateList.tsx
@@ -30,7 +30,6 @@ export const QuestionTemplateList = (props: QuestionTemplateListProps) => {
 
   return (
     <>
-      <h2>Question Templates</h2>
       <ul className="list-group">
         {questionTemplates.map((question, i) => {
           const isReferenced = isQuestionTemplateReferencedInFormContent(formContent, question)

--- a/ui-admin/src/forms/designer/QuestionTemplatesDesigner.tsx
+++ b/ui-admin/src/forms/designer/QuestionTemplatesDesigner.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+
+import { FormContent } from '@juniper/ui-core'
+
+import { QuestionTemplateList } from './QuestionTemplateList'
+
+type QuestionTemplatesDesignerProps = {
+  formContent: FormContent
+  readOnly: boolean
+  onChange: (newValue: FormContent) => void
+}
+
+/** UI for editing question templates in a form. */
+export const QuestionTemplatesDesigner = (props: QuestionTemplatesDesignerProps) => {
+  const { formContent, readOnly, onChange } = props
+  const { questionTemplates = [] } = formContent
+
+  return (
+    <>
+      <h2>Question Templates</h2>
+      {questionTemplates.length === 0
+        ? (
+          <p>This form does not contain any question templates.</p>
+        ) : (
+          <QuestionTemplateList
+            formContent={formContent}
+            readOnly={readOnly}
+            onChange={onChange}
+          />
+        )}
+    </>
+  )
+}


### PR DESCRIPTION
Many of the current forms have no question templates.

Currently, selecting "Question templates" in the designer for those forms shows a view with a title "Question Templates" and nothing else. This adds a message when when there are no question templates.