### PR TITLE
[JN-539] Form JSON editor validation

### DIFF
--- a/ui-admin/src/components/forms/Button.tsx
+++ b/ui-admin/src/components/forms/Button.tsx
@@ -3,6 +3,7 @@ import { IconDefinition } from '@fortawesome/fontawesome-svg-core'
 import classNames from 'classnames'
 import React, { useRef, useState } from 'react'
 import { Overlay, Tooltip } from 'react-bootstrap'
+import {Placement} from "react-bootstrap/types";
 
 type ButtonVariant =
   | 'primary'
@@ -28,13 +29,14 @@ export const supportsFocusVisible = (() => {
 export type ButtonProps = JSX.IntrinsicElements['button'] & {
   outline?: boolean
   tooltip?: string
+  tooltipPlacement?: Placement
   variant?: ButtonVariant
 }
 
 /** A button.  Among other improvements, this handles the 'disabled' prop in a much more robust way
  * than <button>, enabling tooltips to be shown for disabled buttons. */
 export const Button = (props: ButtonProps) => {
-  const { outline = false, tooltip, variant = 'secondary', ...buttonProps } = props
+  const { outline = false, tooltip, tooltipPlacement, variant = 'secondary', ...buttonProps } = props
   const { className, disabled, onBlur, onClick, onFocus, onMouseEnter, onMouseLeave } = buttonProps
 
   const buttonRef = useRef<HTMLButtonElement>(null)
@@ -77,7 +79,7 @@ export const Button = (props: ButtonProps) => {
         }}
       />
       <Overlay
-        placement="top"
+        placement={tooltipPlacement ? tooltipPlacement : 'top'}
         // Show the tooltip if the button is hovered or if the button is focused via the keyboard.
         show={
           !!tooltip && (

--- a/ui-admin/src/components/forms/Button.tsx
+++ b/ui-admin/src/components/forms/Button.tsx
@@ -3,7 +3,7 @@ import { IconDefinition } from '@fortawesome/fontawesome-svg-core'
 import classNames from 'classnames'
 import React, { useRef, useState } from 'react'
 import { Overlay, Tooltip } from 'react-bootstrap'
-import {Placement} from "react-bootstrap/types";
+import { Placement } from 'react-bootstrap/types'
 
 type ButtonVariant =
   | 'primary'

--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -49,9 +49,9 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
                 setEditedContent(newContent)
                 try {
                   validateFormContent(newContent)
-                  onChange(true, newContent)
+                  onChange(undefined, newContent)
                 } catch (err) {
-                  onChange(false, undefined)
+                  onChange(undefined, undefined) //TODO
                 }
               }}
             />
@@ -66,14 +66,15 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
             <FormContentJsonEditor
               initialValue={editedContent}
               readOnly={readOnly}
-              onChange={(isValid, newContent) => {
-                if (isValid) {
-                  setEditedContent(newContent)
-                  onChange(true, newContent)
+              onChange={(validationError, newContent) => {
+                console.log('validationError', validationError)
+                if (!validationError) {
+                  setEditedContent(newContent!)
+                  onChange(undefined, newContent)
                 } else {
-                  onChange(false, undefined)
+                  onChange(validationError, undefined)
                 }
-                setTabsEnabled(isValid)
+                setTabsEnabled(!validationError)
               }}
             />
           </ErrorBoundary>

--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -52,8 +52,8 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
                   const errors = validateFormContent(newContent)
                   onChange(errors, newContent)
                 } catch (err) {
-                  // @ts-ignore
-                  onChange(err.message, undefined)
+                  //@ts-ignore
+                  onChange([err.message], undefined)
                 }
               }}
             />
@@ -69,8 +69,8 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
               initialValue={editedContent}
               readOnly={readOnly}
               onChange={(validationErrors, newContent) => {
-                if (isEmpty(validationErrors)) {
-                  setEditedContent(newContent!)
+                if (isEmpty(validationErrors) && newContent) {
+                  setEditedContent(newContent)
                   onChange(validationErrors, newContent)
                 } else {
                   onChange(validationErrors, undefined)

--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -48,10 +48,11 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
               onChange={newContent => {
                 setEditedContent(newContent)
                 try {
-                  validateFormContent(newContent)
-                  onChange(undefined, newContent)
+                  const validatedFormContent = validateFormContent(JSON.stringify(newContent)) //TODO this is silly
+                  onChange(undefined, validatedFormContent)
                 } catch (err) {
-                  onChange(undefined, undefined) //TODO
+                  // @ts-ignore
+                  onChange(err.message, undefined)
                 }
               }}
             />
@@ -67,7 +68,6 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
               initialValue={editedContent}
               readOnly={readOnly}
               onChange={(validationError, newContent) => {
-                console.log('validationError', validationError)
                 if (!validationError) {
                   setEditedContent(newContent!)
                   onChange(undefined, newContent)

--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -9,6 +9,7 @@ import { FormContentJsonEditor } from './FormContentJsonEditor'
 import { FormPreview } from './FormPreview'
 import { validateFormContent } from './formContentValidation'
 import ErrorBoundary from 'util/ErrorBoundary'
+import { isEmpty } from 'lodash'
 
 type FormContentEditorProps = {
   initialContent: string
@@ -48,8 +49,8 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
               onChange={newContent => {
                 setEditedContent(newContent)
                 try {
-                  const validatedFormContent = validateFormContent(JSON.stringify(newContent)) //TODO this is silly
-                  onChange(undefined, validatedFormContent)
+                  const errors = validateFormContent(newContent)
+                  onChange(errors, newContent)
                 } catch (err) {
                   // @ts-ignore
                   onChange(err.message, undefined)
@@ -67,14 +68,14 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
             <FormContentJsonEditor
               initialValue={editedContent}
               readOnly={readOnly}
-              onChange={(validationError, newContent) => {
-                if (!validationError) {
+              onChange={(validationErrors, newContent) => {
+                if (isEmpty(validationErrors)) {
                   setEditedContent(newContent!)
-                  onChange(undefined, newContent)
+                  onChange(validationErrors, newContent)
                 } else {
-                  onChange(validationError, undefined)
+                  onChange(validationErrors, undefined)
                 }
-                setTabsEnabled(!validationError)
+                setTabsEnabled(isEmpty(validationErrors))
               }}
             />
           </ErrorBoundary>

--- a/ui-admin/src/forms/FormContentJsonEditor.test.tsx
+++ b/ui-admin/src/forms/FormContentJsonEditor.test.tsx
@@ -81,7 +81,7 @@ describe('FormContentJsonEditor', () => {
 
     // Assert
     expect(onChange).toHaveBeenCalledWith(
-      [`SyntaxError: Unexpected token 'F', ..." "title": First name"... is not valid JSON`], undefined)
+      [`Unexpected token 'F', ..." "title": First name"... is not valid JSON`], undefined)
   })
 
   it('shows feedback when edited with invalid JSON', async () => {

--- a/ui-admin/src/forms/FormContentJsonEditor.test.tsx
+++ b/ui-admin/src/forms/FormContentJsonEditor.test.tsx
@@ -64,7 +64,7 @@ describe('FormContentJsonEditor', () => {
     const expectedEditedContent = cloneDeep(formContent)
     ;(expectedEditedContent.pages[0].elements[0] as Question).title = 'Given name'
 
-    expect(onChange).toHaveBeenCalledWith(true, expectedEditedContent)
+    expect(onChange).toHaveBeenCalledWith([], expectedEditedContent)
   })
 
   it('calls onChange when edited with invalid JSON', async () => {
@@ -80,7 +80,8 @@ describe('FormContentJsonEditor', () => {
     await act(() => user.type(textArea, 'First name', { initialSelectionStart: 158, initialSelectionEnd: 170 }))
 
     // Assert
-    expect(onChange).toHaveBeenCalledWith(false, undefined)
+    expect(onChange).toHaveBeenCalledWith(
+      [`SyntaxError: Unexpected token 'F', ..." "title": First name"... is not valid JSON`], undefined)
   })
 
   it('shows feedback when edited with invalid JSON', async () => {

--- a/ui-admin/src/forms/FormContentJsonEditor.test.tsx
+++ b/ui-admin/src/forms/FormContentJsonEditor.test.tsx
@@ -81,7 +81,7 @@ describe('FormContentJsonEditor', () => {
 
     // Assert
     expect(onChange).toHaveBeenCalledWith(
-      [`Unexpected token 'F', ..." "title": First name"... is not valid JSON`], undefined)
+      [expect.stringContaining('Unexpected token')], undefined)
   })
 
   it('shows feedback when edited with invalid JSON', async () => {

--- a/ui-admin/src/forms/FormContentJsonEditor.tsx
+++ b/ui-admin/src/forms/FormContentJsonEditor.tsx
@@ -3,8 +3,9 @@ import React, { useCallback, useState } from 'react'
 
 import { FormContent } from '@juniper/ui-core'
 
-import { validateFormContent } from './formContentValidation'
+import { validateFormContent, validateFormJson } from './formContentValidation'
 import { OnChangeFormContent } from './formEditorTypes'
+import { isEmpty } from 'lodash'
 
 type FormContentJsonEditorProps = {
   initialValue: FormContent
@@ -17,24 +18,26 @@ type FormContentJsonEditorProps = {
 export const FormContentJsonEditor = (props: FormContentJsonEditorProps) => {
   const { initialValue, readOnly = false, onChange } = props
   const [editorValue, _setEditorValue] = useState(() => JSON.stringify(initialValue, null, 2))
-  const [validationError, setValidationError] = useState()
+  const [validationErrors, setValidationErrors] = useState<string[]>([])
   const setEditorValue = useCallback((newEditorValue: string) => {
     _setEditorValue(newEditorValue)
     try {
-      const validatedFormContent = validateFormContent(newEditorValue)
-      setValidationError(undefined)
-      onChange(undefined, validatedFormContent)
+      const validJsonFormContent = validateFormJson(newEditorValue)
+      const validationErrors = validateFormContent(validJsonFormContent)
+      setValidationErrors(validationErrors)
+      onChange(validationErrors, validJsonFormContent)
       //@ts-ignore
     } catch (e: Error) {
-      setValidationError(e.message)
-      onChange(e.message, undefined)
+      setValidationErrors([e.message])
+      onChange([e.message], undefined)
     }
   }, [])
 
   return (
     <div className="d-flex flex-column flex-grow-1">
       <textarea
-        className={classNames('w-100 flex-grow-1 form-control font-monospace', { 'is-invalid': validationError })}
+        className={classNames('w-100 flex-grow-1 form-control font-monospace',
+          { 'is-invalid': !isEmpty(validationErrors) })}
         readOnly={readOnly}
         style={{
           overflowX: 'auto',

--- a/ui-admin/src/forms/FormContentJsonEditor.tsx
+++ b/ui-admin/src/forms/FormContentJsonEditor.tsx
@@ -17,24 +17,25 @@ type FormContentJsonEditorProps = {
 export const FormContentJsonEditor = (props: FormContentJsonEditorProps) => {
   const { initialValue, readOnly = false, onChange } = props
   const [editorValue, _setEditorValue] = useState(() => JSON.stringify(initialValue, null, 2))
-  const [isValid, setIsValid] = useState(true)
+  const [validationError, setValidationError] = useState()
   const setEditorValue = useCallback((newEditorValue: string) => {
     _setEditorValue(newEditorValue)
     try {
-      const formContent = JSON.parse(newEditorValue)
-      validateFormContent(formContent)
-      setIsValid(true)
-      onChange(true, formContent)
-    } catch (e) {
-      setIsValid(false)
-      onChange(false, undefined)
+      const validatedFormContent = validateFormContent(newEditorValue)
+      setValidationError(undefined)
+      onChange(undefined, validatedFormContent)
+      //@ts-ignore
+    } catch (e: Error) {
+      console.log('caught an error')
+      setValidationError(e.message)
+      onChange(e.message, undefined)
     }
   }, [])
 
   return (
     <div className="d-flex flex-column flex-grow-1">
       <textarea
-        className={classNames('w-100 flex-grow-1 form-control font-monospace', { 'is-invalid': !isValid })}
+        className={classNames('w-100 flex-grow-1 form-control font-monospace', { 'is-invalid': validationError })}
         readOnly={readOnly}
         style={{
           overflowX: 'auto',

--- a/ui-admin/src/forms/FormContentJsonEditor.tsx
+++ b/ui-admin/src/forms/FormContentJsonEditor.tsx
@@ -26,7 +26,6 @@ export const FormContentJsonEditor = (props: FormContentJsonEditorProps) => {
       onChange(undefined, validatedFormContent)
       //@ts-ignore
     } catch (e: Error) {
-      console.log('caught an error')
       setValidationError(e.message)
       onChange(e.message, undefined)
     }

--- a/ui-admin/src/forms/formContentValidation.test.ts
+++ b/ui-admin/src/forms/formContentValidation.test.ts
@@ -7,7 +7,7 @@ import {
 import { FormContent } from '@juniper/ui-core'
 
 describe('validateFormContent', () => {
-  it('getAllQuestions throws an exception if a form is missing a pages property', () => {
+  it('getAllElements throws an exception if a form is missing a pages property', () => {
     const formContent: FormContent = {
       title: 'test'
     } as unknown as FormContent //cast in order to simulate invalid form content
@@ -17,7 +17,7 @@ describe('validateFormContent', () => {
     )
   })
 
-  it('getAllQuestions throws an exception if a panel is missing `elements` property', () => {
+  it('getAllElements throws an exception if a panel is missing `elements` property', () => {
     const formContent: FormContent = {
       title: 'test',
       pages: [
@@ -43,7 +43,7 @@ describe('validateFormContent', () => {
     )
   })
 
-  it('getAllQuestions throws an exception if a page is missing `elements` property', () => {
+  it('getAllElements throws an exception if a page is missing `elements` property', () => {
     const formContent: FormContent = {
       title: 'test',
       pages: [
@@ -69,7 +69,7 @@ describe('validateFormContent', () => {
     )
   })
 
-  it('getAllQuestions returns all questions in the form, including those in panels', () => {
+  it('getAllElements returns all elements in the form, including those in panels', () => {
     const formContent: FormContent = {
       title: 'test',
       pages: [
@@ -87,6 +87,11 @@ describe('validateFormContent', () => {
                   name: 'test2',
                   type: 'text',
                   title: 'test title 2'
+                },
+                {
+                  name: 'test_html',
+                  type: 'html',
+                  html: '<strong>test title 2</strong>'
                 }
               ]
             }
@@ -96,12 +101,13 @@ describe('validateFormContent', () => {
     }
 
     const questions = getAllElements(formContent)
-    expect(questions).toHaveLength(2)
+    expect(questions).toHaveLength(3)
     expect(questions[0].name).toBe('test')
     expect(questions[1].name).toBe('test2')
+    expect(questions[2].name).toBe('test_html')
   })
 
-  it('validateQuestionNames returns an error if a question is missing a name', () => {
+  it('validateElementNames returns an error if an element is missing a name', () => {
     const formContent: FormContent = {
       title: 'test',
       pages: [
@@ -120,13 +126,13 @@ describe('validateFormContent', () => {
       ]
     } as unknown as FormContent //cast in order to simulate invalid form content
 
-    const questions = getAllElements(formContent)
-    const errors = validateElementNames(questions)
+    const elements = getAllElements(formContent)
+    const errors = validateElementNames(elements)
     expect(errors).toHaveLength(1)
     expect(errors[0]).toBe(`2 elements are missing a 'name' field.`)
   })
 
-  it('validateQuestionNames returns an error if two questions have a duplicate name', () => {
+  it('validateElementNames returns an error if two elements have a duplicate name', () => {
     const formContent: FormContent = {
       title: 'test',
       pages: [
@@ -147,13 +153,13 @@ describe('validateFormContent', () => {
       ]
     } as FormContent
 
-    const questions = getAllElements(formContent)
-    const errors = validateElementNames(questions)
+    const elements = getAllElements(formContent)
+    const errors = validateElementNames(elements)
     expect(errors).toHaveLength(1)
     expect(errors[0]).toBe(`Duplicate element name: test`)
   })
 
-  it('validateQuestionTypes returns an error if an element is missing a type', () => {
+  it('validateElementTypes returns an error if an element is missing a type', () => {
     const formContent: FormContent = {
       title: 'test',
       pages: [
@@ -172,14 +178,14 @@ describe('validateFormContent', () => {
       ]
     } as unknown as FormContent //cast in order to simulate invalid form content
 
-    const questions = getAllElements(formContent)
-    const errors = validateElementTypes(questions)
+    const elements = getAllElements(formContent)
+    const errors = validateElementTypes(elements)
     expect(errors).toHaveLength(2)
     expect(errors[0]).toBe(`Element oh_test is missing a 'type' field.`)
     expect(errors[1]).toBe(`Element oh_test2 is missing a 'type' field.`)
   })
 
-  it('validateQuestionTypes does not return an error if a TemplatedQuestion is missing a type', () => {
+  it('validateElementTypes does not return an error if a TemplatedQuestion is missing a type', () => {
     const formContent: FormContent = {
       title: 'test',
       pages: [
@@ -195,8 +201,8 @@ describe('validateFormContent', () => {
       ]
     } as unknown as FormContent //cast in order to simulate invalid form content
 
-    const questions = getAllElements(formContent)
-    const errors = validateElementTypes(questions)
+    const elements = getAllElements(formContent)
+    const errors = validateElementTypes(elements)
     expect(errors).toHaveLength(0)
   })
 

--- a/ui-admin/src/forms/formContentValidation.test.ts
+++ b/ui-admin/src/forms/formContentValidation.test.ts
@@ -8,6 +8,16 @@ import {
 import { FormContent } from '@juniper/ui-core'
 
 describe('validateFormContent', () => {
+  it('getAllQuestions throws an exception if a form is missing a pages property', () => {
+    const formContent: FormContent = {
+      title: 'test'
+    } as unknown as FormContent //cast in order to simulate invalid form content
+
+    expect(() => getAllQuestions(formContent)).toThrowError(
+      `Error parsing form. Please ensure that the form has a 'pages' property.`
+    )
+  })
+
   it('getAllQuestions throws an exception if a panel is missing `elements` property', () => {
     const formContent: FormContent = {
       title: 'test',
@@ -30,7 +40,7 @@ describe('validateFormContent', () => {
     } as unknown as FormContent //cast in order to simulate invalid form content
 
     expect(() => getAllQuestions(formContent)).toThrowError(
-      `Error parsing form. Please ensure that all pages and panels have an 'elements' property.`
+      `Error parsing form. Please ensure that all panels have an 'elements' property.`
     )
   })
 
@@ -56,7 +66,7 @@ describe('validateFormContent', () => {
     } as unknown as FormContent //cast in order to simulate invalid form content
 
     expect(() => getAllQuestions(formContent)).toThrowError(
-      `Error parsing form. Please ensure that all pages and panels have an 'elements' property.`
+      `Error parsing form. Please ensure that all pages have an 'elements' property.`
     )
   })
 
@@ -115,6 +125,33 @@ describe('validateFormContent', () => {
     const errors = validateQuestionNames(questions)
     expect(errors.length).toBe(1)
     expect(errors[0]).toBe(`2 questions are missing a 'name' field.`)
+  })
+
+  it('validateQuestionNames returns an error if two questions have a duplicate name', () => {
+    const formContent: FormContent = {
+      title: 'test',
+      pages: [
+        {
+          elements: [
+            {
+              name: 'test',
+              type: 'text',
+              title: 'test title'
+            },
+            {
+              name: 'test',
+              type: 'text',
+              title: 'test title 2'
+            }
+          ]
+        }
+      ]
+    } as FormContent
+
+    const questions = getAllQuestions(formContent)
+    const errors = validateQuestionNames(questions)
+    expect(errors.length).toBe(1)
+    expect(errors[0]).toBe(`Duplicate question name: test`)
   })
 
   it('validateQuestionTypes returns an error if a question is missing a type', () => {

--- a/ui-admin/src/forms/formContentValidation.test.ts
+++ b/ui-admin/src/forms/formContentValidation.test.ts
@@ -97,7 +97,7 @@ describe('validateFormContent', () => {
     }
 
     const questions = getAllQuestions(formContent)
-    expect(questions.length).toBe(2)
+    expect(questions).toHaveLength(2)
     expect(questions[0].name).toBe('test')
     expect(questions[1].name).toBe('test2')
   })
@@ -123,7 +123,7 @@ describe('validateFormContent', () => {
 
     const questions = getAllQuestions(formContent)
     const errors = validateQuestionNames(questions)
-    expect(errors.length).toBe(1)
+    expect(errors).toHaveLength(1)
     expect(errors[0]).toBe(`2 questions are missing a 'name' field.`)
   })
 
@@ -150,7 +150,7 @@ describe('validateFormContent', () => {
 
     const questions = getAllQuestions(formContent)
     const errors = validateQuestionNames(questions)
-    expect(errors.length).toBe(1)
+    expect(errors).toHaveLength(1)
     expect(errors[0]).toBe(`Duplicate question name: test`)
   })
 
@@ -175,7 +175,7 @@ describe('validateFormContent', () => {
 
     const questions = getAllQuestions(formContent)
     const errors = validateQuestionTypes(questions)
-    expect(errors.length).toBe(2)
+    expect(errors).toHaveLength(2)
     expect(errors[0]).toBe(`Question oh_test is missing a 'type' field.`)
     expect(errors[1]).toBe(`Question oh_test2 is missing a 'type' field.`)
   })
@@ -198,7 +198,7 @@ describe('validateFormContent', () => {
 
     const questions = getAllQuestions(formContent)
     const errors = validateQuestionTypes(questions)
-    expect(errors.length).toBe(0)
+    expect(errors).toHaveLength(0)
   })
 
   it('validateTemplatedQuestions returns an error if a' +
@@ -220,7 +220,7 @@ describe('validateFormContent', () => {
 
     const questions = getAllQuestions(formContent)
     const errors = validateTemplatedQuestions(formContent, questions)
-    expect(errors.length).toBe(1)
+    expect(errors).toHaveLength(1)
     expect(errors[0]).toBe(`'oh_test' references non-existent template 'testTemplate'`)
   })
 })

--- a/ui-admin/src/forms/formContentValidation.test.ts
+++ b/ui-admin/src/forms/formContentValidation.test.ts
@@ -1,0 +1,189 @@
+import {
+  getAllQuestions,
+  validateFormContent,
+  validateQuestionNames,
+  validateQuestionTypes,
+  validateTemplatedQuestions
+} from './formContentValidation'
+import { FormContent } from '@juniper/ui-core'
+
+describe('validateFormContent', () => {
+  it('getAllQuestions throws an exception if a panel is missing `elements` property', () => {
+    const formContent: FormContent = {
+      title: 'test',
+      pages: [
+        {
+          elements: [
+            {
+              type: 'panel',
+              elementz: [ //error: simulate typo'd elements property
+                {
+                  name: 'test',
+                  type: 'text',
+                  title: 'test title'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    } as unknown as FormContent //cast in order to simulate invalid form content
+
+    expect(() => getAllQuestions(formContent)).toThrowError(
+      `Error parsing form. Please ensure that all pages and panels have an 'elements' property.`
+    )
+  })
+
+  it('getAllQuestions throws an exception if a page is missing `elements` property', () => {
+    const formContent: FormContent = {
+      title: 'test',
+      pages: [
+        {
+          elementsz: [ //error: simulate typo'd elements property
+            {
+              type: 'panel',
+              elements: [
+                {
+                  name: 'test',
+                  type: 'text',
+                  title: 'test title'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    } as unknown as FormContent //cast in order to simulate invalid form content
+
+    expect(() => getAllQuestions(formContent)).toThrowError(
+      `Error parsing form. Please ensure that all pages and panels have an 'elements' property.`
+    )
+  })
+
+  it('getAllQuestions returns all questions in the form, including those in panels', () => {
+    const formContent: FormContent = {
+      title: 'test',
+      pages: [
+        {
+          elements: [
+            {
+              name: 'test',
+              type: 'text',
+              title: 'test title'
+            },
+            {
+              type: 'panel',
+              elements: [
+                {
+                  name: 'test2',
+                  type: 'text',
+                  title: 'test title 2'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+
+    const questions = getAllQuestions(formContent)
+    expect(questions.length).toBe(2)
+    expect(questions[0].name).toBe('test')
+    expect(questions[1].name).toBe('test2')
+  })
+
+  it('validateQuestionNames returns an error if a question is missing a name', () => {
+    const formContent: FormContent = {
+      title: 'test',
+      pages: [
+        {
+          elements: [
+            {
+              type: 'text',
+              title: 'test title'
+            },
+            {
+              type: 'text',
+              title: 'test title 2'
+            }
+          ]
+        }
+      ]
+    } as unknown as FormContent //cast in order to simulate invalid form content
+
+    const questions = getAllQuestions(formContent)
+    const errors = validateQuestionNames(questions)
+    expect(errors.length).toBe(1)
+    expect(errors[0]).toBe(`2 questions are missing a 'name' field.`)
+  })
+
+  it('validateQuestionTypes returns an error if a question is missing a type', () => {
+    const formContent: FormContent = {
+      title: 'test',
+      pages: [
+        {
+          elements: [
+            {
+              name: 'oh_test',
+              title: 'test title'
+            },
+            {
+              name: 'oh_test2',
+              title: 'test title 2'
+            }
+          ]
+        }
+      ]
+    } as unknown as FormContent //cast in order to simulate invalid form content
+
+    const questions = getAllQuestions(formContent)
+    const errors = validateQuestionTypes(questions)
+    expect(errors.length).toBe(2)
+    expect(errors[0]).toBe(`Question oh_test is missing a 'type' field.`)
+    expect(errors[1]).toBe(`Question oh_test2 is missing a 'type' field.`)
+  })
+
+  it('validateQuestionTypes does not return an error if a TemplatedQuestion is missing a type', () => {
+    const formContent: FormContent = {
+      title: 'test',
+      pages: [
+        {
+          elements: [
+            {
+              name: 'oh_test',
+              title: 'test title',
+              questionTemplateName: 'testTemplate'
+            }
+          ]
+        }
+      ]
+    } as unknown as FormContent //cast in order to simulate invalid form content
+
+    const questions = getAllQuestions(formContent)
+    const errors = validateQuestionTypes(questions)
+    expect(errors.length).toBe(0)
+  })
+
+  it('validateTemplatedQuestions returns an error if a' +
+    'TemplatedQuestion references a template that doesnt exist', () => {
+    const formContent: FormContent = {
+      title: 'test',
+      pages: [
+        {
+          elements: [
+            {
+              name: 'oh_test',
+              title: 'test title',
+              questionTemplateName: 'testTemplate'
+            }
+          ]
+        }
+      ]
+    } as unknown as FormContent //cast in order to simulate invalid form content
+
+    const questions = getAllQuestions(formContent)
+    const errors = validateTemplatedQuestions(formContent, questions)
+    expect(errors.length).toBe(1)
+    expect(errors[0]).toBe(`'oh_test' references non-existent template 'testTemplate'`)
+  })
+})

--- a/ui-admin/src/forms/formContentValidation.test.ts
+++ b/ui-admin/src/forms/formContentValidation.test.ts
@@ -1,7 +1,7 @@
 import {
-  getAllQuestions,
-  validateQuestionNames,
-  validateQuestionTypes,
+  getAllElements,
+  validateElementNames,
+  validateElementTypes,
   validateTemplatedQuestions
 } from './formContentValidation'
 import { FormContent } from '@juniper/ui-core'
@@ -12,7 +12,7 @@ describe('validateFormContent', () => {
       title: 'test'
     } as unknown as FormContent //cast in order to simulate invalid form content
 
-    expect(() => getAllQuestions(formContent)).toThrowError(
+    expect(() => getAllElements(formContent)).toThrowError(
       `Error parsing form. Please ensure that the form has a 'pages' property.`
     )
   })
@@ -38,7 +38,7 @@ describe('validateFormContent', () => {
       ]
     } as unknown as FormContent //cast in order to simulate invalid form content
 
-    expect(() => getAllQuestions(formContent)).toThrowError(
+    expect(() => getAllElements(formContent)).toThrowError(
       `Error parsing form. Please ensure that all panels have an 'elements' property.`
     )
   })
@@ -64,7 +64,7 @@ describe('validateFormContent', () => {
       ]
     } as unknown as FormContent //cast in order to simulate invalid form content
 
-    expect(() => getAllQuestions(formContent)).toThrowError(
+    expect(() => getAllElements(formContent)).toThrowError(
       `Error parsing form. Please ensure that all pages have an 'elements' property.`
     )
   })
@@ -95,7 +95,7 @@ describe('validateFormContent', () => {
       ]
     }
 
-    const questions = getAllQuestions(formContent)
+    const questions = getAllElements(formContent)
     expect(questions).toHaveLength(2)
     expect(questions[0].name).toBe('test')
     expect(questions[1].name).toBe('test2')
@@ -120,10 +120,10 @@ describe('validateFormContent', () => {
       ]
     } as unknown as FormContent //cast in order to simulate invalid form content
 
-    const questions = getAllQuestions(formContent)
-    const errors = validateQuestionNames(questions)
+    const questions = getAllElements(formContent)
+    const errors = validateElementNames(questions)
     expect(errors).toHaveLength(1)
-    expect(errors[0]).toBe(`2 questions are missing a 'name' field.`)
+    expect(errors[0]).toBe(`2 elements are missing a 'name' field.`)
   })
 
   it('validateQuestionNames returns an error if two questions have a duplicate name', () => {
@@ -147,13 +147,13 @@ describe('validateFormContent', () => {
       ]
     } as FormContent
 
-    const questions = getAllQuestions(formContent)
-    const errors = validateQuestionNames(questions)
+    const questions = getAllElements(formContent)
+    const errors = validateElementNames(questions)
     expect(errors).toHaveLength(1)
-    expect(errors[0]).toBe(`Duplicate question name: test`)
+    expect(errors[0]).toBe(`Duplicate element name: test`)
   })
 
-  it('validateQuestionTypes returns an error if a question is missing a type', () => {
+  it('validateQuestionTypes returns an error if an element is missing a type', () => {
     const formContent: FormContent = {
       title: 'test',
       pages: [
@@ -172,11 +172,11 @@ describe('validateFormContent', () => {
       ]
     } as unknown as FormContent //cast in order to simulate invalid form content
 
-    const questions = getAllQuestions(formContent)
-    const errors = validateQuestionTypes(questions)
+    const questions = getAllElements(formContent)
+    const errors = validateElementTypes(questions)
     expect(errors).toHaveLength(2)
-    expect(errors[0]).toBe(`Question oh_test is missing a 'type' field.`)
-    expect(errors[1]).toBe(`Question oh_test2 is missing a 'type' field.`)
+    expect(errors[0]).toBe(`Element oh_test is missing a 'type' field.`)
+    expect(errors[1]).toBe(`Element oh_test2 is missing a 'type' field.`)
   })
 
   it('validateQuestionTypes does not return an error if a TemplatedQuestion is missing a type', () => {
@@ -195,8 +195,8 @@ describe('validateFormContent', () => {
       ]
     } as unknown as FormContent //cast in order to simulate invalid form content
 
-    const questions = getAllQuestions(formContent)
-    const errors = validateQuestionTypes(questions)
+    const questions = getAllElements(formContent)
+    const errors = validateElementTypes(questions)
     expect(errors).toHaveLength(0)
   })
 
@@ -217,9 +217,9 @@ describe('validateFormContent', () => {
       ]
     } as unknown as FormContent //cast in order to simulate invalid form content
 
-    const questions = getAllQuestions(formContent)
+    const questions = getAllElements(formContent)
     const errors = validateTemplatedQuestions(formContent, questions)
     expect(errors).toHaveLength(1)
-    expect(errors[0]).toBe(`'oh_test' references non-existent template 'testTemplate'`)
+    expect(errors[0]).toBe(`'oh_test' references non-existent question template 'testTemplate'`)
   })
 })

--- a/ui-admin/src/forms/formContentValidation.test.ts
+++ b/ui-admin/src/forms/formContentValidation.test.ts
@@ -1,6 +1,5 @@
 import {
   getAllQuestions,
-  validateFormContent,
   validateQuestionNames,
   validateQuestionTypes,
   validateTemplatedQuestions

--- a/ui-admin/src/forms/formContentValidation.ts
+++ b/ui-admin/src/forms/formContentValidation.ts
@@ -1,4 +1,4 @@
-import {FormContent, FormElement, HtmlElement, Question, TemplatedQuestion} from '@juniper/ui-core'
+import { FormContent, HtmlElement, Question, TemplatedQuestion } from '@juniper/ui-core'
 
 /** Returns a validated FormContent object, or throws an error if invalid. */
 export const validateFormJson = (rawFormContent: unknown): FormContent => {

--- a/ui-admin/src/forms/formContentValidation.ts
+++ b/ui-admin/src/forms/formContentValidation.ts
@@ -1,8 +1,28 @@
 import { FormContent } from '@juniper/ui-core'
+import {isPlainObject} from "lodash";
+import {getTableOfContentsTree} from "./FormTableOfContents";
 
 /** Validate that an object is valid FormContent. */
-export const validateFormContent = (formContent: unknown): FormContent => {
-  // TODO: Implement this. Thrown an error if invalid.
-  // See ui-participant landing page section config for examples.
-  return formContent as FormContent
+export const validateFormContent = (rawFormContent: unknown): FormContent => {
+
+  let parsedFormContent: FormContent
+  try {
+    parsedFormContent = JSON.parse(rawFormContent as string) as FormContent
+  } catch (e) {
+    // @ts-ignore
+    throw new Error(`JSON ${e.name}: ${e.message}`)
+  }
+
+  try {
+    getTableOfContentsTree(parsedFormContent)
+  } catch {
+    throw new Error('Error parsing JSON: a page or panel has been misconfigured')
+  }
+
+  if (!isPlainObject(parsedFormContent)) {
+    console.log('huh')
+    throw new Error(`Invalid form, expected an object`)
+  }
+
+  return parsedFormContent
 }

--- a/ui-admin/src/forms/formContentValidation.ts
+++ b/ui-admin/src/forms/formContentValidation.ts
@@ -1,4 +1,4 @@
-import {FormContent, Question, TemplatedQuestion} from '@juniper/ui-core'
+import { FormContent, Question, TemplatedQuestion } from '@juniper/ui-core'
 
 /** Returns a validated FormContent object, or throws an error if invalid. */
 export const validateFormJson = (rawFormContent: unknown): FormContent => {
@@ -33,6 +33,7 @@ export const validateFormContent = (formContent: FormContent): string[] => {
   return validationErrors
 }
 
+/** Returns an array of error messages for all templated questions that reference a template name that doesn't exist. */
 export const validateTemplatedQuestions = (formContent: FormContent, questions: Question[]): string[] => {
   const questionTemplates = formContent.questionTemplates || []
   const questionTemplateNames = questionTemplates.map(qt => qt.name)
@@ -48,6 +49,7 @@ export const validateTemplatedQuestions = (formContent: FormContent, questions: 
   })
 }
 
+/** Returns an array of error messages for all questions that don't have a 'type' field. */
 export const validateQuestionTypes = (questions: Question[]): string[] => {
   const errors: string[] = []
   questions.forEach(question => {
@@ -59,6 +61,7 @@ export const validateQuestionTypes = (questions: Question[]): string[] => {
   return errors
 }
 
+/** Returns a message with the number of questions that don't have a 'name' field. */
 export const validateQuestionNames = (questions: Question[]) => {
   const errors: Question[] = []
   questions.forEach(question => {
@@ -77,6 +80,7 @@ export const validateQuestionNames = (questions: Question[]) => {
   }
 }
 
+/** Returns an array of all Questions in a form, including those in panels. */
 export const getAllQuestions = (formContent: FormContent): Question[] => {
   const questions: Question[] = []
   try {

--- a/ui-admin/src/forms/formContentValidation.ts
+++ b/ui-admin/src/forms/formContentValidation.ts
@@ -1,10 +1,9 @@
 import { FormContent } from '@juniper/ui-core'
-import {isPlainObject} from "lodash";
-import {getTableOfContentsTree} from "./FormTableOfContents";
+import { isPlainObject } from 'lodash'
+import { getTableOfContentsTree } from './FormTableOfContents'
 
 /** Validate that an object is valid FormContent. */
 export const validateFormContent = (rawFormContent: unknown): FormContent => {
-
   let parsedFormContent: FormContent
   try {
     parsedFormContent = JSON.parse(rawFormContent as string) as FormContent

--- a/ui-admin/src/forms/formContentValidation.ts
+++ b/ui-admin/src/forms/formContentValidation.ts
@@ -51,6 +51,7 @@ export const validateElementTypes = (elements: (Question | HtmlElement)[]): stri
   const filterUndefined = elements.filter(q => q.name !== undefined)
   filterUndefined.forEach(element => {
     // @ts-ignore
+    //If the element is a TemplatedQuestion, it's ok if it doesn't have a type
     if (!element.type && !element.questionTemplateName) {
       errors.push(`Element ${element.name} is missing a 'type' field.`)
     }
@@ -58,7 +59,7 @@ export const validateElementTypes = (elements: (Question | HtmlElement)[]): stri
   return errors
 }
 
-/** Returns a message with the number of elements that don't have a 'name' field. */
+/** Returns the number of elements that don't have a 'name' field and the number of duplicate names, if any. */
 export const validateElementNames = (elements: (Question | HtmlElement)[]) => {
   const errorMessages: string[] = []
 
@@ -95,9 +96,7 @@ export const getAllElements = (formContent: FormContent): (Question | HtmlElemen
     throw new Error(`Error parsing form. Please ensure that the form has a 'pages' property.`)
   }
 
-  const pages = formContent.pages
-
-  const pageElements = pages.flatMap(page => {
+  const pageElements = formContent.pages.flatMap(page => {
     if (!('elements' in page)) {
       throw new Error(`Error parsing form. Please ensure that all pages have an 'elements' property.`)
     } else {

--- a/ui-admin/src/forms/formContentValidation.ts
+++ b/ui-admin/src/forms/formContentValidation.ts
@@ -1,5 +1,4 @@
 import { FormContent } from '@juniper/ui-core'
-import { isPlainObject } from 'lodash'
 import { getTableOfContentsTree } from './FormTableOfContents'
 
 /** Validate that an object is valid FormContent. */
@@ -9,18 +8,14 @@ export const validateFormContent = (rawFormContent: unknown): FormContent => {
     parsedFormContent = JSON.parse(rawFormContent as string) as FormContent
   } catch (e) {
     // @ts-ignore
-    throw new Error(`JSON ${e.name}: ${e.message}`)
+    throw new Error(`${e.name}: ${e.message}`)
   }
 
   try {
     getTableOfContentsTree(parsedFormContent)
-  } catch {
-    throw new Error('Error parsing JSON: a page or panel has been misconfigured')
-  }
-
-  if (!isPlainObject(parsedFormContent)) {
-    console.log('huh')
-    throw new Error(`Invalid form, expected an object`)
+  } catch (e) {
+    // @ts-ignore
+    throw new Error(`Error: a page or panel is misconfigured. ${e.message}`)
   }
 
   return parsedFormContent

--- a/ui-admin/src/forms/formContentValidation.ts
+++ b/ui-admin/src/forms/formContentValidation.ts
@@ -5,12 +5,7 @@ export const validateFormJson = (rawFormContent: unknown): FormContent => {
   //Checks for basic JSON validity, and returns the syntax error if invalid
   //As a result, the error message is not very user-friendly because it's
   //the underlying exception message, but it can provide some useful context
-  try {
-    return JSON.parse(rawFormContent as string) as FormContent
-  } catch (e) {
-    // @ts-ignore
-    throw new Error(`${e.name}: ${e.message}`)
-  }
+  return JSON.parse(rawFormContent as string) as FormContent
 }
 
 /** Reasonable attempt to validate that an object is valid FormContent.

--- a/ui-admin/src/forms/formContentValidation.ts
+++ b/ui-admin/src/forms/formContentValidation.ts
@@ -1,4 +1,4 @@
-import { FormContent, Question, TemplatedQuestion } from '@juniper/ui-core'
+import {FormContent, FormElement, HtmlElement, Question, TemplatedQuestion} from '@juniper/ui-core'
 
 /** Returns a validated FormContent object, or throws an error if invalid. */
 export const validateFormJson = (rawFormContent: unknown): FormContent => {
@@ -19,16 +19,16 @@ export const validateFormContent = (formContent: FormContent): string[] => {
   const validationErrors: string[] = []
 
   //Gets all questions and validates that all pages and panels have an 'elements' property.
-  const questions = getAllQuestions(formContent)
+  const questions = getAllElements(formContent)
 
   //Validates that all templated questions references a template name that actually exists.
   validationErrors.push(...validateTemplatedQuestions(formContent, questions))
 
   //Validates that all questions have a 'name' field and there are no duplicate names.
-  validationErrors.push(...validateQuestionNames(questions))
+  validationErrors.push(...validateElementNames(questions))
 
   //Validates that all questions have a 'type' field.
-  validationErrors.push(...validateQuestionTypes(questions))
+  validationErrors.push(...validateElementTypes(questions))
 
   return validationErrors
 }
@@ -45,52 +45,55 @@ export const validateTemplatedQuestions = (formContent: FormContent, questions: 
   return templatedQuestions.filter(question =>
     !questionTemplateNames.includes(question.questionTemplateName)
   ).map(question => {
-    return `'${question.name}' references non-existent template '${question.questionTemplateName}'`
+    return `'${question.name}' references non-existent question template '${question.questionTemplateName}'`
   })
 }
 
-/** Returns an array of error messages for all questions that don't have a 'type' field. */
-export const validateQuestionTypes = (questions: Question[]): string[] => {
+/** Returns an array of error messages for all elements that don't have a 'type' field. */
+export const validateElementTypes = (elements: (Question | HtmlElement)[]): string[] => {
   const errors: string[] = []
-  questions.forEach(question => {
-    //@ts-ignore
-    if (!question.type && !question.questionTemplateName) {
-      errors.push(`Question ${question.name} is missing a 'type' field.`)
+  elements.forEach(element => {
+    // @ts-ignore
+    if (!element.type && !element.questionTemplateName) {
+      errors.push(`Element ${element.name} is missing a 'type' field.`)
     }
   })
   return errors
 }
 
-/** Returns a message with the number of questions that don't have a 'name' field. */
-export const validateQuestionNames = (questions: Question[]) => {
-  const errors: Question[] = []
+/** Returns a message with the number of elements that don't have a 'name' field. */
+export const validateElementNames = (elements: (Question | HtmlElement)[]) => {
   const errorMessages: string[] = []
-  const duplicateNames = questions.filter((question, index) => {
-    return questions.findIndex(q => q.name === question.name) !== index
-  }).filter(q => q.name !== undefined) //filter questions that don't have names, as this can lead to redundant errors
+
+  //Find all elements that have duplicate names
+  const duplicateNames = elements.filter((element, index) => {
+    return elements.findIndex(e => e.name === element.name) !== index
+  }).filter(q => q.name !== undefined) //filter elements that don't have names, as this can lead to redundant errors
 
   duplicateNames.map(question => {
-    errorMessages.push(`Duplicate question name: ${ question.name }`)
+    errorMessages.push(`Duplicate element name: ${ question.name }`)
   })
 
-  questions.forEach(question => {
-    if (!question.name) {
-      errors.push(question)
+  //Find all elements that don't have a name
+  const invalidElements: (Question | HtmlElement)[] = []
+  elements.forEach(element => {
+    if (!element.name) {
+      invalidElements.push(element)
     }
   })
 
-  //It's hard to reference individual questions that don't have names, so just return the count.
-  if (errors.length === 1) {
-    errorMessages.push(`1 question is missing a 'name' field.`)
-  } else if (errors.length > 1) {
-    errorMessages.push(`${errors.length} questions are missing a 'name' field.`)
+  //It's hard to reference individual elements that don't have names, so just return the count.
+  if (invalidElements.length === 1) {
+    errorMessages.push(`1 element is missing a 'name' field.`)
+  } else if (invalidElements.length > 1) {
+    errorMessages.push(`${invalidElements.length} elements are missing a 'name' field.`)
   }
 
   return errorMessages
 }
 
 /** Returns an array of all Questions in a form, including those in panels. */
-export const getAllQuestions = (formContent: FormContent): Question[] => {
+export const getAllElements = (formContent: FormContent): Question[] => {
   if (!('pages' in formContent)) {
     throw new Error(`Error parsing form. Please ensure that the form has a 'pages' property.`)
   }

--- a/ui-admin/src/forms/formContentValidation.ts
+++ b/ui-admin/src/forms/formContentValidation.ts
@@ -1,9 +1,13 @@
-import { FormContent } from '@juniper/ui-core'
+import { FormContent, TemplatedQuestion } from '@juniper/ui-core'
 import { getTableOfContentsTree } from './FormTableOfContents'
 
 /** Validate that an object is valid FormContent. */
 export const validateFormContent = (rawFormContent: unknown): FormContent => {
   let parsedFormContent: FormContent
+
+  //Checks for basic JSON validity, and returns the syntax error if invalid
+  //As a result, the error message is not very user-friendly because it's
+  //the underlying exception message, but it can provide some useful context
   try {
     parsedFormContent = JSON.parse(rawFormContent as string) as FormContent
   } catch (e) {
@@ -11,6 +15,9 @@ export const validateFormContent = (rawFormContent: unknown): FormContent => {
     throw new Error(`${e.name}: ${e.message}`)
   }
 
+  //This will ensure that. It takes advantage of the fact that the
+  //table of contents tree will fail to render. Ideally, the ToC would
+  //be resilient but for the moment I'm just gonna use that as a shortcut
   try {
     getTableOfContentsTree(parsedFormContent)
   } catch (e) {
@@ -18,5 +25,51 @@ export const validateFormContent = (rawFormContent: unknown): FormContent => {
     throw new Error(`Error: a page or panel is misconfigured. ${e.message}`)
   }
 
+  //Validates that all templated questions references a template name
+  //that actually exists.
+  try {
+    validateQuestionTemplates(parsedFormContent)
+  } catch (e) {
+    // @ts-ignore
+    throw new Error(`Error: ${e.message}`)
+  }
+
   return parsedFormContent
+}
+
+type InvalidQuestionTemplate = {
+  questionStableId: string
+  referencedTemplateId: string
+}
+
+const validateQuestionTemplates = (formContent: FormContent): void => {
+  const questionTemplates = formContent.questionTemplates
+  if (!questionTemplates) {
+    return
+  }
+
+  const questionTemplateNames = questionTemplates.map(qt => qt.name)
+
+  const templatedQuestions: TemplatedQuestion[] = formContent.pages.flatMap(page =>
+    page.elements.filter(element =>
+      Object.hasOwnProperty.call(element, 'questionTemplateName')
+    )
+  ) as TemplatedQuestion[]
+
+  const questionsWithInvalidTemplates: InvalidQuestionTemplate[] = templatedQuestions.filter(question =>
+    !questionTemplateNames.includes(question.questionTemplateName)
+  ).map(question => {
+    return {
+      questionStableId: question.name,
+      referencedTemplateId: question.questionTemplateName
+    }
+  })
+
+  if (questionsWithInvalidTemplates.length > 0) {
+    throw new Error(
+      `The following question(s) reference a question template that doesn't exist: 
+      ${questionsWithInvalidTemplates.map(q =>
+        `${q.questionStableId} (references template ${q.referencedTemplateId})`).join(', ')}`
+    )
+  }
 }

--- a/ui-admin/src/forms/formEditorTypes.ts
+++ b/ui-admin/src/forms/formEditorTypes.ts
@@ -1,7 +1,6 @@
 import { FormContent } from '@juniper/ui-core'
 
 export type OnChangeFormContent = (...args:
-                                     [validationError: string | undefined, newValue: FormContent] |
-                                     [validationError: string, newValue: undefined] |
-                                     [undefined, undefined]
+                                     [validationErrors: string[], newValue: FormContent] |
+                                     [validationErrors: string[], newValue: undefined]
 ) => void

--- a/ui-admin/src/forms/formEditorTypes.ts
+++ b/ui-admin/src/forms/formEditorTypes.ts
@@ -1,3 +1,7 @@
 import { FormContent } from '@juniper/ui-core'
 
-export type OnChangeFormContent = (...args: [valid: true, newValue: FormContent] | [false, undefined]) => void
+export type OnChangeFormContent = (...args:
+                                     [validationError: string | undefined, newValue: FormContent] |
+                                     [validationError: string, newValue: undefined] |
+                                     [undefined, undefined]
+) => void

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -34,7 +34,7 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
   const FORM_DRAFT_KEY = getFormDraftKey({ form: currentForm })
   const FORM_DRAFT_SAVE_INTERVAL = 10000
 
-  const [isEditorValid, setIsEditorValid] = useState(true)
+  const [validationError, setValidationError] = useState<string>()
   const [saving, setSaving] = useState(false)
   const [savingDraft, setSavingDraft] = useState(false)
 
@@ -48,7 +48,7 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
   const [draft, setDraft] = useState<FormDraft | undefined>(
     !readOnly ? getDraft({ formDraftKey: FORM_DRAFT_KEY }) : undefined)
 
-  const isSaveEnabled = !!draft && isEditorValid && !saving
+  const isSaveEnabled = !!draft && !validationError && !saving
 
   const saveDraftToLocalStorage = () => {
     setDraft(currentDraft => {
@@ -109,12 +109,13 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
               if (!draft) {
                 return 'Form is unchanged. Make changes to save.'
               }
-              if (!isEditorValid) {
-                return 'Form is invalid. Correct to save.'
+              if (validationError) {
+                return validationError
               }
               return 'Save changes'
             })()}
-            variant="primary"
+            tooltipPlacement={'left'}
+            variant={validationError ? 'danger' : 'primary'}
             onClick={onClickSave}
           >
             Save
@@ -151,11 +152,11 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
         initialContent={draft?.content || currentForm.content} //favor loading the draft, if we find one
         visibleVersionPreviews={visibleVersionPreviews}
         readOnly={readOnly}
-        onChange={(isValid, newContent) => {
-          if (isValid) {
+        onChange={(validationError, newContent) => {
+          if (!validationError) {
             setDraft({ content: JSON.stringify(newContent), date: Date.now() })
           }
-          setIsEditorValid(isValid)
+          setValidationError(validationError)
         }}
       />
     </div>

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -103,7 +103,7 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
           </h5>
         </div>
         { savingDraft && <span className="detail me-2 ms-2">Saving draft...</span> }
-        { validationErrors && !isEmpty(validationErrors) &&
+        { !isEmpty(validationErrors) &&
             <div className="position-relative ms-auto me-2 ms-2">
               <button className="btn btn-outline-danger"
                 onClick={() => setShowErrors(!showErrors)} aria-label="view errors">

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -36,7 +36,6 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
   const FORM_DRAFT_KEY = getFormDraftKey({ form: currentForm })
   const FORM_DRAFT_SAVE_INTERVAL = 10000
 
-  const [validationErrors, setValidationErrors] = useState<string[]>([])
   const [saving, setSaving] = useState(false)
   const [savingDraft, setSavingDraft] = useState(false)
 
@@ -51,6 +50,7 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
   const [draft, setDraft] = useState<FormDraft | undefined>(
     !readOnly ? getDraft({ formDraftKey: FORM_DRAFT_KEY }) : undefined)
 
+  const [validationErrors, setValidationErrors] = useState<string[]>([])
   const isSaveEnabled = !!draft && isEmpty(validationErrors) && !saving
 
   const saveDraftToLocalStorage = () => {

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -130,11 +130,11 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
             disabled={!isSaveEnabled}
             className="me-md-2"
             tooltip={(() => {
-              if (!isEmpty(validationErrors)) {
-                return 'Please correct errors before saving.'
-              }
               if (!draft) {
                 return 'Form is unchanged. Make changes to save.'
+              }
+              if (!isEmpty(validationErrors)) {
+                return 'Form is invalid. Correct to save.'
               }
               return 'Save changes'
             })()}
@@ -177,8 +177,8 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
         visibleVersionPreviews={visibleVersionPreviews}
         readOnly={readOnly}
         onChange={(newValidationErrors, newContent) => {
-          setShowErrors(false)
           if (isEmpty(newValidationErrors)) {
+            setShowErrors(false)
             setDraft({ content: JSON.stringify(newContent), date: Date.now() })
           }
           setValidationErrors(newValidationErrors)

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -92,8 +92,6 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
     }
   }
 
-  console.log(validationErrors)
-
   return (
     <div className="SurveyView d-flex flex-column flex-grow-1 mx-1 mb-1">
       <div className="d-flex p-2 align-items-center">
@@ -141,7 +139,7 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
               }
               return 'Save changes'
             })()}
-            tooltipPlacement={'left'}
+            tooltipPlacement={'bottom'}
             variant={isEmpty(validationErrors) ? 'primary' : 'danger'}
             onClick={onClickSave}
           >

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -106,11 +106,11 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
             disabled={!isSaveEnabled}
             className="me-md-2"
             tooltip={(() => {
-              if (!draft) {
-                return 'Form is unchanged. Make changes to save.'
-              }
               if (validationError) {
                 return validationError
+              }
+              if (!draft) {
+                return 'Form is unchanged. Make changes to save.'
               }
               return 'Save changes'
             })()}

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -8,11 +8,10 @@ import LoadedLocalDraftModal from 'forms/designer/modals/LoadedLocalDraftModal'
 import DiscardLocalDraftModal from 'forms/designer/modals/DiscardLocalDraftModal'
 import { deleteDraft, FormDraft, getDraft, getFormDraftKey, saveDraft } from 'forms/designer/utils/formDraftUtils'
 import { useAutosaveEffect } from '@juniper/ui-core/build/autoSaveUtils'
-import { faClockRotateLeft } from '@fortawesome/free-solid-svg-icons'
+import { faClockRotateLeft, faExclamationCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import VersionSelector from './VersionSelector'
 import { StudyEnvContextT } from '../StudyEnvironmentRouter'
-import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons'
 import { isEmpty } from 'lodash'
 
 type SurveyEditorViewProps = {


### PR DESCRIPTION
This detects a bunch of different cases:

Invalid JSON:
<img width="759" alt="Screenshot 2023-08-30 at 2 18 08 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/e1993939-4467-4ef1-9955-81c5078389f1">

Invalid question template references:
<img width="767" alt="Screenshot 2023-08-30 at 2 17 58 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/7eabacbe-32a2-445e-8814-51c4b499d68a">

Elements with missing types:
<img width="762" alt="Screenshot 2023-08-30 at 2 18 31 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/4cc5e328-e659-4f74-b60b-98be83f5e1d0">

Elements with missing names:
<img width="761" alt="Screenshot 2023-08-30 at 2 18 46 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/dbcc5d9b-458d-43cb-83f8-4e75584bd157">

Elements with duplicate names:
<img width="761" alt="Screenshot 2023-08-30 at 2 19 17 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/fd48ccef-5818-40e1-bc92-9dbe32054d6d">

Forms without pages:
<img width="766" alt="Screenshot 2023-08-30 at 2 21 18 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/9f1d59c7-054d-46aa-82fd-3fbf8832b65e">

Pages without elements:
<img width="761" alt="Screenshot 2023-08-30 at 2 21 29 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/b5512714-dad3-48ca-a639-5ae5c30b99ec">

Panels without elements:
<img width="765" alt="Screenshot 2023-08-30 at 2 21 37 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/103cec52-36b1-4041-bcd3-8b1bf37658c8">


TO TEST:

* Try out all of the above test cases
* Make sure that you can correct the errors and everything still saves correctly
* Make sure that the Designer and Preview tabs are disabled while there are errors, and that the Save button is disabled
* Make sure that you don't encounter any of these errors while playing around in the Designer tab (there are enough guardrails in place, so you shouldn't be able to trigger any of these errors)