### PR TITLE
[JN-609] adding sort order to export

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/EnrolleeExportExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/EnrolleeExportExtService.java
@@ -36,12 +36,12 @@ public class EnrolleeExportExtService {
       EnvironmentName environmentName,
       OutputStream os,
       AdminUser user) {
-    Portal portal = authUtilService.authUserToPortal(user, portalShortcode);
+    authUtilService.authUserToPortal(user, portalShortcode);
     authUtilService.authUserToStudy(user, portalShortcode, studyShortcode);
     StudyEnvironment studyEnv =
         studyEnvironmentService.findByStudy(studyShortcode, environmentName).get();
     try {
-      enrolleeExportService.export(options, portal.getId(), studyEnv.getId(), os);
+      enrolleeExportService.export(options, studyEnv.getId(), os);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeDao.java
@@ -59,8 +59,10 @@ public class EnrolleeDao extends BaseMutableJdbiDao<Enrollee> {
         return findByProperty("shortcode", shortcode);
     }
 
+    /** note this returns enrollees sorted by created_at */
     public List<Enrollee> findByStudyEnvironmentId(UUID studyEnvironmentId) {
-        return findAllByProperty("study_environment_id", studyEnvironmentId);
+        return findAllByPropertySorted("study_environment_id", studyEnvironmentId,
+                "created_at", "DESC");
     }
 
     @Transactional

--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeDao.java
@@ -59,10 +59,13 @@ public class EnrolleeDao extends BaseMutableJdbiDao<Enrollee> {
         return findByProperty("shortcode", shortcode);
     }
 
-    /** note this returns enrollees sorted by created_at */
     public List<Enrollee> findByStudyEnvironmentId(UUID studyEnvironmentId) {
+        return findAllByProperty("study_environment_id", studyEnvironmentId);
+    }
+
+    public List<Enrollee> findByStudyEnvironmentId(UUID studyEnvironmentId, String sortProperty, String sortDir) {
         return findAllByPropertySorted("study_environment_id", studyEnvironmentId,
-                "created_at", "DESC");
+                sortProperty, sortDir);
     }
 
     @Transactional

--- a/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoExportService.java
@@ -172,7 +172,7 @@ public class DataRepoExportService {
 
         try {
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-            enrolleeExportService.export(exportOptions, portalStudy.getPortalId(), studyEnvironmentId, outputStream);
+            enrolleeExportService.export(exportOptions, studyEnvironmentId, outputStream);
             outputStream.close();
 
             String exportData = outputStream.toString();

--- a/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoExportService.java
@@ -217,8 +217,8 @@ public class DataRepoExportService {
         Set<TdrColumn> tdrColumns = new LinkedHashSet<>();
 
         try {
-            List<ModuleExportInfo> moduleExportInfos = enrolleeExportService.generateModuleInfos(exportOptions, portalStudy.getPortalId(), studyEnvironmentId);
-            List<Map<String, String>> enrolleeMaps = enrolleeExportService.generateExportMaps(portalStudy.getPortalId(), studyEnvironmentId,
+            List<ModuleExportInfo> moduleExportInfos = enrolleeExportService.generateModuleInfos(exportOptions, studyEnvironmentId);
+            List<Map<String, String>> enrolleeMaps = enrolleeExportService.generateExportMaps(studyEnvironmentId,
                     moduleExportInfos, exportOptions.limit());
 
             TsvExporter tsvExporter = new TsvExporter(moduleExportInfos, enrolleeMaps);

--- a/core/src/main/java/bio/terra/pearl/core/service/export/DictionaryExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/DictionaryExportService.java
@@ -20,8 +20,7 @@ public class DictionaryExportService {
     public void exportDictionary(ExportOptions exportOptions, UUID portalId,
                                  UUID studyEnvironmentId,
                                  OutputStream os) throws Exception {
-        List<ModuleExportInfo> moduleInfos = enrolleeExportService.generateModuleInfos(exportOptions, portalId,
-                studyEnvironmentId);
+        List<ModuleExportInfo> moduleInfos = enrolleeExportService.generateModuleInfos(exportOptions, studyEnvironmentId);
         // for now, we only support Excel
         DataDictionaryExcelExporter exporter = new DataDictionaryExcelExporter(moduleInfos, objectMapper);
         exporter.export(os);

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
@@ -55,7 +55,7 @@ public class EnrolleeExportService {
 
     /**
      * exports the specified number of enrollees from the given environment
-     * The enrollees will be returned most-recent first
+     * The enrollees will be returned most-recently-created first
      * */
     public void export(ExportOptions exportOptions, UUID studyEnvironmentId, OutputStream os) throws Exception {
         List<ModuleExportInfo> moduleExportInfos = generateModuleInfos(exportOptions, studyEnvironmentId);
@@ -98,7 +98,6 @@ public class EnrolleeExportService {
      * gets information about the modules, which will determine the columns needed for the export
      * e.g. the columns needed to represent the survey questions.
      */
-
     public List<ModuleExportInfo> generateModuleInfos(ExportOptions exportOptions, UUID studyEnvironmentId) throws Exception {
         List<ModuleExportInfo> moduleInfo = new ArrayList<>();
         moduleInfo.add(new EnrolleeFormatter().getModuleExportInfo(exportOptions));

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
@@ -57,7 +57,7 @@ public class EnrolleeExportService {
      * exports the specified number of enrollees from the given environment
      * The enrollees will be returned most-recent first
      * */
-    public void export(ExportOptions exportOptions, UUID portalId, UUID studyEnvironmentId, OutputStream os) throws Exception {
+    public void export(ExportOptions exportOptions, UUID studyEnvironmentId, OutputStream os) throws Exception {
         List<ModuleExportInfo> moduleExportInfos = generateModuleInfos(exportOptions, studyEnvironmentId);
         var enrolleeMaps = generateExportMaps(studyEnvironmentId,
                 moduleExportInfos, exportOptions.limit());
@@ -67,7 +67,7 @@ public class EnrolleeExportService {
 
     public List<Map<String, String>> generateExportMaps(UUID studyEnvironmentId,
                                                    List<ModuleExportInfo> moduleExportInfos, Integer limit) throws Exception {
-        List<Enrollee> enrollees = enrolleeService.findByStudyEnvironment(studyEnvironmentId);
+        List<Enrollee> enrollees = enrolleeService.findByStudyEnvironment(studyEnvironmentId, "created_at", "DESC");
         if (limit != null && enrollees.size() > 0) {
             enrollees = enrollees.subList(0, Math.min(enrollees.size(), limit));
         }

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeService.java
@@ -97,9 +97,12 @@ public class EnrolleeService extends CrudService<Enrollee, EnrolleeDao> {
         return dao.findAllByShortcodes(shortcodes);
     }
 
-    /** note that this returns sorted by created_at */
     public List<Enrollee> findByStudyEnvironment(UUID studyEnvironmentId) {
         return dao.findByStudyEnvironmentId(studyEnvironmentId);
+    }
+
+    public List<Enrollee> findByStudyEnvironment(UUID studyEnvironmentId, String sortProperty, String sortDir) {
+        return dao.findByStudyEnvironmentId(studyEnvironmentId, sortProperty, sortDir);
     }
 
     public List<Enrollee> findForKitManagement(String studyShortcode, EnvironmentName envName) {

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeService.java
@@ -97,6 +97,7 @@ public class EnrolleeService extends CrudService<Enrollee, EnrolleeDao> {
         return dao.findAllByShortcodes(shortcodes);
     }
 
+    /** note that this returns sorted by created_at */
     public List<Enrollee> findByStudyEnvironment(UUID studyEnvironmentId) {
         return dao.findByStudyEnvironmentId(studyEnvironmentId);
     }

--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeExportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeExportServiceTests.java
@@ -1,0 +1,44 @@
+package bio.terra.pearl.core.service.export;
+
+import bio.terra.pearl.core.BaseSpringBootTest;
+import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
+import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
+import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.participant.Profile;
+import bio.terra.pearl.core.model.study.StudyEnvironment;
+import bio.terra.pearl.core.service.export.instance.ExportOptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+public class EnrolleeExportServiceTests extends BaseSpringBootTest {
+    @Autowired
+    private StudyEnvironmentFactory studyEnvironmentFactory;
+    @Autowired
+    private EnrolleeFactory enrolleeFactory;
+    @Autowired
+    private EnrolleeExportService enrolleeExportService;
+
+    @Test
+    public void testExportNumberLimit(TestInfo testInfo) throws Exception {
+        String testName = getTestName(testInfo);
+        StudyEnvironment studyEnv = studyEnvironmentFactory.buildPersisted(testName);
+        Enrollee enrollee1 = enrolleeFactory.buildPersisted(testName, studyEnv, new Profile());
+        Enrollee enrollee2 = enrolleeFactory.buildPersisted(testName, studyEnv, new Profile());
+        Enrollee enrollee3 = enrolleeFactory.buildPersisted(testName, studyEnv, new Profile());
+        var exportModuleInfo = enrolleeExportService.generateModuleInfos(new ExportOptions(), studyEnv.getId());
+        List<Map<String, String>> exportMaps = enrolleeExportService.generateExportMaps(studyEnv.getId(), exportModuleInfo, 2);
+
+        assertThat(exportMaps, hasSize(2));
+        // confirm enrollees are in reverse order of creation
+        assertThat(exportMaps.get(0).get("enrollee.shortcode"), equalTo(enrollee3.getShortcode()));
+        assertThat(exportMaps.get(1).get("enrollee.shortcode"), equalTo(enrollee2.getShortcode()));
+    }
+}

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateOurhealthTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateOurhealthTest.java
@@ -58,7 +58,7 @@ public class PopulateOurhealthTest extends BasePopulatePortalsTest {
         checkParticipantNotes(enrollees);
         checkAdminTasks(sandboxEnvironmentId);
         checkOurhealthSiteContent(portal.getId());
-        checkExportContent(portal.getId(), sandboxEnvironmentId);
+        checkExportContent(sandboxEnvironmentId);
         checkDataDictionary(portal.getId(), sandboxEnvironmentId);
         checkWithdrawn();
 
@@ -111,10 +111,10 @@ public class PopulateOurhealthTest extends BasePopulatePortalsTest {
         assertThat(taskInfo.participantNotes(), hasSize(3));
     }
 
-    private void checkExportContent(UUID portalId, UUID sandboxEnvironmentId) throws Exception {
+    private void checkExportContent(UUID sandboxEnvironmentId) throws Exception {
         ExportOptions options = new ExportOptions(false, false, true, ExportFileFormat.TSV, null);
-        List<ModuleExportInfo> moduleInfos = enrolleeExportService.generateModuleInfos(options, portalId, sandboxEnvironmentId);
-        List<Map<String, String>> exportData = enrolleeExportService.generateExportMaps(portalId, sandboxEnvironmentId, moduleInfos, options.limit());
+        List<ModuleExportInfo> moduleInfos = enrolleeExportService.generateModuleInfos(options, sandboxEnvironmentId);
+        List<Map<String, String>> exportData = enrolleeExportService.generateExportMaps(sandboxEnvironmentId, moduleInfos, options.limit());
 
         assertThat(exportData, hasSize(5));
         Map<String, String> jsalkMap = exportData.stream().filter(map -> "OHSALK".equals(map.get("enrollee.shortcode")))


### PR DESCRIPTION
#### DESCRIPTION

When smoke testing, it's nice to have a predictable order for exports.  This uses most-recent first so that the most recent participant will appear in the export preview which will help study staff confirm the export of the most recent participant.  Along the way, this cleans up some unused params, and adds a test.  

Export was a very-quickly-thrown-together feature that will need some work in the future (most notably `loadAllEnrolleesForExport` loads enrollees individually, which won't scale for long).

Also notable, this PR introduces a DAO getByX() method that takes sorting parameters.  I'm not thrilled with this, since at some level it breaks DAO encapsulation -- column names and SQL sort directions are a DAO concern, and so they shouldn't be specified by services.  But this seems better than adding a million different permutations of getByXSortedByY methods.  I suspect the long term solution is a composable framework, possibly based on JOOQ, that lets DAOs retain responsibility for query formulation, without requiring a separate method for every query.  In the meantime, we can see how this feels

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. repopulate OurHealth `./scripts/populate_portal ourhealth`
2. go to `https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/export/dataBrowser`
3. confirm the enrollees appear most-recent-created first (order will be 
OHBASC | OHSALK | OHSENT | OHNEWB | OHKITS )



