### PR TITLE
[JN-372] Remove announce step from SonarCloud scans

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -59,9 +59,3 @@ jobs:
           args: >
               -Dsonar.branch.target=${{ github.event.repository.default_branch }}
               -Dsonar.branch.name=${{ steps.branch-name.outputs.current_branch }}
-      - name: Announce
-        run: |
-          gh pr comment ${{ github.event.pull_request.number }} \
-            --body "SonarCloud [analyzed ${{ matrix.subproject }} on ${{ steps.branch-name.outputs.current_branch }}](https://sonarcloud.io/summary/new_code?id=broadinstitute_juniper-${{ matrix.subproject }}&branch=${{ steps.branch-name.outputs.current_branch }})"
-        env:
-          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This github workflow is quite noisy- 4 github PR comments per new commit. This removes 3 of them (the individual UI artifact comments). Waiting for confirmation from Tom to see if this is acceptable