### PR TITLE
[JN-378] Allow keeping panel contents when deleting panel

### DIFF
--- a/ui-admin/src/forms/designer/DeletePanelConfirmationModal.tsx
+++ b/ui-admin/src/forms/designer/DeletePanelConfirmationModal.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { Modal, ModalFooter } from 'react-bootstrap'
+
+import { FormPanel } from '@juniper/ui-core'
+
+import { Button } from 'components/forms/Button'
+
+type DeletePanelConfirmationModalProps = {
+  panel: FormPanel
+  onConfirm: (response: { deleteContents: boolean }) => void
+  onDismiss: () => void
+}
+
+/** Modal to confirm deleting a panel from a page. */
+export const DeletePanelConfirmationModal = (props: DeletePanelConfirmationModalProps) => {
+  const { panel, onConfirm, onDismiss } = props
+
+  return (
+    <Modal show onHide={onDismiss}>
+      <Modal.Header>Delete panel contents?</Modal.Header>
+      <Modal.Body>
+        <p>This panel contains {panel.elements.length} element{panel.elements.length !== 1 && 's'}.</p>
+        <ol>
+          {panel.elements.map(el => {
+            return <li key={el.name}>{el.name}</li>
+          })}
+        </ol>
+        <p>Do you want to delete these elements with the panel or keep them on the page?</p>
+      </Modal.Body>
+      <ModalFooter>
+        <Button
+          variant="danger"
+          onClick={() => {
+            onConfirm({ deleteContents: true })
+          }}
+        >
+          Delete contents
+        </Button>
+        <Button
+          variant="primary"
+          onClick={() => {
+            onConfirm({ deleteContents: false })
+          }}
+        >
+          Keep contents
+        </Button>
+        <Button
+          variant="secondary"
+          onClick={onDismiss}
+        >
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  )
+}

--- a/ui-admin/src/forms/designer/ElementList.tsx
+++ b/ui-admin/src/forms/designer/ElementList.tsx
@@ -1,10 +1,11 @@
 import { faChevronDown, faChevronUp, faTimes } from '@fortawesome/free-solid-svg-icons'
-import React from 'react'
+import React, { useState } from 'react'
 
-import { FormElement } from '@juniper/ui-core'
+import { FormElement, FormPanel } from '@juniper/ui-core'
 
 import { IconButton } from 'components/forms/Button'
 
+import { DeletePanelConfirmationModal } from './DeletePanelConfirmationModal'
 import { getElementLabel } from './designer-utils'
 
 type ElementListProps<T extends FormElement> = {
@@ -17,66 +18,110 @@ type ElementListProps<T extends FormElement> = {
 export const ElementList = <T extends FormElement, >(props: ElementListProps<T>) => {
   const { readOnly, value, onChange } = props
 
-  return (
-    <ol className="list-group list-group-numbered">
-      {value.map((element, i) => {
-        return (
-          <li
-            key={i}
-            className="list-group-item d-flex align-items-center"
-          >
-            <div className="flex-grow-1 text-truncate ms-2">
-              {getElementLabel(element)}
-            </div>
-            <div className="flex-shrink-0">
-              <IconButton
-                aria-label="Move this element before the previous one"
-                className="ms-2"
-                disabled={readOnly || i === 0}
-                icon={faChevronUp}
-                variant="light"
-                onClick={() => {
-                  onChange([
-                    ...value.slice(0, i - 1),
-                    value[i],
-                    value[i - 1],
-                    ...value.slice(i + 1)
-                  ])
-                }}
-              />
-              <IconButton
-                aria-label="Move this element after the next one"
-                className="ms-2"
-                disabled={readOnly || i === value.length - 1}
-                icon={faChevronDown}
-                variant="light"
-                onClick={() => {
-                  onChange([
-                    ...value.slice(0, i),
-                    value[i + 1],
-                    value[i],
-                    ...value.slice(i + 2)
-                  ])
-                }}
-              />
+  const [confirmingDeletePanel, setConfirmingDeletePanel] = useState<number>()
 
-              <IconButton
-                aria-label="Delete this element"
-                className="ms-2"
-                disabled={readOnly}
-                icon={faTimes}
-                variant="light"
-                onClick={() => {
-                  onChange([
-                    ...value.slice(0, i),
-                    ...value.slice(i + 1)
-                  ])
-                }}
-              />
-            </div>
-          </li>
-        )
-      })}
-    </ol>
+  return (
+    <>
+      <ol className="list-group list-group-numbered">
+        {value.map((element, i) => {
+          return (
+            <li
+              key={i}
+              className="list-group-item d-flex align-items-center"
+            >
+              <div className="flex-grow-1 text-truncate ms-2">
+                {getElementLabel(element)}
+              </div>
+              <div className="flex-shrink-0">
+                <IconButton
+                  aria-label="Move this element before the previous one"
+                  className="ms-2"
+                  disabled={readOnly || i === 0}
+                  icon={faChevronUp}
+                  variant="light"
+                  onClick={() => {
+                    onChange([
+                      ...value.slice(0, i - 1),
+                      value[i],
+                      value[i - 1],
+                      ...value.slice(i + 1)
+                    ])
+                  }}
+                />
+                <IconButton
+                  aria-label="Move this element after the next one"
+                  className="ms-2"
+                  disabled={readOnly || i === value.length - 1}
+                  icon={faChevronDown}
+                  variant="light"
+                  onClick={() => {
+                    onChange([
+                      ...value.slice(0, i),
+                      value[i + 1],
+                      value[i],
+                      ...value.slice(i + 2)
+                    ])
+                  }}
+                />
+
+                <IconButton
+                  aria-label="Delete this element"
+                  className="ms-2"
+                  disabled={readOnly}
+                  icon={faTimes}
+                  variant="light"
+                  onClick={() => {
+                    const elementToDelete = value[i]
+                    if (
+                      'type' in elementToDelete && elementToDelete.type === 'panel'
+                      && elementToDelete.elements.length > 0
+                    ) {
+                      setConfirmingDeletePanel(i)
+                    } else {
+                      onChange([
+                        ...value.slice(0, i),
+                        ...value.slice(i + 1)
+                      ])
+                    }
+                  }}
+                />
+              </div>
+            </li>
+          )
+        })}
+      </ol>
+
+      {confirmingDeletePanel !== undefined && (
+        <DeletePanelConfirmationModal
+          panel={value[confirmingDeletePanel] as FormPanel}
+          onConfirm={({ deleteContents }) => {
+            setConfirmingDeletePanel(undefined)
+            const indexOfPanelToDelete = confirmingDeletePanel
+            if (deleteContents) {
+              // Delete the panel.
+              onChange([
+                ...value.slice(0, indexOfPanelToDelete),
+                ...value.slice(indexOfPanelToDelete + 1)
+              ])
+            } else {
+              // Delete the panel, but put its contents in its place.
+              onChange([
+                ...value.slice(0, indexOfPanelToDelete),
+                // Cast as T[] isn't great, but is valid for how this component is used.
+                // T is either FormElement when this is used for elements on a page or
+                // HtmlElement | Question when this used for elements in a panel.
+                // FormPanel['elements'] is (HtmlElement | Question)[], so the cast
+                // is valid in either case.
+                ...(value[indexOfPanelToDelete] as FormPanel).elements as T[],
+                ...value.slice(indexOfPanelToDelete + 1)
+              ])
+            }
+          }}
+          onDismiss={() => {
+            setConfirmingDeletePanel(undefined)
+          }}
+        />
+      )}
+    </>
   )
 }


### PR DESCRIPTION
Stacked on #462.

Currently, when deleting a panel from a page, any elements in the panel are also deleted. This prompts the user to choose whether to delete the panel or contents or simply delete the panel and move all its contents to the page level.

https://github.com/broadinstitute/juniper/assets/1156625/2c22d5bb-a9e3-4dd5-8c6b-0b0275d4d974


