### PR TITLE
[JN-561] Remove portal user

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/portal/PortalController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/portal/PortalController.java
@@ -8,6 +8,7 @@ import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.portal.Portal;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
@@ -48,5 +49,12 @@ public class PortalController implements PortalApi {
             .map(portal -> objectMapper.convertValue(portal, PortalShallowDto.class))
             .collect(Collectors.toList());
     return ResponseEntity.ok(portalDtos);
+  }
+
+  @Override
+  public ResponseEntity<Void> removePortalUser(String portalShortcode, UUID userId) {
+    AdminUser operator = requestService.requireAdminUser(request);
+    portalExtService.removeUserFromPortal(userId, portalShortcode, operator);
+    return ResponseEntity.status(204).build();
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/portal/PortalController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/portal/PortalController.java
@@ -52,9 +52,9 @@ public class PortalController implements PortalApi {
   }
 
   @Override
-  public ResponseEntity<Void> removePortalUser(String portalShortcode, UUID userId) {
+  public ResponseEntity<Void> removePortalUser(String portalShortcode, UUID adminUserId) {
     AdminUser operator = requestService.requireAdminUser(request);
-    portalExtService.removeUserFromPortal(userId, portalShortcode, operator);
+    portalExtService.removeUserFromPortal(adminUserId, portalShortcode, operator);
     return ResponseEntity.status(204).build();
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/portal/PortalController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/portal/PortalController.java
@@ -55,6 +55,6 @@ public class PortalController implements PortalApi {
   public ResponseEntity<Void> removePortalUser(String portalShortcode, UUID adminUserId) {
     AdminUser operator = requestService.requireAdminUser(request);
     portalExtService.removeUserFromPortal(adminUserId, portalShortcode, operator);
-    return ResponseEntity.status(204).build();
+    return ResponseEntity.noContent().build();
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/portal/PortalExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/portal/PortalExtService.java
@@ -6,11 +6,13 @@ import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.portal.PortalEnvironmentConfig;
+import bio.terra.pearl.core.service.admin.PortalAdminUserService;
 import bio.terra.pearl.core.service.exception.PermissionDeniedException;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentConfigService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
 import bio.terra.pearl.core.service.portal.PortalService;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 
@@ -19,16 +21,19 @@ public class PortalExtService {
   private PortalService portalService;
   private PortalEnvironmentService portalEnvironmentService;
   private PortalEnvironmentConfigService portalEnvironmentConfigService;
+  private PortalAdminUserService portalAdminUserService;
   private AuthUtilService authUtilService;
 
   public PortalExtService(
       PortalService portalService,
       PortalEnvironmentService portalEnvironmentService,
       PortalEnvironmentConfigService portalEnvironmentConfigService,
+      PortalAdminUserService portalAdminUserService,
       AuthUtilService authUtilService) {
     this.portalService = portalService;
     this.portalEnvironmentService = portalEnvironmentService;
     this.portalEnvironmentConfigService = portalEnvironmentConfigService;
+    this.portalAdminUserService = portalAdminUserService;
     this.authUtilService = authUtilService;
   }
 
@@ -78,5 +83,10 @@ public class PortalExtService {
     PortalEnvironment portalEnv = portalEnvironmentService.findOne(portalShortcode, envName).get();
     portalEnv.setSiteContentId(updatedEnv.getSiteContentId());
     return portalEnvironmentService.update(portalEnv);
+  }
+
+  public void removeUserFromPortal(UUID userId, String portalShortcode, AdminUser operator) {
+    Portal portal = authUtilService.authUserToPortal(operator, portalShortcode);
+    portalAdminUserService.removeUserFromPortal(userId, portal);
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/portal/PortalExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/portal/PortalExtService.java
@@ -85,8 +85,8 @@ public class PortalExtService {
     return portalEnvironmentService.update(portalEnv);
   }
 
-  public void removeUserFromPortal(UUID userId, String portalShortcode, AdminUser operator) {
+  public void removeUserFromPortal(UUID adminUserId, String portalShortcode, AdminUser operator) {
     Portal portal = authUtilService.authUserToPortal(operator, portalShortcode);
-    portalAdminUserService.removeUserFromPortal(userId, portal);
+    portalAdminUserService.removeUserFromPortal(adminUserId, portal);
   }
 }

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -114,6 +114,23 @@ paths:
           content: { application/json: { schema: {type: object} } }
         '500':
           $ref: '#/components/responses/ServerError'
+
+  /api/portals/v1/{portalShortcode}/adminUser/{userId}:
+    delete:
+      summary: Remove an admin user for portal
+      tags: [ portal ]
+      operationId: removePortalUser
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: userId, in: path, required: true, schema: { type: string, format: uuid } }
+      responses:
+        '204':
+          description: admin user removed
+        '404':
+          description: admin user not found
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/adminTasks:
     get:
       summary: Gets all the admin tasks for this study environment

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -115,14 +115,14 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /api/portals/v1/{portalShortcode}/adminUser/{userId}:
+  /api/portals/v1/{portalShortcode}/adminUser/{adminUserId}:
     delete:
       summary: Remove an admin user for portal
       tags: [ portal ]
       operationId: removePortalUser
       parameters:
         - { name: portalShortcode, in: path, required: true, schema: { type: string } }
-        - { name: userId, in: path, required: true, schema: { type: string, format: uuid } }
+        - { name: adminUserId, in: path, required: true, schema: { type: string, format: uuid } }
       responses:
         '204':
           description: admin user removed

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/portal/PortalExtServiceTest.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/portal/PortalExtServiceTest.java
@@ -1,12 +1,16 @@
 package bio.terra.pearl.api.admin.service.portal;
 
+import static org.mockito.Mockito.when;
+
 import bio.terra.pearl.api.admin.service.AuthUtilService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.service.admin.PortalAdminUserService;
 import bio.terra.pearl.core.service.exception.PermissionDeniedException;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentConfigService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
 import bio.terra.pearl.core.service.portal.PortalService;
+import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +28,7 @@ public class PortalExtServiceTest {
   @MockBean private PortalService mockPortalService;
   @MockBean private PortalEnvironmentService portalEnvironmentService;
   @MockBean private PortalEnvironmentConfigService portalEnvironmentConfigService;
+  @MockBean private PortalAdminUserService portalAdminUserService;
 
   @Test
   public void updateConfigRequiresSuperuser() {
@@ -39,5 +44,15 @@ public class PortalExtServiceTest {
     Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> portalExtService.updateEnvironment("foo", EnvironmentName.irb, null, user));
+  }
+
+  @Test
+  public void removePortalUserRequiresPortalAuth() {
+    AdminUser operator = AdminUser.builder().superuser(false).build();
+    when(mockAuthUtilService.authUserToPortal(operator, "testPortal"))
+        .thenThrow(new PermissionDeniedException("test"));
+    Assertions.assertThrows(
+        PermissionDeniedException.class,
+        () -> portalExtService.removeUserFromPortal(UUID.randomUUID(), "testPortal", operator));
   }
 }

--- a/core/src/main/java/bio/terra/pearl/core/dao/admin/PortalAdminUserDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/admin/PortalAdminUserDao.java
@@ -32,14 +32,15 @@ public class PortalAdminUserDao extends BaseJdbiDao<PortalAdminUser> {
         return findAllByProperty("admin_user_id", userId);
     }
 
-    public Optional<PortalAdminUser> findByUserIdAndPortal(UUID userId, UUID portalId) {
-        return findByTwoProperties("admin_user_id",userId,
+    public Optional<PortalAdminUser> findByUserIdAndPortal(UUID adminUserId, UUID portalId) {
+        return findByTwoProperties("admin_user_id", adminUserId,
                 "portal_id", portalId);
     }
 
-    public void deleteByUserId(UUID userId) {
-        deleteByProperty("admin_user_id", userId);
+    public void deleteByUserId(UUID adminUserId) {
+        deleteByProperty("admin_user_id", adminUserId);
     }
+
     public void deleteByPortalId(UUID portalId) {
         deleteByProperty("portal_id", portalId);
     }

--- a/core/src/main/java/bio/terra/pearl/core/dao/admin/PortalAdminUserDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/admin/PortalAdminUserDao.java
@@ -3,6 +3,7 @@ package bio.terra.pearl.core.dao.admin;
 import bio.terra.pearl.core.dao.BaseJdbiDao;
 import bio.terra.pearl.core.model.admin.PortalAdminUser;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.jdbi.v3.core.Jdbi;
 import org.springframework.stereotype.Component;
@@ -29,6 +30,11 @@ public class PortalAdminUserDao extends BaseJdbiDao<PortalAdminUser> {
 
     public List<PortalAdminUser> findByUserId(UUID userId) {
         return findAllByProperty("admin_user_id", userId);
+    }
+
+    public Optional<PortalAdminUser> findByUserIdAndPortal(UUID userId, UUID portalId) {
+        return findByTwoProperties("admin_user_id",userId,
+                "portal_id", portalId);
     }
 
     public void deleteByUserId(UUID userId) {

--- a/core/src/main/java/bio/terra/pearl/core/service/admin/PortalAdminUserRoleService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/admin/PortalAdminUserRoleService.java
@@ -83,4 +83,8 @@ public class PortalAdminUserRoleService extends ImmutableEntityService<PortalAdm
         });
         return portalAdminUserRoles;
     }
+
+    public void deleteByPortalAdminUserId(UUID portalAdminUserId) {
+        dao.deleteByPortalAdminUserId(portalAdminUserId);
+    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/admin/PortalAdminUserService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/admin/PortalAdminUserService.java
@@ -3,12 +3,15 @@ package bio.terra.pearl.core.service.admin;
 import bio.terra.pearl.core.dao.admin.PortalAdminUserDao;
 import bio.terra.pearl.core.model.admin.PortalAdminUser;
 import bio.terra.pearl.core.model.admin.PortalAdminUserRole;
+import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.service.ImmutableEntityService;
+import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.exception.UserNotFoundException;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class PortalAdminUserService extends ImmutableEntityService<PortalAdminUser, PortalAdminUserDao> {
@@ -50,7 +53,24 @@ public class PortalAdminUserService extends ImmutableEntityService<PortalAdminUs
         });
     }
 
+    public Optional<PortalAdminUser> findByUserIdAndPortal(UUID userId, UUID portalId) {
+        return dao.findByUserIdAndPortal(userId, portalId);
+    }
+
+    @Transactional
     public void deleteByUserId(UUID adminUserId) {
+        List<PortalAdminUser> portalAdminUsers = dao.findByUserId(adminUserId);
+        // for now this will probably be a small list, so it's fine to just delete them one by one
+        portalAdminUsers.forEach(portalAdminUser -> portalAdminUserRoleService.deleteByPortalAdminUserId(portalAdminUser.getId()));
         dao.deleteByUserId(adminUserId);
+    }
+
+    @Transactional
+    public void removeUserFromPortal(UUID adminUserId, Portal portal) {
+        PortalAdminUser portalAdminUser = findByUserIdAndPortal(adminUserId, portal.getId()).orElseThrow(() ->
+                new NotFoundException(
+                        String.format("Portal user not found for user ID %s and portal %s", adminUserId, portal.getShortcode())));
+        portalAdminUserRoleService.deleteByPortalAdminUserId(portalAdminUser.getId());
+        dao.delete(portalAdminUser.getId());
     }
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/admin/PortalAdminUserServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/admin/PortalAdminUserServiceTest.java
@@ -1,0 +1,100 @@
+package bio.terra.pearl.core.service.admin;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import bio.terra.pearl.core.BaseSpringBootTest;
+import bio.terra.pearl.core.factory.admin.PortalAdminUserFactory;
+import bio.terra.pearl.core.factory.portal.PortalFactory;
+import bio.terra.pearl.core.model.admin.PortalAdminUser;
+import bio.terra.pearl.core.model.admin.Role;
+import bio.terra.pearl.core.model.portal.Portal;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+public class PortalAdminUserServiceTest extends BaseSpringBootTest {
+
+    @Autowired
+    private PortalAdminUserFactory portalAdminUserFactory;
+    @Autowired
+    private PortalAdminUserRoleService portalAdminUserRoleService;
+    @Autowired
+    private PortalAdminUserService portalAdminUserService;
+    @Autowired
+    private PortalFactory portalFactory;
+    @Autowired
+    private RoleService roleService;
+
+
+    @Transactional
+    @Test
+    public void testRemoveUserFromPortal() {
+        String testName = "testRemoveUserFromPortal";
+        // set up a user in two portals
+        Portal portal1 = portalFactory.buildPersisted(testName);
+        Portal portal2 = portalFactory.buildPersisted(testName);
+        List<PortalAdminUser> portalUsers =
+                portalAdminUserFactory.buildPersistedWithPortals(testName, List.of(portal1, portal2));
+        PortalAdminUser user1Portal1 = portalUsers.get(0);
+        PortalAdminUser user1Portal2 = portalUsers.get(1);
+
+        // add roles for user in each portal
+        roleService.create(Role.builder().name("role1").build());
+        roleService.create(Role.builder().name("role2").build());
+        portalAdminUserRoleService.setRoles(user1Portal1.getId(), List.of("role1", "role2"));
+        portalAdminUserRoleService.setRoles(user1Portal2.getId(), List.of("role2"));
+
+        portalAdminUserService.removeUserFromPortal(user1Portal1.getAdminUserId(), portal1);
+
+        // confirm user is gone in proper portal
+        List<PortalAdminUser> users = portalAdminUserService.findByPortal(portal1.getId());
+        assertThat(users.size(), equalTo(0));
+
+        List<PortalAdminUser> portal2Users = portalAdminUserService.findByPortal(portal2.getId());
+        assertThat(portal2Users.size(), equalTo(1));
+        PortalAdminUser portal2user = portal2Users.get(0);
+        assertThat(portal2user.getAdminUserId(), equalTo(user1Portal2.getAdminUserId()));
+        assertTrue(portalAdminUserService.userHasRole(portal2user.getId(), "role2"));
+    }
+
+    @Transactional
+    @Test
+    public void testDeleteByUserId() {
+        String testName = "testDeleteByUserId";
+        // set up a user in two portals and another in one portal
+        Portal portal1 = portalFactory.buildPersisted(testName);
+        Portal portal2 = portalFactory.buildPersisted(testName);
+        List<PortalAdminUser> portalUsers1 =
+                portalAdminUserFactory.buildPersistedWithPortals(testName, List.of(portal1, portal2));
+        PortalAdminUser user1Portal1 = portalUsers1.get(0);
+        PortalAdminUser user1Portal2 = portalUsers1.get(1);
+
+        List<PortalAdminUser> portalUsers2 = portalAdminUserFactory.buildPersistedWithPortals(testName, List.of(portal1));
+        PortalAdminUser user2 = portalUsers2.get(0);
+
+        // add roles for all
+        roleService.create(Role.builder().name("role1").build());
+        roleService.create(Role.builder().name("role2").build());
+        portalAdminUserRoleService.setRoles(user1Portal1.getId(), List.of("role1", "role2"));
+        portalAdminUserRoleService.setRoles(user1Portal2.getId(), List.of("role2"));
+        portalAdminUserRoleService.setRoles(user2.getId(), List.of("role1"));
+
+        portalAdminUserService.deleteByUserId(user1Portal1.getAdminUserId());
+
+        // confirm user1 is gone in both portals and user2 is unchanged
+        List<PortalAdminUser> users = portalAdminUserService.findByPortal(portal1.getId());
+        assertThat(users.size(), equalTo(1));
+        PortalAdminUser foundUser = users.get(0);
+        assertThat(foundUser.getAdminUserId(), equalTo(user2.getAdminUserId()));
+        assertTrue(portalAdminUserService.userHasRole(foundUser.getId(), "role1"));
+
+        List<PortalAdminUser> portal2Users = portalAdminUserService.findByPortal(portal2.getId());
+        assertThat(portal2Users.size(), equalTo(0));
+    }
+}

--- a/core/src/test/java/bio/terra/pearl/core/service/admin/PortalAdminUserServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/admin/PortalAdminUserServiceTest.java
@@ -12,12 +12,11 @@ import bio.terra.pearl.core.factory.portal.PortalFactory;
 import bio.terra.pearl.core.model.admin.PortalAdminUser;
 import bio.terra.pearl.core.model.admin.Role;
 import bio.terra.pearl.core.model.portal.Portal;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
+
 public class PortalAdminUserServiceTest extends BaseSpringBootTest {
 
     @Autowired

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/admin/PortalAdminUserFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/admin/PortalAdminUserFactory.java
@@ -1,7 +1,12 @@
 package bio.terra.pearl.core.factory.admin;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import bio.terra.pearl.core.factory.portal.PortalFactory;
+import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.admin.PortalAdminUser;
+import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.service.admin.PortalAdminUserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -31,5 +36,17 @@ public class PortalAdminUserFactory {
     public PortalAdminUser buildPersisted(String testName) {
         var portalAdminUser = builderWithDependencies(testName).build();
         return portalAdminUserService.create(portalAdminUser);
+    }
+
+    public List<PortalAdminUser> buildPersistedWithPortals(String testName, List<Portal> portals) {
+        AdminUser adminUser = adminUserFactory.buildPersisted(testName);
+        List<PortalAdminUser> portalUsers = new ArrayList<>();
+        for (var portal: portals) {
+            portalUsers.add(portalAdminUserService.create(PortalAdminUser.builder()
+                    .adminUserId(adminUser.getId())
+                    .portalId(portal.getId())
+                    .build()));
+        }
+        return portalUsers;
     }
 }

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -930,6 +930,15 @@ export default {
     return await this.processJsonResponse(response)
   },
 
+  async removePortalUser(adminUser: AdminUser, portalShortcode: string): Promise<Response> {
+    const url = `${API_ROOT}/portals/v1/${portalShortcode}/adminUser/${adminUser.id}`
+    const response = await fetch(url, {
+      method: 'DELETE',
+      headers: this.getInitHeaders()
+    })
+    return await this.processResponse(response)
+  },
+
   async updatePortalEnv(portalShortcode: string, envName: string, update: PortalEnvironment) {
     const url = `${basePortalEnvUrl(portalShortcode, envName)}`
     const response = await fetch(url, {

--- a/ui-admin/src/user/DeleteUserModal.test.tsx
+++ b/ui-admin/src/user/DeleteUserModal.test.tsx
@@ -8,7 +8,6 @@ import { mockAdminUser } from '../test-utils/user-mocking-utils'
 
 describe('DeleteUserModal', () => {
   test('enables Remove button when user completes matching confirmation string', async () => {
-    //Arrange
     const user = userEvent.setup()
     const portal = mockPortal()
     const subjUser = mockAdminUser(false)
@@ -21,15 +20,13 @@ describe('DeleteUserModal', () => {
       onDismiss={jest.fn()}/>)
     render(RoutedComponent)
 
-    //Assert page content
+    // verify page content and
     const confirmRemoveUserInput = screen.getByText('Confirm by typing "remove user@email" below')
     const removeButton = screen.getByText('Remove user')
     expect(removeButton).toBeDisabled()
 
-    //Act
+    // verify button is enabled when user types matching string
     await user.type(confirmRemoveUserInput, 'remove user@email')
-
-    //Assert action
     expect(removeButton).toBeEnabled()
   })
 })

--- a/ui-admin/src/user/DeleteUserModal.test.tsx
+++ b/ui-admin/src/user/DeleteUserModal.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { mockPortal } from 'test-utils/mocking-utils'
+import  { setupRouterTest } from 'test-utils/router-testing-utils'
+import { render, screen } from '@testing-library/react'
+import DeleteUserModal from './DeleteUserModal'
+import userEvent from '@testing-library/user-event'
+import { mockAdminUser } from '../test-utils/user-mocking-utils'
+
+describe('DeleteUserModal', () => {
+  test('enables Remove button when user completes matching confirmation string', async () => {
+    //Arrange
+    const user = userEvent.setup()
+    const portal = mockPortal()
+    const subjUser = mockAdminUser(false)
+    subjUser.username = 'user@email'
+
+    const { RoutedComponent } = setupRouterTest(<DeleteUserModal
+      subjUser={subjUser}
+      portal={portal}
+      userDeleted={jest.fn()}
+      onDismiss={jest.fn()}/>)
+    render(RoutedComponent)
+
+    //Assert page content
+    const confirmRemoveUserInput = screen.getByText('Confirm by typing "remove user@email" below')
+    const removeButton = screen.getByText('Remove user')
+    expect(removeButton).toBeDisabled()
+
+    //Act
+    await user.type(confirmRemoveUserInput, 'remove user@email')
+
+    //Assert action
+    expect(removeButton).toBeEnabled()
+  })
+})

--- a/ui-admin/src/user/DeleteUserModal.tsx
+++ b/ui-admin/src/user/DeleteUserModal.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react'
+import { Store } from 'react-notifications-component'
+import Api, { AdminUser, Portal } from 'api/api'
+import { failureNotification, successNotification } from 'util/notifications'
+
+/** Modal to remove a user from a portal. */
+const DeleteUserModal = ({ subjUser, portal, userDeleted, onDismiss }:
+                           {subjUser: AdminUser, portal: Portal, userDeleted: () => void, onDismiss: () => void}) => {
+  const [usernameConfirm, setUsernameConfirm] = useState('')
+  const removeString = `remove ${subjUser.username}`
+  const canRemove = usernameConfirm === removeString
+
+  const doRemove = async () => {
+    try {
+      await Api.removePortalUser(subjUser, portal.shortcode)
+      Store.addNotification(successNotification(`${subjUser.username} removed`))
+      userDeleted()
+      onDismiss()
+    } catch (e) {
+      console.log('error removing user', e)
+      Store.addNotification(failureNotification('Error removing user'))
+    }
+  }
+
+  return <div className="p4">
+    <form onSubmit={e => e.preventDefault()}>
+      <h3 className="h5">Remove user from portal: {subjUser.username}</h3>
+      <div className="my-3">
+        <label>
+          Confirm by typing &quot;{removeString}&quot; below<br/>
+          <strong>Removing a user is permanent</strong>
+          <input type="text" className="form-control" value={usernameConfirm}
+            onChange={e => setUsernameConfirm(e.target.value)}/>
+        </label>
+      </div>
+      <button type="button" className="btn btn-primary" onClick={doRemove} disabled={!canRemove}>Remove user</button>
+    </form>
+  </div>
+}
+
+export default DeleteUserModal

--- a/ui-admin/src/user/DeleteUserModal.tsx
+++ b/ui-admin/src/user/DeleteUserModal.tsx
@@ -11,15 +11,12 @@ const DeleteUserModal = ({ subjUser, portal, userDeleted, onDismiss }:
   const canRemove = usernameConfirm === removeString
 
   const doRemove = async () => {
-    try {
-      await Api.removePortalUser(subjUser, portal.shortcode)
-      Store.addNotification(successNotification(`${subjUser.username} removed`))
-      userDeleted()
-      onDismiss()
-    } catch (e) {
-      console.log('error removing user', e)
-      Store.addNotification(failureNotification('Error removing user'))
-    }
+      await doApiLoad(() => {
+         Api.removePortalUser(subjUser, portal.shortcode)
+         Store.addNotification(successNotification(`${subjUser.username} removed`))
+         userDeleted()
+         onDismiss()
+    }, {customErrorMsg: 'Error removing user'} )
   }
 
   return <div className="p4">

--- a/ui-admin/src/user/DeleteUserModal.tsx
+++ b/ui-admin/src/user/DeleteUserModal.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react'
 import { Store } from 'react-notifications-component'
+import { Modal } from 'react-bootstrap'
 import Api, { AdminUser, Portal } from 'api/api'
-import { failureNotification, successNotification } from 'util/notifications'
+import { successNotification } from 'util/notifications'
+import { doApiLoad } from '../api/api-utils'
 
 /** Modal to remove a user from a portal. */
 const DeleteUserModal = ({ subjUser, portal, userDeleted, onDismiss }:
@@ -11,28 +13,32 @@ const DeleteUserModal = ({ subjUser, portal, userDeleted, onDismiss }:
   const canRemove = usernameConfirm === removeString
 
   const doRemove = async () => {
-      await doApiLoad(() => {
-         Api.removePortalUser(subjUser, portal.shortcode)
-         Store.addNotification(successNotification(`${subjUser.username} removed`))
-         userDeleted()
-         onDismiss()
-    }, {customErrorMsg: 'Error removing user'} )
+    doApiLoad(async () => {
+      await Api.removePortalUser(subjUser, portal.shortcode)
+      Store.addNotification(successNotification(`${subjUser.username} removed`))
+      userDeleted()
+      onDismiss()
+    }, { customErrorMsg: 'Error removing user' })
   }
 
-  return <div className="p4">
-    <form onSubmit={e => e.preventDefault()}>
-      <h3 className="h5">Remove user from portal: {subjUser.username}</h3>
-      <div className="my-3">
-        <label>
+  return <Modal show={true} onHide={onDismiss}>
+    <Modal.Header closeButton>
+      <Modal.Title>Remove portal user</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>
+      <form onSubmit={e => e.preventDefault()}>
+        <h3 className="h5">Remove user from portal: {subjUser.username}</h3>
+        <div className="my-3">
+          <label>
           Confirm by typing &quot;{removeString}&quot; below<br/>
-          <strong>Removing a user is permanent</strong>
-          <input type="text" className="form-control" value={usernameConfirm}
-            onChange={e => setUsernameConfirm(e.target.value)}/>
-        </label>
-      </div>
-      <button type="button" className="btn btn-primary" onClick={doRemove} disabled={!canRemove}>Remove user</button>
-    </form>
-  </div>
+            <input type="text" className="form-control" value={usernameConfirm}
+              onChange={e => setUsernameConfirm(e.target.value)}/>
+          </label>
+        </div>
+        <button type="button" className="btn btn-primary" onClick={doRemove} disabled={!canRemove}>Remove user</button>
+      </form>
+    </Modal.Body>
+  </Modal>
 }
 
 export default DeleteUserModal

--- a/ui-admin/src/user/PortalUserList.tsx
+++ b/ui-admin/src/user/PortalUserList.tsx
@@ -15,6 +15,7 @@ import { faPlus } from '@fortawesome/free-solid-svg-icons'
 import CreateUserModal from './CreateUserModal'
 import { failureNotification } from '../util/notifications'
 import { Store } from 'react-notifications-component'
+import UserAction from './UserAction'
 
 // TODO: Add JSDoc
 // eslint-disable-next-line jsdoc/require-jsdoc
@@ -35,6 +36,10 @@ const PortalUserList = ({ portal }: {portal: Portal}) => {
     header: 'Last login',
     accessorKey: 'lastLogin',
     cell: info => instantToDefaultString(info.getValue() as number)
+  }, {
+    header: 'Actions',
+    accessorKey: 'actions',
+    cell: info => <UserAction row={info.row} portal={portal} onUserListChanged={handleUserListChanged}/>
   }]), [users])
 
   const table = useReactTable({
@@ -60,7 +65,7 @@ const PortalUserList = ({ portal }: {portal: Portal}) => {
     setIsLoading(false)
   }
 
-  const handleUserCreated = () => {
+  const handleUserListChanged = () => {
     // just reload everything
     loadUsers()
   }
@@ -74,7 +79,7 @@ const PortalUserList = ({ portal }: {portal: Portal}) => {
       <FontAwesomeIcon icon={faPlus}/> Create user
     </button>
     {showCreateModal && <CreateUserModal onDismiss={() => setShowCreateModal(false)} portals={[portal]}
-      userCreated={handleUserCreated}/>}
+      userCreated={handleUserListChanged}/>}
     <LoadingSpinner isLoading={isLoading}>
       {basicTableLayout(table)}
     </LoadingSpinner>

--- a/ui-admin/src/user/UserAction.tsx
+++ b/ui-admin/src/user/UserAction.tsx
@@ -1,0 +1,23 @@
+import { faTimes } from '@fortawesome/free-solid-svg-icons'
+import React, { useState } from 'react'
+import { Row } from '@tanstack/react-table'
+import { AdminUser, Portal } from 'api/api'
+import DeleteUserModal from './DeleteUserModal'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+
+/** Handle actions for a given portal user. */
+const userAction = ({ row, portal, onUserListChanged }:
+                      {row: Row<AdminUser>, portal: Portal, onUserListChanged: () => void}) => {
+  const [showDeleteModal, setShowDeleteModal] = useState(false)
+
+  return <div>
+    <button className="btn-secondary btn" onClick={() => setShowDeleteModal(true)}>
+      <FontAwesomeIcon icon={faTimes}/>
+    </button>
+    {showDeleteModal &&
+      <DeleteUserModal subjUser={row.original} portal={portal} onDismiss={() => setShowDeleteModal(false)}
+        userDeleted={onUserListChanged}/>}
+  </div>
+}
+
+export default userAction


### PR DESCRIPTION
#### DESCRIPTION
JN-561

This implementation is a bit different from the description in the ticket. Upon discussion we determined to implement a remove user from portal feature, rather than a delete admin user feature. (The latter may be useful at some point, but will likely be implemented by adding a delete flag for the appropriate admin user, since there are a lot of references to the admin user record that need to be resolved, possibly including audit information.)

When a user is removed from a portal, associated records are also removed. Best I can tell, that is only portal user roles. (It was not apparent how to create user roles via the UI, but I will add that to the testing instructions once I figure that out.)

Feel free to point out errors, small and large, since I am not expecting that I got everything right the first time.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. Populate OurHealth (./scripts/populate_portal.sh ourhealth).
2. Navigate to portal admin user page: http://localhost:3000/ourhealth/studies/ourheart/users, and create a new admin user.
3. On that same page in the "Actions" column, select the delete icon and observe the "Remove user from portal" modal.
4. Play with the modal, eventually confirming the removal.
5. Observe the user is no longer in the user list.
6. Navigate to http://localhost:3000/users, and observe the created user still exists as an admin user, but does not have an associated portal.
