### PR TITLE
[JN-598] deactivating studyEnvSurvey configs

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
@@ -143,7 +143,7 @@ public class SurveyExtService {
       throw new IllegalArgumentException(
           "Updates can only be made directly to the sandbox environment".formatted(envName));
     }
-    studyEnvironmentSurveyService.delete(configuredSurveyId, CascadeProperty.EMPTY_SET);
+    studyEnvironmentSurveyService.deactivate(configuredSurveyId);
   }
 
   public StudyEnvironmentSurvey updateConfiguredSurvey(

--- a/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
@@ -295,6 +295,23 @@ public abstract class BaseJdbiDao<T extends BaseEntity> {
         );
     }
 
+    protected List<T> findAllByTwoPropertiesSorted(String column1Name, Object column1Value,
+                                                   String column2Name, Object column2Value,
+                                                   String sortProperty, String sortDir) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("""
+                                select * from %s 
+                                where %s = :column1Value
+                                and %s = :column2Value
+                                order by %s %s
+                                """.formatted(tableName, column1Name, column2Name, sortProperty, sortDir))
+                        .bind("column1Value", column1Value)
+                        .bind("column2Value", column2Value)
+                        .mapTo(clazz)
+                        .list()
+        );
+    }
+
     /** defaults to matching on id if provided. */
     public Optional<T> findOneMatch(T matchObj) {
         if (matchObj.getId() != null) {

--- a/core/src/main/java/bio/terra/pearl/core/dao/study/StudyEnvironmentSurveyDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/study/StudyEnvironmentSurveyDao.java
@@ -59,7 +59,7 @@ public class StudyEnvironmentSurveyDao extends BaseMutableJdbiDao<StudyEnvironme
     }
 
     /** finds by a surveyId and studyEnvironment, limited to active surveys */
-    public Optional<StudyEnvironmentSurvey> findBySurvey(UUID studyEnvId, UUID surveyId) {
+    public Optional<StudyEnvironmentSurvey> findActiveBySurvey(UUID studyEnvId, UUID surveyId) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("""
                                 select * from %s
@@ -74,7 +74,7 @@ public class StudyEnvironmentSurveyDao extends BaseMutableJdbiDao<StudyEnvironme
         );
     }
 
-    public List<StudyEnvironmentSurvey> findBySurvey(UUID studyEnvId, String surveyStableId) {
+    public List<StudyEnvironmentSurvey> findActiveBySurvey(UUID studyEnvId, String surveyStableId) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("""
                                 select %s from %s a

--- a/core/src/main/java/bio/terra/pearl/core/dao/study/StudyEnvironmentSurveyDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/study/StudyEnvironmentSurveyDao.java
@@ -29,8 +29,13 @@ public class StudyEnvironmentSurveyDao extends BaseMutableJdbiDao<StudyEnvironme
     }
 
     public List<StudyEnvironmentSurvey> findAllByStudyEnvironmentId(UUID studyEnvId) {
-        return findAllByPropertySorted("study_environment_id", studyEnvId,
-                "survey_order", "ASC");
+        return findAllByStudyEnvironmentId(studyEnvId, true);
+    }
+
+    public List<StudyEnvironmentSurvey> findAllByStudyEnvironmentId(UUID studyEnvId, boolean active) {
+        return findAllByTwoPropertiesSorted("study_environment_id", studyEnvId,
+                            "active", active,
+                             "survey_order", "ASC");
     }
 
     /** gets all the study environment surveys and attaches the relevant survey objects in a batch */
@@ -53,18 +58,31 @@ public class StudyEnvironmentSurveyDao extends BaseMutableJdbiDao<StudyEnvironme
         deleteByProperty("survey_id", surveyId);
     }
 
-    /** finds by a surveyId and studyEnvironment */
+    /** finds by a surveyId and studyEnvironment, limited to active surveys */
     public Optional<StudyEnvironmentSurvey> findBySurvey(UUID studyEnvId, UUID surveyId) {
-        return findByTwoProperties("study_environment_id",studyEnvId,
-                "survey_id", surveyId);
+        return jdbi.withHandle(handle ->
+                handle.createQuery("""
+                                select * from %s
+                                    where study_environment_id = :studyEnvId
+                                    and survey_id = :surveyId
+                                    and a.active = true;
+                                """.formatted(prefixedGetQueryColumns("a"), tableName))
+                        .bind("surveyId", surveyId)
+                        .bind("studyEnvId", studyEnvId)
+                        .mapTo(clazz)
+                        .findOne()
+        );
     }
 
     public List<StudyEnvironmentSurvey> findBySurvey(UUID studyEnvId, String surveyStableId) {
         return jdbi.withHandle(handle ->
-                handle.createQuery("select " + prefixedGetQueryColumns("a") + " from " + tableName +
-                                " a join survey on survey.id = a.survey_id" +
-                                " where survey.stable_id = :stableId " +
-                                " and a.study_environment_id = :studyEnvId;")
+                handle.createQuery("""
+                                select %s from %s a
+                                    join survey on survey.id = a.survey_id
+                                    where survey.stable_id = :stableId
+                                    and a.study_environment_id = :studyEnvId
+                                    and a.active = true;
+                                """.formatted(prefixedGetQueryColumns("a"), tableName))
                         .bind("stableId", surveyStableId)
                         .bind("studyEnvId", studyEnvId)
                         .mapTo(clazz)

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/StudyEnvironmentSurvey.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/StudyEnvironmentSurvey.java
@@ -18,6 +18,8 @@ import java.util.UUID;
 public class StudyEnvironmentSurvey extends BaseEntity implements VersionedEntityConfig {
     private UUID studyEnvironmentId;
     private UUID surveyId;
+    @Builder.Default
+    private boolean active = true; // whether this represents a current configuration
     private Survey survey;
     @Builder.Default
     private boolean recur = false;

--- a/core/src/main/java/bio/terra/pearl/core/service/publishing/StudyPublishingService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/publishing/StudyPublishingService.java
@@ -113,7 +113,7 @@ public class StudyPublishingService {
             PublishingUtils.assignPublishedVersionIfNeeded(destEnv.getEnvironmentName(), config, surveyService);
         }
         for(StudyEnvironmentSurvey config : listChange.removedItems()) {
-            studyEnvironmentSurveyService.delete(config.getId(), CascadeProperty.EMPTY_SET);
+            studyEnvironmentSurveyService.deactivate(config.getId());
             destEnv.getConfiguredSurveys().remove(config);
         }
         for(VersionedConfigChange change : listChange.changedItems()) {

--- a/core/src/main/java/bio/terra/pearl/core/service/study/StudyEnvironmentSurveyService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/study/StudyEnvironmentSurveyService.java
@@ -19,7 +19,7 @@ public class StudyEnvironmentSurveyService extends CrudService<StudyEnvironmentS
         return dao.findAllByStudyEnvIdWithSurvey(studyEnvId);
     }
 
-    public Optional<StudyEnvironmentSurvey> findBySurvey(UUID studyEnvId, UUID surveyId) {
+    public Optional<StudyEnvironmentSurvey> findActiveBySurvey(UUID studyEnvId, UUID surveyId) {
         return dao.findActiveBySurvey(studyEnvId, surveyId);
     }
 
@@ -30,7 +30,7 @@ public class StudyEnvironmentSurveyService extends CrudService<StudyEnvironmentS
         return dao.update(ses);
     }
 
-    public Optional<StudyEnvironmentSurvey> findBySurvey(UUID studyEnvId, String stableId) {
+    public Optional<StudyEnvironmentSurvey> findActiveBySurvey(UUID studyEnvId, String stableId) {
         var configs = dao.findActiveBySurvey(studyEnvId, stableId);
         // we don't yet have robust support for having multiple surveys with the same stableId configured for an
         // environment.  For now, just pick one

--- a/core/src/main/java/bio/terra/pearl/core/service/study/StudyEnvironmentSurveyService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/study/StudyEnvironmentSurveyService.java
@@ -1,12 +1,14 @@
 package bio.terra.pearl.core.service.study;
 
 import bio.terra.pearl.core.dao.study.StudyEnvironmentSurveyDao;
+import bio.terra.pearl.core.model.notification.NotificationConfig;
 import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
 import bio.terra.pearl.core.service.CrudService;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class StudyEnvironmentSurveyService extends CrudService<StudyEnvironmentSurvey, StudyEnvironmentSurveyDao> {
@@ -20,6 +22,13 @@ public class StudyEnvironmentSurveyService extends CrudService<StudyEnvironmentS
 
     public Optional<StudyEnvironmentSurvey> findBySurvey(UUID studyEnvId, UUID surveyId) {
         return dao.findBySurvey(studyEnvId, surveyId);
+    }
+
+    @Transactional
+    public StudyEnvironmentSurvey deactivate(UUID id) {
+        StudyEnvironmentSurvey ses = dao.find(id).get();
+        ses.setActive(false);
+        return dao.update(ses);
     }
 
     public Optional<StudyEnvironmentSurvey> findBySurvey(UUID studyEnvId, String stableId) {

--- a/core/src/main/java/bio/terra/pearl/core/service/study/StudyEnvironmentSurveyService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/study/StudyEnvironmentSurveyService.java
@@ -1,7 +1,6 @@
 package bio.terra.pearl.core.service.study;
 
 import bio.terra.pearl.core.dao.study.StudyEnvironmentSurveyDao;
-import bio.terra.pearl.core.model.notification.NotificationConfig;
 import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
 import bio.terra.pearl.core.service.CrudService;
 import java.util.List;
@@ -21,7 +20,7 @@ public class StudyEnvironmentSurveyService extends CrudService<StudyEnvironmentS
     }
 
     public Optional<StudyEnvironmentSurvey> findBySurvey(UUID studyEnvId, UUID surveyId) {
-        return dao.findBySurvey(studyEnvId, surveyId);
+        return dao.findActiveBySurvey(studyEnvId, surveyId);
     }
 
     @Transactional
@@ -32,7 +31,7 @@ public class StudyEnvironmentSurveyService extends CrudService<StudyEnvironmentS
     }
 
     public Optional<StudyEnvironmentSurvey> findBySurvey(UUID studyEnvId, String stableId) {
-        var configs = dao.findBySurvey(studyEnvId, stableId);
+        var configs = dao.findActiveBySurvey(studyEnvId, stableId);
         // we don't yet have robust support for having multiple surveys with the same stableId configured for an
         // environment.  For now, just pick one
         return configs.stream().findFirst();

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -99,7 +99,7 @@ public class SurveyResponseService extends ImmutableEntityService<SurveyResponse
             }
         }
         StudyEnvironmentSurvey configSurvey = studyEnvironmentSurveyService
-                .findBySurvey(studyEnvId, stableId).get();
+                .findActiveBySurvey(studyEnvId, stableId).get();
         configSurvey.setSurvey(form);
         return new SurveyWithResponse(
                 configSurvey, lastResponse

--- a/core/src/main/resources/db/changelog/changesets/2023_10_06_survey_config_active.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2023_10_06_survey_config_active.yaml
@@ -6,4 +6,4 @@ databaseChangeLog:
         - addColumn:
             tableName: study_environment_survey
             columns:
-              - column: { name: active, type: boolean, defaultValueBoolean: false, constraints: { nullable: false } }
+              - column: { name: active, type: boolean, defaultValueBoolean: true, constraints: { nullable: false } }

--- a/core/src/main/resources/db/changelog/changesets/2023_10_06_survey_config_active.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2023_10_06_survey_config_active.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: "survey_config_active"
+      author: dbush
+      changes:
+        - addColumn:
+            tableName: study_environment_survey
+            columns:
+              - column: { name: active, type: boolean, defaultValueBoolean: false, constraints: { nullable: false } }

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -140,6 +140,9 @@ databaseChangeLog:
   - include:
       file: changesets/2023_08_25_admin_task.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2023_10_06_survey_config_active.yaml
+      relativeToChangelogFile: true
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements
 # are atomic. When they are grouped in a changeset and one fails the changeset cannot be

--- a/core/src/test/java/bio/terra/pearl/core/service/publishing/StudyPublishingServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/publishing/StudyPublishingServiceTests.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.service.publishing;
 
 import bio.terra.pearl.core.BaseSpringBootTest;
+import bio.terra.pearl.core.dao.study.StudyEnvironmentSurveyDao;
 import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
 import bio.terra.pearl.core.factory.StudyFactory;
 import bio.terra.pearl.core.factory.consent.ConsentFormFactory;
@@ -9,18 +10,24 @@ import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.consent.ConsentForm;
 import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
+import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.service.consent.ConsentFormService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentConfigService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentConsentService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
+import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
 import bio.terra.pearl.core.service.survey.SurveyService;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 public class StudyPublishingServiceTests extends BaseSpringBootTest {
     @Test
@@ -36,9 +43,7 @@ public class StudyPublishingServiceTests extends BaseSpringBootTest {
         irbConfig.setPasswordProtected(true);
         studyEnvironmentConfigService.update(irbConfig);
 
-        var changes = portalDiffService.diffStudyEnvs(study.getShortcode(), EnvironmentName.irb, EnvironmentName.live);
-        var loadedLiveEnv = portalDiffService.loadStudyEnvForProcessing(study.getShortcode(), EnvironmentName.live);
-        studyPublishingService.applyChanges(loadedLiveEnv, changes, null);
+        diffAndApplyChanges(study.getShortcode(), EnvironmentName.irb, EnvironmentName.live);
 
         var liveConfig = studyEnvironmentConfigService.find(liveEnv.getStudyEnvironmentConfigId()).get();
         assertThat(liveConfig.getPassword(), equalTo("foobar"));
@@ -47,8 +52,8 @@ public class StudyPublishingServiceTests extends BaseSpringBootTest {
 
     @Test
     @Transactional
-    public void testApplyChangesPublishSurvey() throws Exception {
-        String testName = "testApplyChangesPublishSurvey";
+    public void testApplyChangesPublishSurvey(TestInfo testInfo) throws Exception {
+        String testName = getTestName(testInfo);
         Study study = studyFactory.buildPersisted(testName);
         StudyEnvironment irbEnv = studyEnvironmentFactory.buildPersisted(EnvironmentName.irb, study.getId(), testName);
         StudyEnvironment liveEnv = studyEnvironmentFactory.buildPersisted(EnvironmentName.live, study.getId(), testName);
@@ -57,13 +62,41 @@ public class StudyPublishingServiceTests extends BaseSpringBootTest {
         irbEnv.setPreEnrollSurveyId(survey.getId());
         studyEnvironmentService.update(irbEnv);
 
-        var changes = portalDiffService.diffStudyEnvs(study.getShortcode(), EnvironmentName.irb, EnvironmentName.live);
-        var loadedLiveEnv = portalDiffService.loadStudyEnvForProcessing(study.getShortcode(), EnvironmentName.live);
-        studyPublishingService.applyChanges(loadedLiveEnv, changes, null);
+        diffAndApplyChanges(study.getShortcode(), EnvironmentName.irb, EnvironmentName.live);
 
         liveEnv = studyEnvironmentService.find(liveEnv.getId()).get();
+        assertThat(liveEnv.getPreEnrollSurveyId(), equalTo(survey.getId()));
         survey = surveyService.find(survey.getId()).get();
         assertThat(survey.getPublishedVersion(), equalTo(1));
+    }
+
+    @Test
+    @Transactional
+    public void testApplyChangesPublishSurveyConfig(TestInfo testInfo) throws Exception {
+        String testName = getTestName(testInfo);
+        Study study = studyFactory.buildPersisted(testName);
+        StudyEnvironment irbEnv = studyEnvironmentFactory.buildPersisted(EnvironmentName.irb, study.getId(), testName);
+        StudyEnvironment liveEnv = studyEnvironmentFactory.buildPersisted(EnvironmentName.live, study.getId(), testName);
+        Survey survey = surveyFactory.buildPersisted(testName);
+        var surveyConfig = studyEnvironmentSurveyService.create(StudyEnvironmentSurvey.builder()
+                .surveyId(survey.getId())
+                .studyEnvironmentId(irbEnv.getId())
+                .build());
+
+        diffAndApplyChanges(study.getShortcode(), EnvironmentName.irb, EnvironmentName.live);
+
+        List<StudyEnvironmentSurvey> liveSurveys = studyEnvironmentSurveyService.findAllByStudyEnvIdWithSurvey(liveEnv.getId());
+        assertThat(liveSurveys, hasSize(1));
+        assertThat(liveSurveys.get(0).getSurveyId(), equalTo(survey.getId()));
+
+        // now test that we can publish a removal
+        studyEnvironmentSurveyService.deactivate(surveyConfig.getId());
+        diffAndApplyChanges(study.getShortcode(), EnvironmentName.irb, EnvironmentName.live);
+
+        liveSurveys = studyEnvironmentSurveyService.findAllByStudyEnvIdWithSurvey(liveEnv.getId());
+        assertThat(liveSurveys, hasSize(0));
+        // confirm the deactivated config is still there
+        assertThat(studyEnvironmentSurveyDao.findAllByStudyEnvironmentId(liveEnv.getId(), false), hasSize(1));
     }
 
     @Test
@@ -76,14 +109,18 @@ public class StudyPublishingServiceTests extends BaseSpringBootTest {
         ConsentForm form = consentFormFactory.buildPersisted(testName);
         consentFormFactory.addConsentToStudyEnv(irbEnv.getId(), form.getId());
 
-        var changes = portalDiffService.diffStudyEnvs(study.getShortcode(), EnvironmentName.irb, EnvironmentName.live);
-        var loadedLiveEnv = portalDiffService.loadStudyEnvForProcessing(study.getShortcode(), EnvironmentName.live);
-        studyPublishingService.applyChanges(loadedLiveEnv, changes, null);
+        diffAndApplyChanges(study.getShortcode(), EnvironmentName.irb, EnvironmentName.live);
 
         assertThat(studyEnvironmentConsentService.findByConsentForm(liveEnv.getId(), form.getId()).isPresent(), equalTo(true));
 
         form = consentFormService.find(form.getId()).get();
         assertThat(form.getPublishedVersion(), equalTo(1));
+    }
+
+    private void diffAndApplyChanges(String studyShortcode, EnvironmentName src, EnvironmentName dest) throws Exception {
+        var changes = portalDiffService.diffStudyEnvs(studyShortcode, src, dest);
+        var loadedLiveEnv = portalDiffService.loadStudyEnvForProcessing(studyShortcode, dest);
+        studyPublishingService.applyChanges(loadedLiveEnv, changes, null);
     }
 
     @Autowired
@@ -99,6 +136,8 @@ public class StudyPublishingServiceTests extends BaseSpringBootTest {
     @Autowired
     private StudyEnvironmentConsentService studyEnvironmentConsentService;
     @Autowired
+    private StudyEnvironmentSurveyService studyEnvironmentSurveyService;
+    @Autowired
     private SurveyService surveyService;
     @Autowired
     private ConsentFormFactory consentFormFactory;
@@ -108,4 +147,6 @@ public class StudyPublishingServiceTests extends BaseSpringBootTest {
     private SurveyFactory surveyFactory;
     @Autowired
     private PortalDiffService portalDiffService;
+    @Autowired
+    private StudyEnvironmentSurveyDao studyEnvironmentSurveyDao;
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentServiceTests.java
@@ -27,8 +27,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 public class EnrollmentServiceTests extends BaseSpringBootTest {
-
-
     @Test
     @Transactional
     public void testAnonymousPreEnroll() throws JsonProcessingException {


### PR DESCRIPTION
#### DESCRIPTION

In order to robustly handle multi-version export, we first need to enhance how we track which survey versions have been associated with a given studyEnvironment.  (And this is a good idea anyway).  So now instead of just deleting StudyEnvironmentSurveys, we deactivate them.  This PR has no functional changes to the application -- from a user perspective, everything appears the same as before.  

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. repopulate ourhealth (do this step *before* restarting the app, the goal is to simulate pre-existing data)
2. redeploy ApiAdminApp
3. go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/forms, confirm surveys appear as usual
4. go to https://localhost:3000/ourhealth/studies/ourheart/publishing, copy the sandbox to irb
5. go back to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/forms, make a change to a survey, then save it
6. go back to https://localhost:3000/ourhealth/studies/ourheart/publishing, copy the sandbox to irb again.  Note the survey you changed should appear as selectable, select it and publish.
7. go to https://localhost:3000/ourhealth/studies/ourheart/env/irb/forms confirm that the updated survey version appears correctly