### PR TITLE
JN-518: fixing portal switching bug

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,6 +58,8 @@ module.exports = {
     'multiline-comment-style': 'off',
     'no-lonely-if': 'off',
     'no-multi-assign': 'warn',
+    'no-return-assign': 'warn',
+    'no-cond-assign': 'warn',
     'no-multiple-empty-lines': 'warn',
     'no-trailing-spaces': 'warn',
     'no-unneeded-ternary': 'warn',

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -593,7 +593,7 @@ export default {
     const url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/kits`
     const response = await fetch(url, this.getGetInit())
     const kits: KitRequest[] = await this.processJsonResponse(response)
-    kits.forEach(kit => kit.pepperStatus = parsePepperKitStatus(kit.dsmStatus))
+    kits.forEach(kit => { kit.pepperStatus = parsePepperKitStatus(kit.dsmStatus) })
     return kits
   },
 

--- a/ui-admin/src/login/IdleStatusMonitor.tsx
+++ b/ui-admin/src/login/IdleStatusMonitor.tsx
@@ -118,7 +118,7 @@ const InactivityTimer = ({ maxIdleSessionDuration, idleWarningDuration, doSignOu
 
   useEffect(() => {
     const targetEvents = ['click', 'keydown']
-    const updateLastActive = () => lastRecordedActivity.current = Date.now()
+    const updateLastActive = () => { lastRecordedActivity.current = Date.now() }
 
     if (!lastRecordedActivity.current) {
       updateLastActive()

--- a/ui-admin/src/study/StudyRouter.tsx
+++ b/ui-admin/src/study/StudyRouter.tsx
@@ -8,6 +8,7 @@ import StudyDashboard from './StudyDashboard'
 import PortalUserList from '../user/PortalUserList'
 import PortalEnvDiffProvider from '../portal/publish/PortalEnvDiffProvider'
 import StudyPublishingView from './publishing/StudyPublishingView'
+import LoadingSpinner from "../util/LoadingSpinner";
 
 export type StudyContextT = {
   updateStudy: (study: Study) => void
@@ -39,10 +40,16 @@ export default function StudyRouter({ portalContext }: {portalContext: LoadedPor
 function StudyRouterFromShortcode({ shortcode, portalContext }:
                        { shortcode: string, portalContext: LoadedPortalContextT}) {
   const matchedPortalStudy = portalContext.portal.portalStudies.find(portalStudy => {
-    return portalStudy.study.shortcode = shortcode
+    return portalStudy.study.shortcode === shortcode
   })
   if (!matchedPortalStudy) {
-    return <div>Study could not be loaded or found.</div>
+    /**
+     * if we can't match it, this is likely because the user has switched studies, but the corresponding
+     * portal hasn't loaded yet.  This can happen due to race conditions in how StudyRouter and PortalProvider
+     * both listen to urlParams to determine what to load.  As the hub-study-portal relationships continue to mature
+     * we may consider a unified studyPortalRouter that can handle everything with more synchronicity.
+     */
+    return <div><LoadingSpinner/></div>
   }
 
   const study = matchedPortalStudy?.study

--- a/ui-admin/src/study/StudyRouter.tsx
+++ b/ui-admin/src/study/StudyRouter.tsx
@@ -8,7 +8,7 @@ import StudyDashboard from './StudyDashboard'
 import PortalUserList from '../user/PortalUserList'
 import PortalEnvDiffProvider from '../portal/publish/PortalEnvDiffProvider'
 import StudyPublishingView from './publishing/StudyPublishingView'
-import LoadingSpinner from "../util/LoadingSpinner";
+import LoadingSpinner from '../util/LoadingSpinner'
 
 export type StudyContextT = {
   updateStudy: (study: Study) => void

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -125,10 +125,11 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     onRowSelectionChange: setRowSelection
   })
 
-  const searchEnrollees = async (facetValues: FacetValue[]) => {
+  const searchEnrollees = async (portalShortcode: string, studyShortcode: string,
+    envName: string, facetValues: FacetValue[]) => {
     setIsLoading(true)
     try {
-      const response = await Api.searchEnrollees(portal.shortcode, study.shortcode, currentEnv.environmentName,
+      const response = await Api.searchEnrollees(portalShortcode, studyShortcode, envName,
         facetValues)
       setParticipantList(response)
     } catch (e) {
@@ -138,8 +139,8 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
   }
 
   useEffect(() => {
-    searchEnrollees(facetValues)
-  }, [study.shortcode, currentEnv.environmentName])
+    searchEnrollees(portal.shortcode, study.shortcode, currentEnv.environmentName, facetValues)
+  }, [portal.shortcode, study.shortcode, currentEnv.environmentName])
 
   const numSelected = Object.keys(rowSelection).length
   const allowSendEmail = numSelected > 0

--- a/ui-participant/src/login/IdleStatusMonitor.tsx
+++ b/ui-participant/src/login/IdleStatusMonitor.tsx
@@ -118,7 +118,7 @@ const InactivityTimer = ({ maxIdleSessionDuration, idleWarningDuration, doSignOu
 
   useEffect(() => {
     const targetEvents = ['click', 'keydown']
-    const updateLastActive = () => lastRecordedActivity.current = Date.now()
+    const updateLastActive = () => { lastRecordedActivity.current = Date.now() }
 
     if (!lastRecordedActivity.current) {
       updateLastActive()


### PR DESCRIPTION
Using the study selector to move between studies in two different portals was causing a couple of different problems -- there can be a race condition where if the study router updates before the portal router, the participant list will fail to load since it's trying to load the study from the wrong portal.  There was also just a straight-up stupid bug in StudyRouter that's been uncaught for months since we never pay attention to portals with more than one study.   In lieu of unit tests, I've updated our eslint to catch those fat-fingered equal signs.

TO TEST:
1. populate ourhealth and hearthive
2. go to https://localhost:3000/hearthive/studies/pacing/env/live/participants
3. use the study selector, and select the OurHealth study
4. confirm no error appears, and the participant list ui switches to OurHealth