### PR TITLE
JN-442 Fixing survey ordering on new versions

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConfiguredConsentController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConfiguredConsentController.java
@@ -1,7 +1,6 @@
 package bio.terra.pearl.api.admin.controller.forms;
 
 import bio.terra.pearl.api.admin.api.ConfiguredConsentApi;
-import bio.terra.pearl.api.admin.model.ConfiguredConsentDto;
 import bio.terra.pearl.api.admin.service.AuthUtilService;
 import bio.terra.pearl.api.admin.service.forms.ConsentFormExtService;
 import bio.terra.pearl.core.model.EnvironmentName;
@@ -32,12 +31,12 @@ public class ConfiguredConsentController implements ConfiguredConsentApi {
   }
 
   @Override
-  public ResponseEntity<ConfiguredConsentDto> patch(
+  public ResponseEntity<Object> patch(
       String portalShortcode,
       String studyShortcode,
       String envName,
       UUID configuredConsentId,
-      ConfiguredConsentDto body) {
+      Object body) {
     AdminUser adminUser = authUtilService.requireAdminUser(request);
     EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
     StudyEnvironmentConsent configuredForm =
@@ -45,6 +44,6 @@ public class ConfiguredConsentController implements ConfiguredConsentApi {
     var savedConfig =
         consentFormExtService.updateConfiguredConsent(
             portalShortcode, environmentName, configuredForm, adminUser);
-    return ResponseEntity.ok(objectMapper.convertValue(savedConfig, ConfiguredConsentDto.class));
+    return ResponseEntity.ok(savedConfig);
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConfiguredSurveyController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConfiguredSurveyController.java
@@ -1,7 +1,6 @@
 package bio.terra.pearl.api.admin.controller.forms;
 
 import bio.terra.pearl.api.admin.api.ConfiguredSurveyApi;
-import bio.terra.pearl.api.admin.model.ConfiguredSurveyDto;
 import bio.terra.pearl.api.admin.service.AuthUtilService;
 import bio.terra.pearl.api.admin.service.forms.SurveyExtService;
 import bio.terra.pearl.core.model.EnvironmentName;
@@ -32,12 +31,12 @@ public class ConfiguredSurveyController implements ConfiguredSurveyApi {
   }
 
   @Override
-  public ResponseEntity<ConfiguredSurveyDto> patch(
+  public ResponseEntity<Object> patch(
       String portalShortcode,
       String studyShortcode,
       String envName,
       UUID configuredSurveyId,
-      ConfiguredSurveyDto body) {
+      Object body) {
     AdminUser adminUser = requestService.requireAdminUser(request);
     EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
     StudyEnvironmentSurvey configuredSurvey =
@@ -46,6 +45,6 @@ public class ConfiguredSurveyController implements ConfiguredSurveyApi {
     StudyEnvironmentSurvey savedSes =
         surveyExtService.updateConfiguredSurvey(
             portalShortcode, environmentName, configuredSurvey, adminUser);
-    return ResponseEntity.ok(objectMapper.convertValue(savedSes, ConfiguredSurveyDto.class));
+    return ResponseEntity.ok(savedSes);
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConsentFormController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConsentFormController.java
@@ -1,7 +1,6 @@
 package bio.terra.pearl.api.admin.controller.forms;
 
 import bio.terra.pearl.api.admin.api.ConsentFormApi;
-import bio.terra.pearl.api.admin.model.VersionedFormDto;
 import bio.terra.pearl.api.admin.service.AuthUtilService;
 import bio.terra.pearl.api.admin.service.forms.ConsentFormExtService;
 import bio.terra.pearl.core.model.admin.AdminUser;
@@ -30,19 +29,14 @@ public class ConsentFormController implements ConsentFormApi {
   }
 
   @Override
-  public ResponseEntity<VersionedFormDto> newVersion(
-      String portalShortcode, String stableId, VersionedFormDto body) {
+  public ResponseEntity<Object> newVersion(String portalShortcode, String stableId, Object body) {
     AdminUser adminUser = requestService.requireAdminUser(request);
-    if (!stableId.equals(body.getStableId())) {
+    ConsentForm consentForm = objectMapper.convertValue(body, ConsentForm.class);
+    if (!stableId.equals(consentForm.getStableId())) {
       throw new IllegalArgumentException("form parameters don't match");
     }
-    ConsentForm consentForm = objectMapper.convertValue(body, ConsentForm.class);
-
     ConsentForm savedConsent =
         consentFormExtService.createNewVersion(portalShortcode, consentForm, adminUser);
-
-    VersionedFormDto savedConsentDto =
-        objectMapper.convertValue(savedConsent, VersionedFormDto.class);
-    return ResponseEntity.ok(savedConsentDto);
+    return ResponseEntity.ok(savedConsent);
   }
 }

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -175,11 +175,11 @@ paths:
         - { name: configSurveyId, in: path, required: true, schema: { type: string, format: uuid } }
       requestBody:
         required: true
-        content: { application/json: { schema: { $ref: '#/components/schemas/ConfiguredSurveyDto' } } }
+        content: { application/json: { schema: { type: object } } }
       responses:
         '200':
           description: saved configuredSurvey object
-          content: { application/json: { schema: { $ref: '#/components/schemas/ConfiguredSurveyDto' } } }
+          content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/consentForms/{stableId}/{version}/newVersion:
@@ -192,11 +192,11 @@ paths:
         - { name: stableId, in: path, required: true, schema: { type: string } }
       requestBody:
         required: true
-        content: { application/json: { schema: { $ref: '#/components/schemas/VersionedFormDto' } } }
+        content: { application/json: { schema: { type: object } } }
       responses:
         '200':
           description: saved survey object
-          content: { application/json: { schema: { $ref: '#/components/schemas/VersionedFormDto' } } }
+          content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/configuredConsents/{configConsentId}:
@@ -211,11 +211,11 @@ paths:
         - { name: configConsentId, in: path, required: true, schema: { type: string, format: uuid } }
       requestBody:
         required: true
-        content: { application/json: { schema: { $ref: '#/components/schemas/ConfiguredConsentDto' } } }
+        content: { application/json: { schema: { schema: { type: object } } } }
       responses:
         '200':
           description: saved configuredConsent object
-          content: { application/json: { schema: { $ref: '#/components/schemas/ConfiguredConsentDto' } } }
+          content: { application/json: { schema: { schema: { type: object } } } }
         '500':
           $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/kitTypes:
@@ -892,26 +892,6 @@ components:
       type: object
       properties:
         token: {type: string}
-    VersionedFormDto:
-      type: object
-      properties:
-        name: {type: string}
-        version: {type: integer}
-        content: {type: string}
-        stableId: {type: string}
-        id: {type: string, format: uuid}
-    ConfiguredSurveyDto:
-      type: object
-      properties:
-        id: {type: string, format: uuid }
-        surveyId: { type: string, format: uuid }
-        studyEnvironmentId: { type: string, format: uuid }
-    ConfiguredConsentDto:
-      type: object
-      properties:
-        id: { type: string, format: uuid }
-        consentFormId: { type: string, format: uuid }
-        studyEnvironmentId: { type: string, format: uuid }
     StudyEnvironmentDto:
       type: object
       properties:

--- a/ui-admin/src/study/StudyContent.test.tsx
+++ b/ui-admin/src/study/StudyContent.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import StudyContent from './StudyContent'
+import { mockConfiguredSurvey, mockStudyEnvContext, mockSurvey } from 'test-utils/mocking-utils'
+import { setupRouterTest } from '../test-utils/router-testing-utils'
+
+test('renders surveys in-order', async () => {
+  const studyEnvContext = mockStudyEnvContext()
+  studyEnvContext.currentEnv.configuredSurveys = [
+    {
+      ...mockConfiguredSurvey(), surveyOrder: 2,
+      survey: {
+        ...mockSurvey(), name: 'Second survey'
+      }
+    },
+    {
+      ...mockConfiguredSurvey(), surveyOrder: 1,
+      survey: {
+        ...mockSurvey(), name: 'First survey'
+      }
+    }
+  ]
+
+  const { RoutedComponent } = setupRouterTest(<StudyContent studyEnvContext={studyEnvContext}/>)
+  render(RoutedComponent)
+  const html = document.body.innerHTML
+  const a = html.search('First survey')
+  const b = html.search('Second survey')
+  expect(a).toBeLessThan(b)
+})

--- a/ui-admin/src/study/StudyContent.tsx
+++ b/ui-admin/src/study/StudyContent.tsx
@@ -25,6 +25,10 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
     .find(env => env.environmentName === currentEnv.environmentName)?.portalEnvironmentConfig as PortalEnvironmentConfig
   const zoneConfig = useConfig()
   const isReadOnlyEnv = !(currentEnv.environmentName === 'sandbox')
+  currentEnv.configuredSurveys
+    .sort((a, b) => a.surveyOrder - b.surveyOrder)
+  currentEnv.configuredConsents
+    .sort((a, b) => a.consentOrder - b.consentOrder)
 
   return <div className="StudyContent container">
     <div className="row">
@@ -69,9 +73,9 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
             </div>
             <div className="flex-grow-1 p-3">
               <ul className="list-unstyled">
-                { currentEnv.configuredConsents.map(config => {
+                { currentEnv.configuredConsents.map((config, index) => {
                   const consentForm = config.consentForm
-                  return <li key={consentForm.stableId}>
+                  return <li key={index}>
                     <Link to={`consentForms/${consentForm.stableId}?readOnly=${isReadOnlyEnv}`}>
                       {consentForm.name} <span className="detail">v{consentForm.version}</span>
                     </Link>
@@ -86,9 +90,9 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
             </div>
             <div className="flex-grow-1 p-3">
               <ul className="list-unstyled">
-                { currentEnv.configuredSurveys.map(surveyConfig => {
+                { currentEnv.configuredSurveys.map((surveyConfig, index) => {
                   const survey = surveyConfig.survey
-                  return <li className="p-1" key={survey.stableId}>
+                  return <li className="p-1" key={index}>
                     <Link to={`surveys/${survey.stableId}?readOnly=${isReadOnlyEnv}`}>
                       {survey.name} <span className="detail">v{survey.version}</span>
                     </Link>


### PR DESCRIPTION
`surveyOrder`, along with some other properties, was being elided by the controller thanks to some outdated API DTOs.  My opinion is still that defining DTOs in the api isn't worth the trouble given that we don't have 3rd party API consumers.  Unless we're going to handwrite typesafe DTO converters (which we might eventually want to do when we need to support really robust APIs), they don't give us any extra guarantees of safety and/or appropriateness, just an extra layer for bugs.
 
TO TEST:
1. restart ApiAdminApp, repopulate ourhealth
2. go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/surveys/oh_oh_famHx?readOnly=false, and make a trivial change
3. save the survey
4. go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox -- confirm the surveys still appear in the correct order (Family History should still appear beneath Other Medical History)