### PR TITLE
[JN-425] update decode uri component to 0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7804,6 +7804,14 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/decode-uri-component": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
@@ -9918,6 +9926,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/finalhandler": {
@@ -17668,6 +17684,23 @@
         "node": ">=0.10.21"
       }
     },
+    "node_modules/query-string": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "dependencies": {
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -19410,6 +19443,14 @@
         "wbuf": "^1.7.3"
       }
     },
+    "node_modules/split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -19597,6 +19638,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
+    "node_modules/strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -22613,7 +22662,7 @@
         "oidc-client-ts": "^2.2.0",
         "plotly.js": "^2.23.0",
         "pluralize": "^8.0.0",
-        "query-string": "^7.1.1",
+        "query-string": "^7.1.3",
         "react": "^18.2.0",
         "react-bootstrap": "^2.8.0",
         "react-contenteditable": "^3.3.6",
@@ -22786,20 +22835,6 @@
       "version": "4.1.1",
       "license": "MIT"
     },
-    "ui-admin/node_modules/decode-uri-component": {
-      "version": "0.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "ui-admin/node_modules/filter-obj": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "ui-admin/node_modules/find-root": {
       "version": "1.1.0",
       "license": "MIT"
@@ -22932,22 +22967,6 @@
         "node": ">=12.13.0"
       }
     },
-    "ui-admin/node_modules/query-string": {
-      "version": "7.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "decode-uri-component": "^0.2.0",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "ui-admin/node_modules/react-contenteditable": {
       "version": "3.3.6",
       "license": "Apache-2.0",
@@ -22996,20 +23015,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "ui-admin/node_modules/split-on-first": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "ui-admin/node_modules/strict-uri-encode": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "ui-admin/node_modules/style-to-js": {
@@ -25440,7 +25445,7 @@
         "oidc-client-ts": "^2.2.0",
         "plotly.js": "^2.23.0",
         "pluralize": "^8.0.0",
-        "query-string": "^7.1.1",
+        "query-string": "^7.1.3",
         "react": "^18.2.0",
         "react-bootstrap": "^2.8.0",
         "react-contenteditable": "^3.3.6",
@@ -25547,12 +25552,6 @@
         "crypto-js": {
           "version": "4.1.1"
         },
-        "decode-uri-component": {
-          "version": "0.2.0"
-        },
-        "filter-obj": {
-          "version": "1.1.0"
-        },
         "find-root": {
           "version": "1.1.0"
         },
@@ -25640,15 +25639,6 @@
             "jwt-decode": "^3.1.2"
           }
         },
-        "query-string": {
-          "version": "7.1.1",
-          "requires": {
-            "decode-uri-component": "^0.2.0",
-            "filter-obj": "^1.1.0",
-            "split-on-first": "^1.0.0",
-            "strict-uri-encode": "^2.0.0"
-          }
-        },
         "react-contenteditable": {
           "version": "3.3.6",
           "requires": {
@@ -25678,12 +25668,6 @@
             "prop-types": "^15.6.0",
             "react-transition-group": "^4.3.0"
           }
-        },
-        "split-on-first": {
-          "version": "1.1.0"
-        },
-        "strict-uri-encode": {
-          "version": "2.0.0"
         },
         "style-to-js": {
           "version": "1.1.1",
@@ -29570,6 +29554,11 @@
         "character-entities": "^2.0.0"
       }
     },
+    "decode-uri-component": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="
+    },
     "decompress-response": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
@@ -31210,6 +31199,11 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="
     },
     "finalhandler": {
       "version": "1.2.0",
@@ -36804,6 +36798,17 @@
       "resolved": "https://registry.npmjs.org/quantize/-/quantize-1.0.2.tgz",
       "integrity": "sha512-25P7wI2UoDbIQsQp50ARkt+5pwPsOq7G/BqvT5xAbapnRoNWMN8/p55H9TXd5MuENiJnm5XICB2H2aDZGwts7w=="
     },
+    "query-string": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "requires": {
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
+    },
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -38156,6 +38161,11 @@
         "wbuf": "^1.7.3"
       }
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -38306,6 +38316,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="
     },
     "string_decoder": {
       "version": "1.3.0",

--- a/ui-admin/package.json
+++ b/ui-admin/package.json
@@ -15,7 +15,7 @@
     "oidc-client-ts": "^2.2.0",
     "plotly.js": "^2.23.0",
     "pluralize": "^8.0.0",
-    "query-string": "^7.1.1",
+    "query-string": "^7.1.3",
     "react": "^18.2.0",
     "react-bootstrap": "^2.8.0",
     "react-contenteditable": "^3.3.6",


### PR DESCRIPTION
#### DESCRIPTION

The vulnerable package came from the direct dependency `query-string`. I updated to the latest minor version of `query-string`, which uses the patched version of `decode-uri-component`

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

I'm not totally sure what part of the app actually uses any of this stuff?
