### PR TITLE
[JN-444] Fix "Welcome to study" banner not appearing

### DIFF
--- a/ui-participant/src/hub/HubPage.test.tsx
+++ b/ui-participant/src/hub/HubPage.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import HubPage from './HubPage'
+import { setupRouterTest } from '../test-utils/router-testing-utils'
+
+
+jest.mock('../providers/PortalProvider', () => {
+  return {
+    usePortalEnv: () => ({
+      portal: {
+        id: 'portal-id',
+        name: 'Test Portal',
+        shortcode: 'TESTPORTAL',
+        portalEnvironments: [],
+        portalStudies: [{
+          study: {
+            name: 'Test Study',
+            shortcode: 'STUDYSHORTCODE',
+            studyEnvironments: [{
+              id: 'test-study-env-id'
+            }]
+          }
+        }]
+      }
+    })
+  }
+})
+
+jest.mock('../providers/UserProvider', () => {
+  return {
+    useUser: () => ({
+      enrollees: [{
+        id: 'enrollee-id',
+        shortcode: 'ENSHORTCODE',
+        consented: false,
+        studyEnvironmentId: 'test-study-env-id',
+        participantTasks: [{
+          id: 'task-id',
+          blocksHub: true,
+          createdAt: 0,
+          enrolleeId: 'enrollee-id',
+          portalParticipantUserId: 'portal-participant-user-id',
+          status: 'NEW',
+          studyEnvironmentId: 'test-study-env-id',
+          taskType: 'CONSENT',
+          targetName: 'Test Survey',
+          targetStableId: 'test_survey_id',
+          targetAssignedVersion: 0,
+          taskOrder: 0
+        }]
+      }]
+    })
+  }
+})
+
+describe('HubPage', () => {
+  it('is rendered with the study name', () => {
+    const { RoutedComponent } = setupRouterTest(<HubPage />)
+    render(RoutedComponent)
+
+    expect(screen.getByText('Test Study')).toBeInTheDocument()
+  })
+
+  it('is rendered with a Start button for the next new task', () => {
+    const { RoutedComponent } = setupRouterTest(<HubPage />)
+    render(RoutedComponent)
+
+    expect(screen.getByText('Start Consent')).toBeInTheDocument()
+  })
+})

--- a/ui-participant/src/hub/HubPage.tsx
+++ b/ui-participant/src/hub/HubPage.tsx
@@ -21,7 +21,6 @@ export default function HubPage() {
 
   const unjoinedStudies = portal.portalStudies.filter(pStudy => !userHasJoinedPortalStudy(pStudy, enrollees))
   const hasUnjoinedStudies = unjoinedStudies.length > 0
-
   return (
     <>
       <DocumentTitle title="Dashboard" />

--- a/ui-participant/src/hub/HubPage.tsx
+++ b/ui-participant/src/hub/HubPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { usePortalEnv } from '../providers/PortalProvider'
 import { useUser } from '../providers/UserProvider'
 
@@ -17,16 +17,10 @@ export default function HubPage() {
   const { enrollees } = useUser()
 
   const hubUpdate = useHubUpdate()
-  const [displayedHubMessage, setDisplayedHubMessage] = useState(hubUpdate?.message)
+  const [showMessage, setShowMessage] = useState(true)
 
   const unjoinedStudies = portal.portalStudies.filter(pStudy => !userHasJoinedPortalStudy(pStudy, enrollees))
   const hasUnjoinedStudies = unjoinedStudies.length > 0
-
-  useEffect(() => {
-    if (hubUpdate) {
-      setDisplayedHubMessage(hubUpdate.message)
-    }
-  }, [hubUpdate])
 
   return (
     <>
@@ -35,14 +29,14 @@ export default function HubPage() {
         className="hub-dashboard-background flex-grow-1"
         style={{ background: 'linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%' }}
       >
-        {!!displayedHubMessage && (
+        {!!hubUpdate?.message && showMessage && (
           <HubMessageAlert
-            message={displayedHubMessage}
+            message={hubUpdate.message}
             className="mx-1 mx-md-auto my-1 my-md-5 shadow-sm"
             role="alert"
             style={{ maxWidth: 768 }}
             onDismiss={() => {
-              setDisplayedHubMessage(undefined)
+              setShowMessage(false)
             }}
           />
         )}

--- a/ui-participant/src/hub/HubPage.tsx
+++ b/ui-participant/src/hub/HubPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { usePortalEnv } from '../providers/PortalProvider'
 import { useUser } from '../providers/UserProvider'
 
@@ -21,6 +21,13 @@ export default function HubPage() {
 
   const unjoinedStudies = portal.portalStudies.filter(pStudy => !userHasJoinedPortalStudy(pStudy, enrollees))
   const hasUnjoinedStudies = unjoinedStudies.length > 0
+
+  useEffect(() => {
+    if (hubUpdate) {
+      setDisplayedHubMessage(hubUpdate.message)
+    }
+  }, [hubUpdate])
+
   return (
     <>
       <DocumentTitle title="Dashboard" />


### PR DESCRIPTION
`hubUpdate` is not always defined when this page renders, so this adds a hook to update `displayedHubMessage` if/when it is eventually defined. I suspect this bug was also impacting other banners as well.

![Screenshot 2023-06-30 at 12 56 31 PM](https://github.com/broadinstitute/juniper/assets/7257391/07ccc3c6-3091-4d4e-b888-50a091e0b9cd)

TO TEST:

1) Enroll in a study as a participant
2) You should now see the welcome banner display.