### PR TITLE
[JN-586] Update tooltip text on participant response view

### DIFF
--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -46,9 +46,9 @@ export default function SurveyFullDataView({ answers, resumeData, survey, userId
         <label className="ms-4">
           <input type="checkbox" className="me-2"
             checked={showFullQuestions} onChange={() => setShowFullQuestions(!showFullQuestions)}/>
-          Show full question texts
+          Show full question text
         </label>
-        <InfoPopup content="Whether truncate question texts longer than 100 characters below"/>
+        <InfoPopup content="Show full question text vs. truncated to first 100 characters"/>
       </div>
       <div className="ms-auto">
         <Link to="print">


### PR DESCRIPTION
#### DESCRIPTION

This updates the shown tooltip text based on recent feedback.

![Screenshot 2023-09-21 at 3 18 30 PM](https://github.com/broadinstitute/juniper/assets/7257391/fc4f13cf-5a8d-4e1a-8fd5-ee0c1a806fd0)

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Load admin UI and verify that you see the updated tooltip: http://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants/OHSALK/preRegistration 
