### PR TITLE
JN-585 Updating stub kit request to current API structure

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/kit/StubPepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/StubPepperDSMClient.java
@@ -7,6 +7,7 @@ import bio.terra.pearl.core.model.participant.Enrollee;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Lazy;
@@ -37,9 +38,9 @@ public class StubPepperDSMClient implements PepperDSMClient {
                 {
                   "kits":[{
                       "error":false,
-                      "juniperKitId":"%s",
-                      "dsmShippingLabel":"GLMBJIYSQA0XHYV",
-                      "participantId":"%2$s",
+                      "juniperKitId":"%1$s",
+                      "dsmShippingLabel":"%2$s",
+                      "participantId":"%3$s",
                       "labelByEmail":"",
                       "scanByEmail":"",
                       "deactivationByEmail":"",
@@ -51,7 +52,7 @@ public class StubPepperDSMClient implements PepperDSMClient {
                       "collaboratorSampleId":"PN_%2$s_SALIVA_1"
                       }],
                   "isError":false}
-                """.formatted(UUID.randomUUID(), enrollee.getShortcode());
+                """.formatted(UUID.randomUUID(), RandomStringUtils.randomAlphabetic(15).toUpperCase(), enrollee.getShortcode());
         return fakeResponse;
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/StubPepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/StubPepperDSMClient.java
@@ -33,19 +33,31 @@ public class StubPepperDSMClient implements PepperDSMClient {
     @Override
     public String sendKitRequest(String studyShortcode, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address) {
         log.info("STUB sending kit request");
-        var statusBuilder = PepperKitStatus.builder()
-                .juniperKitId(kitRequest.getId().toString())
-                .currentStatus("CREATED");
-        try {
-            return objectMapper.writeValueAsString(statusBuilder.build());
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+        String fakeResponse = """
+                {
+                  "kits":[{
+                      "error":false,
+                      "juniperKitId":"%s",
+                      "dsmShippingLabel":"GLMBJIYSQA0XHYV",
+                      "participantId":"%2$s",
+                      "labelByEmail":"",
+                      "scanByEmail":"",
+                      "deactivationByEmail":"",
+                      "trackingScanBy":"",
+                      "errorMessage":"",
+                      "discardBy":"",
+                      "currentStatus":"Kit Without Label",
+                      "collaboratorParticipantId":"PN_%2$s",
+                      "collaboratorSampleId":"PN_%2$s_SALIVA_1"
+                      }],
+                  "isError":false}
+                """.formatted(UUID.randomUUID(), enrollee.getShortcode());
+        return fakeResponse;
     }
 
     @Override
     public PepperKitStatus fetchKitStatus(UUID kitRequestId) {
-        log.info("STUB fethcing kit status");
+        log.info("STUB fetching kit status");
         return PepperKitStatus.builder()
                 .juniperKitId(kitRequestId.toString())
                 .currentStatus("SENT")


### PR DESCRIPTION
#### DESCRIPTION

Updates the stub kit request service to be compatible with the latest API changes.  Previously, sending a kit request with USE_LIVE_DSM=false would always error.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1. confirm USE_LIVE_DSM is set to false in your `api-admin/src/main/resources/application.yml` file
2. redeploy ApiAdminApp
3. go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants/OHKITS
4. click "Create Kit Request" 
5. click "REquest Kit" in the modal
6. confirm a kit request succeeeds and appears.
