### PR TITLE
JN-562 -- better handling of invisible question clearing

### DIFF
--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/survey/SurveyResponseController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/survey/SurveyResponseController.java
@@ -49,7 +49,7 @@ public class SurveyResponseController implements SurveyResponseApi {
   }
 
   @Override
-  public ResponseEntity<Object> response(
+  public ResponseEntity<Object> update(
       String portalShortcode,
       String envName,
       String studyShortcode,
@@ -62,7 +62,7 @@ public class SurveyResponseController implements SurveyResponseApi {
     EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
     SurveyResponse responseDto = objectMapper.convertValue(body, SurveyResponse.class);
     HubResponse hubResponse =
-        surveyResponseExtService.submitResponse(
+        surveyResponseExtService.updateResponse(
             user, portalShortcode, environmentName, responseDto, enrolleeShortcode, taskId);
     return ResponseEntity.ok(hubResponse);
   }

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/service/SurveyResponseExtService.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/service/SurveyResponseExtService.java
@@ -47,7 +47,7 @@ public class SurveyResponseExtService {
         studyEnv.getId(), stableId, version, enrollee, taskId);
   }
 
-  public HubResponse submitResponse(
+  public HubResponse updateResponse(
       ParticipantUser user,
       String portalShortcode,
       EnvironmentName envName,

--- a/api-participant/src/main/resources/api/openapi.yml
+++ b/api-participant/src/main/resources/api/openapi.yml
@@ -236,28 +236,6 @@ paths:
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
-    post:
-      summary: Posts a survey response
-      tags: [ surveyResponse ]
-      operationId: response
-      parameters:
-        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
-        - { name: envName, in: path, required: true, schema: { type: string } }
-        - { name: studyShortcode, in: path, required: true, schema: { type: string } }
-        - { name: enrolleeShortcode, in: path, required: true, schema: { type: string } }
-        - { name: stableId, in: path, required: false, schema: { type: string } }
-        - { name: version, in: path, required: true, schema: { type: integer } }
-        - { name: taskId, in: query, required: false, schema: { type: string, format: uuid } }
-      requestBody:
-        content:
-          application/json:
-            schema: { type: object }
-      responses:
-        '200':
-          description: hub response object
-          content: { application/json: { schema: { type: object } } }
-        '500':
-          $ref: '#/components/responses/ServerError'
     patch:
       summary: updates a snapshot with in-progress save data
       tags: [ surveyResponse ]

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -142,7 +142,7 @@ public class SurveyResponseService extends ImmutableEntityService<SurveyResponse
      * is authorized to update the given task/enrollee, and that the task corresponds to the snapshot
      */
     @Transactional
-    protected SurveyResponse findOrCreateResponse(ParticipantTask task, Enrollee enrollee,
+    public SurveyResponse findOrCreateResponse(ParticipantTask task, Enrollee enrollee,
                                                   UUID participantUserId, SurveyResponse responseDto) {
         UUID taskResponseId = task.getSurveyResponseId();
         Survey survey = surveyService.findByStableId(task.getTargetStableId(), task.getTargetAssignedVersion()).get();
@@ -177,7 +177,7 @@ public class SurveyResponseService extends ImmutableEntityService<SurveyResponse
 
     /** Creates and attaches the answers to the response. */
     @Transactional
-    protected List<Answer> createOrUpdateAnswers(List<Answer> answers, SurveyResponse response,
+    public List<Answer> createOrUpdateAnswers(List<Answer> answers, SurveyResponse response,
                                                  Survey survey, PortalParticipantUser ppUser) {
         List<String> updatedStableIds = answers.stream().map(Answer::getQuestionStableId).toList();
         // bulk-fetch any existingAnswers that will need to be updated
@@ -204,7 +204,7 @@ public class SurveyResponseService extends ImmutableEntityService<SurveyResponse
     }
 
     @Transactional
-    protected Answer updateAnswer(Answer existing, Answer updated, SurveyResponse response,
+    public Answer updateAnswer(Answer existing, Answer updated, SurveyResponse response,
                                   Survey survey, PortalParticipantUser ppUser, List<DataChangeRecord> changeRecords) {
         if (existing.valuesEqual(updated)) {
             // if the values are the same, don't bother with an update
@@ -226,8 +226,7 @@ public class SurveyResponseService extends ImmutableEntityService<SurveyResponse
         return answerService.update(existing);
     }
 
-    @Transactional
-    protected Answer createAnswer(Answer answer, SurveyResponse response,
+    private Answer createAnswer(Answer answer, SurveyResponse response,
                                   Survey survey, PortalParticipantUser ppUser) {
         answer.setCreatingParticipantUserId(ppUser.getParticipantUserId());
         answer.setSurveyResponseId(response.getId());

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -316,7 +316,7 @@ export default {
     return await this.processJsonResponse(response)
   },
 
-  async submitSurveyResponse({
+  async updateSurveyResponse({
     studyShortcode, stableId, version, enrolleeShortcode, response, taskId,
     alertErrors=true
   }: {
@@ -329,7 +329,7 @@ export default {
       url = `${url}?taskId=${taskId}`
     }
     const result = await fetch(url, {
-      method: 'POST',
+      method: 'PATCH',
       headers: this.getInitHeaders(),
       body: JSON.stringify(response)
     })

--- a/ui-participant/src/hub/survey/SurveyView.test.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.test.tsx
@@ -1,10 +1,15 @@
 import React from 'react'
 
-import { generateThreePageSurvey, mockConfiguredSurvey } from 'test-utils/test-survey-factory'
+import {
+  generateThreePageSurvey,
+  mockConfiguredSurvey,
+  mockSurveyWithHiddenQuestion, mockSurveyWithHiddenQuestionClearOnHidden
+} from 'test-utils/test-survey-factory'
 import { PageNumberControl, useSurveyJSModel } from 'util/surveyJsUtils'
 import { render, screen } from '@testing-library/react'
 import { PagedSurveyView, SurveyFooter } from './SurveyView'
 import { usePortalEnv } from 'providers/PortalProvider'
+import { useUser } from 'providers/UserProvider'
 import { Survey } from '@juniper/ui-core'
 import Api from 'api/api'
 import { mockEnrollee, mockHubResponse } from 'test-utils/test-participant-factory'
@@ -18,6 +23,13 @@ beforeEach(() => {
     portalEnv: {
       environmentName: 'sandbox'
     }
+  })
+})
+
+jest.mock('providers/UserProvider', () => ({ useUser: jest.fn() }))
+beforeEach(() => {
+  (useUser as jest.Mock).mockReturnValue({
+    updateEnrollee: jest.fn()
   })
 })
 
@@ -45,31 +57,184 @@ describe('SurveyFooter', () => {
 
 describe('Renders a survey', () => {
   it('allows a user to complete the survey', async () => {
-    const submitSpy = jest.spyOn(Api, 'submitSurveyResponse')
-      .mockImplementation(() => Promise.resolve(mockHubResponse()))
-    const survey = generateThreePageSurvey()
-    const configuredSurvey = {
-      ...mockConfiguredSurvey(),
-      survey
-    }
-    const { RoutedComponent } = setupRouterTest(
-      <PagedSurveyView enrollee={mockEnrollee()} form={configuredSurvey}
-        studyShortcode={'study'} taskId={'guid34'}/>)
-    render(RoutedComponent)
-    expect(screen.getByText('You are on page1')).toBeInTheDocument()
+    const { submitSpy } = setupSurveyTest(generateThreePageSurvey())
     await userEvent.click(screen.getByText('Green'))
     await userEvent.click(screen.getByText('Next'))
     expect(screen.getByText('You are on page2')).toBeInTheDocument()
+    await userEvent.type(screen.getByText('text input'), 'my Text')
     await userEvent.click(screen.getByText('Next'))
     expect(screen.getByText('You are on page3')).toBeInTheDocument()
     await userEvent.click(screen.getByText('Complete'))
     expect(submitSpy).toHaveBeenCalledTimes(1)
     expect(submitSpy).toHaveBeenCalledWith(expect.objectContaining({
       response: expect.objectContaining({
-        answers: [{ questionStableId: 'radio1', stringValue: 'green' }],
+        answers: [{ questionStableId: 'radio1', stringValue: 'green' },
+          { questionStableId: 'text1', stringValue: 'my Text' }],
         complete: true,
         resumeData: '{"user1":{"currentPageNo":1}}'
       })
     }))
   })
+
+  it('autosaves question and page progress', async () => {
+    const { submitSpy } = setupSurveyTest(generateThreePageSurvey())
+
+    await userEvent.click(screen.getByText('Green'))
+    await userEvent.click(screen.getByText('Next'))
+    expect(screen.getByText('You are on page2')).toBeInTheDocument()
+    await userEvent.type(screen.getByText('text input'), 'my Text')
+    await userEvent.click(screen.getByText('Next'))
+    await new Promise(r => setTimeout(r, 600))
+    // should only have been called once, despite multiple intervals passing, since it only is called on diffs
+    expect(submitSpy).toHaveBeenCalledTimes(1)
+    expect(submitSpy).toHaveBeenCalledWith(expect.objectContaining({
+      response: expect.objectContaining({
+        answers: [{ questionStableId: 'radio1', stringValue: 'green' },
+          { questionStableId: 'text1', stringValue: 'my Text' }],
+        complete: false,
+        resumeData: '{"user1":{"currentPageNo":3}}'
+      })
+    }))
+  })
+
+  it('autosaves question and page progress with diffs', async () => {
+    const { submitSpy } = setupSurveyTest(generateThreePageSurvey())
+
+    await userEvent.click(screen.getByText('Green'))
+    await new Promise(r => setTimeout(r, 300))
+    await userEvent.click(screen.getByText('Next'))
+    expect(screen.getByText('You are on page2')).toBeInTheDocument()
+    await userEvent.type(screen.getByText('text input'), 'my Text')
+    await userEvent.click(screen.getByText('Next'))
+    await new Promise(r => setTimeout(r, 300))
+
+    expect(submitSpy).toHaveBeenCalledTimes(2)
+    expect(submitSpy).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      response: expect.objectContaining({
+        answers: [{ questionStableId: 'radio1', stringValue: 'green' }]
+      })
+    }))
+    expect(submitSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      response: expect.objectContaining({
+        answers: [{ questionStableId: 'text1', stringValue: 'my Text' }]
+      })
+    }))
+  })
+
+  it('autosave handles updated questions', async () => {
+    const { submitSpy } = setupSurveyTest(generateThreePageSurvey())
+    await userEvent.click(screen.getByText('Green'))
+    await userEvent.click(screen.getByText('Next'))
+    await new Promise(r => setTimeout(r, 300))
+    await userEvent.click(screen.getByText('Previous'))
+    await userEvent.click(screen.getByText('Blue'))
+    await new Promise(r => setTimeout(r, 300))
+
+    expect(submitSpy).toHaveBeenCalledTimes(2)
+    expect(submitSpy).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      response: expect.objectContaining({
+        answers: [{ questionStableId: 'radio1', stringValue: 'green' }]
+      })
+    }))
+    expect(submitSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      response: expect.objectContaining({
+        answers: [{ questionStableId: 'radio1', stringValue: 'blue' }]
+      })
+    }))
+  })
+
+  it('autosave handles hidden questions with default clear-on-submit behavior', async () => {
+    const { submitSpy } = setupSurveyTest(mockSurveyWithHiddenQuestion())
+    await userEvent.click(screen.getByText('Green'))
+    await userEvent.click(screen.getByText('forest green'))
+    await new Promise(r => setTimeout(r, 300))
+    await userEvent.click(screen.getByText('Blue'))
+    await new Promise(r => setTimeout(r, 300))
+    await userEvent.click(screen.getByText('Complete'))
+
+    expect(submitSpy).toHaveBeenCalledTimes(3)
+    expect(submitSpy).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      response: expect.objectContaining({
+        answers: [{ questionStableId: 'radio1', stringValue: 'green' },
+          { 'questionStableId': 'greenFollow', 'stringValue': 'forest' }]
+      })
+    }))
+    expect(submitSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      response: expect.objectContaining({
+        answers: [{ questionStableId: 'radio1', stringValue: 'blue' }]
+      })
+    }))
+    expect(submitSpy).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      response: expect.objectContaining({
+        answers: [{ questionStableId: 'greenFollow' }]
+      })
+    }))
+  })
+
+  it('autosave handles hidden questions with clear-on-hidden', async () => {
+    const { submitSpy } = setupSurveyTest(mockSurveyWithHiddenQuestionClearOnHidden())
+    await userEvent.click(screen.getByText('Green'))
+    await userEvent.click(screen.getByText('forest green'))
+    await new Promise(r => setTimeout(r, 300))
+    await userEvent.click(screen.getByText('Blue'))
+    await new Promise(r => setTimeout(r, 300))
+    await userEvent.click(screen.getByText('Complete'))
+
+    expect(submitSpy).toHaveBeenCalledTimes(3)
+    expect(submitSpy).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      response: expect.objectContaining({
+        answers: [{ questionStableId: 'radio1', stringValue: 'green' },
+          { 'questionStableId': 'greenFollow', 'stringValue': 'forest' }]
+      })
+    }))
+    expect(submitSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      response: expect.objectContaining({
+        answers: [{ questionStableId: 'radio1', stringValue: 'blue' }, { questionStableId: 'greenFollow' }]
+      })
+    }))
+    expect(submitSpy).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      response: expect.objectContaining({
+        answers: []
+      })
+    }))
+  })
+
+  it('retries autosave if autosave fails', async () => {
+    const { submitSpy } = setupSurveyTest(generateThreePageSurvey())
+    submitSpy.mockImplementation(() => Promise.reject({}))
+
+    await userEvent.click(screen.getByText('Green'))
+    await userEvent.click(screen.getByText('Next'))
+    expect(screen.getByText('You are on page2')).toBeInTheDocument()
+    await new Promise(r => setTimeout(r, 500))
+    const expectedDiffResponse = expect.objectContaining({
+      response: expect.objectContaining({
+        answers: [{ questionStableId: 'radio1', stringValue: 'green' }],
+        complete: false,
+        resumeData: '{"user1":{"currentPageNo":2}}'
+      })
+    })
+    expect(submitSpy).toHaveBeenNthCalledWith(1, expectedDiffResponse)
+    expect(submitSpy).toHaveBeenNthCalledWith(1, expect.objectContaining({ alertErrors: true }))
+    expect(submitSpy).toHaveBeenNthCalledWith(2, expectedDiffResponse)
+    // confirm it doesn't spam the user with alerts
+    expect(submitSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({ alertErrors: false }))
+  })
 })
+
+const setupSurveyTest = (survey: Survey) => {
+  const submitSpy = jest.spyOn(Api, 'updateSurveyResponse')
+    .mockImplementation(() => Promise.resolve(mockHubResponse()))
+  const configuredSurvey = {
+    ...mockConfiguredSurvey(),
+    survey
+  }
+  const { RoutedComponent } = setupRouterTest(
+    <PagedSurveyView enrollee={mockEnrollee()} form={configuredSurvey}
+      studyShortcode={'study'} taskId={'guid34'} autoSaveInterval={200}/>)
+  render(RoutedComponent)
+  expect(screen.getByText('You are on page1')).toBeInTheDocument()
+  return { submitSpy, RoutedComponent }
+}
+
+

--- a/ui-participant/src/hub/survey/SurveyView.test.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.test.tsx
@@ -101,12 +101,12 @@ describe('Renders a survey', () => {
     const { submitSpy } = setupSurveyTest(generateThreePageSurvey())
 
     await userEvent.click(screen.getByText('Green'))
-    await new Promise(r => setTimeout(r, 300))
+    await new Promise(r => setTimeout(r, 250))
     await userEvent.click(screen.getByText('Next'))
     expect(screen.getByText('You are on page2')).toBeInTheDocument()
     await userEvent.type(screen.getByText('text input'), 'my Text')
     await userEvent.click(screen.getByText('Next'))
-    await new Promise(r => setTimeout(r, 300))
+    await new Promise(r => setTimeout(r, 250))
 
     expect(submitSpy).toHaveBeenCalledTimes(2)
     expect(submitSpy).toHaveBeenNthCalledWith(1, expect.objectContaining({
@@ -125,10 +125,10 @@ describe('Renders a survey', () => {
     const { submitSpy } = setupSurveyTest(generateThreePageSurvey())
     await userEvent.click(screen.getByText('Green'))
     await userEvent.click(screen.getByText('Next'))
-    await new Promise(r => setTimeout(r, 300))
+    await new Promise(r => setTimeout(r, 250))
     await userEvent.click(screen.getByText('Previous'))
     await userEvent.click(screen.getByText('Blue'))
-    await new Promise(r => setTimeout(r, 300))
+    await new Promise(r => setTimeout(r, 250))
 
     expect(submitSpy).toHaveBeenCalledTimes(2)
     expect(submitSpy).toHaveBeenNthCalledWith(1, expect.objectContaining({
@@ -147,9 +147,9 @@ describe('Renders a survey', () => {
     const { submitSpy } = setupSurveyTest(mockSurveyWithHiddenQuestion())
     await userEvent.click(screen.getByText('Green'))
     await userEvent.click(screen.getByText('forest green'))
-    await new Promise(r => setTimeout(r, 300))
+    await new Promise(r => setTimeout(r, 250))
     await userEvent.click(screen.getByText('Blue'))
-    await new Promise(r => setTimeout(r, 300))
+    await new Promise(r => setTimeout(r, 250))
     await userEvent.click(screen.getByText('Complete'))
 
     expect(submitSpy).toHaveBeenCalledTimes(3)
@@ -175,9 +175,9 @@ describe('Renders a survey', () => {
     const { submitSpy } = setupSurveyTest(mockSurveyWithHiddenQuestionClearOnHidden())
     await userEvent.click(screen.getByText('Green'))
     await userEvent.click(screen.getByText('forest green'))
-    await new Promise(r => setTimeout(r, 300))
+    await new Promise(r => setTimeout(r, 250))
     await userEvent.click(screen.getByText('Blue'))
-    await new Promise(r => setTimeout(r, 300))
+    await new Promise(r => setTimeout(r, 250))
     await userEvent.click(screen.getByText('Complete'))
 
     expect(submitSpy).toHaveBeenCalledTimes(3)

--- a/ui-participant/src/test-utils/test-survey-factory.tsx
+++ b/ui-participant/src/test-utils/test-survey-factory.tsx
@@ -34,7 +34,10 @@ export function generateThreePageSurvey(overrideObj?: any): Survey { // eslint-d
       },
       {
         elements: [
-          { type: 'html', html: '<span>You are on page2</span>' }
+          { type: 'html', html: '<span>You are on page2</span>' },
+          {
+            type: 'text', title: 'text input', name: 'text1'
+          }
         ]
       },
       {
@@ -47,6 +50,50 @@ export function generateThreePageSurvey(overrideObj?: any): Survey { // eslint-d
   const survey = generateSurvey({ content: JSON.stringify(surveyContent) })
   return Object.assign(survey, overrideObj)
 }
+
+/** survey with a hidden question -- uses surveyjs default clear-on-submit behavior */
+export function mockSurveyWithHiddenQuestion(): Survey {
+  const surveyContent =  {
+    pages: [{
+      elements: [
+        { type: 'html', html: '<span>You are on page1</span>' },
+        {
+          type: 'radiogroup', title: 'radio input', name: 'radio1',
+          choices: [{ text: 'Green', value: 'green' }, { text: 'Blue', value: 'blue' }]
+        },
+        {
+          type: 'radiogroup', title: 'green follower', name: 'greenFollow',
+          choices: [{ text: 'light green', value: 'lightGreen' }, { text: 'forest green', value: 'forest' }],
+          visibleIf: '{radio1} = "green"'
+        }
+      ]
+    }]
+  }
+  return generateSurvey({ content: JSON.stringify(surveyContent) })
+}
+
+/** survey with a hidden question and hidden questions set to clear values as soon as they are invisible */
+export function mockSurveyWithHiddenQuestionClearOnHidden(): Survey {
+  const surveyContent =  {
+    'clearInvisibleValues': 'onHiddenContainer',
+    pages: [{
+      elements: [
+        { type: 'html', html: '<span>You are on page1</span>' },
+        {
+          type: 'radiogroup', title: 'radio input', name: 'radio1',
+          choices: [{ text: 'Green', value: 'green' }, { text: 'Blue', value: 'blue' }]
+        },
+        {
+          type: 'radiogroup', title: 'green follower', name: 'greenFollow',
+          choices: [{ text: 'light green', value: 'lightGreen' }, { text: 'forest green', value: 'forest' }],
+          visibleIf: '{radio1} = "green"'
+        }
+      ]
+    }]
+  }
+  return generateSurvey({ content: JSON.stringify(surveyContent) })
+}
+
 
 /** mock StudyEnvironmentSurvey object */
 export const mockConfiguredSurvey = (): StudyEnvironmentSurvey => {


### PR DESCRIPTION
This updates our participant survey-saving process to always send a diff of answers that have changed, even on form submission.  Previously, on submission, we would resend all answers.  While this was desirable when autosave was new and untrusted, it leads to a lot of corner cases as we have to support two types of answer processing, and edge cases where surveyJS's 'clearOnSubmit' property for hidden questions would cause values that had been cleared for the user to not be deleted from the server.   Also, moving to always sending diffs will avoid lots of synchronous editing issues when we start enabling admin survey editing.

The change is pretty simple--the core is just changing the submit function in SurveyView.tsx to use `answers: getUpdatedAnswers` instead of getting the full answer list. 

For the curious, I first went down the path of supporting both patch and post submissions but just with enhanced server-side diffing and auditing.  You can see the code on the `db-survey-answer-clear` branch.  There's some cool stuff there like a base DataAuditedService that I hope to pull into future work, but it just wasn't worth the time for this change.  

TO TEST:
1. repopulate ourhealth
2.sign in to participant UI as jsalk@test.com
3. start filling out the family history survey, answering a few questions, and then go back and say "not at all" for the first question
4. click 'submit'
5. in the admin tool, at `https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants/OHSALK/surveys/oh_oh_famHx` confirm none of the answers other than the first remain