### PR TITLE
[JN-633] upgrading mock autosave infrastructure

### DIFF
--- a/ui-core/src/autoSaveUtils.ts
+++ b/ui-core/src/autoSaveUtils.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 
-/** TODO JSdoc */
+/** Executes the save function at the specified interval, but only starting the interval after the
+ * previous call returns, guaranteed no overlapping saves */
 export function useAutosaveEffect(saveFn: () => void, autoSaveInterval: number) {
   useEffect(() => {
     let timeoutHandle: number

--- a/ui-core/src/index.ts
+++ b/ui-core/src/index.ts
@@ -8,6 +8,7 @@ export * from './types/portal'
 export * from './types/study'
 export * from './types/task'
 
+export * from './autoSaveUtils'
 export * from './reactUtils'
 export * from './surveyUtils'
 export * from './waitForImages'

--- a/ui-participant/src/hub/survey/SurveyView.test.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.test.tsx
@@ -10,13 +10,23 @@ import { render, screen } from '@testing-library/react'
 import { PagedSurveyView, SurveyFooter } from './SurveyView'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { useUser } from 'providers/UserProvider'
-import { Survey } from '@juniper/ui-core'
+import { Survey, useAutosaveEffect } from '@juniper/ui-core'
 import Api from 'api/api'
 import { mockEnrollee, mockHubResponse } from 'test-utils/test-participant-factory'
 import userEvent from '@testing-library/user-event'
 import { setupRouterTest } from 'test-utils/router-testing-utils'
 
 jest.mock('providers/PortalProvider', () => ({ usePortalEnv: jest.fn() }))
+
+// mock the useAutosaveEffect, but leave other core functions intact
+jest.mock('@juniper/ui-core', () => {
+  const original = jest.requireActual('@juniper/ui-core')
+  return {
+    ...original,
+    useAutosaveEffect: jest.fn()
+  }
+})
+
 beforeEach(() => {
   (usePortalEnv as jest.Mock).mockReturnValue({
     portal: { name: 'demo' },
@@ -78,14 +88,15 @@ describe('Renders a survey', () => {
   })
 
   it('autosaves question and page progress', async () => {
-    const { submitSpy } = setupSurveyTest(generateThreePageSurvey())
+    const { submitSpy, triggerAutosave } = setupSurveyTest(generateThreePageSurvey())
 
     await userEvent.click(screen.getByText('Green'))
     await userEvent.click(screen.getByText('Next'))
     expect(screen.getByText('You are on page2')).toBeInTheDocument()
     await userEvent.type(screen.getByText('text input'), 'my Text')
     await userEvent.click(screen.getByText('Next'))
-    await new Promise(r => setTimeout(r, 600))
+    triggerAutosave()
+    triggerAutosave()
     // should only have been called once, despite multiple intervals passing, since it only is called on diffs
     expect(submitSpy).toHaveBeenCalledTimes(1)
     expect(submitSpy).toHaveBeenCalledWith(expect.objectContaining({
@@ -100,15 +111,15 @@ describe('Renders a survey', () => {
   })
 
   it('autosaves question and page progress with diffs', async () => {
-    const { submitSpy } = setupSurveyTest(generateThreePageSurvey())
+    const { submitSpy, triggerAutosave } = setupSurveyTest(generateThreePageSurvey())
 
     await userEvent.click(screen.getByText('Green'))
-    await new Promise(r => setTimeout(r, 250))
+    triggerAutosave()
     await userEvent.click(screen.getByText('Next'))
     expect(screen.getByText('You are on page2')).toBeInTheDocument()
     await userEvent.type(screen.getByText('text input'), 'my Text')
     await userEvent.click(screen.getByText('Next'))
-    await new Promise(r => setTimeout(r, 250))
+    triggerAutosave()
 
     expect(submitSpy).toHaveBeenCalledTimes(2)
     expect(submitSpy).toHaveBeenNthCalledWith(1, expect.objectContaining({
@@ -125,13 +136,13 @@ describe('Renders a survey', () => {
   })
 
   it('autosave handles updated questions', async () => {
-    const { submitSpy } = setupSurveyTest(generateThreePageSurvey())
+    const { submitSpy, triggerAutosave } = setupSurveyTest(generateThreePageSurvey())
     await userEvent.click(screen.getByText('Green'))
     await userEvent.click(screen.getByText('Next'))
-    await new Promise(r => setTimeout(r, 250))
+    triggerAutosave()
     await userEvent.click(screen.getByText('Previous'))
     await userEvent.click(screen.getByText('Blue'))
-    await new Promise(r => setTimeout(r, 250))
+    triggerAutosave()
 
     expect(submitSpy).toHaveBeenCalledTimes(2)
     expect(submitSpy).toHaveBeenNthCalledWith(1, expect.objectContaining({
@@ -149,12 +160,12 @@ describe('Renders a survey', () => {
   })
 
   it('autosave handles hidden questions with default clear-on-submit behavior', async () => {
-    const { submitSpy } = setupSurveyTest(mockSurveyWithHiddenQuestion())
+    const { submitSpy, triggerAutosave } = setupSurveyTest(mockSurveyWithHiddenQuestion())
     await userEvent.click(screen.getByText('Green'))
     await userEvent.click(screen.getByText('forest green'))
-    await new Promise(r => setTimeout(r, 250))
+    triggerAutosave()
     await userEvent.click(screen.getByText('Blue'))
-    await new Promise(r => setTimeout(r, 250))
+    triggerAutosave()
     await userEvent.click(screen.getByText('Complete'))
 
     expect(submitSpy).toHaveBeenCalledTimes(3)
@@ -177,12 +188,12 @@ describe('Renders a survey', () => {
   })
 
   it('autosave handles hidden questions with clear-on-hidden', async () => {
-    const { submitSpy } = setupSurveyTest(mockSurveyWithHiddenQuestionClearOnHidden())
+    const { submitSpy, triggerAutosave } = setupSurveyTest(mockSurveyWithHiddenQuestionClearOnHidden())
     await userEvent.click(screen.getByText('Green'))
     await userEvent.click(screen.getByText('forest green'))
-    await new Promise(r => setTimeout(r, 200))
+    triggerAutosave()
     await userEvent.click(screen.getByText('Blue'))
-    await new Promise(r => setTimeout(r, 200))
+    triggerAutosave()
     await userEvent.click(screen.getByText('Complete'))
 
     expect(submitSpy).toHaveBeenNthCalledWith(1, expect.objectContaining({
@@ -204,13 +215,16 @@ describe('Renders a survey', () => {
   })
 
   it('retries autosave if autosave fails', async () => {
-    const { submitSpy } = setupSurveyTest(generateThreePageSurvey())
+    const { submitSpy, triggerAutosave } = setupSurveyTest(generateThreePageSurvey())
     submitSpy.mockImplementation(() => Promise.reject({}))
 
     await userEvent.click(screen.getByText('Green'))
     await userEvent.click(screen.getByText('Next'))
     expect(screen.getByText('You are on page2')).toBeInTheDocument()
-    await new Promise(r => setTimeout(r, 500))
+    triggerAutosave()
+    // we need a small wait for the error state to propagate.  the update has no impact on the DOM, so we wait manually
+    await new Promise(r => setTimeout(r, 100))
+    triggerAutosave()
     const expectedDiffResponse = expect.objectContaining({
       response: expect.objectContaining({
         answers: [{ questionStableId: 'radio1', stringValue: 'green' },
@@ -230,16 +244,25 @@ describe('Renders a survey', () => {
 const setupSurveyTest = (survey: Survey) => {
   const submitSpy = jest.spyOn(Api, 'updateSurveyResponse')
     .mockImplementation(() => Promise.resolve(mockHubResponse()))
+  const autosaveManager = {
+    trigger: (): void => { throw 'no autosave registered' }
+  };
+
+  (useAutosaveEffect as jest.Mock).mockImplementation(saveFn => {
+    autosaveManager.trigger = () => { saveFn() }
+  })
+  const triggerAutosave = () => autosaveManager.trigger()
+
   const configuredSurvey = {
     ...mockConfiguredSurvey(),
     survey
   }
   const { RoutedComponent } = setupRouterTest(
     <PagedSurveyView enrollee={mockEnrollee()} form={configuredSurvey}
-      studyShortcode={'study'} taskId={'guid34'} autoSaveInterval={200}/>)
+      studyShortcode={'study'} taskId={'guid34'}/>)
   render(RoutedComponent)
   expect(screen.getByText('You are on page1')).toBeInTheDocument()
-  return { submitSpy, RoutedComponent }
+  return { submitSpy, RoutedComponent, triggerAutosave }
 }
 
 

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -19,7 +19,7 @@ import {
   useRoutablePageNumber,
   useSurveyJSModel
 } from 'util/surveyJsUtils'
-import { makeSurveyJsData, SurveyJsResumeData, Markdown } from '@juniper/ui-core'
+import { makeSurveyJsData, SurveyJsResumeData, Markdown, useAutosaveEffect } from '@juniper/ui-core'
 import { HubUpdate } from 'hub/hubUpdates'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { useUser } from 'providers/UserProvider'
@@ -28,7 +28,6 @@ import { withErrorBoundary } from 'util/ErrorBoundary'
 import SurveyReviewModeButton from './ReviewModeButton'
 import { SurveyModel } from 'survey-core'
 import { DocumentTitle } from 'util/DocumentTitle'
-import { useAutosaveEffect } from '@juniper/ui-core/build/autoSaveUtils'
 
 const TASK_ID_PARAM = 'taskId'
 const AUTO_SAVE_INTERVAL = 3 * 1000  // auto-save every 3 seconds if there are changes
@@ -36,14 +35,10 @@ const AUTO_SAVE_INTERVAL = 3 * 1000  // auto-save every 3 seconds if there are c
 /**
  * display a single survey form to a participant.
  */
-export function RawSurveyView({
-  form, enrollee, resumableData, pager,
-  studyShortcode, taskId, activeResponse, autoSaveInterval=AUTO_SAVE_INTERVAL
-}:
+export function RawSurveyView({ form, enrollee, resumableData, pager, studyShortcode, taskId, activeResponse }:
 {
   form: Survey, enrollee: Enrollee, taskId: string, activeResponse?: SurveyResponse,
-  resumableData: SurveyJsResumeData | null, pager: PageNumberControl, studyShortcode: string,
-  autoSaveInterval?: number
+  resumableData: SurveyJsResumeData | null, pager: PageNumberControl, studyShortcode: string
 }) {
   const navigate = useNavigate()
   const { updateEnrollee } = useUser()
@@ -136,7 +131,7 @@ export function RawSurveyView({
     })
   }
 
-  useAutosaveEffect(saveDiff, autoSaveInterval)
+  useAutosaveEffect(saveDiff, AUTO_SAVE_INTERVAL)
 
   return (
     <>
@@ -168,8 +163,7 @@ export function SurveyFooter({ survey, surveyModel }: { survey: Survey, surveyMo
 
 /** handles paging the form */
 export function PagedSurveyView({
-  form, activeResponse, enrollee, studyShortcode,
-  taskId, autoSaveInterval=AUTO_SAVE_INTERVAL
+  form, activeResponse, enrollee, studyShortcode, taskId
 }:
 {
   form: StudyEnvironmentSurvey, activeResponse?: SurveyResponse, enrollee: Enrollee,
@@ -181,7 +175,7 @@ export function PagedSurveyView({
   const pager = useRoutablePageNumber()
 
   return <RawSurveyView enrollee={enrollee} form={form.survey} taskId={taskId} activeResponse={activeResponse}
-    resumableData={resumableData} pager={pager} studyShortcode={studyShortcode} autoSaveInterval={autoSaveInterval}/>
+    resumableData={resumableData} pager={pager} studyShortcode={studyShortcode}/>
 }
 
 /** handles loading the survey form and responses from the server */


### PR DESCRIPTION
#### DESCRIPTION

Previously, our tests of survey autosaving relied on specifying a specific timeout interval.  This made the tests flaky as timeout intervals, especially in a CI environment, can be very flaky.  We now mock the entire autosave hook, which lets us manually specify when to simulate the autosave interval elapsing, and is much more robust.  This makes no changes to the behavior of the product.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. run `npm -w ui-participant run test` to confirm tests pass