### PR TITLE
[JN-397] Update to latest Google OAuth Java client

### DIFF
--- a/api-admin/build.gradle
+++ b/api-admin/build.gradle
@@ -14,7 +14,10 @@ apply from: 'publishing.gradle'
 
 dependencies {
 
-    implementation 'bio.terra:terra-common-lib'
+    implementation('bio.terra:terra-common-lib') {
+        //Excluding this Google library from TCL until they can update to a non-vulnerable version
+        exclude group: 'com.google.apis', module: 'google-api-services-logging'
+    }
     implementation project(':core')
     implementation project(':populate')
     implementation 'org.apache.commons:commons-dbcp2'

--- a/api-participant/build.gradle
+++ b/api-participant/build.gradle
@@ -12,7 +12,10 @@ apply from: 'generators.gradle'
 apply from: 'publishing.gradle'
 
 dependencies {
-    implementation 'bio.terra:terra-common-lib'
+    implementation('bio.terra:terra-common-lib') {
+        //Excluding this Google library from TCL until they can update to a non-vulnerable version
+        exclude group: 'com.google.apis', module: 'google-api-services-logging'
+    }
     implementation project(':core')
     implementation 'org.apache.commons:commons-dbcp2'
     implementation 'org.apache.commons:commons-text:1.10.0'

--- a/buildSrc/src/main/groovy/bio.terra.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.java-common-conventions.gradle
@@ -48,7 +48,10 @@ dependencies {
 
     testImplementation 'org.hamcrest:hamcrest:2.2'
 
-    implementation 'bio.terra:terra-common-lib:0.0.75-SNAPSHOT'
+    implementation('bio.terra:terra-common-lib:0.0.91-SNAPSHOT') {
+        //Excluding this Google library from TCL until they can update to a non-vulnerable version
+        exclude group: 'com.google.apis', module: 'google-api-services-logging'
+    }
     implementation 'bio.terra:datarepo-client:1.349.0-SNAPSHOT'
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation 'com.sendgrid:sendgrid-java:4.0.1'
     implementation 'com.auth0:java-jwt:4.2.2'
     implementation group: "bio.terra", name: "datarepo-client", version: "1.456.0-SNAPSHOT"
-    implementation 'com.google.auth:google-auth-library-oauth2-http:1.4.0'
+    implementation 'com.google.auth:google-auth-library-oauth2-http:1.18.0'
     implementation 'org.apache.poi:poi:5.2.3'
     implementation 'org.apache.poi:poi-ooxml:5.2.3'
     implementation 'com.azure:azure-storage-blob:12.22.0'

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation 'org.glassfish.jersey.connectors:jersey-jdk-connector'
 
     // Google Dependencies
-    implementation 'com.google.auth:google-auth-library-oauth2-http:1.4.0'
+    implementation 'com.google.auth:google-auth-library-oauth2-http:1.18.0'
 
     // Terra Test Runner Library
     implementation 'bio.terra:terra-test-runner:0.1.5-SNAPSHOT'


### PR DESCRIPTION
Updates the Google oauth client to the latest version (released 11 days ago). This should patch the vulnerability identified in [JN-397](https://broadworkbench.atlassian.net/browse/JN-397)

edit: also need to patch the terra-common-lib. Will do that before undrafting

[JN-397]: https://broadworkbench.atlassian.net/browse/JN-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ