### PR TITLE
JN-467 add url to JS errors

### DIFF
--- a/ui-participant/src/util/loggingUtils.test.tsx
+++ b/ui-participant/src/util/loggingUtils.test.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react'
+import { render, screen } from '@testing-library/react'
+import setupErrorLogger from './loggingUtils'
+import Api from 'api/api'
+
+const TestComponent = () => {
+  useEffect(() => {
+    setupErrorLogger()
+  }, [])
+  useEffect(() => {
+    window.setTimeout(() => { throw { message: 'foo' } }, 100)
+  }, [])
+  return <span>
+        Will throw error
+  </span>
+}
+
+
+test('logs JS exceptions', async () => {
+  const logSpy = jest.spyOn(Api, 'log').mockImplementation(jest.fn())
+  render(<TestComponent/>)
+  expect(screen.getByText('Will throw error')).toBeInTheDocument()
+  await new Promise(r => setTimeout(r, 200))
+  expect(logSpy).toHaveBeenCalledTimes(1)
+  expect(logSpy).toHaveBeenCalledWith({
+    eventDetail: '{"message":"foo"}\nhttp://localhost/',
+    eventName: 'jserror', eventType: 'ERROR', stackTrace: undefined
+  })
+})

--- a/ui-participant/src/util/loggingUtils.ts
+++ b/ui-participant/src/util/loggingUtils.ts
@@ -39,7 +39,7 @@ export const logError = (detail: ErrorEventDetail, stackTrace: string) => {
   Api.log({
     eventType: 'ERROR',
     eventName: 'jserror',
-    eventDetail: JSON.stringify(detail) + '\n' + window.location.href,
+    eventDetail: `${JSON.stringify(detail)}\n${window.location.href}`,
     stackTrace
   })
 }

--- a/ui-participant/src/util/loggingUtils.ts
+++ b/ui-participant/src/util/loggingUtils.ts
@@ -39,7 +39,7 @@ export const logError = (detail: ErrorEventDetail, stackTrace: string) => {
   Api.log({
     eventType: 'ERROR',
     eventName: 'jserror',
-    eventDetail: JSON.stringify(detail),
+    eventDetail: JSON.stringify(detail) + '\n' + window.location.href,
     stackTrace
   })
 }


### PR DESCRIPTION
#### DESCRIPTION

We saw a new JS error in the logs about circular references in JSON.  I'd like to know what page the user received it on, so we're including the URL in error logs now.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1.  edit a participant UI component to throw an error
2. visit the participant UI and trigger that component
3. confirm the JS error is logged via the network tab, and the current href is sent.
