### PR TITLE
JN-591: enabling site content publish

### DIFF
--- a/ui-admin/src/portal/publish/PortalEnvDiff.test.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiff.test.tsx
@@ -52,4 +52,39 @@ describe('PortalEnvDiff', () => {
     expect(spyApplyChanges).toHaveBeenCalledTimes(2)
     expect(spyApplyChanges).toHaveBeenCalledWith(changeSet)
   })
+
+  it('handles changes with siteContent', () => {
+    const { portal } = mockPortalContext()
+    const changeSet: PortalEnvironmentChange = {
+      ...emptyChangeSet,
+      siteContentChange: {
+        changed: true,
+        newVersion: 2,
+        oldVersion: 1,
+        newStableId: 'contentId',
+        oldStableId: 'contentId'
+      }
+    }
+    const spyApplyChanges = jest.fn(() => 1)
+    const { RoutedComponent } = setupRouterTest(<PortalEnvDiffView
+      portal={portal}
+      destEnvName={portal.portalEnvironments[0].environmentName}
+      applyChanges={spyApplyChanges}
+      sourceEnvName="sourceEnv"
+      changeSet={changeSet}/>)
+    render(RoutedComponent)
+    expect(screen.queryAllByText('no changes')).toHaveLength(3)
+    expect(screen.queryAllByRole('checkbox')).toHaveLength(1)
+
+    // if we save without making any changes, the result should be an empty changeset
+    fireEvent.click(screen.getByText('Copy changes'))
+    expect(spyApplyChanges).toHaveBeenCalledTimes(1)
+    expect(spyApplyChanges).toHaveBeenCalledWith(emptyChangeSet)
+
+    // if we save after clicking the password field, we should save with a config change
+    fireEvent.click(screen.getByText('contentId v1'))
+    fireEvent.click(screen.getByText('Copy changes'))
+    expect(spyApplyChanges).toHaveBeenCalledTimes(2)
+    expect(spyApplyChanges).toHaveBeenCalledWith(changeSet)
+  })
 })

--- a/ui-admin/src/portal/publish/PortalEnvDiffProvider.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiffProvider.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import React, { useEffect, useState } from 'react'
 import Api, { PortalEnvironmentChange } from 'api/api'
 import { Store } from 'react-notifications-component'
@@ -24,7 +24,6 @@ const PortalEnvDiffProvider = ({ portal, studyShortcode, updatePortal }: PortalE
   const destEnvName = params.destEnvName
   const [isLoading, setIsLoading] = useState(true)
   const [diffResult, setDiffResult] = useState<PortalEnvironmentChange>()
-  const navigate = useNavigate()
 
   const applyChanges = (changeSet: PortalEnvironmentChange) => {
     Api.applyEnvChanges(portal.shortcode, destEnvName!, changeSet).then(result => {
@@ -33,7 +32,8 @@ const PortalEnvDiffProvider = ({ portal, studyShortcode, updatePortal }: PortalE
       const envIndex = updatedPortal.portalEnvironments.findIndex(env => env.environmentName === result.environmentName)
       updatedPortal.portalEnvironments[envIndex] = result
       updatePortal(updatedPortal)
-      navigate(studyPublishingPath(portal.shortcode, studyShortcode))
+      // for now, do a hard reload to make sure all changes are propagated
+      window.location.pathname = studyPublishingPath(portal.shortcode, studyShortcode)
     }).catch(e => {
       Store.addNotification(failureNotification(`Update failed: ${  e.message}`))
     })

--- a/ui-admin/src/portal/publish/PortalEnvDiffProvider.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiffProvider.tsx
@@ -1,41 +1,37 @@
-import { useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import React, { useEffect, useState } from 'react'
 import Api, { PortalEnvironmentChange } from 'api/api'
 import { Store } from 'react-notifications-component'
-import { failureNotification, successNotification } from 'util/notifications'
-import _cloneDeep from 'lodash/cloneDeep'
+import { successNotification } from 'util/notifications'
 import LoadingSpinner from 'util/LoadingSpinner'
 import PortalEnvDiffView from './PortalEnvDiffView'
 import { Portal } from '@juniper/ui-core/build/types/portal'
 import { studyPublishingPath } from '../../study/StudyRouter'
+import { doApiLoad } from '../../api/api-utils'
 
 type PortalEnvDiffProviderProps = {
   portal: Portal,
   studyShortcode: string,
-  updatePortal: (portal: Portal) => void
+  reloadPortal: () => void
 }
 /**
  * loads a diff between two environments, based on the passed-in environment and an environment name in a url param
  * also contains logic for updating an environment with a changeset
  */
-const PortalEnvDiffProvider = ({ portal, studyShortcode, updatePortal }: PortalEnvDiffProviderProps) => {
+const PortalEnvDiffProvider = ({ portal, studyShortcode, reloadPortal }: PortalEnvDiffProviderProps) => {
   const params = useParams()
   const sourceEnvName = params.sourceEnvName
   const destEnvName = params.destEnvName
   const [isLoading, setIsLoading] = useState(true)
   const [diffResult, setDiffResult] = useState<PortalEnvironmentChange>()
+  const navigate = useNavigate()
 
-  const applyChanges = (changeSet: PortalEnvironmentChange) => {
-    Api.applyEnvChanges(portal.shortcode, destEnvName!, changeSet).then(result => {
+  const applyChanges = async (changeSet: PortalEnvironmentChange) => {
+    doApiLoad(async () => {
+      await Api.applyEnvChanges(portal.shortcode, destEnvName!, changeSet)
       Store.addNotification(successNotification(`${destEnvName} environment updated`))
-      const updatedPortal = _cloneDeep(portal)
-      const envIndex = updatedPortal.portalEnvironments.findIndex(env => env.environmentName === result.environmentName)
-      updatedPortal.portalEnvironments[envIndex] = result
-      updatePortal(updatedPortal)
-      // for now, do a hard reload to make sure all changes are propagated
-      window.location.pathname = studyPublishingPath(portal.shortcode, studyShortcode)
-    }).catch(e => {
-      Store.addNotification(failureNotification(`Update failed: ${  e.message}`))
+      await reloadPortal()
+      navigate(studyPublishingPath(portal.shortcode, studyShortcode))
     })
   }
 

--- a/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
@@ -119,8 +119,17 @@ export default function PortalEnvDiffView(
       <div className="my-2">
         <h2 className="h6">
           Site content</h2>
-        <div className="ms-4">
-          <VersionChangeView record={changeSet.siteContentChange}/>
+        <div className="ms-4 ">
+          { changeSet.siteContentChange.changed &&
+              <label className="d-flex">
+                <input type="checkbox" className="me-3" checked={selectedChanges.siteContentChange.changed}
+                  onChange={e => setSelectedChanges({
+                    ...selectedChanges,
+                    siteContentChange: e.target.checked ? changeSet.siteContentChange : { changed: false }
+                  })}/>
+                <VersionChangeView record={changeSet.siteContentChange}/>
+              </label>}
+          { !changeSet.siteContentChange && <VersionChangeView record={changeSet.siteContentChange}/> }
         </div>
       </div>
       <div className="my-2">

--- a/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
@@ -129,7 +129,7 @@ export default function PortalEnvDiffView(
                   })}/>
                 <VersionChangeView record={changeSet.siteContentChange}/>
               </label>}
-          { !changeSet.siteContentChange && <VersionChangeView record={changeSet.siteContentChange}/> }
+          { !changeSet.siteContentChange.changed && <VersionChangeView record={changeSet.siteContentChange}/> }
         </div>
       </div>
       <div className="my-2">

--- a/ui-admin/src/study/StudyRouter.tsx
+++ b/ui-admin/src/study/StudyRouter.tsx
@@ -59,7 +59,8 @@ function StudyRouterFromShortcode({ shortcode, portalContext }:
       <Route path="env/:studyEnv/*" element={<StudyEnvironmentRouter study={study}/>}/>
       <Route path="diff/:sourceEnvName/:destEnvName" element={
         <PortalEnvDiffProvider portal={portalContext.portal}
-          updatePortal={portalContext.updatePortal} studyShortcode={study.shortcode}/>}/>
+          reloadPortal={() => portalContext.reloadPortal(portalContext.portal.shortcode)}
+          studyShortcode={study.shortcode}/>}/>
       <Route path="publishing" element={<StudyPublishingView portal={portalContext.portal}
         studyShortcode={study.shortcode}/>}/>
       <Route path="users" element={<PortalUserList portal={portalContext.portal}/>}/>


### PR DESCRIPTION
#### DESCRIPTION

This enables selection of sitecontent changes to be published 
<img width="776" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/ededae94-e57d-4aaf-a8df-7a1eabdd30d3">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1. On the ourhealth publishing view, copy your Sandbox env. to irb `https://localhost:3000/ourhealth/studies/ourheart/publishing`
2. Make a small change to the siteContent in the sandbox, and save it, creating a new version
3. go back to the publishing view again, and select copy from sandbox to IRB
4. select the siteContent change
5. hit "copy"
6. confirm the updated version appears
