### PR TITLE
JN-444 more initial screen issues

### DIFF
--- a/ui-participant/src/hub/consent/ConsentView.tsx
+++ b/ui-participant/src/hub/consent/ConsentView.tsx
@@ -65,14 +65,15 @@ function RawConsentView({ form, enrollee, resumableData, pager, studyShortcode, 
       version: form.version, response: responseDto
     }).then(response => {
       response.enrollee.participantTasks = response.tasks
-      updateEnrollee(response.enrollee)
       const hubUpdate: HubUpdate = {
         message: {
           title: `${form.name} completed`,
           type: 'success'
         }
       }
-      navigate('/hub', { state: hubUpdate })
+      updateEnrollee(response.enrollee).then(() => {
+        navigate('/hub', { state: hubUpdate })
+      })
     }).catch(() => {
       refreshSurvey(surveyModel, null)
       alert('an error occurred')

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -68,14 +68,15 @@ function RawSurveyView({ form, enrollee, resumableData, pager, studyShortcode, t
     }).then(response => {
       response.enrollee.participantTasks = response.tasks
       response.enrollee.profile = response.profile
-      updateEnrollee(response.enrollee)
       const hubUpdate: HubUpdate = {
         message: {
           title: `${form.name} completed`,
           type: 'success'
         }
       }
-      navigate('/hub', { state: hubUpdate })
+      updateEnrollee(response.enrollee, {
+        afterFn: () => { navigate('/hub', { state: hubUpdate }) }
+      })
     }).catch(() => {
       refreshSurvey(surveyModel, null)
       alert('an error occurred')

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -74,9 +74,7 @@ function RawSurveyView({ form, enrollee, resumableData, pager, studyShortcode, t
           type: 'success'
         }
       }
-      updateEnrollee(response.enrollee, {
-        afterFn: () => { navigate('/hub', { state: hubUpdate }) }
-      })
+      updateEnrollee(response.enrollee).then(() => { navigate('/hub', { state: hubUpdate }) })
     }).catch(() => {
       refreshSurvey(surveyModel, null)
       alert('an error occurred')

--- a/ui-participant/src/login/RedirectFromOAuth.tsx
+++ b/ui-participant/src/login/RedirectFromOAuth.tsx
@@ -69,7 +69,6 @@ export const RedirectFromOAuth = () => {
                 studyShortcode: portalStudy.study.shortcode,
                 preEnrollResponseId
               })
-              updateEnrollee(response.enrollee)
               const hubUpdate: HubUpdate = {
                 message: {
                   title: 'Welcome to the study.',
@@ -77,7 +76,9 @@ export const RedirectFromOAuth = () => {
                   type: 'info'
                 }
               }
-              navigate('/hub', { replace: true, state: hubUpdate })
+              updateEnrollee(response.enrollee, {
+                afterFn: () => { navigate('/hub', { replace: true, state: hubUpdate }) }
+              })
             } catch {
               alert('an error occurred, please try again, or contact support')
             }

--- a/ui-participant/src/login/RedirectFromOAuth.tsx
+++ b/ui-participant/src/login/RedirectFromOAuth.tsx
@@ -76,8 +76,8 @@ export const RedirectFromOAuth = () => {
                   type: 'info'
                 }
               }
-              updateEnrollee(response.enrollee, {
-                afterFn: () => { navigate('/hub', { replace: true, state: hubUpdate }) }
+              updateEnrollee(response.enrollee).then(() => {
+                navigate('/hub', { replace: true, state: hubUpdate })
               })
             } catch {
               alert('an error occurred, please try again, or contact support')

--- a/ui-participant/src/providers/UserProvider.test.tsx
+++ b/ui-participant/src/providers/UserProvider.test.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import UserProvider, { useUser } from './UserProvider'
 import { mockEnrollee, mockParticipantUser } from '../test-utils/test-participant-factory'
 import { setupRouterTest } from '../test-utils/router-testing-utils'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { AuthProvider } from 'react-oidc-context'
 
@@ -18,7 +18,7 @@ const UpdateEnrolleeTestComponent = () => {
   }, [])
 
   const addEnrollee = () => {
-    updateEnrollee(mockEnrollee(), { afterFn: () => setUpdated(true) })
+    updateEnrollee(mockEnrollee()).then(() => { setUpdated(true) })
   }
 
   return <div>
@@ -45,7 +45,9 @@ describe('UserProvider', () => {
     </AuthProvider>)
     render(RoutedComponent)
     expect(screen.getByText('No updates yet')).toBeInTheDocument()
-    userEvent.click(screen.getByText('Add Enrollee'))
+    act(() => {
+      userEvent.click(screen.getByText('Add Enrollee'))
+    })
     expect(screen.queryByText('Updated state but not enrollee')).toBeNull()
     await waitFor(() => expect(screen.getByText('Updated enrollee and state')).toBeInTheDocument())
   })

--- a/ui-participant/src/providers/UserProvider.test.tsx
+++ b/ui-participant/src/providers/UserProvider.test.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react'
+import UserProvider, { useUser } from './UserProvider'
+import { mockEnrollee, mockParticipantUser } from '../test-utils/test-participant-factory'
+import { setupRouterTest } from '../test-utils/router-testing-utils'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { AuthProvider } from 'react-oidc-context'
+
+/** component for tracing how enrollee update state is propagated */
+const UpdateEnrolleeTestComponent = () => {
+  const { loginUserInternal, enrollees, updateEnrollee } = useUser()
+  const [updated, setUpdated] = useState(false)
+  useEffect(() => {
+    loginUserInternal({
+      user: mockParticipantUser(),
+      enrollees: []
+    })
+  }, [])
+
+  const addEnrollee = () => {
+    updateEnrollee(mockEnrollee(), { afterFn: () => setUpdated(true) })
+  }
+
+  return <div>
+    <button onClick={addEnrollee}>Add Enrollee</button>
+    { (enrollees.length === 0 && !updated) && <span>No updates yet</span>}
+    { (enrollees.length > 0 && !updated) && <span>Updated enrollee but not state</span>}
+    { (enrollees.length === 0 && updated) && <span>Updated state but not enrollee</span>}
+    { (enrollees.length > 0 && updated) && <span>Updated enrollee and state</span>}
+  </div>
+}
+
+jest.mock('react-oidc-context', () => {
+  return {
+    ...jest.requireActual('react-oidc-context'),
+    useAuth: () => ({ events: { addUserLoaded: () => 1 } }),
+    AuthProvider: ({ children }: React.PropsWithChildren) => { return children }
+  }
+})
+
+describe('UserProvider', () => {
+  it('updates an enrollee and calls the afterFn', async () => {
+    const { RoutedComponent } = setupRouterTest(<AuthProvider>
+      <UserProvider><UpdateEnrolleeTestComponent/></UserProvider>
+    </AuthProvider>)
+    render(RoutedComponent)
+    expect(screen.getByText('No updates yet')).toBeInTheDocument()
+    userEvent.click(screen.getByText('Add Enrollee'))
+    expect(screen.queryByText('Updated state but not enrollee')).toBeNull()
+    await waitFor(() => expect(screen.getByText('Updated enrollee and state')).toBeInTheDocument())
+  })
+})

--- a/ui-participant/src/providers/UserProvider.tsx
+++ b/ui-participant/src/providers/UserProvider.tsx
@@ -14,16 +14,13 @@ const anonymousUser: User = {
   username: 'anonymous'
 }
 
-type UpdateEnrolleeOptions = {
-  afterFn?: () => void // function to call after the update is complete (such as to do a navigate)
-}
 export type UserContextT = {
   user: User,
   enrollees: Enrollee[],  // this data is included to speed initial hub rendering.  it is NOT kept current
   loginUser: (result: LoginResult, accessToken: string) => void,
   loginUserInternal: (result: LoginResult) => void,
   logoutUser: () => void,
-  updateEnrollee: (enrollee: Enrollee, opts?: UpdateEnrolleeOptions) => void
+  updateEnrollee: (enrollee: Enrollee) => Promise<void>
 }
 
 /** current user object context */
@@ -90,8 +87,7 @@ export default function UserProvider({ children }: { children: React.ReactNode }
   }
 
   /** updates a single enrollee in the list of enrollees -- the enrollee object should contain an updated task list */
-  function updateEnrollee(enrollee: Enrollee, opts?: UpdateEnrolleeOptions) {
-    const { afterFn } = opts ?? {}
+  function updateEnrollee(enrollee: Enrollee): Promise<void> {
     setLoginState(oldState => {
       if (oldState == null) {
         return oldState
@@ -103,9 +99,9 @@ export default function UserProvider({ children }: { children: React.ReactNode }
         enrollees: updatedEnrollees
       }
     })
-    if (afterFn) {
-      window.setTimeout(afterFn, 0)
-    }
+    return new Promise(resolve => {
+      window.setTimeout(resolve, 0)
+    })
   }
 
   const userContext: UserContextT = {

--- a/ui-participant/src/providers/UserProvider.tsx
+++ b/ui-participant/src/providers/UserProvider.tsx
@@ -14,13 +14,16 @@ const anonymousUser: User = {
   username: 'anonymous'
 }
 
+type UpdateEnrolleeOptions = {
+  afterFn?: () => void // function to call after the update is complete (such as to do a navigate)
+}
 export type UserContextT = {
   user: User,
   enrollees: Enrollee[],  // this data is included to speed initial hub rendering.  it is NOT kept current
   loginUser: (result: LoginResult, accessToken: string) => void,
   loginUserInternal: (result: LoginResult) => void,
   logoutUser: () => void,
-  updateEnrollee: (enrollee: Enrollee) => void
+  updateEnrollee: (enrollee: Enrollee, opts?: UpdateEnrolleeOptions) => void
 }
 
 /** current user object context */
@@ -87,7 +90,8 @@ export default function UserProvider({ children }: { children: React.ReactNode }
   }
 
   /** updates a single enrollee in the list of enrollees -- the enrollee object should contain an updated task list */
-  function updateEnrollee(enrollee: Enrollee) {
+  function updateEnrollee(enrollee: Enrollee, opts?: UpdateEnrolleeOptions) {
+    const { afterFn } = opts ?? {}
     setLoginState(oldState => {
       if (oldState == null) {
         return oldState
@@ -99,6 +103,9 @@ export default function UserProvider({ children }: { children: React.ReactNode }
         enrollees: updatedEnrollees
       }
     })
+    if (afterFn) {
+      window.setTimeout(afterFn, 0)
+    }
   }
 
   const userContext: UserContextT = {

--- a/ui-participant/src/test-utils/test-participant-factory.ts
+++ b/ui-participant/src/test-utils/test-participant-factory.ts
@@ -1,0 +1,30 @@
+import { Enrollee, ParticipantUser } from 'api/api'
+
+export const mockParticipantUser: () => ParticipantUser = () => {
+  return {
+    id: 'user1',
+    username: 'mockUser1@mock.com',
+    token: 'fakeToken'
+  }
+}
+
+export const mockEnrollee: () => Enrollee = () => {
+  return {
+    shortcode: 'AAABBB',
+    consented: true,
+    id: 'enrollee1',
+    participantUserId: 'user1',
+    profile: {
+      sexAtBirth: 'female'
+    },
+    profileId: 'profile1',
+    kitRequests: [],
+    surveyResponses: [],
+    consentResponses: [],
+    preEnrollmentResponseId: undefined,
+    participantTasks: [],
+    createdAt: 0,
+    lastUpdatedAt: 0,
+    studyEnvironmentId: 'studyEnv1'
+  }
+}

--- a/ui-participant/src/test-utils/test-participant-factory.ts
+++ b/ui-participant/src/test-utils/test-participant-factory.ts
@@ -1,5 +1,6 @@
 import { Enrollee, ParticipantUser } from 'api/api'
 
+/** gets a mock ParticipantUser */
 export const mockParticipantUser: () => ParticipantUser = () => {
   return {
     id: 'user1',
@@ -8,6 +9,7 @@ export const mockParticipantUser: () => ParticipantUser = () => {
   }
 }
 
+/** gets a mock Enrollee */
 export const mockEnrollee: () => Enrollee = () => {
   return {
     shortcode: 'AAABBB',


### PR DESCRIPTION
In looking at Matt's PR, I realized there was another problem with the initial hub screen -- we were flashing a list of studies before the proper activity list immediately after people joined, because of a delay between when we routed to the hub, and when we updated the state of the enrollee.  This adds a new option to the `updateEnrollee` function, 'afterFn' which allows the caller to specify a function to be executed only after the enrollee update is complete.  so for both sign up and survey completion, we can delay navigating back to the hub until we've finished handling all the state updates.

TO TEST:
1. go to participant site 
2. Put a breakpoint on line 24 of HubPage.tsx (the return statement)
3. sign up a new enrollee
4. when the breakpoint is hit, continue, and then look at the hub, it should show the list of surveys/consent.   It should not show "List of studies to join".   