### PR TITLE
[JN-474] [JN-366] Integrate with the latest updates to DSM's kit status responses

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/kit/KitController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/kit/KitController.java
@@ -90,4 +90,11 @@ public class KitController implements KitApi {
 
     return ResponseEntity.ok(result);
   }
+
+  @Override
+  public ResponseEntity<Void> refreshKitStatuses(String portalShortcode, String studyShortcode) {
+    AdminUser adminUser = authUtilService.requireAdminUser(request);
+    kitExtService.refreshKitStatuses(adminUser, portalShortcode, studyShortcode);
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
@@ -6,7 +6,6 @@ import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
-import bio.terra.pearl.core.service.exception.PermissionDeniedException;
 import bio.terra.pearl.core.service.kit.KitRequestService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import bio.terra.pearl.core.service.study.StudyService;
@@ -72,9 +71,6 @@ public class KitExtService {
 
   public void refreshKitStatuses(
       AdminUser adminUser, String portalShortcode, String studyShortcode) {
-    if (!adminUser.isSuperuser()) {
-      throw new PermissionDeniedException("You do not have permissions to perform this operation");
-    }
     var portalStudy = authUtilService.authUserToStudy(adminUser, portalShortcode, studyShortcode);
     var study = studyService.find(portalStudy.getStudyId()).get();
     kitRequestService.syncKitStatusesForStudy(study);

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -1068,6 +1068,19 @@ paths:
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/refreshKitStatuses:
+    post:
+      summary: Fetch kit statuses from Pepper and cache in the Juniper database
+      tags: [ kit ]
+      operationId: refreshKitStatuses
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: studyShortcode, in: path, required: true, schema: { type: string } }
+      responses:
+        '204':
+          description: Success
+        '500':
+          $ref: '#/components/responses/ServerError'
 
 components:
   responses:

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -1068,7 +1068,7 @@ paths:
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
-  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/refreshKitStatuses:
+  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/kits/refreshKitStatuses:
     post:
       summary: Fetch kit statuses from Pepper and cache in the Juniper database
       tags: [ kit ]

--- a/api-admin/src/main/resources/application.yml
+++ b/api-admin/src/main/resources/application.yml
@@ -22,6 +22,7 @@ env:
     deploymentZone: ${DEPLOYMENT_ZONE:}
     tdrExportEnabled: ${TDR_EXPORT_ENABLED:false}
   dsm:
+    useLiveDsm: ${USE_LIVE_DSM:false}
     basePath: ${DSM_ADDRESS:https://dsm-dev.datadonationplatform.org/dsm}
     issuerClaim: ${DSM_JWT_ISSUER:admin-d2p.ddp-dev.envs.broadinstitute.org}
     secret: ${DSM_JWT_SIGNING_SECRET:}

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/kit/KitExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/kit/KitExtServiceTests.java
@@ -11,7 +11,6 @@ import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.service.exception.PermissionDeniedException;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
@@ -52,15 +51,13 @@ public class KitExtServiceTests extends BaseSpringBootTest {
 
   @Transactional
   @Test
-  public void testRefreshKitStatusesRequiresSuperuser() {
-    // Arrange
-    AdminUser user = AdminUser.builder().superuser(false).build();
-
-    // "Act"
-    Executable act = () -> kitExtService.refreshKitStatuses(user, "portal", "study");
-
-    // Assert
-    assertThrows(PermissionDeniedException.class, act);
+  public void testRefreshKitStatusesAuthsStudy() {
+    when(mockAuthUtilService.authUserToStudy(any(), any(), any()))
+        .thenThrow(new PermissionDeniedException(""));
+    AdminUser adminUser = new AdminUser();
+    assertThrows(
+        PermissionDeniedException.class,
+        () -> kitExtService.refreshKitStatuses(adminUser, "someportal", "somestudy"));
   }
 
   @MockBean private AuthUtilService mockAuthUtilService;

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/kit/KitExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/kit/KitExtServiceTests.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.api.admin.service.kit;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -9,8 +10,8 @@ import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.service.exception.PermissionDeniedException;
 import java.util.Arrays;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,7 +25,7 @@ public class KitExtServiceTests extends BaseSpringBootTest {
     when(mockAuthUtilService.authUserToStudy(any(), any(), any()))
         .thenThrow(new PermissionDeniedException(""));
     AdminUser adminUser = new AdminUser();
-    Assertions.assertThrows(
+    assertThrows(
         PermissionDeniedException.class,
         () ->
             kitExtService.requestKits(
@@ -42,11 +43,24 @@ public class KitExtServiceTests extends BaseSpringBootTest {
     when(mockAuthUtilService.authUserToStudy(any(), any(), any()))
         .thenThrow(new PermissionDeniedException(""));
     AdminUser adminUser = new AdminUser();
-    Assertions.assertThrows(
+    assertThrows(
         PermissionDeniedException.class,
         () ->
             kitExtService.getKitRequestsByStudyEnvironment(
                 adminUser, "someportal", "somestudy", EnvironmentName.sandbox));
+  }
+
+  @Transactional
+  @Test
+  public void testRefreshKitStatusesRequiresSuperuser() {
+    // Arrange
+    AdminUser user = AdminUser.builder().superuser(false).build();
+
+    // "Act"
+    Executable act = () -> kitExtService.refreshKitStatuses(user, "portal", "study");
+
+    // Assert
+    assertThrows(PermissionDeniedException.class, act);
   }
 
   @MockBean private AuthUtilService mockAuthUtilService;

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
@@ -176,7 +176,8 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
         var pepperKitStatuses = pepperDSMClient.fetchKitStatusByStudy(study.getShortcode());
         var pepperStatusFetchedAt = Instant.now();
         var pepperKitStatusByKitId = pepperKitStatuses.stream().collect(
-                Collectors.toMap(PepperKitStatus::getJuniperKitId, Function.identity()));
+                Collectors.toMap(PepperKitStatus::getJuniperKitId, Function.identity(),
+                        (kit1, kit2) -> !kit1.getCurrentStatus().equals("Deactivated") ? kit1 : kit2));
 
         var studyEnvironments = studyEnvironmentService.findByStudy(study.getId());
         for (StudyEnvironment studyEnvironment : studyEnvironments) {

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/LivePepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/LivePepperDSMClient.java
@@ -199,7 +199,7 @@ public class LivePepperDSMClient implements PepperDSMClient {
         private String secret;
 
         public PepperDSMConfig(Environment environment) {
-            this.useLiveDsm = environment.getProperty("env.dsm.useLiveDsm", Boolean.class);
+            this.useLiveDsm = environment.getProperty("env.dsm.useLiveDsm", Boolean.class, false);
             this.basePath = environment.getProperty("env.dsm.basePath");
             this.issuerClaim = environment.getProperty("env.dsm.issuerClaim");
             this.secret = environment.getProperty("env.dsm.secret");

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/LivePepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/LivePepperDSMClient.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.experimental.Accessors;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ClientResponse;
@@ -191,11 +192,14 @@ public class LivePepperDSMClient implements PepperDSMClient {
     @Getter
     @Setter
     public static class PepperDSMConfig {
+        @Accessors(fluent = true)
+        private boolean useLiveDsm = false;
         private String basePath;
         private String issuerClaim;
         private String secret;
 
         public PepperDSMConfig(Environment environment) {
+            this.useLiveDsm = environment.getProperty("env.dsm.useLiveDsm", Boolean.class);
             this.basePath = environment.getProperty("env.dsm.basePath");
             this.issuerClaim = environment.getProperty("env.dsm.issuerClaim");
             this.secret = environment.getProperty("env.dsm.secret");

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/PepperDSMClientProvider.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/PepperDSMClientProvider.java
@@ -20,7 +20,7 @@ public class PepperDSMClientProvider {
     @Primary
     @Bean
     public PepperDSMClient getPepperDSMClient() {
-        return getStubPepperDSMClient();
+        return getLivePepperDSMClient();
     }
 
     @Bean

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/PepperDSMClientProvider.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/PepperDSMClientProvider.java
@@ -6,10 +6,14 @@ import org.springframework.context.annotation.Primary;
 
 @Configuration
 public class PepperDSMClientProvider {
+    private final LivePepperDSMClient.PepperDSMConfig pepperDSMConfig;
     private final LivePepperDSMClient livePepperDSMClient;
     private final StubPepperDSMClient stubPepperDSMClient;
 
-    public PepperDSMClientProvider(LivePepperDSMClient livePepperDSMClient, StubPepperDSMClient stubPepperDSMClient) {
+    public PepperDSMClientProvider(LivePepperDSMClient.PepperDSMConfig pepperDSMConfig,
+                                   LivePepperDSMClient livePepperDSMClient,
+                                   StubPepperDSMClient stubPepperDSMClient) {
+        this.pepperDSMConfig = pepperDSMConfig;
         this.livePepperDSMClient = livePepperDSMClient;
         this.stubPepperDSMClient = stubPepperDSMClient;
     }
@@ -20,7 +24,9 @@ public class PepperDSMClientProvider {
     @Primary
     @Bean
     public PepperDSMClient getPepperDSMClient() {
-        return getLivePepperDSMClient();
+        return pepperDSMConfig.useLiveDsm() ?
+                getLivePepperDSMClient() :
+                getStubPepperDSMClient();
     }
 
     @Bean

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/PepperKitStatus.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/PepperKitStatus.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.service.kit;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
@@ -12,9 +13,15 @@ import lombok.experimental.SuperBuilder;
 public class PepperKitStatus {
     private String juniperKitId;
     private String currentStatus;
+    private String dsmShippingLabel;
+    @JsonProperty("participantId")
+    private String dsmParticipantId;
     private String labelDate;
+    private String labelByEmail;
     private String scanDate;
+    private String scanByEmail;
     private String receiveDate;
+    private String trackingScanBy;
     private String trackingNumber;
     private String returnTrackingNumber;
     private String errorMessage;

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/PepperKitStatus.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/PepperKitStatus.java
@@ -14,8 +14,7 @@ public class PepperKitStatus {
     private String juniperKitId;
     private String currentStatus;
     private String dsmShippingLabel;
-    @JsonProperty("participantId")
-    private String dsmParticipantId;
+    private String participantId; // Juniper enrollee shortcode
     private String labelDate;
     private String labelByEmail;
     private String scanDate;

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/PepperKitStatusResponse.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/PepperKitStatusResponse.java
@@ -1,7 +1,13 @@
 package bio.terra.pearl.core.service.kit;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+import java.util.Map;
 
 @Getter
 @Setter
@@ -11,4 +17,10 @@ import lombok.experimental.SuperBuilder;
 @ToString
 public class PepperKitStatusResponse extends PepperResponse {
     private PepperKitStatus[] kits;
+
+    public static List<Object> extractUntypedKitStatuses(String json, ObjectMapper objectMapper) throws JsonProcessingException {
+        var parsedResponse = objectMapper.readValue(json, new TypeReference<Map<String, Object>>() {});
+        // This cast won't fail as long as kits is an array
+        return (List<Object>) parsedResponse.get("kits");
+    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/PepperKitStatusResponse.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/PepperKitStatusResponse.java
@@ -18,6 +18,9 @@ import java.util.Map;
 public class PepperKitStatusResponse extends PepperResponse {
     private PepperKitStatus[] kits;
 
+    /**
+     * Minimally parses the given JSON as a PepperKitStatusResponse to extract the list of kits.
+     */
     public static List<Object> extractUntypedKitStatuses(String json, ObjectMapper objectMapper) throws JsonProcessingException {
         var parsedResponse = objectMapper.readValue(json, new TypeReference<Map<String, Object>>() {});
         // This cast won't fail as long as kits is an array

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
@@ -55,6 +55,8 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
                 .phoneNumber("111-222-3333")
                 .build();
         var studyName = "testStudy";
+        when(mockPepperDSMClient.sendKitRequest(any(), any(), any(), any()))
+                .thenReturn("{ \"kits\": [{}] }");
 
         // Act
         var sampleKit = kitRequestService.requestKit(adminUser, studyName, enrollee, "testRequestKit");

--- a/populate/src/main/resources/seed/portals/ourhealth/participants/kitEligible.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/participants/kitEligible.json
@@ -8,7 +8,7 @@
     "contactEmail": "kitEligible@test.com",
     "sexAtBirth": "male",
     "mailingAddress": {
-      "street1": "45 South Street",
+      "street1": "415 Main Street",
       "city": "Cambridge",
       "state": "MA",
       "country": "US",

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/enrollees/kitEligible.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/enrollees/kitEligible.json
@@ -43,7 +43,7 @@
       "answerPopDtos": [
         {"questionStableId": "oh_oh_basic_firstName", "stringValue": "Kitt"},
         {"questionStableId": "oh_oh_basic_lastName", "stringValue": "Eligible"},
-        {"questionStableId": "oh_oh_basic_streetAddress", "stringValue": "45 South Street"},
+        {"questionStableId": "oh_oh_basic_streetAddress", "stringValue": "415 Main Street"},
         {"questionStableId": "oh_oh_basic_mghPatient", "stringValue": "no"},
         {"questionStableId": "oh_oh_basic_dateOfBirth", "stringValue":  "05/19/1983"}
       ],

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -665,6 +665,17 @@ export default {
     return kits
   },
 
+  async refreshKitStatuses(
+    portalShortcode: string,
+    studyShortcode: string,
+    envName: string) {
+    const url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/kits/refreshKitStatuses`
+    return await this.processResponse(await fetch(url, {
+      method: 'POST',
+      headers: this.getInitHeaders()
+    }))
+  },
+
   async fetchEnrolleeKitRequests(
     portalShortcode: string,
     studyShortcode: string,

--- a/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
+++ b/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
@@ -19,6 +19,7 @@ import LoadingSpinner from 'util/LoadingSpinner'
 import { instantToDateString } from 'util/timeUtils'
 import RequestKitModal from '../participants/RequestKitModal'
 import { useLoadingEffect } from 'api/api-utils'
+import { enrolleeKitRequestPath } from '../participants/enrolleeView/EnrolleeView'
 
 type EnrolleeRow = Enrollee & {
   taskCompletionStatus: Record<string, boolean>
@@ -106,7 +107,7 @@ export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvCont
     meta: {
       columnType: 'string'
     },
-    cell: data => <Link to={`${currentEnvPath}/participants/${data.getValue()}`}>{data.getValue()}</Link>
+    cell: data => <Link to={enrolleeKitRequestPath(currentEnvPath, data.getValue().toString())}>{data.getValue()}</Link>
   }, {
     header: 'Join date',
     accessorKey: 'createdAt',

--- a/ui-admin/src/study/kits/KitList.test.tsx
+++ b/ui-admin/src/study/kits/KitList.test.tsx
@@ -1,20 +1,17 @@
 import React from 'react'
-import { act, render, screen } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import { mockEnrollee, mockKitRequest, mockStudyEnvContext } from 'test-utils/mocking-utils'
 import KitList from './KitList'
 import { BrowserRouter } from 'react-router-dom'
 
-jest.mock('api/api', () => ({
-  fetchKitsByStudyEnvironment: () => {
-    return Promise.resolve([mockKitRequest({
-      enrollee: mockEnrollee(),
-      dsmStatus: '{"unexpected": "boom"}'
-    })])
-  }
-}))
+import userEvent from '@testing-library/user-event'
+import Api from 'api/api'
+import { ReactNotifications } from 'react-notifications-component'
+import {MockSuperuserProvider} from "../../test-utils/user-mocking-utils";
 
 describe('KitList', () => {
   it('gracefully handles unexpected JSON from Pepper', async () => {
+    mockFetchKits()
     const studyEnvContext = mockStudyEnvContext()
 
     await act(async () => render(
@@ -26,4 +23,32 @@ describe('KitList', () => {
     expect(screen.getByText('JOSALK')).toBeInTheDocument()
     expect(screen.getByText('Test kit')).toBeInTheDocument()
   })
+
+  it('indicates refresh failed', async () => {
+    mockFetchKits()
+    jest.spyOn(Api, 'refreshKitStatuses').mockImplementation(() => {
+      throw 'failed arrgh'
+    })
+    const studyEnvContext = mockStudyEnvContext()
+    await act(async () => render(
+      <BrowserRouter>
+        <MockSuperuserProvider>
+          <ReactNotifications />
+          <KitList studyEnvContext={studyEnvContext}/>
+        </MockSuperuserProvider>
+      </BrowserRouter>
+    ))
+    userEvent.click(screen.getByText('Refresh'))
+    await waitFor(() => expect(screen.getByText('kit statuses could not be refreshed'))
+      .toBeInTheDocument())
+  })
 })
+
+function mockFetchKits() {
+  jest.spyOn(Api, 'fetchKitsByStudyEnvironment').mockImplementation(() => {
+    return Promise.resolve([mockKitRequest({
+      enrollee: mockEnrollee(),
+      dsmStatus: '{"unexpected": "boom"}'
+    })])
+  })
+}

--- a/ui-admin/src/study/kits/KitList.test.tsx
+++ b/ui-admin/src/study/kits/KitList.test.tsx
@@ -24,8 +24,8 @@ describe('KitList', () => {
         <KitList studyEnvContext={studyEnvContext}/>
       </BrowserRouter>
     ))
-    await user.click(screen.getByText(/Issues/))
 
-    expect(screen.getByText('(unknown)')).toBeInTheDocument()
+    expect(screen.getByText('JOSALK')).toBeInTheDocument()
+    expect(screen.getByText('Test kit')).toBeInTheDocument()
   })
 })

--- a/ui-admin/src/study/kits/KitList.test.tsx
+++ b/ui-admin/src/study/kits/KitList.test.tsx
@@ -3,7 +3,6 @@ import { act, render, screen } from '@testing-library/react'
 import { mockEnrollee, mockKitRequest, mockStudyEnvContext } from 'test-utils/mocking-utils'
 import KitList from './KitList'
 import { BrowserRouter } from 'react-router-dom'
-import userEvent from '@testing-library/user-event'
 
 jest.mock('api/api', () => ({
   fetchKitsByStudyEnvironment: () => {
@@ -16,7 +15,6 @@ jest.mock('api/api', () => ({
 
 describe('KitList', () => {
   it('gracefully handles unexpected JSON from Pepper', async () => {
-    const user = userEvent.setup()
     const studyEnvContext = mockStudyEnvContext()
 
     await act(async () => render(

--- a/ui-admin/src/study/kits/KitList.test.tsx
+++ b/ui-admin/src/study/kits/KitList.test.tsx
@@ -7,7 +7,7 @@ import { BrowserRouter } from 'react-router-dom'
 import userEvent from '@testing-library/user-event'
 import Api from 'api/api'
 import { ReactNotifications } from 'react-notifications-component'
-import {MockSuperuserProvider} from "../../test-utils/user-mocking-utils";
+import { MockSuperuserProvider } from 'test-utils/user-mocking-utils'
 
 describe('KitList', () => {
   it('gracefully handles unexpected JSON from Pepper', async () => {

--- a/ui-admin/src/study/kits/KitList.tsx
+++ b/ui-admin/src/study/kits/KitList.tsx
@@ -13,9 +13,15 @@ import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
 import LoadingSpinner from 'util/LoadingSpinner'
 import { basicTableLayout, ColumnVisibilityControl } from 'util/tableUtils'
 import { instantToDateString, isoToInstant } from 'util/timeUtils'
-import { useLoadingEffect } from '../../api/api-utils'
+import { doApiLoad, useLoadingEffect } from 'api/api-utils'
 import { enrolleeKitRequestPath } from '../participants/enrolleeView/EnrolleeView'
 import KitStatusCell from '../participants/KitStatusCell'
+import { Button } from 'components/forms/Button'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faRefresh } from '@fortawesome/free-solid-svg-icons'
+import { successNotification } from 'util/notifications'
+import { Store } from 'react-notifications-component'
+import {useUser} from "../../user/UserProvider";
 
 type KitStatusTabConfig = {
   status: string,
@@ -99,9 +105,10 @@ const initialColumnVisibility = (tab: KitStatusTabConfig): VisibilityState => {
 /** Loads sample kits for a study and shows them as a list. */
 export default function KitList({ studyEnvContext }: { studyEnvContext: StudyEnvContextT }) {
   const { portal, study, currentEnv } = studyEnvContext
+  const [isRefreshing, setIsRefreshing] = useState(false)
   const [kits, setKits] = useState<KitRequest[]>([])
-
-  const { isLoading } = useLoadingEffect(async () => {
+  const { user } = useUser()
+  const { isLoading, reload } = useLoadingEffect(async () => {
     const kits= await Api.fetchKitsByStudyEnvironment(portal.shortcode, study.shortcode, currentEnv.environmentName)
     setKits(kits)
   }, [studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName])
@@ -111,21 +118,38 @@ export default function KitList({ studyEnvContext }: { studyEnvContext: StudyEnv
   })
 
   const tabLinkStyle = ({ isActive }: {isActive: boolean}) => ({
-    borderBottom: isActive ? '3px solid #333': '',
+    borderBottom: isActive ? '2px solid #666': '',
     background: isActive ? '#ddd' : ''
   })
 
+  const refreshStatuses = async () => {
+    doApiLoad(async () => {
+      await Api.refreshKitStatuses(portal.shortcode, study.shortcode, currentEnv.environmentName)
+      await reload()
+      Store.addNotification(successNotification('kit statuses refreshed'))
+    }, {
+      setIsLoading: setIsRefreshing,
+      customErrorMsg: 'kit statuses could not be refreshed'
+    })
+  }
+
   return <LoadingSpinner isLoading={isLoading}>
-    <div className="container">
-      <div className="d-flex w-100" style={{ backgroundColor: '#ccc' }}>
+    <div className="container p-0 mt-2">
+      <div className="d-flex w-100 align-items-center" style={{ backgroundColor: '#ccc' }}>
         { statusTabs.map(tab => {
           const kits = kitsByStatus[tab.status] || []
           return <NavLink key={tab.key} to={tab.key} style={tabLinkStyle}>
-            <div className="py-3 px-5">
+            <div className="py-2 px-4">
               {kits?.length} {_capitalize(tab.key)}
             </div>
           </NavLink>
         })}
+        <div className="ms-auto">
+          {user.superuser && <Button variant="secondary" onClick={refreshStatuses}>
+            {!isRefreshing && <span>Refresh <FontAwesomeIcon icon={faRefresh}/></span>}
+            {isRefreshing && <LoadingSpinner/>}
+          </Button> }
+        </div>
       </div>
       <Routes>
         <Route index element={<Navigate to={statusTabs[0].key} replace={true}/>}/>

--- a/ui-admin/src/study/kits/KitList.tsx
+++ b/ui-admin/src/study/kits/KitList.tsx
@@ -21,7 +21,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faRefresh } from '@fortawesome/free-solid-svg-icons'
 import { successNotification } from 'util/notifications'
 import { Store } from 'react-notifications-component'
-import {useUser} from "../../user/UserProvider";
+import { useUser } from '../../user/UserProvider'
 
 type KitStatusTabConfig = {
   status: string,

--- a/ui-admin/src/study/kits/KitList.tsx
+++ b/ui-admin/src/study/kits/KitList.tsx
@@ -96,11 +96,6 @@ const initialColumnVisibility = (tab: KitStatusTabConfig): VisibilityState => {
   }
 }
 
-const pepperStatusToHumanStatus = (pepperStatus?: PepperKitStatus): string => {
-  const tab = statusTabs.find(tab => tab.status === pepperStatus?.currentStatus.toLowerCase())
-  return _capitalize(tab?.key) || pepperStatus?.currentStatus || '(unknown)'
-}
-
 /** Loads sample kits for a study and shows them as a list. */
 export default function KitList({ studyEnvContext }: { studyEnvContext: StudyEnvContextT }) {
   const { portal, study, currentEnv } = studyEnvContext

--- a/ui-admin/src/study/kits/KitList.tsx
+++ b/ui-admin/src/study/kits/KitList.tsx
@@ -8,7 +8,7 @@ import {
   getCoreRowModel, getFilteredRowModel, getSortedRowModel, SortingState, useReactTable, VisibilityState
 } from '@tanstack/react-table'
 
-import Api, { KitRequest, PepperKitStatus } from 'api/api'
+import Api, { KitRequest } from 'api/api'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
 import LoadingSpinner from 'util/LoadingSpinner'
 import { basicTableLayout, ColumnVisibilityControl } from 'util/tableUtils'

--- a/ui-admin/src/study/participants/KitRequests.test.tsx
+++ b/ui-admin/src/study/participants/KitRequests.test.tsx
@@ -16,6 +16,6 @@ test('renders kit requsets', async () => {
     expect(screen.getByText('Kit requests')).toBeInTheDocument()
   })
   expect(screen.getByText('Test kit')).toBeInTheDocument()
-  expect(screen.getByText('CREATED')).toBeInTheDocument()
+  expect(screen.getByText('Kit Without Label')).toBeInTheDocument()
   expect(screen.getByText('1234 Fake Street')).toBeInTheDocument()
 })

--- a/ui-admin/src/study/participants/KitRequests.test.tsx
+++ b/ui-admin/src/study/participants/KitRequests.test.tsx
@@ -9,8 +9,7 @@ test('renders kit requsets', async () => {
   const enrollee = mockEnrollee()
   const studyEnvContext = mockStudyEnvContext()
   const { RoutedComponent } = setupRouterTest(
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    <KitRequests enrollee={enrollee} studyEnvContext={studyEnvContext} onUpdate={() => {}}/>)
+    <KitRequests enrollee={enrollee} studyEnvContext={studyEnvContext} onUpdate={jest.fn()}/>)
   render(RoutedComponent)
   await waitFor(() => {
     expect(screen.getByText('Kit requests')).toBeInTheDocument()

--- a/ui-admin/src/study/participants/KitRequests.tsx
+++ b/ui-admin/src/study/participants/KitRequests.tsx
@@ -22,6 +22,26 @@ function KitRequestAddress({ sentToAddressJson }: { sentToAddressJson: string })
   </div>
 }
 
+const columns: ColumnDef<KitRequest, string>[] = [{
+  header: 'Kit type',
+  accessorKey: 'kitType.displayName'
+}, {
+  header: 'Status',
+  accessorKey: 'status',
+  cell: ({ row }) => <KitStatusCell kitRequest={row.original} infoPlacement='right'/>
+}, {
+  header: 'Created',
+  accessorKey: 'createdAt',
+  accessorFn: data => instantToDefaultString(data.createdAt)
+}, {
+  header: 'Address',
+  cell: ({ row }) => <KitRequestAddress sentToAddressJson={row.original.sentToAddress}/>
+}, {
+  header: 'DSM Status',
+  accessorKey: 'dsmStatus',
+  cell: ({ row }) => <InfoPopup content={row.original.dsmStatus} placement='left'/>
+}]
+
 /** Shows a list of all kit requests for an enrollee. */
 export default function KitRequests({ enrollee, studyEnvContext, onUpdate }:
                                       {
@@ -39,26 +59,6 @@ export default function KitRequests({ enrollee, studyEnvContext, onUpdate }:
     setShowRequestKitModal(false)
     onUpdate()
   }
-
-  const columns: ColumnDef<KitRequest, string>[] = [{
-    header: 'Kit type',
-    accessorKey: 'kitType.displayName'
-  }, {
-    header: 'Status',
-    accessorKey: 'status',
-    cell: ({ row }) => <KitStatusCell kitRequest={row.original} infoPlacement='right'/>
-  }, {
-    header: 'Created',
-    accessorKey: 'createdAt',
-    accessorFn: data => instantToDefaultString(data.createdAt)
-  }, {
-    header: 'Address',
-    cell: ({ row }) => <KitRequestAddress sentToAddressJson={row.original.sentToAddress}/>
-  }, {
-    header: 'DSM Status',
-    accessorKey: 'dsmStatus',
-    cell: ({ row }) => <InfoPopup content={row.original.dsmStatus} placement='left'/>
-  }]
 
   const table = useReactTable({
     data: enrollee.kitRequests || [],

--- a/ui-admin/src/study/participants/KitRequests.tsx
+++ b/ui-admin/src/study/participants/KitRequests.tsx
@@ -8,6 +8,8 @@ import { faPlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { instantToDefaultString } from 'util/timeUtils'
 import { useUser } from 'user/UserProvider'
+import InfoPopup from 'components/forms/InfoPopup'
+import KitStatusCell from './KitStatusCell'
 
 /** Component for rendering the address a kit was sent to based on JSON captured at the time of the kit request. */
 function KitRequestAddress({ sentToAddressJson }: { sentToAddressJson: string }) {
@@ -19,24 +21,6 @@ function KitRequestAddress({ sentToAddressJson }: { sentToAddressJson: string })
     <div>{address.city}, {address.state} {address.postalCode} {address.country}</div>
   </div>
 }
-
-const columns: ColumnDef<KitRequest, string>[] = [{
-  header: 'Kit type',
-  accessorKey: 'kitType.displayName'
-}, {
-  header: 'Status',
-  accessorKey: 'status'
-}, {
-  header: 'Created',
-  accessorKey: 'createdAt',
-  accessorFn: data => instantToDefaultString(data.createdAt)
-}, {
-  header: 'Address',
-  cell: ({ row }) => <KitRequestAddress sentToAddressJson={row.original.sentToAddress}/>
-}, {
-  header: 'DSM Status',
-  accessorKey: 'dsmStatus'
-}]
 
 /** Shows a list of all kit requests for an enrollee. */
 export default function KitRequests({ enrollee, studyEnvContext, onUpdate }:
@@ -55,6 +39,26 @@ export default function KitRequests({ enrollee, studyEnvContext, onUpdate }:
     setShowRequestKitModal(false)
     onUpdate()
   }
+
+  const columns: ColumnDef<KitRequest, string>[] = [{
+    header: 'Kit type',
+    accessorKey: 'kitType.displayName'
+  }, {
+    header: 'Status',
+    accessorKey: 'status',
+    cell: ({ row }) => <KitStatusCell kitRequest={row.original} infoPlacement='right'/>
+  }, {
+    header: 'Created',
+    accessorKey: 'createdAt',
+    accessorFn: data => instantToDefaultString(data.createdAt)
+  }, {
+    header: 'Address',
+    cell: ({ row }) => <KitRequestAddress sentToAddressJson={row.original.sentToAddress}/>
+  }, {
+    header: 'DSM Status',
+    accessorKey: 'dsmStatus',
+    cell: ({ row }) => <InfoPopup content={row.original.dsmStatus} placement='left'/>
+  }]
 
   const table = useReactTable({
     data: enrollee.kitRequests || [],

--- a/ui-admin/src/study/participants/KitStatusCell.tsx
+++ b/ui-admin/src/study/participants/KitStatusCell.tsx
@@ -3,6 +3,10 @@ import { KitRequest } from 'api/api'
 import InfoPopup from 'components/forms/InfoPopup'
 import { Placement } from 'react-bootstrap/types'
 
+/**
+ * Component to render the currentStatus as reported by Pepper, including some help text to explain what the statuses
+ * mean and include error detail for error status.
+ */
 export default function KitStatusCell(
   { kitRequest, infoPlacement = 'top' }:
   { kitRequest: KitRequest, infoPlacement?: Placement }

--- a/ui-admin/src/study/participants/KitStatusCell.tsx
+++ b/ui-admin/src/study/participants/KitStatusCell.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { KitRequest } from 'api/api'
+import InfoPopup from 'components/forms/InfoPopup'
+import { Placement } from 'react-bootstrap/types'
+
+export default function KitStatusCell(
+  { kitRequest, infoPlacement = 'top' }:
+  { kitRequest: KitRequest, infoPlacement?: Placement }
+) {
+  const infoTexts: Record<string, string> = {
+    'kit without label': 'Kit request has been received',
+    'queue': 'Shipping label has been printed',
+    'sent': 'Kit has been sent to the participant',
+    'received': 'Kit has been returned by the participant',
+    'error': 'There was a problem fulfilling this kit request',
+    'deactivated': 'Kit is deactivated'
+  }
+  const currentStatus = kitRequest.pepperStatus?.currentStatus
+  const info = currentStatus ? infoTexts[currentStatus.toLowerCase()] : ''
+  const errorMessage = kitRequest.pepperStatus?.errorMessage ? `: ${kitRequest.pepperStatus.errorMessage}` : ''
+  const content = `${info}${errorMessage}`
+  return <>
+    {kitRequest.pepperStatus?.currentStatus}
+    {info && <InfoPopup content={content} placement={infoPlacement}/>}
+  </>
+}

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -159,7 +159,7 @@ export const mockKitRequest: (args?: {
   dsmStatus,
   pepperStatus: {
     kitId: '',
-    currentStatus: '(unknown)',
+    currentStatus: 'Kit Without Label',
     labelDate: '',
     scanDate: '',
     receiveDate: '',

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -164,7 +164,8 @@ export const mockKitRequest: (args?: {
     scanDate: '',
     receiveDate: '',
     trackingNumber: '',
-    returnTrackingNumber: ''
+    returnTrackingNumber: '',
+    errorMessage: ''
   }
 })
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/JN-474

Also includes minor improvements to kit UI for https://broadworkbench.atlassian.net/browse/JN-366

DSM now includes its understanding of the current status of a kit request in its status responses. 

To facilitate testing and demoing, there is also a new superuser-only endpoint to invoke the bulk status update that normally only runs once a day (late at night). To minimize the potential impact on DSM, the endpoint targets a specific study instead of refreshing the status for all in-progress kits in all studies.

#### DESCRIPTION

**IMPORTANT** This PR switches the default Pepper client code from a stub implementation to a live implementation that actually talks to DSM.

<img width="1001" alt="Screenshot 2023-09-20 at 11 48 20 AM" src="https://github.com/broadinstitute/juniper/assets/19228696/a9551d87-f292-4e66-9651-309f3e64e4d2">

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. Start the admin API and repopulate your local database (`OHKITS`'s address has been updated to a valid address)
2. Start the admin UI
3. Go to the list of users eligible for kits in the sandbox environment (https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/kits/eligible)
4. Select `OHKITS`, click "Send sample collection kit", and click "Request Kit"
5. Click over to the "Requested". You should see a new kit filed under the "Created" tab
6. Click on the `OHKITS` link to view the kit details for that participants kits (https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants/OHKITS/kitRequests). Click the (i) in the DSM Status column and notice the raw status JSON from DSM, particularly the `dsmShippingLabel` attribute.
7. Go to https://dsm-dev.datadonationplatform.org/ and sign in with your Broad Google account. Check with Pegah if you need permissions, or have someone who does have permissions perform the steps in DSM. These next steps are acting in the role of someone from GP who ships and receives kits.
8. Select the "Our Heart" study, then under "Samples", click "Kits without labels"
9. Filter the list by Shipping ID using the `dsmShippingLabel` from the JSON status. Notice that the kit that was just created shows up.
10. Since creating labels often fails in dev. Instead, go back to the "Samples" nav and click "Final Scan"
11. For "Kit Label", enter some unique value; I like to use a date/time-based number. For "DSM Label", enter the `dsmShippingLabel` from earlier.
12. Click "Save Scan Pairs", then click it again so you get a "Scanned successfully" message.
13. Go back to the kit details for `OHKITS` in Juniper (https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants/OHKITS/kitRequests) and reload. Notice that the kit status has not changed.
14. Go to http://localhost:8080/swagger-ui.html#/kit/refreshKitStatuses, auth, and run for ourhealth/ourheart to batch-update kit statuses from DSM. This is the process that normally happens overnight.
15. Again, reload https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants/OHKITS/kitRequests and notice that the status has changed from "Kit Without Label" to "Sent".