### PR TITLE
[JN-397 + JN-396] Update Google OAuth and Protobuf libraries

### DIFF
--- a/buildSrc/src/main/groovy/bio.terra.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.java-common-conventions.gradle
@@ -48,7 +48,11 @@ dependencies {
 
     testImplementation 'org.hamcrest:hamcrest:2.2'
 
-    implementation 'bio.terra:terra-common-lib:0.0.75-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:0.0.91-SNAPSHOT'
+    //terra-common-lib pulls in google-oauth-client v1.33.2, which contains vuln CVE-2021-22573
+    //This pulls in a patched version of google-oauth-client that supersedes the vulnerable version
+    //This is a workaround until TCL adopts a patched version
+    implementation 'com.google.oauth-client:google-oauth-client:1.33.3'
     implementation 'bio.terra:datarepo-client:1.349.0-SNAPSHOT'
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation 'com.sendgrid:sendgrid-java:4.0.1'
     implementation 'com.auth0:java-jwt:4.2.2'
     implementation group: "bio.terra", name: "datarepo-client", version: "1.456.0-SNAPSHOT"
-    implementation 'com.google.auth:google-auth-library-oauth2-http:1.4.0'
+    implementation 'com.google.auth:google-auth-library-oauth2-http:1.18.0'
     implementation 'org.apache.poi:poi:5.2.3'
     implementation 'org.apache.poi:poi-ooxml:5.2.3'
     implementation 'com.azure:azure-storage-blob:12.22.0'

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation 'org.glassfish.jersey.connectors:jersey-jdk-connector'
 
     // Google Dependencies
-    implementation 'com.google.auth:google-auth-library-oauth2-http:1.4.0'
+    implementation 'com.google.auth:google-auth-library-oauth2-http:1.18.0'
 
     // Terra Test Runner Library
     implementation 'bio.terra:terra-test-runner:0.1.5-SNAPSHOT'


### PR DESCRIPTION
This PR addresses two security vulnerabilities tagged by AppSec:

1) [JN-397](https://broadworkbench.atlassian.net/browse/JN-397)

`com.google.oauth-client:google-oauth-client:1.33.2` is transitively pulled in from `terra-common-lib`, which contains a vulnerability that was flagged by AppSec. The latest version of TCL still doesn't include a fix, so this PR pulls in the patched version of the OAuth library as a direct dependency in order to supersede the vulnerable version.

As a minor version update, it does not appear to have any breaking changes, and the only entry in the [changelog](https://github.com/googleapis/google-oauth-java-client/releases/tag/v1.33.3) for 1.33.3 was the fix for the vulnerability.

2) [JN-396](https://broadworkbench.atlassian.net/browse/JN-396)

`protobuf-java:3.21.6` was flagged as vulnerable. It's transitively pulled in by `terra-common-lib`. Raising `terra-common-lib` from v0.0.75 to v0.0.91 (latest) brings in `protobuf-java` 3.21.10 (which is patched).


Other:

I also updated the `google-auth-library-oauth2-http` library while I was here (mostly because I incorrectly assumed that this is where the vulnerable OAuth dependency was coming from 😅)

TESTING:

* I verified using Gradle dependency analyzer in IntelliJ

[JN-397]: https://broadworkbench.atlassian.net/browse/JN-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JN-396]: https://broadworkbench.atlassian.net/browse/JN-396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ