### PR TITLE
JN-470 surfacing frontend auth errors

### DIFF
--- a/ui-participant/src/Navbar.tsx
+++ b/ui-participant/src/Navbar.tsx
@@ -46,8 +46,6 @@ export default function Navbar(props: NavbarProps) {
     Api.logout().then(() => {
       logoutUser()
       window.location.href = '/'
-    }).catch(e => {
-      alert(`an error occurred during logout ${e}`)
     })
   }
 

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -155,7 +155,7 @@ export default {
     if (response.ok) {
       return obj
     }
-    return Promise.reject(response)
+    return Promise.reject(obj)
   },
 
   async getConfig(): Promise<Config> {
@@ -327,7 +327,10 @@ export default {
     }
     const result = await fetch(url, {
       method: 'POST',
-      headers: this.getInitHeaders(),
+      headers: {
+        ...this.getInitHeaders(),
+        Authorization: 'foo'
+      },
       body: JSON.stringify(response)
     })
     return await this.processJsonResponse(result)

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -8,7 +8,7 @@ import {
   StudyEnvironmentSurvey,
   SurveyResponse
 } from '@juniper/ui-core'
-import {defaultApiErrorHandle} from "../util/error-utils";
+import { defaultApiErrorHandle } from 'util/error-utils'
 
 export type {
   Answer,
@@ -150,9 +150,9 @@ export default {
       method: 'GET'
     }
   },
-  
+
   /** get the json from the response and alert and log any errors */
-  async processJsonResponse(response: Response, opts: {alertErrors: boolean} = {alertErrors: true}) {
+  async processJsonResponse(response: Response, opts: {alertErrors: boolean} = { alertErrors: true }) {
     const obj = await response.json()
     if (response.ok) {
       return obj
@@ -321,8 +321,10 @@ export default {
     return await this.processJsonResponse(response)
   },
 
-  async submitSurveyResponse({ studyShortcode, stableId, version, enrolleeShortcode, response, taskId, 
-                               alertErrors=true}: {
+  async submitSurveyResponse({
+    studyShortcode, stableId, version, enrolleeShortcode, response, taskId,
+    alertErrors=true
+  }: {
     studyShortcode: string, stableId: string, version: number, response: SurveyResponse, enrolleeShortcode: string,
     taskId: string, alertErrors: boolean
   }): Promise<HubResponse> {
@@ -336,7 +338,7 @@ export default {
       headers: this.getInitHeaders(),
       body: JSON.stringify(response)
     })
-    return await this.processJsonResponse(result, {alertErrors})
+    return await this.processJsonResponse(result, { alertErrors })
   },
 
   async submitMailingListContact(name: string, email: string) {
@@ -371,7 +373,7 @@ export default {
       method: 'POST',
       headers: this.getInitHeaders()
     })
-    const loginResult = await this.processJsonResponse(response, {alertErrors: false})
+    const loginResult = await this.processJsonResponse(response, { alertErrors: false })
     if (loginResult?.user?.token) {
       bearerToken = loginResult.user.token
     }
@@ -395,7 +397,7 @@ export default {
       method: 'POST',
       headers: this.getInitHeaders()
     })
-    return await this.processJsonResponse(response, {alertErrors: false})
+    return await this.processJsonResponse(response, { alertErrors: false })
   },
 
   async logout(): Promise<void> {

--- a/ui-participant/src/hub/consent/ConsentView.tsx
+++ b/ui-participant/src/hub/consent/ConsentView.tsx
@@ -76,7 +76,6 @@ function RawConsentView({ form, enrollee, resumableData, pager, studyShortcode, 
       })
     }).catch(() => {
       refreshSurvey(surveyModel, null)
-      alert('an error occurred')
     })
   }
 
@@ -118,6 +117,8 @@ export default function ConsentView() {
   const stableId = params.stableId
   const version = parseInt(params.version ?? '')
   const studyShortcode = params.studyShortcode
+  const navigate = useNavigate()
+
   if (!stableId || !version || !studyShortcode) {
     return <div>You must specify study, form, and version</div>
   }
@@ -127,12 +128,11 @@ export default function ConsentView() {
     Api.fetchConsentAndResponses({
       studyShortcode,
       enrolleeShortcode: enrollee.shortcode, stableId, version
+    }).then(response => {
+      setFormAndResponses(response)
+    }).catch(() => {
+      navigate('/hub')
     })
-      .then(response => {
-        setFormAndResponses(response)
-      }).catch(() => {
-        alert('error loading consent form - please retry')
-      })
   }, [])
 
   if (!formAndResponses) {

--- a/ui-participant/src/hub/consent/PrintConsentView.tsx
+++ b/ui-participant/src/hub/consent/PrintConsentView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import {useNavigate, useParams} from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { Model } from 'survey-core'
 import { Survey as SurveyComponent } from 'survey-react-ui'
 

--- a/ui-participant/src/hub/consent/PrintConsentView.tsx
+++ b/ui-participant/src/hub/consent/PrintConsentView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import {useNavigate, useParams} from 'react-router-dom'
 import { Model } from 'survey-core'
 import { Survey as SurveyComponent } from 'survey-react-ui'
 
@@ -57,6 +57,7 @@ const usePrintableConsent = (args: UsePrintableConsentArgs) => {
 
   const [loading, setLoading] = useState(true)
   const [surveyModel, setSurveyModel] = useState<Model | null>(null)
+  const navigate = useNavigate()
   useEffect(() => {
     const loadConsent = async () => {
       const consentAndResponses = await Api.fetchConsentAndResponses({
@@ -90,7 +91,7 @@ const usePrintableConsent = (args: UsePrintableConsentArgs) => {
     loadConsent()
       .then(setSurveyModel)
       .catch(() => {
-        alert('Error loading consent form - please retry')
+        navigate('/hub')
       })
       .finally(() => {
         setLoading(false)

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -30,7 +30,6 @@ import SurveyReviewModeButton from './ReviewModeButton'
 import { Markdown } from '../../landing/Markdown'
 import { SurveyModel } from 'survey-core'
 import { DocumentTitle } from 'util/DocumentTitle'
-import { defaultApiErrorHandle } from '../../util/error-utils'
 
 const TASK_ID_PARAM = 'taskId'
 const AUTO_SAVE_INTERVAL = 3 * 1000  // auto-save every 3 seconds if there are changes
@@ -77,8 +76,7 @@ function RawSurveyView({ form, enrollee, resumableData, pager, studyShortcode, t
         }
       }
       updateEnrollee(response.enrollee).then(() => { navigate('/hub', { state: hubUpdate }) })
-    }).catch(e => {
-      defaultApiErrorHandle(e)
+    }).catch(() => {
       refreshSurvey(surveyModel, null)
     })
   }

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -30,7 +30,7 @@ import SurveyReviewModeButton from './ReviewModeButton'
 import { Markdown } from '../../landing/Markdown'
 import { SurveyModel } from 'survey-core'
 import { DocumentTitle } from 'util/DocumentTitle'
-import {defaultApiErrorHandle} from "../../util/error-utils";
+import { defaultApiErrorHandle } from '../../util/error-utils'
 
 const TASK_ID_PARAM = 'taskId'
 const AUTO_SAVE_INTERVAL = 3 * 1000  // auto-save every 3 seconds if there are changes
@@ -77,7 +77,7 @@ function RawSurveyView({ form, enrollee, resumableData, pager, studyShortcode, t
         }
       }
       updateEnrollee(response.enrollee).then(() => { navigate('/hub', { state: hubUpdate }) })
-    }).catch((e) => {
+    }).catch(e => {
       defaultApiErrorHandle(e)
       refreshSurvey(surveyModel, null)
     })
@@ -217,7 +217,7 @@ function SurveyView() {
       .then(response => {
         setFormAndResponse(response)
       }).catch(() => {
-      navigate('/hub')
+        navigate('/hub')
       })
   }, [])
 

--- a/ui-participant/src/landing/MailingListForm.tsx
+++ b/ui-participant/src/landing/MailingListForm.tsx
@@ -24,8 +24,6 @@ export default function MailingListForm(props: MailingListFormProps) {
     Api.submitMailingListContact(name, email).then(() => {
       setJoined(true)
       onJoin?.()
-    }).catch((e: Error) => {
-      alert(`an error occured ${e.message}`)
     })
   }
   // minimal validation - name not null and email has an @ and dots

--- a/ui-participant/src/landing/registration/Preregistration.tsx
+++ b/ui-participant/src/landing/registration/Preregistration.tsx
@@ -40,7 +40,6 @@ export default function PreRegistration({ registrationContext }: { registrationC
         updatePreRegResponseId(result.id as string)
       }
     }).catch(() => {
-      alert('an error occurred, please retry')
       updatePreRegResponseId(null)
       // SurveyJS doesn't support "uncompleting" surveys, so we have to reinitialize it
       // (for now we assume prereg is only a single page)

--- a/ui-participant/src/landing/registration/RegistrationUnauthed.tsx
+++ b/ui-participant/src/landing/registration/RegistrationUnauthed.tsx
@@ -77,7 +77,6 @@ export default function RegistrationUnauthed({ registrationContext, returnTo }: 
         navigate(returnTo)
       }
     }).catch(() => {
-      alert('an error occurred.  Please retry.  If this persists, contact us')
       // if there's an error, reshow the survey (for now, assume registration is a single page)
       refreshSurvey(resumeData, 1)
     })

--- a/ui-participant/src/login/RedirectFromOAuth.tsx
+++ b/ui-participant/src/login/RedirectFromOAuth.tsx
@@ -80,7 +80,7 @@ export const RedirectFromOAuth = () => {
                 navigate('/hub', { replace: true, state: hubUpdate })
               })
             } catch {
-              alert('an error occurred, please try again, or contact support')
+              navigate('/hub', { replace: true })
             }
           } else {
             navigate('/hub', { replace: true })

--- a/ui-participant/src/studies/enroll/PreEnroll.tsx
+++ b/ui-participant/src/studies/enroll/PreEnroll.tsx
@@ -52,7 +52,6 @@ export default function PreEnrollView({ enrollContext, survey }:
         updatePreEnrollResponseId(result.id as string)
       }
     }).catch(() => {
-      alert('an error occurred, please retry')
       updatePreEnrollResponseId(null)
       // SurveyJS doesn't support "uncompleting" surveys, so we have to reinitialize it
       // (for now we assume prereg is only a single page)

--- a/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
+++ b/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
@@ -112,7 +112,7 @@ function StudyEnrollOutletMatched(props: StudyEnrollOutletMatchedProps) {
           }
           navigate('/hub', { replace: true, state: hubUpdate })
         }).catch(() => {
-          alert('an error occurred, please try again, or contact support')
+          navigate('/hub', { replace: true })
         })
       }
     } else {

--- a/ui-participant/src/util/error-utils.tsx
+++ b/ui-participant/src/util/error-utils.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import {logError} from "./loggingUtils";
+
+export type ApiErrorResponse = {
+  message: string,
+  statusCode: number
+}
+
+const errorSuffix = 'If this error persists, please contact support@juniper.terra.bio'
+
+/**
+ * performs default error message alerting if an error occurs during an API request.
+ * shows a specific error message if the error is auth-related.
+ */
+export const defaultApiErrorHandle = (error: ApiErrorResponse,
+                                      errorHeader = 'An unexpected error occurred. ') => {
+  if (error.statusCode === 401 || error.statusCode === 403) {
+    alert(`${errorHeader}\n\nRequest could not be authorized -- you may need to log in again\n\n${errorSuffix}`)
+  } else {
+    alert(`${errorHeader}\n\n${error.message}\n\n${errorSuffix}`)
+  }
+  logError({
+    message: error.message,
+    responseCode: error.statusCode
+  }, Error().stack ?? '')
+}

--- a/ui-participant/src/util/error-utils.tsx
+++ b/ui-participant/src/util/error-utils.tsx
@@ -1,5 +1,4 @@
-import React from 'react'
-import {logError} from "./loggingUtils";
+import { logError } from './loggingUtils'
 
 export type ApiErrorResponse = {
   message: string,
@@ -13,7 +12,7 @@ const errorSuffix = 'If this error persists, please contact support@juniper.terr
  * shows a specific error message if the error is auth-related.
  */
 export const defaultApiErrorHandle = (error: ApiErrorResponse,
-                                      errorHeader = 'An unexpected error occurred. ') => {
+  errorHeader = 'An unexpected error occurred. ') => {
   if (error.statusCode === 401 || error.statusCode === 403) {
     alert(`${errorHeader}\n\nRequest could not be authorized -- you may need to log in again\n\n${errorSuffix}`)
   } else {

--- a/ui-participant/src/util/loggingUtils.ts
+++ b/ui-participant/src/util/loggingUtils.ts
@@ -34,6 +34,7 @@ export type ErrorEventDetail = {
   responseCode?: number
 }
 
+/** specific helper function for logging an error */
 export const logError = (detail: ErrorEventDetail, stackTrace: string) => {
   Api.log({
     eventType: 'ERROR',

--- a/ui-participant/src/util/loggingUtils.ts
+++ b/ui-participant/src/util/loggingUtils.ts
@@ -1,4 +1,4 @@
-import Api, {getEnvSpec, LogEvent} from 'api/api'
+import Api, { getEnvSpec, LogEvent } from 'api/api'
 
 /** listens to all window errors and logs them  */
 const setupErrorLogger = () => {


### PR DESCRIPTION
![image](https://github.com/broadinstitute/juniper/assets/2800795/20d8ebcf-9bd5-4487-b125-302e493c50f2)

This standardizes error messaging for most (but not all) participant API calls.  the UX isn't great, but it's a lot better than the generic "an error has occurred" messages we were doing before.

TO TEST:
1. login to the participant UI.
2. Simulate that you have logged out/user not found.  The easiest way I found to do this was editing lines 37-39 of RequestUtilService to always throw the exception.  
3. Attempt to do an action
4. confirm you see an alert like the screenshot above