### PR TITLE
[JN-453] Preserve fields when switching question types in new question form

### DIFF
--- a/ui-admin/src/forms/designer/NewQuestionForm.tsx
+++ b/ui-admin/src/forms/designer/NewQuestionForm.tsx
@@ -41,11 +41,8 @@ export const NewQuestionForm = (props: NewQuestionFormProps) => {
             onChange={e => {
               const newQuestionType = e.target.value as QuestionType
               setSelectedQuestionType(newQuestionType)
-              const baseQuestion = baseQuestions[newQuestionType]
-              console.log(question)
-              console.log(baseQuestion)
               // @ts-ignore
-              setQuestion({ ...baseQuestion, ...question, type: newQuestionType })
+              setQuestion({ ...baseQuestions[newQuestionType], ...question, type: newQuestionType })
             }}>
             <option value="text">Text</option>
             <option value="checkbox">Checkbox</option>

--- a/ui-admin/src/forms/designer/NewQuestionForm.tsx
+++ b/ui-admin/src/forms/designer/NewQuestionForm.tsx
@@ -17,9 +17,9 @@ type NewQuestionFormProps = {
 export const NewQuestionForm = (props: NewQuestionFormProps) => {
   const { onCreate, readOnly } = props
   const [selectedQuestionType, setSelectedQuestionType] = useState<QuestionType>('text')
-  const [questionName, setQuestionName] = useState<string>('')
 
   const [question, setQuestion] = useState<Question>(baseQuestions[selectedQuestionType])
+  const { name: questionName } = question
 
   return (
     <>
@@ -31,7 +31,6 @@ export const NewQuestionForm = (props: NewQuestionFormProps) => {
               label='Question stable ID'
               value={questionName}
               onChange={value => {
-                setQuestionName(value)
                 setQuestion({ ...question, name: value })
               }}
             />

--- a/ui-admin/src/forms/designer/NewQuestionForm.tsx
+++ b/ui-admin/src/forms/designer/NewQuestionForm.tsx
@@ -5,6 +5,8 @@ import { Question, QuestionType } from '@juniper/ui-core'
 import { Button } from 'components/forms/Button'
 import { QuestionDesigner } from './QuestionDesigner'
 import { TextInput } from 'components/forms/TextInput'
+import { baseQuestions } from './questions/questionTypes'
+import _ from 'lodash'
 
 type NewQuestionFormProps = {
     onCreate: (newQuestion: Question) => void
@@ -16,42 +18,6 @@ export const NewQuestionForm = (props: NewQuestionFormProps) => {
   const { onCreate, readOnly } = props
   const [selectedQuestionType, setSelectedQuestionType] = useState<QuestionType>('text')
   const [questionName, setQuestionName] = useState<string>('')
-
-  const baseQuestions: Record<QuestionType, Question> = {
-    checkbox: {
-      type: 'checkbox',
-      name: questionName,
-      title: '',
-      choices: []
-    },
-    dropdown: {
-      type: 'dropdown',
-      name: questionName,
-      title: '',
-      choices: []
-    },
-    medications: {
-      type: 'medications',
-      name: questionName,
-      title: ''
-    },
-    radiogroup: {
-      type: 'radiogroup',
-      name: questionName,
-      title: '',
-      choices: []
-    },
-    signaturepad: {
-      type: 'signaturepad',
-      name: questionName,
-      title: ''
-    },
-    text: {
-      type: 'text',
-      name: questionName,
-      title: ''
-    }
-  }
 
   const [question, setQuestion] = useState<Question>(baseQuestions[selectedQuestionType])
 
@@ -75,7 +41,11 @@ export const NewQuestionForm = (props: NewQuestionFormProps) => {
             onChange={e => {
               const newQuestionType = e.target.value as QuestionType
               setSelectedQuestionType(newQuestionType)
-              setQuestion(baseQuestions[newQuestionType])
+              const baseQuestion = baseQuestions[newQuestionType]
+              console.log(question)
+              console.log(baseQuestion)
+              // @ts-ignore
+              setQuestion({ ...baseQuestion, ...question, type: newQuestionType })
             }}>
             <option value="text">Text</option>
             <option value="checkbox">Checkbox</option>
@@ -98,7 +68,10 @@ export const NewQuestionForm = (props: NewQuestionFormProps) => {
         <Button
           variant="primary"
           onClick={() => {
-            onCreate(question)
+            //While preserving the state during editing, we may have accumulated some extra fields
+            //that don't exist on the final question type. So we need to remove them before saving.
+            const sanitizedQuestion = _.pick(question, Object.keys(baseQuestions[selectedQuestionType])) as Question
+            onCreate(sanitizedQuestion)
           }}
         >
           Create question

--- a/ui-admin/src/forms/designer/NewQuestionForm.tsx
+++ b/ui-admin/src/forms/designer/NewQuestionForm.tsx
@@ -41,8 +41,7 @@ export const NewQuestionForm = (props: NewQuestionFormProps) => {
             onChange={e => {
               const newQuestionType = e.target.value as QuestionType
               setSelectedQuestionType(newQuestionType)
-              // @ts-ignore
-              setQuestion({ ...baseQuestions[newQuestionType], ...question, type: newQuestionType })
+              setQuestion({ ...baseQuestions[newQuestionType], ...question, type: newQuestionType } as Question)
             }}>
             <option value="text">Text</option>
             <option value="checkbox">Checkbox</option>

--- a/ui-admin/src/forms/designer/questions/questionTypes.tsx
+++ b/ui-admin/src/forms/designer/questions/questionTypes.tsx
@@ -1,4 +1,4 @@
-import { QuestionType } from '@juniper/ui-core'
+import { Question, QuestionType } from '@juniper/ui-core'
 
 export const questionTypeLabels: Record<QuestionType, string> = {
   text: 'Text',
@@ -16,4 +16,72 @@ export const questionTypeDescriptions: Record<QuestionType, string> = {
   radiogroup: 'Shows choices as radio buttons and prompts the participant to select a response.',
   signaturepad: 'Prompts the participant to sign a form.',
   medications: 'Prompts the participant to choose medications from a list.'
+}
+
+//Returns an object with all possible fields for each question type
+export const baseQuestions: Record<QuestionType, Question> = {
+  checkbox: {
+    type: 'checkbox',
+    name: '',
+    title: '',
+    description: '',
+    isRequired: false,
+    choices: [],
+    showNoneItem: undefined,
+    noneText: undefined,
+    noneValue: undefined,
+    showOtherItem: undefined,
+    otherText: undefined,
+    otherPlaceholder: undefined,
+    otherErrorText: undefined
+  },
+  dropdown: {
+    type: 'dropdown',
+    name: '',
+    title: '',
+    description: '',
+    isRequired: false,
+    choices: [],
+    showOtherItem: undefined,
+    otherText: undefined,
+    otherPlaceholder: undefined,
+    otherErrorText: undefined
+  },
+  medications: {
+    type: 'medications',
+    name: '',
+    title: '',
+    description: '',
+    isRequired: false
+  },
+  radiogroup: {
+    type: 'radiogroup',
+    name: '',
+    title: '',
+    description: '',
+    isRequired: false,
+    choices: [],
+    showOtherItem: undefined,
+    otherText: undefined,
+    otherPlaceholder: undefined,
+    otherErrorText: undefined
+  },
+  signaturepad: {
+    type: 'signaturepad',
+    name: '',
+    title: '',
+    description: '',
+    isRequired: false
+  },
+  text: {
+    type: 'text',
+    name: '',
+    title: '',
+    description: '',
+    isRequired: false,
+    inputType: 'text',
+    min: undefined,
+    max: undefined,
+    size: undefined
+  }
 }


### PR DESCRIPTION
This improves the behavior of the `NewQuestionForm` added in https://github.com/broadinstitute/juniper/pull/479

Specifically, it fixes the problem where switching the question type would reset all of the fields, even if the question types had those fields in common. (described in https://github.com/broadinstitute/juniper/pull/479#discussion_r1266734590)

To do this, we keep a `Question` object in state and accumulate all of the possible fields. When the question is saved, we remove any extraneous fields that do not belong to the final selected question type (i.e. if you started as a `TextQuestion`, switched to the `DropdownQuestion` type, added a few choices, but then decided you wanted to go to `DropdownQuestion`, we would omit the `choices` property right before saving)

I intend to add unit tests for this, but want feedback on the approach before investing more time into it.

TO TEST:

1. Start filling out fields for any question type
2. Switch to a question type that has some fields in common with the first type (for example, TextQuestion -> RadiogroupQuestion)
3. Verify that the common fields are still filled out
4. Fill out some fields that are unique to RadiogroupQuestion (`choices` is one of them)
5. Switch back to the original question type (or you can also test by switching to a third question type)
6. Verify that the common fields are still filled out
7. Save the question
8. Verify in the JSON preview that the extraneous fields were not saved and all of the relevant fields were persisted