### PR TITLE
[JN-516] Require survey stable ID and name when creating survey

### DIFF
--- a/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import React from 'react'
 import CreateSurveyModal from './CreateSurveyModal'
 import { mockStudyEnvContext } from 'test-utils/mocking-utils'
-import { setupRouterTest } from '../../test-utils/router-testing-utils'
+import { setupRouterTest } from 'test-utils/router-testing-utils'
 import userEvent from '@testing-library/user-event'
 
 describe('CreateSurveyModal', () => {

--- a/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
@@ -1,4 +1,4 @@
-import {act, render, screen} from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import React from 'react'
 import CreateSurveyModal from './CreateSurveyModal'
 import { mockStudyEnvContext } from '../../test-utils/mocking-utils'

--- a/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import React from 'react'
 import CreateSurveyModal from './CreateSurveyModal'
-import { mockStudyEnvContext } from '../../test-utils/mocking-utils'
+import { mockStudyEnvContext } from 'test-utils/mocking-utils'
 import { setupRouterTest } from '../../test-utils/router-testing-utils'
 import userEvent from '@testing-library/user-event'
 

--- a/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
@@ -1,0 +1,45 @@
+import {act, render, screen} from '@testing-library/react'
+import React from 'react'
+import CreateSurveyModal from './CreateSurveyModal'
+import { mockStudyEnvContext } from '../../test-utils/mocking-utils'
+import { setupRouterTest } from '../../test-utils/router-testing-utils'
+import userEvent from '@testing-library/user-event'
+
+describe('CreateSurveyModal', () => {
+  test('disables Create button when survey name and stable ID are blank', () => {
+    //Arrange
+    const studyEnvContext = mockStudyEnvContext()
+    const { RoutedComponent } = setupRouterTest(<CreateSurveyModal
+      studyEnvContext={studyEnvContext}
+      isReadOnlyEnv={false}
+      show={true}
+      setShow={jest.fn()}/>)
+    render(RoutedComponent)
+
+    //Assert
+    const createButton = screen.getByText('Create')
+    expect(createButton).toBeDisabled()
+  })
+
+  test('enables Create button when survey name and stable ID are filled out', async () => {
+    //Arrange
+    const user = userEvent.setup()
+    const studyEnvContext = mockStudyEnvContext()
+    const { RoutedComponent } = setupRouterTest(<CreateSurveyModal
+      studyEnvContext={studyEnvContext}
+      isReadOnlyEnv={false}
+      show={true}
+      setShow={jest.fn()}/>)
+    render(RoutedComponent)
+
+    //Act
+    const surveyNameInput = screen.getByLabelText('Survey Name')
+    const surveyStableIdInput = screen.getByLabelText('Survey Stable ID')
+    await user.type(surveyNameInput, 'Test Survey')
+    await user.type(surveyStableIdInput, 'test_survey_id')
+
+    //Assert
+    const createButton = screen.getByText('Create')
+    expect(createButton).toBeEnabled()
+  })
+})

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -76,15 +76,13 @@ const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, show, setShow }: {s
     </Modal.Header>
     <Modal.Body>
       <form onSubmit={e => e.preventDefault()}>
-        <label className="form-label"> Survey Name
-          <input type="text" size={50} className="form-control" id="inputSurveyName" value={surveyName}
-            onChange={event => setSurveyName(event.target.value)}/>
-        </label>
-        <label className="form-label"> Survey Stable ID
-          <InfoPopup content={'A stable and unique identifier for the survey. May be shown in exported datasets.'}/>
-          <input type="text" size={50} className="form-control" id="inputSurveyStableId" value={surveyStableId}
-            onChange={event => setSurveyStableId(event.target.value)}/>
-        </label>
+        <label className="form-label" htmlFor="inputSurveyName">Survey Name</label>
+        <input type="text" size={50} className="form-control" id="inputSurveyName" value={surveyName}
+          onChange={event => setSurveyName(event.target.value)}/>
+        <label className="form-label" htmlFor="inputSurveyStableId">Survey Stable ID</label>
+        <InfoPopup content={'A stable and unique identifier for the survey. May be shown in exported datasets.'}/>
+        <input type="text" size={50} className="form-control" id="inputSurveyStableId" value={surveyStableId}
+          onChange={event => setSurveyStableId(event.target.value)}/>
       </form>
     </Modal.Body>
     <Modal.Footer>

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -79,7 +79,7 @@ const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, show, setShow }: {s
         <label className="form-label" htmlFor="inputSurveyName">Survey Name</label>
         <input type="text" size={50} className="form-control" id="inputSurveyName" value={surveyName}
           onChange={event => setSurveyName(event.target.value)}/>
-        <label className="form-label" htmlFor="inputSurveyStableId">Survey Stable ID</label>
+        <label className="form-label mt-3" htmlFor="inputSurveyStableId">Survey Stable ID</label>
         <InfoPopup content={'A stable and unique identifier for the survey. May be shown in exported datasets.'}/>
         <input type="text" size={50} className="form-control" id="inputSurveyStableId" value={surveyStableId}
           onChange={event => setSurveyStableId(event.target.value)}/>

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -89,7 +89,11 @@ const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, show, setShow }: {s
     </Modal.Body>
     <Modal.Footer>
       <LoadingSpinner isLoading={isLoading}>
-        <button className="btn btn-primary" onClick={createSurvey}>Create</button>
+        <button
+          className="btn btn-primary"
+          disabled={!surveyName || !surveyStableId}
+          onClick={createSurvey}
+        >Create</button>
         <button className="btn btn-secondary" onClick={() => {
           setShow(false)
           clearFields()


### PR DESCRIPTION
Requires the stable ID and name to be set when creating a new survey. I know we didn't say this was necessary for tomorrow's release but I had it done by the time team testing was over