### PR TITLE
JN-579: populate image upgrade

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/PopulateExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/PopulateExtService.java
@@ -89,6 +89,10 @@ public class PopulateExtService {
     PortalPopulateContext config =
         new PortalPopulateContext(filePathName, portalShortcode, null, new HashMap<>());
     try {
+      // first, repopulate images to cove any new/changed images.
+      String portalFilePath = "portals/%s/portal.json".formatted(portalShortcode);
+      portalPopulator.populateImages(portalFilePath, overwrite);
+      // then repopulate the sitecontent itself
       return siteContentPopulator.populate(config, overwrite);
     } catch (IOException e) {
       throw new IllegalArgumentException("populate failed", e);

--- a/populate/src/main/java/bio/terra/pearl/populate/service/BasePopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/BasePopulator.java
@@ -24,8 +24,12 @@ public abstract class BasePopulator<T extends BaseEntity, D extends T, P extends
     }
 
     public T populateFromString(String fileString, P context, boolean overwrite) throws IOException {
-        D popDto = objectMapper.readValue(fileString, getDtoClazz());
+        D popDto = readValue(fileString);
         return populateFromDto(popDto, context, overwrite);
+    }
+
+    public D readValue(String popDtoString) throws IOException {
+        return objectMapper.readValue(popDtoString, getDtoClazz());
     }
 
     public T populateFromDto(D popDto, P context, boolean overwrite) throws IOException {

--- a/populate/src/main/java/bio/terra/pearl/populate/service/PortalPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/PortalPopulator.java
@@ -180,7 +180,7 @@ public class PortalPopulator extends BasePopulator<Portal, PortalPopDto, FilePop
     public void populateImages(String portalFilePath, boolean overwrite) throws IOException {
         FilePopulateContext fileContext = new FilePopulateContext(portalFilePath);
         String portalFileString = filePopulateService.readFile(fileContext.getRootFileName(), fileContext);
-        PortalPopDto popDto = objectMapper.readValue(portalFileString, PortalPopDto.class);
+        PortalPopDto popDto = readValue(portalFileString);
         PortalPopulateContext portalPopContext = new PortalPopulateContext(fileContext, popDto.getShortcode(), null);
         for (SiteImagePopDto imagePopDto : popDto.getSiteImageDtos()) {
             siteImagePopulator.populateFromDto(imagePopDto, portalPopContext, overwrite);

--- a/populate/src/main/java/bio/terra/pearl/populate/service/PortalPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/PortalPopulator.java
@@ -172,4 +172,18 @@ public class PortalPopulator extends BasePopulator<Portal, PortalPopDto, FilePop
 
         return portal;
     }
+
+    /**
+     * just populates the images from the given portal.json file.
+     * Useful for populating/updating site content, which may rely on images form the root file
+     * */
+    public void populateImages(String portalFilePath, boolean overwrite) throws IOException {
+        FilePopulateContext fileContext = new FilePopulateContext(portalFilePath);
+        String portalFileString = filePopulateService.readFile(fileContext.getRootFileName(), fileContext);
+        PortalPopDto popDto = objectMapper.readValue(portalFileString, PortalPopDto.class);
+        PortalPopulateContext portalPopContext = new PortalPopulateContext(fileContext, popDto.getShortcode(), null);
+        for (SiteImagePopDto imagePopDto : popDto.getSiteImageDtos()) {
+            siteImagePopulator.populateFromDto(imagePopDto, portalPopContext, overwrite);
+        }
+    }
 }

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.test.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.test.tsx
@@ -5,13 +5,16 @@ import { setupRouterTest } from 'test-utils/router-testing-utils'
 import { render, screen, waitFor } from '@testing-library/react'
 import { emptyApi, mockSiteContent } from 'test-utils/mock-site-content'
 import userEvent from '@testing-library/user-event'
+import { mockPortalEnvironment } from '../../test-utils/mocking-utils'
 
 test('enables live-preview text editing', async () => {
   const siteContent = mockSiteContent()
   const createNewVersionFunc = jest.fn()
   const { RoutedComponent } = setupRouterTest(
     <SiteContentEditor siteContent={siteContent} previewApi={emptyApi} readOnly={false}
-      loadSiteContent={jest.fn()} createNewVersion={createNewVersionFunc} portalShortcode="foo"/>)
+      loadSiteContent={jest.fn()} createNewVersion={createNewVersionFunc} switchToVersion={jest.fn()}
+      portalEnv={mockPortalEnvironment('sandbox')}
+      portalShortcode="foo"/>)
   render(RoutedComponent)
 
   expect(screen.getByText('Landing page')).toBeInTheDocument()
@@ -42,7 +45,9 @@ test('readOnly hides save button', async () => {
   const createNewVersionFunc = jest.fn()
   const { RoutedComponent } = setupRouterTest(
     <SiteContentEditor siteContent={siteContent} previewApi={emptyApi} readOnly={true}
-      loadSiteContent={jest.fn()} createNewVersion={createNewVersionFunc} portalShortcode="foo"/>)
+      loadSiteContent={jest.fn()} createNewVersion={createNewVersionFunc} portalShortcode="foo"
+      switchToVersion={jest.fn()}
+      portalEnv={mockPortalEnvironment('sandbox')}/>)
   render(RoutedComponent)
   expect(screen.getByText('Landing page')).toBeInTheDocument()
   expect(screen.queryByText('Save')).not.toBeInTheDocument()

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { NavbarItemInternal } from 'api/api'
+import { NavbarItemInternal, PortalEnvironment } from 'api/api'
 import Select from 'react-select'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons'
@@ -17,13 +17,18 @@ type InitializedSiteContentViewProps = {
   previewApi: ApiContextT
   loadSiteContent: (stableId: string, version: number) => void
   createNewVersion: (content: SiteContent) => void
+  switchToVersion: (id: string, stableId: string, version: number) => void
   portalShortcode: string
+  portalEnv: PortalEnvironment
   readOnly: boolean
 }
 
 /** shows a site content in editable form with a live preview.  Defaults to english-only for now */
 const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
-  const { siteContent, previewApi, portalShortcode, loadSiteContent, createNewVersion, readOnly } = props
+  const {
+    siteContent, previewApi, portalShortcode,
+    portalEnv, loadSiteContent, switchToVersion, createNewVersion, readOnly
+  } = props
   const selectedLanguage = 'en'
   const [selectedNavOpt, setSelectedNavOpt] = useState<NavbarOption>(landingPageOption)
   const [workingContent, setWorkingContent] = useState<SiteContent>(siteContent)
@@ -76,6 +81,7 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
     }
     updateLocalContent(updatedLocalContent)
   }
+  const isEditable = !readOnly && portalEnv.environmentName === 'sandbox'
 
   const currentNavBarItem = selectedNavOpt.value ? navBarInternalItems
     .find(navItem => navItem.id === selectedNavOpt.value) : null
@@ -92,26 +98,31 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
         <div className="ms-3 text-muted">
           version {siteContent.version}
         </div>
-        <button className="btn btn-secondary"
-          onClick={() => setShowVersionSelector(!showVersionSelector)}>select</button>
+        {isEditable && <button className="btn btn-secondary"
+          onClick={() => setShowVersionSelector(!showVersionSelector)}>select</button> }
       </div>
       <div className="d-flex mb-3 w-100">
         <div>
           <Select options={pageOpts} value={selectedNavOpt}
             onChange={e => setSelectedNavOpt(e ?? landingPageOption)}/>
         </div>
-        <button className="btn btn-secondary" onClick={() => alert('not yet implemented')}>
-          <FontAwesomeIcon icon={faPlus}/> Add page
-        </button>
-        {!readOnly && <Button className="ms-auto" variant="primary"
-          onClick={() => createNewVersion(workingContent)}>
-          Save
-        </Button>}
         {
-          // eslint-disable-next-line
-          // @ts-ignore  Link to type also supports numbers for back operations
-          <Link className="btn btn-cancel" to={-1}>Cancel</Link>
+          isEditable && <>
+            <button className="btn btn-secondary" onClick={() => alert('not yet implemented')}>
+              <FontAwesomeIcon icon={faPlus}/> Add page
+            </button>
+            <Button className="ms-auto" variant="primary"
+              onClick={() => createNewVersion(workingContent)}>
+              Save
+            </Button>
+            {
+              // eslint-disable-next-line
+                // @ts-ignore  Link to type also supports numbers for back operations
+              <Link className="btn btn-cancel" to={-1}>Cancel</Link>
+            }
+          </>
         }
+
       </div>
       <div>
         {pageToRender &&
@@ -123,7 +134,8 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
     </div>
     { showVersionSelector &&
         <SiteContentVersionSelector portalShortcode={portalShortcode} stableId={siteContent.stableId}
-          current={siteContent} loadSiteContent={loadSiteContent}
+          current={siteContent} loadSiteContent={loadSiteContent} portalEnv={portalEnv}
+          switchToVersion={switchToVersion}
           onDismiss={() => setShowVersionSelector(false)}/>
     }
   </div>

--- a/ui-admin/src/portal/siteContent/SiteContentLoader.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentLoader.tsx
@@ -7,7 +7,6 @@ import { failureNotification, successNotification } from 'util/notifications'
 import LoadingSpinner from 'util/LoadingSpinner'
 import SiteContentEditor from './SiteContentEditor'
 
-
 /** logic for loading, changing, and saving SiteContent objects */
 const SiteContentLoader = ({ portalEnvContext }: {portalEnvContext: PortalEnvContext}) => {
   const { portal, portalEnv } = portalEnvContext
@@ -40,6 +39,7 @@ const SiteContentLoader = ({ portalEnvContext }: {portalEnvContext: PortalEnvCon
   /** saves the current content as a new version, and updates the portal environment to use it */
   const createNewVersion = async (workingContent: SiteContent) => {
     let newVersion: SiteContent
+    setIsLoading(true)
     try {
       newVersion = await Api.createNewSiteContentVersion(portalShortcode, workingContent.stableId, workingContent)
       Store.addNotification(successNotification(`Version ${newVersion.version} created`))
@@ -47,25 +47,39 @@ const SiteContentLoader = ({ portalEnvContext }: {portalEnvContext: PortalEnvCon
       Store.addNotification(failureNotification('save failed'))
       return
     }
+    await switchToVersion(newVersion.id, newVersion.stableId, newVersion.version, newVersion)
+    setIsLoading(false)
+  }
+
+  /** switch the environment to the given version specified by id/stableId/version.
+   * if the version has already been retrieved from the server,
+   * it can be passed in as an optional argument to save a duplicate fetch.
+   */
+  const switchToVersion = async (id: string, stableId: string, version: number, loadedContent?: SiteContent) => {
     try {
       let updatedEnv = {
         ...portalEnv,
-        siteContentId: newVersion.id
+        siteContentId: id
       }
       updatedEnv = await Api.updatePortalEnv(portalShortcode, portalEnv.environmentName, updatedEnv)
+      if (!loadedContent) {
+        loadedContent = await Api.getSiteContent(portalShortcode, stableId, version)
+      }
+
       portalEnvContext.updatePortalEnv({
         ...portalEnv,
         ...updatedEnv,
-        siteContent: newVersion
+        siteContent: loadedContent
       })
-      setSiteContent(newVersion)
-      Store.addNotification(successNotification(`Environment updated to use version ${newVersion.version}`))
+      setSiteContent(loadedContent)
+      Store.addNotification(successNotification(`Environment updated to use version ${version}`))
     } catch {
       Store.addNotification(failureNotification(
         'could not update environment--it will still point to prior version'
       ))
     }
   }
+
   const readOnly = portalEnv.environmentName !== 'sandbox'
 
   useEffect(() => {
@@ -79,8 +93,10 @@ const SiteContentLoader = ({ portalEnvContext }: {portalEnvContext: PortalEnvCon
     { !isLoading && <SiteContentEditor siteContent={siteContent}
       createNewVersion={createNewVersion}
       loadSiteContent={loadSiteContent}
+      switchToVersion={switchToVersion}
       previewApi={previewApi}
       portalShortcode={portalShortcode}
+      portalEnv={portalEnv}
       readOnly={readOnly}
     /> }
     { isLoading && <LoadingSpinner/> }

--- a/ui-admin/src/portal/siteContent/SiteContentVersionSelector.test.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentVersionSelector.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import SiteContentVersionSelector from './SiteContentVersionSelector'
 import { select } from 'react-select-event'
 import userEvent from '@testing-library/user-event'
+import { mockPortalEnvironment } from '../../test-utils/mocking-utils'
 
 const mockSiteContents = [
   {
@@ -29,12 +30,38 @@ test('can select a site content version', async () => {
   const loadSiteContentFn = jest.fn()
 
   render(<SiteContentVersionSelector stableId="foo" loadSiteContent={loadSiteContentFn} portalShortcode="portal"
-    current={mockSiteContents[0]} onDismiss={jest.fn()}/>)
+    current={mockSiteContents[0]} onDismiss={jest.fn()}  switchToVersion={jest.fn()}
+    portalEnv={mockPortalEnvironment('sandbox')}/>)
   await waitFor(() => expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument())
   expect(screen.getByText('You are currently editing version 1,')).toBeInTheDocument()
-  await select(screen.getByLabelText('Select version to edit'), ['2'])
+  await select(screen.getByLabelText('Select version'), ['2'])
 
   await userEvent.click(screen.getByText('Edit version 2'))
   expect(loadSiteContentFn).toHaveBeenCalledTimes(1)
   expect(loadSiteContentFn).toHaveBeenCalledWith('foo', 2)
+})
+
+test('does not show switch option for non-sandbox environments', async () => {
+  jest.spyOn(Api, 'getSiteContentVersions').mockImplementation(() => Promise.resolve(mockSiteContents))
+  const loadSiteContentFn = jest.fn()
+
+  render(<SiteContentVersionSelector stableId="foo" loadSiteContent={loadSiteContentFn} portalShortcode="portal"
+    current={mockSiteContents[0]} onDismiss={jest.fn()} switchToVersion={jest.fn()}
+    portalEnv={mockPortalEnvironment('irb')}/>)
+  await waitFor(() => expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument())
+  await select(screen.getByLabelText('Select version'), ['2'])
+  expect(screen.queryByText('Switch sandbox to version 2')).not.toBeInTheDocument()
+})
+test('shows switch option for sandbox environments', async () => {
+  jest.spyOn(Api, 'getSiteContentVersions').mockImplementation(() => Promise.resolve(mockSiteContents))
+  const loadSiteContentFn = jest.fn()
+
+  render(<SiteContentVersionSelector stableId="foo" loadSiteContent={loadSiteContentFn} portalShortcode="portal"
+    current={mockSiteContents[0]} onDismiss={jest.fn()}  switchToVersion={jest.fn()}
+    portalEnv={mockPortalEnvironment('sandbox')}/>)
+  await waitFor(() => expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument())
+  expect(screen.queryByText('Switch to version 2')).not.toBeInTheDocument()
+  await select(screen.getByLabelText('Select version'), ['2'])
+
+  expect(screen.getByText('Switch sandbox to version 2')).toBeInTheDocument()
 })


### PR DESCRIPTION
#### DESCRIPTION

This adds the ability to populate images along with site content, and also gives the ability to use the admin UI to set a particular version for the sandbox.  this will be needed to get the OurHealth updates that we've done locally into production.  

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  run `git checkout e12d64002b1a8f793fb00c1bde615c552db853a8` (this is a commit from prior to the contentupdates)
2.  run `./scripts/populate_portal.sh ourhealth` to reset OurHealth
3. confirm https://sandbox.ourhealth.localhost:3001 shows the old logos (notably with no Yale logo)
![image](https://github.com/broadinstitute/juniper/assets/2800795/95c054ce-5cad-492c-b856-1c110a70e7d4)

5. `git checkout db-site-content-pop-updates`
6. redeploy ApiAdminApp
7. go to https://localhost:3000/populate/siteContent 
8. type in `ourhealth` for the portal shortcode, and hit populate ("no" for overwrite) -- this will create the snew site content and images, but will not update the snadbox
9. go to `https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/siteContent` 
10. click "select" to pop up the version selector
11. choose version 2, and then click  "switch sandbox to version 2"
12. reload https://sandbox.ourhealth.localhost:3001
13. confirm updated logos appear
![image](https://github.com/broadinstitute/juniper/assets/2800795/b32e4d88-1a32-49e5-bd01-4a8781b35535)

