### PR TITLE
[JN-542] Support adding new sections to pages

### DIFF
--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.test.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { setupRouterTest } from 'test-utils/router-testing-utils'
+import { mockHtmlPage } from 'test-utils/mock-site-content'
+import HtmlPageEditView from './HtmlPageEditView'
+import userEvent from '@testing-library/user-event'
+
+test('readOnly disables insert new section button', async () => {
+  const mockPage = mockHtmlPage()
+  const { RoutedComponent } = setupRouterTest(
+    <HtmlPageEditView htmlPage={mockPage} readOnly={true} updatePage={jest.fn()}/>)
+  render(RoutedComponent)
+  expect(screen.getByLabelText('Insert a blank section')).toHaveAttribute('aria-disabled', 'true')
+})
+
+test('Insert Section button calls updatePage with a new blank HERO_WITH_IMAGE section', async () => {
+  //Arrange
+  const mockPage = mockHtmlPage()
+  const mockUpdatePageFn = jest.fn()
+  const { RoutedComponent } = setupRouterTest(
+    <HtmlPageEditView htmlPage={mockPage} readOnly={false} updatePage={mockUpdatePageFn}/>)
+  render(RoutedComponent)
+
+  //Act
+  const insertSectionButton = screen.getByLabelText('Insert a blank section')
+  await userEvent.click(insertSectionButton)
+
+  //Assert
+  expect(insertSectionButton).toHaveAttribute('aria-disabled', 'false')
+  expect(mockUpdatePageFn).toHaveBeenCalledWith({
+    ...mockPage,
+    sections: [
+      ...mockPage.sections,
+      { id: '', sectionType: 'HERO_WITH_IMAGE' }
+    ]
+  })
+})

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
@@ -58,6 +58,7 @@ const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => 
         </div>
         <div className="col-md-12 my-2" style={{ backgroundColor: '#eee' }}>
           <Button variant="secondary"
+            aria-label={'Insert a blank section'}
             tooltip={'Insert a blank section'}
             disabled={readOnly}
             onClick={() => insertNewSection(index + 1, { id: '', sectionType: 'HERO_WITH_IMAGE' })}>

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
@@ -49,7 +49,6 @@ const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => 
   return <div>
     {htmlPage.sections.map((section, index) => {
       return <div key={index} className="row">
-
         <div className="col-md-4 p-2">
           <HtmlSectionEditor
             section={section} sectionIndex={index} readOnly={readOnly} updateSection={updateSection}/>
@@ -60,6 +59,7 @@ const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => 
         <div className="col-md-12 my-2" style={{ backgroundColor: '#eee' }}>
           <Button variant="secondary"
             tooltip={'Insert a blank section'}
+            disabled={readOnly}
             onClick={() => insertNewSection(index + 1, { id: '', sectionType: 'HERO_WITH_IMAGE' })}>
             <FontAwesomeIcon icon={faPlus}/> Insert section
           </Button>

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
@@ -1,21 +1,8 @@
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons'
-import { HtmlPage, HtmlSectionView } from '@juniper/ui-core'
-import Select from 'react-select'
-
-const SECTION_TYPES = [
-  { label: 'FAQ', value: 'FAQ' },
-  { label: 'HERO_CENTERED', value: 'HERO_CENTERED' },
-  { label: 'HERO_WITH_IMAGE', value: 'HERO_WITH_IMAGE' },
-  { label: 'SOCIAL_MEDIA', value: 'SOCIAL_MEDIA' },
-  { label: 'STEP_OVERVIEW', value: 'STEP_OVERVIEW' },
-  { label: 'PHOTO_BLURB_GRID', value: 'PHOTO_BLURB_GRID' },
-  { label: 'PARTICIPATION_DETAIL', value: 'PARTICIPATION_DETAIL' },
-  { label: 'RAW_HTML', value: 'RAW_HTML' },
-  { label: 'LINK_SECTIONS_FOOTER', value: 'LINK_SECTIONS_FOOTER' },
-  { label: 'BANNER_IMAGE', value: 'BANNER_IMAGE' }
-]
+import { HtmlPage, HtmlSection, HtmlSectionView } from '@juniper/ui-core'
+import HtmlSectionEditor from './HtmlSectionEditor'
 
 type HtmlPageViewProps = {
   htmlPage: HtmlPage
@@ -45,25 +32,35 @@ const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => 
     updatePage(htmlPage)
   }
 
+  //Inserts a new HtmlSection at the specified index on the page
+  const insertNewSection = (sectionIndex: number, newSection: HtmlSection) => {
+    const newSectionClean = {
+      ...newSection,
+      id: ''
+    }
+    const newSectionArray = [...htmlPage.sections]
+    newSectionArray.splice(sectionIndex, 0, newSectionClean)
+    htmlPage = {
+      ...htmlPage,
+      sections: newSectionArray
+    }
+    updatePage(htmlPage)
+  }
+
   return <div>
     {htmlPage.sections.map((section, index) => {
-      const textValue = JSON.stringify(JSON.parse(section?.sectionConfig ?? '{}'), null, 2)
-      const sectionTypeOpt = SECTION_TYPES.find(sectionType => sectionType.value === section.sectionType)
       return <div key={index} className="row">
 
         <div className="col-md-4 p-2">
-          <div>
-            <Select options={SECTION_TYPES} value={sectionTypeOpt}/>
-          </div>
-          <textarea value={textValue} style={{ height: 'calc(100% - 2em)', width: '100%' }}
-            readOnly={readOnly}
-            onChange={e => updateSectionConfig(index, e.target.value)}/>
+          <HtmlSectionEditor
+            section={section} sectionIndex={index} readOnly={readOnly} updateSectionConfig={updateSectionConfig}/>
         </div>
         <div className="col-md-8">
           <HtmlSectionView section={section}/>
         </div>
         <div className="col-md-12 my-2" style={{ backgroundColor: '#eee' }}>
-          <button className="btn btn-secondary" onClick={() => alert('not yet implemented')}>
+          <button className="btn btn-secondary"
+            onClick={() => insertNewSection(index + 1, htmlPage.sections.at(index)!)}>
             <FontAwesomeIcon icon={faPlus}/> Insert section
           </button>
         </div>

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
@@ -3,7 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons'
 import { HtmlPage, HtmlSection, HtmlSectionView } from '@juniper/ui-core'
 import HtmlSectionEditor from './HtmlSectionEditor'
-import {Button} from "../../components/forms/Button";
+import { Button } from 'components/forms/Button'
 
 type HtmlPageViewProps = {
   htmlPage: HtmlPage
@@ -13,7 +13,7 @@ type HtmlPageViewProps = {
 
 /** Enables editing of a given page, showing the config and a preview for each section */
 const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => {
-  const updateSectionConfig = (sectionIndex: number, updatedSection: HtmlSection) => {
+  const updateSection = (sectionIndex: number, updatedSection: HtmlSection) => {
     try {
       JSON.parse(updatedSection.sectionConfig ?? '{}')
     } catch (e) {
@@ -52,7 +52,7 @@ const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => 
 
         <div className="col-md-4 p-2">
           <HtmlSectionEditor
-            section={section} sectionIndex={index} readOnly={readOnly} updateSectionConfig={updateSectionConfig}/>
+            section={section} sectionIndex={index} readOnly={readOnly} updateSection={updateSection}/>
         </div>
         <div className="col-md-8">
           <HtmlSectionView section={section}/>

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
@@ -19,16 +19,26 @@ const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => 
       // for now, we just don't allow changing the object structure itself -- just plain text edits
       return
     }
+
+    //TODO
+    const newConfigObj = JSON.parse(newConfig) as HtmlSection
+
+    console.log(newConfig)
     const newSection = {
       ...htmlPage.sections[sectionIndex],
-      sectionConfig: newConfig
+      sectionConfig: newConfig,
+      sectionType: newConfigObj.sectionType
     }
+    console.log(newSection)
     const newSectionArray = [...htmlPage.sections]
+    console.log(newSectionArray)
     newSectionArray[sectionIndex] = newSection
+    console.log(newSectionArray)
     htmlPage = {
       ...htmlPage,
       sections: newSectionArray
     }
+    console.log(htmlPage)
     updatePage(htmlPage)
   }
 

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons'
 import { HtmlPage, HtmlSection, HtmlSectionView } from '@juniper/ui-core'
 import HtmlSectionEditor from './HtmlSectionEditor'
+import {Button} from "../../components/forms/Button";
 
 type HtmlPageViewProps = {
   htmlPage: HtmlPage
@@ -12,44 +13,32 @@ type HtmlPageViewProps = {
 
 /** Enables editing of a given page, showing the config and a preview for each section */
 const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => {
-  const updateSectionConfig = (sectionIndex: number, newConfig: string) => {
+  const updateSectionConfig = (sectionIndex: number, updatedSection: HtmlSection) => {
     try {
-      JSON.parse(newConfig)
+      JSON.parse(updatedSection.sectionConfig ?? '{}')
     } catch (e) {
       // for now, we just don't allow changing the object structure itself -- just plain text edits
       return
     }
 
-    //TODO
-    const newConfigObj = JSON.parse(newConfig) as HtmlSection
-
-    console.log(newConfig)
     const newSection = {
       ...htmlPage.sections[sectionIndex],
-      sectionConfig: newConfig,
-      sectionType: newConfigObj.sectionType
+      sectionType: updatedSection.sectionType,
+      sectionConfig: updatedSection.sectionConfig
     }
-    console.log(newSection)
     const newSectionArray = [...htmlPage.sections]
-    console.log(newSectionArray)
     newSectionArray[sectionIndex] = newSection
-    console.log(newSectionArray)
     htmlPage = {
       ...htmlPage,
       sections: newSectionArray
     }
-    console.log(htmlPage)
     updatePage(htmlPage)
   }
 
   //Inserts a new HtmlSection at the specified index on the page
   const insertNewSection = (sectionIndex: number, newSection: HtmlSection) => {
-    const newSectionClean = {
-      ...newSection,
-      id: ''
-    }
     const newSectionArray = [...htmlPage.sections]
-    newSectionArray.splice(sectionIndex, 0, newSectionClean)
+    newSectionArray.splice(sectionIndex, 0, newSection)
     htmlPage = {
       ...htmlPage,
       sections: newSectionArray
@@ -69,10 +58,11 @@ const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => 
           <HtmlSectionView section={section}/>
         </div>
         <div className="col-md-12 my-2" style={{ backgroundColor: '#eee' }}>
-          <button className="btn btn-secondary"
-            onClick={() => insertNewSection(index + 1, htmlPage.sections.at(index)!)}>
+          <Button variant="secondary"
+            tooltip={'Insert a blank section'}
+            onClick={() => insertNewSection(index + 1, { id: '', sectionType: 'HERO_WITH_IMAGE' })}>
             <FontAwesomeIcon icon={faPlus}/> Insert section
-          </button>
+          </Button>
         </div>
       </div>
     })}

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.test.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { setupRouterTest } from 'test-utils/router-testing-utils'
+import { mockHtmlPage } from 'test-utils/mock-site-content'
+import HtmlSectionEditor from './HtmlSectionEditor'
+
+test('readOnly disables section type selection', async () => {
+  const mockSection = mockHtmlPage().sections[0]
+  const { RoutedComponent } = setupRouterTest(
+    <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={true} updateSection={jest.fn()}/>)
+  render(RoutedComponent)
+  expect(screen.getByLabelText('Select section type')).toBeDisabled()
+})
+
+test('section type selection is enabled if the section type is unsaved', async () => {
+  const mockSection = mockHtmlPage().sections[0]
+  mockSection.id = ''
+  const { RoutedComponent } = setupRouterTest(
+    <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={false} updateSection={jest.fn()}/>)
+  render(RoutedComponent)
+  expect(screen.getByLabelText('Select section type')).toBeEnabled()
+})

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
@@ -36,16 +36,14 @@ const HtmlSectionEditor = ({
 
   return <>
     <div>
-      <Select options={SECTION_TYPES} value={sectionTypeOpt} isDisabled={readOnly}
+      {/* Right now we do not support changing the type for an existing section. The way to identify if a
+          section has been previously saved is to look at the id. If it's empty, it's a new section, and we can
+          allow the user to change the type. */ }
+      <Select options={SECTION_TYPES} value={sectionTypeOpt} isDisabled={readOnly || !isEmpty(section.id)}
         onChange={opt => {
-          if (isEmpty(section.id)) {
-            //Right now we do not support changing the type for an existing section. The way to identify if a
-            //section has been previously saved is to look at the id. If it's empty, it's a new section, and we can
-            //allow the user to change the type.
-            if (opt != undefined) {
-              setSectionTypeOpt(opt)
-              updateSection(sectionIndex, { ...section, sectionType: opt.value as SectionType })
-            }
+          if (opt != undefined) {
+            setSectionTypeOpt(opt)
+            updateSection(sectionIndex, { ...section, sectionType: opt.value as SectionType })
           }
         }}/>
     </div>

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
@@ -39,7 +39,8 @@ const HtmlSectionEditor = ({
       {/* Right now we do not support changing the type for an existing section. The way to identify if a
           section has been previously saved is to look at the id. If it's empty, it's a new section, and we can
           allow the user to change the type. */ }
-      <Select options={SECTION_TYPES} value={sectionTypeOpt} isDisabled={readOnly || !isEmpty(section.id)}
+      <Select options={SECTION_TYPES} value={sectionTypeOpt} aria-label={'Select section type'}
+        isDisabled={readOnly || !isEmpty(section.id)}
         onChange={opt => {
           if (opt != undefined) {
             setSectionTypeOpt(opt)

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import {HtmlSection, SectionType} from '@juniper/ui-core'
+import { HtmlSection, SectionType } from '@juniper/ui-core'
 import Select from 'react-select'
 import { isEmpty } from 'lodash'
 
@@ -23,20 +23,21 @@ const HtmlSectionEditor = ({
   section,
   sectionIndex,
   readOnly,
-  updateSectionConfig
+  updateSection
 }: {
   section: HtmlSection
   sectionIndex: number
   readOnly: boolean
-  updateSectionConfig: (sectionIndex: number, updatedSection: HtmlSection) => void
+  updateSection: (sectionIndex: number, updatedSection: HtmlSection) => void
 }) => {
-  const textValue = JSON.stringify(JSON.parse(section?.sectionConfig ?? '{}'), null, 2)
+  const sectionConfig = JSON.stringify(JSON.parse(section?.sectionConfig ?? '{}'), null, 2)
   const initial = SECTION_TYPES.find(sectionType => sectionType.value === section.sectionType)
   const [sectionTypeOpt, setSectionTypeOpt] = useState(initial)
 
   return <>
     <div>
-      <Select options={SECTION_TYPES} value={sectionTypeOpt}
+      {/* Dropdown for selecting the section type */}
+      <Select options={SECTION_TYPES} value={sectionTypeOpt} isDisabled={readOnly}
         onChange={opt => {
           if (isEmpty(section.id)) {
             //Right now we do not support changing the type of an existing section. The way to identify
@@ -44,14 +45,15 @@ const HtmlSectionEditor = ({
             //and we can allow the user to change the type.
             if (opt != undefined) {
               setSectionTypeOpt(opt)
-              updateSectionConfig(sectionIndex, { ...section, sectionType: opt.value as SectionType })
+              updateSection(sectionIndex, { ...section, sectionType: opt.value as SectionType })
             }
           }
         }}/>
     </div>
-    <textarea value={textValue} style={{ height: 'calc(100% - 2em)', width: '100%' }}
+    {/* Text box for editing the raw JSON section config  */}
+    <textarea value={sectionConfig} style={{ height: 'calc(100% - 2em)', width: '100%' }}
       readOnly={readOnly}
-      onChange={e => updateSectionConfig(sectionIndex, { ...section, sectionConfig: e.target.value })}/>
+      onChange={e => updateSection(sectionIndex, { ...section, sectionConfig: e.target.value })}/>
   </>
 }
 

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { HtmlSection } from '@juniper/ui-core'
+import {HtmlSection, SectionType} from '@juniper/ui-core'
 import Select from 'react-select'
 import { isEmpty } from 'lodash'
 
@@ -28,7 +28,7 @@ const HtmlSectionEditor = ({
   section: HtmlSection
   sectionIndex: number
   readOnly: boolean
-  updateSectionConfig: (sectionIndex: number, newConfig: string) => void
+  updateSectionConfig: (sectionIndex: number, updatedSection: HtmlSection) => void
 }) => {
   const textValue = JSON.stringify(JSON.parse(section?.sectionConfig ?? '{}'), null, 2)
   const initial = SECTION_TYPES.find(sectionType => sectionType.value === section.sectionType)
@@ -37,21 +37,21 @@ const HtmlSectionEditor = ({
   return <>
     <div>
       <Select options={SECTION_TYPES} value={sectionTypeOpt}
-        onChange={e => {
-          if (!isEmpty(section.id)) {
-            setSectionTypeOpt(sectionTypeOpt)
-          } else {
-            setSectionTypeOpt(e!)
-            updateSectionConfig(
-              sectionIndex,
-              JSON.stringify({ ...JSON.parse(textValue), sectionType: e?.value }, null, 2)
-            )
+        onChange={opt => {
+          if (isEmpty(section.id)) {
+            //Right now we do not support changing the type of an existing section. The way to identify
+            //if a section has been previously saved is to look at the id. If it's empty, it's a new section
+            //and we can allow the user to change the type.
+            if (opt != undefined) {
+              setSectionTypeOpt(opt)
+              updateSectionConfig(sectionIndex, { ...section, sectionType: opt.value as SectionType })
+            }
           }
         }}/>
     </div>
     <textarea value={textValue} style={{ height: 'calc(100% - 2em)', width: '100%' }}
       readOnly={readOnly}
-      onChange={e => updateSectionConfig(sectionIndex, e.target.value)}/>
+      onChange={e => updateSectionConfig(sectionIndex, { ...section, sectionConfig: e.target.value })}/>
   </>
 }
 

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react'
+import { HtmlSection } from '@juniper/ui-core'
+import Select from 'react-select'
+import { isEmpty } from 'lodash'
+
+const SECTION_TYPES = [
+  { label: 'FAQ', value: 'FAQ' },
+  { label: 'HERO_CENTERED', value: 'HERO_CENTERED' },
+  { label: 'HERO_WITH_IMAGE', value: 'HERO_WITH_IMAGE' },
+  { label: 'SOCIAL_MEDIA', value: 'SOCIAL_MEDIA' },
+  { label: 'STEP_OVERVIEW', value: 'STEP_OVERVIEW' },
+  { label: 'PHOTO_BLURB_GRID', value: 'PHOTO_BLURB_GRID' },
+  { label: 'PARTICIPATION_DETAIL', value: 'PARTICIPATION_DETAIL' },
+  { label: 'RAW_HTML', value: 'RAW_HTML' },
+  { label: 'LINK_SECTIONS_FOOTER', value: 'LINK_SECTIONS_FOOTER' },
+  { label: 'BANNER_IMAGE', value: 'BANNER_IMAGE' }
+]
+
+/**
+ * Returns an editor for an HtmlSection
+ */
+const HtmlSectionEditor = ({
+  section,
+  sectionIndex,
+  readOnly,
+  updateSectionConfig
+}: {
+  section: HtmlSection
+  sectionIndex: number
+  readOnly: boolean
+  updateSectionConfig: (sectionIndex: number, newConfig: string) => void
+}) => {
+  const textValue = JSON.stringify(JSON.parse(section?.sectionConfig ?? '{}'), null, 2)
+  const initial = SECTION_TYPES.find(sectionType => sectionType.value === section.sectionType)
+  const [sectionTypeOpt, setSectionTypeOpt] = useState(initial)
+
+  return <>
+    <div>
+      <Select options={SECTION_TYPES} value={sectionTypeOpt}
+        onChange={e => {
+          if (!isEmpty(section.id)) {
+            setSectionTypeOpt(sectionTypeOpt)
+          } else {
+            setSectionTypeOpt(e!)
+            updateSectionConfig(
+              sectionIndex,
+              JSON.stringify({ ...JSON.parse(textValue), sectionType: e?.value }, null, 2)
+            )
+          }
+        }}/>
+    </div>
+    <textarea value={textValue} style={{ height: 'calc(100% - 2em)', width: '100%' }}
+      readOnly={readOnly}
+      onChange={e => updateSectionConfig(sectionIndex, e.target.value)}/>
+  </>
+}
+
+export default HtmlSectionEditor

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
@@ -36,13 +36,12 @@ const HtmlSectionEditor = ({
 
   return <>
     <div>
-      {/* Dropdown for selecting the section type */}
       <Select options={SECTION_TYPES} value={sectionTypeOpt} isDisabled={readOnly}
         onChange={opt => {
           if (isEmpty(section.id)) {
-            //Right now we do not support changing the type of an existing section. The way to identify
-            //if a section has been previously saved is to look at the id. If it's empty, it's a new section
-            //and we can allow the user to change the type.
+            //Right now we do not support changing the type for an existing section. The way to identify if a
+            //section has been previously saved is to look at the id. If it's empty, it's a new section, and we can
+            //allow the user to change the type.
             if (opt != undefined) {
               setSectionTypeOpt(opt)
               updateSection(sectionIndex, { ...section, sectionType: opt.value as SectionType })
@@ -50,7 +49,6 @@ const HtmlSectionEditor = ({
           }
         }}/>
     </div>
-    {/* Text box for editing the raw JSON section config  */}
     <textarea value={sectionConfig} style={{ height: 'calc(100% - 2em)', width: '100%' }}
       readOnly={readOnly}
       onChange={e => updateSection(sectionIndex, { ...section, sectionConfig: e.target.value })}/>


### PR DESCRIPTION
#### DESCRIPTION

* Adds ability to create new HtmlSections
* Disables section type dropdown for previously-saved questions
* Full freetex (i.e. structural) editing for the raw JSON is not yet supported (in the same way that full freetext editing for existing sections is not yet supported). There are future tickets to deal with this but putting guard rails in place for JSON validation felt out of scope given the timelines.

Video demonstrating adding new sections:

https://github.com/broadinstitute/juniper/assets/7257391/b3d89b3b-c5c7-43ae-b13b-5c4df460c2f0

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Start up Admin UI
* Copy/paste some JSON from another section
* Cycle through the section types and confirm the right-side preview works as expected
* Make some nonstructural changes to the JSON and confirm the preview updates
* Confirm you can save the changes and the new sections persist