### PR TITLE
[JN-452] Form version selector

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/SurveyController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/SurveyController.java
@@ -36,6 +36,12 @@ public class SurveyController implements SurveyApi {
   }
 
   @Override
+  public ResponseEntity<Object> getAllVersions(String portalShortcode, String stableId) {
+    AdminUser adminUser = requestService.requireAdminUser(request);
+    return ResponseEntity.ok(surveyExtService.listVersions(portalShortcode, stableId, adminUser));
+  }
+
+  @Override
   public ResponseEntity<Object> create(String portalShortcode, Object body) {
     AdminUser adminUser = requestService.requireAdminUser(request);
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
@@ -44,6 +44,9 @@ public class SurveyExtService {
   public List<Survey> listVersions(String portalShortcode, String stableId, AdminUser adminUser) {
     Portal portal = authUtilService.authUserToPortal(adminUser, portalShortcode);
     // TODO: do we need to auth survey to portal here?
+    //This is used to power the version selector in the admin UI. It's not necessary to return the surveys
+    //with any content or answer mappings- the response will be too large. Instead, just get the individual
+    //versions as content is needed.
     List<Survey> surveys = surveyService.findByStableIdNoContent(stableId);
     return surveys;
   }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
@@ -41,6 +41,13 @@ public class SurveyExtService {
     return survey;
   }
 
+  public List<Survey> listVersions(String portalShortcode, String stableId, AdminUser adminUser) {
+    Portal portal = authUtilService.authUserToPortal(adminUser, portalShortcode);
+    // TODO: do we need to auth survey to portal here?
+    List<Survey> surveys = surveyService.findByStableIdNoContent(stableId);
+    return surveys;
+  }
+
   public Survey create(String portalShortcode, Survey survey, AdminUser adminUser) {
     Portal portal = authUtilService.authUserToPortal(adminUser, portalShortcode);
     List<Survey> existing = surveyService.findByStableId(survey.getStableId());

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
@@ -49,7 +49,8 @@ public class SurveyExtService {
     // to return the surveys with any content or answer mappings, the response will
     // be too large. Instead, just get the individual versions as content is needed.
     List<Survey> surveys = surveyService.findByStableIdNoContent(stableId);
-    return surveys;
+    List<Survey> surveysInPortal = surveys.stream().map().filter(survey -> portal.getId().equals(survey.getPortalId())).toList();
+    return surveysInPortal;
   }
 
   public Survey create(String portalShortcode, Survey survey, AdminUser adminUser) {

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
@@ -43,17 +43,12 @@ public class SurveyExtService {
 
   public List<Survey> listVersions(String portalShortcode, String stableId, AdminUser adminUser) {
     Portal portal = authUtilService.authUserToPortal(adminUser, portalShortcode);
-    authSurveyToPortal(portal, stableId, 1); // TODO: this assumes there's always a v1. Bad?
-
     // This is used to populate the version selector in the admin UI. It's not necessary
     // to return the surveys with any content or answer mappings, the response will
     // be too large. Instead, just get the individual versions as content is needed.
     List<Survey> surveys = surveyService.findByStableIdNoContent(stableId);
     List<Survey> surveysInPortal =
-        surveys.stream()
-            .map()
-            .filter(survey -> portal.getId().equals(survey.getPortalId()))
-            .toList();
+        surveys.stream().filter(survey -> portal.getId().equals(survey.getPortalId())).toList();
     return surveysInPortal;
   }
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
@@ -49,7 +49,11 @@ public class SurveyExtService {
     // to return the surveys with any content or answer mappings, the response will
     // be too large. Instead, just get the individual versions as content is needed.
     List<Survey> surveys = surveyService.findByStableIdNoContent(stableId);
-    List<Survey> surveysInPortal = surveys.stream().map().filter(survey -> portal.getId().equals(survey.getPortalId())).toList();
+    List<Survey> surveysInPortal =
+        surveys.stream()
+            .map()
+            .filter(survey -> portal.getId().equals(survey.getPortalId()))
+            .toList();
     return surveysInPortal;
   }
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
@@ -43,10 +43,11 @@ public class SurveyExtService {
 
   public List<Survey> listVersions(String portalShortcode, String stableId, AdminUser adminUser) {
     Portal portal = authUtilService.authUserToPortal(adminUser, portalShortcode);
-    // TODO: do we need to auth survey to portal here?
-    //This is used to power the version selector in the admin UI. It's not necessary to return the surveys
-    //with any content or answer mappings- the response will be too large. Instead, just get the individual
-    //versions as content is needed.
+    authSurveyToPortal(portal, stableId, 1); //TODO: this assumes there's always a v1. Bad?
+
+    // This is used to power the version selector in the admin UI. It's not necessary
+    // to return the surveys with any content or answer mappings, the response will
+    // be too large. Instead, just get the individual versions as content is needed.
     List<Survey> surveys = surveyService.findByStableIdNoContent(stableId);
     return surveys;
   }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
@@ -43,9 +43,9 @@ public class SurveyExtService {
 
   public List<Survey> listVersions(String portalShortcode, String stableId, AdminUser adminUser) {
     Portal portal = authUtilService.authUserToPortal(adminUser, portalShortcode);
-    authSurveyToPortal(portal, stableId, 1); //TODO: this assumes there's always a v1. Bad?
+    authSurveyToPortal(portal, stableId, 1); // TODO: this assumes there's always a v1. Bad?
 
-    // This is used to power the version selector in the admin UI. It's not necessary
+    // This is used to populate the version selector in the admin UI. It's not necessary
     // to return the surveys with any content or answer mappings, the response will
     // be too large. Instead, just get the individual versions as content is needed.
     List<Survey> surveys = surveyService.findByStableIdNoContent(stableId);

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -129,6 +129,20 @@ paths:
           content: { application/json: { schema: {type: object} } }
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/surveys/{stableId}:
+    get:
+      summary: gets all versions of the requested survey
+      tags: [ survey ]
+      operationId: getAllVersions
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: stableId, in: path, required: true, schema: { type: string } }
+      responses:
+        '200':
+          description: survey object
+          content: { application/json: { schema: { type: object } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/surveys:
     post:
       summary: creates the requested survey, will fail if the given stableId already exists

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -139,7 +139,7 @@ paths:
         - { name: stableId, in: path, required: true, schema: { type: string } }
       responses:
         '200':
-          description: survey object
+          description: list of survey version metadata
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/SurveyExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/SurveyExtServiceTests.java
@@ -75,6 +75,15 @@ public class SurveyExtServiceTests {
   }
 
   @Test
+  public void listVersionsRequiresPortalAuth() {
+    AdminUser user = AdminUser.builder().superuser(false).build();
+    when(mockAuthUtilService.authUserToPortal(user, "foo"))
+        .thenThrow(new PermissionDeniedException("test1"));
+    Assertions.assertThrows(
+        PermissionDeniedException.class, () -> surveyExtService.listVersions("foo", "blah", user));
+  }
+
+  @Test
   public void getRequiresSurveyMatchedToPortal() {
     AdminUser user = AdminUser.builder().superuser(false).build();
     Portal portal = Portal.builder().shortcode("testSurveyGet").id(UUID.randomUUID()).build();

--- a/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyDao.java
@@ -26,7 +26,7 @@ public class SurveyDao extends BaseVersionedJdbiDao<Survey> {
 
     public List<Survey> findByStableIdNoContent(String stableId) {
         List<Survey> surveys = jdbi.withHandle(handle ->
-                handle.createQuery("select id, name, created_at, last_updated_at, version, stable_id from survey where stable_id = :stableId;")
+                handle.createQuery("select id, name, created_at, last_updated_at, version, stable_id, portal_id from survey where stable_id = :stableId;")
                         .bind("stableId", stableId)
                         .mapTo(clazz)
                         .list()

--- a/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyDao.java
@@ -23,6 +23,7 @@ public class SurveyDao extends BaseVersionedJdbiDao<Survey> {
         });
         return surveyOpt;
     }
+
     public List<Survey> findByStableIdNoContent(String stableId) {
         List<Survey> surveys = jdbi.withHandle(handle ->
                 handle.createQuery("select id, name, created_at, last_updated_at, version, stable_id from survey where stable_id = :stableId;")

--- a/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyDao.java
@@ -25,7 +25,7 @@ public class SurveyDao extends BaseVersionedJdbiDao<Survey> {
     }
     public List<Survey> findByStableIdNoContent(String stableId) {
         List<Survey> surveys = jdbi.withHandle(handle ->
-                handle.createQuery("select id, name, version, stable_id from survey where stable_id = :stableId;")
+                handle.createQuery("select id, name, created_at, last_updated_at, version, stable_id from survey where stable_id = :stableId;")
                         .bind("stableId", stableId)
                         .mapTo(clazz)
                         .list()

--- a/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyDao.java
@@ -23,12 +23,20 @@ public class SurveyDao extends BaseVersionedJdbiDao<Survey> {
         });
         return surveyOpt;
     }
+    public List<Survey> findByStableIdNoContent(String stableId) {
+        List<Survey> surveys = jdbi.withHandle(handle ->
+                handle.createQuery("select id, name, version, stable_id from survey where stable_id = :stableId;")
+                        .bind("stableId", stableId)
+                        .mapTo(clazz)
+                        .list()
+        );
+        return surveys;
+    }
 
     public List<Survey> findByPortalId(UUID portalId) {
         return findAllByProperty("portal_id", portalId);
     }
 
-    /** omits the content from the return object to save space/fetch time */
     public List<Survey> findByPortalIdNoContent(UUID portalId) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("select id, name, version, stable_id from survey where portal_id = :portalId;")

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyService.java
@@ -36,6 +36,10 @@ public class SurveyService extends ImmutableEntityService<Survey, SurveyDao> imp
         return dao.findByStableId(stableId);
     }
 
+    public List<Survey> findByStableIdNoContent(String stableId) {
+        return dao.findByStableIdNoContent(stableId);
+    }
+
     public Optional<Survey> findByStableIdWithMappings(String stableId, int version) {
         return dao.findByStableIdWithMappings(stableId, version);
     }

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -478,8 +478,8 @@ export default {
     return await this.processJsonResponse(response)
   },
 
-  async getSurveyVersions(studyShortname: string, stableId: string) {
-    const response = await fetch(`${API_ROOT}/studies/${studyShortname}/surveys/${stableId}`, this.getGetInit())
+  async getSurveyVersions(portalShortcode: string, stableId: string): Promise<Survey[]> {
+    const response = await fetch(`${API_ROOT}/portals/v1/${portalShortcode}/surveys/${stableId}`, this.getGetInit())
     return await this.processJsonResponse(response)
   },
 

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -479,7 +479,6 @@ export default {
   },
 
   async getSurveyVersions(portalShortcode: string, stableId: string): Promise<Survey[]> {
-    console.log('wtf')
     const response = await fetch(`${API_ROOT}/portals/v1/${portalShortcode}/surveys/${stableId}`, this.getGetInit())
     return await this.processJsonResponse(response)
   },

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -479,6 +479,7 @@ export default {
   },
 
   async getSurveyVersions(portalShortcode: string, stableId: string): Promise<Survey[]> {
+    console.log('wtf')
     const response = await fetch(`${API_ROOT}/portals/v1/${portalShortcode}/surveys/${stableId}`, this.getGetInit())
     return await this.processJsonResponse(response)
   },

--- a/ui-admin/src/forms/FormContentEditor.test.tsx
+++ b/ui-admin/src/forms/FormContentEditor.test.tsx
@@ -15,7 +15,7 @@ describe('FormContentEditor', () => {
   it('should trap FormDesigner errors in an ErrorBoundary', () => {
     // Arrange
     const { container } = render(<FormContentEditor
-      initialContent={formContent} readOnly={false} onChange={jest.fn()}
+      initialContent={formContent} visibleVersionPreviews={[]} readOnly={false} onChange={jest.fn()}
     />)
 
     // Assert

--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Tab, Tabs } from 'react-bootstrap'
 
-import { FormContent } from '@juniper/ui-core'
+import { FormContent, VersionedForm } from '@juniper/ui-core'
 
 import { FormDesigner } from './FormDesigner'
 import { OnChangeFormContent } from './formEditorTypes'
@@ -12,6 +12,7 @@ import ErrorBoundary from 'util/ErrorBoundary'
 
 type FormContentEditorProps = {
   initialContent: string
+  previewedVersions: VersionedForm[]
   readOnly: boolean
   onChange: OnChangeFormContent
 }
@@ -19,7 +20,7 @@ type FormContentEditorProps = {
 // TODO: Add JSDoc
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const FormContentEditor = (props: FormContentEditorProps) => {
-  const { initialContent, readOnly, onChange } = props
+  const { initialContent, previewedVersions, readOnly, onChange } = props
 
   const [activeTab, setActiveTab] = useState<string | null>('designer')
   const [tabsEnabled, setTabsEnabled] = useState(true)
@@ -86,6 +87,15 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
             <FormPreview formContent={editedContent} />
           </ErrorBoundary>
         </Tab>
+        { previewedVersions.map(form =>
+          <Tab
+            disabled={activeTab !== `preview${form.version}` && !tabsEnabled}
+            eventKey={`preview${form.version}`}
+            title={`Version ${form.version}`}
+          >
+            <FormPreview formContent={JSON.parse(form.content) as FormContent} />
+          </Tab>
+        )}
       </Tabs>
     </div>
   )

--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -90,6 +90,7 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
         { previewedVersions.map(form =>
           <Tab
             disabled={activeTab !== `preview${form.version}` && !tabsEnabled}
+            key={`preview${form.version}`}
             eventKey={`preview${form.version}`}
             title={`Version ${form.version}`}
           >

--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -12,7 +12,7 @@ import ErrorBoundary from 'util/ErrorBoundary'
 
 type FormContentEditorProps = {
   initialContent: string
-  previewedVersions: VersionedForm[]
+  visibleVersionPreviews: VersionedForm[]
   readOnly: boolean
   onChange: OnChangeFormContent
 }
@@ -20,7 +20,7 @@ type FormContentEditorProps = {
 // TODO: Add JSDoc
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const FormContentEditor = (props: FormContentEditorProps) => {
-  const { initialContent, previewedVersions, readOnly, onChange } = props
+  const { initialContent, visibleVersionPreviews, readOnly, onChange } = props
 
   const [activeTab, setActiveTab] = useState<string | null>('designer')
   const [tabsEnabled, setTabsEnabled] = useState(true)
@@ -87,7 +87,7 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
             <FormPreview formContent={editedContent} />
           </ErrorBoundary>
         </Tab>
-        { previewedVersions.map(form =>
+        { visibleVersionPreviews.map(form =>
           <Tab
             disabled={activeTab !== `preview${form.version}` && !tabsEnabled}
             key={`preview${form.version}`}

--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -89,7 +89,6 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
         </Tab>
         { visibleVersionPreviews.map(form =>
           <Tab
-            disabled={activeTab !== `preview${form.version}` && !tabsEnabled}
             key={`preview${form.version}`}
             eventKey={`preview${form.version}`}
             title={`Version ${form.version}`}

--- a/ui-admin/src/study/surveys/ConsentView.tsx
+++ b/ui-admin/src/study/surveys/ConsentView.tsx
@@ -50,6 +50,7 @@ function RawConsentView({ studyEnvContext, consent, readOnly = false }:
 
   return (
     <SurveyEditorView
+      studyEnvContext={studyEnvContext}
       currentForm={currentForm}
       readOnly={readOnly}
       onCancel={() => navigate(studyEnvFormsPath(portal.shortcode, study.shortcode, currentEnv.environmentName))}

--- a/ui-admin/src/study/surveys/PreEnrollView.tsx
+++ b/ui-admin/src/study/surveys/PreEnrollView.tsx
@@ -43,6 +43,7 @@ function RawPreEnrollView({ studyEnvContext, survey, readOnly = false }:
   }
 
   return <SurveyEditorView
+    studyEnvContext={studyEnvContext}
     currentForm={currentSurvey}
     readOnly={readOnly}
     onCancel={() => navigate(studyEnvFormsPath(portal.shortcode, study.shortcode, currentEnv.environmentName))}

--- a/ui-admin/src/study/surveys/SurveyEditorView.test.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react'
 import SurveyEditorView from './SurveyEditorView'
 import { getFormDraftKey } from '../../forms/designer/utils/formDraftUtils'
 import { VersionedForm } from '@juniper/ui-core'
+import { mockStudyEnvContext } from 'test-utils/mocking-utils'
 
 describe('SurveyEditorView', () => {
   const mockForm: VersionedForm = {
@@ -23,6 +24,7 @@ describe('SurveyEditorView', () => {
     jest.spyOn(Storage.prototype, 'getItem')
 
     render(<SurveyEditorView
+      studyEnvContext={mockStudyEnvContext()}
       currentForm={mockForm}
       onCancel={jest.fn()}
       onSave={jest.fn()}
@@ -40,6 +42,7 @@ describe('SurveyEditorView', () => {
     jest.spyOn(Storage.prototype, 'getItem')
 
     render(<SurveyEditorView
+      studyEnvContext={mockStudyEnvContext()}
       currentForm={mockForm}
       onCancel={jest.fn()}
       onSave={jest.fn()}

--- a/ui-admin/src/study/surveys/SurveyEditorView.test.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import SurveyEditorView from './SurveyEditorView'
-import { getFormDraftKey } from '../../forms/designer/utils/formDraftUtils'
+import { getFormDraftKey } from 'forms/designer/utils/formDraftUtils'
 import { VersionedForm } from '@juniper/ui-core'
 import { mockStudyEnvContext } from 'test-utils/mocking-utils'
 

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -11,8 +11,10 @@ import { useAutosaveEffect } from '@juniper/ui-core/build/autoSaveUtils'
 import { faClockRotateLeft } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import VersionSelector from './VersionSelector'
+import { StudyEnvContextT } from '../StudyEnvironmentRouter'
 
 type SurveyEditorViewProps = {
+  studyEnvContext: StudyEnvContextT
   currentForm: VersionedForm
   readOnly?: boolean
   onCancel: () => void
@@ -22,6 +24,7 @@ type SurveyEditorViewProps = {
 /** renders a survey for editing/viewing */
 const SurveyEditorView = (props: SurveyEditorViewProps) => {
   const {
+    studyEnvContext,
     currentForm,
     readOnly = false,
     onCancel,
@@ -30,6 +33,7 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
 
   const FORM_DRAFT_KEY = getFormDraftKey({ form: currentForm })
   const FORM_DRAFT_SAVE_INTERVAL = 10000
+  //returns portal context
 
   const [isEditorValid, setIsEditorValid] = useState(true)
   const [saving, setSaving] = useState(false)
@@ -136,7 +140,7 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
               onDismiss={() => setShowDiscardDraftModal(false)}
             />}
         { showVersionSelector && <VersionSelector
-          portalShortcode={'ourhealth'}
+          portalShortcode={studyEnvContext.portal.shortcode}
           previewedVersions={previewedVersions}
           setPreviewedVersions={setPreviewedVersions}
           stableId={currentForm.stableId}

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -139,7 +139,7 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
               onDismiss={() => setShowDiscardDraftModal(false)}
             />}
         { showVersionSelector && <VersionSelector
-          portalShortcode={studyEnvContext.portal.shortcode}
+          studyEnvContext={studyEnvContext}
           visibleVersionPreviews={visibleVersionPreviews}
           setVisibleVersionPreviews={setVisibleVersionPreviews}
           stableId={currentForm.stableId}

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -8,6 +8,9 @@ import LoadedLocalDraftModal from 'forms/designer/modals/LoadedLocalDraftModal'
 import DiscardLocalDraftModal from 'forms/designer/modals/DiscardLocalDraftModal'
 import { deleteDraft, FormDraft, getDraft, getFormDraftKey, saveDraft } from 'forms/designer/utils/formDraftUtils'
 import { useAutosaveEffect } from '@juniper/ui-core/build/autoSaveUtils'
+import { faClockRotateLeft } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import VersionSelector from './VersionSelector'
 
 type SurveyEditorViewProps = {
   currentForm: VersionedForm
@@ -36,6 +39,8 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
   //for them to know if the version of the survey they're seeing are from a draft or are actually published.
   const [showLoadedDraftModal, setShowLoadedDraftModal] = useState(!!getDraft({ formDraftKey: FORM_DRAFT_KEY }))
   const [showDiscardDraftModal, setShowDiscardDraftModal] = useState(false)
+  const [showVersionSelector, setShowVersionSelector] = useState(false)
+  const [previewedVersions, setPreviewedVersions] = useState<VersionedForm[]>([])
 
   const [draft, setDraft] = useState<FormDraft | undefined>(
     !readOnly ? getDraft({ formDraftKey: FORM_DRAFT_KEY }) : undefined)
@@ -87,6 +92,9 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
         <div className="d-flex flex-grow-1">
           <h5>{currentForm.name}
             <span className="detail me-2 ms-2">version {currentForm.version}</span>
+            <button className="btn btn-secondary" onClick={() => setShowVersionSelector(true)}>
+              <FontAwesomeIcon icon={faClockRotateLeft}/> History
+            </button>
           </h5>
         </div>
         { savingDraft && <span className="detail me-2 ms-2">Saving draft...</span> }
@@ -127,9 +135,18 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
                 })}
               onDismiss={() => setShowDiscardDraftModal(false)}
             />}
+        { showVersionSelector && <VersionSelector
+          portalShortcode={'ourhealth'}
+          previewedVersions={previewedVersions}
+          setPreviewedVersions={setPreviewedVersions}
+          stableId={currentForm.stableId}
+          setShow={setShowVersionSelector}
+          show={showVersionSelector}/>
+        }
       </div>
       <FormContentEditor
         initialContent={draft?.content || currentForm.content} //favor loading the draft, if we find one
+        previewedVersions={previewedVersions}
         readOnly={readOnly}
         onChange={(isValid, newContent) => {
           if (isValid) {

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -33,7 +33,6 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
 
   const FORM_DRAFT_KEY = getFormDraftKey({ form: currentForm })
   const FORM_DRAFT_SAVE_INTERVAL = 10000
-  //returns portal context
 
   const [isEditorValid, setIsEditorValid] = useState(true)
   const [saving, setSaving] = useState(false)
@@ -44,7 +43,7 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
   const [showLoadedDraftModal, setShowLoadedDraftModal] = useState(!!getDraft({ formDraftKey: FORM_DRAFT_KEY }))
   const [showDiscardDraftModal, setShowDiscardDraftModal] = useState(false)
   const [showVersionSelector, setShowVersionSelector] = useState(false)
-  const [previewedVersions, setPreviewedVersions] = useState<VersionedForm[]>([])
+  const [visibleVersionPreviews, setVisibleVersionPreviews] = useState<VersionedForm[]>([])
 
   const [draft, setDraft] = useState<FormDraft | undefined>(
     !readOnly ? getDraft({ formDraftKey: FORM_DRAFT_KEY }) : undefined)
@@ -141,8 +140,8 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
             />}
         { showVersionSelector && <VersionSelector
           portalShortcode={studyEnvContext.portal.shortcode}
-          previewedVersions={previewedVersions}
-          setPreviewedVersions={setPreviewedVersions}
+          visibleVersionPreviews={visibleVersionPreviews}
+          setVisibleVersionPreviews={setVisibleVersionPreviews}
           stableId={currentForm.stableId}
           setShow={setShowVersionSelector}
           show={showVersionSelector}/>
@@ -150,7 +149,7 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
       </div>
       <FormContentEditor
         initialContent={draft?.content || currentForm.content} //favor loading the draft, if we find one
-        previewedVersions={previewedVersions}
+        visibleVersionPreviews={visibleVersionPreviews}
         readOnly={readOnly}
         onChange={(isValid, newContent) => {
           if (isValid) {

--- a/ui-admin/src/study/surveys/SurveyView.tsx
+++ b/ui-admin/src/study/surveys/SurveyView.tsx
@@ -54,6 +54,7 @@ function RawSurveyView({ studyEnvContext, survey, readOnly = false }:
 
   return (
     <SurveyEditorView
+      studyEnvContext={studyEnvContext}
       currentForm={currentSurvey}
       readOnly={readOnly}
       onCancel={() => navigate(studyEnvFormsPath(portal.shortcode, study.shortcode, currentEnv.environmentName))}

--- a/ui-admin/src/study/surveys/VersionSelector.test.tsx
+++ b/ui-admin/src/study/surveys/VersionSelector.test.tsx
@@ -14,7 +14,6 @@ jest.mock('api/api', () => ({
 }))
 
 describe('VersionSelector', () => {
-
   test('renders a list of form versions that can be selected', async () => {
     //Arrange
     const studyEnvContext = mockStudyEnvContext()

--- a/ui-admin/src/study/surveys/VersionSelector.test.tsx
+++ b/ui-admin/src/study/surveys/VersionSelector.test.tsx
@@ -1,0 +1,68 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+import { mockStudyEnvContext, mockSurvey, mockSurveyVersionsList } from 'test-utils/mocking-utils'
+import userEvent from '@testing-library/user-event'
+import VersionSelector from './VersionSelector'
+import { select } from 'react-select-event'
+
+jest.mock('api/api', () => ({
+  getSurveyVersions: () => {
+    return Promise.resolve(mockSurveyVersionsList())
+  },
+  getSurvey: () => {
+    return Promise.resolve(mockSurvey())
+  }
+}))
+
+describe('VersionSelector', () => {
+
+  test('renders the list of form versions', async () => {
+    //Arrange
+    const user = userEvent.setup()
+    const studyEnvContext = mockStudyEnvContext()
+    render(<VersionSelector
+      portalShortcode={studyEnvContext.portal.shortcode}
+      stableId={mockSurvey().stableId}
+      show={true}
+      setShow={jest.fn()}
+      previewedVersions={[]}
+      setPreviewedVersions={jest.fn()}
+    />)
+
+    //Act
+    await waitFor(() => expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument())
+    const versionSelect = screen.getByLabelText('Select version to preview') as HTMLSelectElement
+    await select(screen.getByLabelText('Select version to preview'), ['1'])
+
+    //Assert
+    expect(versionSelect).toHaveValue(1)
+  })
+
+  // test('does not let the user preview the same form version twice', () => {
+  //   //Arrange
+  //   jest.mock('api/api', () => ({
+  //     getSurveyVersions: () => {
+  //       return Promise.resolve(tail(mockSurveyVersionsList()))
+  //     }
+  //   }))
+  //
+  //   const studyEnvContext = mockStudyEnvContext()
+  //   render(<VersionSelector
+  //     portalShortcode={studyEnvContext.portal.shortcode}
+  //     stableId={mockSurvey().stableId}
+  //     show={true}
+  //     setShow={jest.fn()}
+  //     previewedVersions={[head(mockSurveyVersionsList())!]}
+  //     setPreviewedVersions={jest.fn()}
+  //   />)
+  //
+  //   //Assert
+  //   const versionDropdown = screen.getByText('Select version to preview') as HTMLSelectElement
+  //
+  //   console.log(versionDropdown.options)
+  //
+  //   mockSurveyVersionsList().forEach((survey) => {
+  //     expect(versionDropdown.options.namedItem(survey.version.toString())).toBeInTheDocument()
+  //   })
+  // })
+})

--- a/ui-admin/src/study/surveys/VersionSelector.test.tsx
+++ b/ui-admin/src/study/surveys/VersionSelector.test.tsx
@@ -1,7 +1,6 @@
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import { mockStudyEnvContext, mockSurvey, mockSurveyVersionsList } from 'test-utils/mocking-utils'
-import userEvent from '@testing-library/user-event'
 import VersionSelector from './VersionSelector'
 import { select } from 'react-select-event'
 
@@ -24,8 +23,8 @@ describe('VersionSelector', () => {
       stableId={mockSurvey().stableId}
       show={true}
       setShow={jest.fn()}
-      previewedVersions={[]}
-      setPreviewedVersions={jest.fn()}
+      visibleVersionPreviews={[]}
+      setVisibleVersionPreviews={jest.fn()}
     />)
 
     //Act

--- a/ui-admin/src/study/surveys/VersionSelector.test.tsx
+++ b/ui-admin/src/study/surveys/VersionSelector.test.tsx
@@ -29,9 +29,11 @@ describe('VersionSelector', () => {
     //Act
     await waitFor(() => expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument())
     await select(screen.getByLabelText('Select version to preview'), ['1'])
-    const openPreviewButton = screen.getByText('Open version')
+    const openPreviewButton = screen.getByText('View preview')
+    const openEditorButton = screen.getByText('Open read-only editor')
 
     //Assert
     expect(openPreviewButton).toBeEnabled()
+    expect(openEditorButton).toBeEnabled()
   })
 })

--- a/ui-admin/src/study/surveys/VersionSelector.test.tsx
+++ b/ui-admin/src/study/surveys/VersionSelector.test.tsx
@@ -18,7 +18,7 @@ describe('VersionSelector', () => {
     //Arrange
     const studyEnvContext = mockStudyEnvContext()
     render(<VersionSelector
-      portalShortcode={studyEnvContext.portal.shortcode}
+      studyEnvContext={studyEnvContext}
       stableId={mockSurvey().stableId}
       show={true}
       setShow={jest.fn()}

--- a/ui-admin/src/study/surveys/VersionSelector.test.tsx
+++ b/ui-admin/src/study/surveys/VersionSelector.test.tsx
@@ -16,9 +16,8 @@ jest.mock('api/api', () => ({
 
 describe('VersionSelector', () => {
 
-  test('renders the list of form versions', async () => {
+  test('renders a list of form versions that can be selected', async () => {
     //Arrange
-    const user = userEvent.setup()
     const studyEnvContext = mockStudyEnvContext()
     render(<VersionSelector
       portalShortcode={studyEnvContext.portal.shortcode}
@@ -31,38 +30,10 @@ describe('VersionSelector', () => {
 
     //Act
     await waitFor(() => expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument())
-    const versionSelect = screen.getByLabelText('Select version to preview') as HTMLSelectElement
     await select(screen.getByLabelText('Select version to preview'), ['1'])
+    const openPreviewButton = screen.getByText('Open version')
 
     //Assert
-    expect(versionSelect).toHaveValue(1)
+    expect(openPreviewButton).toBeEnabled()
   })
-
-  // test('does not let the user preview the same form version twice', () => {
-  //   //Arrange
-  //   jest.mock('api/api', () => ({
-  //     getSurveyVersions: () => {
-  //       return Promise.resolve(tail(mockSurveyVersionsList()))
-  //     }
-  //   }))
-  //
-  //   const studyEnvContext = mockStudyEnvContext()
-  //   render(<VersionSelector
-  //     portalShortcode={studyEnvContext.portal.shortcode}
-  //     stableId={mockSurvey().stableId}
-  //     show={true}
-  //     setShow={jest.fn()}
-  //     previewedVersions={[head(mockSurveyVersionsList())!]}
-  //     setPreviewedVersions={jest.fn()}
-  //   />)
-  //
-  //   //Assert
-  //   const versionDropdown = screen.getByText('Select version to preview') as HTMLSelectElement
-  //
-  //   console.log(versionDropdown.options)
-  //
-  //   mockSurveyVersionsList().forEach((survey) => {
-  //     expect(versionDropdown.options.namedItem(survey.version.toString())).toBeInTheDocument()
-  //   })
-  // })
 })

--- a/ui-admin/src/study/surveys/VersionSelector.test.tsx
+++ b/ui-admin/src/study/surveys/VersionSelector.test.tsx
@@ -30,10 +30,12 @@ describe('VersionSelector', () => {
     await waitFor(() => expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument())
     await select(screen.getByLabelText('Select version to preview'), ['1'])
     const openPreviewButton = screen.getByText('View preview')
-    const openEditorButton = screen.getByText('Open read-only editor')
+    const openEditorLink = screen.getByText('Open read-only editor')
 
     //Assert
     expect(openPreviewButton).toBeEnabled()
-    expect(openEditorButton).toBeEnabled()
+    expect(openEditorLink).toBeEnabled()
+    expect(openEditorLink)
+      .toHaveAttribute('href', '/portalCode/studies/fakeStudy/env/sandbox/forms/surveys/survey1/1?readOnly=true')
   })
 })

--- a/ui-admin/src/study/surveys/VersionSelector.tsx
+++ b/ui-admin/src/study/surveys/VersionSelector.tsx
@@ -26,7 +26,7 @@ export default function VersionSelector({
     Api.getSurveyVersions(portalShortcode, stableId).then(result => {
       setVersionList(result.sort((a, b) => b.version - a.version))
     }).catch(() => {
-      Store.addNotification(failureNotification('Error loading form versions'))
+      Store.addNotification(failureNotification('Error loading form history'))
       setShow(false)
     })
     setIsLoading(false)

--- a/ui-admin/src/study/surveys/VersionSelector.tsx
+++ b/ui-admin/src/study/surveys/VersionSelector.tsx
@@ -66,6 +66,7 @@ export default function VersionSelector({
     <Modal.Footer>
       <Button
         variant="primary"
+        disabled={!selectedVersion}
         onClick={() => {
           if (selectedVersion) {
             loadVersion(selectedVersion)

--- a/ui-admin/src/study/surveys/VersionSelector.tsx
+++ b/ui-admin/src/study/surveys/VersionSelector.tsx
@@ -5,6 +5,8 @@ import Modal from 'react-bootstrap/Modal'
 import { Button } from '../../components/forms/Button'
 import { instantToDefaultString } from 'util/timeUtils'
 import Select from 'react-select'
+import { failureNotification } from 'util/notifications'
+import { Store } from 'react-notifications-component'
 
 /** component for selecting versions of a form */
 export default function VersionSelector({
@@ -23,8 +25,11 @@ export default function VersionSelector({
     setIsLoading(true)
     Api.getSurveyVersions(portalShortcode, stableId).then(result => {
       setVersionList(result.sort((a, b) => b.version - a.version))
-      setIsLoading(false)
+    }).catch(() => {
+      Store.addNotification(failureNotification('Error loading form versions'))
+      setShow(false)
     })
+    setIsLoading(false)
   }, [])
 
   function loadVersion(version: number) {

--- a/ui-admin/src/study/surveys/VersionSelector.tsx
+++ b/ui-admin/src/study/surveys/VersionSelector.tsx
@@ -25,11 +25,12 @@ export default function VersionSelector({
     setIsLoading(true)
     Api.getSurveyVersions(portalShortcode, stableId).then(result => {
       setVersionList(result.sort((a, b) => b.version - a.version))
+      setIsLoading(false)
     }).catch(() => {
       Store.addNotification(failureNotification('Error loading form history'))
       setShow(false)
+      setIsLoading(false)
     })
-    setIsLoading(false)
   }, [])
 
   function loadVersion(version: number) {
@@ -48,8 +49,7 @@ export default function VersionSelector({
     value: formVersion.version
   })).filter(opt => previewedVersions.every(previewedVersion => previewedVersion.version !== opt.value))
 
-  const selectedOpt = versionOpts
-    .find(opt => opt.value === selectedVersion!)
+  const selectedOpt = versionOpts.find(opt => opt.value === selectedVersion)
 
   return <Modal show={show} onHide={() => setShow(false)}>
     <Modal.Header closeButton>

--- a/ui-admin/src/study/surveys/VersionSelector.tsx
+++ b/ui-admin/src/study/surveys/VersionSelector.tsx
@@ -9,13 +9,14 @@ import { failureNotification } from 'util/notifications'
 import { Store } from 'react-notifications-component'
 import { faArrowRightFromBracket } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { StudyEnvContextT, studyEnvFormsPath } from '../StudyEnvironmentRouter'
 
 /** component for selecting versions of a form */
 export default function VersionSelector({
-  portalShortcode, stableId, show, setShow,
+  studyEnvContext, stableId, show, setShow,
   visibleVersionPreviews, setVisibleVersionPreviews
 }:
-                                          {portalShortcode: string, stableId: string,
+                                          {studyEnvContext: StudyEnvContextT, stableId: string,
                                             show: boolean, setShow: (show: boolean) => void
                                             visibleVersionPreviews: VersionedForm[],
                                             setVisibleVersionPreviews: (versions: VersionedForm[]) => void}) {
@@ -26,7 +27,7 @@ export default function VersionSelector({
 
   useEffect(() => {
     setIsLoading(true)
-    Api.getSurveyVersions(portalShortcode, stableId).then(result => {
+    Api.getSurveyVersions(studyEnvContext.portal.shortcode, stableId).then(result => {
       setVersionList(result.sort((a, b) => b.version - a.version))
       setIsLoading(false)
     }).catch(() => {
@@ -37,7 +38,7 @@ export default function VersionSelector({
   }, [])
 
   function loadVersion(version: number) {
-    Api.getSurvey(portalShortcode, stableId, version).then(result => {
+    Api.getSurvey(studyEnvContext.portal.shortcode, stableId, version).then(result => {
       setVisibleVersionPreviews([...visibleVersionPreviews, result])
     })
   }
@@ -85,7 +86,12 @@ export default function VersionSelector({
         disabled={!selectedVersion}
         onClick={() => {
           if (selectedVersion) {
-            window.open(`../${stableId}/${selectedVersion}?readOnly=true`)
+            const path = `${studyEnvFormsPath(
+              studyEnvContext.portal.shortcode,
+              studyEnvContext.study.shortcode,
+              studyEnvContext.currentEnv.environmentName
+            )}/surveys/${stableId}/${selectedVersion}?readOnly=true`
+            window.open(path, '_blank')
           }
           setShow(false)
         }}

--- a/ui-admin/src/study/surveys/VersionSelector.tsx
+++ b/ui-admin/src/study/surveys/VersionSelector.tsx
@@ -1,10 +1,12 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useId, useState } from 'react'
 import LoadingSpinner from 'util/LoadingSpinner'
-import Api, { Survey, VersionedForm } from 'api/api'
+import Api, { VersionedForm } from 'api/api'
 import Modal from 'react-bootstrap/Modal'
 import { Button } from '../../components/forms/Button'
+import { instantToDefaultString } from 'util/timeUtils'
+import Select from 'react-select'
 
-/** component for selecting versions of a survey */
+/** component for selecting versions of a form */
 export default function VersionSelector({
   portalShortcode, stableId, show, setShow,
   previewedVersions, setPreviewedVersions
@@ -13,10 +15,12 @@ export default function VersionSelector({
                                             show: boolean, setShow: (show: boolean) => void
                                             previewedVersions: VersionedForm[],
                                             setPreviewedVersions: (versions: VersionedForm[]) => void}) {
-  const [versionList, setVersionList] = useState<Survey[]>([])
+  const [versionList, setVersionList] = useState<VersionedForm[]>([])
   const [selectedVersion, setSelectedVersion] = useState<number>()
   const [isLoading, setIsLoading] = useState(true)
+  const selectId = useId()
   useEffect(() => {
+    setIsLoading(true)
     Api.getSurveyVersions(portalShortcode, stableId).then(result => {
       setVersionList(result.sort((a, b) => b.version - a.version))
       setIsLoading(false)
@@ -29,27 +33,29 @@ export default function VersionSelector({
     })
   }
 
+  const versionOpts = versionList.map(formVersion => ({
+    label: <span>
+            Version <strong>{ formVersion.version }</strong>
+      <span className="text-muted fst-italic ms-2">
+                ({instantToDefaultString(formVersion.createdAt)})
+      </span>
+    </span>,
+    value: formVersion.version
+  })).filter(opt => previewedVersions.every(previewedVersion => previewedVersion.version !== opt.value))
+
+  const selectedOpt = versionOpts
+    .find(opt => opt.value === selectedVersion!)
+
   return <Modal show={show} onHide={() => setShow(false)}>
     <Modal.Header closeButton>
       <Modal.Title>View a previous version</Modal.Title>
     </Modal.Header>
     <Modal.Body>
-      <p>Selecting a previous survey version will allow you to preview it in a new tab of the survey editor.</p>
       <LoadingSpinner isLoading={isLoading}>
-        <select
-          className="form-control"
-          id="form-preview-version"
-          value={selectedVersion}
-          onChange={e => {
-            setSelectedVersion(parseInt(e.target.value))
-          }}
-        >
-          {versionList.map(version => (
-            <option key={version.version} value={version.version}>
-              {version.version}
-            </option>
-          ))}
-        </select>
+        <p>Selecting a previous form version will allow you to preview it in a new tab of the form editor.</p>
+        <label htmlFor={selectId}>Select version to preview</label>
+        <Select inputId={selectId} options={versionOpts} value={selectedOpt} onChange={opt =>
+          setSelectedVersion(opt?.value)}/>
       </LoadingSpinner>
     </Modal.Body>
     <Modal.Footer>

--- a/ui-admin/src/study/surveys/VersionSelector.tsx
+++ b/ui-admin/src/study/surveys/VersionSelector.tsx
@@ -7,6 +7,8 @@ import { instantToDefaultString } from 'util/timeUtils'
 import Select from 'react-select'
 import { failureNotification } from 'util/notifications'
 import { Store } from 'react-notifications-component'
+import { faArrowRightFromBracket } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 /** component for selecting versions of a form */
 export default function VersionSelector({
@@ -21,6 +23,7 @@ export default function VersionSelector({
   const [selectedVersion, setSelectedVersion] = useState<number>()
   const [isLoading, setIsLoading] = useState(true)
   const selectId = useId()
+
   useEffect(() => {
     setIsLoading(true)
     Api.getSurveyVersions(portalShortcode, stableId).then(result => {
@@ -57,7 +60,8 @@ export default function VersionSelector({
     </Modal.Header>
     <Modal.Body>
       <LoadingSpinner isLoading={isLoading}>
-        <p>Selecting a previous form version will allow you to preview it in a new tab of the form editor.</p>
+        <p>Viewing as a preview will open a new tab in the current editor.
+        Opening in read-only mode will allow you to view the full editor in an entirely new browser tab.</p>
         <label htmlFor={selectId}>Select version to preview</label>
         <Select inputId={selectId} options={versionOpts} value={selectedOpt} onChange={opt =>
           setSelectedVersion(opt?.value)}/>
@@ -74,7 +78,19 @@ export default function VersionSelector({
           setShow(false)
         }}
       >
-        Open version
+        View preview
+      </Button>
+      <Button
+        variant="light"
+        disabled={!selectedVersion}
+        onClick={() => {
+          if (selectedVersion) {
+            window.open(`../${stableId}/${selectedVersion}?readOnly=true`)
+          }
+          setShow(false)
+        }}
+      >
+        Open read-only editor <FontAwesomeIcon icon={faArrowRightFromBracket}/>
       </Button>
       <Button
         variant="secondary"

--- a/ui-admin/src/study/surveys/VersionSelector.tsx
+++ b/ui-admin/src/study/surveys/VersionSelector.tsx
@@ -1,41 +1,75 @@
 import React, { useEffect, useState } from 'react'
 import LoadingSpinner from 'util/LoadingSpinner'
-import Api, { Survey } from 'api/api'
+import Api, { Survey, VersionedForm } from 'api/api'
 import Modal from 'react-bootstrap/Modal'
+import { Button } from '../../components/forms/Button'
 
 /** component for selecting versions of a survey */
-export default function VersionSelector({ studyShortname, stableId, updateVersion, show, setShow }:
-                                          {studyShortname: string, stableId: string,
-                                            show: boolean, setShow: (show: boolean) => void,
-                                            updateVersion: (version: number) => void}) {
+export default function VersionSelector({
+  portalShortcode, stableId, show, setShow,
+  previewedVersions, setPreviewedVersions
+}:
+                                          {portalShortcode: string, stableId: string,
+                                            show: boolean, setShow: (show: boolean) => void
+                                            previewedVersions: VersionedForm[],
+                                            setPreviewedVersions: (versions: VersionedForm[]) => void}) {
   const [versionList, setVersionList] = useState<Survey[]>([])
+  const [selectedVersion, setSelectedVersion] = useState<number>()
   const [isLoading, setIsLoading] = useState(true)
   useEffect(() => {
-    Api.getSurveyVersions(studyShortname, stableId).then(result => {
-      setVersionList(result)
+    Api.getSurveyVersions(portalShortcode, stableId).then(result => {
+      setVersionList(result.sort((a, b) => b.version - a.version))
       setIsLoading(false)
     })
   }, [])
 
+  function loadVersion(version: number) {
+    Api.getSurvey(portalShortcode, stableId, version).then(result => {
+      setPreviewedVersions([...previewedVersions, result])
+    })
+  }
+
   return <Modal show={show} onHide={() => setShow(false)}>
     <Modal.Header closeButton>
-      <Modal.Title>Select a version</Modal.Title>
+      <Modal.Title>View a previous version</Modal.Title>
     </Modal.Header>
     <Modal.Body>
+      <p>Selecting a previous survey version will allow you to preview it in a new tab of the survey editor.</p>
       <LoadingSpinner isLoading={isLoading}>
-        <ul>
-          { versionList.map(survey => {
-            return <li key={survey.version}>
-              <button className="btn btn-secondary" onClick={() => updateVersion(survey.version)}>
-                {survey.version} {/*<span className="detail">({survey.createdAt?.substring(0, 16)})</span>*/}
-              </button>
-            </li>
-          })}
-        </ul>
+        <select
+          className="form-control"
+          id="form-preview-version"
+          value={selectedVersion}
+          onChange={e => {
+            setSelectedVersion(parseInt(e.target.value))
+          }}
+        >
+          {versionList.map(version => (
+            <option key={version.version} value={version.version}>
+              {version.version}
+            </option>
+          ))}
+        </select>
       </LoadingSpinner>
     </Modal.Body>
     <Modal.Footer>
-      <button type="button" className="btn btn-secondary" onClick={() => setShow(false)}>Cancel</button>
+      <Button
+        variant="primary"
+        onClick={() => {
+          if (selectedVersion) {
+            loadVersion(selectedVersion)
+          }
+          setShow(false)
+        }}
+      >
+        Open version
+      </Button>
+      <Button
+        variant="secondary"
+        onClick={() => setShow(false)}
+      >
+        Cancel
+      </Button>
     </Modal.Footer>
   </Modal>
 }

--- a/ui-admin/src/study/surveys/VersionSelector.tsx
+++ b/ui-admin/src/study/surveys/VersionSelector.tsx
@@ -81,23 +81,19 @@ export default function VersionSelector({
       >
         View preview
       </Button>
-      <Button
-        variant="light"
-        disabled={!selectedVersion}
-        onClick={() => {
-          if (selectedVersion) {
-            const path = `${studyEnvFormsPath(
-              studyEnvContext.portal.shortcode,
-              studyEnvContext.study.shortcode,
-              studyEnvContext.currentEnv.environmentName
-            )}/surveys/${stableId}/${selectedVersion}?readOnly=true`
-            window.open(path, '_blank')
-          }
-          setShow(false)
-        }}
+      <a href={`${studyEnvFormsPath(
+        studyEnvContext.portal.shortcode,
+        studyEnvContext.study.shortcode,
+        studyEnvContext.currentEnv.environmentName
+      )}/surveys/${stableId}/${selectedVersion}?readOnly=true`}
+      className="btn btn-secondary"
+      aria-disabled={!selectedVersion}
+      style={{ pointerEvents: selectedVersion ? undefined : 'none' }}
+      onClick={() => setShow(false)}
+      target="_blank"
       >
         Open read-only editor <FontAwesomeIcon icon={faArrowRightFromBracket}/>
-      </Button>
+      </a>
       <Button
         variant="secondary"
         onClick={() => setShow(false)}

--- a/ui-admin/src/study/surveys/VersionSelector.tsx
+++ b/ui-admin/src/study/surveys/VersionSelector.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useId, useState } from 'react'
 import LoadingSpinner from 'util/LoadingSpinner'
 import Api, { VersionedForm } from 'api/api'
 import Modal from 'react-bootstrap/Modal'
-import { Button } from '../../components/forms/Button'
+import { Button } from 'components/forms/Button'
 import { instantToDefaultString } from 'util/timeUtils'
 import Select from 'react-select'
 import { failureNotification } from 'util/notifications'
@@ -11,12 +11,12 @@ import { Store } from 'react-notifications-component'
 /** component for selecting versions of a form */
 export default function VersionSelector({
   portalShortcode, stableId, show, setShow,
-  previewedVersions, setPreviewedVersions
+  visibleVersionPreviews, setVisibleVersionPreviews
 }:
                                           {portalShortcode: string, stableId: string,
                                             show: boolean, setShow: (show: boolean) => void
-                                            previewedVersions: VersionedForm[],
-                                            setPreviewedVersions: (versions: VersionedForm[]) => void}) {
+                                            visibleVersionPreviews: VersionedForm[],
+                                            setVisibleVersionPreviews: (versions: VersionedForm[]) => void}) {
   const [versionList, setVersionList] = useState<VersionedForm[]>([])
   const [selectedVersion, setSelectedVersion] = useState<number>()
   const [isLoading, setIsLoading] = useState(true)
@@ -35,7 +35,7 @@ export default function VersionSelector({
 
   function loadVersion(version: number) {
     Api.getSurvey(portalShortcode, stableId, version).then(result => {
-      setPreviewedVersions([...previewedVersions, result])
+      setVisibleVersionPreviews([...visibleVersionPreviews, result])
     })
   }
 
@@ -47,7 +47,7 @@ export default function VersionSelector({
       </span>
     </span>,
     value: formVersion.version
-  })).filter(opt => previewedVersions.every(previewedVersion => previewedVersion.version !== opt.value))
+  })).filter(opt => visibleVersionPreviews.every(previewedVersion => previewedVersion.version !== opt.value))
 
   const selectedOpt = versionOpts.find(opt => opt.value === selectedVersion)
 

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -57,6 +57,28 @@ export const mockSurvey: () => Survey = () => ({
   createdAt: 0
 })
 
+/** returns a list of survey versions */
+export const mockSurveyVersionsList: () => Survey[] = () => ([
+  {
+    id: 'surveyId1',
+    stableId: 'survey1',
+    version: 1,
+    content: '{}',
+    name: 'Survey number one',
+    lastUpdatedAt: 0,
+    createdAt: 0
+  },
+  {
+    id: 'surveyId1',
+    stableId: 'survey1',
+    version: 2,
+    content: '{}',
+    name: 'Survey number one',
+    lastUpdatedAt: 0,
+    createdAt: 0
+  }
+])
+
 /** returns a simple studyEnvContext object for use/extension in tests */
 export const mockStudyEnvContext: () => StudyEnvContextT = () => ({
   study: { name: 'Fake study', studyEnvironments: [], shortcode: 'fakeStudy' },

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -60,22 +60,16 @@ export const mockSurvey: () => Survey = () => ({
 /** returns a list of survey versions */
 export const mockSurveyVersionsList: () => Survey[] = () => ([
   {
+    ...mockSurvey(),
     id: 'surveyId1',
     stableId: 'survey1',
-    version: 1,
-    content: '{}',
-    name: 'Survey number one',
-    lastUpdatedAt: 0,
-    createdAt: 0
+    version: 1
   },
   {
-    id: 'surveyId1',
+    ...mockSurvey(),
+    id: 'surveyId2',
     stableId: 'survey1',
-    version: 2,
-    content: '{}',
-    name: 'Survey number one',
-    lastUpdatedAt: 0,
-    createdAt: 0
+    version: 2
   }
 ])
 


### PR DESCRIPTION
This adds a new "History" button next to the form version in the editor, allowing you to open previous versions in a new tab in the editor. Previous versions open in "Preview" mode.

Video of the version selector in use (now out of date, doesn't show open in new browser tab option):

https://github.com/broadinstitute/juniper/assets/7257391/a4b8c886-bd0e-421a-bd41-3abf103de006


