### PR TITLE
[JN-519] Fix "subsequent saves to surveys are lost"

### DIFF
--- a/ui-admin/src/study/surveys/SurveyView.tsx
+++ b/ui-admin/src/study/surveys/SurveyView.tsx
@@ -24,9 +24,11 @@ function RawSurveyView({ studyEnvContext, survey, readOnly = false }:
   const [currentSurvey, setCurrentSurvey] = useState(survey)
   /** saves the survey as a new version */
   async function createNewVersion({ content: updatedTextContent }: { content: string }): Promise<void> {
-    survey.content = updatedTextContent
     try {
-      const updatedSurvey = await Api.createNewSurveyVersion(portal.shortcode, currentSurvey)
+      const updatedSurvey = await Api.createNewSurveyVersion(
+        portal.shortcode,
+        { ...currentSurvey, content: updatedTextContent }
+      )
       const configuredSurvey = currentEnv.configuredSurveys
         .find(s => s.survey.stableId === updatedSurvey.stableId) as StudyEnvironmentSurvey
       const updatedConfig = { ...configuredSurvey, surveyId: updatedSurvey.id, survey: updatedSurvey }


### PR DESCRIPTION
Currently fighting with jest mocks and the unit test is taking a bit longer to get working than I had hoped. Here's the fix for now and we can opt to merge it ahead of the unit test if we'd like.

To test:

Repro the case described in https://broadworkbench.atlassian.net/browse/JN-519