### PR TITLE
JN-479: adding download of mailing list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "e2e-tests"
       ],
       "devDependencies": {
-        "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/jest-dom": "^5.17.0",
+        "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "@types/jest": "^27.5.2",
         "@types/node": "^16.11.58",
@@ -3868,7 +3868,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.2.0.tgz",
       "integrity": "sha512-xTEnpUKiV/bMyEsE5bT4oYA0x0Z/colMtxzUY8bKyPXBNLn/e0V4ZjBZkEhms0xE4pv9QsPfSRu9AWS4y5wGvA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3884,9 +3883,9 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "5.16.5",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.5.tgz",
-      "integrity": "sha512-N5ixQ2qKpi5OLYfwQmUb/5mSV9LneAcaUfp32pn4yCnpb8r/Yz0pXFPck21dIicKmi+ta5WRAknkZCfA8refMA==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.17.0.tgz",
+      "integrity": "sha512-ynmNeT7asXyH3aSVv4vvX4Rb+0qjOhdNHnO/3vuZNqPmhDpV/+rCSGwQ7bLcmU2cJ4dvoheIO85LQj0IbJHEtg==",
       "dev": true,
       "dependencies": {
         "@adobe/css-tools": "^4.0.1",
@@ -3919,40 +3918,21 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.4.0.tgz",
-      "integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.0.0.tgz",
+      "integrity": "sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.5.0",
+        "@testing-library/dom": "^9.0.0",
         "@types/react-dom": "^18.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/@testing-library/dom": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.0.tgz",
-      "integrity": "sha512-d9ULIT+a4EXLX3UU8FBjauG9NnsZHkHztXoIcTsOKoOw030fyjheN9svkTULjJxtYag9DZz5Jz5qkWZDPxTFwA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "^5.0.0",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.4.4",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@testing-library/user-event": {
@@ -26415,7 +26395,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.2.0.tgz",
       "integrity": "sha512-xTEnpUKiV/bMyEsE5bT4oYA0x0Z/colMtxzUY8bKyPXBNLn/e0V4ZjBZkEhms0xE4pv9QsPfSRu9AWS4y5wGvA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -26428,9 +26407,9 @@
       }
     },
     "@testing-library/jest-dom": {
-      "version": "5.16.5",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.5.tgz",
-      "integrity": "sha512-N5ixQ2qKpi5OLYfwQmUb/5mSV9LneAcaUfp32pn4yCnpb8r/Yz0pXFPck21dIicKmi+ta5WRAknkZCfA8refMA==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.17.0.tgz",
+      "integrity": "sha512-ynmNeT7asXyH3aSVv4vvX4Rb+0qjOhdNHnO/3vuZNqPmhDpV/+rCSGwQ7bLcmU2cJ4dvoheIO85LQj0IbJHEtg==",
       "dev": true,
       "requires": {
         "@adobe/css-tools": "^4.0.1",
@@ -26457,32 +26436,14 @@
       }
     },
     "@testing-library/react": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.4.0.tgz",
-      "integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.0.0.tgz",
+      "integrity": "sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.5.0",
+        "@testing-library/dom": "^9.0.0",
         "@types/react-dom": "^18.0.0"
-      },
-      "dependencies": {
-        "@testing-library/dom": {
-          "version": "8.20.0",
-          "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.0.tgz",
-          "integrity": "sha512-d9ULIT+a4EXLX3UU8FBjauG9NnsZHkHztXoIcTsOKoOw030fyjheN9svkTULjJxtYag9DZz5Jz5qkWZDPxTFwA==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/runtime": "^7.12.5",
-            "@types/aria-query": "^5.0.1",
-            "aria-query": "^5.0.0",
-            "chalk": "^4.1.0",
-            "dom-accessibility-api": "^0.5.9",
-            "lz-string": "^1.4.4",
-            "pretty-format": "^27.0.2"
-          }
-        }
       }
     },
     "@testing-library/user-event": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "e2e-tests"
   ],
   "devDependencies": {
-    "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/jest-dom": "^5.17.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.11.58",

--- a/ui-admin/src/components/forms/InfoPopup.test.tsx
+++ b/ui-admin/src/components/forms/InfoPopup.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitForElementToBeRemoved } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 

--- a/ui-admin/src/components/forms/InfoPopup.test.tsx
+++ b/ui-admin/src/components/forms/InfoPopup.test.tsx
@@ -18,7 +18,7 @@ describe('InfoPopup', () => {
     expect(await screen.findByText('blah blah')).toBeTruthy()
     await userEvent.click(button)
     // tooltip disappears on second click
-    await waitForElementToBeRemoved(() => screen.queryByText('blah blah'))
+    expect(screen.queryByText('blah blah')).toBeNull()
   })
 
   it('disappears on clicks outside', async () => {
@@ -33,6 +33,6 @@ describe('InfoPopup', () => {
 
     // tooltip disappears on click of outside thing
     await userEvent.click(screen.getByText('Something complicated'))
-    await waitForElementToBeRemoved(() => screen.queryByText('blah blah'))
+    expect(screen.queryByText('blah blah')).toBeNull()
   })
 })

--- a/ui-admin/src/portal/MailingListView.test.tsx
+++ b/ui-admin/src/portal/MailingListView.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+
+import { MailingListContact } from 'api/api'
+import { mockPortalContext } from 'test-utils/mocking-utils'
+import { setupRouterTest } from 'test-utils/router-testing-utils'
+import userEvent from '@testing-library/user-event'
+import MailingListView from './MailingListView'
+
+jest.mock('api/api', () => ({
+  fetchMailingList: () => {
+    const contacts: MailingListContact[] = [{
+      name: 'person1',
+      email: 'fake1@test.com',
+      createdAt: 0
+    }, {
+      name: 'person2',
+      email: 'fake2@test.com',
+      createdAt: 0
+    }]
+    return Promise.resolve(contacts)
+  }
+}))
+
+test('renders a mailing list', async () => {
+  const portalContext = mockPortalContext()
+  const portalEnv = portalContext.portal.portalEnvironments[0]
+  const { RoutedComponent } =
+        setupRouterTest(<MailingListView portalContext={portalContext} portalEnv={portalEnv}/>)
+  render(RoutedComponent)
+  await waitFor(() => {
+    expect(screen.getByText('person1')).toBeInTheDocument()
+  })
+  expect(screen.getByText('fake1@test.com')).toBeInTheDocument()
+  expect(screen.getByText('person2')).toBeInTheDocument()
+})
+
+test('download is toggled depending on contacts selected', async () => {
+  const portalContext = mockPortalContext()
+  const portalEnv = portalContext.portal.portalEnvironments[0]
+  const { RoutedComponent } =
+        setupRouterTest(<MailingListView portalContext={portalContext} portalEnv={portalEnv}/>)
+  render(RoutedComponent)
+  await waitFor(() => {
+    expect(screen.getByText('person1')).toBeInTheDocument()
+  })
+  const downloadLink = screen.getByText('Download')
+  expect(downloadLink).toHaveAttribute('aria-disabled', 'true')
+
+  // click on the 'select all' checkbox
+  await userEvent.click(screen.getAllByRole('checkbox')[0])
+  expect(screen.getByText('2 of 2 selected')).toBeInTheDocument()
+  expect(downloadLink).toHaveAttribute('aria-disabled', 'false')
+})

--- a/ui-admin/src/study/participants/export/ExportDataControl.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataControl.tsx
@@ -7,6 +7,7 @@ import { currentIsoDate } from 'util/timeUtils'
 import { failureNotification } from 'util/notifications'
 import { Store } from 'react-notifications-component'
 import { Link } from 'react-router-dom'
+import { saveBlobAsDownload } from '../../../util/downloadUtils'
 
 const FILE_FORMATS = [{
   label: 'Tab-delimted (.tsv)',
@@ -43,11 +44,7 @@ const ExportDataControl = ({ studyEnvContext, show, setShow }: {studyEnvContext:
       return
     }
     const blob = await response.blob()
-    const url = window.URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = fileName
-    a.click()
+    saveBlobAsDownload(blob, fileName)
     setIsLoading(false)
   }
 

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -26,6 +26,7 @@ import AdHocEmailModal from '../AdHocEmailModal'
 import EnrolleeSearchFacets, {} from './facets/EnrolleeSearchFacets'
 import { facetValuesFromString, facetValuesToString, SAMPLE_FACETS, FacetValue }
   from 'api/enrolleeSearch'
+import { Button } from 'components/forms/Button'
 
 /** Shows a list of (for now) enrollees */
 function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
@@ -185,11 +186,11 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
                 {table.getPreFilteredRowModel().rows.length} selected ({table.getFilteredRowModel().rows.length} shown)
               </span>
               <span className="me-2">
-                <button onClick={() => setShowEmailModal(allowSendEmail)}
-                  aria-disabled={!allowSendEmail} className="btn btn-secondary"
-                  title={allowSendEmail ? 'Send email' : 'Select at least one participant'}>
+                <Button onClick={() => setShowEmailModal(allowSendEmail)}
+                  variant="link" disabled={!allowSendEmail}
+                  tooltip={allowSendEmail ? 'Send email' : 'Select at least one participant'}>
                   Send email
-                </button>
+                </Button>
               </span>
               { showEmailModal && <AdHocEmailModal enrolleeShortcodes={enrolleesSelected}
                 studyEnvContext={studyEnvContext}

--- a/ui-admin/src/util/downloadUtils.test.ts
+++ b/ui-admin/src/util/downloadUtils.test.ts
@@ -1,0 +1,15 @@
+import { escapeCsvValue } from './downloadUtils'
+
+describe('downloadUtils escapeCsvValue', () => {
+  it('handles boring strings', () => {
+    expect(escapeCsvValue('foobar')).toEqual('foobar')
+    expect(escapeCsvValue('foobar')).toEqual('foobar')
+    expect(escapeCsvValue(' space test ')).toEqual(' space test ')
+  })
+
+  it('quotes strings with special characters', () => {
+    expect(escapeCsvValue('line1\nline2')).toEqual('"line1\nline2"')
+    expect(escapeCsvValue('1,2')).toEqual('"1,2"')
+    expect(escapeCsvValue('foo "quote" bar')).toEqual('"foo ""quote"" bar"')
+  })
+})

--- a/ui-admin/src/util/downloadUtils.ts
+++ b/ui-admin/src/util/downloadUtils.ts
@@ -1,0 +1,17 @@
+/** escapes double quotes with an extra ", and adds double quotes around any values that contain commas or newlines */
+export const escapeCsvValue = (value: string) => {
+  value = value.replaceAll('"', '""')
+  if (value && (value.includes(',') || value.includes('\n') || value.includes('"'))) {
+    return `"${value}"`
+  }
+  return value
+}
+
+/** takes a blob and saves it to the users computer as a download */
+export const saveBlobAsDownload = (blob: Blob, fileName: string) => {
+  const url = window.URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = fileName
+  a.click()
+}


### PR DESCRIPTION
Clicking the "download" link above the mailing list view now downloads the selected members of the mailing list as a CSV.  

![image](https://github.com/broadinstitute/juniper/assets/2800795/ab33fab0-f886-4bcf-a8e1-e7f181e666e5)

This also has a couple of related general changes:
1.  Upgraded our versions of testing libraries -- this solves some "updates happening outside of 'act'" warnings we were getting in tests", and required tweaking some other tests to better handle user events
2. Swapped the "send email" button on the participant list with our button component that properly handles disabled tooltips.

TO TEST:
1. go to https://localhost:3000/ourhealth/env/sandbox/mailingList
2. select some/all entries
3. click "download"
4. confirm a csv file with the selected participants is downloaded  