### PR TITLE
[JN-541] improved message for misconfigured portal

### DIFF
--- a/ui-participant/src/providers/PortalProvider.test.tsx
+++ b/ui-participant/src/providers/PortalProvider.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import Api from 'api/api'
+import PortalProvider from './PortalProvider'
+
+describe('PortalProvider', () => {
+  it('shows support email on non-existent portal', async () => {
+    jest.spyOn(Api, 'getPortal').mockImplementation(() => Promise.reject(null))
+    render(<PortalProvider><span>some stuff</span></PortalProvider>)
+
+    await waitFor(() => expect(screen.getByText('support@juniper.terra.bio')).toBeInTheDocument())
+    expect(screen.queryByText('some stuff')).not.toBeInTheDocument()
+  })
+})

--- a/ui-participant/src/providers/PortalProvider.tsx
+++ b/ui-participant/src/providers/PortalProvider.tsx
@@ -49,8 +49,9 @@ export default function PortalProvider({ children }: { children: React.ReactNode
       <div className="position-absolute top-50 start-50 translate-middle">Loading...</div>
     </div>}
     {isError && <div className="bg-white h-100 w-100">
-      <div className="position-absolute top-50 start-50 translate-middle">
-        The page you are looking for does not exist
+      <div className="position-absolute top-50 start-50 translate-middle text-center">
+        There is no Juniper site configured for this url.<br/>
+        If this is an error, contact <a href="mailto:support@juniper.terra.bio">support@juniper.terra.bio</a>.
       </div>
     </div>}
     {!isLoading && !isError && <PortalContext.Provider value={envState}>


### PR DESCRIPTION
Better message than just "the site you are looking for doesn't exist"

<img width="566" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/4d8f09d7-6d64-4770-9a40-fc0bb049f8d9">


TO TEST:
1. go to foobar.localhost:3001
2. confirm better error appears