### PR TITLE
[JN-378] Allow creating panels from existing questions

### DIFF
--- a/ui-admin/src/forms/designer/ElementList.tsx
+++ b/ui-admin/src/forms/designer/ElementList.tsx
@@ -7,14 +7,14 @@ import { IconButton } from 'components/forms/Button'
 
 import { getElementLabel } from './designer-utils'
 
-type ElementListProps = {
+type ElementListProps<T extends FormElement> = {
   readOnly: boolean
-  value: FormElement[]
-  onChange: (newValue: FormElement[]) => void
+  value: T[]
+  onChange: (newValue: T[]) => void
 }
 
 /** UI for re-ordering a list of form elements. */
-export const ElementList = (props: ElementListProps) => {
+export const ElementList = <T extends FormElement, >(props: ElementListProps<T>) => {
   const { readOnly, value, onChange } = props
 
   return (

--- a/ui-admin/src/forms/designer/NewPanelForm.tsx
+++ b/ui-admin/src/forms/designer/NewPanelForm.tsx
@@ -1,0 +1,64 @@
+import { concat, flow, uniq, without } from 'lodash/fp'
+import React, { useState } from 'react'
+
+import { FormPanel } from '@juniper/ui-core'
+
+import { Button } from 'components/forms/Button'
+import { Checkbox } from 'components/forms/Checkbox'
+
+type NewPanelFormProps = {
+  availableElements: FormPanel['elements']
+  onCreate: (newPanel: FormPanel) => void
+}
+
+/** UI for creating a new panel. */
+export const NewPanelForm = (props: NewPanelFormProps) => {
+  const { availableElements, onCreate } = props
+
+  const [selectedElements, setSelectedElements] = useState<string[]>([])
+
+  return (
+    <>
+      <fieldset className="pb-3 border-bottom mb-3">
+        <legend className="form-label fs-6 mb-2">Select elements to include</legend>
+
+        {availableElements.map(element => {
+          return (
+            <div key={element.name} className="mb-2">
+              <Checkbox
+                checked={selectedElements.includes(element.name)}
+                label={element.name}
+                onChange={checked => {
+                  if (checked) {
+                    setSelectedElements(flow(concat([element.name]), uniq))
+                  } else {
+                    setSelectedElements(without([element.name]))
+                  }
+                }}
+              />
+            </div>
+          )
+        })}
+      </fieldset>
+      <div className="text-align-right">
+        <Button
+          disabled={selectedElements.length === 0}
+          tooltip={
+            selectedElements.length === 0
+              ? 'Select questions to create a panel'
+              : undefined
+          }
+          variant="primary"
+          onClick={() => {
+            onCreate({
+              type: 'panel',
+              elements: availableElements.filter(element => selectedElements.includes(element.name))
+            })
+          }}
+        >
+          Create panel
+        </Button>
+      </div>
+    </>
+  )
+}

--- a/ui-admin/src/forms/designer/PageDesigner.test.tsx
+++ b/ui-admin/src/forms/designer/PageDesigner.test.tsx
@@ -1,0 +1,87 @@
+import { act, getAllByRole, getByLabelText, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+
+import { FormContentPage } from '@juniper/ui-core'
+
+import { PageDesigner } from './PageDesigner'
+
+describe('PageDesigner', () => {
+  describe('creating a panel', () => {
+    const page: FormContentPage = {
+      elements: [
+        { name: 'q1', title: '1?', type: 'text' },
+        { name: 'q2', title: '2?', type: 'text' },
+        { name: 'q3', type: 'html', html: '3' },
+        {
+          type: 'panel',
+          elements: [
+            { name: 'q4', title: '4?', type: 'text' },
+            { name: 'q5', title: '5?', type: 'text' }
+          ]
+        },
+        { name: 'q6', title: '6?', type: 'text' }
+      ]
+    }
+
+    it('shows a modal with questions available to include in panel', async () => {
+      // Arrange
+      const user = userEvent.setup()
+
+      render(<PageDesigner readOnly={false} value={page} onChange={jest.fn()} />)
+
+      const createPanelButton = screen.getByText('Add panel')
+
+      // Act
+      await act(() => user.click(createPanelButton))
+
+      // Assert
+      const elementsToIncludeFieldset = screen.getByRole('group', { name: 'Select elements to include' })
+      // Should only include questions / HTML elements, not panels
+      const elementCheckboxes = getAllByRole(elementsToIncludeFieldset, 'checkbox')
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const elementNames = elementCheckboxes.map(el => (el as HTMLInputElement).labels![0].textContent)
+      expect(elementNames).toEqual(['q1', 'q2', 'q3', 'q6'])
+    })
+
+    it('updates page with new panel', async () => {
+      // Arrange
+      const user = userEvent.setup()
+
+      const onChange = jest.fn()
+      render(<PageDesigner readOnly={false} value={page} onChange={onChange} />)
+
+      await act(() => user.click(screen.getByText('Add panel')))
+
+      // Act
+      const elementsToIncludeFieldset = screen.getByRole('group', { name: 'Select elements to include' })
+      await act(() => user.click(getByLabelText(elementsToIncludeFieldset, 'q3')))
+      await act(() => user.click(getByLabelText(elementsToIncludeFieldset, 'q6')))
+
+      await act(() => user.click(screen.getByText('Create panel')))
+
+      // Assert
+      expect(onChange).toHaveBeenCalledWith({
+        ...page,
+        elements: [
+          { name: 'q1', title: '1?', type: 'text' },
+          { name: 'q2', title: '2?', type: 'text' },
+          {
+            type: 'panel',
+            elements: [
+              { name: 'q3', type: 'html', html: '3' },
+              { name: 'q6', title: '6?', type: 'text' }
+            ]
+          },
+          {
+            type: 'panel',
+            elements: [
+              { name: 'q4', title: '4?', type: 'text' },
+              { name: 'q5', title: '5?', type: 'text' }
+            ]
+          }
+        ]
+      })
+    })
+  })
+})

--- a/ui-core/src/types/forms.ts
+++ b/ui-core/src/types/forms.ts
@@ -83,7 +83,7 @@ export type FormElement = FormPanel | HtmlElement | Question
 
 export type FormPanel = BaseElement & {
   type: 'panel'
-  elements: FormElement[]
+  elements: (HtmlElement | Question)[]
 }
 
 export type HtmlElement = {


### PR DESCRIPTION
This allows creating a panel from existing questions within a page.

Along the way, realized that the FormPanel type needed an update... FormPanels should not contain nested panels.

https://github.com/broadinstitute/juniper/assets/1156625/efd9a5b6-fac3-4369-99e8-b14fee20615d

