### PR TITLE
[JN-474] Fix a gap in Juniper's comprehension of Pepper's kit status

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/kit/PepperKitStatus.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/PepperKitStatus.java
@@ -1,9 +1,10 @@
 package bio.terra.pearl.core.service.kit;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+
+import java.util.Set;
 
 @Getter @Setter
 @SuperBuilder @NoArgsConstructor
@@ -11,6 +12,40 @@ import lombok.experimental.SuperBuilder;
 @ToString
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PepperKitStatus {
+
+    public enum Status {
+        CREATED("kit without label"),
+        QUEUED("queue"),
+        SENT("sent"),
+        RECEIVED("received"),
+        ERRORED("error"),
+        DEACTIVATED("deactivated");
+
+        Status(String currentStatus) {
+            this.currentStatus = currentStatus;
+        }
+
+        final String currentStatus;
+
+        public static Status fromCurrentStatus(String currentStatus) {
+            for (Status status : Status.values()) {
+                if (status.currentStatus.equals(currentStatus.toLowerCase())) {
+                    return status;
+                }
+            }
+            throw new IllegalArgumentException("Unexpected Pepper currentStatus: " + currentStatus);
+        }
+
+        public static boolean isCompleted(Status status) {
+            return Set.of(Status.RECEIVED, Status.DEACTIVATED).contains(status);
+        }
+
+        public static boolean isFailed(Status status) {
+            return status == Status.ERRORED;
+        }
+
+    }
+
     private String juniperKitId;
     private String currentStatus;
     private String dsmShippingLabel;

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
@@ -183,15 +183,15 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
          */
         var kitStatus1a = PepperKitStatus.builder()
                 .juniperKitId(kitRequest1a.getId().toString())
-                .currentStatus("SENT")
+                .currentStatus(PepperKitStatus.Status.SENT.currentStatus)
                 .build();
         var kitStatus1b = PepperKitStatus.builder()
                 .juniperKitId(kitRequest1b.getId().toString())
-                .currentStatus("PROCESSED")
+                .currentStatus(PepperKitStatus.Status.RECEIVED.currentStatus)
                 .build();
         var kitStatus2 = PepperKitStatus.builder()
                 .juniperKitId(kitRequest2.getId().toString())
-                .currentStatus("CONTAMINATED")
+                .currentStatus(PepperKitStatus.Status.ERRORED.currentStatus)
                 .errorMessage("Something went wrong")
                 .errorDate(DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneId.systemDefault()).format(Instant.now()))
                 .build();


### PR DESCRIPTION
#### DESCRIPTION

While rehydrating some refactorings I had stashed along the way, I discovered a gap in Juniper's understanding of the current status according to Pepper. The UI was aware of the possible status values, but the server-side was not. This affected Juniper's tracking of complete/in-progress kits.

Why does Juniper keep a separate status from Pepper? In most cases, the Juniper status can be fully derived from the Pepper status. The exception is when Pepper doesn't have a status because it rejected the kit request. In that case, we might end up with a record in our database with no corresponding record in the Pepper database. There may be other reasons why this may be useful in the future such as handling Juniper-specific workflow branches that aren't modeled in Pepper (such as resolving address validation errors).

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

The functionality is covered by the automated tests, which were previously based on fake `currentStatus` values. Tests have been adjusted and should still pass. No testing to do beyond that.