### PR TITLE
[JN-564] Fix: Switching to an uninitialized study env breaks the survey view

### DIFF
--- a/ui-admin/src/study/surveys/SurveyView.test.tsx
+++ b/ui-admin/src/study/surveys/SurveyView.test.tsx
@@ -1,0 +1,25 @@
+import { mockStudyEnvContext } from 'test-utils/mocking-utils'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import SurveyView from './SurveyView'
+
+
+describe('SurveyView', () => {
+  test('displays a message if loading a survey for an uninitialized study env', async () => {
+    //Arrange
+    const studyEnvContext = {
+      ...mockStudyEnvContext(),
+      currentEnv: {
+        ...mockStudyEnvContext().currentEnv,
+        studyEnvironmentConfig: {
+          ...mockStudyEnvContext().currentEnv.studyEnvironmentConfig,
+          initialized: false
+        }
+      }
+    }
+    render(<SurveyView studyEnvContext={studyEnvContext}/>)
+
+    //Assert
+    expect(screen.getByText('Study environment not initialized')).toBeInTheDocument()
+  })
+})

--- a/ui-admin/src/study/surveys/SurveyView.tsx
+++ b/ui-admin/src/study/surveys/SurveyView.tsx
@@ -89,8 +89,13 @@ export const useSurveyParams = () => {
 
 /** routable component for survey editing */
 function SurveyView({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
-  const { isReadOnly, version, stableId } = useSurveyParams()
   const { currentEnv, portal } = studyEnvContext
+
+  if (!currentEnv.studyEnvironmentConfig.initialized) {
+    return <span>Study environment not initialized</span>
+  }
+
+  const { isReadOnly, version, stableId } = useSurveyParams()
   const applyReadOnly = isReadOnly || currentEnv.environmentName !== 'sandbox'
   const envSurvey = currentEnv.configuredSurveys
     .find(s => s.survey.stableId === stableId)?.survey


### PR DESCRIPTION
#### DESCRIPTION

Previously if you viewed a survey in the admin tool and switched to an uninitialized study env, the screen would go blank and the user would be forced to refresh. This adds a check earlier in the component to check if the study env is initialized and display a message if not.



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1) Repopulate ourhealth: `./scripts/populate_portal.sh ourhealth`
2) Load a survey in the sandbox env: https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/forms/surveys/oh_oh_basicInfo?readOnly=false
3) Use the study environment dropdown to switch to IRB or Live.
4) You should see `Study environment not initialized` rather than a blank screen or React error