### PR TITLE
JN-606 Adding integration UX dashboard

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/kit/KitController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/kit/KitController.java
@@ -92,9 +92,11 @@ public class KitController implements KitApi {
   }
 
   @Override
-  public ResponseEntity<Void> refreshKitStatuses(String portalShortcode, String studyShortcode) {
+  public ResponseEntity<Void> refreshKitStatuses(
+      String portalShortcode, String studyShortcode, String envName) {
     AdminUser adminUser = authUtilService.requireAdminUser(request);
-    kitExtService.refreshKitStatuses(adminUser, portalShortcode, studyShortcode);
+    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
+    kitExtService.refreshKitStatuses(adminUser, portalShortcode, studyShortcode, environmentName);
     return ResponseEntity.noContent().build();
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
@@ -70,9 +70,12 @@ public class KitExtService {
   }
 
   public void refreshKitStatuses(
-      AdminUser adminUser, String portalShortcode, String studyShortcode) {
+      AdminUser adminUser,
+      String portalShortcode,
+      String studyShortcode,
+      EnvironmentName environmentName) {
     var portalStudy = authUtilService.authUserToStudy(adminUser, portalShortcode, studyShortcode);
     var study = studyService.find(portalStudy.getStudyId()).get();
-    kitRequestService.syncKitStatusesForStudy(study);
+    kitRequestService.syncKitStatusesForStudy(study, environmentName);
   }
 }

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -1102,6 +1102,7 @@ paths:
       parameters:
         - { name: portalShortcode, in: path, required: true, schema: { type: string } }
         - { name: studyShortcode, in: path, required: true, schema: { type: string } }
+        - { name: envName, in: path, required: true, schema: { type: string } }
       responses:
         '204':
           description: Success

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/kit/KitExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/kit/KitExtServiceTests.java
@@ -57,7 +57,9 @@ public class KitExtServiceTests extends BaseSpringBootTest {
     AdminUser adminUser = new AdminUser();
     assertThrows(
         PermissionDeniedException.class,
-        () -> kitExtService.refreshKitStatuses(adminUser, "someportal", "somestudy"));
+        () ->
+            kitExtService.refreshKitStatuses(
+                adminUser, "someportal", "somestudy", EnvironmentName.irb));
   }
 
   @MockBean private AuthUtilService mockAuthUtilService;

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/StubPepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/StubPepperDSMClient.java
@@ -6,6 +6,7 @@ import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Lazy;
@@ -15,8 +16,8 @@ import java.util.Collection;
 import java.util.UUID;
 
 @Component
+@Slf4j
 public class StubPepperDSMClient implements PepperDSMClient {
-    private static final Logger logger = LoggerFactory.getLogger(PepperDSMClient.class);
     private final KitRequestService kitRequestService;
     private final StudyEnvironmentDao studyEnvironmentDao;
     private final ObjectMapper objectMapper;
@@ -31,7 +32,7 @@ public class StubPepperDSMClient implements PepperDSMClient {
 
     @Override
     public String sendKitRequest(String studyShortcode, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address) {
-        logger.info("STUB sending kit request");
+        log.info("STUB sending kit request");
         var statusBuilder = PepperKitStatus.builder()
                 .juniperKitId(kitRequest.getId().toString())
                 .currentStatus("CREATED");
@@ -44,7 +45,7 @@ public class StubPepperDSMClient implements PepperDSMClient {
 
     @Override
     public PepperKitStatus fetchKitStatus(UUID kitRequestId) {
-        logger.info("STUB fethcing kit status");
+        log.info("STUB fethcing kit status");
         return PepperKitStatus.builder()
                 .juniperKitId(kitRequestId.toString())
                 .currentStatus("SENT")
@@ -53,7 +54,7 @@ public class StubPepperDSMClient implements PepperDSMClient {
 
     @Override
     public Collection<PepperKitStatus> fetchKitStatusByStudy(String studyShortcode) {
-        logger.info("STUB fetching status by study");
+        log.info("STUB fetching status by study");
         var studyEnvironment = studyEnvironmentDao.findByStudy(studyShortcode, EnvironmentName.sandbox).get();
         return kitRequestService.findIncompleteKits(studyEnvironment.getId()).stream().map(kit -> {
             PepperKitStatus status = PepperKitStatus.builder()

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/StubPepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/StubPepperDSMClient.java
@@ -6,6 +6,8 @@ import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
@@ -14,6 +16,7 @@ import java.util.UUID;
 
 @Component
 public class StubPepperDSMClient implements PepperDSMClient {
+    private static final Logger logger = LoggerFactory.getLogger(PepperDSMClient.class);
     private final KitRequestService kitRequestService;
     private final StudyEnvironmentDao studyEnvironmentDao;
     private final ObjectMapper objectMapper;
@@ -28,6 +31,7 @@ public class StubPepperDSMClient implements PepperDSMClient {
 
     @Override
     public String sendKitRequest(String studyShortcode, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address) {
+        logger.info("STUB sending kit request");
         var statusBuilder = PepperKitStatus.builder()
                 .juniperKitId(kitRequest.getId().toString())
                 .currentStatus("CREATED");
@@ -40,19 +44,21 @@ public class StubPepperDSMClient implements PepperDSMClient {
 
     @Override
     public PepperKitStatus fetchKitStatus(UUID kitRequestId) {
+        logger.info("STUB fethcing kit status");
         return PepperKitStatus.builder()
                 .juniperKitId(kitRequestId.toString())
-                .currentStatus("SHIPPED")
+                .currentStatus("SENT")
                 .build();
     }
 
     @Override
     public Collection<PepperKitStatus> fetchKitStatusByStudy(String studyShortcode) {
+        logger.info("STUB fetching status by study");
         var studyEnvironment = studyEnvironmentDao.findByStudy(studyShortcode, EnvironmentName.sandbox).get();
         return kitRequestService.findIncompleteKits(studyEnvironment.getId()).stream().map(kit -> {
             PepperKitStatus status = PepperKitStatus.builder()
                     .juniperKitId(kit.getId().toString())
-                    .currentStatus("SHIPPED")
+                    .currentStatus("SENT")
                     .build();
             return status;
         }).toList();

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/StubPepperDSMClientTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/StubPepperDSMClientTest.java
@@ -40,7 +40,7 @@ class StubPepperDSMClientTest extends BaseSpringBootTest {
         var kitStatus = stubPepperDSMClient.fetchKitStatus(kit.getId());
 
         // Assert
-        assertThat(kitStatus, hasProperty("currentStatus", equalTo("SHIPPED")));
+        assertThat(kitStatus, hasProperty("currentStatus", equalTo("SENT")));
     }
 
     @Transactional
@@ -65,7 +65,7 @@ class StubPepperDSMClientTest extends BaseSpringBootTest {
         assertThat(kitStatuses.size(), equalTo(1));
         var kitStatus = kitStatuses.stream().findFirst().get();
         assertThat(kitStatus.getJuniperKitId(), equalTo(kit.getId().toString()));
-        assertThat(kitStatus.getCurrentStatus(), equalTo("SHIPPED"));
+        assertThat(kitStatus.getCurrentStatus(), equalTo("SENT"));
     }
 
     @Autowired

--- a/ui-admin/src/App.tsx
+++ b/ui-admin/src/App.tsx
@@ -25,6 +25,7 @@ import { IdleStatusMonitor } from 'login/IdleStatusMonitor'
 import AdminSidebar from './navbar/AdminSidebar'
 import NavContextProvider from 'navbar/NavContextProvider'
 import PopulateRouteSelect from './populate/PopulateRouteSelect'
+import IntegrationDashboard from './integration/IntegrationDashboard'
 
 /** auto-scroll-to-top on any navigation */
 const ScrollToTop = () => {
@@ -57,6 +58,7 @@ function App() {
                       </ProtectedRoute>}>
                         <Route path="populate/*" element={<PopulateRouteSelect/>}/>
                         <Route path="users" element={<UserList/>}/>
+                        <Route path="integrations/*" element={<IntegrationDashboard/>}/>
                         <Route path=":portalShortcode/*" element={<PortalProvider><PortalRouter/></PortalProvider>}/>
                         <Route index element={<HomePage/>}/>
                       </Route>

--- a/ui-admin/src/integration/IntegrationDashboard.tsx
+++ b/ui-admin/src/integration/IntegrationDashboard.tsx
@@ -1,0 +1,28 @@
+import { NavLink, Outlet, Route, Routes } from 'react-router-dom'
+import React from 'react'
+import KitIntegrationDashboard from './KitIntegrationDashboard'
+
+/** shows links to the populate control panels, and handles the routing for them */
+export default function IntegrationDashboard() {
+  /** styles links as bold if they are the current path */
+  const navStyleFunc = ({ isActive }: {isActive: boolean}) => {
+    return isActive ? { fontWeight: 'bold' } : {}
+  }
+
+  return <div className="container-fluid">
+    <div className="bg-white p-3 ps-5 row">
+      <div className="col-md-2 px-0 py-3 mh-100 bg-white border-end">
+        <h2 className="h4 px-3">Integrations</h2>
+        <ul className="">
+          <li className="py-1"><NavLink to="kits" style={navStyleFunc}>Kits</NavLink></li>
+        </ul>
+      </div>
+      <div className="col-md-6 py-3">
+        <Routes>
+          <Route path="kits" element={<KitIntegrationDashboard/>}/>
+        </Routes>
+        <Outlet/>
+      </div>
+    </div>
+  </div>
+}

--- a/ui-admin/src/integration/KitIntegrationDashboard.tsx
+++ b/ui-admin/src/integration/KitIntegrationDashboard.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react'
+import InfoPopup from '../components/forms/InfoPopup'
+import { Button } from '../components/forms/Button'
+import { doApiLoad } from '../api/api-utils'
+import Api from '../api/api'
+import { Store } from 'react-notifications-component'
+import { successNotification } from 'util/notifications'
+import LoadingSpinner from 'util/LoadingSpinner'
+
+/** shows controls and debug info for testing kit request (Pepper) integrations */
+export default function KitIntegrationDashboard() {
+  const [isStatusSyncing, setIsStatusSyncing] = useState(false)
+  const syncStatuses = async () => {
+    doApiLoad(async () => {
+      await Api.refreshKitStatuses('ourhealth', 'ourheart', 'sandbox')
+      Store.addNotification(successNotification('kit status sync succeeded'))
+    }, {
+      setIsLoading: setIsStatusSyncing,
+      customErrorMsg: 'kit statuses could not be synced'
+    })
+  }
+
+  return <div>
+    <div>
+            Test kit status sync &nbsp;
+      {isStatusSyncing && <LoadingSpinner/> }
+      {!isStatusSyncing && <Button variant="primary" onClick={syncStatuses}>Test</Button>}
+      <InfoPopup content={'Sends a request to sync OurHealth sandbox kit requests'}/>
+    </div>
+  </div>
+}

--- a/ui-admin/src/navbar/AdminSidebar.tsx
+++ b/ui-admin/src/navbar/AdminSidebar.tsx
@@ -50,8 +50,11 @@ const AdminSidebar = () => {
           <li className="mb-2">
             <NavLink to="/users" className="text-white">All users</NavLink>
           </li>
-          <li>
+          <li className="mb-2">
             <NavLink to="/populate" className="text-white">Populate</NavLink>
+          </li>
+          <li>
+            <NavLink to="/integrations" className="text-white">Integrations</NavLink>
           </li>
         </ul>}/>}
     </>}

--- a/ui-admin/src/study/participants/KitRequests.tsx
+++ b/ui-admin/src/study/participants/KitRequests.tsx
@@ -10,6 +10,7 @@ import { instantToDefaultString } from 'util/timeUtils'
 import { useUser } from 'user/UserProvider'
 import InfoPopup from 'components/forms/InfoPopup'
 import KitStatusCell from './KitStatusCell'
+import { doApiLoad } from '../../api/api-utils'
 
 /** Component for rendering the address a kit was sent to based on JSON captured at the time of the kit request. */
 function KitRequestAddress({ sentToAddressJson }: { sentToAddressJson: string }) {
@@ -54,10 +55,12 @@ export default function KitRequests({ enrollee, studyEnvContext, onUpdate }:
   const [showRequestKitModal, setShowRequestKitModal] = useState(false)
 
   const onSubmit = async (kitType: string) => {
-    await Api.createKitRequest(
-      portal.shortcode, study.shortcode, currentEnv.environmentName, enrollee.shortcode, kitType)
-    setShowRequestKitModal(false)
-    onUpdate()
+    await doApiLoad(async () => {
+      await Api.createKitRequest(portal.shortcode, study.shortcode,
+        currentEnv.environmentName, enrollee.shortcode, kitType)
+      setShowRequestKitModal(false)
+      onUpdate()
+    })
   }
 
   const table = useReactTable({


### PR DESCRIPTION
#### DESCRIPTION

This adds a new section "Integrations" to superuser functions in the admin UI.  The goal is to support dashboards that show config, debug and test information for external integrations.  It adds a Kit Integration dashboard which for now is just a "test" button.  To support the "Test" button, the status sync features have been updated to be environment specific so that the "Test" button can be pressed without causing any side effects in live data.  (Eventually we might want a dedicated test endpoint, but the goal was good-enough-for-now).  

This also cleans up the stub service to add logging and use valid Pepper kit statuses

Later PR will update the dashboard with current config information, so the user can see, e.g., which DSM instance is being pointed to.



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. Redeploy ApiAdminApp
2. go to `https://localhost:3000/integrations/kits`
3. click the "Test" button
4. confirm a success message appears
5. <Optional> change StubPepperDsmClient.java  `fetchKitStatusByStudy` to throw an exception, and retry.  Confirm error is indicated in UI
