### PR TITLE
[JN-453] Add new questions to a survey

### DIFF
--- a/ui-admin/src/forms/FormDesigner.tsx
+++ b/ui-admin/src/forms/FormDesigner.tsx
@@ -129,6 +129,7 @@ export const FormDesigner = (props: FormDesignerProps) => {
             <QuestionDesigner
               question={selectedElement}
               readOnly={readOnly}
+              showTitle={true}
               onChange={updatedElement => {
                 onChange(set(selectedElementPath, updatedElement, value))
               }}

--- a/ui-admin/src/forms/FormDesigner.tsx
+++ b/ui-admin/src/forms/FormDesigner.tsx
@@ -129,7 +129,7 @@ export const FormDesigner = (props: FormDesignerProps) => {
             <QuestionDesigner
               question={selectedElement}
               readOnly={readOnly}
-              showTitle={true}
+              showName={true}
               onChange={updatedElement => {
                 onChange(set(selectedElementPath, updatedElement, value))
               }}

--- a/ui-admin/src/forms/designer/NewQuestionForm.test.tsx
+++ b/ui-admin/src/forms/designer/NewQuestionForm.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { NewQuestionForm } from './NewQuestionForm'
+import { questionTypeDescriptions } from './questions/questionTypes'
+
+describe('NewQuestionForm', () => {
+  test('renders the default view for a new question', () => {
+    //Arrange
+    render(<NewQuestionForm onCreate={() => jest.fn()} readOnly={false} />)
+
+    //Assert
+    const questionNameInput = screen.getByLabelText('Question name')
+    const questionTypeSelect = screen.getByLabelText('Question type')
+    expect(questionNameInput).toBeInTheDocument()
+    expect(questionTypeSelect).toBeInTheDocument()
+    expect((questionTypeSelect as HTMLSelectElement).value).toBe('text')
+  })
+
+  test('updates to the appropriate QuestionDesigner when a new question type is selected', () => {
+    //Arrange
+    render(<NewQuestionForm onCreate={() => jest.fn()} readOnly={false} />)
+
+    //Act
+    const questionTypeSelect = screen.getByLabelText('Question type')
+    fireEvent.change(questionTypeSelect, { target: { value: 'checkbox' } })
+
+    //Assert
+    expect((questionTypeSelect as HTMLSelectElement).value).toBe('checkbox')
+    expect(screen.getByText(questionTypeDescriptions.checkbox)).toBeInTheDocument()
+  })
+})

--- a/ui-admin/src/forms/designer/NewQuestionForm.test.tsx
+++ b/ui-admin/src/forms/designer/NewQuestionForm.test.tsx
@@ -9,9 +9,9 @@ describe('NewQuestionForm', () => {
     render(<NewQuestionForm onCreate={() => jest.fn()} readOnly={false} />)
 
     //Assert
-    const questionNameInput = screen.getByLabelText('Question name')
+    const questionStableIdInput = screen.getByLabelText('Question stable ID')
     const questionTypeSelect = screen.getByLabelText('Question type')
-    expect(questionNameInput).toBeInTheDocument()
+    expect(questionStableIdInput).toBeInTheDocument()
     expect(questionTypeSelect).toBeInTheDocument()
     expect((questionTypeSelect as HTMLSelectElement).value).toBe('text')
   })

--- a/ui-admin/src/forms/designer/NewQuestionForm.tsx
+++ b/ui-admin/src/forms/designer/NewQuestionForm.tsx
@@ -8,15 +8,16 @@ import { TextInput } from '../../components/forms/TextInput'
 
 type NewQuestionFormProps = {
     onCreate: (newQuestion: Question) => void
+    readOnly: boolean
 }
 
 /** UI for creating a new question. */
 export const NewQuestionForm = (props: NewQuestionFormProps) => {
-  const { onCreate } = props
+  const { onCreate, readOnly } = props
   const [selectedQuestionType, setSelectedQuestionType] = useState<QuestionType>('text')
   const [questionName, setQuestionName] = useState<string>('')
 
-  const emptyQuestions: Record<QuestionType, Question> = {
+  const baseQuestions: Record<QuestionType, Question> = {
     checkbox: {
       type: 'checkbox',
       name: questionName,
@@ -52,12 +53,7 @@ export const NewQuestionForm = (props: NewQuestionFormProps) => {
     }
   }
 
-  const [question, setQuestion] = useState<Question>(emptyQuestions[selectedQuestionType])
-
-  // //TODO: probably don't need this as an effect
-  // useEffect(() => {
-  //   setQuestion(emptyQuestions[selectedQuestionType])
-  // }, [selectedQuestionType])
+  const [question, setQuestion] = useState<Question>(baseQuestions[selectedQuestionType])
 
   return (
     <>
@@ -74,12 +70,12 @@ export const NewQuestionForm = (props: NewQuestionFormProps) => {
               }}
             />
           </div>
-          <label className="form-label" htmlFor="text-question-input-type">Question type</label>
+          <label className="form-label" htmlFor="questionType">Question type</label>
           <select id="questionType" className="form-select" value={selectedQuestionType}
             onChange={e => {
               const newQuestionType = e.target.value as QuestionType
               setSelectedQuestionType(newQuestionType)
-              setQuestion(emptyQuestions[newQuestionType])
+              setQuestion(baseQuestions[newQuestionType])
             }}>
             <option value="text">Text</option>
             <option value="checkbox">Checkbox</option>
@@ -93,7 +89,7 @@ export const NewQuestionForm = (props: NewQuestionFormProps) => {
         { selectedQuestionType && <QuestionDesigner
           question={question}
           showName={false}
-          readOnly={false} //maybe pass this in from parent component, but you can't really get here if it's read-only
+          readOnly={readOnly}
           onChange={updatedElement => {
             setQuestion(updatedElement)
           }}

--- a/ui-admin/src/forms/designer/NewQuestionForm.tsx
+++ b/ui-admin/src/forms/designer/NewQuestionForm.tsx
@@ -4,7 +4,7 @@ import { Question, QuestionType } from '@juniper/ui-core'
 
 import { Button } from 'components/forms/Button'
 import { QuestionDesigner } from './QuestionDesigner'
-import { TextInput } from '../../components/forms/TextInput'
+import { TextInput } from 'components/forms/TextInput'
 
 type NewQuestionFormProps = {
     onCreate: (newQuestion: Question) => void

--- a/ui-admin/src/forms/designer/NewQuestionForm.tsx
+++ b/ui-admin/src/forms/designer/NewQuestionForm.tsx
@@ -4,7 +4,6 @@ import { Question, QuestionType } from '@juniper/ui-core'
 
 import { Button } from 'components/forms/Button'
 import { QuestionDesigner } from './QuestionDesigner'
-import { questionTypeLabels } from './questions/questionTypes'
 import { TextInput } from '../../components/forms/TextInput'
 
 type NewQuestionFormProps = {
@@ -16,44 +15,49 @@ export const NewQuestionForm = (props: NewQuestionFormProps) => {
   const { onCreate } = props
   const [selectedQuestionType, setSelectedQuestionType] = useState<QuestionType>('text')
   const [questionName, setQuestionName] = useState<string>('')
-  const [title, setTitle] = useState<string>('')
-  const [question, setQuestion] = useState<Question>()
 
   const emptyQuestions: Record<QuestionType, Question> = {
     checkbox: {
       type: 'checkbox',
       name: questionName,
-      title,
+      title: '',
       choices: []
     },
     dropdown: {
       type: 'dropdown',
       name: questionName,
-      title,
+      title: '',
       choices: []
     },
     medications: {
       type: 'medications',
       name: questionName,
-      title
+      title: ''
     },
     radiogroup: {
       type: 'radiogroup',
       name: questionName,
-      title,
+      title: '',
       choices: []
     },
     signaturepad: {
       type: 'signaturepad',
       name: questionName,
-      title
+      title: ''
     },
     text: {
       type: 'text',
       name: questionName,
-      title
+      title: ''
     }
   }
+
+  const [question, setQuestion] = useState<Question>(emptyQuestions[selectedQuestionType])
+
+  // //TODO: probably don't need this as an effect
+  // useEffect(() => {
+  //   setQuestion(emptyQuestions[selectedQuestionType])
+  // }, [selectedQuestionType])
 
   return (
     <>
@@ -66,23 +70,28 @@ export const NewQuestionForm = (props: NewQuestionFormProps) => {
               value={questionName}
               onChange={value => {
                 setQuestionName(value)
+                setQuestion({ ...question, name: value })
               }}
             />
           </div>
           <label className="form-label" htmlFor="text-question-input-type">Question type</label>
           <select id="questionType" className="form-select" value={selectedQuestionType}
-            onChange={e => setSelectedQuestionType(e.target.value as QuestionType)}>
+            onChange={e => {
+              const newQuestionType = e.target.value as QuestionType
+              setSelectedQuestionType(newQuestionType)
+              setQuestion(emptyQuestions[newQuestionType])
+            }}>
             <option value="text">Text</option>
             <option value="checkbox">Checkbox</option>
             <option value="dropdown">Dropdown</option>
             <option value="medications">Medications</option>
-            <option value="radiogroup">Radiogroup</option>
+            <option value="radiogroup">Radio group</option>
             <option value="signaturepad">Signature</option>
           </select>
         </div>
 
         { selectedQuestionType && <QuestionDesigner
-          question={emptyQuestions[selectedQuestionType]}
+          question={question}
           showTitle={false}
           readOnly={false} //maybe pass this in from parent component, but you can't really get here if it's read-only
           onChange={updatedElement => {
@@ -93,7 +102,7 @@ export const NewQuestionForm = (props: NewQuestionFormProps) => {
         <Button
           variant="primary"
           onClick={() => {
-            onCreate(question!)
+            onCreate(question)
           }}
         >
                     Create question

--- a/ui-admin/src/forms/designer/NewQuestionForm.tsx
+++ b/ui-admin/src/forms/designer/NewQuestionForm.tsx
@@ -92,7 +92,7 @@ export const NewQuestionForm = (props: NewQuestionFormProps) => {
 
         { selectedQuestionType && <QuestionDesigner
           question={question}
-          showTitle={false}
+          showName={false}
           readOnly={false} //maybe pass this in from parent component, but you can't really get here if it's read-only
           onChange={updatedElement => {
             setQuestion(updatedElement)
@@ -105,7 +105,7 @@ export const NewQuestionForm = (props: NewQuestionFormProps) => {
             onCreate(question)
           }}
         >
-                    Create question
+          Create question
         </Button>
       </div>
     </>

--- a/ui-admin/src/forms/designer/NewQuestionForm.tsx
+++ b/ui-admin/src/forms/designer/NewQuestionForm.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from 'react'
+
+import { Question, QuestionType } from '@juniper/ui-core'
+
+import { Button } from 'components/forms/Button'
+import { QuestionDesigner } from './QuestionDesigner'
+import { questionTypeLabels } from './questions/questionTypes'
+import { TextInput } from '../../components/forms/TextInput'
+
+type NewQuestionFormProps = {
+    onCreate: (newQuestion: Question) => void
+}
+
+/** UI for creating a new question. */
+export const NewQuestionForm = (props: NewQuestionFormProps) => {
+  const { onCreate } = props
+  const [selectedQuestionType, setSelectedQuestionType] = useState<QuestionType>('text')
+  const [questionName, setQuestionName] = useState<string>('')
+  const [title, setTitle] = useState<string>('')
+  const [question, setQuestion] = useState<Question>()
+
+  const emptyQuestions: Record<QuestionType, Question> = {
+    checkbox: {
+      type: 'checkbox',
+      name: questionName,
+      title,
+      choices: []
+    },
+    dropdown: {
+      type: 'dropdown',
+      name: questionName,
+      title,
+      choices: []
+    },
+    medications: {
+      type: 'medications',
+      name: questionName,
+      title
+    },
+    radiogroup: {
+      type: 'radiogroup',
+      name: questionName,
+      title,
+      choices: []
+    },
+    signaturepad: {
+      type: 'signaturepad',
+      name: questionName,
+      title
+    },
+    text: {
+      type: 'text',
+      name: questionName,
+      title
+    }
+  }
+
+  return (
+    <>
+      <div className="text-align-right">
+        <div className="mb-3">
+          <div className="mb-3">
+            <TextInput
+              description='The stable identifier for the survey question'
+              label='Question name'
+              value={questionName}
+              onChange={value => {
+                setQuestionName(value)
+              }}
+            />
+          </div>
+          <label className="form-label" htmlFor="text-question-input-type">Question type</label>
+          <select id="questionType" className="form-select" value={selectedQuestionType}
+            onChange={e => setSelectedQuestionType(e.target.value as QuestionType)}>
+            <option value="text">Text</option>
+            <option value="checkbox">Checkbox</option>
+            <option value="dropdown">Dropdown</option>
+            <option value="medications">Medications</option>
+            <option value="radiogroup">Radiogroup</option>
+            <option value="signaturepad">Signature</option>
+          </select>
+        </div>
+
+        { selectedQuestionType && <QuestionDesigner
+          question={emptyQuestions[selectedQuestionType]}
+          showTitle={false}
+          readOnly={false} //maybe pass this in from parent component, but you can't really get here if it's read-only
+          onChange={updatedElement => {
+            setQuestion(updatedElement)
+          }}
+        /> }
+
+        <Button
+          variant="primary"
+          onClick={() => {
+            onCreate(question!)
+          }}
+        >
+                    Create question
+        </Button>
+      </div>
+    </>
+  )
+}

--- a/ui-admin/src/forms/designer/NewQuestionForm.tsx
+++ b/ui-admin/src/forms/designer/NewQuestionForm.tsx
@@ -61,8 +61,8 @@ export const NewQuestionForm = (props: NewQuestionFormProps) => {
         <div className="mb-3">
           <div className="mb-3">
             <TextInput
-              description='The stable identifier for the survey question'
-              label='Question name'
+              description='The unique stable identifier for the survey question'
+              label='Question stable ID'
               value={questionName}
               onChange={value => {
                 setQuestionName(value)

--- a/ui-admin/src/forms/designer/PageDesigner.tsx
+++ b/ui-admin/src/forms/designer/PageDesigner.tsx
@@ -7,6 +7,7 @@ import { Button } from 'components/forms/Button'
 
 import { PageElementList } from './PageElementList'
 import { NewPanelForm } from './NewPanelForm'
+import { NewQuestionForm } from './NewQuestionForm'
 import { faPlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
@@ -33,12 +34,23 @@ export const PageDesigner = (props: PageDesignerProps) => {
   const { readOnly, value, onChange } = props
 
   const [showCreatePanelModal, setShowCreatePanelModal] = useState(false)
+  const [showCreateQuestionModal, setShowCreateQuestionModal] = useState(false)
 
   return (
     <div>
       <h2>Page</h2>
 
       <div className="mb-3">
+        <Button
+          disabled={readOnly}
+          tooltip="Create a new question."
+          variant="secondary"
+          onClick={() => {
+            setShowCreateQuestionModal(true)
+          }}
+        >
+          <FontAwesomeIcon icon={faPlus}/> Add question
+        </Button>
         <Button
           disabled={readOnly || value.elements.filter(canBeIncludedInPanel).length === 0}
           tooltip="Group some elements into a panel."
@@ -58,6 +70,28 @@ export const PageDesigner = (props: PageDesignerProps) => {
           onChange({ ...value, elements: newValue })
         }}
       />
+
+      {showCreateQuestionModal && (
+        <Modal show className="modal-lg" onHide={() => setShowCreateQuestionModal(false)}>
+          <Modal.Header closeButton>New Question</Modal.Header>
+          <Modal.Body>
+            <NewQuestionForm
+              onCreate={newQuestion => {
+                console.log(newQuestion)
+
+                setShowCreateQuestionModal(false)
+                onChange({
+                  ...value,
+                  elements: [
+                    ...value.elements,
+                    newQuestion
+                  ]
+                })
+              }}
+            />
+          </Modal.Body>
+        </Modal>
+      )}
 
       {showCreatePanelModal && (
         <Modal show onHide={() => setShowCreatePanelModal(false)}>

--- a/ui-admin/src/forms/designer/PageDesigner.tsx
+++ b/ui-admin/src/forms/designer/PageDesigner.tsx
@@ -76,9 +76,8 @@ export const PageDesigner = (props: PageDesignerProps) => {
           <Modal.Header closeButton>New Question</Modal.Header>
           <Modal.Body>
             <NewQuestionForm
+              readOnly={readOnly}
               onCreate={newQuestion => {
-                console.log(newQuestion)
-
                 setShowCreateQuestionModal(false)
                 onChange({
                   ...value,

--- a/ui-admin/src/forms/designer/QuestionDesigner.tsx
+++ b/ui-admin/src/forms/designer/QuestionDesigner.tsx
@@ -13,18 +13,19 @@ import { VisibilityFields } from './questions/VisibilityFields'
 export type QuestionDesignerProps = {
   question: Question
   readOnly: boolean
+  showTitle: boolean
   onChange: (newValue: Question) => void
 }
 
 /** UI for editing a question in a form. */
 export const QuestionDesigner = (props: QuestionDesignerProps) => {
-  const { question, readOnly, onChange } = props
+  const { question, readOnly, showTitle, onChange } = props
 
   const isTemplated = 'questionTemplateName' in question
 
   return (
     <div>
-      <h2>{question.name}</h2>
+      {showTitle && <h2>{question.name}</h2>}
 
       {!isTemplated && (
         <>

--- a/ui-admin/src/forms/designer/QuestionDesigner.tsx
+++ b/ui-admin/src/forms/designer/QuestionDesigner.tsx
@@ -13,19 +13,19 @@ import { VisibilityFields } from './questions/VisibilityFields'
 export type QuestionDesignerProps = {
   question: Question
   readOnly: boolean
-  showTitle: boolean
+  showName: boolean
   onChange: (newValue: Question) => void
 }
 
 /** UI for editing a question in a form. */
 export const QuestionDesigner = (props: QuestionDesignerProps) => {
-  const { question, readOnly, showTitle, onChange } = props
+  const { question, readOnly, showName, onChange } = props
 
   const isTemplated = 'questionTemplateName' in question
 
   return (
     <div>
-      {showTitle && <h2>{question.name}</h2>}
+      {showName && <h2>{question.name}</h2>}
 
       {!isTemplated && (
         <>

--- a/ui-admin/src/forms/designer/questions/BaseFields.tsx
+++ b/ui-admin/src/forms/designer/questions/BaseFields.tsx
@@ -22,7 +22,7 @@ export const BaseFields = (props: BaseFieldsProps) => {
           disabled={disabled}
           label="Question text"
           rows={2}
-          value={question.title}
+          value={question.title || ''}
           onChange={value => {
             onChange({
               ...question,
@@ -38,7 +38,7 @@ export const BaseFields = (props: BaseFieldsProps) => {
           disabled={disabled}
           label="Description"
           rows={2}
-          value={question.description}
+          value={question.description || ''}
           onChange={value => {
             onChange({
               ...question,


### PR DESCRIPTION
This adds the ability to add new questions to a survey page. Not included in this PR is the autofill "scratch box" functionality. That will be coming in the next PR.

![Untitled](https://github.com/broadinstitute/juniper/assets/7257391/b35a1ac0-ac09-4973-8d59-d867d5be9278)

![Screenshot 2023-07-14 at 12 43 38 PM](https://github.com/broadinstitute/juniper/assets/7257391/cf950cdf-8862-4a70-bd53-6eae75f73457)


TO TEST:

Play around with the question designer. Make sure that switching between types works correctly and that the questions are saved correctly by viewing the generated JSON in the JSON Editor, as well as the final result in the Survey Preview tab.
