### PR TITLE
[JN-451] Add ability to create a new survey

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConfiguredSurveyController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConfiguredSurveyController.java
@@ -47,4 +47,18 @@ public class ConfiguredSurveyController implements ConfiguredSurveyApi {
             portalShortcode, environmentName, configuredSurvey, adminUser);
     return ResponseEntity.ok(savedSes);
   }
+
+  @Override
+  public ResponseEntity<Object> create(
+      String portalShortcode, String studyShortcode, String envName, Object body) {
+    AdminUser adminUser = requestService.requireAdminUser(request);
+    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
+    StudyEnvironmentSurvey configuredSurvey =
+        objectMapper.convertValue(body, StudyEnvironmentSurvey.class);
+
+    StudyEnvironmentSurvey savedSes =
+        surveyExtService.createConfiguredSurvey(
+            portalShortcode, environmentName, configuredSurvey, adminUser);
+    return ResponseEntity.ok(savedSes);
+  }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConfiguredSurveyController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConfiguredSurveyController.java
@@ -58,7 +58,7 @@ public class ConfiguredSurveyController implements ConfiguredSurveyApi {
 
     StudyEnvironmentSurvey savedSes =
         surveyExtService.createConfiguredSurvey(
-            portalShortcode, environmentName, configuredSurvey, adminUser);
+            portalShortcode, studyShortcode, environmentName, configuredSurvey, adminUser);
     return ResponseEntity.ok(savedSes);
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/SurveyController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/SurveyController.java
@@ -4,6 +4,7 @@ import bio.terra.pearl.api.admin.api.SurveyApi;
 import bio.terra.pearl.api.admin.service.AuthUtilService;
 import bio.terra.pearl.api.admin.service.forms.SurveyExtService;
 import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
 import bio.terra.pearl.core.model.survey.Survey;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.servlet.http.HttpServletRequest;
@@ -36,14 +37,12 @@ public class SurveyController implements SurveyApi {
   }
 
   @Override
-  public ResponseEntity<Object> create(String portalShortcode, String stableId, Object body) {
+  public ResponseEntity<Object> create(String portalShortcode, String studyShortCode, Object body) {
     AdminUser adminUser = requestService.requireAdminUser(request);
 
     Survey survey = objectMapper.convertValue(body, Survey.class);
-    if (!stableId.equals(survey.getStableId())) {
-      throw new IllegalArgumentException("survey parameters don't match");
-    }
-    Survey savedSurvey = surveyExtService.create(portalShortcode, survey, adminUser);
+    StudyEnvironmentSurvey savedSurvey =
+        surveyExtService.create(portalShortcode, studyShortCode, survey, adminUser);
     return ResponseEntity.ok(savedSurvey);
   }
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/SurveyController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/SurveyController.java
@@ -4,7 +4,6 @@ import bio.terra.pearl.api.admin.api.SurveyApi;
 import bio.terra.pearl.api.admin.service.AuthUtilService;
 import bio.terra.pearl.api.admin.service.forms.SurveyExtService;
 import bio.terra.pearl.core.model.admin.AdminUser;
-import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
 import bio.terra.pearl.core.model.survey.Survey;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.servlet.http.HttpServletRequest;
@@ -37,12 +36,11 @@ public class SurveyController implements SurveyApi {
   }
 
   @Override
-  public ResponseEntity<Object> create(String portalShortcode, String studyShortCode, Object body) {
+  public ResponseEntity<Object> create(String portalShortcode, Object body) {
     AdminUser adminUser = requestService.requireAdminUser(request);
 
     Survey survey = objectMapper.convertValue(body, Survey.class);
-    StudyEnvironmentSurvey savedSurvey =
-        surveyExtService.create(portalShortcode, studyShortCode, survey, adminUser);
+    Survey savedSurvey = surveyExtService.create(portalShortcode, survey, adminUser);
     return ResponseEntity.ok(savedSurvey);
   }
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
@@ -64,6 +64,7 @@ public class SurveyExtService {
 
   public StudyEnvironmentSurvey createConfiguredSurvey(
       String portalShortcode,
+      String studyShortcode,
       EnvironmentName envName,
       StudyEnvironmentSurvey surveyToConfigure,
       AdminUser user) {
@@ -72,7 +73,7 @@ public class SurveyExtService {
       return studyEnvironmentSurveyService.create(surveyToConfigure);
     }
     throw new PermissionDeniedException(
-        "You do not have permission to update the {} environment".formatted(envName));
+        "You do not have permission to update the %s environment".formatted(envName));
   }
 
   public StudyEnvironmentSurvey updateConfiguredSurvey(
@@ -88,7 +89,7 @@ public class SurveyExtService {
       return studyEnvironmentSurveyService.update(existing);
     }
     throw new PermissionDeniedException(
-        "You do not have permission to update the {} environment".formatted(envName));
+        "You do not have permission to update the %s environment".formatted(envName));
   }
 
   /** confirms that the Survey is accessible from the given portal */

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
@@ -50,7 +50,6 @@ public class SurveyExtService {
     }
     survey.setPortalId(portal.getId());
     survey.setVersion(1);
-
     return surveyService.create(survey);
   }
 

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -129,14 +129,13 @@ paths:
           content: { application/json: { schema: {type: object} } }
         '500':
           $ref: '#/components/responses/ServerError'
-  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/surveys:
+  /api/portals/v1/{portalShortcode}/surveys:
     post:
       summary: creates the requested survey, will fail if the given stableId already exists
       tags: [ survey ]
       operationId: create
       parameters:
         - { name: portalShortcode, in: path, required: true, schema: { type: string } }
-        - { name: studyShortcode, in: path, required: true, schema: { type: string } }
       requestBody:
         required: true
         content: { application/json: { schema: {type: object} } }
@@ -161,6 +160,24 @@ paths:
         '200':
           description: saved survey object
           content: { application/json: { schema: {type: object} } }
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/configuredSurveys:
+    post:
+      summary: Creates a configured survey in a study environment
+      tags: [ configuredSurvey ]
+      operationId: create
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: studyShortcode, in: path, required: true, schema: { type: string } }
+        - { name: envName, in: path, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content: { application/json: { schema: { type: object } } }
+      responses:
+        '200':
+          description: saved configuredSurvey object
+          content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/configuredSurveys/{configSurveyId}:

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -129,14 +129,14 @@ paths:
           content: { application/json: { schema: {type: object} } }
         '500':
           $ref: '#/components/responses/ServerError'
-  /api/portals/v1/{portalShortcode}/surveys/{stableId}:
+  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/surveys:
     post:
       summary: creates the requested survey, will fail if the given stableId already exists
       tags: [ survey ]
       operationId: create
       parameters:
         - { name: portalShortcode, in: path, required: true, schema: { type: string } }
-        - { name: stableId, in: path, required: true, schema: { type: string } }
+        - { name: studyShortcode, in: path, required: true, schema: { type: string } }
       requestBody:
         required: true
         content: { application/json: { schema: {type: object} } }

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/SurveyExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/SurveyExtServiceTests.java
@@ -45,7 +45,7 @@ public class SurveyExtServiceTests {
   public void createRequiresSuperuser() {
     AdminUser user = AdminUser.builder().superuser(false).build();
     Assertions.assertThrows(
-        PermissionDeniedException.class, () -> surveyExtService.create("foo", null, user));
+        PermissionDeniedException.class, () -> surveyExtService.create("foo", "bar", null, user));
   }
 
   @Test

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/SurveyExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/SurveyExtServiceTests.java
@@ -10,6 +10,7 @@ import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.exception.PermissionDeniedException;
+import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
 import bio.terra.pearl.core.service.survey.SurveyService;
 import java.util.Optional;
@@ -32,6 +33,7 @@ public class SurveyExtServiceTests {
   @MockBean private AuthUtilService mockAuthUtilService;
   @MockBean private SurveyService mockSurveyService;
   @MockBean private StudyEnvironmentSurveyService studyEnvironmentSurveyService;
+  @MockBean private StudyEnvironmentService studyEnvironmentService;
 
   @Test
   public void createNewVersionRequiresSuperuser() {

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -363,6 +363,17 @@ export default {
     return await this.processJsonResponse(response)
   },
 
+  async createNewSurvey(portalShortcode: string, survey: Survey): Promise<Survey> {
+    const url = `${API_ROOT}/portals/v1/${portalShortcode}/surveys/${survey.stableId}`
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: this.getInitHeaders(),
+      body: JSON.stringify(survey)
+    })
+    return await this.processJsonResponse(response)
+  },
+
   async createNewSurveyVersion(portalShortcode: string, survey: Survey): Promise<Survey> {
     const url = `${API_ROOT}/portals/v1/${portalShortcode}/surveys/${survey.stableId}/newVersion`
 

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -363,8 +363,8 @@ export default {
     return await this.processJsonResponse(response)
   },
 
-  async createNewSurvey(portalShortcode: string, studyShortcode: string, survey: Survey): Promise<Survey> {
-    const url = `${API_ROOT}/portals/v1/${portalShortcode}/studies/${studyShortcode}/surveys`
+  async createNewSurvey(portalShortcode: string, survey: Survey): Promise<Survey> {
+    const url = `${API_ROOT}/portals/v1/${portalShortcode}/surveys`
 
     const response = await fetch(url, {
       method: 'POST',
@@ -410,6 +410,19 @@ export default {
 
   async getSurveyVersions(studyShortname: string, stableId: string) {
     const response = await fetch(`${API_ROOT}/studies/${studyShortname}/surveys/${stableId}`, this.getGetInit())
+    return await this.processJsonResponse(response)
+  },
+
+  async createConfiguredSurvey(portalShortcode: string, studyShortcode: string, environmentName: string,
+    configuredSurvey: StudyEnvironmentSurvey): Promise<StudyEnvironmentSurvey> {
+    const url =`${API_ROOT}/portals/v1/${portalShortcode}/studies/${studyShortcode}` +
+        `/env/${environmentName}/configuredSurveys`
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: this.getInitHeaders(),
+      body: JSON.stringify(configuredSurvey)
+    })
     return await this.processJsonResponse(response)
   },
 

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -363,8 +363,8 @@ export default {
     return await this.processJsonResponse(response)
   },
 
-  async createNewSurvey(portalShortcode: string, survey: Survey): Promise<Survey> {
-    const url = `${API_ROOT}/portals/v1/${portalShortcode}/surveys/${survey.stableId}`
+  async createNewSurvey(portalShortcode: string, studyShortcode: string, survey: Survey): Promise<Survey> {
+    const url = `${API_ROOT}/portals/v1/${portalShortcode}/studies/${studyShortcode}/surveys`
 
     const response = await fetch(url, {
       method: 'POST',

--- a/ui-admin/src/portal/PortalProvider.tsx
+++ b/ui-admin/src/portal/PortalProvider.tsx
@@ -7,7 +7,7 @@ import { NavBreadcrumb } from 'navbar/AdminNavbar'
 
 export type PortalContextT = {
   updatePortal: (portal: Portal) => void
-  reloadPortal: (shortcode: string) => void,
+  reloadPortal: (shortcode: string, onReload: () => void) => void,
   portal: Portal | null,
   isLoading: boolean,
   isError: boolean
@@ -15,7 +15,7 @@ export type PortalContextT = {
 
 export type LoadedPortalContextT = {
   updatePortal: (portal: Portal) => void
-  reloadPortal: (shortcode: string) => void
+  reloadPortal: (shortcode: string, onReload: () => void) => void
   portal: Portal
 }
 
@@ -58,11 +58,12 @@ function RawPortalProvider({ shortcode, children }:
   }
 
   /** grabs the latest from the server and updates the portal object */
-  function reloadPortal(shortcode: string) {
+  function reloadPortal(shortcode: string, onReload: () => void) {
     Api.getPortal(shortcode).then(result => {
       setPortalState(result)
       setIsError(false)
       setIsLoading(false)
+      onReload()
     }).catch(() => {
       setIsError(true)
       setIsLoading(false)
@@ -71,7 +72,7 @@ function RawPortalProvider({ shortcode, children }:
   }
 
   useEffect(() => {
-    reloadPortal(shortcode)
+    reloadPortal(shortcode, () => undefined)
   }, [shortcode])
 
   const portalContext: PortalContextT  = {

--- a/ui-admin/src/portal/PortalProvider.tsx
+++ b/ui-admin/src/portal/PortalProvider.tsx
@@ -7,6 +7,7 @@ import { NavBreadcrumb } from 'navbar/AdminNavbar'
 
 export type PortalContextT = {
   updatePortal: (portal: Portal) => void
+  reloadPortal: (shortcode: string) => void,
   portal: Portal | null,
   isLoading: boolean,
   isError: boolean
@@ -14,6 +15,7 @@ export type PortalContextT = {
 
 export type LoadedPortalContextT = {
   updatePortal: (portal: Portal) => void
+  reloadPortal: (shortcode: string) => void
   portal: Portal
 }
 
@@ -24,6 +26,7 @@ export type PortalParams = {
 
 export const PortalContext = React.createContext<PortalContextT>({
   updatePortal: () => alert('error - portal not yet loaded'),
+  reloadPortal: () => alert('error - portal not yet loaded'),
   portal: null,
   isLoading: true,
   isError: false
@@ -54,7 +57,8 @@ function RawPortalProvider({ shortcode, children }:
     setPortalState(updatedPortal)
   }
 
-  useEffect(() => {
+  /** grabs the latest from the server and updates the portal object */
+  function reloadPortal(shortcode: string) {
     Api.getPortal(shortcode).then(result => {
       setPortalState(result)
       setIsError(false)
@@ -64,11 +68,16 @@ function RawPortalProvider({ shortcode, children }:
       setIsLoading(false)
       setPortalState(null)
     })
+  }
+
+  useEffect(() => {
+    reloadPortal(shortcode)
   }, [shortcode])
 
   const portalContext: PortalContextT  = {
     portal: portalState,
     updatePortal,
+    reloadPortal,
     isLoading,
     isError
   }

--- a/ui-admin/src/study/StudyContent.test.tsx
+++ b/ui-admin/src/study/StudyContent.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import {fireEvent, render, screen} from '@testing-library/react'
+import { GetBy } from '@testing-library/dom'
 
 import StudyContent from './StudyContent'
 import { mockConfiguredSurvey, mockStudyEnvContext, mockSurvey } from 'test-utils/mocking-utils'
@@ -28,4 +29,16 @@ test('renders surveys in-order', async () => {
   const a = html.search('First survey')
   const b = html.search('Second survey')
   expect(a).toBeLessThan(b)
+})
+
+test('renders a Create Survey modal', async () => {
+  const studyEnvContext = mockStudyEnvContext()
+
+  const { RoutedComponent } = setupRouterTest(<StudyContent studyEnvContext={studyEnvContext}/>)
+  render(RoutedComponent)
+
+  const addSurveyButton = screen.getByTestId('addSurvey')
+  fireEvent.click(addSurveyButton)
+  expect(screen.getByText('Survey Name')).toBeInTheDocument()
+  expect(screen.getByText('Survey Stable ID')).toBeInTheDocument()
 })

--- a/ui-admin/src/study/StudyContent.test.tsx
+++ b/ui-admin/src/study/StudyContent.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import {fireEvent, render, screen} from '@testing-library/react'
-import { GetBy } from '@testing-library/dom'
+import { fireEvent, render, screen } from '@testing-library/react'
 
 import StudyContent from './StudyContent'
 import { mockConfiguredSurvey, mockStudyEnvContext, mockSurvey } from 'test-utils/mocking-utils'

--- a/ui-admin/src/study/StudyContent.tsx
+++ b/ui-admin/src/study/StudyContent.tsx
@@ -18,6 +18,8 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
     padding: '1em 0 0 1em',
     borderBottom: '1px solid #f6f6f6'
   }
+
+
   const preEnrollSurvey = currentEnv.preEnrollSurvey
   const envConfig = currentEnv.studyEnvironmentConfig
   const portalEnvConfig = portal.portalEnvironments

--- a/ui-admin/src/study/StudyContent.tsx
+++ b/ui-admin/src/study/StudyContent.tsx
@@ -102,15 +102,11 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
                   </li>
                 }) }
                 <li>
-                  <button className="btn btn-secondary" onClick={() => {
+                  <button className="btn btn-secondary" data-testid={'addSurvey'} onClick={() => {
                     setShowCreateSurveyModal(!showCreateSurveyModal)
                   }}>
                     <FontAwesomeIcon icon={faPlus}/> Add
                   </button>
-                  <CreateSurveyModal studyEnvContext={studyEnvContext}
-                    isReadOnlyEnv={isReadOnlyEnv}
-                    show={showCreateSurveyModal}
-                    setShow={setShowCreateSurveyModal}/>
                 </li>
               </ul>
 
@@ -139,6 +135,10 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
             </div>
           </li>
         </ul> }
+        { <CreateSurveyModal studyEnvContext={studyEnvContext}
+          isReadOnlyEnv={isReadOnlyEnv}
+          show={showCreateSurveyModal}
+          setShow={setShowCreateSurveyModal}/> }
         { !currentEnv.studyEnvironmentConfig.initialized && <div>Not yet initialized</div> }
       </div>
     </div>

--- a/ui-admin/src/study/StudyContent.tsx
+++ b/ui-admin/src/study/StudyContent.tsx
@@ -108,6 +108,7 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
                     <FontAwesomeIcon icon={faPlus}/> Add
                   </button>
                   <CreateSurveyModal studyEnvContext={studyEnvContext}
+                    isReadOnlyEnv={isReadOnlyEnv}
                     show={showCreateSurveyModal}
                     setShow={setShowCreateSurveyModal}/>
                 </li>

--- a/ui-admin/src/study/StudyContent.tsx
+++ b/ui-admin/src/study/StudyContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useState} from 'react'
 
 import { StudyEnvContextT } from './StudyEnvironmentRouter'
 import { Link } from 'react-router-dom'
@@ -9,6 +9,8 @@ import Api, { PortalEnvironmentConfig } from 'api/api'
 import NotificationConfigTypeDisplay, { deliveryTypeDisplayMap } from './notifications/NotifcationConfigTypeDisplay'
 import { faEdit } from '@fortawesome/free-solid-svg-icons'
 import { useConfig } from '../providers/ConfigProvider'
+import CreateDatasetModal from "./participants/datarepo/CreateDatasetModal";
+import CreateSurveyModal from "./surveys/CreateSurveyModal";
 
 /** renders the main configuration page for a study environment */
 function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
@@ -25,6 +27,8 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
     .find(env => env.environmentName === currentEnv.environmentName)?.portalEnvironmentConfig as PortalEnvironmentConfig
   const zoneConfig = useConfig()
   const isReadOnlyEnv = !(currentEnv.environmentName === 'sandbox')
+  const [showCreateSurveyModal, setShowCreateSurveyModal] = useState(false)
+
   currentEnv.configuredSurveys
     .sort((a, b) => a.surveyOrder - b.surveyOrder)
   currentEnv.configuredConsents
@@ -99,9 +103,14 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
                   </li>
                 }) }
                 <li>
-                  <button className="btn btn-secondary" onClick={() => alert('not yet implemented')}>
+                  <button className="btn btn-secondary" onClick={() => {
+                    setShowCreateSurveyModal(!showCreateSurveyModal)
+                  }}>
                     <FontAwesomeIcon icon={faPlus}/> Add
                   </button>
+                  <CreateSurveyModal studyEnvContext={studyEnvContext}
+                    show={showCreateSurveyModal}
+                    setShow={setShowCreateSurveyModal}/>
                 </li>
               </ul>
 

--- a/ui-admin/src/study/StudyContent.tsx
+++ b/ui-admin/src/study/StudyContent.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react'
+import React, { useState } from 'react'
 
 import { StudyEnvContextT } from './StudyEnvironmentRouter'
 import { Link } from 'react-router-dom'
@@ -9,8 +9,7 @@ import Api, { PortalEnvironmentConfig } from 'api/api'
 import NotificationConfigTypeDisplay, { deliveryTypeDisplayMap } from './notifications/NotifcationConfigTypeDisplay'
 import { faEdit } from '@fortawesome/free-solid-svg-icons'
 import { useConfig } from '../providers/ConfigProvider'
-import CreateDatasetModal from "./participants/datarepo/CreateDatasetModal";
-import CreateSurveyModal from "./surveys/CreateSurveyModal";
+import CreateSurveyModal from './surveys/CreateSurveyModal'
 
 /** renders the main configuration page for a study environment */
 function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {

--- a/ui-admin/src/study/StudyContent.tsx
+++ b/ui-admin/src/study/StudyContent.tsx
@@ -18,8 +18,6 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
     padding: '1em 0 0 1em',
     borderBottom: '1px solid #f6f6f6'
   }
-
-
   const preEnrollSurvey = currentEnv.preEnrollSurvey
   const envConfig = currentEnv.studyEnvironmentConfig
   const portalEnvConfig = portal.portalEnvironments

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -17,7 +17,7 @@ const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, show, setShow }: {s
 
   const navigate = useNavigate()
 
-  const createDataset = async () => {
+  const createSurvey = async () => {
     setIsLoading(true)
     await Api.createNewSurvey(studyEnvContext.portal.shortcode,
       studyEnvContext.study.shortcode,
@@ -58,7 +58,7 @@ const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, show, setShow }: {s
     </Modal.Body>
     <Modal.Footer>
       <LoadingSpinner isLoading={isLoading}>
-        <button className="btn btn-primary" onClick={createDataset}>Create</button>
+        <button className="btn btn-primary" onClick={createSurvey}>Create</button>
         <button className="btn btn-secondary" onClick={() => {
           setShow(false)
           clearFields()

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react'
+import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
+import Modal from 'react-bootstrap/Modal'
+import LoadingSpinner from 'util/LoadingSpinner'
+import Api from 'api/api'
+import { failureNotification, successNotification } from 'util/notifications'
+import { Store } from 'react-notifications-component'
+
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
+const CreateSurveyModal = ({ studyEnvContext, show, setShow }: {studyEnvContext: StudyEnvContextT,
+    show: boolean, setShow:  React.Dispatch<React.SetStateAction<boolean>> }) => {
+  const [isLoading, setIsLoading] = useState(false)
+  const [surveyName, setSurveyName] = useState('')
+  const [surveyStableId, setSurveyStableId] = useState('')
+  const createDataset = async () => {
+    setIsLoading(true)
+    const response = await Api.createNewSurvey(studyEnvContext.portal.shortcode,
+      {content: "", createdAt: 0, footer: "", id: "", lastUpdatedAt: 0,
+        version: 0, name: surveyName, stableId: surveyStableId })
+    setShow(false)
+    setIsLoading(false)
+    clearFields()
+  }
+  const clearFields = () => {
+    setSurveyName('')
+    setSurveyStableId('')
+  }
+
+  return <Modal show={show} onHide={() => setShow(false)}>
+    <Modal.Header closeButton>
+      <Modal.Title>Create New Survey</Modal.Title>
+      <div className="ms-4">
+        {studyEnvContext.study.name}: {studyEnvContext.currentEnv.environmentName}
+      </div>
+    </Modal.Header>
+    <Modal.Body>
+      <form onSubmit={e => e.preventDefault()}>
+        <label className="form-label"> Survey Name
+          <input type="text" size={50} className="form-control" id="inputSurveyName" value={surveyName}
+            onChange={event => setSurveyName(event.target.value)}/>
+        </label>
+        <label className="form-label"> Survey Stable ID
+          <input type="text" size={50} className="form-control" id="inputSurveyStableId" value={surveyStableId}
+            onChange={event => setSurveyStableId(event.target.value)}/>
+        </label>
+      </form>
+    </Modal.Body>
+    <Modal.Footer>
+      <LoadingSpinner isLoading={isLoading}>
+        <button className="btn btn-primary" onClick={createDataset}>Create</button>
+        <button className="btn btn-secondary" onClick={() => {
+          setShow(false)
+          clearFields()
+        }}>Cancel</button>
+      </LoadingSpinner>
+    </Modal.Footer>
+  </Modal>
+}
+
+export default CreateSurveyModal

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -8,8 +8,7 @@ import { Store } from 'react-notifications-component'
 import { failureNotification } from '../../util/notifications'
 import { PortalContext, PortalContextT } from '../../portal/PortalProvider'
 
-// TODO: Add JSDoc
-// eslint-disable-next-line jsdoc/require-jsdoc
+/** renders a modal that creates a new survey in a portal and configures it to the current study env */
 const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, show, setShow }: {studyEnvContext: StudyEnvContextT,
   isReadOnlyEnv: boolean, show: boolean, setShow:  React.Dispatch<React.SetStateAction<boolean>> }) => {
   const [isLoading, setIsLoading] = useState(false)

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -3,25 +3,34 @@ import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
 import Modal from 'react-bootstrap/Modal'
 import LoadingSpinner from 'util/LoadingSpinner'
 import Api from 'api/api'
+import { useNavigate } from 'react-router-dom'
+import { Store } from 'react-notifications-component'
+import { failureNotification } from '../../util/notifications'
 
 // TODO: Add JSDoc
 // eslint-disable-next-line jsdoc/require-jsdoc
-const CreateSurveyModal = ({ studyEnvContext, show, setShow }: {studyEnvContext: StudyEnvContextT,
-    show: boolean, setShow:  React.Dispatch<React.SetStateAction<boolean>> }) => {
+const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, show, setShow }: {studyEnvContext: StudyEnvContextT,
+  isReadOnlyEnv: boolean, show: boolean, setShow:  React.Dispatch<React.SetStateAction<boolean>> }) => {
   const [isLoading, setIsLoading] = useState(false)
   const [surveyName, setSurveyName] = useState('')
   const [surveyStableId, setSurveyStableId] = useState('')
+
+  const navigate = useNavigate()
+
   const createDataset = async () => {
     setIsLoading(true)
     await Api.createNewSurvey(studyEnvContext.portal.shortcode,
       studyEnvContext.study.shortcode,
       {
-        content: '{}', createdAt: 0, footer: '', id: '', lastUpdatedAt: 0,
-        version: 0, name: surveyName, stableId: surveyStableId
-      })
+        createdAt: 0, id: '', lastUpdatedAt: 0, version: 1,
+        content: '{"pages":[]}', name: surveyName, stableId: surveyStableId
+      }).catch(e =>
+      Store.addNotification(failureNotification(`Error creating survey: ${e.message}`))
+    )
     setShow(false)
+    //TODO: this requires a full refresh of the portal context to work. for now, just refresh the page after it errors
+    navigate(`surveys/${surveyStableId}?readOnly=${isReadOnlyEnv}`)
     setIsLoading(false)
-    clearFields()
   }
   const clearFields = () => {
     setSurveyName('')

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -37,7 +37,11 @@ const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, show, setShow }: {s
     setSurveyStableId('')
   }
 
-  return <Modal show={show} onHide={() => setShow(false)}>
+  return <Modal show={show}
+    onHide={() => {
+      setShow(false)
+      clearFields()
+    }}>
     <Modal.Header closeButton>
       <Modal.Title>Create New Survey</Modal.Title>
       <div className="ms-4">

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -3,8 +3,6 @@ import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
 import Modal from 'react-bootstrap/Modal'
 import LoadingSpinner from 'util/LoadingSpinner'
 import Api from 'api/api'
-import { failureNotification, successNotification } from 'util/notifications'
-import { Store } from 'react-notifications-component'
 
 // TODO: Add JSDoc
 // eslint-disable-next-line jsdoc/require-jsdoc
@@ -15,9 +13,12 @@ const CreateSurveyModal = ({ studyEnvContext, show, setShow }: {studyEnvContext:
   const [surveyStableId, setSurveyStableId] = useState('')
   const createDataset = async () => {
     setIsLoading(true)
-    const response = await Api.createNewSurvey(studyEnvContext.portal.shortcode,
-      {content: "", createdAt: 0, footer: "", id: "", lastUpdatedAt: 0,
-        version: 0, name: surveyName, stableId: surveyStableId })
+    await Api.createNewSurvey(studyEnvContext.portal.shortcode,
+      studyEnvContext.study.shortcode,
+      {
+        content: '{}', createdAt: 0, footer: '', id: '', lastUpdatedAt: 0,
+        version: 0, name: surveyName, stableId: surveyStableId
+      })
     setShow(false)
     setIsLoading(false)
     clearFields()

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from 'react-router-dom'
 import { Store } from 'react-notifications-component'
 import { failureNotification } from '../../util/notifications'
 import { PortalContext, PortalContextT } from '../../portal/PortalProvider'
+import InfoPopup from '../../components/forms/InfoPopup'
 
 /** renders a modal that creates a new survey in a portal and configures it to the current study env */
 const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, show, setShow }: {studyEnvContext: StudyEnvContextT,
@@ -80,6 +81,7 @@ const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, show, setShow }: {s
             onChange={event => setSurveyName(event.target.value)}/>
         </label>
         <label className="form-label"> Survey Stable ID
+          <InfoPopup content={'A stable and unique identifier for the survey. May be shown in exported datasets.'}/>
           <input type="text" size={50} className="form-control" id="inputSurveyStableId" value={surveyStableId}
             onChange={event => setSurveyStableId(event.target.value)}/>
         </label>

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -47,9 +47,8 @@ const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, show, setShow }: {s
         }
       )
 
-      portalContext.reloadPortal(studyEnvContext.portal.shortcode, () => {
-        navigate(`surveys/${surveyStableId}?readOnly=${isReadOnlyEnv}`)
-      })
+      await portalContext.reloadPortal(studyEnvContext.portal.shortcode)
+      navigate(`surveys/${surveyStableId}?readOnly=${isReadOnlyEnv}`)
     } catch (err) {
       Store.addNotification(
         failureNotification(`Error configuring survey: ${err}`))

--- a/ui-admin/src/study/surveys/SurveyView.tsx
+++ b/ui-admin/src/study/surveys/SurveyView.tsx
@@ -24,8 +24,6 @@ function RawSurveyView({ studyEnvContext, survey, readOnly = false }:
   const [currentSurvey, setCurrentSurvey] = useState(survey)
   /** saves the survey as a new version */
   async function createNewVersion({ content: updatedTextContent }: { content: string }): Promise<void> {
-    console.log('woot')
-
     if (!user.superuser) {
       Store.addNotification(failureNotification('you do not have permissions to save surveys'))
       return

--- a/ui-admin/src/study/surveys/SurveyView.tsx
+++ b/ui-admin/src/study/surveys/SurveyView.tsx
@@ -24,6 +24,8 @@ function RawSurveyView({ studyEnvContext, survey, readOnly = false }:
   const [currentSurvey, setCurrentSurvey] = useState(survey)
   /** saves the survey as a new version */
   async function createNewVersion({ content: updatedTextContent }: { content: string }): Promise<void> {
+    console.log('woot')
+
     if (!user.superuser) {
       Store.addNotification(failureNotification('you do not have permissions to save surveys'))
       return

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
-import { AdminUser, DatasetDetails, Enrollee } from 'api/api'
+import {AdminUser, DatasetDetails, Enrollee, Portal} from 'api/api'
 import { Survey } from '@juniper/ui-core/build/types/forms'
 import { ParticipantTask } from '@juniper/ui-core/build/types/task'
 
@@ -15,19 +15,21 @@ const randomString = (length: number) => {
   return _times(length, () => _random(35).toString(36)).join('')
 }
 
+export const mockPortal: () => Portal = () => ({
+  id: 'fakeportalid1',
+  name: 'mock portal',
+  shortcode: 'mock4u',
+  portalStudies: [],
+  portalEnvironments: [
+    mockPortalEnvironment('sandbox')
+  ]
+})
+
 /** returns a simple portalContext, loosely modeled on OurHealth */
 export const mockPortalContext: () => LoadedPortalContextT = () => ({
-  portal: {
-    id: 'fakeportalid1',
-    name: 'mock portal',
-    shortcode: 'mock4u',
-    portalStudies: [],
-    portalEnvironments: [
-      mockPortalEnvironment('sandbox')
-    ]
-  },
+  portal: mockPortal(),
   updatePortal: () => null,
-  reloadPortal: () => null,
+  reloadPortal: () => Promise.resolve(mockPortal()),
   isError: false,
   isLoading: false
 })

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -15,6 +15,7 @@ const randomString = (length: number) => {
   return _times(length, () => _random(35).toString(36)).join('')
 }
 
+/** returns a mock portal */
 export const mockPortal: () => Portal = () => ({
   id: 'fakeportalid1',
   name: 'mock portal',

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -27,6 +27,7 @@ export const mockPortalContext: () => LoadedPortalContextT = () => ({
     ]
   },
   updatePortal: () => null,
+  reloadPortal: () => null,
   isError: false,
   isLoading: false
 })

--- a/ui-core/src/types/study.ts
+++ b/ui-core/src/types/study.ts
@@ -34,7 +34,8 @@ export type StudyEnvironmentSurvey = {
   allowAdminEdit: boolean
   allowParticipantStart: boolean
   allowParticipantReedit: boolean
-  prepopulate: boolean
+  prepopulate: boolean,
+  studyEnvironmentId?: string
 }
 
 export type StudyEnvironmentConsent = {


### PR DESCRIPTION
* Adds a new endpoint to configure a survey for a study environment
* Adds new modal for creating a survey in the study admin UI: 
![Screenshot 2023-07-06 at 5 07 03 PM](https://github.com/broadinstitute/juniper/assets/7257391/f1c79bc1-acca-4cb0-a872-05dc6a466cde)

Note that this is the bare minimum needed to unblock survey creation. There are other bits of configuration that we will eventually want to surface to the user: whether or not the survey is required, what the eligibility rules are, survey order, etc.



TO TEST:

1. Boot up Admin API + Admin UI
2. Go to the survey list in the study content manager and add a new survey
3. Verify that a blank survey gets created and it takes you to the survey builder
