### PR TITLE
JN-474 admin kit refresh

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
@@ -6,7 +6,6 @@ import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
-import bio.terra.pearl.core.service.exception.PermissionDeniedException;
 import bio.terra.pearl.core.service.kit.KitRequestService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import bio.terra.pearl.core.service.study.StudyService;
@@ -72,9 +71,6 @@ public class KitExtService {
 
   public void refreshKitStatuses(
       AdminUser adminUser, String portalShortcode, String studyShortcode) {
-    if (!adminUser.isSuperuser()) {
-      throw new PermissionDeniedException("You do not have permissions to perform this operation");
-    }
     var portalStudy = authUtilService.authUserToStudy(adminUser, portalShortcode, studyShortcode);
     var study = studyService.find(portalStudy.getStudyId()).get();
     kitRequestService.syncKitStatusesForStudy(study);

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -1068,7 +1068,7 @@ paths:
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
-  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/refreshKitStatuses:
+  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/kits/refreshKitStatuses:
     post:
       summary: Fetch kit statuses from Pepper and cache in the Juniper database
       tags: [ kit ]

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/kit/KitExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/kit/KitExtServiceTests.java
@@ -11,7 +11,6 @@ import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.service.exception.PermissionDeniedException;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
@@ -52,15 +51,13 @@ public class KitExtServiceTests extends BaseSpringBootTest {
 
   @Transactional
   @Test
-  public void testRefreshKitStatusesRequiresSuperuser() {
-    // Arrange
-    AdminUser user = AdminUser.builder().superuser(false).build();
-
-    // "Act"
-    Executable act = () -> kitExtService.refreshKitStatuses(user, "portal", "study");
-
-    // Assert
-    assertThrows(PermissionDeniedException.class, act);
+  public void testRefreshKitStatusesAuthsStudy() {
+    when(mockAuthUtilService.authUserToStudy(any(), any(), any()))
+        .thenThrow(new PermissionDeniedException(""));
+    AdminUser adminUser = new AdminUser();
+    assertThrows(
+        PermissionDeniedException.class,
+        () -> kitExtService.refreshKitStatuses(adminUser, "someportal", "somestudy"));
   }
 
   @MockBean private AuthUtilService mockAuthUtilService;

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -669,7 +669,7 @@ export default {
     portalShortcode: string,
     studyShortcode: string,
     envName: string) {
-    const url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/kitds/refreshKitStatuses`
+    const url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/kits/refreshKitStatuses`
     return await this.processResponse(await fetch(url, {
       method: 'POST',
       headers: this.getInitHeaders()

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -665,6 +665,17 @@ export default {
     return kits
   },
 
+  async refreshKitStatuses(
+    portalShortcode: string,
+    studyShortcode: string,
+    envName: string) {
+    const url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/kitds/refreshKitStatuses`
+    return await this.processResponse(await fetch(url, {
+      method: 'POST',
+      headers: this.getInitHeaders()
+    }))
+  },
+
   async fetchEnrolleeKitRequests(
     portalShortcode: string,
     studyShortcode: string,

--- a/ui-admin/src/study/kits/KitList.test.tsx
+++ b/ui-admin/src/study/kits/KitList.test.tsx
@@ -8,8 +8,6 @@ import userEvent from '@testing-library/user-event'
 import Api from 'api/api'
 import { ReactNotifications } from 'react-notifications-component'
 
-
-
 describe('KitList', () => {
   it('gracefully handles unexpected JSON from Pepper', async () => {
     mockFetchKits()

--- a/ui-admin/src/study/kits/KitList.test.tsx
+++ b/ui-admin/src/study/kits/KitList.test.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter } from 'react-router-dom'
 import userEvent from '@testing-library/user-event'
 import Api from 'api/api'
 import { ReactNotifications } from 'react-notifications-component'
+import {MockSuperuserProvider} from "../../test-utils/user-mocking-utils";
 
 describe('KitList', () => {
   it('gracefully handles unexpected JSON from Pepper', async () => {
@@ -31,8 +32,10 @@ describe('KitList', () => {
     const studyEnvContext = mockStudyEnvContext()
     await act(async () => render(
       <BrowserRouter>
-        <ReactNotifications />
-        <KitList studyEnvContext={studyEnvContext}/>
+        <MockSuperuserProvider>
+          <ReactNotifications />
+          <KitList studyEnvContext={studyEnvContext}/>
+        </MockSuperuserProvider>
       </BrowserRouter>
     ))
     userEvent.click(screen.getByText('Refresh'))

--- a/ui-admin/src/study/kits/KitList.test.tsx
+++ b/ui-admin/src/study/kits/KitList.test.tsx
@@ -1,21 +1,16 @@
 import React from 'react'
-import { act, render, screen } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import { mockEnrollee, mockKitRequest, mockStudyEnvContext } from 'test-utils/mocking-utils'
 import KitList from './KitList'
 import { BrowserRouter } from 'react-router-dom'
 import userEvent from '@testing-library/user-event'
+import Api from 'api/api'
+import { ReactNotifications } from 'react-notifications-component'
 
-jest.mock('api/api', () => ({
-  fetchKitsByStudyEnvironment: () => {
-    return Promise.resolve([mockKitRequest({
-      enrollee: mockEnrollee(),
-      dsmStatus: '{"unexpected": "boom"}'
-    })])
-  }
-}))
 
 describe('KitList', () => {
   it('gracefully handles unexpected JSON from Pepper', async () => {
+    mockFetchKits()
     const user = userEvent.setup()
     const studyEnvContext = mockStudyEnvContext()
 
@@ -28,4 +23,30 @@ describe('KitList', () => {
 
     expect(screen.getByText('(unknown)')).toBeInTheDocument()
   })
+
+  it('indicates refresh failed', async () => {
+    mockFetchKits()
+    jest.spyOn(Api, 'refreshKitStatuses').mockImplementation(() => {
+      throw 'failed arrgh'
+    })
+    const studyEnvContext = mockStudyEnvContext()
+    await act(async () => render(
+      <BrowserRouter>
+        <ReactNotifications />
+        <KitList studyEnvContext={studyEnvContext}/>
+      </BrowserRouter>
+    ))
+    userEvent.click(screen.getByText('Refresh'))
+    await waitFor(() => expect(screen.getByText('kit statuses could not be refreshed'))
+      .toBeInTheDocument())
+  })
 })
+
+function mockFetchKits() {
+  jest.spyOn(Api, 'fetchKitsByStudyEnvironment').mockImplementation(() => {
+    return Promise.resolve([mockKitRequest({
+      enrollee: mockEnrollee(),
+      dsmStatus: '{"unexpected": "boom"}'
+    })])
+  })
+}

--- a/ui-admin/src/study/kits/KitList.tsx
+++ b/ui-admin/src/study/kits/KitList.tsx
@@ -21,6 +21,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faRefresh } from '@fortawesome/free-solid-svg-icons'
 import { successNotification } from 'util/notifications'
 import { Store } from 'react-notifications-component'
+import {useUser} from "../../user/UserProvider";
 
 type KitStatusTabConfig = {
   status: string,
@@ -106,7 +107,7 @@ export default function KitList({ studyEnvContext }: { studyEnvContext: StudyEnv
   const { portal, study, currentEnv } = studyEnvContext
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [kits, setKits] = useState<KitRequest[]>([])
-
+  const { user } = useUser()
   const { isLoading, reload } = useLoadingEffect(async () => {
     const kits= await Api.fetchKitsByStudyEnvironment(portal.shortcode, study.shortcode, currentEnv.environmentName)
     setKits(kits)
@@ -144,10 +145,10 @@ export default function KitList({ studyEnvContext }: { studyEnvContext: StudyEnv
           </NavLink>
         })}
         <div className="ms-auto">
-          <Button variant="secondary" onClick={refreshStatuses}>
+          {user.superuser && <Button variant="secondary" onClick={refreshStatuses}>
             {!isRefreshing && <span>Refresh <FontAwesomeIcon icon={faRefresh}/></span>}
             {isRefreshing && <LoadingSpinner/>}
-          </Button>
+          </Button> }
         </div>
       </div>
       <Routes>

--- a/ui-admin/src/study/participants/KitRequests.test.tsx
+++ b/ui-admin/src/study/participants/KitRequests.test.tsx
@@ -9,8 +9,7 @@ test('renders kit requsets', async () => {
   const enrollee = mockEnrollee()
   const studyEnvContext = mockStudyEnvContext()
   const { RoutedComponent } = setupRouterTest(
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    <KitRequests enrollee={enrollee} studyEnvContext={studyEnvContext} onUpdate={() => {}}/>)
+    <KitRequests enrollee={enrollee} studyEnvContext={studyEnvContext} onUpdate={jest.fn()}/>)
   render(RoutedComponent)
   await waitFor(() => {
     expect(screen.getByText('Kit requests')).toBeInTheDocument()


### PR DESCRIPTION
#### DESCRIPTION
This adds a "refresh" button on the kit list page to refresh statuses.  this also opens up the status refresh endpoint to all admins, instead of just superusers, as I imagine OurHealth will want to be able to refresh statuses when handling support.
(along the way, this does some touchup styling to the nav tabs)

<img width="1279" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/f954933b-790d-4b99-a40a-34aa1397bdf7">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to `https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/kits/requested/created`
2. click 'refresh'
3. confirm kit display is refreshed, and a successful call is made to  `POST /api/portals/v1/ourhealth/studies/ourheart/env/sandbox/kits/refreshKitStatuses`
4. (follow the instructions in https://github.com/broadinstitute/juniper/pull/556 if you want to see statuses change)