### PR TITLE
[JN-480] enabling mailing list contact delete

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/MailingListController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/MailingListController.java
@@ -7,6 +7,7 @@ import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.portal.MailingListContact;
 import java.util.List;
+import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -34,5 +35,13 @@ public class MailingListController implements MailingListApi {
     List<MailingListContact> contacts =
         mailingListExtService.getAll(portalShortcode, environmentName, user);
     return ResponseEntity.ok(contacts);
+  }
+
+  @Override
+  public ResponseEntity<Void> delete(String portalShortcode, String envName, UUID contactId) {
+    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
+    AdminUser user = authUtilService.requireAdminUser(request);
+    mailingListExtService.delete(portalShortcode, environmentName, contactId, user);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/MailingListExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/MailingListExtService.java
@@ -5,24 +5,38 @@ import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.portal.MailingListContact;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
+import bio.terra.pearl.core.model.workflow.DataChangeRecord;
+import bio.terra.pearl.core.service.CascadeProperty;
+import bio.terra.pearl.core.service.exception.PermissionDeniedException;
 import bio.terra.pearl.core.service.portal.MailingListContactService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
+import bio.terra.pearl.core.service.workflow.DataChangeRecordService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class MailingListExtService {
   private AuthUtilService authUtilService;
   private MailingListContactService mailingListContactService;
   private PortalEnvironmentService portalEnvironmentService;
+  private DataChangeRecordService dataChangeRecordService;
+  private ObjectMapper objectMapper;
 
   public MailingListExtService(
       AuthUtilService requestUtilService,
       MailingListContactService mailingListContactService,
-      PortalEnvironmentService portalEnvironmentService) {
+      PortalEnvironmentService portalEnvironmentService,
+      DataChangeRecordService dataChangeRecordService,
+      ObjectMapper objectMapper) {
     this.authUtilService = requestUtilService;
     this.mailingListContactService = mailingListContactService;
     this.portalEnvironmentService = portalEnvironmentService;
+    this.dataChangeRecordService = dataChangeRecordService;
+    this.objectMapper = objectMapper;
   }
 
   public List<MailingListContact> getAll(
@@ -31,5 +45,31 @@ public class MailingListExtService {
     PortalEnvironment portalEnv =
         portalEnvironmentService.findOne(portal.getShortcode(), envName).get();
     return mailingListContactService.findByPortalEnv(portalEnv.getId());
+  }
+
+  @Transactional
+  public void delete(
+      String portalShortcode, EnvironmentName envName, UUID contactId, AdminUser user) {
+    Portal portal = authUtilService.authUserToPortal(user, portalShortcode);
+    PortalEnvironment portalEnv =
+        portalEnvironmentService.findOne(portal.getShortcode(), envName).get();
+    MailingListContact contact = mailingListContactService.find(contactId).get();
+    if (!contact.getPortalEnvironmentId().equals(portalEnv.getId())) {
+      throw new PermissionDeniedException("Contact does not belong to the given portal");
+    }
+    try {
+      DataChangeRecord changeRecord =
+          DataChangeRecord.builder()
+              .modelName(MailingListContact.class.getSimpleName())
+              .responsibleAdminUserId(user.getId())
+              .portalEnvironmentId(portalEnv.getId())
+              .newValue(null)
+              .oldValue(objectMapper.writeValueAsString(contact))
+              .build();
+      dataChangeRecordService.create(changeRecord);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("could not create audit trail", e);
+    }
+    mailingListContactService.delete(contactId, CascadeProperty.EMPTY_SET);
   }
 }

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -581,6 +581,20 @@ paths:
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/env/{envName}/mailingList/{contactId}:
+    delete:
+      summary: Removes an entry from the mailing list
+      tags: [ mailingList ]
+      operationId: delete
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: envName, in: path, required: true, schema: { type: string } }
+        - { name: contactId, in: path, required: true, schema: { type: string, format: uuid } }
+      responses:
+        '204':
+          description: indication of successful deletion
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/current-user/v1/unauthed/login:
     post:
       summary: Unauthenticated login (dev only)

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/MailingServiceExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/MailingServiceExtServiceTests.java
@@ -1,20 +1,77 @@
 package bio.terra.pearl.api.admin.service;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import bio.terra.pearl.api.admin.BaseSpringBootTest;
 import bio.terra.pearl.api.admin.MockAuthServiceAlwaysRejects;
+import bio.terra.pearl.core.factory.admin.AdminUserFactory;
+import bio.terra.pearl.core.factory.portal.PortalEnvironmentFactory;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.model.portal.MailingListContact;
+import bio.terra.pearl.core.model.portal.Portal;
+import bio.terra.pearl.core.model.portal.PortalEnvironment;
+import bio.terra.pearl.core.model.workflow.DataChangeRecord;
 import bio.terra.pearl.core.service.exception.PermissionDeniedException;
+import bio.terra.pearl.core.service.portal.MailingListContactService;
+import bio.terra.pearl.core.service.portal.PortalService;
+import bio.terra.pearl.core.service.workflow.DataChangeRecordService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
-public class MailingServiceExtServiceTests {
+public class MailingServiceExtServiceTests extends BaseSpringBootTest {
+  @Autowired MailingListExtService mailingListExtService;
+  @Autowired MailingListContactService mailingListService;
+  @Autowired PortalEnvironmentFactory portalEnvironmentFactory;
+  @Autowired AdminUserFactory adminUserFactory;
+  @Autowired PortalService portalService;
+  @Autowired DataChangeRecordService dataChangeRecordService;
+  @Autowired ObjectMapper objectMapper;
+
   @Test
   public void mailingListRequiresAuth() {
-    var listExtService = new MailingListExtService(new MockAuthServiceAlwaysRejects(), null, null);
+    var listExtService =
+        new MailingListExtService(new MockAuthServiceAlwaysRejects(), null, null, null, null);
     // testing that this exception is thrown even when everything else is null is a good check that
     // no work is done prior to auth
     Assertions.assertThrows(
         PermissionDeniedException.class,
-        () -> listExtService.getAll("ourhealth", EnvironmentName.live, new AdminUser()));
+        () ->
+            listExtService.delete(
+                "ourhealth", EnvironmentName.live, UUID.randomUUID(), new AdminUser()));
+  }
+
+  @Test
+  @Transactional
+  public void deleteMailingListContact() throws Exception {
+    PortalEnvironment portalEnvironment =
+        portalEnvironmentFactory.buildPersisted("deleteMailingListContact");
+    AdminUser adminUser = adminUserFactory.buildPersisted("deleteMailingListContact", true);
+    Portal portal = portalService.find(portalEnvironment.getPortalId()).get();
+    MailingListContact contact =
+        mailingListService.create(
+            MailingListContact.builder()
+                .name("test1")
+                .email("test1@test.com")
+                .portalEnvironmentId(portalEnvironment.getId())
+                .build());
+
+    MailingListContact createdContact = mailingListService.find(contact.getId()).get();
+    mailingListExtService.delete(
+        portal.getShortcode(), portalEnvironment.getEnvironmentName(), contact.getId(), adminUser);
+    assertThat(mailingListService.find(contact.getId()).isPresent(), equalTo(false));
+    List<DataChangeRecord> changeRecords =
+        dataChangeRecordService.findByPortalEnvironmentId(portalEnvironment.getId());
+    assertThat(changeRecords, hasSize(1));
+    assertThat(changeRecords.get(0).getResponsibleAdminUserId(), equalTo(adminUser.getId()));
+    assertThat(
+        changeRecords.get(0).getOldValue(),
+        equalTo(objectMapper.writeValueAsString(createdContact)));
   }
 }

--- a/core/src/main/java/bio/terra/pearl/core/dao/workflow/DataChangeRecordDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/workflow/DataChangeRecordDao.java
@@ -23,8 +23,16 @@ public class DataChangeRecordDao extends BaseJdbiDao<DataChangeRecord> {
         return findAllByProperty("enrollee_id", enrolleeId);
     }
 
+    public List<DataChangeRecord> findByPortalEnvironmentId(UUID portalEnvId) {
+        return findAllByProperty("portal_environment_id", portalEnvId);
+    }
+
     public void deleteByPortalParticipantUserId(UUID ppUserId) {
         deleteByProperty("portal_participant_user_id", ppUserId);
+    }
+
+    public void deleteByPortalEnvironmentId(UUID portalEnvId) {
+        deleteByProperty("portal_environment_id", portalEnvId);
     }
 
     public void deleteByEnrolleeId(UUID enrolleeId) {

--- a/core/src/main/java/bio/terra/pearl/core/model/workflow/DataChangeRecord.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/workflow/DataChangeRecord.java
@@ -18,6 +18,7 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @NoArgsConstructor
 public class DataChangeRecord extends BaseEntity {
+    private UUID portalEnvironmentId; // id of the associated portal, for operations not tied to an enrollee
     private UUID responsibleUserId; // id of the user making the change, if it was a participant
     private UUID responsibleAdminUserId; // id of the user making the change, if it was an admin
     private UUID enrolleeId; // id of impacted enrollee (may be null)

--- a/core/src/main/java/bio/terra/pearl/core/service/portal/MailingListContactService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/portal/MailingListContactService.java
@@ -24,6 +24,7 @@ public class MailingListContactService extends ImmutableEntityService<MailingLis
         return dao.findByPortalEnv(portalEnvId, emailAddress);
     }
 
+    @Transactional
     public void deleteByPortalEnvId(UUID portalEnvId) {
         dao.deleteByPortalEnvId(portalEnvId);
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/portal/MailingListContactService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/portal/MailingListContactService.java
@@ -1,12 +1,15 @@
 package bio.terra.pearl.core.service.portal;
 
 import bio.terra.pearl.core.dao.portal.MailingListContactDao;
+import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.portal.MailingListContact;
+import bio.terra.pearl.core.model.workflow.DataChangeRecord;
 import bio.terra.pearl.core.service.ImmutableEntityService;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class MailingListContactService extends ImmutableEntityService<MailingListContact, MailingListContactDao> {
@@ -20,6 +23,7 @@ public class MailingListContactService extends ImmutableEntityService<MailingLis
     public Optional<MailingListContact> findByPortalEnv(UUID portalEnvId, String emailAddress) {
         return dao.findByPortalEnv(portalEnvId, emailAddress);
     }
+
     public void deleteByPortalEnvId(UUID portalEnvId) {
         dao.deleteByPortalEnvId(portalEnvId);
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/portal/PortalEnvironmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/portal/PortalEnvironmentService.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import bio.terra.pearl.core.service.workflow.DataChangeRecordService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +28,7 @@ public class PortalEnvironmentService extends CrudService<PortalEnvironment, Por
     private PreregistrationResponseDao preregistrationResponseDao;
     private NotificationConfigService notificationConfigService;
     private MailingListContactService mailingListContactService;
+    private DataChangeRecordService dataChangeRecordService;
 
     public PortalEnvironmentService(PortalEnvironmentDao portalEnvironmentDao,
                                     PortalEnvironmentConfigService portalEnvironmentConfigService,
@@ -33,7 +36,8 @@ public class PortalEnvironmentService extends CrudService<PortalEnvironment, Por
                                     ParticipantUserService participantUserService,
                                     PreregistrationResponseDao preregistrationResponseDao,
                                     NotificationConfigService notificationConfigService,
-                                    MailingListContactService mailingListContactService) {
+                                    MailingListContactService mailingListContactService,
+                                    DataChangeRecordService dataChangeRecordService) {
         super(portalEnvironmentDao);
         this.portalEnvironmentConfigService = portalEnvironmentConfigService;
         this.portalParticipantUserService = portalParticipantUserService;
@@ -41,6 +45,7 @@ public class PortalEnvironmentService extends CrudService<PortalEnvironment, Por
         this.preregistrationResponseDao = preregistrationResponseDao;
         this.notificationConfigService = notificationConfigService;
         this.mailingListContactService = mailingListContactService;
+        this.dataChangeRecordService = dataChangeRecordService;
     }
 
     public List<PortalEnvironment> findByPortal(UUID portalId) {
@@ -92,6 +97,7 @@ public class PortalEnvironmentService extends CrudService<PortalEnvironment, Por
         }
         notificationConfigService.deleteByPortalEnvironmentId(id);
         mailingListContactService.deleteByPortalEnvId(id);
+        dataChangeRecordService.deleteByPortalEnvironmentId(id);
         dao.delete(id);
         portalEnvironmentConfigService.delete(envConfigId, cascades);
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/DataChangeRecordService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/DataChangeRecordService.java
@@ -23,9 +23,18 @@ public class DataChangeRecordService extends ImmutableEntityService<DataChangeRe
         return dao.findByEnrolleeId(enrolleeId);
     }
 
+    public List<DataChangeRecord> findByPortalEnvironmentId(UUID portalEnvId) {
+        return dao.findByPortalEnvironmentId(portalEnvId);
+    }
+
     @Transactional
     public void deleteByPortalParticipantUserId(UUID ppUserId) {
         dao.deleteByPortalParticipantUserId(ppUserId);
+    }
+
+    @Transactional
+    public void deleteByPortalEnvironmentId(UUID portalEnvId) {
+        dao.deleteByPortalEnvironmentId(portalEnvId);
     }
     @Transactional
     public void deleteByEnrolleeId(UUID enrolleeId) {

--- a/core/src/main/resources/db/changelog/changesets/2023_08_24_data_change_record_portal.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2023_08_24_data_change_record_portal.yaml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - changeSet:
+      id: data_change_record_portal_env
+      author: dbush
+      changes:
+        - dropNotNullConstraint: # drop null constraint since fieldName could be null if the change is a delete
+            columnName: field_name
+            tableName: data_change_record
+        - dropNotNullConstraint: # drop null constraint since portal participant user could be null if the change is a mailing list
+            columnName: portal_participant_user_id
+            tableName: data_change_record
+        - addColumn:
+            tableName: data_change_record
+            columns:
+              - column:
+                  name: portal_environment_id
+                  type: uuid
+                  constraints:
+                    foreignKeyName: fk_change_record_portal_env_id
+                    references: portal_environment(id)
+

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -128,6 +128,9 @@ databaseChangeLog:
   - include:
       file: changesets/2023_08_21_add_site_content_constraint.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2023_08_24_data_change_record_portal.yaml
+      relativeToChangelogFile: true
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements
 # are atomic. When they are grouped in a changeset and one fails the changeset cannot be

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/admin/AdminUserFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/admin/AdminUserFactory.java
@@ -14,14 +14,19 @@ public class AdminUserFactory {
 
     public AdminUser.AdminUserBuilder builder(String testName) {
         return AdminUser.builder()
-                .username(RandomStringUtils.randomAlphabetic(10) + "@admin.test.com");
+                .username(testName + "_" + RandomStringUtils.randomAlphabetic(5) + "@test.com");
     }
 
     public AdminUser buildPersisted(String testName) {
-        return adminUserService.create(builder(testName).build());
+        return buildPersisted(testName, false);
+    }
+
+    public AdminUser buildPersisted(String testName, boolean superuser) {
+        return adminUserService.create(builder(testName).superuser(superuser).build());
     }
 
     public AdminUser buildPersisted(AdminUser.AdminUserBuilder builder) {
         return adminUserService.create(builder.build());
     }
+
 }

--- a/ui-admin/src/App.css
+++ b/ui-admin/src/App.css
@@ -14,8 +14,9 @@
 }
 
 .btn-secondary[aria-disabled="true"] {
-  color: #666;
+  color: #444;
   font-style: italic;
+  background: none;
 }
 
 .btn-secondary:focus, .btn-secondary:hover {

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -213,6 +213,7 @@ export type Config = {
 }
 
 export type MailingListContact = {
+  id: string,
   name: string,
   email: string,
   createdAt: number
@@ -347,6 +348,13 @@ export default {
     const obj = await response.json()
     if (response.ok) {
       return obj
+    }
+    return Promise.reject(response)
+  },
+
+  async processResponse(response: Response) {
+    if (response.ok) {
+      return response
     }
     return Promise.reject(response)
   },
@@ -764,6 +772,15 @@ export default {
     const url = `${basePortalEnvUrl(portalShortcode, envName)}/mailingList`
     const response = await fetch(url, this.getGetInit())
     return await this.processJsonResponse(response)
+  },
+
+  async deleteMailingListContact(portalShortcode: string, envName: string, contactId: string): Promise<Response> {
+    const url = `${basePortalEnvUrl(portalShortcode, envName)}/mailingList/${contactId}`
+    const response = await fetch(url, {
+      method: 'DELETE',
+      headers: this.getInitHeaders()
+    })
+    return await this.processResponse(response)
   },
 
   async fetchAdminUsers(): Promise<AdminUser[]> {

--- a/ui-admin/src/portal/MailingListView.test.tsx
+++ b/ui-admin/src/portal/MailingListView.test.tsx
@@ -1,28 +1,26 @@
 import React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 
-import { MailingListContact } from 'api/api'
+import Api, { MailingListContact } from 'api/api'
 import { mockPortalContext } from 'test-utils/mocking-utils'
 import { setupRouterTest } from 'test-utils/router-testing-utils'
 import userEvent from '@testing-library/user-event'
 import MailingListView from './MailingListView'
 
-jest.mock('api/api', () => ({
-  fetchMailingList: () => {
-    const contacts: MailingListContact[] = [{
-      name: 'person1',
-      email: 'fake1@test.com',
-      createdAt: 0
-    }, {
-      name: 'person2',
-      email: 'fake2@test.com',
-      createdAt: 0
-    }]
-    return Promise.resolve(contacts)
-  }
-}))
+const contacts: MailingListContact[] = [{
+  id: 'id1',
+  name: 'person1',
+  email: 'fake1@test.com',
+  createdAt: 0
+}, {
+  id: 'id2',
+  name: 'person2',
+  email: 'fake2@test.com',
+  createdAt: 0
+}]
 
 test('renders a mailing list', async () => {
+  jest.spyOn(Api, 'fetchMailingList').mockImplementation(() => Promise.resolve(contacts))
   const portalContext = mockPortalContext()
   const portalEnv = portalContext.portal.portalEnvironments[0]
   const { RoutedComponent } =
@@ -36,6 +34,7 @@ test('renders a mailing list', async () => {
 })
 
 test('download is toggled depending on contacts selected', async () => {
+  jest.spyOn(Api, 'fetchMailingList').mockImplementation(() => Promise.resolve(contacts))
   const portalContext = mockPortalContext()
   const portalEnv = portalContext.portal.portalEnvironments[0]
   const { RoutedComponent } =
@@ -51,4 +50,24 @@ test('download is toggled depending on contacts selected', async () => {
   await userEvent.click(screen.getAllByRole('checkbox')[0])
   expect(screen.getByText('2 of 2 selected')).toBeInTheDocument()
   expect(downloadLink).toHaveAttribute('aria-disabled', 'false')
+})
+
+
+test('delete button shows confirmation', async () => {
+  jest.spyOn(Api, 'fetchMailingList').mockImplementation(() => Promise.resolve(contacts))
+  const portalContext = mockPortalContext()
+  const portalEnv = portalContext.portal.portalEnvironments[0]
+  const { RoutedComponent } =
+      setupRouterTest(<MailingListView portalContext={portalContext} portalEnv={portalEnv}/>)
+  render(RoutedComponent)
+  await waitFor(() => {
+    expect(screen.getByText('person1')).toBeInTheDocument()
+  })
+  expect(screen.getByText('Remove')).toHaveAttribute('aria-disabled', 'true')
+
+
+  const selectAll = screen.getAllByRole('checkbox')[0]
+  await userEvent.click(selectAll)
+  await userEvent.click(screen.getByText('Remove'))
+  expect(screen.getByText('This operation CANNOT BE UNDONE.')).toBeInTheDocument()
 })

--- a/ui-admin/src/portal/MailingListView.tsx
+++ b/ui-admin/src/portal/MailingListView.tsx
@@ -146,7 +146,7 @@ export default function MailingListView({ portalContext, portalEnv }:
           <div className="pt-3">This operation CANNOT BE UNDONE.</div>
         </Modal.Body>
         <Modal.Footer>
-          <button type="button" className="btn btn-primary" onClick={performDelete}>
+          <button type="button" className="btn btn-danger" onClick={performDelete}>
             Delete
           </button>
           <button type="button" className="btn btn-secondary" onClick={() => setShowDeleteConfirm(false)}>

--- a/ui-admin/src/portal/MailingListView.tsx
+++ b/ui-admin/src/portal/MailingListView.tsx
@@ -13,30 +13,10 @@ import { basicTableLayout, IndeterminateCheckbox } from 'util/tableUtils'
 import { currentIsoDate, instantToDateString, instantToDefaultString } from 'util/timeUtils'
 import { Button } from 'components/forms/Button'
 import { escapeCsvValue, saveBlobAsDownload } from 'util/downloadUtils'
+import { failureNotification, successNotification } from '../util/notifications'
+import { Store } from 'react-notifications-component'
+import Modal from 'react-bootstrap/Modal'
 
-const columns: ColumnDef<MailingListContact>[] = [{
-  id: 'select',
-  header: ({ table }) => <IndeterminateCheckbox
-    checked={table.getIsAllRowsSelected()} indeterminate={table.getIsSomeRowsSelected()}
-    onChange={table.getToggleAllRowsSelectedHandler()}/>,
-  cell: ({ row }) => (
-    <div className="px-1">
-      <IndeterminateCheckbox
-        checked={row.getIsSelected()} indeterminate={row.getIsSomeSelected()}
-        onChange={row.getToggleSelectedHandler()} disabled={!row.getCanSelect()}/>
-    </div>
-  )
-}, {
-  header: 'Email',
-  accessorKey: 'email'
-}, {
-  header: 'Name',
-  accessorKey: 'name'
-}, {
-  header: 'Joined',
-  accessorKey: 'createdAt',
-  cell: info => instantToDefaultString(info.getValue() as number)
-}]
 
 /** show the mailing list in table */
 export default function MailingListView({ portalContext, portalEnv }:
@@ -45,6 +25,31 @@ export default function MailingListView({ portalContext, portalEnv }:
   const [isLoading, setIsLoading] = useState(true)
   const [sorting, setSorting] = React.useState<SortingState>([])
   const [rowSelection, setRowSelection] = React.useState<Record<string, boolean>>({})
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const columns: ColumnDef<MailingListContact>[] = [{
+    id: 'select',
+    header: ({ table }) => <IndeterminateCheckbox
+      checked={table.getIsAllRowsSelected()} indeterminate={table.getIsSomeRowsSelected()}
+      onChange={table.getToggleAllRowsSelectedHandler()}/>,
+    cell: ({ row }) => (
+      <div className="px-1">
+        <IndeterminateCheckbox
+          checked={row.getIsSelected()} indeterminate={row.getIsSomeSelected()}
+          onChange={row.getToggleSelectedHandler()} disabled={!row.getCanSelect()}/>
+      </div>
+    )
+  }, {
+    header: 'Email',
+    accessorKey: 'email'
+  }, {
+    header: 'Name',
+    accessorKey: 'name'
+  }, {
+    header: 'Joined',
+    accessorKey: 'createdAt',
+    cell: info => instantToDefaultString(info.getValue() as number)
+  }]
+
 
   const table = useReactTable({
     data: contacts,
@@ -78,8 +83,9 @@ export default function MailingListView({ portalContext, portalEnv }:
   }
   const numSelected = Object.keys(rowSelection).length
 
-
-  useEffect(() => {
+  const loadMailingList = () => {
+    setIsLoading(true)
+    setRowSelection({})
     Api.fetchMailingList(portalContext.portal.shortcode, portalEnv.environmentName).then(result => {
       setContacts(result)
       setIsLoading(false)
@@ -87,7 +93,32 @@ export default function MailingListView({ portalContext, portalEnv }:
       alert(`error loading mailing list ${  e}`)
       setIsLoading(false)
     })
+  }
+
+  const performDelete = async () => {
+    const contactsSelected = Object.keys(rowSelection)
+      .filter(key => rowSelection[key])
+      .map(key => contacts[parseInt(key)])
+    try {
+      // this might get gnarly with more than a few entries, but that's okay for now -- this is not expected to be
+      // a heavy-use feature.
+      await Promise.all(
+        contactsSelected.map(contact =>
+          Api.deleteMailingListContact(portalContext.portal.shortcode, portalEnv.environmentName, contact.id)
+        )
+      )
+      Store.addNotification(successNotification(`${contactsSelected.length} entries removed`))
+    } catch {
+      Store.addNotification(failureNotification('Error: some entries could not be removed'))
+    }
+    loadMailingList() // just reload the whole thing to be safe
+    setShowDeleteConfirm(false)
+  }
+
+  useEffect(() => {
+    loadMailingList()
   }, [portalContext.portal.shortcode, portalEnv.environmentName])
+
   return <div className="container p-3">
     <h1 className="h4">Mailing list </h1>
     <LoadingSpinner isLoading={isLoading}>
@@ -95,16 +126,34 @@ export default function MailingListView({ portalContext, portalEnv }:
         <div>
           {numSelected} of {table.getPreFilteredRowModel().rows.length} selected
         </div>
-        <div>
-          <Button onClick={download}
-            variant="link" disabled={!numSelected}
-            tooltip={numSelected ? 'Download selected contacts' : 'you must select contacts to download'}>
-            Download
-          </Button>
-        </div>
+        <Button onClick={download}
+          variant="secondary" disabled={!numSelected}
+          tooltip={numSelected ? 'Download selected contacts' : 'you must select contacts to download'}>
+          Download
+        </Button>
+        <Button onClick={() => setShowDeleteConfirm(!showDeleteConfirm)}
+          variant="secondary" disabled={!numSelected} className="ms-auto"
+          tooltip={numSelected ? 'Remove selected contacts' : 'you must select contacts to remove'}>
+          Remove
+        </Button>
       </div>
 
       {basicTableLayout(table)}
+      { showDeleteConfirm && <Modal show={true} onHide={() => setShowDeleteConfirm(false)}>
+        <Modal.Body>
+          <div>Do you want to delete the <strong>{ numSelected }</strong> selected entries?</div>
+
+          <div className="pt-3">This operation CANNOT BE UNDONE.</div>
+        </Modal.Body>
+        <Modal.Footer>
+          <button type="button" className="btn btn-primary" onClick={performDelete}>
+            Delete
+          </button>
+          <button type="button" className="btn btn-secondary" onClick={() => setShowDeleteConfirm(false)}>
+            Cancel
+          </button>
+        </Modal.Footer>
+      </Modal> }
     </LoadingSpinner>
   </div>
 }


### PR DESCRIPTION
Enables deletion from the MailingList, along with creating an audit trail of the delete operation.  I'm not going to lie, I made the backend endpoint first, and then realized that the frontend UX made way more sense as multiselect, so there's a bit of a hack where the frontend just calls delete over and over again to do multi-deletes.  But given how rarely this feature is expected to be used, I don't think it's worth going back and changing the backend to support bulk deletes.  

This has some schema changes to DataChangeRecord to support auditing participant data that isn't directly tied to a PortalParticipantUser.   I suspect soon we'll want to add an explicit "operationType" enum to DataChangeRecord (CREATE, EDIT, DELETE), but for now I'm just marking DELETE as the fieldName.  Again, I didn't want to do a lot for a very out-of-critical-path feature.

![image](https://github.com/broadinstitute/juniper/assets/2800795/78eef1fb-b4af-413d-b6c8-a7105d582df6)

TO TEST:
1. go to the sandbox mailingList for ourhealth https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/mailingList
2. select one or more entries
3. select "Remove"
4. confirm the deletion
5. observe the entries are deleted and the table is updated.
