### PR TITLE
[JN-368] adding jacoco to core and populate

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'java'
     id 'org.liquibase.gradle' version '2.1.0'
     id "java-test-fixtures"
+    id 'jacoco'
 }
 
 group = 'bio.terra.pearl.core'
@@ -58,6 +59,16 @@ test {
         // By default, exclude `@IntegrationTest`s
         excludeTags "integration"
     }
+    finalizedBy jacocoTestReport // report is always generated after tests run
+}
+
+jacocoTestReport {
+    dependsOn test // tests are required to run before generating the report
+}
+
+jacoco {
+    toolVersion = "0.8.9"
+    reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir')
 }
 
 // Explicitly run `@IntegrationTest`s that are excluded from default test runs: `./gradlew integrationTest`

--- a/populate/build.gradle
+++ b/populate/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "io.freefair.lombok" version "5.3.3.3"
     id 'java'
+    id 'jacoco'
 }
 
 group = 'bio.terra.pearl.core'
@@ -34,4 +35,14 @@ dependencies {
 
 test {
     useJUnitPlatform ()
+    finalizedBy jacocoTestReport // report is always generated after tests run
+}
+
+jacocoTestReport {
+    dependsOn test // tests are required to run before generating the report
+}
+
+jacoco {
+    toolVersion = "0.8.9"
+    reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir')
 }


### PR DESCRIPTION
This adds generation of code coverage reports to core and populate modules (it is already on api-admin and api-participant).  See also https://broadworkbench.atlassian.net/wiki/spaces/PEARL/pages/2842230785/Code+coverage

TO TEST:
1. run `./gradlew core:test` 
2. in Chrome, open the file `core/build/customJacocoReportDir/test/html/index.html`
3. run `./gradlew populate:test`
4. in Chrome, open the file `populate/build/customJacocoReportDir/test/html/index.html`