### PR TITLE
JN-540 . fix createdAt and lastUpdated timestamp values on new survey creation

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
@@ -9,7 +9,6 @@ import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
 import bio.terra.pearl.core.service.survey.SurveyService;
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.beans.BeanUtils;
@@ -56,9 +55,6 @@ public class SurveyExtService {
     }
     survey.setPortalId(portal.getId());
     survey.setVersion(1);
-    Instant now = Instant.now();
-    survey.setCreatedAt(now);
-    survey.setLastUpdatedAt(now);
     return surveyService.create(survey);
   }
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
@@ -9,6 +9,7 @@ import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
 import bio.terra.pearl.core.service.survey.SurveyService;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.beans.BeanUtils;
@@ -55,6 +56,9 @@ public class SurveyExtService {
     }
     survey.setPortalId(portal.getId());
     survey.setVersion(1);
+    Instant now = Instant.now();
+    survey.setCreatedAt(now);
+    survey.setLastUpdatedAt(now);
     return surveyService.create(survey);
   }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyService.java
@@ -12,7 +12,6 @@ import bio.terra.pearl.core.service.VersionedEntityService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.time.Instant;
 import java.util.*;
 import org.springframework.beans.BeanUtils;
@@ -52,7 +51,6 @@ public class SurveyService extends VersionedEntityService<Survey, SurveyDao> {
         Instant now = Instant.now();
         survey.setCreatedAt(now);
         survey.setLastUpdatedAt(now);
-
         Survey savedSurvey = dao.create(survey);
         for (AnswerMapping answerMapping : survey.getAnswerMappings()) {
             answerMapping.setSurveyId(savedSurvey.getId());

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyService.java
@@ -12,6 +12,8 @@ import bio.terra.pearl.core.service.VersionedEntityService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.time.Instant;
 import java.util.*;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
@@ -47,6 +49,10 @@ public class SurveyService extends VersionedEntityService<Survey, SurveyDao> {
     @Transactional
     @Override
     public Survey create(Survey survey) {
+        Instant now = Instant.now();
+        survey.setCreatedAt(now);
+        survey.setLastUpdatedAt(now);
+
         Survey savedSurvey = dao.create(survey);
         for (AnswerMapping answerMapping : survey.getAnswerMappings()) {
             answerMapping.setSurveyId(savedSurvey.getId());

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyServiceTests.java
@@ -14,7 +14,6 @@ import static org.hamcrest.Matchers.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
 import java.util.List;
 
 public class SurveyServiceTests extends BaseSpringBootTest {

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyServiceTests.java
@@ -14,6 +14,7 @@ import static org.hamcrest.Matchers.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.util.List;
 
 public class SurveyServiceTests extends BaseSpringBootTest {
@@ -27,6 +28,7 @@ public class SurveyServiceTests extends BaseSpringBootTest {
     @Test
     @Transactional
     public void testCreateSurvey() {
+        Instant now = Instant.now();
         Survey survey = surveyFactory.builder("testPublishSurvey").build();
         Survey savedSurvey = surveyService.create(survey);
         DaoTestUtils.assertGeneratedProperties(savedSurvey);
@@ -34,6 +36,8 @@ public class SurveyServiceTests extends BaseSpringBootTest {
 
         Survey fetchedSurvey = surveyService.findByStableId(savedSurvey.getStableId(), savedSurvey.getVersion()).get();
         Assertions.assertEquals(fetchedSurvey.getId(), savedSurvey.getId());
+        assertThat(survey.getCreatedAt(), greaterThan(now));
+        assertThat(survey.getLastUpdatedAt(), greaterThan(now));
     }
 
     @Test

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyServiceTests.java
@@ -28,16 +28,15 @@ public class SurveyServiceTests extends BaseSpringBootTest {
     @Test
     @Transactional
     public void testCreateSurvey() {
-        Instant now = Instant.now();
         Survey survey = surveyFactory.builder("testPublishSurvey").build();
+        survey.setCreatedAt(null);
+        survey.setLastUpdatedAt(null);
         Survey savedSurvey = surveyService.create(survey);
         DaoTestUtils.assertGeneratedProperties(savedSurvey);
         Assertions.assertEquals(savedSurvey.getName(), survey.getName());
 
         Survey fetchedSurvey = surveyService.findByStableId(savedSurvey.getStableId(), savedSurvey.getVersion()).get();
         Assertions.assertEquals(fetchedSurvey.getId(), savedSurvey.getId());
-        assertThat(survey.getCreatedAt(), greaterThan(now));
-        assertThat(survey.getLastUpdatedAt(), greaterThan(now));
     }
 
     @Test


### PR DESCRIPTION
Let the backend service set createdAt and lastUpdated timestamps(instant) during new survey creation.
front-end/client passed values are ignored


QA
Add a new survey from admin tools
Click “Add Survey” and fill in a name/stableId

in the juniper database, run select id, name, created_at, last_updated_at from survey; and make sure current date/timestamp is populated.