### PR TITLE
JN-450: Fixing survey rerender bug

### DIFF
--- a/ui-participant/src/hub/survey/SurveyView.test.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+import { generateThreePageSurvey } from 'test-utils/test-survey-factory'
+import { PageNumberControl, useSurveyJSModel } from 'util/surveyJsUtils'
+import { render, screen } from '@testing-library/react'
+import { SurveyFooter } from './SurveyView'
+import { usePortalEnv } from 'providers/PortalProvider'
+import { Survey } from '@juniper/ui-core'
+
+jest.mock('providers/PortalProvider', () => ({ usePortalEnv: jest.fn() }))
+beforeEach(() => {
+  // @ts-expect-error TS doesn't realize this function is mocked
+  usePortalEnv.mockReturnValue({
+    portalEnv: {
+      environmentName: 'sandbox'
+    }
+  })
+})
+
+const FooterTestComponent = ({ pageNum, survey }: {pageNum: number, survey: Survey}) => {
+  const pager: PageNumberControl = { pageNumber: pageNum, updatePageNumber: () => 1 }
+  const { surveyModel } = useSurveyJSModel(survey, null,
+    () => 1, pager, { sexAtBirth: 'male' })
+  return <SurveyFooter survey={survey} surveyModel={surveyModel}/>
+}
+
+describe('SurveyFooter', () => {
+  it('does not render if not on the last page', () => {
+    const survey = generateThreePageSurvey({ footer: 'footer stuff' })
+    render(<FooterTestComponent survey={survey} pageNum={1}/>)
+    expect(screen.queryByText('footer stuff')).toBeNull()
+  })
+
+  it('renders if on the last page', () => {
+    const survey = generateThreePageSurvey({ footer: 'footer stuff' })
+    render(<FooterTestComponent survey={survey} pageNum={3}/>)
+    expect(screen.queryByText('footer stuff')).toBeTruthy()
+  })
+})

--- a/ui-participant/src/hub/survey/SurveyView.test.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.test.tsx
@@ -9,8 +9,7 @@ import { Survey } from '@juniper/ui-core'
 
 jest.mock('providers/PortalProvider', () => ({ usePortalEnv: jest.fn() }))
 beforeEach(() => {
-  // @ts-expect-error TS doesn't realize this function is mocked
-  usePortalEnv.mockReturnValue({
+  (usePortalEnv as jest.Mock).mockReturnValue({
     portalEnv: {
       environmentName: 'sandbox'
     }

--- a/ui-participant/src/providers/UserProvider.tsx
+++ b/ui-participant/src/providers/UserProvider.tsx
@@ -20,7 +20,7 @@ export type UserContextT = {
   loginUser: (result: LoginResult, accessToken: string) => void,
   loginUserInternal: (result: LoginResult) => void,
   logoutUser: () => void,
-  updateEnrollee: (enrollee: Enrollee) => Promise<void>
+  updateEnrollee: (enrollee: Enrollee, rerender?: boolean) => Promise<void>
 }
 
 /** current user object context */
@@ -87,18 +87,25 @@ export default function UserProvider({ children }: { children: React.ReactNode }
   }
 
   /** updates a single enrollee in the list of enrollees -- the enrollee object should contain an updated task list */
-  function updateEnrollee(enrollee: Enrollee): Promise<void> {
-    setLoginState(oldState => {
-      if (oldState == null) {
-        return oldState
-      }
-      const updatedEnrollees = oldState.enrollees.filter(exEnrollee => exEnrollee.shortcode != enrollee.shortcode)
-      updatedEnrollees.push(enrollee)
-      return {
-        user: oldState?.user,
-        enrollees: updatedEnrollees
-      }
-    })
+  function updateEnrollee(enrollee: Enrollee, updateWtihoutRerender=false): Promise<void> {
+    if (updateWtihoutRerender && loginState) {
+      // update the underlying value, but don't call setLoginState, so no refresh
+      // this should obviously be used with great care
+      const matchIndex = loginState.enrollees.findIndex(exEnrollee => exEnrollee.shortcode === enrollee.shortcode)
+      loginState.enrollees[matchIndex] = enrollee
+    } else {
+      setLoginState(oldState => {
+        if (oldState == null) {
+          return oldState
+        }
+        const updatedEnrollees = oldState.enrollees.filter(exEnrollee => exEnrollee.shortcode != enrollee.shortcode)
+        updatedEnrollees.push(enrollee)
+        return {
+          user: oldState?.user,
+          enrollees: updatedEnrollees
+        }
+      })
+    }
     return new Promise(resolve => {
       window.setTimeout(resolve, 0)
     })

--- a/ui-participant/src/providers/UserProvider.tsx
+++ b/ui-participant/src/providers/UserProvider.tsx
@@ -20,7 +20,7 @@ export type UserContextT = {
   loginUser: (result: LoginResult, accessToken: string) => void,
   loginUserInternal: (result: LoginResult) => void,
   logoutUser: () => void,
-  updateEnrollee: (enrollee: Enrollee, rerender?: boolean) => Promise<void>
+  updateEnrollee: (enrollee: Enrollee, updateWtihoutRerender?: boolean) => Promise<void>
 }
 
 /** current user object context */


### PR DESCRIPTION
there was a bug where moving quickly through a survey would sometimes cause fields to be erased while you were typing them.  This was caused by a rerender trigged by the `updateEnrollee` call after each in-progress answer save.  SurveyJS doesn't save answers to state until the field has lost focus, so if a rerender happens while a user is typing, the typing is lost.  This fixes the issue by making the updateEnrollee call not trigger a rerender.  
This also simplifies the useSurveyJsModel hook to avoid additional rerenders there.  While I couldn't write a full automated regression test for the issue, I did start adding tests to the participant survey view components.

TO TEST:
1. log in as consented@test.com to participant portal
2. start filling out basics
3. on the second page of the survey, fill out one address text field, then quickly start filling in another.  Confirm your typing is not suddenly erased in the second field
4. generally click around the survey and refresh the page use back button to confirm I haven't introduced any other regressions