### PR TITLE
JN-482: adding admin survey printing

### DIFF
--- a/ui-admin/src/App.tsx
+++ b/ui-admin/src/App.tsx
@@ -3,6 +3,7 @@ import 'react-notifications-component/dist/theme.css'
 import 'styles/notifications.css'
 import 'survey-core/defaultV2.min.css'
 import './App.css'
+import './print.css'
 
 import { BrowserRouter, Outlet, Route, Routes } from 'react-router-dom'
 import { ReactNotifications } from 'react-notifications-component'

--- a/ui-admin/src/print.css
+++ b/ui-admin/src/print.css
@@ -12,6 +12,9 @@
     .modal-fullscreen .modal-body {
         overflow-y: visible;
     }
+    header,footer {
+        display: none;
+    }
 }
 
 

--- a/ui-admin/src/print.css
+++ b/ui-admin/src/print.css
@@ -1,0 +1,17 @@
+@media print {
+    /** allow fullscreen bootstrap modals to print all content, even with vertical scroll */
+    .modal {
+        position: absolute !important;
+        left: 0;
+        top: 0;
+        margin: 0;
+        padding: 0;
+        overflow: visible !important;
+        max-height: none;
+    }
+    .modal-fullscreen .modal-body {
+        overflow-y: visible;
+    }
+}
+
+

--- a/ui-admin/src/study/participants/consent/EnrolleeConsentView.tsx
+++ b/ui-admin/src/study/participants/consent/EnrolleeConsentView.tsx
@@ -10,6 +10,7 @@ import SurveyFullDataView from 'study/participants/survey/SurveyFullDataView'
 import { ConsentResponseMapT } from '../enrolleeView/EnrolleeView'
 import { EnrolleeParams } from '../enrolleeView/EnrolleeLoader'
 import { instantToDefaultString } from 'util/timeUtils'
+import DocumentTitle from 'util/DocumentTitle'
 
 /** shows consent forms for a given enrollee, based on url params specifying the form */
 export default function EnrolleeConsentView({ enrollee, responseMap }:
@@ -41,6 +42,7 @@ export function RawEnrolleeConsentView({ enrollee, configConsent, responses }:
   const answers: Answer[] = JSON.parse(lastResponse.fullData)
 
   return <div>
+    <DocumentTitle title={`${enrollee.shortcode} - ${configConsent.consentForm.name}`}/>
     <h6>{configConsent.consentForm.name}</h6>
     <div>
       <span className="fst-italic">completed {instantToDefaultString(lastResponse.createdAt)}</span>

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeView.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeView.tsx
@@ -80,7 +80,7 @@ export default function EnrolleeView({ enrollee, studyEnvContext, onUpdate }:
     <div className="row mt-2">
       <div className="col-12">
         <div className="d-flex">
-          <div className="participantTabs" style={{ minWidth: '280', maxWidth: '280px' }}>
+          <div style={{ minWidth: '280', maxWidth: '280px' }}>
             <ul className="list-group">
               <li className="list-group-item">
                 <NavLink to="profile" className={getLinkCssClasses}>Profile &amp; Notes</NavLink>

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeView.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeView.tsx
@@ -156,19 +156,18 @@ export default function EnrolleeView({ enrollee, studyEnvContext, onUpdate }:
                 <Route path="profile" element={<EnrolleeProfile enrollee={enrollee}
                   studyEnvContext={studyEnvContext}
                   onUpdate={onUpdate}/>}/>
-                <Route path="consents" element={<div>consents</div>}/>
-                { currentEnv.preEnrollSurvey && <Route path="preRegistration" element={
+                { currentEnv.preEnrollSurvey && <Route path="preRegistration/*" element={
                   <PreEnrollmentView preEnrollSurvey={currentEnv.preEnrollSurvey}
                     preEnrollResponse={enrollee.preEnrollmentResponse}/>
                 }/> }
                 <Route path="surveys">
-                  <Route path=":surveyStableId" element={<EnrolleeSurveyView enrollee={enrollee}
+                  <Route path=":surveyStableId/*" element={<EnrolleeSurveyView enrollee={enrollee}
                     responseMap={responseMap}/>}/>
                   <Route path="*" element={<div>Unknown participant survey page</div>}/>
                 </Route>
                 <Route path="tasks" element={<ParticipantTaskView enrollee={enrollee}/>}/>
                 <Route path="consents">
-                  <Route path=":consentStableId" element={<EnrolleeConsentView enrollee={enrollee}
+                  <Route path=":consentStableId/*" element={<EnrolleeConsentView enrollee={enrollee}
                     responseMap={consentMap}/>}/>
                   <Route path="*" element={<div>Unknown participant survey page</div>}/>
                 </Route>

--- a/ui-admin/src/study/participants/survey/DownloadFormView.tsx
+++ b/ui-admin/src/study/participants/survey/DownloadFormView.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect } from 'react'
+import { Survey as SurveyComponent } from 'survey-react-ui'
+
+import {
+  surveyJSModelFromForm,
+  makeSurveyJsData,
+  waitForImages,
+  Survey,
+  ConsentForm,
+  configureModelForPrint
+} from '@juniper/ui-core'
+
+import { Answer } from 'api/api'
+import Modal from 'react-bootstrap/Modal'
+import { Button } from 'components/forms/Button'
+
+
+type DownloadFormViewProps = {
+    answers: Answer[],
+    resumeData?: string,
+    survey: Survey | ConsentForm,
+    onDismiss: () => void
+}
+
+
+// TODO: Add JSDoc
+// eslint-disable-next-line jsdoc/require-jsdoc
+const DownloadFormModal = ({ survey, answers, resumeData, onDismiss }: DownloadFormViewProps) => {
+  const surveyJsData = makeSurveyJsData(resumeData, answers, undefined)
+  const surveyJsModel = surveyJSModelFromForm(survey)
+  surveyJsModel.data = surveyJsData.data
+  configureModelForPrint(surveyJsModel)
+  useEffect(() => {
+    waitForImages().then(() => { window.print() })
+  }, [surveyJsModel])
+
+
+  return <Modal show={true} onHide={onDismiss} fullscreen={true}>
+    <Modal.Body className="m-0 p-0">
+      <div className="d-print-none d-flex justify-content-center py-2">
+        <Button variant="secondary" className="d-print-none" onClick={onDismiss}>
+                    Done
+        </Button>
+        <hr/>
+      </div>
+      <SurveyComponent model={surveyJsModel} />
+    </Modal.Body>
+  </Modal>
+}
+
+export default DownloadFormModal

--- a/ui-admin/src/study/participants/survey/EnrolleeSurveyView.tsx
+++ b/ui-admin/src/study/participants/survey/EnrolleeSurveyView.tsx
@@ -7,6 +7,7 @@ import SurveyEditView from './SurveyEditView'
 import { ResponseMapT } from '../enrolleeView/EnrolleeView'
 import { EnrolleeParams } from '../enrolleeView/EnrolleeLoader'
 import { instantToDefaultString } from 'util/timeUtils'
+import DocumentTitle from 'util/DocumentTitle'
 
 /** Show responses for a survey based on url param */
 export default function EnrolleeSurveyView({ enrollee, responseMap }:
@@ -41,6 +42,7 @@ export function RawEnrolleeSurveyView({ enrollee, configSurvey, responses }:
   }
 
   return <div>
+    <DocumentTitle title={`${enrollee.shortcode} - ${configSurvey.survey.name}`}/>
     <h6>{configSurvey.survey.name}</h6>
     <div>
       <span className="fst-italic">

--- a/ui-admin/src/study/participants/survey/PrintFormModal.tsx
+++ b/ui-admin/src/study/participants/survey/PrintFormModal.tsx
@@ -14,7 +14,6 @@ import { Answer } from 'api/api'
 import Modal from 'react-bootstrap/Modal'
 import { Link } from 'react-router-dom'
 
-
 type DownloadFormViewProps = {
     answers: Answer[],
     resumeData?: string,

--- a/ui-admin/src/study/participants/survey/PrintFormModal.tsx
+++ b/ui-admin/src/study/participants/survey/PrintFormModal.tsx
@@ -23,9 +23,8 @@ type DownloadFormViewProps = {
 }
 
 
-// TODO: Add JSDoc
-// eslint-disable-next-line jsdoc/require-jsdoc
-const DownloadFormModal = ({ survey, answers, resumeData, onDismiss }: DownloadFormViewProps) => {
+/** renders the form in a fullscreen modal, and pops up the print dialog */
+const PrintFormModal = ({ survey, answers, resumeData, onDismiss }: DownloadFormViewProps) => {
   const surveyJsData = makeSurveyJsData(resumeData, answers, undefined)
   const surveyJsModel = surveyJSModelFromForm(survey)
   surveyJsModel.data = surveyJsData.data
@@ -48,4 +47,4 @@ const DownloadFormModal = ({ survey, answers, resumeData, onDismiss }: DownloadF
   </Modal>
 }
 
-export default DownloadFormModal
+export default PrintFormModal

--- a/ui-admin/src/study/participants/survey/PrintFormModal.tsx
+++ b/ui-admin/src/study/participants/survey/PrintFormModal.tsx
@@ -12,19 +12,18 @@ import {
 
 import { Answer } from 'api/api'
 import Modal from 'react-bootstrap/Modal'
-import { Button } from 'components/forms/Button'
+import { Link } from 'react-router-dom'
 
 
 type DownloadFormViewProps = {
     answers: Answer[],
     resumeData?: string,
-    survey: Survey | ConsentForm,
-    onDismiss: () => void
+    survey: Survey | ConsentForm
 }
 
 
 /** renders the form in a fullscreen modal, and pops up the print dialog */
-const PrintFormModal = ({ survey, answers, resumeData, onDismiss }: DownloadFormViewProps) => {
+const PrintFormModal = ({ survey, answers, resumeData }: DownloadFormViewProps) => {
   const surveyJsData = makeSurveyJsData(resumeData, answers, undefined)
   const surveyJsModel = surveyJSModelFromForm(survey)
   surveyJsModel.data = surveyJsData.data
@@ -34,12 +33,14 @@ const PrintFormModal = ({ survey, answers, resumeData, onDismiss }: DownloadForm
   }, [surveyJsModel])
 
 
-  return <Modal show={true} onHide={onDismiss} fullscreen={true}>
+  return <Modal show={true} fullscreen={true}>
     <Modal.Body className="m-0 p-0">
       <div className="d-print-none d-flex justify-content-center py-2">
-        <Button variant="secondary" className="d-print-none" onClick={onDismiss}>
-                    Done
-        </Button>
+        {
+          // eslint-disable-next-line
+          // @ts-ignore  Link to type also supports numbers for back operations
+          <Link className="btn btn-secondary" to={-1}>Done</Link>
+        }
         <hr/>
       </div>
       <SurveyComponent model={surveyJsModel} />

--- a/ui-admin/src/study/participants/survey/PrintFormModal.tsx
+++ b/ui-admin/src/study/participants/survey/PrintFormModal.tsx
@@ -36,11 +36,7 @@ const PrintFormModal = ({ survey, answers, resumeData }: DownloadFormViewProps) 
   return <Modal show={true} fullscreen={true}>
     <Modal.Body className="m-0 p-0">
       <div className="d-print-none d-flex justify-content-center py-2">
-        {
-          // eslint-disable-next-line
-          // @ts-ignore  Link to type also supports numbers for back operations
-          <Link className="btn btn-secondary" to={-1}>Done</Link>
-        }
+        <Link className="btn btn-secondary" to="..">Done</Link>
         <hr/>
       </div>
       <SurveyComponent model={surveyJsModel} />

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
@@ -1,9 +1,12 @@
-import { render, screen } from '@testing-library/react'
+import {render, screen, waitFor} from '@testing-library/react'
 import React from 'react'
 
-import { getDisplayValue } from './SurveyFullDataView'
+import SurveyFullDataView, { getDisplayValue } from './SurveyFullDataView'
 import { Question } from 'survey-core'
 import { Answer } from '@juniper/ui-core/build/types/forms'
+import {setupRouterTest} from "../../../test-utils/router-testing-utils";
+import {mockSurvey} from "../../../test-utils/mocking-utils";
+import userEvent from "@testing-library/user-event/index";
 
 
 describe('getDisplayValue', () => {
@@ -48,4 +51,16 @@ describe('getDisplayValue', () => {
     render(<span>{getDisplayValue(answer, question)}</span>)
     expect(screen.getByText('["option 2","option 4"]')).toBeTruthy()
   })
+})
+
+test('shows the download/print modal', async () => {
+  const printSpy = jest.spyOn(window, 'print').mockImplementation(() => {});
+  const { RoutedComponent } = setupRouterTest(
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      <SurveyFullDataView answers={[]} survey={mockSurvey()}/>)
+  render(RoutedComponent)
+  expect(screen.queryByText('Done')).not.toBeInTheDocument()
+  await userEvent.click(screen.getByText('print/download'))
+  expect(screen.getByText('Done')).toBeVisible()
+  await waitFor(() => expect(printSpy).toHaveBeenCalledTimes(1))
 })

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
@@ -1,12 +1,12 @@
-import {render, screen, waitFor} from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 
 import SurveyFullDataView, { getDisplayValue } from './SurveyFullDataView'
 import { Question } from 'survey-core'
 import { Answer } from '@juniper/ui-core/build/types/forms'
-import {setupRouterTest} from "../../../test-utils/router-testing-utils";
-import {mockSurvey} from "../../../test-utils/mocking-utils";
-import userEvent from "@testing-library/user-event/index";
+import { setupRouterTest } from 'test-utils/router-testing-utils'
+import { mockSurvey } from 'test-utils/mocking-utils'
+import userEvent from '@testing-library/user-event'
 
 
 describe('getDisplayValue', () => {
@@ -54,10 +54,9 @@ describe('getDisplayValue', () => {
 })
 
 test('shows the download/print modal', async () => {
-  const printSpy = jest.spyOn(window, 'print').mockImplementation(() => {});
+  const printSpy = jest.spyOn(window, 'print').mockImplementation(() => 1)
   const { RoutedComponent } = setupRouterTest(
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      <SurveyFullDataView answers={[]} survey={mockSurvey()}/>)
+    <SurveyFullDataView answers={[]} survey={mockSurvey()}/>)
   render(RoutedComponent)
   expect(screen.queryByText('Done')).not.toBeInTheDocument()
   await userEvent.click(screen.getByText('print/download'))

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -4,10 +4,10 @@ import { Question } from 'survey-core'
 import { surveyJSModelFromForm, makeSurveyJsData } from '@juniper/ui-core'
 import { Answer, ConsentForm, Survey } from 'api/api'
 import InfoPopup from 'components/forms/InfoPopup'
-import { Button } from 'components/forms/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faDownload } from '@fortawesome/free-solid-svg-icons'
 import PrintFormModal from './PrintFormModal'
+import { Link, Route, Routes } from 'react-router-dom'
 type SurveyFullDataViewProps = {
   answers: Answer[],
   survey: Survey | ConsentForm,
@@ -18,7 +18,6 @@ type SurveyFullDataViewProps = {
 /** renders every item in a survey response */
 export default function SurveyFullDataView({ answers, resumeData, survey, userId }:
   SurveyFullDataViewProps) {
-  const [isPrintMode, setIsPrintMode] = useState(false)
   const [showAllQuestions, setShowAllQuestions] = useState(true)
   const [showFullQuestions, setShowFullQuestions] = useState(false)
   const surveyJsData = makeSurveyJsData(resumeData, answers, userId)
@@ -52,22 +51,23 @@ export default function SurveyFullDataView({ answers, resumeData, survey, userId
         <InfoPopup content="Whether truncate question texts longer than 100 characters below"/>
       </div>
       <div className="ms-auto">
-        <Button variant="secondary" onClick={() => setIsPrintMode(!isPrintMode)}>
+        <Link to="print">
           <FontAwesomeIcon icon={faDownload}/> print/download
-        </Button>
+        </Link>
       </div>
     </div>
     <hr/>
-    { isPrintMode && <PrintFormModal answers={answers}
-      resumeData={resumeData}
-      survey={survey}
-      onDismiss={() => setIsPrintMode(false)}
-    />}
-    { !isPrintMode && <dl>
-      {questions.map((question, index) =>
-        <ItemDisplay key={index} question={question} answerMap={answerMap}
-          surveyVersion={survey.version} showFullQuestions={showFullQuestions}/>)}
-    </dl> }
+    <Routes>
+      <Route path="print" element={<PrintFormModal answers={answers}
+        resumeData={resumeData}
+        survey={survey}/>
+      }/>
+      <Route index element={<dl>
+        {questions.map((question, index) =>
+          <ItemDisplay key={index} question={question} answerMap={answerMap}
+            surveyVersion={survey.version} showFullQuestions={showFullQuestions}/>)}
+      </dl>}/>
+    </Routes>
   </div>
 }
 

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -7,7 +7,7 @@ import InfoPopup from 'components/forms/InfoPopup'
 import { Button } from 'components/forms/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faDownload } from '@fortawesome/free-solid-svg-icons'
-import DownloadFormView from './DownloadFormView'
+import PrintFormModal from './PrintFormModal'
 type SurveyFullDataViewProps = {
   answers: Answer[],
   survey: Survey | ConsentForm,
@@ -58,16 +58,16 @@ export default function SurveyFullDataView({ answers, resumeData, survey, userId
       </div>
     </div>
     <hr/>
-    { isPrintMode && <DownloadFormView answers={answers}
+    { isPrintMode && <PrintFormModal answers={answers}
       resumeData={resumeData}
       survey={survey}
       onDismiss={() => setIsPrintMode(false)}
     />}
-    <dl>
+    { !isPrintMode && <dl>
       {questions.map((question, index) =>
         <ItemDisplay key={index} question={question} answerMap={answerMap}
           surveyVersion={survey.version} showFullQuestions={showFullQuestions}/>)}
-    </dl>
+    </dl> }
   </div>
 }
 

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -4,6 +4,10 @@ import { Question } from 'survey-core'
 import { surveyJSModelFromForm, makeSurveyJsData } from '@juniper/ui-core'
 import { Answer, ConsentForm, Survey } from 'api/api'
 import InfoPopup from 'components/forms/InfoPopup'
+import { Button } from 'components/forms/Button'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faDownload } from '@fortawesome/free-solid-svg-icons'
+import DownloadFormView from './DownloadFormView'
 type SurveyFullDataViewProps = {
   answers: Answer[],
   survey: Survey | ConsentForm,
@@ -14,6 +18,7 @@ type SurveyFullDataViewProps = {
 /** renders every item in a survey response */
 export default function SurveyFullDataView({ answers, resumeData, survey, userId }:
   SurveyFullDataViewProps) {
+  const [isPrintMode, setIsPrintMode] = useState(false)
   const [showAllQuestions, setShowAllQuestions] = useState(true)
   const [showFullQuestions, setShowFullQuestions] = useState(false)
   const surveyJsData = makeSurveyJsData(resumeData, answers, userId)
@@ -29,7 +34,7 @@ export default function SurveyFullDataView({ answers, resumeData, survey, userId
   }
 
   return <div>
-    <div className="d-flex">
+    <div className="d-flex d-print-none">
       <div className="d-flex align-items-center">
         <label>
           <input type="checkbox" className="me-2"
@@ -46,8 +51,18 @@ export default function SurveyFullDataView({ answers, resumeData, survey, userId
         </label>
         <InfoPopup content="Whether truncate question texts longer than 100 characters below"/>
       </div>
+      <div className="ms-auto">
+        <Button variant="secondary" onClick={() => setIsPrintMode(!isPrintMode)}>
+          <FontAwesomeIcon icon={faDownload}/> print/download
+        </Button>
+      </div>
     </div>
     <hr/>
+    { isPrintMode && <DownloadFormView answers={answers}
+      resumeData={resumeData}
+      survey={survey}
+      onDismiss={() => setIsPrintMode(false)}
+    />}
     <dl>
       {questions.map((question, index) =>
         <ItemDisplay key={index} question={question} answerMap={answerMap}

--- a/ui-admin/src/util/DocumentTitle.test.tsx
+++ b/ui-admin/src/util/DocumentTitle.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import React, { useState } from 'react'
+
+import DocumentTitle from './DocumentTitle'
+import userEvent from '@testing-library/user-event'
+
+
+const DocTitleTestComponent = () => {
+  const [showTitledComponent, setShowTitledComponent] = useState(false)
+  return <div>
+        hello
+    { showTitledComponent && <div>
+            subcomponent
+      <DocumentTitle title="foo"/>
+    </div>
+    }
+    <button onClick={() => setShowTitledComponent(!showTitledComponent)}>show subcomponent</button>
+  </div>
+}
+
+describe('DocumentTitle', () => {
+  it('updates, then restores the document title', async () => {
+    render(<DocTitleTestComponent/>)
+    expect(document.title).toEqual('')
+    await userEvent.click(screen.getByText('show subcomponent'))
+    expect(document.title).toEqual('foo | Juniper')
+    await userEvent.click(screen.getByText('show subcomponent'))
+    expect(document.title).toEqual('')
+  })
+})

--- a/ui-admin/src/util/DocumentTitle.tsx
+++ b/ui-admin/src/util/DocumentTitle.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from 'react'
+
+
+type DocumentTitleProps = {
+    title?: string, // html document.title
+    defaultSuffix?: boolean, // whether to append ' | Juniper' to the end of the title
+    printTitle?: string  // optional print-specific title
+}
+
+/** changes the document title of the page.  By default adds ' | Juniper' as a suffix */
+const DocumentTitle = (props: DocumentTitleProps) => {
+  const { title, defaultSuffix=true, printTitle } = props
+  let fullTitle = 'Juniper'
+  if (defaultSuffix && title) {
+    fullTitle = `${title} | Juniper`
+  } else if (title) {
+    fullTitle = title
+  }
+  const beforePrintHandler = () => {
+    document.title = printTitle ?? fullTitle
+  }
+  const afterPrintHandler = () => {
+    document.title = fullTitle
+  }
+
+  useEffect(() => {
+    const previousTitle = document.title
+    document.title = fullTitle
+    window.addEventListener('beforeprint', beforePrintHandler)
+    window.addEventListener('afterprint', afterPrintHandler)
+
+    return () => {
+      document.title = previousTitle
+      window.removeEventListener('beforeprint', beforePrintHandler)
+      window.removeEventListener('afterprint', beforePrintHandler)
+    }
+  }, [fullTitle, printTitle])
+
+  return null
+}
+
+export default DocumentTitle

--- a/ui-core/src/index.ts
+++ b/ui-core/src/index.ts
@@ -10,6 +10,7 @@ export * from './types/task'
 
 export * from './reactUtils'
 export * from './surveyUtils'
+export * from './waitForImages'
 
 export * from './participant/landing/sections/HtmlSectionView'
 export * from './participant/landing/Markdown'

--- a/ui-core/src/surveyUtils.ts
+++ b/ui-core/src/surveyUtils.ts
@@ -96,3 +96,10 @@ export function makeSurveyJsData(resumeData: string | undefined,
   }
 }
 
+/** sets surveyjs model with print-friendly settings */
+export const configureModelForPrint = (surveyModel: SurveyModel) => {
+  surveyModel.mode = 'display'
+  surveyModel.questionsOnPageMode = 'singlePage'
+  surveyModel.showProgressBar = 'off'
+}
+

--- a/ui-core/src/surveyjs/surveyJsStyle.scss
+++ b/ui-core/src/surveyjs/surveyJsStyle.scss
@@ -34,3 +34,40 @@
 .sd-element--invisible {
   opacity: 1;
 }
+
+@media print {
+  .sd-root-modern {
+    background: none;
+  }
+
+  .sd-body--static {
+    max-width: none !important;
+  }
+
+  .sd-element--with-frame {
+    padding: 0 !important;
+    box-shadow: none !important;
+  }
+
+  .sd-element--nested.sd-panel {
+    border: none !important;
+    padding: 0 !important;
+  }
+
+  .sd-page__row {
+    page-break-after: always;
+    margin-top: 0 !important;
+  }
+  .sd-page__row:last-child {
+    page-break-after: unset;
+  }
+
+  .sd-item--disabled.sd-item--disabled .sd-item__decorator {
+    print-color-adjust: exact;
+    background-color: #eee;
+  }
+  .sd-item--disabled.sd-item--disabled .sd-item__decorator::after {
+    print-color-adjust: exact;
+    background-color: #666;
+  }
+}

--- a/ui-core/src/surveyjs/surveyJsStyle.scss
+++ b/ui-core/src/surveyjs/surveyJsStyle.scss
@@ -55,11 +55,11 @@
   }
 
   .sd-page__row {
-    page-break-after: always;
+    break-after: page;
     margin-top: 0 !important;
   }
   .sd-page__row:last-child {
-    page-break-after: unset;
+    break-after: unset;
   }
 
   .sd-item--disabled.sd-item--disabled .sd-item__decorator {

--- a/ui-core/src/waitForImages.ts
+++ b/ui-core/src/waitForImages.ts
@@ -1,0 +1,24 @@
+/** returns a promise that resolves when all images on the page are finished loading */
+export const waitForImages = () => new Promise(resolve => {
+  const images = Array.from(document.querySelectorAll('img'))
+  if (images.length === 0) {
+    resolve(undefined)
+    return
+  }
+
+  let nComplete = 0
+
+  const cb = () => {
+    nComplete += 1
+    if (nComplete === images.length) {
+      resolve(undefined)
+    }
+  }
+
+  for (const image of images) {
+    const clone = new Image()
+    clone.onload = cb
+    clone.onerror = cb
+    clone.src = image.src
+  }
+})

--- a/ui-participant/src/index.scss
+++ b/ui-participant/src/index.scss
@@ -162,30 +162,4 @@ a {
   .navbar {
     display: none !important;
   }
-
-  .sd-root-modern {
-    background: none;
-  }
-
-  .sd-body--static {
-    max-width: none !important;
-  }
-
-  .sd-element--with-frame {
-    padding: 0 !important;
-    box-shadow: none !important;
-  }
-
-  .sd-element--nested.sd-panel {
-    border: none !important;
-    padding: 0 !important;
-  }
-
-  .sd-page__row {
-    page-break-after: always;
-
-    &:last-child {
-      page-break-after: unset;
-    }
-  }
 }


### PR DESCRIPTION
This adds a new print/download button to all admin survey pages.  Clicking the button brings up a full-screen view of the document, and auto-prompts the printing dialog.  
<img width="863" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/73dd4765-413b-4be4-807c-787bf62cd1b7">

<img width="1211" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/5105d052-4d44-4207-aa6d-80ed3c4170a4">

Most of the effort on this PR went to print style refinements, like page breaks and radio button appearance.  Chrome works ok, but I couldn't get page breaks to render properly in safari.   Likewise, I suspect soon we'll want to generate these pdfs server-side in bulk so they can be sent in batches alongside medical record requests.  But that's a problem for another day that will depend on whether we support admins providing a separate pdf template (as pepper does now), or whether we always auto-generate the pdfs from surveyjs configs.

TO TEST:
1. go to `https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants/OHSALK/consents/oh_oh_consent` 
2. select "print/download'
3. confirm modal pops up, and print dialog appears.
4. confirm form appears ok in print preview
