### PR TITLE
[JN-508] Fix navbar dropdown

### DIFF
--- a/ui-participant/src/Navbar.tsx
+++ b/ui-participant/src/Navbar.tsx
@@ -68,7 +68,7 @@ export default function Navbar(props: NavbarProps) {
       <button
         aria-controls={dropdownId} aria-expanded="false" aria-label="Toggle navigation"
         className="navbar-toggler"
-        data-bs-toggle="collapse" data-bs-target={`#${CSS.escape(dropdownId)}`}
+        data-bs-toggle="collapse" data-bs-target={`#${dropdownId}`}
         type="button"
       >
         <span className="navbar-toggler-icon"/>

--- a/ui-participant/src/Navbar.tsx
+++ b/ui-participant/src/Navbar.tsx
@@ -13,6 +13,7 @@ import { useUser } from 'providers/UserProvider'
 import { useConfig } from 'providers/ConfigProvider'
 import { getOidcConfig } from 'authConfig'
 import { UserManager } from 'oidc-client-ts'
+import { uniqueId } from 'lodash'
 
 const navLinkClasses = 'nav-link fs-5 ms-lg-3'
 
@@ -57,7 +58,7 @@ export default function Navbar(props: NavbarProps) {
     }
   }, [location.pathname])
 
-  const dropdownId = useId()
+  const dropdownId = uniqueId('navDropdown')
 
   return <nav {...props} className={classNames('navbar navbar-expand-lg navbar-light', props.className)}>
     <div className="container-fluid">


### PR DESCRIPTION
See https://broadworkbench.atlassian.net/browse/JN-508

Downsizing the window for ourhealthstudy.org collapses the navbar items into a hamburger menu. The hamburger button was no longer clickable, meaning users couldn't log in unless their browser was a certain minimum width. This most likely affected mobile users.

This seems to have been fallout from https://github.com/broadinstitute/juniper/pull/478, which changed the React Bootstrap versions. Isolated by testing the before and after of that commit.