### PR TITLE
[JN-637] fixing handling of missing versions in export

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/SurveyFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/SurveyFormatter.java
@@ -175,6 +175,11 @@ public class SurveyFormatter implements ExportFormatter {
         Answer matchedAnswer = matchedAnswers.get(0);
         // use the ItemExport Info matching the answer version so choices get translated correctly
         ItemExportInfo matchedItemExportInfo = itemExportInfo.getVersionMap().get(matchedAnswer.getSurveyVersion());
+        if (matchedItemExportInfo == null) {
+            // if we can't find a match (likely because we're in a demo environment and the answer refers to a version that no longer exists)
+            // just use the current version
+            matchedItemExportInfo = itemExportInfo;
+        }
         addAnswerToMap(moduleInfo, matchedItemExportInfo, matchedAnswer, valueMap);
     }
 

--- a/core/src/test/java/bio/terra/pearl/core/service/export/SurveyFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/SurveyFormatterTests.java
@@ -6,7 +6,11 @@ import bio.terra.pearl.core.model.survey.SurveyQuestionDefinition;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
 import bio.terra.pearl.core.service.export.formatters.SurveyFormatter;
 import bio.terra.pearl.core.service.export.instance.ExportOptions;
+import bio.terra.pearl.core.service.export.instance.ItemExportInfo;
+import bio.terra.pearl.core.service.export.instance.ModuleExportInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -50,5 +54,32 @@ public class SurveyFormatterTests {
         assertThat(valueMap.get("oh_surveyA.complete"), equalTo("false"));
 
 
+    }
+
+    public void testAddAnswerToMapHandlesMissingVersion() throws Exception {
+        Survey survey = Survey.builder()
+                .id(UUID.randomUUID())
+                .stableId("oh_surveyA")
+                .version(1)
+                .build();
+        SurveyQuestionDefinition questionDef = SurveyQuestionDefinition.builder()
+                .questionStableId("oh_surveyA_q1")
+                .questionType("text")
+                .exportOrder(1)
+                .build();
+        SurveyFormatter surveyFormatter = new SurveyFormatter(objectMapper);
+        var moduleExportInfo = surveyFormatter
+                .getModuleExportInfo(new ExportOptions(), "oh_surveyA", List.of(survey), List.of(questionDef));
+        ItemExportInfo itemExportInfo = moduleExportInfo.getItems().get(0);
+        Map<String, String> valueMap = new HashMap<>();
+        Answer answerToMissingSurvey = Answer.builder()
+                        .questionStableId("oh_surveyA_q1")
+                        .surveyStableId("oh_surveyA")
+                        .surveyVersion(18)
+                        .stringValue("test123").build();
+        Map<String, List<Answer>> answerMap = Map.of("oh_surveyA_q1", List.of(answerToMissingSurvey));
+        surveyFormatter.addAnswersToMap(moduleExportInfo, itemExportInfo, answerMap, valueMap);
+
+        assertThat(valueMap.get("oh_surveyA.oh_surveyA_q1"), equalTo("test123"));
     }
 }


### PR DESCRIPTION
#### DESCRIPTION

Export fails in demo->sandbox right now due to some answers that refer to surveys that are no longer configured.  This adds a fallback in case the exact version of the survey completed can't be found (this is a case that is only expected to occur in dev/demo environments where we allow destroying surveys.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  The full  reproduction steps are not worth it -- you'd need to check out a version of the codebase prior to when we switched to deactivating, rather than deleting, old StudyEnvironmentSurveys, then configure some surveys, remove them, and then take some surveys, and then do an export.  
2. Just confirm the test runs, and the code looks sensible