### PR TITLE
[JN-645] study setting config

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/StudyEnvironmentController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/StudyEnvironmentController.java
@@ -3,7 +3,7 @@ package bio.terra.pearl.api.admin.controller;
 import bio.terra.pearl.api.admin.api.StudyEnvironmentApi;
 import bio.terra.pearl.api.admin.model.StudyEnvironmentDto;
 import bio.terra.pearl.api.admin.service.AuthUtilService;
-import bio.terra.pearl.api.admin.service.StudyEnvironmentExtService;
+import bio.terra.pearl.api.admin.service.study.StudyEnvironmentExtService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.study.StudyEnvironment;

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/StudyEnvironmentController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/StudyEnvironmentController.java
@@ -7,6 +7,7 @@ import bio.terra.pearl.api.admin.service.StudyEnvironmentExtService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
+import bio.terra.pearl.core.model.study.StudyEnvironmentConfig;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
@@ -35,10 +36,26 @@ public class StudyEnvironmentController implements StudyEnvironmentApi {
   public ResponseEntity<StudyEnvironmentDto> patch(
       String portalShortcode, String studyShortcode, String envName, StudyEnvironmentDto body) {
     AdminUser adminUser = requestService.requireAdminUser(request);
+    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
     StudyEnvironment envUpdate = objectMapper.convertValue(body, StudyEnvironment.class);
     StudyEnvironment savedEnv =
-        studyEnvExtService.update(adminUser, portalShortcode, studyShortcode, envUpdate);
+        studyEnvExtService.update(
+            adminUser, portalShortcode, studyShortcode, environmentName, envUpdate);
     return ResponseEntity.ok(objectMapper.convertValue(savedEnv, StudyEnvironmentDto.class));
+  }
+
+  /** updates the config object associated with the environment */
+  @Override
+  public ResponseEntity<Object> patchConfig(
+      String portalShortcode, String studyShortcode, String envName, Object body) {
+    AdminUser adminUser = requestService.requireAdminUser(request);
+    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
+    StudyEnvironmentConfig configUpdate =
+        objectMapper.convertValue(body, StudyEnvironmentConfig.class);
+    StudyEnvironmentConfig savedConfig =
+        studyEnvExtService.updateConfig(
+            adminUser, portalShortcode, studyShortcode, environmentName, configUpdate);
+    return ResponseEntity.ok(savedConfig);
   }
 
   @Override

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/study/StudyController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/study/StudyController.java
@@ -2,7 +2,7 @@ package bio.terra.pearl.api.admin.controller.study;
 
 import bio.terra.pearl.api.admin.api.StudyApi;
 import bio.terra.pearl.api.admin.service.AuthUtilService;
-import bio.terra.pearl.api.admin.service.StudyExtService;
+import bio.terra.pearl.api.admin.service.study.StudyExtService;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.service.study.StudyService;
 import javax.servlet.http.HttpServletRequest;

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/StudyEnvironmentExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/StudyEnvironmentExtService.java
@@ -3,24 +3,29 @@ package bio.terra.pearl.api.admin.service;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
+import bio.terra.pearl.core.model.study.StudyEnvironmentConfig;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.participant.WithdrawnEnrolleeService;
+import bio.terra.pearl.core.service.study.StudyEnvironmentConfigService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import org.springframework.stereotype.Service;
 
 @Service
 public class StudyEnvironmentExtService {
   private StudyEnvironmentService studyEnvService;
+  private StudyEnvironmentConfigService studyEnvConfigService;
   private AuthUtilService authUtilService;
   private EnrolleeService enrolleeService;
   private WithdrawnEnrolleeService withdrawnEnrolleeService;
 
   public StudyEnvironmentExtService(
       StudyEnvironmentService studyEnvService,
+      StudyEnvironmentConfigService studyEnvConfigService,
       AuthUtilService authUtilService,
       EnrolleeService enrolleeService,
       WithdrawnEnrolleeService withdrawnEnrolleeService) {
     this.studyEnvService = studyEnvService;
+    this.studyEnvConfigService = studyEnvConfigService;
     this.authUtilService = authUtilService;
     this.enrolleeService = enrolleeService;
     this.withdrawnEnrolleeService = withdrawnEnrolleeService;
@@ -28,23 +33,45 @@ public class StudyEnvironmentExtService {
 
   /** currently only supports changing the pre-enroll survey id */
   public StudyEnvironment update(
-      AdminUser user, String portalShortcode, String studyShortcode, StudyEnvironment update) {
-    authUtilService.authUserToStudy(user, portalShortcode, studyShortcode);
-    StudyEnvironment existing = studyEnvService.find(update.getId()).get();
-    existing.setPreEnrollSurveyId(update.getPreEnrollSurveyId());
-    return studyEnvService.update(existing);
+      AdminUser operator,
+      String portalShortcode,
+      String studyShortcode,
+      EnvironmentName envName,
+      StudyEnvironment update) {
+    StudyEnvironment studyEnv = authToStudyEnv(operator, portalShortcode, studyShortcode, envName);
+    studyEnv.setPreEnrollSurveyId(update.getPreEnrollSurveyId());
+    return studyEnvService.update(studyEnv);
+  }
+
+  public StudyEnvironmentConfig updateConfig(
+      AdminUser operator,
+      String portalShortcode,
+      String studyShortcode,
+      EnvironmentName envName,
+      StudyEnvironmentConfig update) {
+    StudyEnvironment studyEnv = authToStudyEnv(operator, portalShortcode, studyShortcode, envName);
+    StudyEnvironmentConfig existing =
+        studyEnvConfigService.find(studyEnv.getStudyEnvironmentConfigId()).get();
+    // we don't allow directly setting the 'initialized' field -- that comes from the publishing
+    // flows
+    existing.setPasswordProtected(update.isPasswordProtected());
+    existing.setAcceptingEnrollment(update.isAcceptingEnrollment());
+    existing.setPassword(update.getPassword());
+    return studyEnvConfigService.update(existing);
   }
 
   public StudyEnvStats getStats(
-      AdminUser user,
-      String portalShortcode,
-      String studyShortcode,
-      EnvironmentName environmentName) {
-    authUtilService.authUserToStudy(user, portalShortcode, studyShortcode);
-    StudyEnvironment studyEnv = studyEnvService.findByStudy(studyShortcode, environmentName).get();
+      AdminUser operator, String portalShortcode, String studyShortcode, EnvironmentName envName) {
+    StudyEnvironment studyEnv = authToStudyEnv(operator, portalShortcode, studyShortcode, envName);
     return new StudyEnvStats(
         enrolleeService.countByStudyEnvironmentId(studyEnv.getId()),
         withdrawnEnrolleeService.countByStudyEnvironmentId(studyEnv.getId()));
+  }
+
+  private StudyEnvironment authToStudyEnv(
+      AdminUser operator, String portalShortcode, String studyShortcode, EnvironmentName envName) {
+    authUtilService.authUserToStudy(operator, portalShortcode, studyShortcode);
+    return studyEnvService.findByStudy(studyShortcode, envName).get();
   }
 
   public record StudyEnvStats(int enrolleeCount, int withdrawnCount) {}

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/study/StudyEnvironmentExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/study/StudyEnvironmentExtService.java
@@ -1,5 +1,6 @@
-package bio.terra.pearl.api.admin.service;
+package bio.terra.pearl.api.admin.service.study;
 
+import bio.terra.pearl.api.admin.service.AuthUtilService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.study.StudyEnvironment;

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/study/StudyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/study/StudyExtService.java
@@ -1,5 +1,6 @@
-package bio.terra.pearl.api.admin.service;
+package bio.terra.pearl.api.admin.service.study;
 
+import bio.terra.pearl.api.admin.service.AuthUtilService;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.kit.KitType;
 import bio.terra.pearl.core.service.kit.StudyKitTypeService;

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -410,7 +410,7 @@ paths:
           $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}:
     patch:
-      summary: Updates a study environment configuration
+      summary: Updates a study environment object, such as by setting the pre-enroll survey
       tags: [ studyEnvironment ]
       operationId: patch
       parameters:
@@ -424,6 +424,24 @@ paths:
         '200':
           description: saved studyEnvironment object
           content: { application/json: { schema: { $ref: '#/components/schemas/StudyEnvironmentDto' } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/config:
+    patch:
+      summary: Updates a study environment config object, such as setting password
+      tags: [ studyEnvironment ]
+      operationId: patchConfig
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: studyShortcode, in: path, required: true, schema: { type: string } }
+        - { name: envName, in: path, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content: { application/json: { schema: {type: object} } }
+      responses:
+        '200':
+          description: saved studyEnvironment object
+          content: { application/json: { schema:  {type: object} } }
         '500':
           $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/stats:

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/study/StudyEnvironmentExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/study/StudyEnvironmentExtServiceTests.java
@@ -1,0 +1,62 @@
+package bio.terra.pearl.api.admin.service.study;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import bio.terra.pearl.api.admin.BaseSpringBootTest;
+import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
+import bio.terra.pearl.core.factory.admin.AdminUserFactory;
+import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.model.study.StudyEnvironmentConfig;
+import bio.terra.pearl.core.service.exception.NotFoundException;
+import bio.terra.pearl.core.service.study.StudyEnvironmentConfigService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+public class StudyEnvironmentExtServiceTests extends BaseSpringBootTest {
+  @Autowired private StudyEnvironmentExtService studyEnvironmentExtService;
+  @Autowired private StudyEnvironmentFactory studyEnvironmentFactory;
+  @Autowired private AdminUserFactory adminUserFactory;
+  @Autowired private StudyEnvironmentConfigService studyEnvironmentConfigService;
+
+  @Test
+  @Transactional
+  public void updateConfigAuthsToStudy() {
+    var studyEnvBundle =
+        studyEnvironmentFactory.buildBundle("updateConfigAuthsToStudy", EnvironmentName.irb);
+    AdminUser operator = adminUserFactory.buildPersisted("updateConfigAuthsToStudy", false);
+    Assertions.assertThrows(
+        NotFoundException.class,
+        () -> {
+          studyEnvironmentExtService.updateConfig(
+              operator,
+              studyEnvBundle.getPortal().getShortcode(),
+              studyEnvBundle.getStudy().getShortcode(),
+              EnvironmentName.irb,
+              new StudyEnvironmentConfig());
+        });
+  }
+
+  @Test
+  @Transactional
+  public void updateConfigAllowsSuperuser() {
+    var studyEnvBundle =
+        studyEnvironmentFactory.buildBundle("updateConfigAuthsToStudy", EnvironmentName.irb);
+    AdminUser superUser = adminUserFactory.buildPersisted("updateConfigAllowsSuperuser", true);
+    studyEnvironmentExtService.updateConfig(
+        superUser,
+        studyEnvBundle.getPortal().getShortcode(),
+        studyEnvBundle.getStudy().getShortcode(),
+        EnvironmentName.irb,
+        StudyEnvironmentConfig.builder().password("test456").build());
+
+    var updatedConfig =
+        studyEnvironmentConfigService
+            .find(studyEnvBundle.getStudyEnv().getStudyEnvironmentConfigId())
+            .get();
+    assertThat(updatedConfig.getPassword(), equalTo("test456"));
+  }
+}

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/study/StudyEnvironmentExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/study/StudyEnvironmentExtServiceTests.java
@@ -44,7 +44,7 @@ public class StudyEnvironmentExtServiceTests extends BaseSpringBootTest {
   @Transactional
   public void updateConfigAllowsSuperuser() {
     var studyEnvBundle =
-        studyEnvironmentFactory.buildBundle("updateConfigAuthsToStudy", EnvironmentName.irb);
+        studyEnvironmentFactory.buildBundle("updateConfigAllowsSuperuser", EnvironmentName.irb);
     AdminUser superUser = adminUserFactory.buildPersisted("updateConfigAllowsSuperuser", true);
     studyEnvironmentExtService.updateConfig(
         superUser,

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/StudyEnvironmentFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/StudyEnvironmentFactory.java
@@ -3,12 +3,17 @@ package bio.terra.pearl.core.factory;
 import bio.terra.pearl.core.factory.participant.ParticipantUserFactory;
 import bio.terra.pearl.core.factory.portal.PortalEnvironmentFactory;
 import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.study.StudyEnvironmentConfig;
 import bio.terra.pearl.core.service.participant.PortalParticipantUserService;
+import bio.terra.pearl.core.service.portal.PortalService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.RandomUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -29,6 +34,8 @@ public class StudyEnvironmentFactory {
     private ParticipantUserFactory participantUserFactory;
     @Autowired
     private PortalParticipantUserService portalParticipantUserService;
+    @Autowired
+    private PortalService portalService;
 
     public StudyEnvironment.StudyEnvironmentBuilder builder(String testName) {
         EnvironmentName envName = EnvironmentName.values()[RandomUtils.nextInt(0, 3)];
@@ -60,6 +67,28 @@ public class StudyEnvironmentFactory {
                 .environmentName(envName)
                 .studyEnvironmentConfig(new StudyEnvironmentConfig()).build();
         return studyEnvironmentService.create(studyEnv);
+    }
+
+    public StudyEnvironmentBundle buildBundle(String testName, EnvironmentName envName) {
+        PortalEnvironment portalEnvironment = portalEnvironmentFactory.buildPersisted(testName);
+        Study study = studyFactory.buildPersisted(portalEnvironment.getPortalId(), testName);
+        StudyEnvironment studyEnvironment = buildPersisted(envName, study.getId(), testName);
+        Portal portal = portalService.find(portalEnvironment.getPortalId()).get();
+        return StudyEnvironmentBundle.builder()
+                .study(study)
+                .studyEnv(studyEnvironment)
+                .portal(portal)
+                .portalEnv(portalEnvironment)
+                .build();
+    }
+
+    @Getter @Setter
+    @Builder
+    public static class StudyEnvironmentBundle {
+        private Study study;
+        private StudyEnvironment studyEnv;
+        private Portal portal;
+        private PortalEnvironment portalEnv;
     }
 
 }

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -533,7 +533,7 @@ export default {
   },
 
   async updateStudyEnvironmentConfig(portalShortcode: string, studyShortcode: string, envName: string,
-                               studyEnvConfigUpdate: StudyEnvironmentConfig): Promise<StudyEnvironmentConfig> {
+    studyEnvConfigUpdate: StudyEnvironmentConfig): Promise<StudyEnvironmentConfig> {
     const url = `${API_ROOT}/portals/v1/${portalShortcode}/studies/${studyShortcode}/env/${envName}/config`
     const response = await fetch(url, {
       method: 'PATCH',

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -9,6 +9,7 @@ import {
   PortalEnvironment,
   PortalEnvironmentConfig,
   SiteContent,
+  StudyEnvironmentConfig,
   StudyEnvironmentConsent,
   StudyEnvironmentSurvey,
   SurveyResponse,
@@ -527,6 +528,17 @@ export default {
       method: 'PATCH',
       headers: this.getInitHeaders(),
       body: JSON.stringify(studyEnvUpdate)
+    })
+    return await this.processJsonResponse(response)
+  },
+
+  async updateStudyEnvironmentConfig(portalShortcode: string, studyShortcode: string, envName: string,
+                               studyEnvConfigUpdate: StudyEnvironmentConfig): Promise<StudyEnvironmentConfig> {
+    const url = `${API_ROOT}/portals/v1/${portalShortcode}/studies/${studyShortcode}/env/${envName}/config`
+    const response = await fetch(url, {
+      method: 'PATCH',
+      headers: this.getInitHeaders(),
+      body: JSON.stringify(studyEnvConfigUpdate)
     })
     return await this.processJsonResponse(response)
   },

--- a/ui-admin/src/portal/PortalEnvConfigView.test.tsx
+++ b/ui-admin/src/portal/PortalEnvConfigView.test.tsx
@@ -5,7 +5,7 @@ import PortalEnvConfigView from './PortalEnvConfigView'
 import { mockPortalContext } from 'test-utils/mocking-utils'
 import { MockRegularUserProvider, MockSuperuserProvider } from 'test-utils/user-mocking-utils'
 import { PortalEnvironment } from '@juniper/ui-core'
-import userEvent from "@testing-library/user-event";
+import userEvent from '@testing-library/user-event'
 
 test('renders a portal env. config', async () => {
   const portalContext = mockPortalContext()
@@ -30,7 +30,7 @@ test('updates a portal env. config', async () => {
   </MockSuperuserProvider>)
   const input = screen.getByLabelText('password') as HTMLInputElement
   // select all:
-  input.setSelectionRange(0, input.value.length)
+  await userEvent.clear(input)
   await userEvent.type(input, 'newPass')
   expect(input).toHaveValue('newPass')
   expect(screen.getByText('Save website config')).toHaveAttribute('aria-disabled', 'false')

--- a/ui-admin/src/portal/PortalEnvConfigView.test.tsx
+++ b/ui-admin/src/portal/PortalEnvConfigView.test.tsx
@@ -12,8 +12,7 @@ test('renders a portal env. config', async () => {
   const envConfig = portalEnv.portalEnvironmentConfig
   render(
     <MockSuperuserProvider>
-      <PortalEnvConfigView portal={portalContext.portal as Portal}
-        portalEnv={portalEnv} updatePortal={portalContext.updatePortal}/>
+      <PortalEnvConfigView portalContext={portalContext} portalEnv={portalEnv}/>
     </MockSuperuserProvider>)
 
   expect(screen.getByLabelText('password')).toHaveValue(envConfig.password)
@@ -26,8 +25,7 @@ test('updates a portal env. config', async () => {
   const portalContext = mockPortalContext()
   const portalEnv = portalContext.portal?.portalEnvironments[0] as PortalEnvironment
   render(<MockSuperuserProvider>
-    <PortalEnvConfigView portal={portalContext.portal as Portal}
-      portalEnv={portalEnv} updatePortal={portalContext.updatePortal}/>
+    <PortalEnvConfigView portalContext={portalContext} portalEnv={portalEnv}/>
   </MockSuperuserProvider>)
   fireEvent.change(screen.getByLabelText('password'), { target: { value: 'newPass' } })
   expect(screen.getByLabelText('password')).toHaveValue('newPass')
@@ -39,8 +37,7 @@ test('save disabled for non-superusers', async () => {
   const portalEnv = portalContext.portal?.portalEnvironments[0] as PortalEnvironment
   render(
     <MockRegularUserProvider>
-      <PortalEnvConfigView portal={portalContext.portal as Portal}
-        portalEnv={portalEnv} updatePortal={portalContext.updatePortal}/>
+      <PortalEnvConfigView portalContext={portalContext} portalEnv={portalEnv}/>
     </MockRegularUserProvider>)
 
   expect(screen.getByText('Save')).toHaveAttribute('aria-disabled', 'true')

--- a/ui-admin/src/portal/PortalEnvConfigView.test.tsx
+++ b/ui-admin/src/portal/PortalEnvConfigView.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 
 import PortalEnvConfigView from './PortalEnvConfigView'
 import { mockPortalContext } from 'test-utils/mocking-utils'
 import { MockRegularUserProvider, MockSuperuserProvider } from 'test-utils/user-mocking-utils'
-import { Portal, PortalEnvironment } from '@juniper/ui-core/build/types/portal'
+import { PortalEnvironment } from '@juniper/ui-core'
+import userEvent from "@testing-library/user-event";
 
 test('renders a portal env. config', async () => {
   const portalContext = mockPortalContext()
@@ -27,9 +28,12 @@ test('updates a portal env. config', async () => {
   render(<MockSuperuserProvider>
     <PortalEnvConfigView portalContext={portalContext} portalEnv={portalEnv}/>
   </MockSuperuserProvider>)
-  fireEvent.change(screen.getByLabelText('password'), { target: { value: 'newPass' } })
-  expect(screen.getByLabelText('password')).toHaveValue('newPass')
-  expect(screen.getByText('Save')).toHaveAttribute('aria-disabled', 'false')
+  const input = screen.getByLabelText('password') as HTMLInputElement
+  // select all:
+  input.setSelectionRange(0, input.value.length)
+  await userEvent.type(input, 'newPass')
+  expect(input).toHaveValue('newPass')
+  expect(screen.getByText('Save website config')).toHaveAttribute('aria-disabled', 'false')
 })
 
 test('save disabled for non-superusers', async () => {
@@ -40,5 +44,5 @@ test('save disabled for non-superusers', async () => {
       <PortalEnvConfigView portalContext={portalContext} portalEnv={portalEnv}/>
     </MockRegularUserProvider>)
 
-  expect(screen.getByText('Save')).toHaveAttribute('aria-disabled', 'true')
+  expect(screen.getByText('Save website config')).toHaveAttribute('aria-disabled', 'true')
 })

--- a/ui-admin/src/portal/PortalEnvConfigView.tsx
+++ b/ui-admin/src/portal/PortalEnvConfigView.tsx
@@ -78,7 +78,7 @@ const PortalEnvConfigView = ({ portalContext, portalEnv }: PortalEnvConfigViewPr
       variant="primary" disabled={!user.superuser || isLoading}
       tooltip={user.superuser ? 'Save' : 'You do not have permission to edit these settings'}>
       {isLoading && <LoadingSpinner/>}
-      {!isLoading && <span>Save</span>}
+      {!isLoading && 'Save website config'}
     </Button>
   </form>
 }

--- a/ui-admin/src/portal/PortalEnvConfigView.tsx
+++ b/ui-admin/src/portal/PortalEnvConfigView.tsx
@@ -1,15 +1,13 @@
 import React, { useState } from 'react'
 import Api, { PortalEnvironment } from 'api/api'
-import { useUser } from '../user/UserProvider'
-import _cloneDeep from 'lodash/cloneDeep'
-import { failureNotification, successNotification } from '../util/notifications'
+import { useUser } from 'user/UserProvider'
+import { successNotification } from 'util/notifications'
 import { Store } from 'react-notifications-component'
-import { Portal } from '@juniper/ui-core/build/types/portal'
 import { Button } from 'components/forms/Button'
 import { set } from 'lodash/fp'
-import {LoadedPortalContextT} from "./PortalProvider";
-import {doApiLoad} from "api/api-utils";
-import LoadingSpinner from "../util/LoadingSpinner";
+import { LoadedPortalContextT } from './PortalProvider'
+import { doApiLoad } from 'api/api-utils'
+import LoadingSpinner from '../util/LoadingSpinner'
 
 
 type PortalEnvConfigViewProps = {
@@ -33,10 +31,10 @@ const PortalEnvConfigView = ({ portalContext, portalEnv }: PortalEnvConfigViewPr
   const save = async (e: React.MouseEvent) => {
     e.preventDefault()
     doApiLoad(async () => {
-      const updatedConfig = await Api.updatePortalEnvConfig(portal.shortcode, portalEnv.environmentName, config)
+      await Api.updatePortalEnvConfig(portal.shortcode, portalEnv.environmentName, config)
       Store.addNotification(successNotification('Portal config saved'))
       reloadPortal(portal.shortcode)
-    }, {setIsLoading})
+    }, { setIsLoading })
   }
   return <form className="bg-white p-3">
     <h2 className="h4">Website configuration ({portalContext.portal.name})</h2>

--- a/ui-admin/src/portal/PortalRouter.tsx
+++ b/ui-admin/src/portal/PortalRouter.tsx
@@ -52,8 +52,7 @@ function PortalEnvRouter({ portalContext }: {portalContext: LoadedPortalContextT
 
   return <>
     <Routes>
-      <Route path="config" element={<PortalEnvConfigView portal={portal} portalEnv={portalEnv}
-        updatePortal={portalContext.updatePortal}/>}/>
+      <Route path="config" element={<PortalEnvConfigView portalContext={portalContext} portalEnv={portalEnv}/>}/>
       <Route path="participants" element={<PortalParticipantsView portalEnv={portalEnv} portal={portal}/>}/>
       <Route path="siteContent" element={<SiteContentLoader portalEnvContext={portalEnvContext}/>}/>
       <Route path="mailingList" element={<MailingListView portalContext={portalContext}

--- a/ui-admin/src/study/StudySettings.test.tsx
+++ b/ui-admin/src/study/StudySettings.test.tsx
@@ -18,8 +18,6 @@ test('renders a study env. config', async () => {
   expect(screen.getByLabelText('password')).toHaveValue(expectedConfig.password)
   expect((screen.getByLabelText('password protected') as HTMLInputElement).checked)
     .toBe(expectedConfig.passwordProtected)
-  expect((screen.getByLabelText('accepting registration') as HTMLInputElement).checked)
-    .toBe(expectedConfig.acceptingEnrollment)
 })
 
 test('updates a study env. config', async () => {

--- a/ui-admin/src/study/StudySettings.test.tsx
+++ b/ui-admin/src/study/StudySettings.test.tsx
@@ -1,47 +1,48 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 
-import StudySettings, {StudyEnvConfigView} from './StudySettings'
-import {mockPortalContext, mockStudyEnvContext} from 'test-utils/mocking-utils'
-import {MockRegularUserProvider, MockSuperuserProvider} from 'test-utils/user-mocking-utils'
-import userEvent from "@testing-library/user-event";
+import { StudyEnvConfigView } from './StudySettings'
+import { mockPortalContext, mockStudyEnvContext } from 'test-utils/mocking-utils'
+import { MockRegularUserProvider, MockSuperuserProvider } from 'test-utils/user-mocking-utils'
+import userEvent from '@testing-library/user-event'
 
 test('renders a study env. config', async () => {
-    const portalContext = mockPortalContext()
-    const studyEnvContext = mockStudyEnvContext()
-    const expectedConfig = studyEnvContext.currentEnv.studyEnvironmentConfig
-    render(
-        <MockSuperuserProvider>
-            <StudyEnvConfigView portalContext={portalContext} studyEnvContext={studyEnvContext}/>
-        </MockSuperuserProvider>)
+  const portalContext = mockPortalContext()
+  const studyEnvContext = mockStudyEnvContext()
+  const expectedConfig = studyEnvContext.currentEnv.studyEnvironmentConfig
+  render(
+    <MockSuperuserProvider>
+      <StudyEnvConfigView portalContext={portalContext} studyEnvContext={studyEnvContext}/>
+    </MockSuperuserProvider>)
 
-    expect(screen.getByLabelText('password')).toHaveValue(expectedConfig.password)
-    expect((screen.getByLabelText('password protected') as HTMLInputElement).checked).toBe(expectedConfig.passwordProtected)
-    expect((screen.getByLabelText('accepting registration') as HTMLInputElement).checked)
-        .toBe(expectedConfig.acceptingEnrollment)
+  expect(screen.getByLabelText('password')).toHaveValue(expectedConfig.password)
+  expect((screen.getByLabelText('password protected') as HTMLInputElement).checked)
+    .toBe(expectedConfig.passwordProtected)
+  expect((screen.getByLabelText('accepting registration') as HTMLInputElement).checked)
+    .toBe(expectedConfig.acceptingEnrollment)
 })
 
 test('updates a study env. config', async () => {
-    const portalContext = mockPortalContext()
-    const studyEnvContext = mockStudyEnvContext()
-    render(
-        <MockSuperuserProvider>
-            <StudyEnvConfigView portalContext={portalContext} studyEnvContext={studyEnvContext}/>
-        </MockSuperuserProvider>)
-    const input = screen.getByLabelText('password') as HTMLInputElement
-    // select all:
-    input.setSelectionRange(0, input.value.length)
-    await userEvent.type(input, 'newPass')
-    expect(input).toHaveValue('newPass')
-    expect(screen.getByText('Save study config')).toHaveAttribute('aria-disabled', 'false')
+  const portalContext = mockPortalContext()
+  const studyEnvContext = mockStudyEnvContext()
+  render(
+    <MockSuperuserProvider>
+      <StudyEnvConfigView portalContext={portalContext} studyEnvContext={studyEnvContext}/>
+    </MockSuperuserProvider>)
+  const input = screen.getByLabelText('password') as HTMLInputElement
+  // select all:
+  await userEvent.clear(input)
+  await userEvent.type(input, 'newPass')
+  expect(input).toHaveValue('newPass')
+  expect(screen.getByText('Save study config')).toHaveAttribute('aria-disabled', 'false')
 })
 
 test('save disabled for non-superusers', async () => {
-    const portalContext = mockPortalContext()
-    const studyEnvContext = mockStudyEnvContext()
-    render(
-        <MockRegularUserProvider>
-            <StudyEnvConfigView portalContext={portalContext} studyEnvContext={studyEnvContext}/>
-        </MockRegularUserProvider>)
-    expect(screen.getByText('Save study config')).toHaveAttribute('aria-disabled', 'true')
+  const portalContext = mockPortalContext()
+  const studyEnvContext = mockStudyEnvContext()
+  render(
+    <MockRegularUserProvider>
+      <StudyEnvConfigView portalContext={portalContext} studyEnvContext={studyEnvContext}/>
+    </MockRegularUserProvider>)
+  expect(screen.getByText('Save study config')).toHaveAttribute('aria-disabled', 'true')
 })

--- a/ui-admin/src/study/StudySettings.test.tsx
+++ b/ui-admin/src/study/StudySettings.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+import StudySettings, {StudyEnvConfigView} from './StudySettings'
+import {mockPortalContext, mockStudyEnvContext} from 'test-utils/mocking-utils'
+import {MockRegularUserProvider, MockSuperuserProvider} from 'test-utils/user-mocking-utils'
+import userEvent from "@testing-library/user-event";
+
+test('renders a study env. config', async () => {
+    const portalContext = mockPortalContext()
+    const studyEnvContext = mockStudyEnvContext()
+    const expectedConfig = studyEnvContext.currentEnv.studyEnvironmentConfig
+    render(
+        <MockSuperuserProvider>
+            <StudyEnvConfigView portalContext={portalContext} studyEnvContext={studyEnvContext}/>
+        </MockSuperuserProvider>)
+
+    expect(screen.getByLabelText('password')).toHaveValue(expectedConfig.password)
+    expect((screen.getByLabelText('password protected') as HTMLInputElement).checked).toBe(expectedConfig.passwordProtected)
+    expect((screen.getByLabelText('accepting registration') as HTMLInputElement).checked)
+        .toBe(expectedConfig.acceptingEnrollment)
+})
+
+test('updates a study env. config', async () => {
+    const portalContext = mockPortalContext()
+    const studyEnvContext = mockStudyEnvContext()
+    render(
+        <MockSuperuserProvider>
+            <StudyEnvConfigView portalContext={portalContext} studyEnvContext={studyEnvContext}/>
+        </MockSuperuserProvider>)
+    const input = screen.getByLabelText('password') as HTMLInputElement
+    // select all:
+    input.setSelectionRange(0, input.value.length)
+    await userEvent.type(input, 'newPass')
+    expect(input).toHaveValue('newPass')
+    expect(screen.getByText('Save study config')).toHaveAttribute('aria-disabled', 'false')
+})
+
+test('save disabled for non-superusers', async () => {
+    const portalContext = mockPortalContext()
+    const studyEnvContext = mockStudyEnvContext()
+    render(
+        <MockRegularUserProvider>
+            <StudyEnvConfigView portalContext={portalContext} studyEnvContext={studyEnvContext}/>
+        </MockRegularUserProvider>)
+    expect(screen.getByText('Save study config')).toHaveAttribute('aria-disabled', 'true')
+})

--- a/ui-admin/src/study/StudySettings.tsx
+++ b/ui-admin/src/study/StudySettings.tsx
@@ -17,6 +17,17 @@ import LoadingSpinner from "../util/LoadingSpinner";
 /** shows settings for both a study and its containing portal */
 export default function StudySettings({ studyEnvContext, portalContext }:
 {studyEnvContext: StudyEnvContextT, portalContext: LoadedPortalContextT}) {
+  const portalEnv = portalContext.portal.portalEnvironments
+          .find(env =>
+              env.environmentName === studyEnvContext.currentEnv.environmentName) as PortalEnvironment
+  return <div className="ps-4">
+    <StudyEnvConfigView studyEnvContext={studyEnvContext} portalContext={portalContext}/>
+    <PortalEnvConfigView portalEnv={portalEnv} portalContext={portalContext}/>
+  </div>
+}
+
+export function StudyEnvConfigView({ studyEnvContext, portalContext }:
+                                       {studyEnvContext: StudyEnvContextT, portalContext: LoadedPortalContextT}) {
   const [config, setConfig] = useState(studyEnvContext.currentEnv.studyEnvironmentConfig)
   const { user } = useUser()
   const [isLoading, setIsLoading] = useState(false)
@@ -24,9 +35,6 @@ export default function StudySettings({ studyEnvContext, portalContext }:
   const updateConfig = (propName: string, value: string | boolean) => {
     setConfig(set(propName, value))
   }
-  const portalEnv = portalContext.portal.portalEnvironments
-    .find(env =>
-      env.environmentName === studyEnvContext.currentEnv.environmentName) as PortalEnvironment
 
   /** saves any changes to the server */
   const save = async (e: React.MouseEvent) => {
@@ -39,37 +47,34 @@ export default function StudySettings({ studyEnvContext, portalContext }:
     }, {setIsLoading})
   }
 
-  return <div className="bg-white ps-4">
-    <form className="bg-white p-3 mb-5">
-      <h2 className="h4">{studyEnvContext.study.name} study configuration</h2>
-      <p>Configure whether participants can access study content, such as surveys and consents.</p>
-      <div>
-        <label className="form-label">
-          password protected <input type="checkbox" checked={config.passwordProtected}
-                                    onChange={e => updateConfig('passwordProtected', e.target.checked)}/>
-        </label>
-      </div>
-      <div>
-        <label className="form-label">
-          password <input type="text" className="form-control" value={config.password}
-                          onChange={e => updateConfig('password', e.target.value)}/>
-        </label>
-      </div>
-      <div>
-        <label className="form-label">
-          accepting registration
-          <input type="checkbox" checked={config.acceptingEnrollment}
-                 onChange={e => updateConfig('acceptingEnrollment', e.target.checked)}/>
-        </label>
-      </div>
+  return <form className="bg-white p-3 mb-5">
+    <h2 className="h4">{studyEnvContext.study.name} study configuration</h2>
+    <p>Configure whether participants can access study content, such as surveys and consents.</p>
+    <div>
+      <label className="form-label">
+        password protected <input type="checkbox" checked={config.passwordProtected}
+                                  onChange={e => updateConfig('passwordProtected', e.target.checked)}/>
+      </label>
+    </div>
+    <div>
+      <label className="form-label">
+        password <input type="text" className="form-control" value={config.password}
+                        onChange={e => updateConfig('password', e.target.value)}/>
+      </label>
+    </div>
+    <div>
+      <label className="form-label">
+        accepting registration
+        <input type="checkbox" checked={config.acceptingEnrollment}
+               onChange={e => updateConfig('acceptingEnrollment', e.target.checked)}/>
+      </label>
+    </div>
 
-      <Button onClick={save}
-              variant="primary" disabled={!user.superuser || isLoading}
-              tooltip={user.superuser ? 'Save' : 'You do not have permission to edit these settings'}>
-        {isLoading && <LoadingSpinner/>}
-        {!isLoading && <span>Save</span>}
-      </Button>
-    </form>
-    <PortalEnvConfigView portalEnv={portalEnv} portalContext={portalContext}/>
-  </div>
+    <Button onClick={save}
+            variant="primary" disabled={!user.superuser || isLoading}
+            tooltip={user.superuser ? 'Save' : 'You do not have permission to edit these settings'}>
+      {isLoading && <LoadingSpinner/>}
+      {!isLoading && 'Save study config'}
+    </Button>
+  </form>
 }

--- a/ui-admin/src/study/StudySettings.tsx
+++ b/ui-admin/src/study/StudySettings.tsx
@@ -1,31 +1,30 @@
-import React, {useState} from 'react'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faEdit } from '@fortawesome/free-solid-svg-icons'
+import React, { useState } from 'react'
 import { StudyEnvContextT } from './StudyEnvironmentRouter'
 import { LoadedPortalContextT } from '../portal/PortalProvider'
 import PortalEnvConfigView from '../portal/PortalEnvConfigView'
 import { PortalEnvironment } from '@juniper/ui-core'
-import {doApiLoad} from "../api/api-utils";
-import {Button} from "../components/forms/Button";
-import {set} from "lodash/fp";
-import {useUser} from "../user/UserProvider";
-import Api from "../api/api";
-import {Store} from "react-notifications-component";
-import {successNotification} from "../util/notifications";
-import LoadingSpinner from "../util/LoadingSpinner";
+import { doApiLoad } from 'api/api-utils'
+import { Button } from 'components/forms/Button'
+import { set } from 'lodash/fp'
+import { useUser } from 'user/UserProvider'
+import Api from 'api/api'
+import { Store } from 'react-notifications-component'
+import { successNotification } from 'util/notifications'
+import LoadingSpinner from 'util/LoadingSpinner'
 
 /** shows settings for both a study and its containing portal */
 export default function StudySettings({ studyEnvContext, portalContext }:
 {studyEnvContext: StudyEnvContextT, portalContext: LoadedPortalContextT}) {
   const portalEnv = portalContext.portal.portalEnvironments
-          .find(env =>
-              env.environmentName === studyEnvContext.currentEnv.environmentName) as PortalEnvironment
+    .find(env =>
+      env.environmentName === studyEnvContext.currentEnv.environmentName) as PortalEnvironment
   return <div className="ps-4">
     <StudyEnvConfigView studyEnvContext={studyEnvContext} portalContext={portalContext}/>
     <PortalEnvConfigView portalEnv={portalEnv} portalContext={portalContext}/>
   </div>
 }
 
+/** allows editing config settings for a particular study */
 export function StudyEnvConfigView({ studyEnvContext, portalContext }:
                                        {studyEnvContext: StudyEnvContextT, portalContext: LoadedPortalContextT}) {
   const [config, setConfig] = useState(studyEnvContext.currentEnv.studyEnvironmentConfig)
@@ -40,11 +39,11 @@ export function StudyEnvConfigView({ studyEnvContext, portalContext }:
   const save = async (e: React.MouseEvent) => {
     e.preventDefault()
     doApiLoad(async () => {
-      const updatedConfig = await Api.updateStudyEnvironmentConfig(portalContext.portal.shortcode,
-          studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName, config)
+      await Api.updateStudyEnvironmentConfig(portalContext.portal.shortcode,
+        studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName, config)
       Store.addNotification(successNotification('Config saved'))
       portalContext.reloadPortal(portalContext.portal.shortcode)
-    }, {setIsLoading})
+    }, { setIsLoading })
   }
 
   return <form className="bg-white p-3 mb-5">
@@ -53,26 +52,26 @@ export function StudyEnvConfigView({ studyEnvContext, portalContext }:
     <div>
       <label className="form-label">
         password protected <input type="checkbox" checked={config.passwordProtected}
-                                  onChange={e => updateConfig('passwordProtected', e.target.checked)}/>
+          onChange={e => updateConfig('passwordProtected', e.target.checked)}/>
       </label>
     </div>
     <div>
       <label className="form-label">
         password <input type="text" className="form-control" value={config.password}
-                        onChange={e => updateConfig('password', e.target.value)}/>
+          onChange={e => updateConfig('password', e.target.value)}/>
       </label>
     </div>
     <div>
       <label className="form-label">
         accepting registration
         <input type="checkbox" checked={config.acceptingEnrollment}
-               onChange={e => updateConfig('acceptingEnrollment', e.target.checked)}/>
+          onChange={e => updateConfig('acceptingEnrollment', e.target.checked)}/>
       </label>
     </div>
 
     <Button onClick={save}
-            variant="primary" disabled={!user.superuser || isLoading}
-            tooltip={user.superuser ? 'Save' : 'You do not have permission to edit these settings'}>
+      variant="primary" disabled={!user.superuser || isLoading}
+      tooltip={user.superuser ? 'Save' : 'You do not have permission to edit these settings'}>
       {isLoading && <LoadingSpinner/>}
       {!isLoading && 'Save study config'}
     </Button>

--- a/ui-admin/src/study/StudySettings.tsx
+++ b/ui-admin/src/study/StudySettings.tsx
@@ -1,39 +1,75 @@
-import React from 'react'
+import React, {useState} from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEdit } from '@fortawesome/free-solid-svg-icons'
 import { StudyEnvContextT } from './StudyEnvironmentRouter'
 import { LoadedPortalContextT } from '../portal/PortalProvider'
 import PortalEnvConfigView from '../portal/PortalEnvConfigView'
 import { PortalEnvironment } from '@juniper/ui-core'
+import {doApiLoad} from "../api/api-utils";
+import {Button} from "../components/forms/Button";
+import {set} from "lodash/fp";
+import {useUser} from "../user/UserProvider";
+import Api from "../api/api";
+import {Store} from "react-notifications-component";
+import {successNotification} from "../util/notifications";
+import LoadingSpinner from "../util/LoadingSpinner";
 
 /** shows settings for both a study and its containing portal */
 export default function StudySettings({ studyEnvContext, portalContext }:
 {studyEnvContext: StudyEnvContextT, portalContext: LoadedPortalContextT}) {
-  const envConfig = studyEnvContext.currentEnv.studyEnvironmentConfig
+  const [config, setConfig] = useState(studyEnvContext.currentEnv.studyEnvironmentConfig)
+  const { user } = useUser()
+  const [isLoading, setIsLoading] = useState(false)
+  /** update a given field in the config */
+  const updateConfig = (propName: string, value: string | boolean) => {
+    setConfig(set(propName, value))
+  }
   const portalEnv = portalContext.portal.portalEnvironments
     .find(env =>
       env.environmentName === studyEnvContext.currentEnv.environmentName) as PortalEnvironment
-  return <div className="container bg-white">
 
-    <div className="p-3">
-      <h2 className="h5">Study Configuration</h2>
-      <div className="form-group">
-        <div className="form-group-item">
-          <label>Accepting enrollment: </label> { envConfig.acceptingEnrollment ? 'Yes' : 'No'}
-          <br/>
-          <label>Enrollment Password protected:</label> { envConfig.passwordProtected ? 'Yes' : 'No'}
-          <br/>
-          <label>Enrollment Password:</label> { envConfig.password }
-        </div>
-        <button className="btn btn-secondary" onClick={() => alert('not yet implemented')}>
-          <FontAwesomeIcon icon={faEdit}/> Edit
-        </button>
+  /** saves any changes to the server */
+  const save = async (e: React.MouseEvent) => {
+    e.preventDefault()
+    doApiLoad(async () => {
+      const updatedConfig = await Api.updateStudyEnvironmentConfig(portalContext.portal.shortcode,
+          studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName, config)
+      Store.addNotification(successNotification('Config saved'))
+      portalContext.reloadPortal(portalContext.portal.shortcode)
+    }, {setIsLoading})
+  }
+
+  return <div className="bg-white ps-4">
+    <form className="bg-white p-3 mb-5">
+      <h2 className="h4">{studyEnvContext.study.name} study configuration</h2>
+      <p>Configure whether participants can access study content, such as surveys and consents.</p>
+      <div>
+        <label className="form-label">
+          password protected <input type="checkbox" checked={config.passwordProtected}
+                                    onChange={e => updateConfig('passwordProtected', e.target.checked)}/>
+        </label>
       </div>
-    </div>
-    <div className="p-3">
-      <h2 className="h5">Website configuration ({portalContext.portal.name})</h2>
-      <PortalEnvConfigView portalEnv={portalEnv} portal={portalContext.portal}
-        updatePortal={portalContext.updatePortal}/>
-    </div>
+      <div>
+        <label className="form-label">
+          password <input type="text" className="form-control" value={config.password}
+                          onChange={e => updateConfig('password', e.target.value)}/>
+        </label>
+      </div>
+      <div>
+        <label className="form-label">
+          accepting registration
+          <input type="checkbox" checked={config.acceptingEnrollment}
+                 onChange={e => updateConfig('acceptingEnrollment', e.target.checked)}/>
+        </label>
+      </div>
+
+      <Button onClick={save}
+              variant="primary" disabled={!user.superuser || isLoading}
+              tooltip={user.superuser ? 'Save' : 'You do not have permission to edit these settings'}>
+        {isLoading && <LoadingSpinner/>}
+        {!isLoading && <span>Save</span>}
+      </Button>
+    </form>
+    <PortalEnvConfigView portalEnv={portalEnv} portalContext={portalContext}/>
   </div>
 }

--- a/ui-admin/src/study/StudySettings.tsx
+++ b/ui-admin/src/study/StudySettings.tsx
@@ -36,8 +36,7 @@ export function StudyEnvConfigView({ studyEnvContext, portalContext }:
   }
 
   /** saves any changes to the server */
-  const save = async (e: React.MouseEvent) => {
-    e.preventDefault()
+  const save = async () => {
     doApiLoad(async () => {
       await Api.updateStudyEnvironmentConfig(portalContext.portal.shortcode,
         studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName, config)
@@ -46,7 +45,7 @@ export function StudyEnvConfigView({ studyEnvContext, portalContext }:
     }, { setIsLoading })
   }
 
-  return <form className="bg-white p-3 mb-5">
+  return <form className="bg-white p-3 mb-5" onSubmit={e => e.preventDefault()}>
     <h2 className="h4">{studyEnvContext.study.name} study configuration</h2>
     <p>Configure whether participants can access study content, such as surveys and consents.</p>
     <div>

--- a/ui-admin/src/study/StudySettings.tsx
+++ b/ui-admin/src/study/StudySettings.tsx
@@ -61,13 +61,6 @@ export function StudyEnvConfigView({ studyEnvContext, portalContext }:
           onChange={e => updateConfig('password', e.target.value)}/>
       </label>
     </div>
-    <div>
-      <label className="form-label">
-        accepting registration
-        <input type="checkbox" checked={config.acceptingEnrollment}
-          onChange={e => updateConfig('acceptingEnrollment', e.target.checked)}/>
-      </label>
-    </div>
 
     <Button onClick={save}
       variant="primary" disabled={!user.superuser || isLoading}

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -119,7 +119,7 @@ export const mockStudyEnvContext: () => StudyEnvContextT = () => ({
     notificationConfigs: [],
     studyEnvironmentConfig: {
       initialized: true,
-      password: '',
+      password: 'blah',
       passwordProtected: false,
       acceptingEnrollment: true
     }


### PR DESCRIPTION
#### DESCRIPTION

This enables changing password protection and other study-environment level configurations.  This is what I had to do manually for OurHealth today to make their study public.  This also cleans up a bunch of the PortalSettings controls and brings them inline with our latest patterns.

<img width="891" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/7820b070-2020-4db5-b7ec-a0f5bbdb1735">

One pattern I've been trying out in the last couple PRs is using "real" data in our ExtService auth tests instead of the "mock everything and just confirm a method is called" pattern we've been using.  The real data approach requires a bit more setup, and the tests will take a bit longer to execute, but I think it's worth it because then our ExtService tests serve as backup module/integration tests (and also encourage us to develop more streamlined factory patterns).  Curious about y'all's thoughts. 

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1. redeploy ApiAdminApp 
2. go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/settings
3. edit the study settings password
4. click "Save study config"
5. confirm the value is persisted.
