### PR TITLE
JN-454 refinements to admin survey response view

### DIFF
--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -80,6 +80,7 @@ export type EnrolleeSearchResult = {
 export type Enrollee = {
   id: string,
   shortcode: string,
+  participantUserId: string,
   surveyResponses: SurveyResponse[],
   consentResponses: ConsentResponse[],
   preRegResponse?: PreregistrationResponse,

--- a/ui-admin/src/components/forms/Button.tsx
+++ b/ui-admin/src/components/forms/Button.tsx
@@ -16,7 +16,7 @@ type ButtonVariant =
   | 'link'
 
 // Mainly for tests. JSDOM does not support the :focus-visible selector.
-const supportsFocusVisible = (() => {
+export const supportsFocusVisible = (() => {
   try {
     document.querySelector(':focus-visible')
     return true

--- a/ui-admin/src/components/forms/InfoPopup.test.tsx
+++ b/ui-admin/src/components/forms/InfoPopup.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, waitForElementToBeRemoved } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+
+import InfoPopup from './InfoPopup'
+
+describe('InfoPopup', () => {
+  it('renders a clickable tooltip button', async () => {
+    render(<div>
+      <InfoPopup content={'blah blah'}/>
+    </div>)
+    // tooltip doesn't appear by default
+    expect(screen.queryByText('blah blah')).toBeNull()
+
+    const button = screen.getByRole('button')
+    await userEvent.click(button)
+    // tooltip appears on click
+    expect(await screen.findByText('blah blah')).toBeTruthy()
+    await userEvent.click(button)
+    // tooltip disappears on second click
+    await waitForElementToBeRemoved(() => screen.queryByText('blah blah'))
+  })
+
+  it('disappears on clicks outside', async () => {
+    render(<div>
+      <span>Something complicated</span>
+      <InfoPopup content={'blah blah'}/>
+    </div>)
+    const button = screen.getByRole('button')
+    await userEvent.click(button)
+    // tooltip appears on click
+    expect(await screen.findByText('blah blah')).toBeTruthy()
+
+    // tooltip disappears on click of outside thing
+    await userEvent.click(screen.getByText('Something complicated'))
+    await waitForElementToBeRemoved(() => screen.queryByText('blah blah'))
+  })
+})

--- a/ui-admin/src/components/forms/InfoPopup.tsx
+++ b/ui-admin/src/components/forms/InfoPopup.tsx
@@ -1,0 +1,35 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import React, { useId } from 'react'
+import { OverlayTrigger, Popover } from 'react-bootstrap'
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
+import { Placement } from 'react-bootstrap/types'
+import { OverlayTriggerType } from 'react-bootstrap/OverlayTrigger'
+
+export type InfoPopupProps = JSX.IntrinsicElements['button'] & {
+  content: React.ReactNode  // content of the popup
+  target?: React.ReactNode  // the element to attach the popover to
+  placement?: Placement
+  trigger?: OverlayTriggerType[] // what actions trigger the popup, for hover tips, use ['hover', 'focus']
+  className?: string
+}
+
+/**
+ * thin wrapper around OverlayTrigger and Popover to render popup help content
+ * popup will work even when underlying element is disabled.
+ * All arguments are passed through to either Popover or OverlayTrigger
+ */
+export default function InfoPopup({
+  content, // the content of the popover
+  target=<FontAwesomeIcon icon={faInfoCircle}/>,
+  trigger=['click'],
+  placement='top',
+  className='tooltip-wide'
+}: InfoPopupProps) {
+  const id = useId()
+  const popoverContent = <Popover id={id} className={className}>
+    <div className="p-2">{content}</div>
+  </Popover>
+  return <OverlayTrigger rootClose trigger={trigger} placement={placement} overlay={popoverContent}>
+    <button aria-label="info popup" className="btn btn-link p-0 mx-2">{target}</button>
+  </OverlayTrigger>
+}

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeView.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeView.tsx
@@ -80,7 +80,7 @@ export default function EnrolleeView({ enrollee, studyEnvContext, onUpdate }:
     <div className="row mt-2">
       <div className="col-12">
         <div className="d-flex">
-          <div className="participantTabs">
+          <div className="participantTabs" style={{ minWidth: '280', maxWidth: '280px' }}>
             <ul className="list-group">
               <li className="list-group-item">
                 <NavLink to="profile" className={getLinkCssClasses}>Profile</NavLink>

--- a/ui-admin/src/study/participants/survey/EnrolleeSurveyView.tsx
+++ b/ui-admin/src/study/participants/survey/EnrolleeSurveyView.tsx
@@ -6,7 +6,7 @@ import SurveyFullDataView from './SurveyFullDataView'
 import SurveyEditView from './SurveyEditView'
 import { ResponseMapT } from '../enrolleeView/EnrolleeView'
 import { EnrolleeParams } from '../enrolleeView/EnrolleeLoader'
-import { instantToDefaultString } from '../../../util/timeUtils'
+import { instantToDefaultString } from 'util/timeUtils'
 
 /** Show responses for a survey based on url param */
 export default function EnrolleeSurveyView({ enrollee, responseMap }:
@@ -50,7 +50,8 @@ export function RawEnrolleeSurveyView({ enrollee, configSurvey, responses }:
         {isEditing ? 'cancel' : 'update / edit'}
       </button>
       <hr/>
-      {!isEditing && <SurveyFullDataView answers={lastResponse.answers} survey={configSurvey.survey}/> }
+      {!isEditing && <SurveyFullDataView answers={lastResponse.answers} survey={configSurvey.survey}
+        userId={enrollee.participantUserId}/> }
       {isEditing && <SurveyEditView survey={configSurvey.survey} response={lastResponse}/>}
     </div>
   </div>

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+import { getDisplayValue } from './SurveyFullDataView'
+import { Question } from 'survey-core'
+import { Answer } from '@juniper/ui-core/build/types/forms'
+
+
+describe('getDisplayValue', () => {
+  it('renders a plaintext value', async () => {
+    const question: Question = { isVisible: true } as Question
+    const answer: Answer = { stringValue: 'test123', questionStableId: 'testQ' } as Answer
+    render(<span>{getDisplayValue(answer, question)}</span>)
+    expect(screen.getByText('test123')).toBeTruthy()
+  })
+
+  it('renders a choice value', async () => {
+    const question: Question = {
+      isVisible: true,
+      choices: [{
+        text: 'option 1', value: 'option1Val'
+      }, {
+        text: 'option 2', value: 'option2Val'
+      }]
+    } as unknown as Question
+    const answer: Answer = { stringValue: 'option2Val', questionStableId: 'testQ' } as Answer
+    render(<span>{getDisplayValue(answer, question)}</span>)
+    expect(screen.getByText('option 2')).toBeTruthy()
+  })
+
+  it('renders a choice array value', async () => {
+    const question: Question = {
+      isVisible: true,
+      choices: [{
+        text: 'option 1', value: 'option1Val'
+      }, {
+        text: 'option 2', value: 'option2Val'
+      }, {
+        text: 'option 3', value: 'option3Val'
+      }, {
+        text: 'option 4', value: 'option4Val'
+      }]
+    } as unknown as Question
+    const answer: Answer = {
+      objectValue: JSON.stringify(['option2Val', 'option4Val']),
+      questionStableId: 'testQ'
+    } as Answer
+    render(<span>{getDisplayValue(answer, question)}</span>)
+    expect(screen.getByText('["option 2","option 4"]')).toBeTruthy()
+  })
+})

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -113,6 +113,7 @@ export const mockEnrollee: () => Enrollee = () => {
   return {
     id: enrolleeId,
     shortcode: 'JOSALK',
+    participantUserId: 'userId1',
     surveyResponses: [],
     consented: false,
     consentResponses: [],

--- a/ui-core/src/surveyUtils.ts
+++ b/ui-core/src/surveyUtils.ts
@@ -69,8 +69,7 @@ export const surveyJSModelFromForm = (form: VersionedForm): SurveyModel => {
 
 /** convert a list of answers and resumeData into the resume data format surveyJs expects */
 export function makeSurveyJsData(resumeData: string | undefined,
-                                 answers: Answer[] | undefined,
-                                 userId: string | undefined):
+  answers: Answer[] | undefined, userId: string | undefined):
   SurveyJsResumeData {
   answers = answers ?? []
   const answerHash = answers.reduce(

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -52,11 +52,6 @@ export type LoginResult = {
   enrollees: Enrollee[]
 }
 
-export type SurveyJsResumeData = {
-  currentPageNo: number,
-  data: object
-}
-
 export type Enrollee = {
   id: string
   consented: boolean

--- a/ui-participant/src/hub/consent/ConsentView.tsx
+++ b/ui-participant/src/hub/consent/ConsentView.tsx
@@ -7,8 +7,7 @@ import Api, {
   ConsentWithResponses,
   Enrollee,
   Portal,
-  StudyEnvironmentConsent,
-  SurveyJsResumeData
+  StudyEnvironmentConsent
 } from 'api/api'
 
 import { Survey as SurveyComponent } from 'survey-react-ui'
@@ -19,7 +18,7 @@ import {
   useRoutablePageNumber,
   useSurveyJSModel
 } from 'util/surveyJsUtils'
-import { makeSurveyJsData } from '@juniper/ui-core'
+import { makeSurveyJsData, SurveyJsResumeData } from '@juniper/ui-core'
 import { HubUpdate } from 'hub/hubUpdates'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { useUser } from 'providers/UserProvider'

--- a/ui-participant/src/hub/consent/ConsentView.tsx
+++ b/ui-participant/src/hub/consent/ConsentView.tsx
@@ -15,11 +15,11 @@ import { Survey as SurveyComponent } from 'survey-react-ui'
 import {
   getResumeData,
   getSurveyJsAnswerList,
-  makeSurveyJsData,
   PageNumberControl,
   useRoutablePageNumber,
   useSurveyJSModel
 } from 'util/surveyJsUtils'
+import { makeSurveyJsData } from '@juniper/ui-core'
 import { HubUpdate } from 'hub/hubUpdates'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { useUser } from 'providers/UserProvider'

--- a/ui-participant/src/hub/consent/PrintConsentView.tsx
+++ b/ui-participant/src/hub/consent/PrintConsentView.tsx
@@ -3,15 +3,13 @@ import { useParams } from 'react-router-dom'
 import { Model } from 'survey-core'
 import { Survey as SurveyComponent } from 'survey-react-ui'
 
-import { surveyJSModelFromForm } from '@juniper/ui-core'
+import { surveyJSModelFromForm, makeSurveyJsData } from '@juniper/ui-core'
 
 import Api, { Answer, Enrollee } from 'api/api'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { useUser } from 'providers/UserProvider'
 import { DocumentTitle } from 'util/DocumentTitle'
 import { PageLoadingIndicator } from 'util/LoadingSpinner'
-import { makeSurveyJsData } from '@juniper/ui-core'
-
 import { enrolleeForStudy } from './ConsentView'
 
 /**

--- a/ui-participant/src/hub/consent/PrintConsentView.tsx
+++ b/ui-participant/src/hub/consent/PrintConsentView.tsx
@@ -10,7 +10,7 @@ import { usePortalEnv } from 'providers/PortalProvider'
 import { useUser } from 'providers/UserProvider'
 import { DocumentTitle } from 'util/DocumentTitle'
 import { PageLoadingIndicator } from 'util/LoadingSpinner'
-import { makeSurveyJsData } from 'util/surveyJsUtils'
+import { makeSurveyJsData } from '@juniper/ui-core'
 
 import { enrolleeForStudy } from './ConsentView'
 

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -16,18 +16,18 @@ import {
   getResumeData,
   getSurveyJsAnswerList,
   getUpdatedAnswers,
-  makeSurveyJsData,
   PageNumberControl,
   useRoutablePageNumber,
   useSurveyJSModel
 } from 'util/surveyJsUtils'
+import { makeSurveyJsData } from '@juniper/ui-core'
 import { HubUpdate } from 'hub/hubUpdates'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { useUser } from 'providers/UserProvider'
 import { PageLoadingIndicator } from 'util/LoadingSpinner'
-import { withErrorBoundary } from '../../util/ErrorBoundary'
+import { withErrorBoundary } from 'util/ErrorBoundary'
 import SurveyReviewModeButton from './ReviewModeButton'
-import { Markdown } from '../../landing/Markdown'
+import { Markdown } from 'landing/Markdown'
 import { SurveyModel } from 'survey-core'
 import { DocumentTitle } from 'util/DocumentTitle'
 

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -6,7 +6,6 @@ import Api, {
   Portal,
   StudyEnvironmentSurvey,
   Survey,
-  SurveyJsResumeData,
   SurveyResponse,
   SurveyWithResponse
 } from 'api/api'
@@ -20,7 +19,7 @@ import {
   useRoutablePageNumber,
   useSurveyJSModel
 } from 'util/surveyJsUtils'
-import { makeSurveyJsData } from '@juniper/ui-core'
+import { makeSurveyJsData, SurveyJsResumeData } from '@juniper/ui-core'
 import { HubUpdate } from 'hub/hubUpdates'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { useUser } from 'providers/UserProvider'

--- a/ui-participant/src/util/surveyJsUtils.tsx
+++ b/ui-participant/src/util/surveyJsUtils.tsx
@@ -9,12 +9,10 @@ import { useSearchParams } from 'react-router-dom'
 import { SurveyModel } from 'survey-core'
 import { Survey as SurveyJSComponent } from 'survey-react-ui'
 
-import { surveyJSModelFromForm } from '@juniper/ui-core'
+import { SURVEY_JS_OTHER_SUFFIX, surveyJSModelFromForm, SurveyJsResumeData } from '@juniper/ui-core'
 
-import { Answer, ConsentForm, Profile, Survey, SurveyJsResumeData, UserResumeData } from 'api/api'
+import { Answer, ConsentForm, Profile, Survey, UserResumeData } from 'api/api'
 import { usePortalEnv } from 'providers/PortalProvider'
-
-const SURVEY_JS_OTHER_SUFFIX = '-Comment'
 
 const PAGE_NUMBER_PARAM_NAME = 'page'
 
@@ -180,34 +178,6 @@ export function getSurveyJsAnswerList(surveyJSModel: SurveyModel): Answer[] {
       return !key.endsWith(SURVEY_JS_OTHER_SUFFIX) && surveyJSModel.getQuestionByName(key)?.getType() !== 'html'
     })
     .map(([key, value]) => makeAnswer(value as SurveyJsValueType, key, surveyJSModel.data))
-}
-
-/** convert a list of answers and resumeData into the resume data format surveyJs expects */
-export function makeSurveyJsData(resumeData: string | undefined, answers: Answer[] | undefined, userId: string):
-  SurveyJsResumeData | null {
-  answers = answers ?? []
-  const answerHash = answers.reduce(
-    (hash: Record<string, SurveyJsValueType>, answer: Answer) => {
-      if (answer.objectValue) {
-        hash[answer.questionStableId] = JSON.parse(answer.objectValue)
-      } else {
-        hash[answer.questionStableId] = answer.stringValue ?? answer.numberValue ?? null
-      }
-      if (answer.otherDescription) {
-        hash[answer.questionStableId + SURVEY_JS_OTHER_SUFFIX] = answer.otherDescription
-      }
-      return hash
-    }, {})
-  let currentPageNo = 0
-  if (resumeData) {
-    const userResumeData = JSON.parse(resumeData)[userId]
-    // subtract 1 since surveyJS is 0-indexed
-    currentPageNo = userResumeData?.currentPageNo - 1
-  }
-  return {
-    data: answerHash,
-    currentPageNo
-  }
 }
 
 /** return an Answer for the given value.  This should be updated to take some sort of questionType/dataType param */


### PR DESCRIPTION
As shown in demo, this improves the display of survey responses in the admin tool in multiple ways:
1. questions are shown in survey-order, rather than the order in which they were answered
2. we now have the option to show all questions, or just the answered questions
3. we have the option to show full question text, or truncated
4. Unanswered questions show either 'no answer' or 'n/a' depending on whether they are logically visilble.  Note that this is still somewhat unrefined -- it doesn't take into account shown/hidden questions based on the enrollee's profile
5. Adds a new InfoPopup component for displaying help text 
![image](https://github.com/broadinstitute/juniper/assets/2800795/d8152c7c-8590-43d6-92bc-713f31b407bc)


![image](https://github.com/broadinstitute/juniper/assets/2800795/89047c62-3919-4d46-ade8-279dac668a11)

TO TEST:
1. go to Jonas Salk's basic survey https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants/OHSALK/surveys/oh_oh_basicInfo
2. click around, confirm answers appear, options and tooltips work