### PR TITLE
[JN-538] Add error boundaries to form editor tabs

### DIFF
--- a/ui-admin/src/forms/FormContentEditor.test.tsx
+++ b/ui-admin/src/forms/FormContentEditor.test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 
 import { FormContentEditor } from './FormContentEditor'
 
+//This is valid JSON, but invalid survey JSON
 const formContent: string = JSON.stringify({
   title: 'Test survey',
   pages: [

--- a/ui-admin/src/forms/FormContentEditor.test.tsx
+++ b/ui-admin/src/forms/FormContentEditor.test.tsx
@@ -12,7 +12,7 @@ const formContent: string = JSON.stringify({
 })
 
 describe('FormContentEditor', () => {
-  it('should trap errors in an ErrorBoundary', () => {
+  it('should trap FormDesigner errors in an ErrorBoundary', () => {
     // Arrange
     const { container } = render(<FormContentEditor
       initialContent={formContent} readOnly={false} onChange={jest.fn()}

--- a/ui-admin/src/forms/FormContentEditor.test.tsx
+++ b/ui-admin/src/forms/FormContentEditor.test.tsx
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+
+import { FormContentEditor } from './FormContentEditor'
+
+const formContent: string = JSON.stringify({
+  title: 'Test survey',
+  pages: [
+    {}
+  ]
+})
+
+describe('FormContentEditor', () => {
+  it('should trap errors in an ErrorBoundary', () => {
+    // Arrange
+    const { container } = render(<FormContentEditor
+      initialContent={formContent} readOnly={false} onChange={jest.fn()}
+    />)
+
+    // Assert
+    // Our custom ErrorBoundary text
+    expect(container).toHaveTextContent('Something went wrong')
+    // JSON Editor and Preview tabs should still be visible
+    expect(container).toHaveTextContent('JSON Editor')
+    expect(container).toHaveTextContent('Preview')
+  })
+})

--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -8,6 +8,7 @@ import { OnChangeFormContent } from './formEditorTypes'
 import { FormContentJsonEditor } from './FormContentJsonEditor'
 import { FormPreview } from './FormPreview'
 import { validateFormContent } from './formContentValidation'
+import ErrorBoundary from 'util/ErrorBoundary'
 
 type FormContentEditorProps = {
   initialContent: string
@@ -39,45 +40,51 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
           eventKey="designer"
           title="Designer"
         >
-          <FormDesigner
-            readOnly={readOnly}
-            value={editedContent}
-            onChange={newContent => {
-              setEditedContent(newContent)
-              try {
-                validateFormContent(newContent)
-                onChange(true, newContent)
-              } catch (err) {
-                onChange(false, undefined)
-              }
-            }}
-          />
+          <ErrorBoundary>
+            <FormDesigner
+              readOnly={readOnly}
+              value={editedContent}
+              onChange={newContent => {
+                setEditedContent(newContent)
+                try {
+                  validateFormContent(newContent)
+                  onChange(true, newContent)
+                } catch (err) {
+                  onChange(false, undefined)
+                }
+              }}
+            />
+          </ErrorBoundary>
         </Tab>
         <Tab
           disabled={activeTab !== 'json' && !tabsEnabled}
           eventKey="json"
           title="JSON Editor"
         >
-          <FormContentJsonEditor
-            initialValue={editedContent}
-            readOnly={readOnly}
-            onChange={(isValid, newContent) => {
-              if (isValid) {
-                setEditedContent(newContent)
-                onChange(true, newContent)
-              } else {
-                onChange(false, undefined)
-              }
-              setTabsEnabled(isValid)
-            }}
-          />
+          <ErrorBoundary>
+            <FormContentJsonEditor
+              initialValue={editedContent}
+              readOnly={readOnly}
+              onChange={(isValid, newContent) => {
+                if (isValid) {
+                  setEditedContent(newContent)
+                  onChange(true, newContent)
+                } else {
+                  onChange(false, undefined)
+                }
+                setTabsEnabled(isValid)
+              }}
+            />
+          </ErrorBoundary>
         </Tab>
         <Tab
           disabled={activeTab !== 'preview' && !tabsEnabled}
           eventKey="preview"
           title="Preview"
         >
-          <FormPreview formContent={editedContent} />
+          <ErrorBoundary>
+            <FormPreview formContent={editedContent} />
+          </ErrorBoundary>
         </Tab>
       </Tabs>
     </div>


### PR DESCRIPTION
To test: use the JSON editor to add an empty page with no elements in it.

![Screenshot 2023-08-22 at 4 54 40 PM](https://github.com/broadinstitute/juniper/assets/7257391/88818680-7734-4473-b570-00e79b3f8e81)
