### PR TITLE
[JN-569] Autofill survey stable ID

### DIFF
--- a/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
@@ -42,4 +42,27 @@ describe('CreateSurveyModal', () => {
     const createButton = screen.getByText('Create')
     expect(createButton).toBeEnabled()
   })
+
+  test('should autofill the stable ID as the user fills in the survey name', async () => {
+    //Arrange
+    const user = userEvent.setup()
+    const studyEnvContext = mockStudyEnvContext()
+    const { RoutedComponent } = setupRouterTest(<CreateSurveyModal
+      studyEnvContext={studyEnvContext}
+      isReadOnlyEnv={false}
+      show={true}
+      setShow={jest.fn()}/>)
+    render(RoutedComponent)
+
+    //Act
+    const surveyNameInput = screen.getByLabelText('Survey Name')
+    const surveyStableIdInput = screen.getByLabelText('Survey Stable ID')
+    await user.type(surveyNameInput, 'Test Survey')
+
+    //Assert
+    const createButton = screen.getByText('Create')
+    //Confirm that auto-fill stable ID worked
+    expect(surveyStableIdInput).toHaveValue('testSurvey')
+    expect(createButton).toBeEnabled()
+  })
 })

--- a/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
@@ -60,9 +60,7 @@ describe('CreateSurveyModal', () => {
     await user.type(surveyNameInput, 'Test Survey')
 
     //Assert
-    const createButton = screen.getByText('Create')
     //Confirm that auto-fill stable ID worked
     expect(surveyStableIdInput).toHaveValue('testSurvey')
-    expect(createButton).toBeEnabled()
   })
 })

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -5,9 +5,10 @@ import LoadingSpinner from 'util/LoadingSpinner'
 import Api, { VersionedForm } from 'api/api'
 import { useNavigate } from 'react-router-dom'
 import { Store } from 'react-notifications-component'
-import { failureNotification } from '../../util/notifications'
-import { PortalContext, PortalContextT } from '../../portal/PortalProvider'
-import InfoPopup from '../../components/forms/InfoPopup'
+import { failureNotification } from 'util/notifications'
+import { PortalContext, PortalContextT } from 'portal/PortalProvider'
+import InfoPopup from 'components/forms/InfoPopup'
+import { generateStableId } from 'util/pearlSurveyUtils'
 
 /** renders a modal that creates a new survey in a portal and configures it to the current study env */
 const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, show, setShow }: {studyEnvContext: StudyEnvContextT,
@@ -15,6 +16,7 @@ const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, show, setShow }: {s
   const [isLoading, setIsLoading] = useState(false)
   const [surveyName, setSurveyName] = useState('')
   const [surveyStableId, setSurveyStableId] = useState('')
+  const [enableAutofillStableId, setEnableAutofillStableId] = useState(true)
 
   const portalContext = useContext(PortalContext) as PortalContextT
   const navigate = useNavigate()
@@ -62,6 +64,7 @@ const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, show, setShow }: {s
   const clearFields = () => {
     setSurveyName('')
     setSurveyStableId('')
+    setEnableAutofillStableId(true)
   }
 
   return <Modal show={show}
@@ -79,11 +82,21 @@ const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, show, setShow }: {s
       <form onSubmit={e => e.preventDefault()}>
         <label className="form-label" htmlFor="inputSurveyName">Survey Name</label>
         <input type="text" size={50} className="form-control" id="inputSurveyName" value={surveyName}
-          onChange={event => setSurveyName(event.target.value)}/>
+          onChange={event => {
+            setSurveyName(event.target.value)
+            if (enableAutofillStableId) {
+              setSurveyStableId(generateStableId(event.target.value))
+            }
+          }}/>
         <label className="form-label mt-3" htmlFor="inputSurveyStableId">Survey Stable ID</label>
         <InfoPopup content={'A stable and unique identifier for the survey. May be shown in exported datasets.'}/>
         <input type="text" size={50} className="form-control" id="inputSurveyStableId" value={surveyStableId}
-          onChange={event => setSurveyStableId(event.target.value)}/>
+          onChange={event => {
+            setSurveyStableId(event.target.value)
+            //Once the user has modified the stable ID on their own, disable autofill in order to prevent overwriting
+            setEnableAutofillStableId(false)
+          }
+          }/>
       </form>
     </Modal.Body>
     <Modal.Footer>

--- a/ui-admin/src/util/pearlSurveyUtils.tsx
+++ b/ui-admin/src/util/pearlSurveyUtils.tsx
@@ -35,10 +35,16 @@ export type QuestionObj = {
   isRequired?: boolean
 }
 
+/** converts the specified text into a suitable stableId */
+export function generateStableId(text: string) {
+  let value =_camelCase(text)
+  value = value.replace(/[^a-zA-Z\d]/g, '')
+  return value
+}
+
 /** renders a choice text into a stableId-suitable string */
 export function getValueForChoice(choiceText: string) {
-  let value =_camelCase(choiceText)
-  value = value.replace(/[^a-zA-Z\d]/g, '')
+  let value = generateStableId(choiceText)
   if (CHOICE_VALUE_MAPPINGS[value]) {
     value = CHOICE_VALUE_MAPPINGS[value]
   }


### PR DESCRIPTION
#### DESCRIPTION

This adds autofill for survey stable IDs during creation

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Create a new survey and verify that as you type a name, the survey stable ID is automatically generated.
Confirm that once you make a single edit to the stable ID, it no longer autofills based on changes to the name field.