### PR TITLE
JN-494: adding created at to participant list

### DIFF
--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -81,6 +81,7 @@ export type EnrolleeSearchResult = {
 export type Enrollee = {
   id: string,
   shortcode: string,
+  createdAt: number,
   participantUserId: string,
   surveyResponses: SurveyResponse[],
   consentResponses: ConsentResponse[],

--- a/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
@@ -29,6 +29,7 @@ test('renders a participant with link', async () => {
   })
   const participantLink = screen.getByText('JOSALK')
   expect(participantLink).toHaveAttribute('href', `/${studyEnvContext.currentEnvPath}/participants/JOSALK`)
+  expect(screen.getByText('Created')).toBeInTheDocument()
 })
 
 test('renders filters for participant columns', async () => {

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -26,6 +26,7 @@ import AdHocEmailModal from '../AdHocEmailModal'
 import EnrolleeSearchFacets, {} from './facets/EnrolleeSearchFacets'
 import { facetValuesFromString, facetValuesToString, SAMPLE_FACETS, FacetValue }
   from 'api/enrolleeSearch'
+import { instantToDefaultString } from '../../../util/timeUtils'
 
 /** Shows a list of (for now) enrollees */
 function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
@@ -65,6 +66,11 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
       columnType: 'string'
     },
     cell: info => <Link to={`${currentEnvPath}/participants/${info.getValue()}`}>{info.getValue()}</Link>
+  }, {
+    header: 'Created',
+    accessorKey: 'enrollee.createdAt',
+    enableColumnFilter: false,
+    cell: info => instantToDefaultString(info.getValue() as unknown as number)
   }, {
     id: 'familyName',
     header: 'Family name',

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -114,6 +114,7 @@ export const mockEnrollee: () => Enrollee = () => {
   const enrolleeId = randomString(10)
   return {
     id: enrolleeId,
+    createdAt: 0,
     shortcode: 'JOSALK',
     participantUserId: 'userId1',
     surveyResponses: [],

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -130,7 +130,7 @@ export function tableHeader<A, B>(
     sortDirection ? (sortDirection === 'desc' ? 'descending' : 'ascending') : 'none' : undefined
 
   return <th key={header.id}
-    aria-sort={ariaSort}>
+    aria-sort={ariaSort} style={{ verticalAlign: 'top' }}>
     { options.sortable ? sortableTableHeader(header) : null }
     { options.filterable ? filterableTableHeader(header) : null }
   </th>


### PR DESCRIPTION
This adds the created at field to the participant list. This is helpful when quickly looking at the production participants to see if any new participants have been created and when.   It doesn't enable filtering on dates yet, but that can be done later (sorting does work).

![image](https://github.com/broadinstitute/juniper/assets/2800795/9696f40c-8b4e-41c6-99e4-5aa27624a2e2)

TO TEST:
1. go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants 
2. confirm you see the created at date and it's sortable.