### PR TITLE
[JN-535] edit notification configs

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/notifications/NotificationConfigController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/notifications/NotificationConfigController.java
@@ -6,22 +6,29 @@ import bio.terra.pearl.api.admin.service.notifications.NotificationConfigExtServ
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import javax.servlet.http.HttpServletRequest;
+
+import bio.terra.pearl.core.model.notification.NotificationConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+
+import java.util.UUID;
 
 @Controller
 public class NotificationConfigController implements NotificationConfigApi {
   private AuthUtilService authUtilService;
   private HttpServletRequest request;
   private NotificationConfigExtService notificationConfigExtService;
+  private ObjectMapper objectMapper;
 
   public NotificationConfigController(
-      AuthUtilService authUtilService,
-      HttpServletRequest request,
-      NotificationConfigExtService notificationConfigExtService) {
+          AuthUtilService authUtilService,
+          HttpServletRequest request,
+          NotificationConfigExtService notificationConfigExtService, ObjectMapper objectMapper) {
     this.authUtilService = authUtilService;
     this.request = request;
     this.notificationConfigExtService = notificationConfigExtService;
+    this.objectMapper = objectMapper;
   }
 
   @Override
@@ -32,6 +39,18 @@ public class NotificationConfigController implements NotificationConfigApi {
     var configs =
         notificationConfigExtService.findForStudy(
             adminUser, portalShortcode, studyShortcode, environmentName);
+    return ResponseEntity.ok(configs);
+  }
+
+  @Override
+  public ResponseEntity<Object> replace(
+          String portalShortcode, String studyShortcode, String envName, UUID configId, Object body ) {
+    AdminUser adminUser = authUtilService.requireAdminUser(request);
+    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
+    NotificationConfig config = objectMapper.convertValue(body, NotificationConfig.class);
+    var configs =
+            notificationConfigExtService.findForStudy(
+                    adminUser, portalShortcode, studyShortcode, environmentName);
     return ResponseEntity.ok(configs);
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/notifications/NotificationConfigController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/notifications/NotificationConfigController.java
@@ -5,14 +5,12 @@ import bio.terra.pearl.api.admin.service.AuthUtilService;
 import bio.terra.pearl.api.admin.service.notifications.NotificationConfigExtService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
-import javax.servlet.http.HttpServletRequest;
-
 import bio.terra.pearl.core.model.notification.NotificationConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import javax.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-
-import java.util.UUID;
 
 @Controller
 public class NotificationConfigController implements NotificationConfigApi {
@@ -22,9 +20,10 @@ public class NotificationConfigController implements NotificationConfigApi {
   private ObjectMapper objectMapper;
 
   public NotificationConfigController(
-          AuthUtilService authUtilService,
-          HttpServletRequest request,
-          NotificationConfigExtService notificationConfigExtService, ObjectMapper objectMapper) {
+      AuthUtilService authUtilService,
+      HttpServletRequest request,
+      NotificationConfigExtService notificationConfigExtService,
+      ObjectMapper objectMapper) {
     this.authUtilService = authUtilService;
     this.request = request;
     this.notificationConfigExtService = notificationConfigExtService;
@@ -44,13 +43,13 @@ public class NotificationConfigController implements NotificationConfigApi {
 
   @Override
   public ResponseEntity<Object> replace(
-          String portalShortcode, String studyShortcode, String envName, UUID configId, Object body ) {
+      String portalShortcode, String studyShortcode, String envName, UUID configId, Object body) {
     AdminUser adminUser = authUtilService.requireAdminUser(request);
     EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
     NotificationConfig config = objectMapper.convertValue(body, NotificationConfig.class);
-    var configs =
-            notificationConfigExtService.findForStudy(
-                    adminUser, portalShortcode, studyShortcode, environmentName);
-    return ResponseEntity.ok(configs);
+    NotificationConfig newConfig =
+        notificationConfigExtService.replace(
+            portalShortcode, studyShortcode, environmentName, configId, config, adminUser);
+    return ResponseEntity.ok(newConfig);
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/notifications/NotificationConfigExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/notifications/NotificationConfigExtService.java
@@ -1,30 +1,44 @@
 package bio.terra.pearl.api.admin.service.notifications;
 
 import bio.terra.pearl.api.admin.service.AuthUtilService;
+import bio.terra.pearl.core.dao.publishing.PortalEnvironmentChangeRecordDao;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.notification.NotificationConfig;
 import bio.terra.pearl.core.model.portal.Portal;
+import bio.terra.pearl.core.model.portal.PortalEnvironment;
+import bio.terra.pearl.core.model.publishing.PortalEnvironmentChange;
+import bio.terra.pearl.core.model.publishing.StudyEnvironmentChange;
 import bio.terra.pearl.core.model.study.PortalStudy;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.service.notification.NotificationConfigService;
+import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
+import bio.terra.pearl.core.service.publishing.PortalDiffService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import java.util.List;
+import java.util.UUID;
+
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class NotificationConfigExtService {
   private NotificationConfigService notificationConfigService;
   private AuthUtilService authUtilService;
   private StudyEnvironmentService studyEnvironmentService;
+  private PortalEnvironmentService portalEnvironmentService;
+  private PortalEnvironmentChangeRecordDao portalEnvironmentChangeRecordDao;
 
   public NotificationConfigExtService(
-      NotificationConfigService notificationConfigService,
-      AuthUtilService authUtilService,
-      StudyEnvironmentService studyEnvironmentService) {
+          NotificationConfigService notificationConfigService,
+          AuthUtilService authUtilService,
+          StudyEnvironmentService studyEnvironmentService, PortalEnvironmentService portalEnvironmentService,
+          PortalEnvironmentChangeRecordDao portalEnvironmentChangeRecordDao) {
     this.notificationConfigService = notificationConfigService;
     this.authUtilService = authUtilService;
     this.studyEnvironmentService = studyEnvironmentService;
+    this.portalEnvironmentService = portalEnvironmentService;
+    this.portalEnvironmentChangeRecordDao = portalEnvironmentChangeRecordDao;
   }
 
   public List<NotificationConfig> findForStudy(
@@ -40,5 +54,35 @@ public class NotificationConfigExtService {
     var configs = notificationConfigService.findByStudyEnvironmentId(studyEnvironment.getId());
     notificationConfigService.attachTemplates(configs);
     return configs;
+  }
+
+  /**
+   * deactivates the notification config with configId, and adds a new config as specified in the update object. Note though that the
+   * portalEnvironmentId and studyEnvironmentId will be set from the portalShortcode and studyShortcode params.
+   * If the update contains a new email template, that template will be created as well.
+   */
+  @Transactional
+  public NotificationConfig replace(String portalShortcode, String studyShortcode, EnvironmentName environmentName, UUID configId,
+                                    NotificationConfig update, AdminUser user) {
+    authUtilService.authUserToPortal(user, portalShortcode);
+    PortalEnvironment portalEnvironment = portalEnvironmentService.findOne(portalShortcode, environmentName).get();
+    authUtilService.authUserToStudy(user, portalShortcode, studyShortcode);
+    StudyEnvironment studyEnvironment =
+            studyEnvironmentService.findByStudy(studyShortcode, environmentName).get();
+    NotificationConfig existing = notificationConfigService.find(configId).get();
+
+    update.cleanForCopying();
+    update.setStudyEnvironmentId(studyEnvironment.getId());
+    update.setPortalEnvironmentId(portalEnvironment.getId());
+    if (update.getEmailTemplate() != null && update.getEmailTemplateId() == null) {
+      // this is a new email template, set the portal appropriately
+      update.getEmailTemplate().setPortalId(portalEnvironment.getPortalId());
+    }
+    NotificationConfig newConfig = notificationConfigService.create(update);
+
+    // once the new creation succeeds, deactivate the prior config.
+    existing.setActive(false);
+    notificationConfigService.update(existing);
+    return newConfig;
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/notifications/NotificationConfigExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/notifications/NotificationConfigExtService.java
@@ -23,19 +23,16 @@ public class NotificationConfigExtService {
   private AuthUtilService authUtilService;
   private StudyEnvironmentService studyEnvironmentService;
   private PortalEnvironmentService portalEnvironmentService;
-  private PortalEnvironmentChangeRecordDao portalEnvironmentChangeRecordDao;
 
   public NotificationConfigExtService(
       NotificationConfigService notificationConfigService,
       AuthUtilService authUtilService,
       StudyEnvironmentService studyEnvironmentService,
-      PortalEnvironmentService portalEnvironmentService,
-      PortalEnvironmentChangeRecordDao portalEnvironmentChangeRecordDao) {
+      PortalEnvironmentService portalEnvironmentService) {
     this.notificationConfigService = notificationConfigService;
     this.authUtilService = authUtilService;
     this.studyEnvironmentService = studyEnvironmentService;
     this.portalEnvironmentService = portalEnvironmentService;
-    this.portalEnvironmentChangeRecordDao = portalEnvironmentChangeRecordDao;
   }
 
   public List<NotificationConfig> findForStudy(

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/notifications/NotificationConfigExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/notifications/NotificationConfigExtService.java
@@ -1,7 +1,6 @@
 package bio.terra.pearl.api.admin.service.notifications;
 
 import bio.terra.pearl.api.admin.service.AuthUtilService;
-import bio.terra.pearl.core.dao.publishing.PortalEnvironmentChangeRecordDao;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.notification.NotificationConfig;

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/notifications/NotificationConfigExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/notifications/NotificationConfigExtService.java
@@ -7,17 +7,13 @@ import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.notification.NotificationConfig;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
-import bio.terra.pearl.core.model.publishing.PortalEnvironmentChange;
-import bio.terra.pearl.core.model.publishing.StudyEnvironmentChange;
 import bio.terra.pearl.core.model.study.PortalStudy;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.service.notification.NotificationConfigService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
-import bio.terra.pearl.core.service.publishing.PortalDiffService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import java.util.List;
 import java.util.UUID;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,10 +26,11 @@ public class NotificationConfigExtService {
   private PortalEnvironmentChangeRecordDao portalEnvironmentChangeRecordDao;
 
   public NotificationConfigExtService(
-          NotificationConfigService notificationConfigService,
-          AuthUtilService authUtilService,
-          StudyEnvironmentService studyEnvironmentService, PortalEnvironmentService portalEnvironmentService,
-          PortalEnvironmentChangeRecordDao portalEnvironmentChangeRecordDao) {
+      NotificationConfigService notificationConfigService,
+      AuthUtilService authUtilService,
+      StudyEnvironmentService studyEnvironmentService,
+      PortalEnvironmentService portalEnvironmentService,
+      PortalEnvironmentChangeRecordDao portalEnvironmentChangeRecordDao) {
     this.notificationConfigService = notificationConfigService;
     this.authUtilService = authUtilService;
     this.studyEnvironmentService = studyEnvironmentService;
@@ -57,18 +54,25 @@ public class NotificationConfigExtService {
   }
 
   /**
-   * deactivates the notification config with configId, and adds a new config as specified in the update object. Note though that the
-   * portalEnvironmentId and studyEnvironmentId will be set from the portalShortcode and studyShortcode params.
-   * If the update contains a new email template, that template will be created as well.
+   * deactivates the notification config with configId, and adds a new config as specified in the
+   * update object. Note though that the portalEnvironmentId and studyEnvironmentId will be set from
+   * the portalShortcode and studyShortcode params. If the update contains a new email template,
+   * that template will be created as well.
    */
   @Transactional
-  public NotificationConfig replace(String portalShortcode, String studyShortcode, EnvironmentName environmentName, UUID configId,
-                                    NotificationConfig update, AdminUser user) {
+  public NotificationConfig replace(
+      String portalShortcode,
+      String studyShortcode,
+      EnvironmentName environmentName,
+      UUID configId,
+      NotificationConfig update,
+      AdminUser user) {
     authUtilService.authUserToPortal(user, portalShortcode);
-    PortalEnvironment portalEnvironment = portalEnvironmentService.findOne(portalShortcode, environmentName).get();
+    PortalEnvironment portalEnvironment =
+        portalEnvironmentService.findOne(portalShortcode, environmentName).get();
     authUtilService.authUserToStudy(user, portalShortcode, studyShortcode);
     StudyEnvironment studyEnvironment =
-            studyEnvironmentService.findByStudy(studyShortcode, environmentName).get();
+        studyEnvironmentService.findByStudy(studyShortcode, environmentName).get();
     NotificationConfig existing = notificationConfigService.find(configId).get();
 
     update.cleanForCopying();

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -476,6 +476,26 @@ paths:
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/notificationConfigs/{configId}:
+    patch:
+      summary: Since configs are immutable, a new config is made and the current one is deactivated.  The new config is attached to the study and is returned
+      tags: [ notificationConfig ]
+      operationId: replace
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: studyShortcode, in: path, required: true, schema: { type: string } }
+        - { name: envName, in: path, required: true, schema: { type: string } }
+        - { name: configId, in: path, required: true, schema: { type: string, format: uuid} }
+      requestBody:
+        required: true
+        content: { application/json: { schema: { type: object } } }
+      responses:
+        '200':
+          description: The new notification config
+          content: { application/json: { schema: { type: object } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/notifications/adhoc:
     post:
       summary: Send a one-off notification/message to one or more enrollees with a specified notification config

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/notifications/NotifcationConfigExtAuthServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/notifications/NotifcationConfigExtAuthServiceTests.java
@@ -1,0 +1,56 @@
+package bio.terra.pearl.api.admin.service.notifications;
+
+import static org.mockito.Mockito.when;
+
+import bio.terra.pearl.api.admin.service.AuthUtilService;
+import bio.terra.pearl.core.dao.publishing.PortalEnvironmentChangeRecordDao;
+import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.service.exception.PermissionDeniedException;
+import bio.terra.pearl.core.service.notification.NotificationConfigService;
+import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
+import bio.terra.pearl.core.service.study.StudyEnvironmentService;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ContextConfiguration(classes = NotificationConfigExtService.class)
+@WebMvcTest
+public class NotifcationConfigExtAuthServiceTests {
+  @Autowired private MockMvc mockMvc;
+  @Autowired private NotificationConfigExtService notificationConfigExtService;
+
+  @MockBean private AuthUtilService mockAuthUtilService;
+
+  @MockBean private NotificationConfigService notificationConfigService;
+  @MockBean private StudyEnvironmentService studyEnvironmentService;
+  @MockBean private PortalEnvironmentService portalEnvironmentService;
+  @MockBean private PortalEnvironmentChangeRecordDao portalEnvironmentChangeRecordDao;
+
+  @Test
+  public void replaceConfigAuthsToPortal() {
+    AdminUser user = AdminUser.builder().superuser(false).build();
+    when(mockAuthUtilService.authUserToPortal(user, "foo"))
+        .thenThrow(new PermissionDeniedException("test1"));
+    Assertions.assertThrows(
+        PermissionDeniedException.class,
+        () ->
+            notificationConfigExtService.replace(
+                "foo", "studyCode", EnvironmentName.live, UUID.randomUUID(), null, user));
+  }
+
+  @Test
+  public void findForSutdyAuthsToStudy() {
+    AdminUser user = AdminUser.builder().superuser(false).build();
+    when(mockAuthUtilService.authUserToStudy(user, "foo", "bar"))
+        .thenThrow(new PermissionDeniedException("test1"));
+    Assertions.assertThrows(
+        PermissionDeniedException.class,
+        () -> notificationConfigExtService.findForStudy(user, "foo", "bar", EnvironmentName.live));
+  }
+}

--- a/core/src/main/java/bio/terra/pearl/core/model/notification/NotificationConfig.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/notification/NotificationConfig.java
@@ -50,7 +50,7 @@ public class NotificationConfig extends BaseEntity implements VersionedEntityCon
     @Builder.Default
     private int reminderIntervalMinutes = (int) Duration.ofHours(72).toMinutes();
     @Builder.Default
-    private int maxNumReminders = -1; // -1 means to keep reminding indefinitely
+    private int maxNumReminders = 5; // -1 means to keep reminding indefinitely
 
     @Override
     public Versioned versionedEntity() {

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -641,6 +641,17 @@ export default {
     return await this.processJsonResponse(response)
   },
 
+  async updateNotificationConfig(portalShortcode: string, envName: string, studyShortcode: string,
+                               oldConfigId: string, updatedConfig: NotificationConfig): Promise<NotificationConfig> {
+    const url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/notificationConfigs/${oldConfigId}`
+    const response = await fetch(url, {
+      method: 'PATCH',
+      headers: this.getInitHeaders(),
+      body: JSON.stringify(updatedConfig)
+    })
+    return await this.processJsonResponse(response)
+  },
+
   async testNotification(portalShortcode: string, envName: string,
     notificationConfigId: string, enrolleeRuleData: object): Promise<NotificationConfig> {
     const url = `${basePortalEnvUrl(portalShortcode, envName)}/notificationConfigs/${notificationConfigId}`

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -642,7 +642,7 @@ export default {
   },
 
   async updateNotificationConfig(portalShortcode: string, envName: string, studyShortcode: string,
-                               oldConfigId: string, updatedConfig: NotificationConfig): Promise<NotificationConfig> {
+    oldConfigId: string, updatedConfig: NotificationConfig): Promise<NotificationConfig> {
     const url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/notificationConfigs/${oldConfigId}`
     const response = await fetch(url, {
       method: 'PATCH',

--- a/ui-admin/src/study/StudyEnvironmentRouter.tsx
+++ b/ui-admin/src/study/StudyEnvironmentRouter.tsx
@@ -11,7 +11,6 @@ import PreEnrollView from './surveys/PreEnrollView'
 import StudyContent from './StudyContent'
 import KitsRouter from './kits/KitsRouter'
 import ParticipantsRouter from './participants/ParticipantsRouter'
-import NotificationConfigView from './notifications/NotificationConfigView'
 import QuestionScratchbox from './surveys/editor/QuestionScratchbox'
 import ExportDataBrowser from './participants/export/ExportDataBrowser'
 import StudyEnvMetricsView from './metrics/StudyEnvMetricsView'
@@ -76,8 +75,7 @@ function StudyEnvironmentRouter({ study }: {study: Study}) {
       />
     </NavBreadcrumb>
     <Routes>
-      <Route path="notificationContent/*" element={<NotificationContent studyEnvContext={studyEnvContext}
-                                                                        portalContext={portalContext}/>}/>
+      <Route path="notificationContent/*" element={<NotificationContent studyEnvContext={studyEnvContext}/>}/>
       <Route path="participants/*" element={<ParticipantsRouter studyEnvContext={studyEnvContext}/>}/>
       <Route path="kits/*" element={<KitsRouter studyEnvContext={studyEnvContext}/>}/>
       <Route path="siteContent" element={<SiteContentView portalEnv={portalEnv} portalShortcode={portal.shortcode}/>}/>

--- a/ui-admin/src/study/StudyEnvironmentRouter.tsx
+++ b/ui-admin/src/study/StudyEnvironmentRouter.tsx
@@ -76,11 +76,8 @@ function StudyEnvironmentRouter({ study }: {study: Study}) {
       />
     </NavBreadcrumb>
     <Routes>
-      <Route path="notificationContent">
-        <Route path="configs/:configId"
-          element={<NotificationConfigView studyEnvContext={studyEnvContext}/>}/>
-        <Route index element={<NotificationContent studyEnvContext={studyEnvContext}/>}/>
-      </Route>
+      <Route path="notificationContent/*" element={<NotificationContent studyEnvContext={studyEnvContext}
+                                                                        portalContext={portalContext}/>}/>
       <Route path="participants/*" element={<ParticipantsRouter studyEnvContext={studyEnvContext}/>}/>
       <Route path="kits/*" element={<KitsRouter studyEnvContext={studyEnvContext}/>}/>
       <Route path="siteContent" element={<SiteContentView portalEnv={portalEnv} portalShortcode={portal.shortcode}/>}/>

--- a/ui-admin/src/study/notifications/NotificationConfigView.tsx
+++ b/ui-admin/src/study/notifications/NotificationConfigView.tsx
@@ -1,25 +1,30 @@
-import React, { useState } from 'react'
+import React, {useEffect, useState} from 'react'
 import { StudyEnvContextT } from '../StudyEnvironmentRouter'
-import { useParams } from 'react-router-dom'
+import {useNavigate, useParams} from 'react-router-dom'
 import Select from 'react-select'
 import TestEmailSender from './TestEmailSender'
 import { cloneDeep } from 'lodash'
+import Api from "../../api/api";
+import {LoadedPortalContextT, PortalContextT} from "../../portal/PortalProvider";
+import {failureNotification, successNotification} from "../../util/notifications";
+import {Store} from "react-notifications-component";
 
 const configTypeOptions = [{ label: 'Event', value: 'EVENT' }, { label: 'Task reminder', value: 'TASK_REMINDER' },
   { label: 'Ad hoc', value: 'AD_HOC' }]
 const deliveryTypeOptions = [{ label: 'Email', value: 'EMAIL' }]
 const eventTypeOptions = [{ label: 'Study Enrollment', value: 'STUDY_ENROLLMENT' },
-  { label: 'Study Consent', value: 'STUDY_CONSENT' }]
+  { label: 'Study Consent', value: 'STUDY_CONSENT'}, {label: 'Survey Response', value: 'SURVEY_RESPONSE' }]
 const taskTypeOptions = [{ label: 'Survey', value: 'SURVEY' }, { label: 'Consent', value: 'CONSENT' }]
 
 
 /** for viewing and editing a notification config.  saving not yet implemented */
-export default function NotificationConfigView({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
-  const { currentEnv, portal } = studyEnvContext
+export default function NotificationConfigView({ studyEnvContext, portalContext }:
+{studyEnvContext: StudyEnvContextT, portalContext: LoadedPortalContextT}) {
+  const { currentEnv, portal, study, currentEnvPath } = studyEnvContext
   const [showSendModal, setShowSendModal] = useState(false)
+  const navigate = useNavigate()
 
   const configId = useParams().configId
-
   const matchedConfig  = currentEnv.notificationConfigs.find(cfig => cfig.id === configId)
   const [config, setConfig] = useState(matchedConfig)
   if (!config) {
@@ -35,71 +40,114 @@ export default function NotificationConfigView({ studyEnvContext }: {studyEnvCon
     setConfig(newConfig)
   }
 
-  return <div className="row justify-content-center">
-    <div className="col-md-8 p-2">
-      <h5>Configure notification</h5>
-      <form className="bg-white p-3 my-2">
-        <div >
-          <label className="form-label">Notification type
-            <Select options={configTypeOptions} isDisabled={true}
-              value={configTypeOptions.find(opt => opt.value === config.notificationType)}/>
-          </label>
-        </div>
-        { isEventConfig && <div>
-          <label className="form-label">Event name
-            <Select options={eventTypeOptions}
-              value={eventTypeOptions.find(opt => opt.value === config.eventType)}/>
-          </label>
-        </div> }
-        { isTaskReminder && <div>
-          <div>
-            <label className="form-label">Task type
-              <Select options={eventTypeOptions}
-                value={taskTypeOptions.find(opt => opt.value === config.taskType)}/>
-            </label>
-          </div>
-          <div>
-            <label className="form-label">Remind after:
-              <div className="d-flex"> <input className="form-control" type="text" readOnly={true}
-                value={config.afterMinutesIncomplete}/> minutes</div>
-            </label>
-            <label className="form-label ms-3">Repeat reminder after:
-              <div className="d-flex"><input className="form-control" type="text"
-                readOnly={true} value={config.reminderIntervalMinutes}/>
-                minutes</div>
-            </label>
-            <label className="form-label ms-3">Max reminders:
-              <input className="form-control" type="text" readOnly={true} value={config.maxNumReminders}/>
-            </label>
-          </div>
-        </div>
-        }
+  const saveConfig = async () => {
+    if (!matchedConfig) {
+      return
+    }
+    try {
+      const savedConfig = await Api.updateNotificationConfig(portal.shortcode,
+          currentEnv.environmentName, study.shortcode, matchedConfig.id, config)
+      Store.addNotification(successNotification('Notification saved'))
+      const matchedConfigIndex = currentEnv.notificationConfigs.findIndex(cfig => cfig.id === configId)
+      if (!matchedConfigIndex) {
+        return
+      }
+      currentEnv.notificationConfigs = [...currentEnv.notificationConfigs]
+      currentEnv.notificationConfigs[matchedConfigIndex] = savedConfig
+      navigate(`${currentEnvPath}/notificationContent/configs/${savedConfig.id}`)
+    } catch {
+      Store.addNotification(failureNotification('Save failed'))
+    }
+  }
+
+  const loadConfig = async (configId: string) => {
+    setConfig(matchedConfig)
+  }
+
+  useEffect(() => {
+    if (configId) {
+      loadConfig(configId)
+    }
+  }, [configId])
+
+  return <div>
+    <form className="bg-white p-3 my-2">
+      <div >
+        <label className="form-label">Notification type
+          <Select options={configTypeOptions} isDisabled={true}
+            value={configTypeOptions.find(opt => opt.value === config.notificationType)}/>
+        </label>
+      </div>
+      { isEventConfig && <div>
+        <label className="form-label">Event name
+          <Select options={eventTypeOptions} isDisabled={true}
+            value={eventTypeOptions.find(opt => opt.value === config.eventType)}/>
+        </label>
+      </div> }
+      { isTaskReminder && <div>
         <div>
-          <label className="form-label">Delivery
-            <Select options={deliveryTypeOptions}
-              value={deliveryTypeOptions.find(opt => opt.value === config.deliveryType)}/>
+          <label className="form-label">Task type
+            <Select options={eventTypeOptions} isDisabled={true}
+              value={taskTypeOptions.find(opt => opt.value === config.taskType)}/>
           </label>
         </div>
-
-        { hasTemplate && <div className="mt-3">
-          <h6>Email Template</h6>
-          <div>
-            <label className="form-label">Subject
-              <input className="form-control" type="text" size={100} value={config.emailTemplate.subject}/>
-            </label>
-          </div>
-          <textarea rows={20} cols={100} value={config.emailTemplate.body}
-            onChange={e => updateEmailBody(e.target.value)}/>
-        </div>}
-
-        <div className="d-flex justify-content-center">
-          <button type="button" className="btn btn-primary" onClick={() => alert('not yet implemented')}>Save</button>
-          <button type="button" className="btn btn-secondary ms-4"
-            onClick={() => setShowSendModal(true)}>Send test email</button>
+        <div>
+          <label className="form-label">Remind after:
+            <div className="d-flex align-items-center">
+              <input className="form-control me-2" type="text" value={config.afterMinutesIncomplete}
+                     onChange={e => setConfig(
+                         {...config, afterMinutesIncomplete: parseInt(e.target.value) || 0}
+               )}/>
+              minutes
+            </div>
+          </label>
         </div>
-        <TestEmailSender portalShortcode={portal.shortcode} environmentName={currentEnv.environmentName}
-          show={showSendModal} setShow={setShowSendModal} notificationConfig={config}/>
-      </form>
-    </div>
+        <div>
+          <label className="form-label">Repeat reminder after:
+            <div className="d-flex align-items-center">
+              <input className="form-control me-2" type="text" value={config.reminderIntervalMinutes}
+                     onChange={e => setConfig(
+                         {...config, reminderIntervalMinutes: parseInt(e.target.value) || 0}
+                     )}
+              />
+              minutes</div>
+          </label>
+        </div>
+        <div>
+          <label className="form-label">Max reminders:
+            <input className="form-control" type="text" value={config.maxNumReminders}
+              onChange={e => setConfig(
+                  {...config, maxNumReminders: parseInt(e.target.value) || 0}
+              )}/>
+          </label>
+        </div>
+      </div>
+      }
+      <div>
+        <label className="form-label">Delivery
+          <Select options={deliveryTypeOptions}  isDisabled={true}
+            value={deliveryTypeOptions.find(opt => opt.value === config.deliveryType)}/>
+        </label>
+      </div>
+
+      { hasTemplate && <div className="mt-3">
+        <h6>Email Template</h6>
+        <div>
+          <label className="form-label">Subject
+            <input className="form-control" type="text" size={100} value={config.emailTemplate.subject}
+              readOnly={true}/>
+          </label>
+        </div>
+        <textarea rows={20} cols={100} value={config.emailTemplate.body} readOnly={true}/>
+      </div>}
+
+      <div className="d-flex justify-content-center">
+        <button type="button" className="btn btn-primary" onClick={saveConfig}>Save</button>
+        <button type="button" className="btn btn-secondary ms-4"
+          onClick={() => setShowSendModal(true)}>Send test email</button>
+      </div>
+      <TestEmailSender portalShortcode={portal.shortcode} environmentName={currentEnv.environmentName}
+        show={showSendModal} setShow={setShowSendModal} notificationConfig={config}/>
+    </form>
   </div>
 }

--- a/ui-admin/src/study/notifications/NotificationConfigView.tsx
+++ b/ui-admin/src/study/notifications/NotificationConfigView.tsx
@@ -85,9 +85,9 @@ export default function NotificationConfigView({ studyEnvContext }: {studyEnvCon
           </label>
         </div>
         <div>
-          <label className="form-label">Remind after:
+          <label className="form-label">Remind after
             <div className="d-flex align-items-center">
-              <input className="form-control me-2" type="text" value={config.afterMinutesIncomplete}
+              <input className="form-control me-2" type="number" value={config.afterMinutesIncomplete}
                 onChange={e => setConfig(
                   { ...config, afterMinutesIncomplete: parseInt(e.target.value) || 0 }
                 )}/>
@@ -96,9 +96,9 @@ export default function NotificationConfigView({ studyEnvContext }: {studyEnvCon
           </label>
         </div>
         <div>
-          <label className="form-label">Repeat reminder after:
+          <label className="form-label">Repeat reminder after
             <div className="d-flex align-items-center">
-              <input className="form-control me-2" type="text" value={config.reminderIntervalMinutes}
+              <input className="form-control me-2" type="number" value={config.reminderIntervalMinutes}
                 onChange={e => setConfig(
                   { ...config, reminderIntervalMinutes: parseInt(e.target.value) || 0 }
                 )}
@@ -107,8 +107,8 @@ export default function NotificationConfigView({ studyEnvContext }: {studyEnvCon
           </label>
         </div>
         <div>
-          <label className="form-label">Max reminders:
-            <input className="form-control" type="text" value={config.maxNumReminders}
+          <label className="form-label">Max reminders
+            <input className="form-control" type="number" value={config.maxNumReminders}
               onChange={e => setConfig(
                 { ...config, maxNumReminders: parseInt(e.target.value) || 0 }
               )}/>

--- a/ui-admin/src/study/notifications/NotificationConfigView.tsx
+++ b/ui-admin/src/study/notifications/NotificationConfigView.tsx
@@ -1,25 +1,22 @@
-import React, {useEffect, useState} from 'react'
+import React, { useEffect, useState } from 'react'
 import { StudyEnvContextT } from '../StudyEnvironmentRouter'
-import {useNavigate, useParams} from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import Select from 'react-select'
 import TestEmailSender from './TestEmailSender'
-import { cloneDeep } from 'lodash'
-import Api from "../../api/api";
-import {LoadedPortalContextT, PortalContextT} from "../../portal/PortalProvider";
-import {failureNotification, successNotification} from "../../util/notifications";
-import {Store} from "react-notifications-component";
+import Api from 'api/api'
+import { failureNotification, successNotification } from 'util/notifications'
+import { Store } from 'react-notifications-component'
 
 const configTypeOptions = [{ label: 'Event', value: 'EVENT' }, { label: 'Task reminder', value: 'TASK_REMINDER' },
   { label: 'Ad hoc', value: 'AD_HOC' }]
 const deliveryTypeOptions = [{ label: 'Email', value: 'EMAIL' }]
 const eventTypeOptions = [{ label: 'Study Enrollment', value: 'STUDY_ENROLLMENT' },
-  { label: 'Study Consent', value: 'STUDY_CONSENT'}, {label: 'Survey Response', value: 'SURVEY_RESPONSE' }]
+  { label: 'Study Consent', value: 'STUDY_CONSENT' }, { label: 'Survey Response', value: 'SURVEY_RESPONSE' }]
 const taskTypeOptions = [{ label: 'Survey', value: 'SURVEY' }, { label: 'Consent', value: 'CONSENT' }]
 
 
 /** for viewing and editing a notification config.  saving not yet implemented */
-export default function NotificationConfigView({ studyEnvContext, portalContext }:
-{studyEnvContext: StudyEnvContextT, portalContext: LoadedPortalContextT}) {
+export default function NotificationConfigView({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
   const { currentEnv, portal, study, currentEnvPath } = studyEnvContext
   const [showSendModal, setShowSendModal] = useState(false)
   const navigate = useNavigate()
@@ -34,19 +31,13 @@ export default function NotificationConfigView({ studyEnvContext, portalContext 
   const isTaskReminder = config.notificationType === 'TASK_REMINDER'
   const isEventConfig = config.notificationType === 'EVENT'
 
-  const updateEmailBody = (newBody: string) => {
-    const newConfig = cloneDeep(config)
-    newConfig.emailTemplate.body = newBody
-    setConfig(newConfig)
-  }
-
   const saveConfig = async () => {
     if (!matchedConfig) {
       return
     }
     try {
       const savedConfig = await Api.updateNotificationConfig(portal.shortcode,
-          currentEnv.environmentName, study.shortcode, matchedConfig.id, config)
+        currentEnv.environmentName, study.shortcode, matchedConfig.id, config)
       Store.addNotification(successNotification('Notification saved'))
       const matchedConfigIndex = currentEnv.notificationConfigs.findIndex(cfig => cfig.id === configId)
       if (!matchedConfigIndex) {
@@ -60,13 +51,15 @@ export default function NotificationConfigView({ studyEnvContext, portalContext 
     }
   }
 
-  const loadConfig = async (configId: string) => {
+  const loadConfig = async () => {
+    // we'll want to load the config from the server in the future to not be dependent on initial bulk study loads
+    // for now, we just pull it off the study
     setConfig(matchedConfig)
   }
 
   useEffect(() => {
     if (configId) {
-      loadConfig(configId)
+      loadConfig()
     }
   }, [configId])
 
@@ -95,9 +88,9 @@ export default function NotificationConfigView({ studyEnvContext, portalContext 
           <label className="form-label">Remind after:
             <div className="d-flex align-items-center">
               <input className="form-control me-2" type="text" value={config.afterMinutesIncomplete}
-                     onChange={e => setConfig(
-                         {...config, afterMinutesIncomplete: parseInt(e.target.value) || 0}
-               )}/>
+                onChange={e => setConfig(
+                  { ...config, afterMinutesIncomplete: parseInt(e.target.value) || 0 }
+                )}/>
               minutes
             </div>
           </label>
@@ -106,9 +99,9 @@ export default function NotificationConfigView({ studyEnvContext, portalContext 
           <label className="form-label">Repeat reminder after:
             <div className="d-flex align-items-center">
               <input className="form-control me-2" type="text" value={config.reminderIntervalMinutes}
-                     onChange={e => setConfig(
-                         {...config, reminderIntervalMinutes: parseInt(e.target.value) || 0}
-                     )}
+                onChange={e => setConfig(
+                  { ...config, reminderIntervalMinutes: parseInt(e.target.value) || 0 }
+                )}
               />
               minutes</div>
           </label>
@@ -117,7 +110,7 @@ export default function NotificationConfigView({ studyEnvContext, portalContext 
           <label className="form-label">Max reminders:
             <input className="form-control" type="text" value={config.maxNumReminders}
               onChange={e => setConfig(
-                  {...config, maxNumReminders: parseInt(e.target.value) || 0}
+                { ...config, maxNumReminders: parseInt(e.target.value) || 0 }
               )}/>
           </label>
         </div>

--- a/ui-admin/src/study/notifications/NotificationContent.test.tsx
+++ b/ui-admin/src/study/notifications/NotificationContent.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+import { mockNotificationConfig, mockStudyEnvContext } from 'test-utils/mocking-utils'
+import { setupRouterTest } from 'test-utils/router-testing-utils'
+import NotificationContent from './NotificationContent'
+import userEvent from '@testing-library/user-event'
+
+test('renders routable config list', async () => {
+  const studyEnvContext = mockStudyEnvContext()
+  const enrollEmailConfig = {
+    ...mockNotificationConfig(),
+    id: 'event1',
+    notificationType: 'EVENT',
+    eventType: 'STUDY_ENROLLMENT'
+  }
+  studyEnvContext.currentEnv.notificationConfigs = [
+    enrollEmailConfig,
+    {
+      ...mockNotificationConfig(),
+      id: 'reminder1',
+      notificationType: 'TASK_REMINDER',
+      taskType: 'CONSENT'
+    },
+    {
+      ...mockNotificationConfig(),
+      id: 'reminder2',
+      notificationType: 'TASK_REMINDER',
+      taskType: 'SURVEY'
+    }
+  ]
+
+  const { RoutedComponent, router } = setupRouterTest(<NotificationContent studyEnvContext={studyEnvContext}/>)
+  render(RoutedComponent)
+  expect(screen.getByText('Participant Notifications')).toBeInTheDocument()
+  expect(screen.getByText('Study enrollment')).toBeInTheDocument()
+  expect(screen.getByText('Reminder: CONSENT')).toBeInTheDocument()
+  expect(screen.getByText('Reminder: SURVEY')).toBeInTheDocument()
+
+  await userEvent.click(screen.getByText('Study enrollment'))
+  expect(router.state.location.pathname).toEqual(`/configs/${enrollEmailConfig.id}`)
+})

--- a/ui-admin/src/study/notifications/NotificationContent.tsx
+++ b/ui-admin/src/study/notifications/NotificationContent.tsx
@@ -16,17 +16,17 @@ const CONFIG_GROUPS = [
 export default function NotificationContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
   const currentEnv = studyEnvContext.currentEnv
   const navigate = useNavigate()
-  const [prevEnv, setPrevEnv] = useState<string>(currentEnv.environmentName)
+  const [previousEnv, setPreviousEnv] = useState<string>(currentEnv.environmentName)
   /** styles links as bold if they are the current path */
   const navStyleFunc = ({ isActive }: {isActive: boolean}) => {
     return isActive ? { fontWeight: 'bold' } : {}
   }
 
   useEffect(() => {
-    if (prevEnv !== currentEnv.environmentName) {
+    if (previousEnv !== currentEnv.environmentName) {
       // the user has changed the environment -- we need to clear the id off the path if there
       navigate(`${studyEnvContext.currentEnvPath}/notificationContent`)
-      setPrevEnv(currentEnv.environmentName)
+      setPreviousEnv(currentEnv.environmentName)
     }
   }, [currentEnv.environmentName])
 

--- a/ui-admin/src/study/notifications/NotificationContent.tsx
+++ b/ui-admin/src/study/notifications/NotificationContent.tsx
@@ -1,21 +1,19 @@
-import React, {useEffect, useState} from 'react'
-import {Link, NavLink, Outlet, Route, Routes, useNavigate} from 'react-router-dom'
+import React, { useEffect, useState } from 'react'
+import { NavLink, Outlet, Route, Routes, useNavigate } from 'react-router-dom'
 import NotificationConfigTypeDisplay, { deliveryTypeDisplayMap } from './NotifcationConfigTypeDisplay'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus'
-import {StudyEnvContextT, studyEnvPath} from '../StudyEnvironmentRouter'
-import NotificationConfigView from "./NotificationConfigView";
-import {LoadedPortalContextT} from "portal/PortalProvider";
+import { StudyEnvContextT } from '../StudyEnvironmentRouter'
+import NotificationConfigView from './NotificationConfigView'
 
 const CONFIG_GROUPS = [
-  {title: 'Event', type: 'EVENT'},
-  {title: 'Reminder', type: 'TASK_REMINDER'},
-  {title: 'Ad-hoc', type: 'AD_HOC'}
+  { title: 'Event', type: 'EVENT' },
+  { title: 'Reminder', type: 'TASK_REMINDER' },
+  { title: 'Ad-hoc', type: 'AD_HOC' }
 ]
 
 /** shows configuration of notifications for a study */
-export default function NotificationContent({ studyEnvContext, portalContext }:
-{studyEnvContext: StudyEnvContextT, portalContext: LoadedPortalContextT}) {
+export default function NotificationContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
   const currentEnv = studyEnvContext.currentEnv
   const navigate = useNavigate()
   const [prevEnv, setPrevEnv] = useState<string>(currentEnv.environmentName)
@@ -23,11 +21,6 @@ export default function NotificationContent({ studyEnvContext, portalContext }:
   const navStyleFunc = ({ isActive }: {isActive: boolean}) => {
     return isActive ? { fontWeight: 'bold' } : {}
   }
-
-  const eventConfigs = currentEnv.notificationConfigs.filter(config => config.notificationType === 'EVENT')
-  const reminderConfigs = currentEnv.notificationConfigs.filter(config => config.notificationType === 'REMINDER')
-  const otherConfigs = currentEnv.notificationConfigs
-      .filter(config => config.notificationType !== 'EVENT' && config.notificationType !== 'EVENT')
 
   useEffect(() => {
     if (prevEnv !== currentEnv.environmentName) {
@@ -46,16 +39,16 @@ export default function NotificationContent({ studyEnvContext, portalContext }:
             <h3 className="h6">{group.title}</h3>
             <ul>
               { currentEnv.notificationConfigs
-                  .filter(config => config.notificationType === group.type)
-                  .map(config => <li key={config.id} className="py-1">
-                    <div className="d-flex">
-                      <NavLink to={`configs/${config.id}`} style={navStyleFunc}>
-                        <NotificationConfigTypeDisplay config={config}/>
-                        <span className="detail"> ({deliveryTypeDisplayMap[config.deliveryType]})</span>
-                      </NavLink>
-                    </div>
-                  </li>
-              ) }
+                .filter(config => config.notificationType === group.type)
+                .map(config => <li key={config.id} className="py-1">
+                  <div className="d-flex">
+                    <NavLink to={`configs/${config.id}`} style={navStyleFunc}>
+                      <NotificationConfigTypeDisplay config={config}/>
+                      <span className="text-muted fst-italic"> ({deliveryTypeDisplayMap[config.deliveryType]})</span>
+                    </NavLink>
+                  </div>
+                </li>
+                ) }
             </ul>
           </li>)}
         </ul>
@@ -66,7 +59,7 @@ export default function NotificationContent({ studyEnvContext, portalContext }:
       <div className="col-md-9 py-3">
         <Routes>
           <Route path="configs/:configId"
-                 element={<NotificationConfigView studyEnvContext={studyEnvContext} portalContext={portalContext}/>}/>
+            element={<NotificationConfigView studyEnvContext={studyEnvContext}/>}/>
         </Routes>
         <Outlet/>
       </div>

--- a/ui-admin/src/study/notifications/NotificationContent.tsx
+++ b/ui-admin/src/study/notifications/NotificationContent.tsx
@@ -1,30 +1,75 @@
-import React from 'react'
-import { Link } from 'react-router-dom'
+import React, {useEffect, useState} from 'react'
+import {Link, NavLink, Outlet, Route, Routes, useNavigate} from 'react-router-dom'
 import NotificationConfigTypeDisplay, { deliveryTypeDisplayMap } from './NotifcationConfigTypeDisplay'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus'
-import { StudyEnvContextT } from '../StudyEnvironmentRouter'
+import {StudyEnvContextT, studyEnvPath} from '../StudyEnvironmentRouter'
+import NotificationConfigView from "./NotificationConfigView";
+import {LoadedPortalContextT} from "portal/PortalProvider";
+
+const CONFIG_GROUPS = [
+  {title: 'Event', type: 'EVENT'},
+  {title: 'Reminder', type: 'TASK_REMINDER'},
+  {title: 'Ad-hoc', type: 'AD_HOC'}
+]
 
 /** shows configuration of notifications for a study */
-export default function NotificationContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
+export default function NotificationContent({ studyEnvContext, portalContext }:
+{studyEnvContext: StudyEnvContextT, portalContext: LoadedPortalContextT}) {
   const currentEnv = studyEnvContext.currentEnv
-  return <div className="container m-3 p-3 bg-white">
-    <h2 className="h4">Participant Notifications</h2>
-    <div className="flex-grow-1 p-3">
-      <ul className="list-unstyled">
-        { currentEnv.notificationConfigs.map(config => <li key={config.id} className="p-1">
-          <div className="d-flex">
-            <Link to={`configs/${config.id}`}>
-              <NotificationConfigTypeDisplay config={config}/>
-              <span className="detail"> ({deliveryTypeDisplayMap[config.deliveryType]})</span>
-            </Link>
-          </div>
-        </li>
-        ) }
-      </ul>
-      <button className="btn btn-secondary" onClick={() => alert('not yet implemented')}>
-        <FontAwesomeIcon icon={faPlus}/> Add
-      </button>
+  const navigate = useNavigate()
+  const [prevEnv, setPrevEnv] = useState<string>(currentEnv.environmentName)
+  /** styles links as bold if they are the current path */
+  const navStyleFunc = ({ isActive }: {isActive: boolean}) => {
+    return isActive ? { fontWeight: 'bold' } : {}
+  }
+
+  const eventConfigs = currentEnv.notificationConfigs.filter(config => config.notificationType === 'EVENT')
+  const reminderConfigs = currentEnv.notificationConfigs.filter(config => config.notificationType === 'REMINDER')
+  const otherConfigs = currentEnv.notificationConfigs
+      .filter(config => config.notificationType !== 'EVENT' && config.notificationType !== 'EVENT')
+
+  useEffect(() => {
+    if (prevEnv !== currentEnv.environmentName) {
+      // the user has changed the environment -- we need to clear the id off the path if there
+      navigate(`${studyEnvContext.currentEnvPath}/notificationContent`)
+      setPrevEnv(currentEnv.environmentName)
+    }
+  }, [currentEnv.environmentName])
+
+  return <div className="container-fluid">
+    <div className="bg-white p-3 ps-5 row">
+      <div className="col-md-3 px-0 py-3 mh-100 bg-white border-end">
+        <h2 className="h5">Participant Notifications</h2>
+        <ul className="list-unstyled px-2">
+          { CONFIG_GROUPS.map(group => <li key={group.type}>
+            <h3 className="h6">{group.title}</h3>
+            <ul>
+              { currentEnv.notificationConfigs
+                  .filter(config => config.notificationType === group.type)
+                  .map(config => <li key={config.id} className="py-1">
+                    <div className="d-flex">
+                      <NavLink to={`configs/${config.id}`} style={navStyleFunc}>
+                        <NotificationConfigTypeDisplay config={config}/>
+                        <span className="detail"> ({deliveryTypeDisplayMap[config.deliveryType]})</span>
+                      </NavLink>
+                    </div>
+                  </li>
+              ) }
+            </ul>
+          </li>)}
+        </ul>
+        <button className="btn btn-secondary" onClick={() => alert('not yet implemented')}>
+          <FontAwesomeIcon icon={faPlus}/> Add
+        </button>
+      </div>
+      <div className="col-md-9 py-3">
+        <Routes>
+          <Route path="configs/:configId"
+                 element={<NotificationConfigView studyEnvContext={studyEnvContext} portalContext={portalContext}/>}/>
+        </Routes>
+        <Outlet/>
+      </div>
     </div>
   </div>
 }

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -1,11 +1,11 @@
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
-import { DatasetDetails, Enrollee, KitRequest, KitType, ParticipantNote, Portal } from 'api/api'
+import { DatasetDetails, Enrollee, KitRequest, KitType, NotificationConfig, ParticipantNote, Portal } from 'api/api'
 import { Survey } from '@juniper/ui-core/build/types/forms'
 import { ParticipantTask } from '@juniper/ui-core/build/types/task'
 
 import _times from 'lodash/times'
 import _random from 'lodash/random'
-import { StudyEnvironmentSurvey } from '@juniper/ui-core/build/types/study'
+import { EmailTemplate, StudyEnvironmentSurvey } from '@juniper/ui-core/build/types/study'
 import { LoadedPortalContextT } from '../portal/PortalProvider'
 import { PortalEnvironment } from '@juniper/ui-core/build/types/portal'
 
@@ -202,5 +202,38 @@ export const mockParticipantNote = (): ParticipantNote => {
     createdAt: 0,
     lastUpdatedAt: 0,
     text: 'some note text'
+  }
+}
+
+/** mock NotificationConfig */
+export const mockNotificationConfig = (): NotificationConfig => {
+  return {
+    id: 'noteId1',
+    notificationType: 'EVENT',
+    eventType: 'CONSENT',
+    deliveryType: 'EMAIL',
+    taskType: '',
+    portalEnvironmentId: 'portalEnvId',
+    studyEnvironmentId: 'studyEnvId',
+    maxNumReminders: -1,
+    afterMinutesIncomplete: -1,
+    reminderIntervalMinutes: 10,
+    taskTargetStableId: '',
+    active: true,
+    emailTemplateId: 'emailTemplateId',
+    emailTemplate: mockEmailTemplate(),
+    rule: ''
+  }
+}
+
+/** Mock EmailTemplate */
+export const mockEmailTemplate = (): EmailTemplate => {
+  return {
+    id: 'emailTemplate1',
+    name: 'Mock template',
+    subject: 'Mock subject',
+    stableId: 'mock1',
+    version: 1,
+    body: 'Mock email message'
   }
 }

--- a/ui-core/src/types/study.ts
+++ b/ui-core/src/types/study.ts
@@ -68,6 +68,7 @@ export type NotificationConfig = {
 }
 
 export type EmailTemplate = {
+  id?: string  // id may not be present if the template is newly created client-side
   subject: string
   body: string
   name: string


### PR DESCRIPTION
This enables some properties of notification configs to be editable via UI.  Not the email templates, but the param values like max number of reminders.  (The backend supports creating a new email template, but updating the frontend was outside the scope of this ticket).  This also upgrades the notifcation config UX to match the recently restyled populate UX.

![image](https://github.com/broadinstitute/juniper/assets/2800795/2fd3869d-0be6-460e-b620-f97481f5b729)

TO TEST:
1. go to http://localhost:3000/ourhealth/studies/ourheart/env/sandbox/notificationContent/configs
2. choose a config
3. update the Max reminders value
4. hit save
5. confirm the updated value is saved, and persists on refresh 