### PR TITLE
[JN-576] Download participant list

### DIFF
--- a/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
@@ -71,7 +71,7 @@ test('send email is toggled depending on participants selected', async () => {
     expect(screen.getByText('JOSALK')).toBeInTheDocument()
   })
   const sendEmailButton = screen.getByText('Send email')
-  expect(sendEmailButton).toBeDisabled()
+  expect(sendEmailButton).toHaveAttribute('aria-disabled', 'true')
 })
 
 test('keyword search sends search api request', async () => {

--- a/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
@@ -74,34 +74,6 @@ test('send email is toggled depending on participants selected', async () => {
   expect(sendEmailButton).toBeDisabled()
 })
 
-test('download button is toggled depending on if there are participants or not', async () => {
-  mockSearchApi(1)
-  const studyEnvContext = mockStudyEnvContext()
-  const { RoutedComponent } = setupRouterTest(<ParticipantList studyEnvContext={studyEnvContext}/>)
-  render(RoutedComponent)
-  await waitFor(() => {
-    expect(screen.getByText('Showing 0 of 0 rows')).toBeInTheDocument()
-  })
-  const downloadButton = screen.getByLabelText('Download table data')
-  expect(downloadButton).toBeDisabled()
-})
-
-test('clicking the download button prompts the user with the correct number of rows', async () => {
-  mockSearchApi(43)
-  const studyEnvContext = mockStudyEnvContext()
-  const { RoutedComponent } = setupRouterTest(<ParticipantList studyEnvContext={studyEnvContext}/>)
-  render(RoutedComponent)
-
-  //Wait for results to be rendered
-  await screen.findAllByText('JOSALK')
-
-  const downloadButton = screen.getByText('Download')
-  expect(downloadButton).toBeEnabled()
-  await userEvent.click(downloadButton)
-  expect(screen.getByText('This will download 43 rows')).toBeInTheDocument()
-})
-
-
 test('keyword search sends search api request', async () => {
   const searchSpy = mockSearchApi(1)
   const studyEnvContext = mockStudyEnvContext()

--- a/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
@@ -86,17 +86,18 @@ test('download button is toggled depending on if there are participants or not',
   expect(downloadButton).toBeDisabled()
 })
 
-test('clicking the download button prompts the user', async () => {
+test('clicking the download button prompts the user with the correct number of rows', async () => {
   mockSearchApi(43)
   const studyEnvContext = mockStudyEnvContext()
   const { RoutedComponent } = setupRouterTest(<ParticipantList studyEnvContext={studyEnvContext}/>)
   render(RoutedComponent)
-  await waitFor(() => {
-    expect(screen.getByText('JOSALK')).toBeInTheDocument()
-  })
-  const sendEmailButton = screen.getByText('Download')
-  expect(sendEmailButton).toBeEnabled()
-  await act(() => userEvent.click(sendEmailButton))
+
+  //Wait for results to be rendered
+  await screen.findAllByText('JOSALK')
+
+  const downloadButton = screen.getByText('Download')
+  expect(downloadButton).toBeEnabled()
+  await userEvent.click(downloadButton)
   expect(screen.getByText('This will download 43 rows')).toBeInTheDocument()
 })
 

--- a/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
@@ -70,8 +70,34 @@ test('send email is toggled depending on participants selected', async () => {
   await waitFor(() => {
     expect(screen.getByText('JOSALK')).toBeInTheDocument()
   })
-  const participantLink = screen.getByText('Send email')
-  expect(participantLink).toHaveAttribute('aria-disabled', 'true')
+  const sendEmailButton = screen.getByText('Send email')
+  expect(sendEmailButton).toBeDisabled()
+})
+
+test('download button is toggled depending on if there are participants or not', async () => {
+  mockSearchApi(1)
+  const studyEnvContext = mockStudyEnvContext()
+  const { RoutedComponent } = setupRouterTest(<ParticipantList studyEnvContext={studyEnvContext}/>)
+  render(RoutedComponent)
+  await waitFor(() => {
+    expect(screen.getByText('Showing 0 of 0 rows')).toBeInTheDocument()
+  })
+  const downloadButton = screen.getByLabelText('Download table data')
+  expect(downloadButton).toBeDisabled()
+})
+
+test('clicking the download button prompts the user', async () => {
+  mockSearchApi(43)
+  const studyEnvContext = mockStudyEnvContext()
+  const { RoutedComponent } = setupRouterTest(<ParticipantList studyEnvContext={studyEnvContext}/>)
+  render(RoutedComponent)
+  await waitFor(() => {
+    expect(screen.getByText('JOSALK')).toBeInTheDocument()
+  })
+  const sendEmailButton = screen.getByText('Download')
+  expect(sendEmailButton).toBeEnabled()
+  await act(() => userEvent.click(sendEmailButton))
+  expect(screen.getByText('This will download 43 rows')).toBeInTheDocument()
 })
 
 

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -14,9 +14,9 @@ import {
   useReactTable,
   VisibilityState
 } from '@tanstack/react-table'
-import { basicTableLayout, ColumnVisibilityControl, IndeterminateCheckbox } from 'util/tableUtils'
+import { basicTableLayout, ColumnVisibilityControl, DownloadControl, IndeterminateCheckbox } from 'util/tableUtils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCheck } from '@fortawesome/free-solid-svg-icons'
+import { faCheck, faEnvelope } from '@fortawesome/free-solid-svg-icons'
 import AdHocEmailModal from '../AdHocEmailModal'
 import {
   ALL_FACETS,
@@ -25,7 +25,6 @@ import {
   facetValuesToString,
   KEYWORD_FACET
 } from 'api/enrolleeSearch'
-import { Button } from 'components/forms/Button'
 import { instantToDefaultString } from 'util/timeUtils'
 import { useLoadingEffect } from 'api/api-utils'
 import { FacetView, getUpdatedFacetValues } from './facets/EnrolleeSearchFacets'
@@ -76,12 +75,18 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     id: 'createdAt',
     accessorKey: 'enrollee.createdAt',
     enableColumnFilter: false,
+    meta: {
+      columnType: 'instant'
+    },
     cell: info => instantToDefaultString(info.getValue() as unknown as number)
   }, {
     id: 'lastLogin',
     header: 'Last login',
     accessorKey: 'participantUser.lastLogin',
     enableColumnFilter: false,
+    meta: {
+      columnType: 'instant'
+    },
     cell: info => instantToDefaultString(info.getValue() as unknown as number)
   }, {
     id: 'familyName',
@@ -187,22 +192,28 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
       <div className="col-12">
         <LoadingSpinner isLoading={isLoading}>
           <div>
-            <div className="d-flex align-items-center">
-              <span className="me-2">
-                {numSelected} of{' '}
-                {table.getPreFilteredRowModel().rows.length} selected ({table.getFilteredRowModel().rows.length} shown)
-              </span>
-              <span className="me-2">
-                <Button onClick={() => setShowEmailModal(allowSendEmail)}
-                  variant="link" disabled={!allowSendEmail}
-                  tooltip={allowSendEmail ? 'Send email' : 'Select at least one participant'}>
-                  Send email
-                </Button>
-              </span>
-              { showEmailModal && <AdHocEmailModal enrolleeShortcodes={enrolleesSelected}
-                studyEnvContext={studyEnvContext}
-                onDismiss={() => setShowEmailModal(false)}/> }
-              <ColumnVisibilityControl table={table}/>
+            <div className="d-flex align-items-center justify-content-between mx-3">
+              <div className="d-flex">
+                <span className="me-2">
+                  {numSelected} of{' '}
+                  {/* eslint-disable-next-line max-len */}
+                  {table.getPreFilteredRowModel().rows.length} selected ({table.getFilteredRowModel().rows.length} shown)
+                </span>
+                { showEmailModal && <AdHocEmailModal enrolleeShortcodes={enrolleesSelected}
+                  studyEnvContext={studyEnvContext}
+                  onDismiss={() => setShowEmailModal(false)}/> }
+              </div>
+              <div className="d-flex">
+                <button
+                  className="btn btn-light border m-1"
+                  disabled={!allowSendEmail}
+                  onClick={() => setShowEmailModal(allowSendEmail)}
+                  aria-label="download data">
+                  <FontAwesomeIcon icon={faEnvelope} className="fa-lg"/> Send email
+                </button>
+                <DownloadControl table={table}/>
+                <ColumnVisibilityControl table={table}/>
+              </div>
             </div>
           </div>
           { basicTableLayout(table, { filterable: true })}

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -208,7 +208,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
                   className="btn btn-light border m-1"
                   disabled={!allowSendEmail}
                   onClick={() => setShowEmailModal(allowSendEmail)}
-                  aria-label="download data">
+                  aria-label="send email">
                   <FontAwesomeIcon icon={faEnvelope} className="fa-lg"/> Send email
                 </button>
                 <DownloadControl table={table} fileName={`${portal.shortcode}-ParticipantList-${currentIsoDate()}`}/>

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -25,7 +25,7 @@ import {
   facetValuesToString,
   KEYWORD_FACET
 } from 'api/enrolleeSearch'
-import { instantToDefaultString } from 'util/timeUtils'
+import { currentIsoDate, instantToDefaultString } from 'util/timeUtils'
 import { useLoadingEffect } from 'api/api-utils'
 import { FacetView, getUpdatedFacetValues } from './facets/EnrolleeSearchFacets'
 import TableClientPagination from 'util/TablePagination'
@@ -211,7 +211,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
                   aria-label="download data">
                   <FontAwesomeIcon icon={faEnvelope} className="fa-lg"/> Send email
                 </button>
-                <DownloadControl table={table}/>
+                <DownloadControl table={table} fileName={`${portal.shortcode}-ParticipantList-${currentIsoDate()}`}/>
                 <ColumnVisibilityControl table={table}/>
               </div>
             </div>

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -29,6 +29,7 @@ import { currentIsoDate, instantToDefaultString } from 'util/timeUtils'
 import { useLoadingEffect } from 'api/api-utils'
 import { FacetView, getUpdatedFacetValues } from './facets/EnrolleeSearchFacets'
 import TableClientPagination from 'util/TablePagination'
+import { Button } from 'components/forms/Button'
 
 /** Shows a list of (for now) enrollees */
 function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
@@ -204,13 +205,11 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
                   onDismiss={() => setShowEmailModal(false)}/> }
               </div>
               <div className="d-flex">
-                <button
-                  className="btn btn-light border m-1"
-                  disabled={!allowSendEmail}
-                  onClick={() => setShowEmailModal(allowSendEmail)}
-                  aria-label="send email">
+                <Button onClick={() => setShowEmailModal(allowSendEmail)}
+                  variant="light" className="border m-1" disabled={!allowSendEmail}
+                  tooltip={allowSendEmail ? 'Send email' : 'Select at least one participant'}>
                   <FontAwesomeIcon icon={faEnvelope} className="fa-lg"/> Send email
-                </button>
+                </Button>
                 <DownloadControl table={table} fileName={`${portal.shortcode}-ParticipantList-${currentIsoDate()}`}/>
                 <ColumnVisibilityControl table={table}/>
               </div>

--- a/ui-admin/src/util/tableUtils.test.tsx
+++ b/ui-admin/src/util/tableUtils.test.tsx
@@ -12,7 +12,7 @@ import {
 import { basicTableLayout, checkboxColumnCell, ColumnVisibilityControl, DownloadControl } from './tableUtils'
 import userEvent from '@testing-library/user-event'
 
-const DEFAULT_INITIAL_DATA = [{ consented: true, name: 'Fred' }, { consented: false, name: 'James' }]
+const SAMPLE_INITIAL_DATA = [{ consented: true, name: 'Fred' }, { consented: false, name: 'James' }]
 
 /** simple table with filters, a download control, and a column control */
 const TestTableComponent = ({ initialValue, initialData }: {
@@ -57,20 +57,20 @@ const TestTableComponent = ({ initialValue, initialData }: {
 }
 
 test('renders rows with default filters', async () => {
-  render(<TestTableComponent initialValue={[{ id: 'consented', value: true }]} initialData={DEFAULT_INITIAL_DATA}/>)
+  render(<TestTableComponent initialValue={[{ id: 'consented', value: true }]} initialData={SAMPLE_INITIAL_DATA}/>)
   expect(screen.queryByText('James')).not.toBeInTheDocument()
   expect(screen.getByText('Fred')).toBeInTheDocument()
 })
 
 test('renders with no default filters', async () => {
-  render(<TestTableComponent initialValue={[]} initialData={DEFAULT_INITIAL_DATA}/>)
+  render(<TestTableComponent initialValue={[]} initialData={SAMPLE_INITIAL_DATA}/>)
   expect(screen.getByText('Fred')).toBeInTheDocument()
   expect(screen.getByText('James')).toBeInTheDocument()
 })
 
 
 test('show/hide column controls work', async () => {
-  render(<TestTableComponent initialValue={[]} initialData={DEFAULT_INITIAL_DATA}/>)
+  render(<TestTableComponent initialValue={[]} initialData={SAMPLE_INITIAL_DATA}/>)
   expect(screen.getByText('Columns')).toBeInTheDocument()
   expect(screen.getByText('Consented')).toBeInTheDocument()
   await userEvent.click(screen.getByText('Columns'))
@@ -82,7 +82,7 @@ test('show/hide column controls work', async () => {
 })
 
 test('download button is enabled if there are rows in the table', async () => {
-  render(<TestTableComponent initialValue={[]} initialData={DEFAULT_INITIAL_DATA}/>)
+  render(<TestTableComponent initialValue={[]} initialData={SAMPLE_INITIAL_DATA}/>)
   const downloadButton = screen.getByText('Download')
   expect(downloadButton).toBeEnabled()
 })
@@ -95,7 +95,7 @@ test('download button is disabled if there aren\'t any rows in the table', async
 
 test('download data modal should specify the number of rows to be downloaded', async () => {
   //Arrange
-  render(<TestTableComponent initialValue={[]} initialData={DEFAULT_INITIAL_DATA}/>)
+  render(<TestTableComponent initialValue={[]} initialData={SAMPLE_INITIAL_DATA}/>)
   const downloadButton = screen.getByText('Download')
 
   //Act

--- a/ui-admin/src/util/tableUtils.test.tsx
+++ b/ui-admin/src/util/tableUtils.test.tsx
@@ -90,7 +90,7 @@ test('download button is enabled if there are rows in the table', async () => {
 test('download button is disabled if there aren\'t any rows in the table', async () => {
   render(<TestTableComponent initialValue={[]} initialData={[]}/>)
   const downloadButton = screen.getByText('Download')
-  expect(downloadButton).toBeDisabled()
+  expect(downloadButton).toHaveAttribute('aria-disabled', 'true')
 })
 
 test('download data modal should specify the number of rows to be downloaded', async () => {
@@ -102,9 +102,9 @@ test('download data modal should specify the number of rows to be downloaded', a
   await userEvent.click(downloadButton)
 
   //Assert
-  const downloadText = screen.getByText('This will download', { exact: false })
+  const downloadText = screen.getByText('The current data filters', { exact: false })
   const rawTextContent = downloadText.textContent
-  const expectedText = 'This will download 2 rows to test.csv. ' +
-    'Your current row and column filters will be applied to the downloaded data.'
+  const expectedText = 'Download 2 rows to test.csv. ' +
+    'The current data filters and shown columns will be applied.'
   expect(rawTextContent).toEqual(expectedText)
 })

--- a/ui-admin/src/util/tableUtils.test.tsx
+++ b/ui-admin/src/util/tableUtils.test.tsx
@@ -9,11 +9,15 @@ import {
   getSortedRowModel,
   useReactTable
 } from '@tanstack/react-table'
-import { basicTableLayout, checkboxColumnCell, ColumnVisibilityControl } from './tableUtils'
+import { basicTableLayout, checkboxColumnCell, ColumnVisibilityControl, DownloadControl } from './tableUtils'
 import userEvent from '@testing-library/user-event'
 
-/** simple table with filters and a show/hide column control */
-const TestTableComponent = ({ initialValue }: {initialValue: ColumnFiltersState}) => {
+const DEFAULT_INITIAL_DATA = [{ consented: true, name: 'Fred' }, { consented: false, name: 'James' }]
+
+/** simple table with filters, a download control, and a column control */
+const TestTableComponent = ({ initialValue, initialData }: {
+  initialValue: ColumnFiltersState, initialData: object[]
+}) => {
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(
     initialValue
   )
@@ -36,7 +40,7 @@ const TestTableComponent = ({ initialValue }: {initialValue: ColumnFiltersState}
   }]
 
   const table = useReactTable({
-    data: [{ consented: true, name: 'Fred' }, { consented: false, name: 'James' }],
+    data: initialData,
     columns,
     state: { columnFilters },
     onColumnFiltersChange: setColumnFilters,
@@ -47,31 +51,60 @@ const TestTableComponent = ({ initialValue }: {initialValue: ColumnFiltersState}
 
   return <div>
     <ColumnVisibilityControl table={table}/>
+    <DownloadControl table={table} fileName={'test'}/>
     { basicTableLayout(table, { filterable: true }) }
   </div>
 }
 
 test('renders rows with default filters', async () => {
-  render(<TestTableComponent initialValue={[{ id: 'consented', value: true }]}/>)
+  render(<TestTableComponent initialValue={[{ id: 'consented', value: true }]} initialData={DEFAULT_INITIAL_DATA}/>)
   expect(screen.queryByText('James')).not.toBeInTheDocument()
   expect(screen.getByText('Fred')).toBeInTheDocument()
 })
 
 test('renders with no default filters', async () => {
-  render(<TestTableComponent initialValue={[]}/>)
+  render(<TestTableComponent initialValue={[]} initialData={DEFAULT_INITIAL_DATA}/>)
   expect(screen.getByText('Fred')).toBeInTheDocument()
   expect(screen.getByText('James')).toBeInTheDocument()
 })
 
 
 test('show/hide column controls work', async () => {
-  render(<TestTableComponent initialValue={[]}/>)
-  expect(screen.getByText('Show/hide columns')).toBeInTheDocument()
+  render(<TestTableComponent initialValue={[]} initialData={DEFAULT_INITIAL_DATA}/>)
+  expect(screen.getByText('Columns')).toBeInTheDocument()
   expect(screen.getByText('Consented')).toBeInTheDocument()
-  await userEvent.click(screen.getByText('Show/hide columns'))
+  await userEvent.click(screen.getByText('Columns'))
   await waitFor(() => expect(screen.getByText('Toggle column visibility')).toBeVisible())
   await userEvent.click(screen.getByLabelText('Consented'))
   await userEvent.click(screen.getByText('Ok'))
   await waitFor(() => expect(screen.queryByText('Toggle column visibility')).not.toBeInTheDocument())
   expect(screen.queryByText('Consented')).not.toBeInTheDocument()
+})
+
+test('download button is enabled if there are rows in the table', async () => {
+  render(<TestTableComponent initialValue={[]} initialData={DEFAULT_INITIAL_DATA}/>)
+  const downloadButton = screen.getByText('Download')
+  expect(downloadButton).toBeEnabled()
+})
+
+test('download button is disabled if there aren\'t any rows in the table', async () => {
+  render(<TestTableComponent initialValue={[]} initialData={[]}/>)
+  const downloadButton = screen.getByText('Download')
+  expect(downloadButton).toBeDisabled()
+})
+
+test('download data modal should specify the number of rows to be downloaded', async () => {
+  //Arrange
+  render(<TestTableComponent initialValue={[]} initialData={DEFAULT_INITIAL_DATA}/>)
+  const downloadButton = screen.getByText('Download')
+
+  //Act
+  await userEvent.click(downloadButton)
+
+  //Assert
+  const downloadText = screen.getByText('This will download', { exact: false })
+  const rawTextContent = downloadText.textContent
+  const expectedText = 'This will download 2 rows to test.csv. ' +
+    'Your current row and column filters will be applied to the downloaded data.'
+  expect(rawTextContent).toEqual(expectedText)
 })

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLProps, useEffect, useState } from 'react'
-import { Cell, CellContext, Column, flexRender, Header, RowData, Table } from '@tanstack/react-table'
+import { CellContext, Column, flexRender, Header, RowData, Table } from '@tanstack/react-table'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCaretDown, faCaretUp, faCheck, faColumns, faDownload } from '@fortawesome/free-solid-svg-icons'
 import Select from 'react-select'
@@ -269,7 +269,7 @@ export function ColumnVisibilityControl<T>({ table }: {table: Table<T>}) {
   </div>
 }
 
-function cellToString(cellType: string, cellValue: unknown): string {
+function cellToCsvString(cellType: string, cellValue: unknown): string {
   switch (cellType) {
     case 'instant':
       return escapeCsvValue(instantToDefaultString(cellValue as number))
@@ -283,9 +283,9 @@ function cellToString(cellType: string, cellValue: unknown): string {
 }
 
 /**
- *
+ * Adds a control to download the table data as a csv file
  */
-export function DownloadControl<T>({ table }: {table: Table<T>}) {
+export function DownloadControl<T>({ table, fileName }: {table: Table<T>, fileName: string}) {
   const [show, setShow] = useState(false)
 
   const download = () => {
@@ -296,12 +296,12 @@ export function DownloadControl<T>({ table }: {table: Table<T>}) {
     const rows = table.getFilteredRowModel().rows.map(row => {
       return row.getVisibleCells().map(cell => {
         const cellType = cell.column.columnDef.meta?.columnType || 'string'
-        return cellToString(cellType, cell.getValue())
+        return cellToCsvString(cellType, cell.getValue())
       }).join(',')
     }).join('\n')
 
     const blob = new Blob([headers, '\n', rows], { type: 'text/plain' })
-    saveBlobAsDownload(blob, `table-data.csv`) //todo rename file
+    saveBlobAsDownload(blob, `${fileName}.csv`)
   }
 
   return <div className="ms-auto">
@@ -318,7 +318,8 @@ export function DownloadControl<T>({ table }: {table: Table<T>}) {
       <Modal.Body>
         <div className="border-b border-black">
                 This will download <strong>{table.getFilteredRowModel().rows.length}</strong> rows
-                as a <code>.csv</code> file. Your current filters will be applied to the downloaded data.
+                to <code>{fileName}.csv</code>. Your current row and column filters will be applied to the
+                downloaded data.
         </div>
       </Modal.Body>
       <Modal.Footer>

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -269,16 +269,19 @@ export function ColumnVisibilityControl<T>({ table }: {table: Table<T>}) {
   </div>
 }
 
+/**
+ * Converts a cell value to an escaped string for csv export
+ */
 function cellToCsvString(cellType: string, cellValue: unknown): string {
   switch (cellType) {
+    case 'string':
+      return cellValue ? escapeCsvValue(cellValue as string) : ''
     case 'instant':
       return escapeCsvValue(instantToDefaultString(cellValue as number))
     case 'boolean':
       return cellValue as boolean ? 'true' : 'false'
-    case 'string':
-      return cellValue ? escapeCsvValue(cellValue as string) : ''
     default:
-      return ''
+      return cellValue ? escapeCsvValue(cellValue as string) : ''
   }
 }
 

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -222,9 +222,11 @@ export function IndeterminateCheckbox({
 export function ColumnVisibilityControl<T>({ table }: {table: Table<T>}) {
   const [show, setShow] = useState(false)
   return <div className="ms-auto">
-    <button className="btn btn-light border m-1" onClick={() => setShow(!show)} aria-label="show or hide columns">
+    <Button onClick={() => setShow(!show)}
+      variant="light" className="border m-1"
+      tooltip={'Show or hide columns'}>
       <FontAwesomeIcon icon={faColumns} className="fa-lg"/> Columns
-    </button>
+    </Button>
     { show && <Modal show={show} onHide={() => setShow(false)}>
       <Modal.Header closeButton>
         <Modal.Title>
@@ -307,11 +309,14 @@ export function DownloadControl<T>({ table, fileName }: {table: Table<T>, fileNa
     saveBlobAsDownload(blob, `${fileName}.csv`)
   }
 
+  const disableDownload = isEmpty(table.getFilteredRowModel().rows)
+
   return <div className="ms-auto">
-    <button className="btn btn-light border m-1" disabled={isEmpty(table.getFilteredRowModel().rows)}
-      onClick={() => setShow(!show)} aria-label="download table data">
+    <Button onClick={() => setShow(!show)}
+      variant="light" className="border m-1" disabled={disableDownload}
+      tooltip={!disableDownload ? 'Download table' : 'At least one row must be visible in order to download'}>
       <FontAwesomeIcon icon={faDownload} className="fa-lg"/> Download
-    </button>
+    </Button>
     { show && <Modal show={show} onHide={() => setShow(false)}>
       <Modal.Header closeButton>
         <Modal.Title>

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -289,13 +289,14 @@ export function DownloadControl<T>({ table, fileName }: {table: Table<T>, fileNa
   const [show, setShow] = useState(false)
 
   const download = () => {
-    const headers = table.getLeafHeaders().map(header => {
+    const headers = table.getFlatHeaders().map(header => {
       return header.id
     }).join(',')
 
     const rows = table.getFilteredRowModel().rows.map(row => {
       return row.getVisibleCells().map(cell => {
         const cellType = cell.column.columnDef.meta?.columnType || 'string'
+        console.log(cell.getContext().renderValue())
         return cellToCsvString(cellType, cell.getValue())
       }).join(',')
     }).join('\n')

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -290,16 +290,20 @@ function cellToCsvString(cellType: string, cellValue: unknown): string {
 /**
  * Adds a control to download the table data as a csv file
  */
-export function DownloadControl<T>({ table, fileName }: {table: Table<T>, fileName: string}) {
+export function DownloadControl<T>({ table, fileName, excludedColumns = ['select'] }:{
+  table: Table<T>, fileName: string, excludedColumns?: string[]}
+) {
   const [show, setShow] = useState(false)
 
   const download = () => {
-    const headers = table.getFlatHeaders().map(header => {
+    const headers = table.getFlatHeaders().filter(header => !excludedColumns.includes(header.id)).map(header => {
       return header.id
     }).join(',')
 
     const rows = table.getFilteredRowModel().rows.map(row => {
-      return row.getVisibleCells().map(cell => {
+      const visibleCells = row.getVisibleCells().filter(cell => !excludedColumns.includes(cell.column.id))
+
+      return visibleCells.map(cell => {
         const cellType = cell.column.columnDef.meta?.columnType || 'string'
         return cellToCsvString(cellType, cell.getValue())
       }).join(',')

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -320,9 +320,8 @@ export function DownloadControl<T>({ table, fileName }: {table: Table<T>, fileNa
       </Modal.Header>
       <Modal.Body>
         <div className="border-b border-black">
-                This will download <strong>{table.getFilteredRowModel().rows.length}</strong> rows
-                to <code>{fileName}.csv</code>. Your current row and column filters will be applied to the
-                downloaded data.
+                Download <strong>{table.getFilteredRowModel().rows.length}</strong> rows
+                to <code>{fileName}.csv</code>. The current data filters and shown columns will be applied.
         </div>
       </Modal.Body>
       <Modal.Footer>

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -296,7 +296,6 @@ export function DownloadControl<T>({ table, fileName }: {table: Table<T>, fileNa
     const rows = table.getFilteredRowModel().rows.map(row => {
       return row.getVisibleCells().map(cell => {
         const cellType = cell.column.columnDef.meta?.columnType || 'string'
-        console.log(cell.getContext().renderValue())
         return cellToCsvString(cellType, cell.getValue())
       }).join(',')
     }).join('\n')


### PR DESCRIPTION
#### DESCRIPTION

This adds the ability to download the participant list as a .csv file. The resulting .csv file will be exactly what is visible in the table when the user clicks the download button; we will respect filters and column selections. I also made a few other related UX tweaks to better match Erin's mockups for the buttons in the upper right corner of the table.

![Screenshot 2023-10-11 at 10 31 09 AM](https://github.com/broadinstitute/juniper/assets/7257391/bf785916-7e4b-4e2f-9611-baab7524cdb7)

![Screenshot 2023-10-11 at 10 49 22 AM](https://github.com/broadinstitute/juniper/assets/7257391/d897695a-4903-41b3-ad30-95a04b58eb4b)


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Launch admin API and UI
* Verify that the download button is disabled if there aren't any rows visible
* Verify that you can download the csv when there are visible rows. Apply some filters and hide some columns, and verify that only the visible columns and rows are in the csv
* Verify that there aren't any formatting issues in the file (making sure that everything is escaped when necessary, specifically for dates/times)
