### PR TITLE
[JN-499] prevent multiple hub oauth redirects 

### DIFF
--- a/ui-participant/src/login/RedirectFromOAuth.tsx
+++ b/ui-participant/src/login/RedirectFromOAuth.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, {useEffect, useRef} from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from 'react-oidc-context'
 import { usePortalEnv } from 'providers/PortalProvider'
@@ -50,6 +50,7 @@ export const RedirectFromOAuth = () => {
           //   * handle possible study enrollment
           //   * navigate to the hub
           // TODO: remember where the user was trying to go and navigate there instead of hard-coding /hub
+
           const email = auth.user.profile.email as string
           const accessToken = auth.user.access_token
 
@@ -57,6 +58,7 @@ export const RedirectFromOAuth = () => {
           const loginResult = auth.user.profile.newUser
             ? await Api.register({ preRegResponseId, email, accessToken })
             : await Api.tokenLogin(accessToken)
+
           loginUser(loginResult, accessToken)
 
           // Decide if there's a study that has either been explicitly selected or is implicit because it's the only one
@@ -94,7 +96,12 @@ export const RedirectFromOAuth = () => {
     }
 
     handleRedirectFromOauth()
-  })
+    /**
+     * only process redirect logic if the auth token has changed.  Previously, we were redirecting
+     * on all rerenders, which was leading to multiple redirects if, for example, the useUser() was
+     * updated in response to the loginUser() call
+     */
+  }, [auth.user?.access_token])
 
   return <PageLoadingIndicator />
 }

--- a/ui-participant/src/login/RedirectFromOAuth.tsx
+++ b/ui-participant/src/login/RedirectFromOAuth.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef} from 'react'
+import React, { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from 'react-oidc-context'
 import { usePortalEnv } from 'providers/PortalProvider'


### PR DESCRIPTION
This fixes that troublesome bug that caused some confusion during demos where, after coming back from the b2c screens, "studies you can join" flashes briefly prior the enrolled hub rendering.  

TO TEST:
1. go to the participant ui https://sandbox.ourhealth.localhost:3001/
2. in chrome debugger, put a breakpoint on line 51 of HubPage.tsx -- this the code that renders the "studies you can join" content -- we want to make sure it is never hit.  And when working locally, sometimes it flashes too fast to notice visually
3. Join the study
4. confirm after you join you are taken to the hub and shown the signed-in hub with welcome banner, and the breakpoint you set never gets triggered