### PR TITLE
[JN-447]  Making admin date display more robust

### DIFF
--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -98,7 +98,7 @@ export type Profile = {
   doNotEmailSolicit: boolean,
   mailingAddress: MailingAddress,
   phoneNumber: string,
-  birthDate: number
+  birthDate: number[]
 }
 
 export type MailingAddress = {

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -120,7 +120,7 @@ export const mockEnrollee: () => Enrollee = () => {
       givenName: 'Jonas',
       familyName: 'Salk',
       contactEmail: 'jsalk@test.com',
-      birthDate: 0,
+      birthDate: [1994, 11, 20],
       doNotEmail: false,
       doNotEmailSolicit: false,
       phoneNumber: '555.1212',

--- a/ui-admin/src/util/timeUtils.test.ts
+++ b/ui-admin/src/util/timeUtils.test.ts
@@ -1,0 +1,13 @@
+import { dateToDefaultString } from './timeUtils'
+
+describe('timeUtils dateToDefaultString', () => {
+  it('handles realistic dates', () => {
+    expect(dateToDefaultString([1984, 3, 14])).toEqual('3/14/1984')
+    expect(dateToDefaultString([1984, 12, 14])).toEqual('12/14/1984')
+  })
+
+  it('handles nullish values', () => {
+    expect(dateToDefaultString([])).toEqual('')
+    expect(dateToDefaultString(undefined)).toEqual('')
+  })
+})

--- a/ui-admin/src/util/timeUtils.tsx
+++ b/ui-admin/src/util/timeUtils.tsx
@@ -6,7 +6,7 @@ export function instantToDefaultString(instant?: number) {
   return new Date(instant * 1000).toLocaleString()
 }
 /** renders a java LocalDate as a date string.  this should be sensitive to the user's locale */
-export function dateToDefaultString(date?: number[]) {
+export function dateToDefaultString(date: number[] | undefined) {
   if (typeof date === 'undefined' || date.length != 3) {
     return ''
   }

--- a/ui-admin/src/util/timeUtils.tsx
+++ b/ui-admin/src/util/timeUtils.tsx
@@ -6,8 +6,12 @@ export function instantToDefaultString(instant?: number) {
   return new Date(instant * 1000).toLocaleString()
 }
 /** renders a java LocalDate as a date string.  this should be sensitive to the user's locale */
-export function dateToDefaultString(date: number) {
-  return new Date(date).toLocaleDateString()
+export function dateToDefaultString(date?: number[]) {
+  if (typeof date === 'undefined' || date.length != 3) {
+    return ''
+  }
+  // note we need to subtract one from the month parameter since java months are one-indexed and JS is zero-indexed
+  return new Date(date[0], date[1]  - 1, date[2]).toLocaleDateString()
 }
 
 /** returns current date in ISO format, e.g. 2023-04-15 */


### PR DESCRIPTION
this adds better handling of null birthdates, which would previously show "Invalid date" on the admin tool.  This also fixes up the type signatures -- I realized the array Date() constructor we were using (and that automatically handled the zero->one conversion) is actually undocumented?    Fun fact, `new Date(1996, 5, 16) != new Date([1996, 5, 16])`. 

TO TEST:
1. go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants/OHBASC  
2. confirm bithdate field is empty
3. go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants/OHSALK
4. confirm birthdate shows as 11/12/1979 