### PR TITLE
[JN-506] url-linkable mailing list 

### DIFF
--- a/ui-participant/src/landing/LandingPage.test.tsx
+++ b/ui-participant/src/landing/LandingPage.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { usePortalEnv } from 'providers/PortalProvider'
+import {
+    HtmlPage,
+    HtmlSection,
+    LocalSiteContent,
+    NavbarItem,
+    Portal,
+    PortalEnvironment, PortalEnvironmentConfig,
+    PortalStudy, SiteContent, Survey
+} from "@juniper/ui-core";
+import {render, screen} from "@testing-library/react";
+import HtmlPageView from "./HtmlPageView";
+import LandingPage from "./LandingPage";
+import {setupRouterTest} from "../test-utils/router-testing-utils";
+import HubPage from "../hub/HubPage";
+
+const emptySiteContent: LocalSiteContent = {
+    language: "en",
+    navbarItems: [],
+    landingPage: {
+        title: '',
+        path: '',
+        sections: []
+    },
+    navLogoCleanFileName: '',
+    navLogoVersion: 1
+}
+
+const emptyPortal: Portal = {
+    id: '',
+    name: '',
+    shortcode: '',
+    portalEnvironments: [],
+    portalStudies: []
+}
+
+describe('LandingPage', () => {
+    it('handles trivial landing page', () => {
+        const { RoutedComponent } =
+            setupRouterTest(
+                    <LandingPage localContent={emptySiteContent}/>)
+        render(RoutedComponent)
+        expect(screen.getByText('Join Mailing List')).not.toBeVisible()
+    })
+})

--- a/ui-participant/src/landing/LandingPage.tsx
+++ b/ui-participant/src/landing/LandingPage.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import React, { useEffect, useRef } from 'react'
-import {Link, Outlet, useLocation, useSearchParams} from 'react-router-dom'
+import { Link, Outlet, useLocation, useSearchParams } from 'react-router-dom'
 import { LocalSiteContent, MailingListModal, HtmlSectionView } from '@juniper/ui-core'
 import _uniqueId from 'lodash/uniqueId'
 import Navbar from '../Navbar'
@@ -15,7 +15,7 @@ function LandingPageView({ localContent }: { localContent: LocalSiteContent }) {
   // see https://blog.openreplay.com/understanding-the-useid-hook-in-react/
   const mailingListModalId = useRef(_uniqueId('mailingListModel'))
   const [searchParams] = useSearchParams()
-  const mailingList = searchParams.get(MAILING_LIST_QUERY_PARAM)
+  const mailingListParamValue = searchParams.get(MAILING_LIST_QUERY_PARAM)
 
   useEffect(() => {
     const mailingListLinks = document.querySelectorAll<HTMLLinkElement>('a[href="#mailing-list"]')
@@ -27,7 +27,7 @@ function LandingPageView({ localContent }: { localContent: LocalSiteContent }) {
 
   useEffect(() => {
     /** if the mailingList query param is present, auto-trigger the modal */
-    if (mailingList !== 'true') {
+    if (mailingListParamValue !== 'true') {
       return
     }
     const modalEl = document.querySelector(`#${mailingListModalId.current}`)

--- a/ui-participant/src/landing/LandingPage.tsx
+++ b/ui-participant/src/landing/LandingPage.tsx
@@ -1,9 +1,12 @@
 import classNames from 'classnames'
 import React, { useEffect, useRef } from 'react'
-import { Link, Outlet, useLocation } from 'react-router-dom'
+import {Link, Outlet, useLocation, useSearchParams} from 'react-router-dom'
 import { LocalSiteContent, MailingListModal, HtmlSectionView } from '@juniper/ui-core'
 import _uniqueId from 'lodash/uniqueId'
 import Navbar from '../Navbar'
+import * as bootstrap from 'bootstrap'
+
+export const MAILING_LIST_QUERY_PARAM = 'showJoinMailingList'
 
 /** renders the landing page for a portal (e.g. hearthive.org) */
 function LandingPageView({ localContent }: { localContent: LocalSiteContent }) {
@@ -11,6 +14,8 @@ function LandingPageView({ localContent }: { localContent: LocalSiteContent }) {
   // we don't use useId() since this needs to be used in a CSS selector
   // see https://blog.openreplay.com/understanding-the-useid-hook-in-react/
   const mailingListModalId = useRef(_uniqueId('mailingListModel'))
+  const [searchParams] = useSearchParams()
+  const mailingList = searchParams.get(MAILING_LIST_QUERY_PARAM)
 
   useEffect(() => {
     const mailingListLinks = document.querySelectorAll<HTMLLinkElement>('a[href="#mailing-list"]')
@@ -19,6 +24,17 @@ function LandingPageView({ localContent }: { localContent: LocalSiteContent }) {
       el.dataset.bsTarget = `#${mailingListModalId.current}`
     })
   }, [location.pathname])
+
+  useEffect(() => {
+    /** if the mailingList query param is present, auto-trigger the modal */
+    if (mailingList !== 'true') {
+      return
+    }
+    const modalEl = document.querySelector(`#${mailingListModalId.current}`)
+    if (!modalEl) { return }
+    const modal = bootstrap.Modal.getOrCreateInstance(modalEl)
+    modal.show()
+  }, [])
 
   const hasFooter = !!localContent.footerSection
 

--- a/ui-participant/src/test-utils/router-testing-utils.tsx
+++ b/ui-participant/src/test-utils/router-testing-utils.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { Router as RemixRouter } from '@remix-run/router/dist/router'
+import { waitFor } from '@testing-library/react'
 
 /**
  * return both the component wrapped in a router, and the router object itself,
@@ -26,4 +27,12 @@ export function setupRouterTest(ComponentToRender: ReactElement, initialEntries=
   const RoutedComponent = <RouterProvider router={router} />
 
   return { RoutedComponent, router }
+}
+
+/**
+ * confirm even after useEffects, the callback will still be true
+ * from https://stackoverflow.com/questions/68400489/how-to-wait-to-assert-an-element-never-appears-in-the-document
+  */
+export async function expectNever(callable: () => unknown): Promise<void> {
+  await expect(() => waitFor(callable)).rejects.toEqual(expect.anything())
 }

--- a/ui-participant/src/test-utils/test-portal-factory.ts
+++ b/ui-participant/src/test-utils/test-portal-factory.ts
@@ -1,0 +1,62 @@
+import {
+  HtmlPage,
+  LocalSiteContent,
+  Portal,
+  PortalEnvironment,
+  PortalEnvironmentConfig,
+  SiteContent
+} from '@juniper/ui-core'
+
+export const mockPortal = (): Portal => {
+  return {
+    name: 'mock portal',
+    id: 'portal123',
+    shortcode: 'mockportal',
+    portalStudies: [],
+    portalEnvironments: [mockPortalEnvironment()]
+  }
+}
+
+export const mockPortalEnvironment = (): PortalEnvironment => {
+  return {
+    environmentName: 'sandbox',
+    portalEnvironmentConfig: mockPortalEnvironmentConfig(),
+    siteContent: mockSiteContent()
+  }
+}
+
+export const mockPortalEnvironmentConfig = (): PortalEnvironmentConfig => {
+  return {
+    acceptingRegistration: true,
+    initialized: true,
+    password: 'password',
+    passwordProtected: false
+  }
+}
+
+export const mockSiteContent = (): SiteContent => {
+  return {
+    defaultLanguage: 'en',
+    localizedSiteContents: [mockLocalSiteContent()],
+    stableId: 'mockContent',
+    version: 1
+  }
+}
+
+export const mockLocalSiteContent = (): LocalSiteContent => {
+  return {
+    language: 'en',
+    navbarItems: [],
+    landingPage: mockHtmlPage(),
+    navLogoCleanFileName: 'navLogo.png',
+    navLogoVersion: 1
+  }
+}
+
+export const mockHtmlPage = (): HtmlPage => {
+  return {
+    title: 'mock home page',
+    path: '/',
+    sections: []
+  }
+}

--- a/ui-participant/src/test-utils/test-portal-factory.ts
+++ b/ui-participant/src/test-utils/test-portal-factory.ts
@@ -18,7 +18,7 @@ export const mockPortal = (): Portal => {
   }
 }
 
-/* mock environment with a siteContent */
+/** mock environment with a siteContent */
 export const mockPortalEnvironment = (): PortalEnvironment => {
   return {
     environmentName: 'sandbox',

--- a/ui-participant/src/test-utils/test-portal-factory.ts
+++ b/ui-participant/src/test-utils/test-portal-factory.ts
@@ -7,6 +7,7 @@ import {
   SiteContent
 } from '@juniper/ui-core'
 
+/** mock portal object with one environment */
 export const mockPortal = (): Portal => {
   return {
     name: 'mock portal',
@@ -17,6 +18,7 @@ export const mockPortal = (): Portal => {
   }
 }
 
+/* mock environment with a siteContent */
 export const mockPortalEnvironment = (): PortalEnvironment => {
   return {
     environmentName: 'sandbox',
@@ -25,6 +27,7 @@ export const mockPortalEnvironment = (): PortalEnvironment => {
   }
 }
 
+/** mock config with everything open */
 export const mockPortalEnvironmentConfig = (): PortalEnvironmentConfig => {
   return {
     acceptingRegistration: true,
@@ -34,6 +37,7 @@ export const mockPortalEnvironmentConfig = (): PortalEnvironmentConfig => {
   }
 }
 
+/** mock site content with one localization */
 export const mockSiteContent = (): SiteContent => {
   return {
     defaultLanguage: 'en',
@@ -43,6 +47,7 @@ export const mockSiteContent = (): SiteContent => {
   }
 }
 
+/** mock local content with a single empty landing page */
 export const mockLocalSiteContent = (): LocalSiteContent => {
   return {
     language: 'en',
@@ -53,6 +58,7 @@ export const mockLocalSiteContent = (): LocalSiteContent => {
   }
 }
 
+/** mock empty page */
 export const mockHtmlPage = (): HtmlPage => {
   return {
     title: 'mock home page',


### PR DESCRIPTION
Appending a query parameter of `showJoinMailingList=true` to any participant landing page will now result in that page auto-popping up the "Join Mailing List" modal.  This will let OurHealth send out links like `ourhealthstudy.org?showJoinMailingList=true` to people and have them immediately see the mailing list modal.

TO TEST:
1. go to `https://sandbox.ourhealth.localhost:3001/?showJoinMailingList=true`
2. confirm mailing list modal immmediately appears
3. go to `https://sandbox.ourhealth.localhost:3001` 
4. confirm mailing list modal does not appear, but does if you scroll down and click "Join mailing list"