### PR TITLE
[JN-378] Allow removing elements from panels

### DIFF
--- a/ui-admin/src/forms/designer/PageDesigner.tsx
+++ b/ui-admin/src/forms/designer/PageDesigner.tsx
@@ -5,7 +5,7 @@ import { FormContentPage, FormElement, HtmlElement, Question } from '@juniper/ui
 
 import { Button } from 'components/forms/Button'
 
-import { ElementList } from './ElementList'
+import { PageElementList } from './PageElementList'
 import { NewPanelForm } from './NewPanelForm'
 
 /** Can the given FormElement be included in a panel (is it a Question or HtmlElement)? */
@@ -49,7 +49,7 @@ export const PageDesigner = (props: PageDesignerProps) => {
         </Button>
       </div>
 
-      <ElementList
+      <PageElementList
         readOnly={readOnly}
         value={value.elements}
         onChange={newValue => {

--- a/ui-admin/src/forms/designer/PageElementList.test.tsx
+++ b/ui-admin/src/forms/designer/PageElementList.test.tsx
@@ -4,9 +4,9 @@ import React from 'react'
 
 import { FormElement, FormPanel } from '@juniper/ui-core'
 
-import { ElementList } from './ElementList'
+import { PageElementList } from './PageElementList'
 
-describe('ElementList', () => {
+describe('PageElementList', () => {
   const elements: FormElement[] = [
     {
       name: 'foo',
@@ -27,7 +27,7 @@ describe('ElementList', () => {
 
   it('renders elements', () => {
     // Act
-    render(<ElementList readOnly={false} value={elements} onChange={jest.fn()} />)
+    render(<PageElementList readOnly={false} value={elements} onChange={jest.fn()} />)
 
     // Assert
     const listItems = screen.getAllByRole('listitem')
@@ -39,7 +39,7 @@ describe('ElementList', () => {
     const user = userEvent.setup()
 
     const onChange = jest.fn()
-    render(<ElementList readOnly={false} value={elements} onChange={onChange} />)
+    render(<PageElementList readOnly={false} value={elements} onChange={onChange} />)
 
     // Act
     const moveBarUpButton = screen.getAllByLabelText('Move this element before the previous one')[1]
@@ -108,7 +108,7 @@ describe('ElementList', () => {
       const user = userEvent.setup()
 
       const onChange = jest.fn()
-      render(<ElementList readOnly={false} value={elements} onChange={onChange} />)
+      render(<PageElementList readOnly={false} value={elements} onChange={onChange} />)
 
       // Act
       const deleteButton = screen.getAllByLabelText('Delete this element')[0]
@@ -123,7 +123,7 @@ describe('ElementList', () => {
       const user = userEvent.setup()
 
       const onChange = jest.fn()
-      render(<ElementList readOnly={false} value={elements} onChange={onChange} />)
+      render(<PageElementList readOnly={false} value={elements} onChange={onChange} />)
 
       // Act
       const deleteButton = screen.getAllByLabelText('Delete this element')[1]
@@ -139,7 +139,7 @@ describe('ElementList', () => {
         const user = userEvent.setup()
 
         const onChange = jest.fn()
-        render(<ElementList readOnly={false} value={elements} onChange={onChange} />)
+        render(<PageElementList readOnly={false} value={elements} onChange={onChange} />)
 
         // Act
         const deleteButton = screen.getAllByLabelText('Delete this element')[2]
@@ -155,7 +155,7 @@ describe('ElementList', () => {
         const user = userEvent.setup()
 
         const onChange = jest.fn()
-        render(<ElementList readOnly={false} value={elements} onChange={onChange} />)
+        render(<PageElementList readOnly={false} value={elements} onChange={onChange} />)
 
         const deleteButton = screen.getAllByLabelText('Delete this element')[2]
         await act(() => user.click(deleteButton))
@@ -172,7 +172,7 @@ describe('ElementList', () => {
         const user = userEvent.setup()
 
         const onChange = jest.fn()
-        render(<ElementList readOnly={false} value={elements} onChange={onChange} />)
+        render(<PageElementList readOnly={false} value={elements} onChange={onChange} />)
 
         const deleteButton = screen.getAllByLabelText('Delete this element')[2]
         await act(() => user.click(deleteButton))

--- a/ui-admin/src/forms/designer/PageElementList.tsx
+++ b/ui-admin/src/forms/designer/PageElementList.tsx
@@ -1,21 +1,21 @@
 import { faChevronDown, faChevronUp, faTimes } from '@fortawesome/free-solid-svg-icons'
 import React, { useState } from 'react'
 
-import { FormElement, FormPanel } from '@juniper/ui-core'
+import { FormContentPage, FormPanel } from '@juniper/ui-core'
 
 import { IconButton } from 'components/forms/Button'
 
 import { DeletePanelConfirmationModal } from './DeletePanelConfirmationModal'
 import { getElementLabel } from './designer-utils'
 
-type ElementListProps<T extends FormElement> = {
+type PageElementListProps = {
   readOnly: boolean
-  value: T[]
-  onChange: (newValue: T[]) => void
+  value: FormContentPage['elements']
+  onChange: (newValue: FormContentPage['elements']) => void
 }
 
 /** UI for re-ordering a list of form elements. */
-export const ElementList = <T extends FormElement, >(props: ElementListProps<T>) => {
+export const PageElementList = (props: PageElementListProps) => {
   const { readOnly, value, onChange } = props
 
   const [confirmingDeletePanel, setConfirmingDeletePanel] = useState<number>()
@@ -107,12 +107,7 @@ export const ElementList = <T extends FormElement, >(props: ElementListProps<T>)
               // Delete the panel, but put its contents in its place.
               onChange([
                 ...value.slice(0, indexOfPanelToDelete),
-                // Cast as T[] isn't great, but is valid for how this component is used.
-                // T is either FormElement when this is used for elements on a page or
-                // HtmlElement | Question when this used for elements in a panel.
-                // FormPanel['elements'] is (HtmlElement | Question)[], so the cast
-                // is valid in either case.
-                ...(value[indexOfPanelToDelete] as FormPanel).elements as T[],
+                ...(value[indexOfPanelToDelete] as FormPanel).elements,
                 ...value.slice(indexOfPanelToDelete + 1)
               ])
             }

--- a/ui-admin/src/forms/designer/PanelDesigner.tsx
+++ b/ui-admin/src/forms/designer/PanelDesigner.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { FormPanel } from '@juniper/ui-core'
 
-import { ElementList } from './ElementList'
+import { PanelElementList } from './PanelElementList'
 
 export type PanelDesignerProps = {
   readOnly: boolean
@@ -17,7 +17,7 @@ export const PanelDesigner = (props: PanelDesignerProps) => {
   return (
     <div>
       <h2>Panel</h2>
-      <ElementList
+      <PanelElementList
         readOnly={readOnly}
         value={value.elements}
         onChange={newValue => {

--- a/ui-admin/src/forms/designer/PanelDesigner.tsx
+++ b/ui-admin/src/forms/designer/PanelDesigner.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 
-import { FormPanel } from '@juniper/ui-core'
+import { FormElement, FormPanel } from '@juniper/ui-core'
 
 import { PanelElementList } from './PanelElementList'
 
 export type PanelDesignerProps = {
   readOnly: boolean
   value: FormPanel
-  onChange: (newValue: FormPanel) => void
+  onChange: (newValue: FormPanel, removedElement?: FormElement) => void
 }
 
 /** UI for editing a panel in a form. */
@@ -20,8 +20,8 @@ export const PanelDesigner = (props: PanelDesignerProps) => {
       <PanelElementList
         readOnly={readOnly}
         value={value.elements}
-        onChange={newValue => {
-          onChange({ ...value, elements: newValue })
+        onChange={(newValue, removedElement) => {
+          onChange({ ...value, elements: newValue }, removedElement)
         }}
       />
     </div>

--- a/ui-admin/src/forms/designer/PanelElementList.test.tsx
+++ b/ui-admin/src/forms/designer/PanelElementList.test.tsx
@@ -1,0 +1,115 @@
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+
+import { FormPanel } from '@juniper/ui-core'
+
+import { PanelElementList } from './PanelElementList'
+
+describe('PanelElementList', () => {
+  const elements: FormPanel['elements'] = [
+    {
+      name: 'foo',
+      type: 'html',
+      html: '<p>foo</p>'
+    },
+    {
+      name: 'bar',
+      type: 'html',
+      html: '<p>bar</p>'
+    },
+    {
+      name: 'baz',
+      type: 'html',
+      html: '<p>baz</p>'
+    }
+  ]
+
+  it('renders elements', () => {
+    // Act
+    render(<PanelElementList readOnly={false} value={elements} onChange={jest.fn()} />)
+
+    // Assert
+    const listItems = screen.getAllByRole('listitem')
+    expect(listItems.map(el => el.textContent)).toEqual(['foo', 'bar', 'baz'])
+  })
+
+  it('allows reodering elements', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const onChange = jest.fn()
+    render(<PanelElementList readOnly={false} value={elements} onChange={onChange} />)
+
+    // Act
+    const moveBarUpButton = screen.getAllByLabelText('Move this element before the previous one')[1]
+    await act(() => user.click(moveBarUpButton))
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith([
+      {
+        name: 'bar',
+        type: 'html',
+        html: '<p>bar</p>'
+      },
+      {
+        name: 'foo',
+        type: 'html',
+        html: '<p>foo</p>'
+      },
+      {
+        name: 'baz',
+        type: 'html',
+        html: '<p>baz</p>'
+      }
+    ])
+
+    const moveBarDownButton = screen.getAllByLabelText('Move this element after the next one')[1]
+    await act(() => user.click(moveBarDownButton))
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith([
+      {
+        name: 'foo',
+        type: 'html',
+        html: '<p>foo</p>'
+      },
+      {
+        name: 'baz',
+        type: 'html',
+        html: '<p>baz</p>'
+      },
+      {
+        name: 'bar',
+        type: 'html',
+        html: '<p>bar</p>'
+      }
+    ])
+  })
+
+  it('allows deleting elements', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const onChange = jest.fn()
+    render(<PanelElementList readOnly={false} value={elements} onChange={onChange} />)
+
+    // Act
+    const deleteBarButton = screen.getAllByLabelText('Delete this element')[1]
+    await act(() => user.click(deleteBarButton))
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith([
+      {
+        name: 'foo',
+        type: 'html',
+        html: '<p>foo</p>'
+      },
+      {
+        name: 'baz',
+        type: 'html',
+        html: '<p>baz</p>'
+      }
+    ])
+  })
+})

--- a/ui-admin/src/forms/designer/PanelElementList.test.tsx
+++ b/ui-admin/src/forms/designer/PanelElementList.test.tsx
@@ -87,6 +87,39 @@ describe('PanelElementList', () => {
     ])
   })
 
+  it('allows removing elements from panel', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const onChange = jest.fn()
+    render(<PanelElementList readOnly={false} value={elements} onChange={onChange} />)
+
+    // Act
+    const deleteBarButton = screen.getAllByLabelText('Move this element out of panel')[1]
+    await act(() => user.click(deleteBarButton))
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith(
+      [
+        {
+          name: 'foo',
+          type: 'html',
+          html: '<p>foo</p>'
+        },
+        {
+          name: 'baz',
+          type: 'html',
+          html: '<p>baz</p>'
+        }
+      ],
+      {
+        name: 'bar',
+        type: 'html',
+        html: '<p>bar</p>'
+      }
+    )
+  })
+
   it('allows deleting elements', async () => {
     // Arrange
     const user = userEvent.setup()

--- a/ui-admin/src/forms/designer/PanelElementList.tsx
+++ b/ui-admin/src/forms/designer/PanelElementList.tsx
@@ -1,7 +1,7 @@
-import { faChevronDown, faChevronUp, faTimes } from '@fortawesome/free-solid-svg-icons'
+import { faArrowRightFromBracket, faChevronDown, faChevronUp, faTimes } from '@fortawesome/free-solid-svg-icons'
 import React from 'react'
 
-import { FormPanel } from '@juniper/ui-core'
+import { FormElement, FormPanel } from '@juniper/ui-core'
 
 import { IconButton } from 'components/forms/Button'
 
@@ -10,7 +10,7 @@ import { getElementLabel } from './designer-utils'
 type PanelElementListProps = {
   readOnly: boolean
   value: FormPanel['elements']
-  onChange: (newValue: FormPanel['elements']) => void
+  onChange: (newValue: FormPanel['elements'], removedElement?: FormElement) => void
 }
 
 /** UI for editing a list of form elements in a panel. */
@@ -58,6 +58,23 @@ export const PanelElementList = (props: PanelElementListProps) => {
                       value[i],
                       ...value.slice(i + 2)
                     ])
+                  }}
+                />
+
+                <IconButton
+                  aria-label="Move this element out of panel"
+                  className="ms-2"
+                  disabled={readOnly}
+                  icon={faArrowRightFromBracket}
+                  variant="light"
+                  onClick={() => {
+                    onChange(
+                      [
+                        ...value.slice(0, i),
+                        ...value.slice(i + 1)
+                      ],
+                      value[i]
+                    )
                   }}
                 />
 

--- a/ui-admin/src/forms/designer/PanelElementList.tsx
+++ b/ui-admin/src/forms/designer/PanelElementList.tsx
@@ -1,0 +1,84 @@
+import { faChevronDown, faChevronUp, faTimes } from '@fortawesome/free-solid-svg-icons'
+import React from 'react'
+
+import { FormPanel } from '@juniper/ui-core'
+
+import { IconButton } from 'components/forms/Button'
+
+import { getElementLabel } from './designer-utils'
+
+type PanelElementListProps = {
+  readOnly: boolean
+  value: FormPanel['elements']
+  onChange: (newValue: FormPanel['elements']) => void
+}
+
+/** UI for editing a list of form elements in a panel. */
+export const PanelElementList = (props: PanelElementListProps) => {
+  const { readOnly, value, onChange } = props
+
+  return (
+    <>
+      <ol className="list-group list-group-numbered">
+        {value.map((element, i) => {
+          return (
+            <li
+              key={i}
+              className="list-group-item d-flex align-items-center"
+            >
+              <div className="flex-grow-1 text-truncate ms-2">
+                {getElementLabel(element)}
+              </div>
+              <div className="flex-shrink-0">
+                <IconButton
+                  aria-label="Move this element before the previous one"
+                  className="ms-2"
+                  disabled={readOnly || i === 0}
+                  icon={faChevronUp}
+                  variant="light"
+                  onClick={() => {
+                    onChange([
+                      ...value.slice(0, i - 1),
+                      value[i],
+                      value[i - 1],
+                      ...value.slice(i + 1)
+                    ])
+                  }}
+                />
+                <IconButton
+                  aria-label="Move this element after the next one"
+                  className="ms-2"
+                  disabled={readOnly || i === value.length - 1}
+                  icon={faChevronDown}
+                  variant="light"
+                  onClick={() => {
+                    onChange([
+                      ...value.slice(0, i),
+                      value[i + 1],
+                      value[i],
+                      ...value.slice(i + 2)
+                    ])
+                  }}
+                />
+
+                <IconButton
+                  aria-label="Delete this element"
+                  className="ms-2"
+                  disabled={readOnly}
+                  icon={faTimes}
+                  variant="light"
+                  onClick={() => {
+                    onChange([
+                      ...value.slice(0, i),
+                      ...value.slice(i + 1)
+                    ])
+                  }}
+                />
+              </div>
+            </li>
+          )
+        })}
+      </ol>
+    </>
+  )
+}


### PR DESCRIPTION
This splits up ElementList into two components: one for page elements and one for panel elements.

It also adds the ability to remove an element from a panel.

https://github.com/broadinstitute/juniper/assets/1156625/a6a9d4d1-4781-442f-b2d0-fbffe03aedbf

