### PR TITLE
[JN-378] Add stub for validating form content

### DIFF
--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -7,6 +7,7 @@ import { FormDesigner } from './FormDesigner'
 import { OnChangeFormContent } from './formEditorTypes'
 import { FormContentJsonEditor } from './FormContentJsonEditor'
 import { FormPreview } from './FormPreview'
+import { validateFormContent } from './formContentValidation'
 
 type FormContentEditorProps = {
   initialContent: string
@@ -43,7 +44,12 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
             value={editedContent}
             onChange={newContent => {
               setEditedContent(newContent)
-              onChange(true, newContent)
+              try {
+                validateFormContent(newContent)
+                onChange(true, newContent)
+              } catch (err) {
+                onChange(false, undefined)
+              }
             }}
           />
         </Tab>

--- a/ui-admin/src/forms/FormContentJsonEditor.tsx
+++ b/ui-admin/src/forms/FormContentJsonEditor.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useState } from 'react'
 
 import { FormContent } from '@juniper/ui-core'
 
+import { validateFormContent } from './formContentValidation'
 import { OnChangeFormContent } from './formEditorTypes'
 
 type FormContentJsonEditorProps = {
@@ -21,6 +22,7 @@ export const FormContentJsonEditor = (props: FormContentJsonEditorProps) => {
     _setEditorValue(newEditorValue)
     try {
       const formContent = JSON.parse(newEditorValue)
+      validateFormContent(formContent)
       setIsValid(true)
       onChange(true, formContent)
     } catch (e) {

--- a/ui-admin/src/forms/formContentValidation.ts
+++ b/ui-admin/src/forms/formContentValidation.ts
@@ -1,0 +1,8 @@
+import { FormContent } from '@juniper/ui-core'
+
+/** Validate that an object is valid FormContent. */
+export const validateFormContent = (formContent: unknown): FormContent => {
+  // TODO: Implement this. Thrown an error if invalid.
+  // See ui-participant landing page section config for examples.
+  return formContent as FormContent
+}


### PR DESCRIPTION
Currently, nothing validates that edited form content actually conforms to the FormContent type or other requirements (like question title shouldn't be an empty string).

This allows saving invalid form content and also invalidates assumptions made by the editor UI. For example, replacing form content in the JSON editor with an empty object crashes the form designer.

This adds a stub function for validation and wires it into the form editor.