### PR TITLE
[JN-462] Survey Builder: Add new pages to a survey

### DIFF
--- a/ui-admin/src/forms/FormDesigner.tsx
+++ b/ui-admin/src/forms/FormDesigner.tsx
@@ -10,6 +10,7 @@ import { PanelDesigner } from './designer/PanelDesigner'
 import { QuestionDesigner } from './designer/QuestionDesigner'
 import { QuestionTemplatesDesigner } from './designer/QuestionTemplatesDesigner'
 import { FormTableOfContents } from './FormTableOfContents'
+import {PageListDesigner} from "./designer/PageListDesigner";
 
 type FormDesignerProps = {
   readOnly?: boolean
@@ -42,7 +43,7 @@ export const FormDesigner = (props: FormDesignerProps) => {
 
           if (selectedElementPath === 'pages') {
             return (
-              <PagesList
+              <PageListDesigner
                 formContent={value}
                 readOnly={readOnly}
                 onChange={onChange}

--- a/ui-admin/src/forms/FormDesigner.tsx
+++ b/ui-admin/src/forms/FormDesigner.tsx
@@ -5,12 +5,11 @@ import { FormContent, FormContentPage, FormElement } from '@juniper/ui-core'
 
 import { HtmlDesigner } from './designer/HtmlDesigner'
 import { PageDesigner } from './designer/PageDesigner'
-import { PagesList } from './designer/PagesList'
 import { PanelDesigner } from './designer/PanelDesigner'
 import { QuestionDesigner } from './designer/QuestionDesigner'
 import { QuestionTemplatesDesigner } from './designer/QuestionTemplatesDesigner'
 import { FormTableOfContents } from './FormTableOfContents'
-import {PageListDesigner} from "./designer/PageListDesigner";
+import { PageListDesigner } from './designer/PageListDesigner'
 
 type FormDesignerProps = {
   readOnly?: boolean

--- a/ui-admin/src/forms/designer/PageDesigner.tsx
+++ b/ui-admin/src/forms/designer/PageDesigner.tsx
@@ -33,7 +33,6 @@ export const PageDesigner = (props: PageDesignerProps) => {
   const { readOnly, value, onChange } = props
 
   const [showCreatePanelModal, setShowCreatePanelModal] = useState(false)
-  const [showCreateQuestionModal, setShowCreateQuestionModal] = useState(false)
 
   return (
     <div>

--- a/ui-admin/src/forms/designer/PageDesigner.tsx
+++ b/ui-admin/src/forms/designer/PageDesigner.tsx
@@ -7,6 +7,8 @@ import { Button } from 'components/forms/Button'
 
 import { PageElementList } from './PageElementList'
 import { NewPanelForm } from './NewPanelForm'
+import { faPlus } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 /** Can the given FormElement be included in a panel (is it a Question or HtmlElement)? */
 export const canBeIncludedInPanel = (element: FormElement): element is HtmlElement | Question => {
@@ -31,6 +33,7 @@ export const PageDesigner = (props: PageDesignerProps) => {
   const { readOnly, value, onChange } = props
 
   const [showCreatePanelModal, setShowCreatePanelModal] = useState(false)
+  const [showCreateQuestionModal, setShowCreateQuestionModal] = useState(false)
 
   return (
     <div>
@@ -45,7 +48,7 @@ export const PageDesigner = (props: PageDesignerProps) => {
             setShowCreatePanelModal(true)
           }}
         >
-          Add panel
+          <FontAwesomeIcon icon={faPlus}/> Add panel
         </Button>
       </div>
 

--- a/ui-admin/src/forms/designer/PageListDesigner.test.tsx
+++ b/ui-admin/src/forms/designer/PageListDesigner.test.tsx
@@ -52,4 +52,13 @@ describe('PageListDesigner', () => {
       ]
     })
   })
+
+  it('shows a message when there are no pages', async () => {
+    // Arrange
+    const onChange = jest.fn()
+    render(<PageListDesigner formContent={{ title: 'Empty form', pages: [] }} readOnly={false} onChange={onChange} />)
+
+    // Assert
+    expect(screen.getByText('This form does not contain any pages.')).toBeInTheDocument()
+  })
 })

--- a/ui-admin/src/forms/designer/PageListDesigner.test.tsx
+++ b/ui-admin/src/forms/designer/PageListDesigner.test.tsx
@@ -1,0 +1,55 @@
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+
+import { FormContent } from '@juniper/ui-core'
+
+import { PageListDesigner } from './PageListDesigner';
+
+describe('PageListDesigner', () => {
+  const formContent: FormContent = {
+    title: 'Test form',
+    pages: [
+      {
+        elements: [
+          {
+            name: 'page1Intro',
+            type: 'html',
+            html: '<p>This is page 1</p>'
+          }
+        ]
+      }
+    ]
+  }
+
+  it('allows creating pages', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const onChange = jest.fn()
+    render(<PageListDesigner formContent={formContent} readOnly={false} onChange={onChange} />)
+
+    // Act
+    const addPageButton = screen.getByText('Add page')
+    await act(() => user.click(addPageButton))
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith({
+      ...formContent,
+      pages: [
+        {
+          elements: [
+            {
+              name: 'page1Intro',
+              type: 'html',
+              html: '<p>This is page 1</p>'
+            }
+          ]
+        },
+        {
+          elements: []
+        }
+      ]
+    })
+  })
+})

--- a/ui-admin/src/forms/designer/PageListDesigner.test.tsx
+++ b/ui-admin/src/forms/designer/PageListDesigner.test.tsx
@@ -53,6 +53,21 @@ describe('PageListDesigner', () => {
     })
   })
 
+  it('does not allow adding a page when in readOnly mode', async () => {
+    // Arrange
+    const user = userEvent.setup()
+
+    const onChange = jest.fn()
+    render(<PageListDesigner formContent={formContent} readOnly={true} onChange={onChange} />)
+
+    // Act
+    const addPageButton = screen.getByText('Add page')
+    await act(() => user.click(addPageButton))
+
+    // Assert
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
   it('shows a message when there are no pages', async () => {
     // Arrange
     const onChange = jest.fn()

--- a/ui-admin/src/forms/designer/PageListDesigner.test.tsx
+++ b/ui-admin/src/forms/designer/PageListDesigner.test.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 import { FormContent } from '@juniper/ui-core'
 
-import { PageListDesigner } from './PageListDesigner';
+import { PageListDesigner } from './PageListDesigner'
 
 describe('PageListDesigner', () => {
   const formContent: FormContent = {

--- a/ui-admin/src/forms/designer/PageListDesigner.tsx
+++ b/ui-admin/src/forms/designer/PageListDesigner.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { FormContent } from '@juniper/ui-core'
 
 import { PagesList } from './PagesList'
-import { Button } from '../../components/forms/Button'
+import { Button } from 'components/forms/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons'
 

--- a/ui-admin/src/forms/designer/PageListDesigner.tsx
+++ b/ui-admin/src/forms/designer/PageListDesigner.tsx
@@ -19,6 +19,8 @@ export const PageListDesigner = (props: PageListDesignerProps) => {
   const { formContent, readOnly, onChange } = props
   const { pages = [] } = formContent
 
+  const newPage = () => ({ elements: [] })
+
   return (
     <>
       <h2>Pages</h2>
@@ -30,7 +32,7 @@ export const PageListDesigner = (props: PageListDesignerProps) => {
           onClick={() => {
             onChange({
               ...formContent,
-              pages: concat(pages, { elements: [] })
+              pages: concat(pages, newPage())
             })
           }}
         >

--- a/ui-admin/src/forms/designer/PageListDesigner.tsx
+++ b/ui-admin/src/forms/designer/PageListDesigner.tsx
@@ -22,7 +22,6 @@ export const PageListDesigner = (props: PageListDesignerProps) => {
   return (
     <>
       <h2>Pages</h2>
-
       <div className="mb-3">
         <Button
           disabled={readOnly}

--- a/ui-admin/src/forms/designer/PageListDesigner.tsx
+++ b/ui-admin/src/forms/designer/PageListDesigner.tsx
@@ -1,0 +1,54 @@
+import { concat } from 'lodash/fp'
+import React from 'react'
+
+import { FormContent } from '@juniper/ui-core'
+
+import { PagesList } from './PagesList'
+import { Button } from '../../components/forms/Button'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faPlus } from '@fortawesome/free-solid-svg-icons'
+
+type PageListDesignerProps = {
+    formContent: FormContent
+    readOnly: boolean
+    onChange: (newValue: FormContent) => void
+}
+
+/** UI for editing pages in a form. */
+export const PageListDesigner = (props: PageListDesignerProps) => {
+  const { formContent, readOnly, onChange } = props
+  const { pages = [] } = formContent
+
+  return (
+    <>
+      <h2>Pages</h2>
+
+      <div className="mb-3">
+        <Button
+          disabled={readOnly}
+          tooltip="Add a new page."
+          variant="secondary"
+          onClick={() => {
+            onChange({
+              ...formContent,
+              pages: concat(pages, { elements: [] })
+            })
+          }}
+        >
+          <FontAwesomeIcon icon={faPlus}/> Add page
+        </Button>
+      </div>
+
+      {pages.length === 0
+        ? (
+          <p>This form does not contain any pages.</p>
+        ) : (
+          <PagesList
+            formContent={formContent}
+            readOnly={readOnly}
+            onChange={onChange}
+          />
+        )}
+    </>
+  )
+}


### PR DESCRIPTION
Adds support for adding a new blank page. Next step is being able to add questions to a page.

![Screenshot 2023-07-11 at 4 39 35 PM](https://github.com/broadinstitute/juniper/assets/7257391/c03d0b05-2bab-43a3-a0c4-edddf6068446)

TO TEST:

1. Boot up Admin API and Admin UI
2. Go to the survey builder
3. Click on 'Pages' in the survey table of contents
4. Add a new page and verify that it shows up in the table of contents, pages list, and JSON editor. Note that blank pages do not show up in the Preview tab, but you can manually add a question to the JSON if you want to test that
5. Verify that you can save the survey and the new page is persisted