### PR TITLE
JN-507: participant email link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Open the root folder in IntelliJ.
        * set environment variable: `B2C_CLIENT_ID=<<vault read -field value secret/dsp/ddp/b2c/dev/application_id>>`
        * set environment variable: `B2C_POLICY_NAME=B2C_1A_ddp_participant_signup_signin_dev`
        * set environment variable: `DSM_JWT_SIGNING_SECRET=<<vault read -field jwt_signing_secret secret/dsp/ddp/d2p/dev/dsm>>`
+       * set environment variable: `SENDGRID_API_KEY=<<vault read -field=api_key secret/dsp/ddp/d2p/dev/sendgrid>>`
      * ApiParticipantApp (in api-participant module)
         * set active profiles of "human-readable-logging" and "development"
         * set environment variable: `SENDGRID_API_KEY=<<vault read -field=api_key secret/dsp/ddp/d2p/dev/sendgrid>>`

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
@@ -9,6 +9,7 @@ import bio.terra.pearl.core.shared.ApplicationRoutingPaths;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.beanutils.PropertyUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.apache.commons.text.lookup.StringLookup;
 import org.slf4j.Logger;
@@ -35,6 +36,7 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
                         contextInfo.portal(), contextInfo.study()),
                 "dashboardUrl", getDashboardUrl(contextInfo.portalEnv(), contextInfo.portal()),
                 "siteLink", getSiteLink(contextInfo.portalEnv(), contextInfo.portal()),
+                "participantSupportEmailLink", getParticipantSupportEmailLink(contextInfo.portalEnv()),
                 "siteImageBaseUrl", getImageBaseUrl(contextInfo.portalEnv(), contextInfo.portal().getShortcode()),
                 // providing a study isn't required, since emails might come from the portal, rather than a study
                 // but immutable map doesn't allow nulls
@@ -92,6 +94,15 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
         return routingPaths.getParticipantBaseUrl(portalEnvironment, portalShortcode)
                 + "/api/public/portals/v1/" + portalShortcode + "/env/" + portalEnvironment.getEnvironmentName()
                 + "/siteImages";
+    }
+
+    public String getParticipantSupportEmailLink(PortalEnvironment portalEnvironment) {
+        String emailAddress =portalEnvironment.getPortalEnvironmentConfig().getEmailSourceAddress();
+        if (StringUtils.isBlank(emailAddress)) {
+            // if there's nothing configured for the study, default to the site-wide Juniper support email
+            emailAddress = routingPaths.getSupportEmailAddress();
+        }
+        return String.format("<a href=\"mailto:%s\" rel=\"noopener\" target=\"_blank\">%s</a>", emailAddress, emailAddress);
     }
 
 

--- a/core/src/main/java/bio/terra/pearl/core/shared/ApplicationRoutingPaths.java
+++ b/core/src/main/java/bio/terra/pearl/core/shared/ApplicationRoutingPaths.java
@@ -19,7 +19,8 @@ public class ApplicationRoutingPaths {
     @Getter
     private final String participantDashboardPath = "/hub";
     @Getter
-    private final String supportEmailAddress;
+    private final String supportEmailAddress;  // the site-wide support email address (e.g. support@juniper...) NOT study-specific
+
 
     public ApplicationRoutingPaths(Environment env) {
         participantUiHostname = env.getProperty("env.hostnames.participantUi");

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailSubstitutorTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailSubstitutorTests.java
@@ -16,6 +16,8 @@ import bio.terra.pearl.core.shared.ApplicationRoutingPaths;
 import org.apache.commons.text.StringSubstitutor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -99,6 +101,24 @@ public class EnrolleeEmailSubstitutorTests extends BaseSpringBootTest {
         assertThat(replacerLive.replace("here's a dashboard link: ${dashboardLink}"),
                 equalTo("here's a dashboard link: <a href=\"https://newstudy.org/hub\">Return to PortalA</a>"));
 
+    }
+
+    @Test
+    public void testMailLinkVariablesReplaced() {
+        Profile profile = Profile.builder().build();
+        Enrollee enrollee = Enrollee.builder().build();
+        EnrolleeRuleData ruleData = new EnrolleeRuleData(enrollee, profile);
+        PortalEnvironmentConfig portalEnvironmentConfig = PortalEnvironmentConfig.builder()
+                .emailSourceAddress("info@test.edu")
+                .build();
+        PortalEnvironment portalEnv = portalEnvironmentFactory.builder("testMailLinkVariablesReplaced")
+                .portalEnvironmentConfig(portalEnvironmentConfig).environmentName(EnvironmentName.irb).build();
+        Portal portal = Portal.builder().name("PortalA").build();
+
+        var contextInfo = new NotificationContextInfo(portal, portalEnv, portalEnvironmentConfig, null, null);
+        StringSubstitutor replacer = EnrolleeEmailSubstitutor.newSubstitutor(ruleData, contextInfo, routingPaths);
+        assertThat(replacer.replace("Contact us at: ${participantSupportEmailLink}"),
+                equalTo("Contact us at: <a href=\"mailto:info@test.edu\" rel=\"noopener\" target=\"_blank\">info@test.edu</a>"));
     }
 
     @Test

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/adHoc.html
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/adHoc.html
@@ -213,7 +213,7 @@
                                         <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
 
                                             <div style="font-family: 'Montserrat',sans-serif; line-height: 140%; text-align: left; word-wrap: break-word;">
-                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at ${siteLink} if you have any questions.</span></p>
+                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at ${participantSupportEmailLink} if you have any questions.</span></p>
                                             </div>
 
                                         </td>

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/consentReminder.html
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/consentReminder.html
@@ -229,7 +229,7 @@
                                         <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
 
                                             <div style="font-family: 'Montserrat',sans-serif; line-height: 140%; text-align: left; word-wrap: break-word;">
-                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at <a rel="noopener" href="https://ourhealthstudy.org" target="_blank">ourhealthstudy.org</a> if you have any questions.</span></p>
+                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at ${participantSupportEmailLink} if you have any questions.</span></p>
                                             </div>
 
                                         </td>

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/studyEnroll.html
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/studyEnroll.html
@@ -229,7 +229,7 @@
                                         <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
 
                                             <div style="font-family: 'Montserrat',sans-serif; line-height: 140%; text-align: left; word-wrap: break-word;">
-                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at <a rel="noopener" href="https://ourhealthstudy.org" target="_blank">ourhealthstudy.org</a> if you have any questions.</span></p>
+                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at ${participantSupportEmailLink} if you have any questions.</span></p>
                                             </div>
 
                                         </td>

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/surveyReminder.html
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/surveyReminder.html
@@ -229,7 +229,7 @@
                                         <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
 
                                             <div style="font-family: 'Montserrat',sans-serif; line-height: 140%; text-align: left; word-wrap: break-word;">
-                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at <a rel="noopener" href="https://ourhealthstudy.org" target="_blank">ourhealthstudy.org</a> if you have any questions.</span></p>
+                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at ${participantSupportEmailLink} if you have any questions.</span></p>
                                             </div>
 
                                         </td>

--- a/populate/src/main/resources/seed/portals/hearthive/studies/cardiomyopathy/emails/studyEnroll.html
+++ b/populate/src/main/resources/seed/portals/hearthive/studies/cardiomyopathy/emails/studyEnroll.html
@@ -9,7 +9,7 @@
     ${dashboardLink}
 </p>
 <p>
-    Please contact us at ${envConfig.emailSourceAddress} if you have any questions or concerns.
+    Please contact us at ${participantSupportEmailLink} if you have any questions or concerns.
 </p>
 <p>
     Thank you!

--- a/populate/src/main/resources/seed/portals/ourhealth/siteContent/footerSection.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/siteContent/footerSection.json
@@ -52,7 +52,7 @@
       "title": "Donate",
       "items": [{
         "text": "Contribute funds",
-        "href": "https://because.massgeneral.org/campaign/our-health-a-transformative-initiative-for-south-asian-cardiac-health-research-spearheaded-by-mgh/c348220 "
+        "href": "mailto:info@ourhealthstudy.org"
       }]
     },{
       "title": "For Participants",

--- a/populate/src/main/resources/seed/portals/ourhealth/siteContent/footerSection.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/siteContent/footerSection.json
@@ -52,7 +52,7 @@
       "title": "Donate",
       "items": [{
         "text": "Contribute funds",
-        "href": "mailto:info@ourhealthstudy.org"
+        "href": "https://because.massgeneral.org/campaign/our-health-a-transformative-initiative-for-south-asian-cardiac-health-research-spearheaded-by-mgh/c348220 "
       }]
     },{
       "title": "For Participants",

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/emails/adHoc.html
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/emails/adHoc.html
@@ -213,7 +213,7 @@
                                         <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
 
                                             <div style="font-family: 'Montserrat',sans-serif; line-height: 140%; text-align: left; word-wrap: break-word;">
-                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at ${siteLink} if you have any questions.</span></p>
+                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at ${participantSupportEmailLink} if you have any questions.</span></p>
                                             </div>
 
                                         </td>

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/emails/consentReminder.html
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/emails/consentReminder.html
@@ -229,7 +229,7 @@
                                         <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
 
                                             <div style="font-family: 'Montserrat',sans-serif; line-height: 140%; text-align: left; word-wrap: break-word;">
-                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at <a rel="noopener" href="https://ourhealthstudy.org" target="_blank">ourhealthstudy.org</a> if you have any questions.</span></p>
+                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at ${participantSupportEmailLink} if you have any questions.</span></p>
                                             </div>
 
                                         </td>

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/emails/studyEnroll.html
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/emails/studyEnroll.html
@@ -229,7 +229,7 @@
                                         <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
 
                                             <div style="font-family: 'Montserrat',sans-serif; line-height: 140%; text-align: left; word-wrap: break-word;">
-                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at <a rel="noopener" href="https://ourhealthstudy.org" target="_blank">ourhealthstudy.org</a> if you have any questions.</span></p>
+                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at ${participantSupportEmailLink} if you have any questions.</span></p>
                                             </div>
 
                                         </td>

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/emails/surveyReminder.html
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/emails/surveyReminder.html
@@ -229,7 +229,7 @@
                                         <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
 
                                             <div style="font-family: 'Montserrat',sans-serif; line-height: 140%; text-align: left; word-wrap: break-word;">
-                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at <a rel="noopener" href="https://ourhealthstudy.org" target="_blank">ourhealthstudy.org</a> if you have any questions.</span></p>
+                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at ${participantSupportEmailLink} if you have any questions.</span></p>
                                             </div>
 
                                         </td>


### PR DESCRIPTION
Previously, we had to either hardcode email addresses in templates, or just link to the participant website.  This adds participant support email to things we can substitute in, in the process of updating the ourhealth email templates. 

TO TEST:
1. repopulate ourhealth
2. redeploy admin and participant apis
3. go to https://sandbox.ourhealth.localhost:3001/
4. join the study
5. confirm you get a welcome email with an appropriate info@ourhealthstudy.org email
![image](https://github.com/broadinstitute/juniper/assets/2800795/a9303d6d-9615-458e-8236-c2ba41109421)
