### PR TITLE
[JN-574] Participant table client side pagination

### DIFF
--- a/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
@@ -101,13 +101,13 @@ test('allows the user to cycle pages', async () => {
   await screen.findAllByText('JOSALK')
 
   expect(screen.getByText('Showing 10 of 100 rows')).toBeInTheDocument()
-  expect(screen.queryByText('Page 1 of 10')).toBeInTheDocument()
+  expect(screen.getByText('Page 1 of 10')).toBeInTheDocument()
 
   await act(() => userEvent.click(screen.getByLabelText('Next page')))
-  expect(screen.queryByText('Page 2 of 10')).toBeInTheDocument()
+  expect(screen.getByText('Page 2 of 10')).toBeInTheDocument()
 
   await act(() => userEvent.click(screen.getByLabelText('Previous page')))
-  expect(screen.queryByText('Page 1 of 10')).toBeInTheDocument()
+  expect(screen.getByText('Page 1 of 10')).toBeInTheDocument()
 })
 
 test('allows the user to change the page size', async () => {
@@ -120,12 +120,12 @@ test('allows the user to change the page size', async () => {
   await screen.findAllByText('JOSALK')
 
   expect(screen.getByText('Showing 10 of 100 rows')).toBeInTheDocument()
-  expect(screen.queryByText('Page 1 of 10')).toBeInTheDocument()
+  expect(screen.getByText('Page 1 of 10')).toBeInTheDocument()
 
   jest.spyOn(Storage.prototype, 'setItem')
   await act(() => userEvent.selectOptions(screen.getByLabelText('Number of rows per page'), '25'))
   expect(screen.getByText('Showing 25 of 100 rows')).toBeInTheDocument()
-  expect(screen.queryByText('Page 1 of 4')).toBeInTheDocument()
+  expect(screen.getByText('Page 1 of 4')).toBeInTheDocument()
 
   //Also assert that the preferred number of rows is saved to local storage
   expect(localStorage.setItem).toHaveBeenCalledWith('participantList.portalCode.fakeStudy.preferredNumRows', '25')

--- a/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
@@ -62,6 +62,35 @@ test('filters participants based on shortcode', async () => {
   })
 })
 
+test('send email is toggled depending on participants selected', async () => {
+  mockSearchApi(1)
+  const studyEnvContext = mockStudyEnvContext()
+  const { RoutedComponent } = setupRouterTest(<ParticipantList studyEnvContext={studyEnvContext}/>)
+  render(RoutedComponent)
+  await waitFor(() => {
+    expect(screen.getByText('JOSALK')).toBeInTheDocument()
+  })
+  const participantLink = screen.getByText('Send email')
+  expect(participantLink).toHaveAttribute('aria-disabled', 'true')
+})
+
+
+test('keyword search sends search api request', async () => {
+  const searchSpy = mockSearchApi(1)
+  const studyEnvContext = mockStudyEnvContext()
+  const { RoutedComponent } = setupRouterTest(<ParticipantList studyEnvContext={studyEnvContext}/>)
+  render(RoutedComponent)
+  await waitFor(() => {
+    expect(screen.getByText('JOSALK')).toBeInTheDocument()
+  })
+  await userEvent.type(screen.getByTitle('search name, email and shortcode'), 'foo')
+  await userEvent.click(screen.getByTitle('submit search'))
+  expect(searchSpy).toHaveBeenCalledTimes(2)
+  expect(searchSpy).toHaveBeenNthCalledWith(2, 'portalCode', 'fakeStudy', 'sandbox', [
+    { facet: KEYWORD_FACET, values: ['foo'] }
+  ])
+})
+
 test('allows the user to cycle pages', async () => {
   mockSearchApi(100)
   const studyEnvContext = mockStudyEnvContext()
@@ -100,33 +129,4 @@ test('allows the user to change the page size', async () => {
 
   //Also assert that the preferred number of rows is saved to local storage
   expect(localStorage.setItem).toHaveBeenCalledWith('participantList.portalCode.fakeStudy.preferredNumRows', '25')
-})
-
-test('send email is toggled depending on participants selected', async () => {
-  mockSearchApi(1)
-  const studyEnvContext = mockStudyEnvContext()
-  const { RoutedComponent } = setupRouterTest(<ParticipantList studyEnvContext={studyEnvContext}/>)
-  render(RoutedComponent)
-  await waitFor(() => {
-    expect(screen.getByText('JOSALK')).toBeInTheDocument()
-  })
-  const participantLink = screen.getByText('Send email')
-  expect(participantLink).toHaveAttribute('aria-disabled', 'true')
-})
-
-
-test('keyword search sends search api request', async () => {
-  const searchSpy = mockSearchApi(1)
-  const studyEnvContext = mockStudyEnvContext()
-  const { RoutedComponent } = setupRouterTest(<ParticipantList studyEnvContext={studyEnvContext}/>)
-  render(RoutedComponent)
-  await waitFor(() => {
-    expect(screen.getByText('JOSALK')).toBeInTheDocument()
-  })
-  await userEvent.type(screen.getByTitle('search name, email and shortcode'), 'foo')
-  await userEvent.click(screen.getByTitle('submit search'))
-  expect(searchSpy).toHaveBeenCalledTimes(2)
-  expect(searchSpy).toHaveBeenNthCalledWith(2, 'portalCode', 'fakeStudy', 'sandbox', [
-    { facet: KEYWORD_FACET, values: ['foo'] }
-  ])
 })

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -135,7 +135,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     },
     initialState: {
       pagination: {
-        pageSize: Number(localStorage.getItem(preferredNumRowsKey) || '10')
+        pageSize: parseInt(localStorage.getItem(preferredNumRowsKey) || '10')
       }
     },
     onColumnVisibilityChange: setColumnVisibility,

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -6,7 +6,7 @@ import { StudyEnvContextT } from '../../StudyEnvironmentRouter'
 import {
   ColumnDef,
   getCoreRowModel,
-  getFilteredRowModel,
+  getFilteredRowModel, getPaginationRowModel,
   getSortedRowModel, PaginationState,
   SortingState, Updater,
   useReactTable, VisibilityState
@@ -50,16 +50,16 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
   const keywordFacetIndex = facetValues.findIndex(facet => facet.facet.category === 'keyword')
   const keywordFacetValue = facetValues[keywordFacetIndex]
 
-  const pageIndex = parseInt(searchParams.get('pageIndex') ?? '1')
-  const pageSize = parseInt(searchParams.get('pageSize') ?? DEFAULT_PAGE_SIZE)
-  const pagination = useMemo(() => ({pageSize, pageIndex}),
-      [pageSize, pageIndex])
-  const setPagination = (pagination: PaginationState | (Updater<PaginationState>)) => {
-    //searchParams.set('pageIndex', pagination.pageIndex.toString())
-    //searchParams.set('pageSize', pagination.pageSize.toString())
-    setSearchParams(searchParams)
-    return pagination
-  }
+  // const pageIndex = parseInt(searchParams.get('pageIndex') ?? '1')
+  // const pageSize = parseInt(searchParams.get('pageSize') ?? DEFAULT_PAGE_SIZE)
+  // const pagination = useMemo(() => ({pageSize, pageIndex}),
+  //     [pageSize, pageIndex])
+  // const setPagination = (pagination: PaginationState | (Updater<PaginationState>)) => {
+  //   //searchParams.set('pageIndex', pagination.pageIndex.toString())
+  //   //searchParams.set('pageSize', pagination.pageSize.toString())
+  //   setSearchParams(searchParams)
+  //   return pagination
+  // }
 
   const columns = useMemo<ColumnDef<EnrolleeSearchResult, string>[]>(() => [{
     id: 'select',
@@ -141,17 +141,18 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     state: {
       sorting,
       rowSelection,
-      pagination,
+      // pagination,
       columnVisibility
     },
     onColumnVisibilityChange: setColumnVisibility,
     enableRowSelection: true,
-    onPaginationChange: setPagination,
-    manualPagination: true,
+    // onPaginationChange: setPagination,
+    // manualPagination: true,
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
     onRowSelectionChange: setRowSelection
   })
 

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -9,6 +9,7 @@ import {
   getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
+  PaginationState,
   SortingState,
   useReactTable,
   VisibilityState
@@ -124,6 +125,11 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     }
   }], [study.shortcode, currentEnv.environmentName])
 
+  const [{ pageIndex, pageSize }] =
+    React.useState<PaginationState>({
+      pageIndex: parseInt(searchParams.get('pageIndex') || '0'),
+      pageSize: parseInt(searchParams.get('pageSize') || localStorage.getItem(preferredNumRowsKey) || '10')
+    })
 
   const table = useReactTable({
     data: participantList,
@@ -135,7 +141,8 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     },
     initialState: {
       pagination: {
-        pageSize: parseInt(localStorage.getItem(preferredNumRowsKey) || '10')
+        pageIndex,
+        pageSize
       }
     },
     onColumnVisibilityChange: setColumnVisibility,

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -6,10 +6,12 @@ import { StudyEnvContextT } from '../../StudyEnvironmentRouter'
 import {
   ColumnDef,
   getCoreRowModel,
-  getFilteredRowModel, getPaginationRowModel,
-  getSortedRowModel, PaginationState,
-  SortingState, Updater,
-  useReactTable, VisibilityState
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable,
+  VisibilityState
 } from '@tanstack/react-table'
 import { basicTableLayout, ColumnVisibilityControl, IndeterminateCheckbox } from 'util/tableUtils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -26,9 +28,7 @@ import { Button } from 'components/forms/Button'
 import { instantToDefaultString } from 'util/timeUtils'
 import { useLoadingEffect } from 'api/api-utils'
 import { FacetView, getUpdatedFacetValues } from './facets/EnrolleeSearchFacets'
-import TableClientPagination from "util/TablePagination";
-
-const DEFAULT_PAGE_SIZE = '20'
+import TableClientPagination from 'util/TablePagination'
 
 /** Shows a list of (for now) enrollees */
 function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
@@ -49,17 +49,6 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
   const facetValues = facetValuesFromString(searchParams.get('facets') ?? '{}', ALL_FACETS)
   const keywordFacetIndex = facetValues.findIndex(facet => facet.facet.category === 'keyword')
   const keywordFacetValue = facetValues[keywordFacetIndex]
-
-  // const pageIndex = parseInt(searchParams.get('pageIndex') ?? '1')
-  // const pageSize = parseInt(searchParams.get('pageSize') ?? DEFAULT_PAGE_SIZE)
-  // const pagination = useMemo(() => ({pageSize, pageIndex}),
-  //     [pageSize, pageIndex])
-  // const setPagination = (pagination: PaginationState | (Updater<PaginationState>)) => {
-  //   //searchParams.set('pageIndex', pagination.pageIndex.toString())
-  //   //searchParams.set('pageSize', pagination.pageSize.toString())
-  //   setSearchParams(searchParams)
-  //   return pagination
-  // }
 
   const columns = useMemo<ColumnDef<EnrolleeSearchResult, string>[]>(() => [{
     id: 'select',
@@ -141,13 +130,10 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     state: {
       sorting,
       rowSelection,
-      // pagination,
       columnVisibility
     },
     onColumnVisibilityChange: setColumnVisibility,
     enableRowSelection: true,
-    // onPaginationChange: setPagination,
-    // manualPagination: true,
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -7,8 +7,8 @@ import {
   ColumnDef,
   getCoreRowModel,
   getFilteredRowModel,
-  getSortedRowModel,
-  SortingState,
+  getSortedRowModel, PaginationState,
+  SortingState, Updater,
   useReactTable, VisibilityState
 } from '@tanstack/react-table'
 import { basicTableLayout, ColumnVisibilityControl, IndeterminateCheckbox } from 'util/tableUtils'
@@ -26,7 +26,9 @@ import { Button } from 'components/forms/Button'
 import { instantToDefaultString } from 'util/timeUtils'
 import { useLoadingEffect } from 'api/api-utils'
 import { FacetView, getUpdatedFacetValues } from './facets/EnrolleeSearchFacets'
+import TableClientPagination from "util/TablePagination";
 
+const DEFAULT_PAGE_SIZE = '20'
 
 /** Shows a list of (for now) enrollees */
 function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
@@ -48,6 +50,16 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
   const keywordFacetIndex = facetValues.findIndex(facet => facet.facet.category === 'keyword')
   const keywordFacetValue = facetValues[keywordFacetIndex]
 
+  const pageIndex = parseInt(searchParams.get('pageIndex') ?? '1')
+  const pageSize = parseInt(searchParams.get('pageSize') ?? DEFAULT_PAGE_SIZE)
+  const pagination = useMemo(() => ({pageSize, pageIndex}),
+      [pageSize, pageIndex])
+  const setPagination = (pagination: PaginationState | (Updater<PaginationState>)) => {
+    //searchParams.set('pageIndex', pagination.pageIndex.toString())
+    //searchParams.set('pageSize', pagination.pageSize.toString())
+    setSearchParams(searchParams)
+    return pagination
+  }
 
   const columns = useMemo<ColumnDef<EnrolleeSearchResult, string>[]>(() => [{
     id: 'select',
@@ -129,10 +141,13 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     state: {
       sorting,
       rowSelection,
+      pagination,
       columnVisibility
     },
     onColumnVisibilityChange: setColumnVisibility,
     enableRowSelection: true,
+    onPaginationChange: setPagination,
+    manualPagination: true,
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
@@ -191,7 +206,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
             </div>
           </div>
           { basicTableLayout(table, { filterable: true })}
-          { participantList.length === 0 && <span className="text-muted fst-italic">No participants</span>}
+          <TableClientPagination table={table}/>
         </LoadingSpinner>
       </div>
     </div>

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -49,6 +49,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
   const facetValues = facetValuesFromString(searchParams.get('facets') ?? '{}', ALL_FACETS)
   const keywordFacetIndex = facetValues.findIndex(facet => facet.facet.category === 'keyword')
   const keywordFacetValue = facetValues[keywordFacetIndex]
+  const preferredNumRowsKey = `participantList.${portal.shortcode}.${study.shortcode}.preferredNumRows`
 
   const columns = useMemo<ColumnDef<EnrolleeSearchResult, string>[]>(() => [{
     id: 'select',
@@ -132,6 +133,11 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
       rowSelection,
       columnVisibility
     },
+    initialState: {
+      pagination: {
+        pageSize: Number(localStorage.getItem(preferredNumRowsKey) || '10')
+      }
+    },
     onColumnVisibilityChange: setColumnVisibility,
     enableRowSelection: true,
     onSortingChange: setSorting,
@@ -193,7 +199,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
             </div>
           </div>
           { basicTableLayout(table, { filterable: true })}
-          <TableClientPagination table={table}/>
+          <TableClientPagination table={table} preferredNumRowsKey={preferredNumRowsKey}/>
         </LoadingSpinner>
       </div>
     </div>

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -126,7 +126,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
   }], [study.shortcode, currentEnv.environmentName])
 
   const [{ pageIndex, pageSize }] =
-    React.useState<PaginationState>({
+    useState<PaginationState>({
       pageIndex: parseInt(searchParams.get('pageIndex') || '0'),
       pageSize: parseInt(searchParams.get('pageSize') || localStorage.getItem(preferredNumRowsKey) || '10')
     })

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -3,6 +3,7 @@ import {
   ConsentForm,
   DatasetDetails,
   Enrollee,
+  EnrolleeSearchResult,
   KitRequest,
   KitType,
   NotificationConfig,
@@ -258,6 +259,18 @@ export const mockEnrollee: () => Enrollee = () => {
     },
     participantTasks: [],
     kitRequests: [mockKitRequest()]
+  }
+}
+
+export const mockEnrolleeSearchResult: () => EnrolleeSearchResult = () => {
+  return {
+    enrollee: mockEnrollee(),
+    profile: mockEnrollee().profile,
+    mostRecentKitStatus: null,
+    participantUser: {
+      lastLogin: 50405345,
+      username: `${randomString(10)}@test.com`
+    }
   }
 }
 

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -262,6 +262,7 @@ export const mockEnrollee: () => Enrollee = () => {
   }
 }
 
+/** returns a mock enrollee search result */
 export const mockEnrolleeSearchResult: () => EnrolleeSearchResult = () => {
   return {
     enrollee: mockEnrollee(),

--- a/ui-admin/src/util/TablePagination.tsx
+++ b/ui-admin/src/util/TablePagination.tsx
@@ -16,6 +16,7 @@ export default function TableClientPagination<R>({ table, preferredNumRowsKey }:
     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
       <div>Showing {table.getRowModel().rows.length} of {table.getFilteredRowModel().rows.length} rows</div>
       <select
+        aria-label={'Number of rows per page'}
         className="form-select m-1 w-auto"
         value={table.getState().pagination.pageSize}
         onChange={e => {

--- a/ui-admin/src/util/TablePagination.tsx
+++ b/ui-admin/src/util/TablePagination.tsx
@@ -1,72 +1,47 @@
 import React from 'react'
-import {Table} from "@tanstack/react-table";
+import { Table } from '@tanstack/react-table'
+import { faCaretLeft, faCaretRight } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 /** renders a client-side pagination control (as in, the data is all loaded from the server at once, but
  * paged on the UI for readability */
-export default function TableClientPagination<R>({table}: {table: Table<R>}) {
-    return <div>
-        <div className="flex items-center gap-2">
-            <button
-                className="border rounded p-1"
-                onClick={() => table.setPageIndex(0)}
-                disabled={!table.getCanPreviousPage()}
-            >
-                {'<<'}
-            </button>
-            <button
-                className="border rounded p-1"
-                onClick={() => table.previousPage()}
-                disabled={!table.getCanPreviousPage()}
-            >
-                {'<'}
-            </button>
-            <button
-                className="border rounded p-1"
-                onClick={() => table.nextPage()}
-                disabled={!table.getCanNextPage()}
-            >
-                {'>'}
-            </button>
-            <button
-                className="border rounded p-1"
-                onClick={() => table.setPageIndex(table.getPageCount() - 1)}
-                disabled={!table.getCanNextPage()}
-            >
-                {'>>'}
-            </button>
-            <span className="flex items-center gap-1">
-          <div>Page</div>
-          <strong>
-            {table.getState().pagination.pageIndex + 1} of{' '}
-              {table.getPageCount()}
-          </strong>
-        </span>
-            <span className="flex items-center gap-1">
-          | Go to page:
-          <input
-              type="number"
-              defaultValue={table.getState().pagination.pageIndex + 1}
-              onChange={e => {
-                  const page = e.target.value ? Number(e.target.value) - 1 : 0
-                  table.setPageIndex(page)
-              }}
-              className="border p-1 rounded w-16"
-          />
-        </span>
-            <select
-                value={table.getState().pagination.pageSize}
-                onChange={e => {
-                    table.setPageSize(Number(e.target.value))
-                }}
-            >
-                {[10, 20, 30, 40, 50].map(pageSize => (
-                    <option key={pageSize} value={pageSize}>
-                        Show {pageSize}
-                    </option>
-                ))}
-            </select>
-        </div>
-        <div>{table.getRowModel().rows.length} Rows</div>
-        <pre>{JSON.stringify(table.getState().pagination, null, 2)}</pre>
+export default function TableClientPagination<R>({ table }: {table: Table<R>}) {
+  return <div style={{ padding: "0 1rem 1rem 1rem",
+    display: 'flex', justifyContent: 'space-between' }}>
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <div>Showing {table.getRowModel().rows.length} of {table.getFilteredRowModel().rows.length} rows</div>
+      <select
+        className="form-select m-1 w-auto"
+        value={table.getState().pagination.pageSize}
+        onChange={e => {
+          table.setPageSize(Number(e.target.value))
+        }}
+      >
+        {[10, 25, 50, 100].map(pageSize => (
+          <option key={pageSize} value={pageSize}>
+            {pageSize}
+          </option>
+        ))}
+      </select>
     </div>
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <button
+        className="btn btn-light border m-1"
+        onClick={() => table.previousPage()}
+        disabled={!table.getCanPreviousPage()}
+      >
+        <FontAwesomeIcon icon={faCaretLeft} className="fa-sm"/>
+      </button>
+      <span>
+        Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
+      </span>
+      <button
+        className="btn btn-light border m-1"
+        onClick={() => table.nextPage()}
+        disabled={!table.getCanNextPage()}
+      >
+        <FontAwesomeIcon icon={faCaretRight} className="fa-sm"/>
+      </button>
+    </div>
+  </div>
 }

--- a/ui-admin/src/util/TablePagination.tsx
+++ b/ui-admin/src/util/TablePagination.tsx
@@ -1,7 +1,8 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Table } from '@tanstack/react-table'
 import { faCaretLeft, faCaretRight } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { useSearchParams } from 'react-router-dom'
 
 /** renders a client-side pagination control (as in, the data is all loaded from the server at once, but
  * paged on the UI for readability */
@@ -9,6 +10,28 @@ export default function TableClientPagination<R>({ table, preferredNumRowsKey }:
   table: Table<R>,
   preferredNumRowsKey: string | undefined
 }) {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const updateSearchParams = () => {
+    searchParams.set('pageIndex', table.getState().pagination.pageIndex.toString())
+    searchParams.set('pageSize', table.getState().pagination.pageSize.toString())
+    setSearchParams(searchParams)
+  }
+
+  useEffect(() => {
+    updateSearchParams()
+  }, [table.getState().pagination.pageIndex, table.getState().pagination.pageSize])
+
+  useEffect(() => {
+    const preferredPageSize = preferredNumRowsKey ? localStorage.getItem(preferredNumRowsKey) : undefined
+    const pageSizeParam = searchParams.get('pageSize')
+    const pageSize = parseInt(pageSizeParam || preferredPageSize || '10')
+    const pageIndex = parseInt(searchParams.get('pageIndex') || '0')
+
+    table.setPageIndex(pageIndex)
+    table.setPageSize(pageSize)
+  }, [table])
+
   return <div style={{
     padding: '0 1rem 1rem 1rem',
     display: 'flex', justifyContent: 'space-between'

--- a/ui-admin/src/util/TablePagination.tsx
+++ b/ui-admin/src/util/TablePagination.tsx
@@ -5,7 +5,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 /** renders a client-side pagination control (as in, the data is all loaded from the server at once, but
  * paged on the UI for readability */
-export default function TableClientPagination<R>({ table }: {table: Table<R>}) {
+export default function TableClientPagination<R>({ table, preferredNumRowsKey }: {
+  table: Table<R>,
+  preferredNumRowsKey: string | undefined
+}) {
   return <div style={{
     padding: '0 1rem 1rem 1rem',
     display: 'flex', justifyContent: 'space-between'
@@ -17,6 +20,8 @@ export default function TableClientPagination<R>({ table }: {table: Table<R>}) {
         value={table.getState().pagination.pageSize}
         onChange={e => {
           table.setPageSize(Number(e.target.value))
+          // save the preferred number of rows to local storage so the user doesn't have to keep changing it
+          if (preferredNumRowsKey) { localStorage.setItem(preferredNumRowsKey, e.target.value) }
         }}
       >
         {[10, 25, 50, 100].map(pageSize => (

--- a/ui-admin/src/util/TablePagination.tsx
+++ b/ui-admin/src/util/TablePagination.tsx
@@ -6,8 +6,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 /** renders a client-side pagination control (as in, the data is all loaded from the server at once, but
  * paged on the UI for readability */
 export default function TableClientPagination<R>({ table }: {table: Table<R>}) {
-  return <div style={{ padding: "0 1rem 1rem 1rem",
-    display: 'flex', justifyContent: 'space-between' }}>
+  return <div style={{
+    padding: '0 1rem 1rem 1rem',
+    display: 'flex', justifyContent: 'space-between'
+  }}>
     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
       <div>Showing {table.getRowModel().rows.length} of {table.getFilteredRowModel().rows.length} rows</div>
       <select

--- a/ui-admin/src/util/TablePagination.tsx
+++ b/ui-admin/src/util/TablePagination.tsx
@@ -12,25 +12,11 @@ export default function TableClientPagination<R>({ table, preferredNumRowsKey }:
 }) {
   const [searchParams, setSearchParams] = useSearchParams()
 
-  const updateSearchParams = () => {
+  useEffect(() => {
     searchParams.set('pageIndex', table.getState().pagination.pageIndex.toString())
     searchParams.set('pageSize', table.getState().pagination.pageSize.toString())
     setSearchParams(searchParams)
-  }
-
-  useEffect(() => {
-    updateSearchParams()
   }, [table.getState().pagination.pageIndex, table.getState().pagination.pageSize])
-
-  useEffect(() => {
-    const preferredPageSize = preferredNumRowsKey ? localStorage.getItem(preferredNumRowsKey) : undefined
-    const pageSizeParam = searchParams.get('pageSize')
-    const pageSize = parseInt(pageSizeParam || preferredPageSize || '10')
-    const pageIndex = parseInt(searchParams.get('pageIndex') || '0')
-
-    table.setPageIndex(pageIndex)
-    table.setPageSize(pageSize)
-  }, [table])
 
   return <div style={{
     padding: '0 1rem 1rem 1rem',

--- a/ui-admin/src/util/TablePagination.tsx
+++ b/ui-admin/src/util/TablePagination.tsx
@@ -33,6 +33,7 @@ export default function TableClientPagination<R>({ table, preferredNumRowsKey }:
     </div>
     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
       <button
+        aria-label={'Previous page'}
         className="btn btn-light border m-1"
         onClick={() => table.previousPage()}
         disabled={!table.getCanPreviousPage()}
@@ -43,6 +44,7 @@ export default function TableClientPagination<R>({ table, preferredNumRowsKey }:
         Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
       </span>
       <button
+        aria-label={'Next page'}
         className="btn btn-light border m-1"
         onClick={() => table.nextPage()}
         disabled={!table.getCanNextPage()}

--- a/ui-admin/src/util/TablePagination.tsx
+++ b/ui-admin/src/util/TablePagination.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import {Table} from "@tanstack/react-table";
+
+/** renders a client-side pagination control (as in, the data is all loaded from the server at once, but
+ * paged on the UI for readability */
+export default function TableClientPagination<R>({table}: {table: Table<R>}) {
+    return <div>
+        <div className="flex items-center gap-2">
+            <button
+                className="border rounded p-1"
+                onClick={() => table.setPageIndex(0)}
+                disabled={!table.getCanPreviousPage()}
+            >
+                {'<<'}
+            </button>
+            <button
+                className="border rounded p-1"
+                onClick={() => table.previousPage()}
+                disabled={!table.getCanPreviousPage()}
+            >
+                {'<'}
+            </button>
+            <button
+                className="border rounded p-1"
+                onClick={() => table.nextPage()}
+                disabled={!table.getCanNextPage()}
+            >
+                {'>'}
+            </button>
+            <button
+                className="border rounded p-1"
+                onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+                disabled={!table.getCanNextPage()}
+            >
+                {'>>'}
+            </button>
+            <span className="flex items-center gap-1">
+          <div>Page</div>
+          <strong>
+            {table.getState().pagination.pageIndex + 1} of{' '}
+              {table.getPageCount()}
+          </strong>
+        </span>
+            <span className="flex items-center gap-1">
+          | Go to page:
+          <input
+              type="number"
+              defaultValue={table.getState().pagination.pageIndex + 1}
+              onChange={e => {
+                  const page = e.target.value ? Number(e.target.value) - 1 : 0
+                  table.setPageIndex(page)
+              }}
+              className="border p-1 rounded w-16"
+          />
+        </span>
+            <select
+                value={table.getState().pagination.pageSize}
+                onChange={e => {
+                    table.setPageSize(Number(e.target.value))
+                }}
+            >
+                {[10, 20, 30, 40, 50].map(pageSize => (
+                    <option key={pageSize} value={pageSize}>
+                        Show {pageSize}
+                    </option>
+                ))}
+            </select>
+        </div>
+        <div>{table.getRowModel().rows.length} Rows</div>
+        <pre>{JSON.stringify(table.getState().pagination, null, 2)}</pre>
+    </div>
+}


### PR DESCRIPTION
#### DESCRIPTION

This adds client side pagination to the participant table. Based on Erin's mockups in [JN-574](https://broadworkbench.atlassian.net/browse/JN-574)

![Screenshot 2023-10-04 at 1 42 13 PM](https://github.com/broadinstitute/juniper/assets/7257391/3424535d-287d-422c-a315-8280224fb2f1)



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Start up local admin API + UI
* Run the bulk populate script to add 1000 new users (see the new helper script [here](https://github.com/broadinstitute/juniper/blob/development/scripts/populate_enrollee_bulk.sh))
* Play around with pagination and filtering to make sure it works as expected and performs well (I tested with about 4000 participants and it was fine)
* Test out that your pageSize preference is remembered after refreshing and that it's updated when you change to a different pageSize. Also verify that this preference persists across study environments within the same study.

[JN-574]: https://broadworkbench.atlassian.net/browse/JN-574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ