### PR TITLE
[JN-548] Add Download JSON button to form editor

### DIFF
--- a/ui-admin/src/study/surveys/SurveyEditorView.test.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.test.tsx
@@ -52,4 +52,22 @@ describe('SurveyEditorView', () => {
     expect(localStorage.getItem).toHaveBeenCalledWith(FORM_DRAFT_KEY)
     expect(screen.queryByText('Survey Draft Loaded')).not.toBeInTheDocument()
   })
+
+  test('allows the user to download the JSON file', async () => {
+    //Arrange
+    render(<SurveyEditorView
+      studyEnvContext={mockStudyEnvContext()}
+      currentForm={mockForm}
+      onCancel={jest.fn()}
+      onSave={jest.fn()}
+    />)
+
+    //Act
+    const downloadButton = screen.getByRole('button', { name: 'Download JSON' })
+    downloadButton.click()
+
+    //Assert
+    expect(downloadButton).toBeInTheDocument()
+    expect(downloadButton).toBeEnabled()
+  })
 })

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -8,11 +8,12 @@ import LoadedLocalDraftModal from 'forms/designer/modals/LoadedLocalDraftModal'
 import DiscardLocalDraftModal from 'forms/designer/modals/DiscardLocalDraftModal'
 import { deleteDraft, FormDraft, getDraft, getFormDraftKey, saveDraft } from 'forms/designer/utils/formDraftUtils'
 import { useAutosaveEffect } from '@juniper/ui-core/build/autoSaveUtils'
-import { faClockRotateLeft, faExclamationCircle } from '@fortawesome/free-solid-svg-icons'
+import { faClockRotateLeft, faDownload, faExclamationCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import VersionSelector from './VersionSelector'
 import { StudyEnvContextT } from '../StudyEnvironmentRouter'
 import { isEmpty } from 'lodash'
+import { saveBlobAsDownload } from 'util/downloadUtils'
 
 type SurveyEditorViewProps = {
   studyEnvContext: StudyEnvContextT
@@ -106,6 +107,23 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
             <button className="btn btn-secondary" onClick={() => setShowVersionSelector(true)}>
               <FontAwesomeIcon icon={faClockRotateLeft}/> History
             </button>
+            <Button variant="secondary"
+              disabled={!isEditorValid}
+              tooltip={isEditorValid ?
+                'Download the current contents of the JSON Editor as a JSON file.' :
+                'The form contains invalid JSON. Please correct the errors before downloading.'
+              }
+              onClick={() => {
+                const content = draft?.content || currentForm.content
+                // To get this formatted nicely and not as one giant line, need to parse
+                // this as an object and then stringify the result.
+                const blob = new Blob(
+                  [JSON.stringify(JSON.parse(content), null, 2)],
+                  { type: 'application/json' })
+                saveBlobAsDownload(blob, `${currentForm.stableId}_v${currentForm.version}_${Date.now()}.json`)
+              }}>
+              <FontAwesomeIcon icon={faDownload}/> Download JSON
+            </Button>
           </h5>
         </div>
         { savingDraft && <span className="detail me-2 ms-2">Saving draft...</span> }

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -108,8 +108,8 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
               <FontAwesomeIcon icon={faClockRotateLeft}/> History
             </button>
             <Button variant="secondary"
-              disabled={!isEditorValid}
-              tooltip={isEditorValid ?
+              disabled={!isEmpty(validationErrors)}
+              tooltip={isEmpty(validationErrors) ?
                 'Download the current contents of the JSON Editor as a JSON file.' :
                 'The form contains invalid JSON. Please correct the errors before downloading.'
               }
@@ -120,7 +120,9 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
                 const blob = new Blob(
                   [JSON.stringify(JSON.parse(content), null, 2)],
                   { type: 'application/json' })
-                saveBlobAsDownload(blob, `${currentForm.stableId}_v${currentForm.version}_${Date.now()}.json`)
+                const filename = !draft ? `${currentForm.stableId}_v${currentForm.version}.json` :
+                  `${currentForm.stableId}_v${currentForm.version}_draft_${Date.now()}.json`
+                saveBlobAsDownload(blob, filename)
               }}>
               <FontAwesomeIcon icon={faDownload}/> Download JSON
             </Button>


### PR DESCRIPTION
<img width="544" alt="Screenshot 2023-08-30 at 10 12 06 AM" src="https://github.com/broadinstitute/juniper/assets/7257391/02dd2924-0bf9-4b5f-a225-e9cf6269fdc6">

To test:

* Click the button and verify that it downloads properly formatted JSON