### PR TITLE
JN-551 fixing participant list table styling

### DIFF
--- a/ui-admin/src/App.tsx
+++ b/ui-admin/src/App.tsx
@@ -69,7 +69,7 @@ function PageFrame() {
   return (
     <div className="d-flex">
       <AdminSidebar/>
-      <div className="flex-grow-1 d-flex flex-column">
+      <div className="flex-grow-1 d-flex flex-column" style={{ backgroundColor: '#ededed' }}>
         <AdminNavbar/>
         <Outlet/>
       </div>

--- a/ui-admin/src/navbar/AdminNavbar.tsx
+++ b/ui-admin/src/navbar/AdminNavbar.tsx
@@ -17,7 +17,7 @@ function AdminNavbar() {
     return <div></div>
   }
   return <>
-    <nav className="Navbar navbar navbar-expand-lg navbar-light" style={{ maxWidth: '100vw' }}>
+    <nav className="Navbar navbar navbar-expand-lg navbar-light">
       <div className="collapse navbar-collapse" id="navbarNavDropdown">
         <ul className="navbar-nav ms-3">
           { breadCrumbs.map((crumb, index) => <li key={index}
@@ -26,7 +26,10 @@ function AdminNavbar() {
               <FontAwesomeIcon icon={faChevronRight} className="fa-xs text-muted"/>}
           </li>)}
         </ul>
-        <ul className="navbar-nav ms-auto">
+        <ul className="navbar-nav ms-auto" style={{
+          position: 'sticky',
+          right: 0
+        }}>
           <li className="nav-item dropdown">
             <a className="nav-link" href="#"
               role="button" data-bs-toggle="dropdown" aria-expanded="false">

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -7,14 +7,13 @@ import { Link, useSearchParams } from 'react-router-dom'
 import { StudyEnvContextT } from '../../StudyEnvironmentRouter'
 import {
   ColumnDef,
-  flexRender,
   getCoreRowModel,
   getFilteredRowModel,
   getSortedRowModel,
   SortingState,
   useReactTable, VisibilityState
 } from '@tanstack/react-table'
-import { ColumnVisibilityControl, IndeterminateCheckbox, tableHeader } from 'util/tableUtils'
+import { basicTableLayout, ColumnVisibilityControl, IndeterminateCheckbox } from 'util/tableUtils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheck } from '@fortawesome/free-solid-svg-icons'
 import AdHocEmailModal from '../AdHocEmailModal'
@@ -151,7 +150,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     .filter(key => rowSelection[key])
     .map(key => participantList[parseInt(key)].enrollee.shortcode)
 
-  return <div className="ParticipantList container pt-2">
+  return <div className="ParticipantList container-fluid pt-2">
     <div className="row">
       <div className="col-12 align-items-baseline d-flex">
         <h2 className="h4 text-center me-4">{study.name} Participants</h2>
@@ -177,28 +176,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
               <ColumnVisibilityControl table={table}/>
             </div>
           </div>
-          <table className="table table-striped">
-            <thead>
-              <tr>
-                {table.getFlatHeaders().map(header => tableHeader(header, { sortable: true, filterable: true }))}
-              </tr>
-            </thead>
-            <tbody>
-              {table.getRowModel().rows.map(row => {
-                return (
-                  <tr key={row.id}>
-                    {row.getVisibleCells().map(cell => {
-                      return (
-                        <td key={cell.id}>
-                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                        </td>
-                      )
-                    })}
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
+          { basicTableLayout(table, { filterable: true })}
           { participantList.length === 0 && <span className="text-muted fst-italic">No participants</span>}
         </LoadingSpinner>
       </div>

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -3,6 +3,8 @@ import { CellContext, Column, flexRender, Header, RowData, Table } from '@tansta
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCaretDown, faCaretUp, faCheck, faColumns } from '@fortawesome/free-solid-svg-icons'
 import Select from 'react-select'
+import Modal from 'react-bootstrap/Modal'
+import { Button } from '../components/forms/Button'
 
 /**
  * Returns a debounced input react component
@@ -216,42 +218,51 @@ export function IndeterminateCheckbox({
  * */
 export function ColumnVisibilityControl<T>({ table }: {table: Table<T>}) {
   const [show, setShow] = useState(false)
-  return <div className="position-relative ms-auto">
+  return <div className="ms-auto">
     <button className="btn btn-secondary" onClick={() => setShow(!show)} aria-label="show or hide columns">
       Show/hide columns <FontAwesomeIcon icon={faColumns} className="fa-lg"/>
     </button>
-    { show && <div className="position-absolute border border-gray rounded bg-white p-3"
-      style={{ width: '300px', zIndex: 100, right: 0 }}>
-      <div className="border-b border-black">
-        <label>
-          <input
-            {...{
-              type: 'checkbox',
-              checked: table.getIsAllColumnsVisible(),
-              onChange: table.getToggleAllColumnsVisibilityHandler()
-            }}
-          />
-          <span className="ps-2">Toggle All</span>
-        </label>
-      </div>
-      <hr/>
-      {table.getAllLeafColumns().map(column => {
-        return (
-          <div key={column.id} className="pb-1">
-            <label>
-              <input
-                {...{
-                  type: 'checkbox',
-                  checked: column.getIsVisible(),
-                  onChange: column.getToggleVisibilityHandler()
-                }}
-              />
-              <span className="ps-2">{ column.columnDef.header as string ?? column.columnDef.id }</span>
-            </label>
-          </div>
-        )
-      })}
-    </div> }
+    { show && <Modal show={show} onHide={() => setShow(false)}>
+      <Modal.Header closeButton>
+        <Modal.Title>
+          Toggle column visibility
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <div className="border-b border-black">
+          <label>
+            <input
+              {...{
+                type: 'checkbox',
+                checked: table.getIsAllColumnsVisible(),
+                onChange: table.getToggleAllColumnsVisibilityHandler()
+              }}
+            />
+            <span className="ps-2">Toggle All</span>
+          </label>
+        </div>
+        <hr/>
+        {table.getAllLeafColumns().map(column => {
+          return (
+            <div key={column.id} className="pb-1">
+              <label>
+                <input
+                  {...{
+                    type: 'checkbox',
+                    checked: column.getIsVisible(),
+                    onChange: column.getToggleVisibilityHandler()
+                  }}
+                />
+                <span className="ps-2">{ column.columnDef.header as string ?? column.columnDef.id }</span>
+              </label>
+            </div>
+          )
+        })}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="primary" onClick={() => setShow(false)}>Ok</Button>
+      </Modal.Footer>
+    </Modal> }
   </div>
 }
 


### PR DESCRIPTION
Previously, when the table was too wide to fit in the page, it would flow onto a white background, looking funny.  Now the parent container expands with to to contain it in a gray background.  the navbar user and help menus are given 'sticky' position so that they flow naturally as the user scrolls.    (Note this does not solve the pre-existing problem that the nav goes away at small screen sizes -- that's a fix for another ticket)

![image](https://github.com/broadinstitute/juniper/assets/2800795/fea1fd72-95bd-4c07-b084-659cd16ea48f)


This PR also has two other ride-along changes:
1. the participant list table is upgraded to use table utils
2. the column show/hide feature is put in a proper modal, so it's not so annoying to dismiss, and has better accessibility affordances.

TO TEST:
1. go to `https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants`
2. use the show/hide control to toggle on all columns
3. confirm that even if the table forces horizontal scroll, it stays within the page-styled gray background