### PR TITLE
[JN-549] adding scroll-to-top for admin

### DIFF
--- a/ui-admin/src/App.tsx
+++ b/ui-admin/src/App.tsx
@@ -1,11 +1,11 @@
-import React, {useEffect} from 'react'
+import React, { useEffect } from 'react'
 import 'react-notifications-component/dist/theme.css'
 import 'styles/notifications.css'
 import 'survey-core/defaultV2.min.css'
 import './App.css'
 import './print.css'
 
-import {BrowserRouter, Outlet, Route, Routes, useLocation} from 'react-router-dom'
+import { BrowserRouter, Outlet, Route, Routes, useLocation } from 'react-router-dom'
 import { ReactNotifications } from 'react-notifications-component'
 
 import { RedirectFromOAuth } from 'login/RedirectFromOAuth'
@@ -28,12 +28,12 @@ import PopulateRouteSelect from './populate/PopulateRouteSelect'
 
 /** auto-scroll-to-top on any navigation */
 const ScrollToTop = () => {
-    const location = useLocation()
-    useEffect(() => {
-        // @ts-expect-error TS thinks "instant" isn't a valid scroll behavior.
-        window.scrollTo({ top: 0, left: 0, behavior: 'instant' })
-    }, [location.pathname])
-    return null
+  const location = useLocation()
+  useEffect(() => {
+    // @ts-expect-error TS thinks "instant" isn't a valid scroll behavior.
+    window.scrollTo({ top: 0, left: 0, behavior: 'instant' })
+  }, [location.pathname])
+  return null
 }
 
 

--- a/ui-admin/src/App.tsx
+++ b/ui-admin/src/App.tsx
@@ -1,11 +1,11 @@
-import React from 'react'
+import React, {useEffect} from 'react'
 import 'react-notifications-component/dist/theme.css'
 import 'styles/notifications.css'
 import 'survey-core/defaultV2.min.css'
 import './App.css'
 import './print.css'
 
-import { BrowserRouter, Outlet, Route, Routes } from 'react-router-dom'
+import {BrowserRouter, Outlet, Route, Routes, useLocation} from 'react-router-dom'
 import { ReactNotifications } from 'react-notifications-component'
 
 import { RedirectFromOAuth } from 'login/RedirectFromOAuth'
@@ -26,6 +26,16 @@ import AdminSidebar from './navbar/AdminSidebar'
 import NavContextProvider from 'navbar/NavContextProvider'
 import PopulateRouteSelect from './populate/PopulateRouteSelect'
 
+/** auto-scroll-to-top on any navigation */
+const ScrollToTop = () => {
+    const location = useLocation()
+    useEffect(() => {
+        // @ts-expect-error TS thinks "instant" isn't a valid scroll behavior.
+        window.scrollTo({ top: 0, left: 0, behavior: 'instant' })
+    }, [location.pathname])
+    return null
+}
+
 
 /** container for the app including the router  */
 function App() {
@@ -39,6 +49,7 @@ function App() {
                 <IdleStatusMonitor maxIdleSessionDuration={30 * 60 * 1000} idleWarningDuration={5 * 60 * 1000}/>
                 <ReactNotifications />
                 <BrowserRouter>
+                  <ScrollToTop/>
                   <Routes>
                     <Route path="/">
                       <Route element={<ProtectedRoute>


### PR DESCRIPTION
#### DESCRIPTION

When navigating in the admin tool, users should be taken to the top of each new page.  this uses the same component as the participant frontend.  I did not pull it into a common component, because I'm not sure we'll always want scrolling to be the same in admin and participant UXes.  Also, I don't have a test for this -- testing scrolling seemed too fiddly to be worth the cost

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to `https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/export/dataBrowser`
2. scroll down a little bit
3. click "website" in the left menu
4. confirm you are taken to the top of the website page
