### PR TITLE
[JN-495] fixing logout for participants

### DIFF
--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/CurrentUserController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/CurrentUserController.java
@@ -4,11 +4,10 @@ import bio.terra.pearl.api.participant.api.CurrentUserApi;
 import bio.terra.pearl.api.participant.service.CurrentUserService;
 import bio.terra.pearl.api.participant.service.RequestUtilService;
 import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.participant.ParticipantUser;
 import java.util.Optional;
 import java.util.function.Function;
 import javax.servlet.http.HttpServletRequest;
-
-import bio.terra.pearl.core.model.participant.ParticipantUser;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/CurrentUserController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/CurrentUserController.java
@@ -7,6 +7,8 @@ import bio.terra.pearl.core.model.EnvironmentName;
 import java.util.Optional;
 import java.util.function.Function;
 import javax.servlet.http.HttpServletRequest;
+
+import bio.terra.pearl.core.model.participant.ParticipantUser;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
@@ -48,8 +50,8 @@ public class CurrentUserController implements CurrentUserApi {
      * this currently does a global logout. That may change as we determine how portals interact
      * with each other and how we whitelabel.
      */
-    String token = requestUtilService.requireToken(request);
-    currentUserService.logout(token);
+    ParticipantUser user = requestUtilService.requireUser(request);
+    currentUserService.logout(user);
     return ResponseEntity.noContent().build();
   }
 }

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/service/CurrentUserService.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/service/CurrentUserService.java
@@ -86,11 +86,9 @@ public class CurrentUserService {
   public record UserWithEnrollees(ParticipantUser user, List<Enrollee> enrollees) {}
 
   @Transactional
-  public void logout(String token) {
-    Optional<ParticipantUser> userOpt = participantUserDao.findByToken(token);
-    ParticipantUser user = userOpt.get();
-    user.setToken(null);
-    participantUserDao.update(user);
+  public void logout(ParticipantUser user) {
+    // we don't store token information locally yet (we might have to later if we take async
+    // actions on their behalf). So for now, this is a no-op, B2C handles the logout mechanics
   }
 
   public Optional<ParticipantUser> findByUsername(


### PR DESCRIPTION
There was some cruft in the logout method for participants from pre-B2C days where we still stored user tokens in the database.  This was producing errors in the server logs (but AFAIK would have no user-visible impact).  This cleans that out.

TO TEST:
1. redeploy participantApiApp
2. login to the participant app
3. logout
4. confirm no stack traces appear