### PR TITLE
[JN-460] Move bulk kit request batches from UI to server

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeController.java
@@ -5,9 +5,7 @@ import bio.terra.pearl.api.admin.service.AuthUtilService;
 import bio.terra.pearl.api.admin.service.enrollee.EnrolleeExtService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
-import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.participant.Enrollee;
-import bio.terra.pearl.core.service.kit.PepperException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
@@ -59,33 +57,6 @@ public class EnrolleeController implements EnrolleeApi {
     } catch (JsonProcessingException e) {
       return ResponseEntity.internalServerError().body(e.getMessage());
     }
-  }
-
-  @Override
-  public ResponseEntity<Object> requestKit(
-      String portalShortcode,
-      String studyShortcode,
-      String envName,
-      String enrolleeShortcode,
-      String kitType) {
-    AdminUser adminUser = authUtilService.requireAdminUser(request);
-    try {
-      KitRequest sampleKit = enrolleeExtService.requestKit(adminUser, enrolleeShortcode, kitType);
-      return ResponseEntity.ok(sampleKit);
-    } catch (PepperException e) {
-      log.error("Error requesting sample kit from Pepper", e);
-      // In the case of a PepperException, we can do better than this because we'll likely know what
-      // Pepper was unhappy about, such as an address failing to validate.
-      return ResponseEntity.internalServerError().body(e.getMessage());
-    }
-  }
-
-  @Override
-  public ResponseEntity<Object> getKitRequests(
-      String portalShortcode, String studyShortcode, String envName, String enrolleeShortcode) {
-    AdminUser adminUser = authUtilService.requireAdminUser(request);
-    var kitRequests = enrolleeExtService.getKitRequests(adminUser, enrolleeShortcode);
-    return ResponseEntity.ok(kitRequests);
   }
 
   @Override

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeController.java
@@ -75,8 +75,7 @@ public class EnrolleeController implements EnrolleeApi {
     } catch (PepperException e) {
       log.error("Error requesting sample kit from Pepper", e);
       // In the case of a PepperException, we can do better than this because we'll likely know what
-      // Pepper was unhappy
-      // about, such as an address failing to validate.
+      // Pepper was unhappy about, such as an address failing to validate.
       return ResponseEntity.internalServerError().body(e.getMessage());
     }
   }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/kit/KitController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/kit/KitController.java
@@ -5,6 +5,8 @@ import bio.terra.pearl.api.admin.service.AuthUtilService;
 import bio.terra.pearl.api.admin.service.kit.KitExtService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.model.kit.KitRequest;
+import bio.terra.pearl.core.service.kit.PepperException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import javax.servlet.http.HttpServletRequest;
@@ -40,6 +42,33 @@ public class KitController implements KitApi {
             adminUser, portalShortcode, studyShortcode, environmentName);
 
     return ResponseEntity.ok(kits);
+  }
+
+  @Override
+  public ResponseEntity<Object> requestKit(
+      String portalShortcode,
+      String studyShortcode,
+      String envName,
+      String enrolleeShortcode,
+      String kitType) {
+    AdminUser adminUser = authUtilService.requireAdminUser(request);
+    try {
+      KitRequest sampleKit = kitExtService.requestKit(adminUser, enrolleeShortcode, kitType);
+      return ResponseEntity.ok(sampleKit);
+    } catch (PepperException e) {
+      log.error("Error requesting sample kit from Pepper", e);
+      // In the case of a PepperException, we can do better than this because we'll likely know what
+      // Pepper was unhappy about, such as an address failing to validate.
+      return ResponseEntity.internalServerError().body(e.getMessage());
+    }
+  }
+
+  @Override
+  public ResponseEntity<Object> getKitRequests(
+      String portalShortcode, String studyShortcode, String envName, String enrolleeShortcode) {
+    AdminUser adminUser = authUtilService.requireAdminUser(request);
+    var kitRequests = kitExtService.getKitRequests(adminUser, enrolleeShortcode);
+    return ResponseEntity.ok(kitRequests);
   }
 
   @Override

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeExtService.java
@@ -3,13 +3,11 @@ package bio.terra.pearl.api.admin.service.enrollee;
 import bio.terra.pearl.api.admin.service.AuthUtilService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
-import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.EnrolleeSearchResult;
 import bio.terra.pearl.core.model.participant.WithdrawnEnrollee;
 import bio.terra.pearl.core.model.workflow.DataChangeRecord;
 import bio.terra.pearl.core.service.exception.PermissionDeniedException;
-import bio.terra.pearl.core.service.kit.KitRequestService;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.participant.WithdrawnEnrolleeService;
 import bio.terra.pearl.core.service.participant.search.EnrolleeSearchService;
@@ -18,7 +16,6 @@ import bio.terra.pearl.core.service.portal.PortalService;
 import bio.terra.pearl.core.service.study.PortalStudyService;
 import bio.terra.pearl.core.service.workflow.DataChangeRecordService;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import java.util.Collection;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
@@ -30,7 +27,6 @@ public class EnrolleeExtService {
   private PortalService portalService;
   private PortalStudyService portalStudyService;
   private DataChangeRecordService dataChangeRecordService;
-  private KitRequestService kitRequestService;
 
   private EnrolleeSearchService enrolleeSearchService;
 
@@ -41,7 +37,6 @@ public class EnrolleeExtService {
       PortalService portalService,
       PortalStudyService portalStudyService,
       DataChangeRecordService dataChangeRecordService,
-      KitRequestService kitRequestService,
       EnrolleeSearchService enrolleeSearchService) {
     this.authUtilService = authUtilService;
     this.enrolleeService = enrolleeService;
@@ -49,7 +44,6 @@ public class EnrolleeExtService {
     this.portalService = portalService;
     this.portalStudyService = portalStudyService;
     this.dataChangeRecordService = dataChangeRecordService;
-    this.kitRequestService = kitRequestService;
     this.enrolleeSearchService = enrolleeSearchService;
   }
 
@@ -89,15 +83,5 @@ public class EnrolleeExtService {
     }
     Enrollee enrollee = authUtilService.authAdminUserToEnrollee(user, enroleeShortcode);
     return withdrawnEnrolleeService.withdrawEnrollee(enrollee);
-  }
-
-  public KitRequest requestKit(AdminUser adminUser, String enrolleeShortcode, String kitTypeName) {
-    Enrollee enrollee = authUtilService.authAdminUserToEnrollee(adminUser, enrolleeShortcode);
-    return kitRequestService.requestKit(adminUser, enrollee, kitTypeName);
-  }
-
-  public Collection<KitRequest> getKitRequests(AdminUser adminUser, String enrolleeShortcode) {
-    Enrollee enrollee = authUtilService.authAdminUserToEnrollee(adminUser, enrolleeShortcode);
-    return kitRequestService.getKitRequests(enrollee);
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.api.admin.service.kit;
 
 import bio.terra.pearl.api.admin.service.AuthUtilService;
+import bio.terra.pearl.api.admin.service.enrollee.EnrolleeExtService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.kit.KitRequest;
@@ -8,21 +9,41 @@ import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.service.kit.KitRequestService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import java.util.Collection;
+import java.util.List;
 import org.springframework.stereotype.Service;
 
 @Service
 public class KitExtService {
   private final AuthUtilService authUtilService;
+  private final EnrolleeExtService enrolleeExtService;
   private final KitRequestService kitRequestService;
   private final StudyEnvironmentService studyEnvironmentService;
 
   public KitExtService(
       AuthUtilService authUtilService,
+      EnrolleeExtService enrolleeExtService,
       KitRequestService kitRequestService,
       StudyEnvironmentService studyEnvironmentService) {
     this.authUtilService = authUtilService;
+    this.enrolleeExtService = enrolleeExtService;
     this.kitRequestService = kitRequestService;
     this.studyEnvironmentService = studyEnvironmentService;
+  }
+
+  public List<KitRequest> requestKits(
+      AdminUser adminUser,
+      String portalShortcode,
+      String studyShortcode,
+      EnvironmentName environmentName,
+      List<String> enrolleeShortcodes,
+      String kitType) {
+    authUtilService.authUserToStudy(adminUser, portalShortcode, studyShortcode);
+
+    return enrolleeShortcodes.stream()
+        .map(
+            enrolleeShortcode ->
+                enrolleeExtService.requestKit(adminUser, enrolleeShortcode, kitType))
+        .toList();
   }
 
   public Collection<KitRequest> getKitRequestsByStudyEnvironment(

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
@@ -1,10 +1,10 @@
 package bio.terra.pearl.api.admin.service.kit;
 
 import bio.terra.pearl.api.admin.service.AuthUtilService;
-import bio.terra.pearl.api.admin.service.enrollee.EnrolleeExtService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.kit.KitRequest;
+import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.service.kit.KitRequestService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
@@ -15,17 +15,14 @@ import org.springframework.stereotype.Service;
 @Service
 public class KitExtService {
   private final AuthUtilService authUtilService;
-  private final EnrolleeExtService enrolleeExtService;
   private final KitRequestService kitRequestService;
   private final StudyEnvironmentService studyEnvironmentService;
 
   public KitExtService(
       AuthUtilService authUtilService,
-      EnrolleeExtService enrolleeExtService,
       KitRequestService kitRequestService,
       StudyEnvironmentService studyEnvironmentService) {
     this.authUtilService = authUtilService;
-    this.enrolleeExtService = enrolleeExtService;
     this.kitRequestService = kitRequestService;
     this.studyEnvironmentService = studyEnvironmentService;
   }
@@ -40,9 +37,7 @@ public class KitExtService {
     authUtilService.authUserToStudy(adminUser, portalShortcode, studyShortcode);
 
     return enrolleeShortcodes.stream()
-        .map(
-            enrolleeShortcode ->
-                enrolleeExtService.requestKit(adminUser, enrolleeShortcode, kitType))
+        .map(enrolleeShortcode -> requestKit(adminUser, enrolleeShortcode, kitType))
         .toList();
   }
 
@@ -57,5 +52,15 @@ public class KitExtService {
         studyEnvironmentService.findByStudy(studyShortcode, environmentName).get();
 
     return kitRequestService.getSampleKitsByStudyEnvironment(studyEnvironment);
+  }
+
+  public KitRequest requestKit(AdminUser adminUser, String enrolleeShortcode, String kitTypeName) {
+    Enrollee enrollee = authUtilService.authAdminUserToEnrollee(adminUser, enrolleeShortcode);
+    return kitRequestService.requestKit(adminUser, enrollee, kitTypeName);
+  }
+
+  public Collection<KitRequest> getKitRequests(AdminUser adminUser, String enrolleeShortcode) {
+    Enrollee enrollee = authUtilService.authAdminUserToEnrollee(adminUser, enrolleeShortcode);
+    return kitRequestService.getKitRequests(enrollee);
   }
 }

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -432,7 +432,7 @@ paths:
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/enrollees/{enrolleeShortcode}/kitRequests:
     get:
       summary: List kit requests for an enrollee
-      tags: [ enrollee ]
+      tags: [ kit ]
       operationId: getKitRequests
       parameters:
         - { name: portalShortcode, in: path, required: true, schema: { type: string } }
@@ -448,7 +448,7 @@ paths:
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/enrollees/{enrolleeShortcode}/requestKit:
     post:
       summary: Request a sample kit for an enrollee
-      tags: [ enrollee ]
+      tags: [ kit ]
       operationId: requestKit
       parameters:
         - { name: portalShortcode, in: path, required: true, schema: { type: string } }

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -282,7 +282,7 @@ paths:
           $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/requestKits:
     post:
-      summary: Request a sample kit for an enrollee
+      summary: Request sample kits for a batch of enrollees
       tags: [ kit ]
       operationId: requestKits
       parameters:
@@ -292,6 +292,7 @@ paths:
         - { name: kitType, in: query, required: true, schema: { type: string } }
       requestBody:
         required: true
+        description: JSON array of enrollee shortcodes
         content: { application/json: { schema: { type: object } } }
       responses:
         '200':

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -280,6 +280,25 @@ paths:
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/requestKits:
+    post:
+      summary: Request a sample kit for an enrollee
+      tags: [ kit ]
+      operationId: requestKits
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: studyShortcode, in: path, required: true, schema: { type: string } }
+        - { name: envName, in: path, required: true, schema: { type: string } }
+        - { name: kitType, in: query, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content: { application/json: { schema: { type: object } } }
+      responses:
+        '200':
+          description: Kit requests
+          content: { application/json: { schema: { type: object } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}:
     patch:
       summary: Updates a study environment configuration

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/kit/KitExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/kit/KitExtServiceTests.java
@@ -8,6 +8,7 @@ import bio.terra.pearl.api.admin.service.AuthUtilService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.service.exception.PermissionDeniedException;
+import java.util.Arrays;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +17,24 @@ import org.springframework.transaction.annotation.Transactional;
 
 public class KitExtServiceTests extends BaseSpringBootTest {
   @Autowired private KitExtService kitExtService;
+
+  @Test
+  @Transactional
+  public void testRequestKitsRequiresAdmin() {
+    when(mockAuthUtilService.authUserToStudy(any(), any(), any()))
+        .thenThrow(new PermissionDeniedException(""));
+    AdminUser adminUser = new AdminUser();
+    Assertions.assertThrows(
+        PermissionDeniedException.class,
+        () ->
+            kitExtService.requestKits(
+                adminUser,
+                "someportal",
+                "somestudy",
+                EnvironmentName.sandbox,
+                Arrays.asList("enrollee1", "enrollee2"),
+                "kitType"));
+  }
 
   @Test
   @Transactional

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -620,7 +620,28 @@ export default {
     const url =
       `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/enrollees/${enrolleeShortcode}/requestKit?${params}`
     const response = await fetch(url, { method: 'POST', headers: this.getInitHeaders() })
-    return await this.processJsonResponse(response)
+    const kit = await this.processJsonResponse(response)
+    kit.pepperStatus = parsePepperKitStatus(kit.dsmStatus)
+    return kit
+  },
+
+  async requestKits(
+    portalShortcode: string,
+    studyShortcode: string,
+    envName: string,
+    enrolleeShortcodes: string[],
+    kitType: string
+  ): Promise<KitRequest[]> {
+    const params = new URLSearchParams({ kitType })
+    const url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/requestKits?${params}`
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: this.getInitHeaders(),
+      body: JSON.stringify(enrolleeShortcodes)
+    })
+    const kits: KitRequest[] = await this.processJsonResponse(response)
+    kits.forEach(kit => { kit.pepperStatus = parsePepperKitStatus(kit.dsmStatus) })
+    return kits
   },
 
   async fetchEnrolleeKitRequests(

--- a/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
+++ b/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
@@ -63,10 +63,8 @@ export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvCont
       .map(key => enrollees[parseInt(key)].shortcode)
 
     // This iteration should be happening server-side: JN-460
-    for (const shortcode of enrolleesSelected) {
-      await Api.createKitRequest(
-        portal.shortcode, study.shortcode, currentEnv.environmentName, shortcode, kitType)
-    }
+    await Api.requestKits(
+      portal.shortcode, study.shortcode, currentEnv.environmentName, enrolleesSelected, kitType)
 
     setShowRequestKitModal(false)
     loadEnrollees()


### PR DESCRIPTION
Pretty straightforward change from `n` API calls to `1`. To test:
1. Go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/kits/byEnrollee
2. Select multiple rows, click "Send sample collection kit" and "Request Kit"
3. Open the Kits tab (https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/kits/byKit) and see that there are new kits (assuming a freshly populated database, there will be 1 more than the number of enrollees you selected)
