### PR TITLE
[JN-476] Added robust handling of errors from Pepper

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeController.java
@@ -73,7 +73,7 @@ public class EnrolleeController implements EnrolleeApi {
       KitRequest sampleKit = enrolleeExtService.requestKit(adminUser, enrolleeShortcode, kitType);
       return ResponseEntity.ok(sampleKit);
     } catch (PepperException e) {
-      log.warn("Error requesting sample kit from Pepper", e);
+      log.error("Error requesting sample kit from Pepper", e);
       // In the case of a PepperException, we can do better than this because we'll likely know what
       // Pepper was unhappy
       // about, such as an address failing to validate.

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeController.java
@@ -7,14 +7,19 @@ import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.service.kit.PepperException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 @Controller
 public class EnrolleeController implements EnrolleeApi {
+  Logger log = LoggerFactory.getLogger(EnrolleeController.class);
+
   private AuthUtilService authUtilService;
   private EnrolleeExtService enrolleeExtService;
   private HttpServletRequest request;
@@ -67,7 +72,11 @@ public class EnrolleeController implements EnrolleeApi {
     try {
       KitRequest sampleKit = enrolleeExtService.requestKit(adminUser, enrolleeShortcode, kitType);
       return ResponseEntity.ok(sampleKit);
-    } catch (JsonProcessingException e) {
+    } catch (PepperException e) {
+      log.warn("Error requesting sample kit from Pepper", e);
+      // In the case of a PepperException, we can do better than this because we'll likely know what
+      // Pepper was unhappy
+      // about, such as an address failing to validate.
       return ResponseEntity.internalServerError().body(e.getMessage());
     }
   }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeExtService.java
@@ -91,8 +91,7 @@ public class EnrolleeExtService {
     return withdrawnEnrolleeService.withdrawEnrollee(enrollee);
   }
 
-  public KitRequest requestKit(AdminUser adminUser, String enrolleeShortcode, String kitTypeName)
-      throws JsonProcessingException {
+  public KitRequest requestKit(AdminUser adminUser, String enrolleeShortcode, String kitTypeName) {
     Enrollee enrollee = authUtilService.authAdminUserToEnrollee(adminUser, enrolleeShortcode);
     return kitRequestService.requestKit(adminUser, enrollee, kitTypeName);
   }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
     testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.10'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.11.0'
 
     testFixturesImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.10'
     testFixturesImplementation 'org.apache.commons:commons-text:1.10.0'
@@ -53,5 +54,16 @@ dependencies {
 }
 
 test {
-    useJUnitPlatform ()
+    useJUnitPlatform {
+        // By default, exclude `@IntegrationTest`s
+        excludeTags "integration"
+    }
+}
+
+// Explicitly run `@IntegrationTest`s that are excluded from default test runs: `./gradlew integrationTest`
+tasks.register("integrationTest", Test) {
+    useJUnitPlatform {
+        includeTags "integration"
+    }
+    mustRunAfter check
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/LivePepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/LivePepperDSMClient.java
@@ -91,26 +91,15 @@ public class LivePepperDSMClient implements PepperDSMClient {
      * these possibilities and, when possible, converting them into a useful PepperException.
      */
     private <T> T retrieveAndDeserializeResponse(WebClient.RequestHeadersSpec<?> requestHeadersSpec, Class<T> clazz) {
-//        try {
-            // Read the body as a String and manually deserialize so we can capture and log the body if deserialization fails
-            return requestHeadersSpec
-                    .retrieve()
-                    .onStatus(
-                            status -> status.is4xxClientError() || status.is5xxServerError(),
-                            this::deserializePepperError)
-                    .bodyToMono(String.class)
-                    .flatMap(deserializeTo(clazz))
-                    .block();
-//        } catch (RuntimeException e) {
-//            var cause = e.getCause();
-//            // Unwrap a PepperException if it came from handling of 4xx/5xx response or deserialization error
-//            if (cause instanceof PepperException) {
-//                throw (PepperException) cause;
-//            } else {
-//                // A truly unexpected runtime exception
-//                throw e;
-//            }
-//        }
+        // Read the body as a String and manually deserialize so we can capture and log the body if deserialization fails
+        return requestHeadersSpec
+                .retrieve()
+                .onStatus(
+                        status -> status.is4xxClientError() || status.is5xxServerError(),
+                        this::deserializePepperError)
+                .bodyToMono(String.class)
+                .flatMap(deserializeTo(clazz))
+                .block();
     }
 
     /**

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/LivePepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/LivePepperDSMClient.java
@@ -91,7 +91,6 @@ public class LivePepperDSMClient implements PepperDSMClient {
      * these possibilities and, when possible, converting them into a useful PepperException.
      */
     private <T> T retrieveAndDeserializeResponse(WebClient.RequestHeadersSpec<?> requestHeadersSpec, Class<T> clazz) {
-        // Read the body as a String and manually deserialize so we can capture and log the body if deserialization fails
         return requestHeadersSpec
                 .retrieve()
                 .onStatus(

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/PepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/PepperDSMClient.java
@@ -8,8 +8,16 @@ import java.util.Collection;
 import java.util.UUID;
 
 public interface PepperDSMClient {
-    String sendKitRequest(Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address)
-            throws JsonProcessingException;
+    /**
+     * Sends a sample kit request to Pepper.
+     *
+     * @param enrollee   the enrollee to receive the sample kit
+     * @param kitRequest sample kit request details
+     * @param address    mailing address for the sample kit
+     * @return status result from Pepper
+     * @throws PepperException on error from Pepper or failure to process the Pepper response
+     */
+    String sendKitRequest(Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address);
     PepperKitStatus fetchKitStatus(UUID kitRequestId);
     Collection<PepperKitStatus> fetchKitStatusByStudy(UUID studyId);
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/PepperDSMKitRequest.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/PepperDSMKitRequest.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 
 @Getter @Builder
 public class PepperDSMKitRequest {
-    @JsonProperty("JuniperKitRequest")
     private JuniperKitRequest juniperKitRequest;
     @JsonProperty("juniperStudyGUID")
     private String juniperStudyId;
@@ -38,6 +37,7 @@ public class PepperDSMKitRequest {
                     .city(address.getCity())
                     .state(address.getState())
                     .postalCode(address.getPostalCode())
+                    .country(address.getCountry())
                     .phoneNumber(address.getPhoneNumber());
         }
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/PepperErrorResponse.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/PepperErrorResponse.java
@@ -1,0 +1,15 @@
+package bio.terra.pearl.core.service.kit;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Getter @Setter
+@SuperBuilder @NoArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class PepperErrorResponse {
+    private String errorMessage;
+    private String juniperKitId;
+    private String value;
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/PepperException.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/PepperException.java
@@ -1,0 +1,32 @@
+package bio.terra.pearl.core.service.kit;
+
+import lombok.Getter;
+
+/**
+ * Runtime exception thrown when there's an error with a request to Pepper. Note: This very intentionally extends
+ * RuntimeException in order to auto-trigger rollback when it escapes a @Transactional method. If this was a checked
+ * exception, it would need to be called out in @Transactional's rollbackFor where it might be thrown to prevent
+ * committing the transaction for a failed operation. This is extra code/configuration that is difficult to test, so
+ * instead we'll choose to not "fight the framework".
+ */
+@Getter
+public class PepperException extends RuntimeException {
+    private PepperErrorResponse errorResponse;
+
+    public PepperException(String message) {
+        super(message);
+    }
+
+    public PepperException(String message, Exception cause) {
+        super(message, cause);
+    }
+
+    public PepperException(String message, PepperErrorResponse errorResponse) {
+        super("%s for kit %s: %s".formatted(
+                message,
+                errorResponse.getJuniperKitId(),
+                errorResponse.getErrorMessage()
+        ));
+        this.errorResponse = errorResponse;
+    }
+}

--- a/core/src/main/resources/db/changelog/changesets/2023_08_15_update_saliva_kit_type_name.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2023_08_15_update_saliva_kit_type_name.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: update_saliva_kit_type_name
+      author: breilly
+      changes:
+        - update:
+            tableName: kit_type
+            columns:
+              - column:
+                  { name: name, value: "SALIVA" }
+            where: name='saliva'

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -122,6 +122,9 @@ databaseChangeLog:
   - include:
       file: changesets/2023_07_07_admin_notes.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2023_08_15_update_saliva_kit_type_name.yaml
+      relativeToChangelogFile: true
 
 
 

--- a/core/src/test/java/bio/terra/pearl/core/IntegrationTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/IntegrationTest.java
@@ -1,0 +1,20 @@
+package bio.terra.pearl.core;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker for integration tests that rely on external dependencies and therefore should not be automatically executed
+ * as part of an automated build (or at least treated differently if they fail).
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Test
+@Tag("integration")
+public @interface IntegrationTest {
+}

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/LivePepperDSMClientIntegrationTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/LivePepperDSMClientIntegrationTest.java
@@ -1,0 +1,46 @@
+package bio.terra.pearl.core.service.kit;
+
+import bio.terra.pearl.core.BaseSpringBootTest;
+import bio.terra.pearl.core.IntegrationTest;
+import bio.terra.pearl.core.factory.kit.KitRequestFactory;
+import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
+import org.junit.jupiter.api.Assertions;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class LivePepperDSMClientIntegrationTest extends BaseSpringBootTest {
+
+    @Autowired
+    private LivePepperDSMClient livePepperDSMClient;
+
+    @Transactional
+    @IntegrationTest
+    public void testSendKitRequestParsesInvalidAddressError() throws Exception {
+        // Arrange
+        var enrollee = enrolleeFactory.buildPersisted("testSendKitRequestParsesInvalidAddressError");
+        var kitRequest = kitRequestFactory.buildPersisted("testSendKitRequestParsesInvalidAddressError", enrollee.getId());
+        var address = PepperKitAddress.builder()
+                .firstName("Juniper")
+                .lastName("Testerson")
+                .street1("123 Fake Street")
+                .city("Cambridge")
+                .state("MA")
+                .postalCode("02142")
+                .country("USA")
+                .build();
+
+        PepperException pepperException = Assertions.assertThrows(PepperException.class, () -> {
+            livePepperDSMClient.sendKitRequest(enrollee, kitRequest, address);
+        });
+
+        assertThat(pepperException.getErrorResponse().getErrorMessage(), equalTo("UNKNOWN_KIT_TYPE"));
+    }
+
+    @Autowired
+    private EnrolleeFactory enrolleeFactory;
+    @Autowired
+    private KitRequestFactory kitRequestFactory;
+}

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/LivePepperDSMClientTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/LivePepperDSMClientTest.java
@@ -1,0 +1,146 @@
+package bio.terra.pearl.core.service.kit;
+
+import bio.terra.pearl.core.BaseSpringBootTest;
+import bio.terra.pearl.core.factory.kit.KitRequestFactory;
+import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
+import bio.terra.pearl.core.model.kit.KitRequest;
+import bio.terra.pearl.core.model.participant.Enrollee;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.apache.http.entity.ContentType;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.function.Executable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+public class LivePepperDSMClientTest extends BaseSpringBootTest {
+
+    // Common test fixture entities
+    private Enrollee enrollee;
+    private KitRequest kitRequest;
+    private PepperKitAddress address;
+
+    @MockBean
+    private PepperDSMConfig pepperDSMConfig;
+
+    // select the LivePepperDSMClient @Component, not PepperDSMClientProvider.getLivePepperDSMClient()
+    // (which should be exactly the same thing in this case, but Spring can't know that)
+    @Qualifier("livePepperDSMClient")
+    @Autowired
+    private LivePepperDSMClient client;
+
+    public static MockWebServer mockWebServer;
+
+    @BeforeEach
+    void startup(TestInfo info) throws Exception {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        when(pepperDSMConfig.getBasePath())
+                .thenReturn("http://localhost:%d".formatted(mockWebServer.getPort()));
+        when(pepperDSMConfig.getSecret())
+                .thenReturn("secret");
+
+        enrollee = enrolleeFactory.buildPersisted(info.getDisplayName());
+        kitRequest = kitRequestFactory.buildPersisted(info.getDisplayName(), enrollee.getId());
+        address = PepperKitAddress.builder().build();
+    }
+
+    @AfterEach void shutdown() throws Exception {
+        mockWebServer.shutdown();
+    }
+
+    @Transactional
+    @Test
+    public void testSuccessResponseFromPepper() throws Exception {
+        // Arrange
+        PepperKitStatus kitStatus = PepperKitStatus.builder()
+                .kitId(kitRequest.getId().toString())
+                .currentStatus("New")
+                .build();
+        mockPepperResponse(HttpStatus.OK, objectMapper.writeValueAsString(kitStatus));
+
+        // Act
+        var response = client.sendKitRequest(enrollee, kitRequest, address);
+
+        assertThat(response, containsString(kitStatus.getKitId()));
+        assertThat(response, containsString("New"));
+    }
+
+    @Transactional
+    @Test
+    public void testMalformedErrorResponseFromPepper() throws Exception {
+        // Arrange
+        var unexpectedJsonBody = "{\"error\": \"boom\"}";
+        mockPepperResponse(HttpStatus.BAD_REQUEST, unexpectedJsonBody);
+
+        // "Act"
+        Executable act = () -> client.sendKitRequest(enrollee, kitRequest, address);
+
+        // Assert
+        PepperException pepperException = assertThrows(PepperException.class, act);
+        assertThat(pepperException.getMessage(), containsString(unexpectedJsonBody));
+    }
+
+    @Transactional
+    @Test
+    public void test4xxResponseFromPepper() throws Exception {
+        // Arrange
+        var kitId = "111-222-333";
+        var errorMessage = "UNABLE_TO_VERIFY_ADDRESS";
+        mockPepperResponse(
+                HttpStatus.BAD_REQUEST,
+                objectMapper.writeValueAsString(PepperErrorResponse.builder()
+                        .juniperKitId(kitId)
+                        .errorMessage(errorMessage)
+                        .build()
+        ));
+
+        // "Act"
+        Executable act = () -> client.sendKitRequest(enrollee, kitRequest, address);
+
+        // Assert
+        var pepperException = assertThrows(PepperException.class, act);
+        assertThat(pepperException.getMessage(), containsString(kitId));
+        assertThat(pepperException.getMessage(), containsString(errorMessage));
+    }
+
+    @Transactional
+    @Test
+    public void test5xxResponseFromPepper() throws Exception {
+        // Arrange
+        var errorResponseBody = "Internal server error";
+        mockPepperResponse(HttpStatus.INTERNAL_SERVER_ERROR, errorResponseBody);
+
+        // "Act"
+        Executable act = () -> client.sendKitRequest(enrollee, kitRequest, address);
+
+        // Assert
+        var pepperException = assertThrows(PepperException.class, act);
+        assertThat(pepperException.getMessage(), containsString(errorResponseBody));
+    }
+
+    private static void mockPepperResponse(HttpStatus status, String pepperResponse) {
+        mockWebServer.enqueue(new MockResponse()
+                .addHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON)
+                .setResponseCode(status.value())
+                .setBody(pepperResponse));
+    }
+
+    @Autowired
+    private EnrolleeFactory enrolleeFactory;
+    @Autowired
+    private KitRequestFactory kitRequestFactory;
+    @Autowired
+    private ObjectMapper objectMapper;
+}

--- a/core/src/test/resources/application.yml
+++ b/core/src/test/resources/application.yml
@@ -8,6 +8,9 @@ env:
     password: ${DATABASE_USER_PASSWORD:dbpwd}
     user: ${DATABASE_USER:test_dbuser}
 
+  dsm:
+    basePath: ${DSM_ADDRESS:https://dsm-dev.datadonationplatform.org/ddp}
+    secret: ${DSM_JWT_SIGNING_SECRET:}
   tracing:
     exportEnabled: ${CLOUD_TRACE_ENABLED:false}
     samplingRate: ${SAMPLING_PROBABILITY:0}

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/kit/KitRequestFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/kit/KitRequestFactory.java
@@ -38,7 +38,9 @@ public class KitRequestFactory {
 
     public KitRequest buildPersisted(String testName, UUID enrolleeId) throws JsonProcessingException {
         KitType kitType = kitTypeFactory.buildPersisted(testName);
-        return buildPersisted(testName, enrolleeId, kitType.getId());
+        var kitRequest = buildPersisted(testName, enrolleeId, kitType.getId());
+        kitRequest.setKitType(kitType);
+        return kitRequest;
     }
 
     public KitRequest buildPersisted(String testName, UUID enrolleeId, UUID kitTypeId) throws JsonProcessingException {

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
@@ -79,7 +79,7 @@
   "kitRequestDtos": [
     {
       "creatingAdminUsername": "staff@heartdemo.org",
-      "kitTypeName": "saliva",
+      "kitTypeName": "SALIVA",
       "statusName": "CREATED",
       "dsmStatusJson": {
         "kitId": "11111111-2222-3333-4444-555555555555",

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
@@ -23,7 +23,7 @@
     "emails/surveyReminder.json",
     "emails/adHoc.json"
   ],
-  "kitTypeNames": [ "saliva" ],
+  "kitTypeNames": [ "SALIVA" ],
   "studyEnvironmentDtos": [
     {
       "environmentName": "sandbox",

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/enrollees/jsalk.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/enrollees/jsalk.json
@@ -69,7 +69,7 @@
   "kitRequestDtos": [
     {
       "creatingAdminUsername": "staff@ourhealth.org",
-      "kitTypeName": "saliva",
+      "kitTypeName": "SALIVA",
       "statusName": "CREATED",
       "dsmStatusJson": {
         "kitId": "11111111-2222-3333-4444-555555555555",

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/enrollees/seed.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/enrollees/seed.json
@@ -94,7 +94,7 @@
   "kitRequestDtos": [
     {
       "creatingAdminUsername": "staff@ourhealth.org",
-      "kitTypeName": "saliva",
+      "kitTypeName": "SALIVA",
       "statusName": "CREATED",
       "dsmStatusJson": {
         "kitId": "11111111-2222-3333-4444-555555555555",

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/study.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/study.json
@@ -22,7 +22,7 @@
     "emails/surveyReminder.json",
     "emails/adHoc.json"
   ],
-  "kitTypeNames": [ "saliva" ],
+  "kitTypeNames": [ "SALIVA" ],
   "studyEnvironmentDtos": [
     {
       "environmentName": "sandbox",


### PR DESCRIPTION
Includes additional tests, including integration tests against dev pepper (which currently must be invoked manually).

To test:
1. Run all tests
2. Run integration tests: `./gradlew integrationTest`; note: the existing test intentionally makes a Pepper request that should fail to avoid accumulation of test data in Pepper