### PR TITLE
[JN-469] Update API token on auto-refresh

### DIFF
--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -401,6 +401,10 @@ export default {
     bearerToken = null
   },
 
+  setBearerToken(token: string): void {
+    bearerToken = token
+  },
+
   async log(logEvent: LogEvent): Promise<void> {
     const url = `${API_ROOT}/public/log/v1/log`
     await fetch(url, {

--- a/ui-participant/src/providers/UserProvider.tsx
+++ b/ui-participant/src/providers/UserProvider.tsx
@@ -122,6 +122,7 @@ export default function UserProvider({ children }: { children: React.ReactNode }
 
   useEffect(() => {
     auth.events.addUserLoaded(user => {
+      Api.setBearerToken(user.access_token)
       localStorage.setItem(OAUTH_ACCRESS_TOKEN_KEY, user.access_token)
     })
 


### PR DESCRIPTION
Pretty simple change. Testing requires waiting 25 minutes or modifying the configuration; I recommend the latter.

1. Modify `ui-participant/src/authConfig.ts` to make the oauth library refresh 29 minutes or so before token expiration:
```Index: ui-participant/src/authConfig.ts
diff --git a/ui-participant/src/authConfig.ts b/ui-participant/src/authConfig.ts
--- a/ui-participant/src/authConfig.ts	(revision 600f133489ffd382b8df9309ed645b55da1f7ae4)
+++ b/ui-participant/src/authConfig.ts	(date 1689012518592)
@@ -52,7 +52,7 @@
     stateStore: new WebStorageStateStore({ store: window.localStorage }),
     userStore: new WebStorageStateStore({ store: window.localStorage }),
     automaticSilentRenew: true,
-    accessTokenExpiringNotificationTimeInSeconds: 300,
+    accessTokenExpiringNotificationTimeInSeconds: 29 * 60,
     includeIdTokenInSilentRenew: true,
     extraQueryParams: { access_type: 'offline' }
   }
```
2. Start up the participant API and UI with OurHealth populated
3. Sign in with an existing account (such as jsalk)
4. Open the web console, inspect an API request to Juniper, and note the bearer token in the `Authorization` HTTP header
5. Wait a minute
6. Do something in the app (like answer a question in a survey to trigger an auto-save), inspect that API request, and note that the bearer token is different than it was before

If you want to be extra diligent with testing, wait 30+ minutes until the original token actually expires (make sure you don't idle-out in that time), answer some survey questions, and verify through the admin that the responses were recorded.
