### PR TITLE
[JN-625] Add new site pages + bonus features

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/site/NavbarItemService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/site/NavbarItemService.java
@@ -26,7 +26,9 @@ public class NavbarItemService extends ImmutableEntityService<NavbarItem, Navbar
             htmlPage = htmlPageService.create(htmlPage);
             item.setHtmlPageId(htmlPage.getId());
         }
-        return dao.create(item);
+        item = dao.create(item);
+        item.setHtmlPage(htmlPage);
+        return item;
     }
 
     public void deleteByLocalSiteId(UUID localSiteId, Set<CascadeProperty> cascades) {

--- a/ui-admin/src/portal/siteContent/AddPageModal.test.tsx
+++ b/ui-admin/src/portal/siteContent/AddPageModal.test.tsx
@@ -1,0 +1,81 @@
+import userEvent from '@testing-library/user-event'
+import { mockPortalEnvironment } from 'test-utils/mocking-utils'
+import { setupRouterTest } from 'test-utils/router-testing-utils'
+import AddPageModal from './AddPageModal'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+describe('AddPageModal', () => {
+  test('disables Create button when title and path aren\'t filled out', async () => {
+    //Arrange
+    const { RoutedComponent } = setupRouterTest(<AddPageModal
+      show={true}
+      setShow={jest.fn()}
+      insertNewPage={jest.fn()}
+      portalEnv={mockPortalEnvironment('sandbox')}
+      portalShortcode={'test'}
+    />)
+
+    render(RoutedComponent)
+
+    //Act
+    const createButton = screen.getByText('Create')
+
+    //Assert
+    expect(createButton).toBeDisabled()
+  })
+
+  test('enables Create button when title and path are filled out', async () => {
+    //Arrange
+    const { RoutedComponent } = setupRouterTest(<AddPageModal
+      show={true}
+      setShow={jest.fn()}
+      insertNewPage={jest.fn()}
+      portalEnv={mockPortalEnvironment('sandbox')}
+      portalShortcode={'test'}
+    />)
+
+    render(RoutedComponent)
+
+    //Act
+    const pageTitleInput = screen.getByLabelText('Page Title')
+    const pagePathInput = screen.getByLabelText('Page Path')
+    const createButton = screen.getByText('Create')
+
+    await userEvent.type(pageTitleInput, 'test')
+    await userEvent.type(pagePathInput, 'test')
+
+    //Assert
+    expect(createButton).toBeEnabled()
+  })
+
+  test('Create button calls insertNewPage with a new page', async () => {
+    //Arrange
+    const mockInsertNewPageFn = jest.fn()
+    const { RoutedComponent } = setupRouterTest(<AddPageModal
+      show={true}
+      setShow={jest.fn()}
+      insertNewPage={mockInsertNewPageFn}
+      portalEnv={mockPortalEnvironment('sandbox')}
+      portalShortcode={'test'}
+    />)
+
+    render(RoutedComponent)
+
+    //Act
+    const pageTitleInput = screen.getByLabelText('Page Title')
+    const pagePathInput = screen.getByLabelText('Page Path')
+    const createButton = screen.getByText('Create')
+
+    await userEvent.type(pageTitleInput, 'My New Page')
+    await userEvent.type(pagePathInput, 'newPage')
+    await userEvent.click(createButton)
+
+    //Assert
+    expect(mockInsertNewPageFn).toHaveBeenCalledWith({
+      title: 'My New Page',
+      path: 'newPage',
+      sections: []
+    })
+  })
+})

--- a/ui-admin/src/portal/siteContent/AddPageModal.test.tsx
+++ b/ui-admin/src/portal/siteContent/AddPageModal.test.tsx
@@ -18,10 +18,8 @@ describe('AddPageModal', () => {
 
     render(RoutedComponent)
 
-    //Act
-    const createButton = screen.getByText('Create')
-
     //Assert
+    const createButton = screen.getByText('Create')
     expect(createButton).toBeDisabled()
   })
 

--- a/ui-admin/src/portal/siteContent/AddPageModal.tsx
+++ b/ui-admin/src/portal/siteContent/AddPageModal.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react'
+import Modal from 'react-bootstrap/Modal'
+import { HtmlPage, PortalEnvironment } from '@juniper/ui-core'
+import Api from 'api/api'
+import { useConfig } from 'providers/ConfigProvider'
+
+/** renders a modal that adds a new page to the site */
+const AddPageModal = ({ portalEnv, portalShortcode, insertNewPage, show, setShow }: {
+  portalEnv: PortalEnvironment, portalShortcode: string, insertNewPage: (page: HtmlPage) => void,
+  show: boolean, setShow:  React.Dispatch<React.SetStateAction<boolean>>
+}) => {
+  const zoneConfig = useConfig()
+
+  const [pageTitle, setPageTitle] = useState('')
+  const [pagePath, setPagePath] = useState('')
+
+  const addPage = async () => {
+    insertNewPage({
+      title: pageTitle,
+      path: pagePath,
+      sections: []
+    })
+    setShow(false)
+  }
+
+  const clearFields = () => {
+    setPageTitle('')
+    setPagePath('')
+  }
+
+  const portalUrl = Api.getParticipantLink(portalEnv.portalEnvironmentConfig, zoneConfig.participantUiHostname,
+    portalShortcode, portalEnv.environmentName)
+
+  return <Modal show={show}
+    onHide={() => {
+      setShow(false)
+      clearFields()
+    }}>
+    <Modal.Header closeButton>
+      <Modal.Title>Add New Page</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>
+      <form onSubmit={e => e.preventDefault()}>
+        <label htmlFor="inputPageTitle">Page Title</label>
+        <input type="text" size={50} className="form-control mb-3" id="inputPageTitle" value={pageTitle}
+          onChange={event => {
+            setPageTitle(event.target.value)
+          }}/>
+        <label htmlFor="inputPagePath">Page Path</label>
+        <div className="input-group">
+          <div className="input-group-prepend">
+            <span className="input-group-text" id="pathPrefix">{portalUrl}/</span>
+          </div>
+          <input type="text" className="form-control" id="inputPagePath"
+            value={pagePath} aria-describedby="pathPrefix"
+            onChange={event => {
+              setPagePath(event.target.value)
+            }}/>
+        </div>
+      </form>
+    </Modal.Body>
+    <Modal.Footer>
+      <button
+        className="btn btn-primary"
+        disabled={!pageTitle || !pagePath}
+        onClick={addPage}
+      >Create</button>
+      <button className="btn btn-secondary" onClick={() => {
+        setShow(false)
+        clearFields()
+      }}>Cancel</button>
+    </Modal.Footer>
+  </Modal>
+}
+
+export default AddPageModal

--- a/ui-admin/src/portal/siteContent/AddPageModal.tsx
+++ b/ui-admin/src/portal/siteContent/AddPageModal.tsx
@@ -49,7 +49,8 @@ const AddPageModal = ({ portalEnv, portalShortcode, insertNewPage, show, setShow
         <label htmlFor="inputPagePath">Page Path</label>
         <div className="input-group">
           <div className="input-group-prepend">
-            <span className="input-group-text" id="pathPrefix">{portalUrl}/</span>
+            <span className="input-group-text" style={{ borderTopRightRadius: 0, borderBottomRightRadius: 0 }}
+              id="pathPrefix">{portalUrl}/</span>
           </div>
           <input type="text" className="form-control" id="inputPagePath"
             value={pagePath} aria-describedby="pathPrefix"

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.test.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.test.tsx
@@ -10,7 +10,7 @@ test('readOnly disables insert new section button', async () => {
   const { RoutedComponent } = setupRouterTest(
     <HtmlPageEditView htmlPage={mockPage} readOnly={true} updatePage={jest.fn()}/>)
   render(RoutedComponent)
-  expect(screen.getByLabelText('Insert a blank section')).toHaveAttribute('aria-disabled', 'true')
+  expect(screen.getAllByLabelText('Insert a blank section')[0]).toHaveAttribute('aria-disabled', 'true')
 })
 
 test('Insert Section button calls updatePage with a new blank HERO_WITH_IMAGE section', async () => {
@@ -22,7 +22,7 @@ test('Insert Section button calls updatePage with a new blank HERO_WITH_IMAGE se
   render(RoutedComponent)
 
   //Act
-  const insertSectionButton = screen.getByLabelText('Insert a blank section')
+  const insertSectionButton = screen.getAllByLabelText('Insert a blank section')[1]
   await userEvent.click(insertSectionButton)
 
   //Assert

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
@@ -13,7 +13,6 @@ type HtmlPageViewProps = {
 
 /** Enables editing of a given page, showing the config and a preview for each section */
 const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => {
-
   //Inserts a new HtmlSection at the specified index on the page
   const insertNewSection = (sectionIndex: number, newSection: HtmlSection) => {
     const newSectionArray = [...htmlPage.sections]

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
@@ -13,27 +13,6 @@ type HtmlPageViewProps = {
 
 /** Enables editing of a given page, showing the config and a preview for each section */
 const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => {
-  const updateSection = (sectionIndex: number, updatedSection: HtmlSection) => {
-    try {
-      JSON.parse(updatedSection.sectionConfig ?? '{}')
-    } catch (e) {
-      // for now, we just don't allow changing the object structure itself -- just plain text edits
-      return
-    }
-
-    const newSection = {
-      ...htmlPage.sections[sectionIndex],
-      sectionType: updatedSection.sectionType,
-      sectionConfig: updatedSection.sectionConfig
-    }
-    const newSectionArray = [...htmlPage.sections]
-    newSectionArray[sectionIndex] = newSection
-    htmlPage = {
-      ...htmlPage,
-      sections: newSectionArray
-    }
-    updatePage(htmlPage)
-  }
 
   //Inserts a new HtmlSection at the specified index on the page
   const insertNewSection = (sectionIndex: number, newSection: HtmlSection) => {
@@ -47,11 +26,20 @@ const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => 
   }
 
   return <div>
+    <div className="col-md-12 my-2" style={{ backgroundColor: '#eee' }}>
+      <Button variant="secondary"
+        aria-label={'Insert a blank section'}
+        tooltip={'Insert a blank section'}
+        disabled={readOnly}
+        onClick={() => insertNewSection(0, { id: '', sectionType: 'HERO_WITH_IMAGE' })}>
+        <FontAwesomeIcon icon={faPlus}/> Insert section
+      </Button>
+    </div>
     {htmlPage.sections.map((section, index) => {
-      return <div key={index} className="row">
+      return <div key={`${section.id}-${index}`} className="row g-0">
         <div className="col-md-4 p-2">
-          <HtmlSectionEditor
-            section={section} sectionIndex={index} readOnly={readOnly} updateSection={updateSection}/>
+          <HtmlSectionEditor updatePage={updatePage} htmlPage={htmlPage}
+            section={section} sectionIndex={index} readOnly={readOnly}/>
         </div>
         <div className="col-md-8">
           <HtmlSectionView section={section}/>

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.test.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.test.tsx
@@ -1,8 +1,9 @@
 import { render, screen } from '@testing-library/react'
 import React from 'react'
 import { setupRouterTest } from 'test-utils/router-testing-utils'
-import { mockHtmlPage } from 'test-utils/mock-site-content'
+import { mockHtmlPage, mockHtmlSection } from 'test-utils/mock-site-content'
 import HtmlSectionEditor from './HtmlSectionEditor'
+import userEvent from '@testing-library/user-event'
 
 test('readOnly disables section type selection', async () => {
   const mockPage = mockHtmlPage()
@@ -23,4 +24,79 @@ test('section type selection is enabled if the section type is unsaved', async (
       htmlPage={mockPage} updatePage={jest.fn}/>)
   render(RoutedComponent)
   expect(screen.getByLabelText('Select section type')).toBeEnabled()
+})
+
+test('DeleteSection button removes the section', async () => {
+  //Arrange
+  const mockPage = mockHtmlPage()
+  const mockSection = mockPage.sections[0]
+  const mockUpdatePageFn = jest.fn()
+  const { RoutedComponent } = setupRouterTest(
+    <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={false}
+      htmlPage={mockPage} updatePage={mockUpdatePageFn}/>)
+  render(RoutedComponent)
+
+  //Act
+  const deleteButton = screen.getByLabelText('Delete this section')
+  await userEvent.click(deleteButton)
+
+  //Assert
+  expect(mockUpdatePageFn).toHaveBeenCalledWith({
+    ...mockPage,
+    sections: []
+  })
+})
+
+test('MoveSectionUp button allows reordering', async () => {
+  //Arrange
+  const mockPage = {
+    ...mockHtmlPage(),
+    sections: [
+      { ...mockHtmlSection(), id: 'firstSection' },
+      { ...mockHtmlSection(), id: 'secondSection' }
+    ]
+  }
+  const mockSection = mockPage.sections[1]
+  const mockUpdatePageFn = jest.fn()
+  const { RoutedComponent } = setupRouterTest(
+    <HtmlSectionEditor sectionIndex={1} section={mockSection} readOnly={false}
+      htmlPage={mockPage} updatePage={mockUpdatePageFn}/>)
+  render(RoutedComponent)
+
+  //Act
+  const moveUpButton = screen.getByLabelText('Move this section before the previous one')
+  await userEvent.click(moveUpButton)
+
+  //Assert
+  expect(mockUpdatePageFn).toHaveBeenCalledWith({
+    ...mockPage,
+    sections: [mockPage.sections[1], mockPage.sections[0]]
+  })
+})
+
+test('MoveSectionDown button allows reordering', async () => {
+  //Arrange
+  const mockPage = {
+    ...mockHtmlPage(),
+    sections: [
+      { ...mockHtmlSection(), id: 'firstSection' },
+      { ...mockHtmlSection(), id: 'secondSection' }
+    ]
+  }
+  const mockSection = mockPage.sections[0]
+  const mockUpdatePageFn = jest.fn()
+  const { RoutedComponent } = setupRouterTest(
+    <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={false}
+      htmlPage={mockPage} updatePage={mockUpdatePageFn}/>)
+  render(RoutedComponent)
+
+  //Act
+  const moveDownButton = screen.getByLabelText('Move this section after the next one')
+  await userEvent.click(moveDownButton)
+
+  //Assert
+  expect(mockUpdatePageFn).toHaveBeenCalledWith({
+    ...mockPage,
+    sections: [mockPage.sections[1], mockPage.sections[0]]
+  })
 })

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.test.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.test.tsx
@@ -5,18 +5,22 @@ import { mockHtmlPage } from 'test-utils/mock-site-content'
 import HtmlSectionEditor from './HtmlSectionEditor'
 
 test('readOnly disables section type selection', async () => {
-  const mockSection = mockHtmlPage().sections[0]
+  const mockPage = mockHtmlPage()
+  const mockSection = mockPage.sections[0]
   const { RoutedComponent } = setupRouterTest(
-    <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={true} updateSection={jest.fn()}/>)
+    <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={true}
+      htmlPage={mockPage} updatePage={jest.fn}/>)
   render(RoutedComponent)
   expect(screen.getByLabelText('Select section type')).toBeDisabled()
 })
 
 test('section type selection is enabled if the section type is unsaved', async () => {
-  const mockSection = mockHtmlPage().sections[0]
+  const mockPage = mockHtmlPage()
+  const mockSection = mockPage.sections[0]
   mockSection.id = ''
   const { RoutedComponent } = setupRouterTest(
-    <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={false} updateSection={jest.fn()}/>)
+    <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={false}
+      htmlPage={mockPage} updatePage={jest.fn}/>)
   render(RoutedComponent)
   expect(screen.getByLabelText('Select section type')).toBeEnabled()
 })

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react'
-import { HtmlSection, SectionType } from '@juniper/ui-core'
+import {HtmlPage, HtmlSection, SectionType} from '@juniper/ui-core'
 import Select from 'react-select'
 import { isEmpty } from 'lodash'
+import { IconButton } from 'components/forms/Button'
+import { faChevronDown, faChevronUp, faTimes } from '@fortawesome/free-solid-svg-icons'
 
 const SECTION_TYPES = [
   { label: 'FAQ', value: 'FAQ' },
@@ -20,26 +22,77 @@ const SECTION_TYPES = [
  * Returns an editor for an HtmlSection
  */
 const HtmlSectionEditor = ({
+  htmlPage,
+  updatePage,
   section,
   sectionIndex,
-  readOnly,
-  updateSection
+  readOnly
 }: {
+  htmlPage: HtmlPage,
+  updatePage: (page: HtmlPage) => void,
   section: HtmlSection
   sectionIndex: number
   readOnly: boolean
-  updateSection: (sectionIndex: number, updatedSection: HtmlSection) => void
 }) => {
   const sectionConfig = JSON.stringify(JSON.parse(section?.sectionConfig ?? '{}'), null, 2)
   const initial = SECTION_TYPES.find(sectionType => sectionType.value === section.sectionType)
   const [sectionTypeOpt, setSectionTypeOpt] = useState(initial)
 
+  const updateSection = (sectionIndex: number, updatedSection: HtmlSection) => {
+    try {
+      JSON.parse(updatedSection.sectionConfig ?? '{}')
+    } catch (e) {
+      // for now, we just don't allow changing the object structure itself -- just plain text edits
+      return
+    }
+
+    const newSection = {
+      ...htmlPage.sections[sectionIndex],
+      sectionType: updatedSection.sectionType,
+      sectionConfig: updatedSection.sectionConfig
+    }
+    const newSectionArray = [...htmlPage.sections]
+    newSectionArray[sectionIndex] = newSection
+    htmlPage = {
+      ...htmlPage,
+      sections: newSectionArray
+    }
+    updatePage(htmlPage)
+  }
+
+  const removeSection = (sectionIndex: number) => {
+    const newSectionArray = [...htmlPage.sections]
+    newSectionArray.splice(sectionIndex, 1)
+    htmlPage = {
+      ...htmlPage,
+      sections: newSectionArray
+    }
+    updatePage(htmlPage)
+  }
+
+  const moveSection = (sectionIndex: number, direction: 'up' | 'down') => {
+    if (sectionIndex === 0 && direction === 'up') { return }
+    const newSectionArray = [...htmlPage.sections]
+    const sectionToMove = newSectionArray[sectionIndex]
+    newSectionArray.splice(sectionIndex, 1)
+    if (direction === 'up') {
+      newSectionArray.splice(sectionIndex - 1, 0, sectionToMove)
+    } else {
+      newSectionArray.splice(sectionIndex + 1, 0, sectionToMove)
+    }
+    htmlPage = {
+      ...htmlPage,
+      sections: newSectionArray
+    }
+    updatePage(htmlPage)
+  }
+
   return <>
-    <div>
+    <div className="d-flex flex-grow-1 mb-1">
       {/* Right now we do not support changing the type for an existing section. The way to identify if a
-          section has been previously saved is to look at the id. If it's empty, it's a new section, and we can
-          allow the user to change the type. */ }
-      <Select options={SECTION_TYPES} value={sectionTypeOpt} aria-label={'Select section type'}
+        section has been previously saved is to look at the id. If it's empty, it's a new section, and we can
+        allow the user to change the type. */ }
+      <Select className='w-100' options={SECTION_TYPES} value={sectionTypeOpt} aria-label={'Select section type'}
         isDisabled={readOnly || !isEmpty(section.id)}
         onChange={opt => {
           if (opt != undefined) {
@@ -47,6 +100,34 @@ const HtmlSectionEditor = ({
             updateSection(sectionIndex, { ...section, sectionType: opt.value as SectionType })
           }
         }}/>
+      <IconButton
+        aria-label="Move this section before the previous one"
+        className="ms-2"
+        disabled={readOnly || sectionIndex === 0}
+        icon={faChevronUp}
+        variant="light"
+        onClick={() => {
+          moveSection(sectionIndex, 'up')
+        }}
+      />
+      <IconButton
+        aria-label="Move this section after the next one"
+        className="ms-2"
+        disabled={readOnly}
+        icon={faChevronDown}
+        variant="light"
+        onClick={() => {
+          moveSection(sectionIndex, 'down')
+        }}
+      />
+      <IconButton
+        aria-label="Delete this section"
+        className="ms-2"
+        disabled={readOnly}
+        icon={faTimes}
+        variant="light"
+        onClick={() => removeSection(sectionIndex)}
+      />
     </div>
     <textarea value={sectionConfig} style={{ height: 'calc(100% - 2em)', width: '100%' }}
       readOnly={readOnly}

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import {HtmlPage, HtmlSection, SectionType} from '@juniper/ui-core'
+import { HtmlPage, HtmlSection, SectionType } from '@juniper/ui-core'
 import Select from 'react-select'
 import { isEmpty } from 'lodash'
 import { IconButton } from 'components/forms/Button'

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -123,7 +123,7 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
               onClick={() => setShowVersionSelector(!showVersionSelector)}>
               <FontAwesomeIcon icon={faClockRotateLeft}/> History
             </button> }
-            <Link to="../images" className="btn btn-secondary m-1 ms-3">
+            <Link to="../images" className="btn btn-secondary">
               <FontAwesomeIcon icon={faImage} className="fa-lg"/> Manage images
             </Link>
           </h5>

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -74,19 +74,19 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
   }
 
   /** updates the global SiteContent object with the given HtmlPage, which may be associated with a navItem */
-  const updatePage = (page: HtmlPage, navItemId?: string) => {
+  const updatePage = (page: HtmlPage, navItemText?: string) => {
     if (!localContent) {
       return
     }
     let updatedLocalContent
-    if (!navItemId) {
+    if (!navItemText) {
       updatedLocalContent = {
         ...localContent,
         landingPage: page
       }
     } else {
       const updatedNavBarItems = [...localContent.navbarItems]
-      const matchedNavItem = navBarInternalItems.find(navItem => navItem.id === navItemId)
+      const matchedNavItem = navBarInternalItems.find(navItem => navItem.text === navItemText)
       if (!matchedNavItem) {
         return
       }
@@ -164,7 +164,7 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
         {pageToRender &&
           <ApiProvider api={previewApi}>
             <HtmlPageEditView htmlPage={pageToRender} readOnly={readOnly}
-              updatePage={page => updatePage(page, currentNavBarItem?.id)}/>
+              updatePage={page => updatePage(page, currentNavBarItem?.text)}/>
           </ApiProvider>}
       </div>
     </div>

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -2,15 +2,16 @@ import React, { useState } from 'react'
 import { NavbarItemInternal, PortalEnvironment } from 'api/api'
 import Select from 'react-select'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faImage, faPlus } from '@fortawesome/free-solid-svg-icons'
+import { faClockRotateLeft, faImage, faPlus } from '@fortawesome/free-solid-svg-icons'
 import HtmlPageEditView from './HtmlPageEditView'
 import { HtmlPage, LocalSiteContent, ApiProvider, SiteContent, ApiContextT } from '@juniper/ui-core'
 import { Link } from 'react-router-dom'
 import SiteContentVersionSelector from './SiteContentVersionSelector'
 import { Button } from '../../components/forms/Button'
+import AddPageModal from './AddPageModal'
 
-type NavbarOption = {label: string, value: string | null}
-const landingPageOption = { label: 'Landing page', value: null }
+type NavbarOption = {label: string, value: string}
+const landingPageOption = { label: 'Landing page', value: 'Landing page' }
 
 type InitializedSiteContentViewProps = {
   siteContent: SiteContent
@@ -33,6 +34,7 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
   const [selectedNavOpt, setSelectedNavOpt] = useState<NavbarOption>(landingPageOption)
   const [workingContent, setWorkingContent] = useState<SiteContent>(siteContent)
   const [showVersionSelector, setShowVersionSelector] = useState(false)
+  const [showAddPageModal, setShowAddPageModal] = useState(false)
   const localContent = workingContent.localizedSiteContents.find(lsc => lsc.language === selectedLanguage)
   if (!localContent) {
     return <div>no content for language {selectedLanguage}</div>
@@ -51,6 +53,24 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
       localizedSiteContents: updatedLocalContents
     }
     setWorkingContent(newWorkingContent)
+  }
+
+  const insertNewPage = (page: HtmlPage) => {
+    if (!localContent) {
+      return
+    }
+    const newNavBarItem: NavbarItemInternal = {
+      itemType: 'INTERNAL',
+      itemOrder: localContent.navbarItems.length,
+      text: page.title,
+      htmlPage: page
+    }
+    const updatedLocalContent = {
+      ...localContent,
+      navbarItems: [...localContent.navbarItems, newNavBarItem]
+    }
+    updateLocalContent(updatedLocalContent)
+    setSelectedNavOpt({ label: newNavBarItem.text, value: newNavBarItem.text || 'Landing page' })
   }
 
   /** updates the global SiteContent object with the given HtmlPage, which may be associated with a navItem */
@@ -84,46 +104,60 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
   const isEditable = !readOnly && portalEnv.environmentName === 'sandbox'
 
   const currentNavBarItem = selectedNavOpt.value ? navBarInternalItems
-    .find(navItem => navItem.id === selectedNavOpt.value) : null
+    .find(navItem => navItem.text === selectedNavOpt.value) : null
   const pageToRender = currentNavBarItem ? currentNavBarItem.htmlPage : localContent.landingPage
 
-  const pageOpts: {label: string, value: string | null}[] = navBarInternalItems
-    .map(navItem => ({ label: navItem.text, value: navItem.id }))
-  pageOpts.unshift({ label: 'Landing page', value: null })
+  const pageOpts: {label: string, value: string}[] = navBarInternalItems
+    .map(navItem => ({ label: navItem.text, value: navItem.text }))
+  pageOpts.unshift(landingPageOption)
 
-  return <div className="d-flex bg-white p-3">
-    <div className="ps-3">
-      <div className="d-flex mb-2 align-items-baseline">
-        <h2 className="h5">Website content</h2>
-        <div className="ms-3 text-muted">
-          version {siteContent.version}
+  return <div className="d-flex bg-white">
+    <div className="d-flex flex-column flex-grow-1 mx-1 mb-1">
+      <div className="d-flex p-2 align-items-center">
+        <div className="d-flex flex-grow-1">
+          <h5>Website Content
+            <span className="fs-6 text-muted fst-italic me-2 ms-2">
+            (v{siteContent.version})
+            </span>
+            {isEditable && <button className="btn btn-secondary"
+              onClick={() => setShowVersionSelector(!showVersionSelector)}>
+              <FontAwesomeIcon icon={faClockRotateLeft}/> History
+            </button> }
+            <Link to="../images" className="btn btn-secondary m-1 ms-3">
+              <FontAwesomeIcon icon={faImage} className="fa-lg"/> Manage images
+            </Link>
+          </h5>
         </div>
-        {isEditable && <button className="btn btn-secondary"
-          onClick={() => setShowVersionSelector(!showVersionSelector)}>select</button> }
-      </div>
-      <div className="d-flex mb-3 w-100">
-        <div>
-          <Select options={pageOpts} value={selectedNavOpt}
-            onChange={e => setSelectedNavOpt(e ?? landingPageOption)}/>
-        </div>
-        { isEditable && <button className="btn btn-secondary" onClick={() => alert('not yet implemented')}>
-          <FontAwesomeIcon icon={faPlus}/> Add page
-        </button> }
-        <Link to="../images" className="btn btn-secondary m-1 ms-3">
-          <FontAwesomeIcon icon={faImage} className="fa-lg"/> Manage images
-        </Link>
-        { isEditable && <>
-          <Button variant="primary" className="ms-auto"
-            onClick={() => createNewVersion(workingContent)}>
-              Save
-          </Button>
-          {
+        {
+          isEditable && <div className="d-flex flex-grow-1">
+            <Button className="ms-auto me-md-2" variant="primary"
+              disabled={readOnly}
+              onClick={() => createNewVersion(workingContent)}>
+                  Save
+            </Button>
+            {
             // eslint-disable-next-line
-                // @ts-ignore  Link to type also supports numbers for back operations
-            <Link className="btn btn-cancel" to={-1}>Cancel</Link>
-          }
-        </>
+            // @ts-ignore  Link to type also supports numbers for back operations
+              <Link className="btn btn-cancel" to={-1}>Cancel</Link>
+            }
+          </div>
         }
+      </div>
+      <div className="px-2">
+        <div className="d-flex flex-grow-1 mb-1">
+          <div style={{ width: 250 }}>
+            <Select options={pageOpts} value={selectedNavOpt}
+              onChange={e => {
+                setSelectedNavOpt(e ?? landingPageOption)
+              }}/>
+          </div>
+          <Button className="btn btn-secondary"
+            tooltip={'Add a new page'}
+            disabled={readOnly || !isEditable}
+            onClick={() => setShowAddPageModal(!showAddPageModal)}>
+            <FontAwesomeIcon icon={faPlus}/> Add page
+          </Button>
+        </div>
 
       </div>
       <div>
@@ -139,6 +173,10 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
           current={siteContent} loadSiteContent={loadSiteContent} portalEnv={portalEnv}
           switchToVersion={switchToVersion}
           onDismiss={() => setShowVersionSelector(false)}/>
+    }
+    { showAddPageModal &&
+        <AddPageModal portalEnv={portalEnv} portalShortcode={portalShortcode} insertNewPage={insertNewPage}
+          show={showAddPageModal} setShow={setShowAddPageModal}/>
     }
   </div>
 }

--- a/ui-admin/src/portal/siteContent/SiteContentLoader.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentLoader.tsx
@@ -47,7 +47,7 @@ const SiteContentLoader = ({ portalEnvContext }: {portalEnvContext: PortalEnvCon
       Store.addNotification(failureNotification('save failed'))
       return
     }
-    await switchToVersion(newVersion.id, newVersion.stableId, newVersion.version, newVersion)
+    await switchToVersion(newVersion.id, newVersion.stableId, newVersion.version, undefined)
     setIsLoading(false)
   }
 

--- a/ui-admin/src/portal/siteContent/SiteContentLoader.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentLoader.tsx
@@ -47,7 +47,7 @@ const SiteContentLoader = ({ portalEnvContext }: {portalEnvContext: PortalEnvCon
       Store.addNotification(failureNotification('save failed'))
       return
     }
-    await switchToVersion(newVersion.id, newVersion.stableId, newVersion.version, undefined)
+    await switchToVersion(newVersion.id, newVersion.stableId, newVersion.version, newVersion)
     setIsLoading(false)
   }
 

--- a/ui-core/src/types/landingPageConfig.ts
+++ b/ui-core/src/types/landingPageConfig.ts
@@ -53,7 +53,7 @@ export type NavbarItem =
   | NavbarItemExternal
 
 type BaseNavBarItem = {
-  id: string
+  id?: string
   itemType: 'INTERNAL' | 'INTERNAL_ANCHOR' | 'MAILING_LIST' | 'EXTERNAL'
   text: string
   itemOrder: number


### PR DESCRIPTION
#### DESCRIPTION

This adds a bunch of new functionality to the site content editor. The main thing is the ability to add new pages (which automatically adds them to the navbar). I was having fun with it so I added a few extra small features that were inspired by the functionality in the survey editor. I also spent some time making the styling a little more consistent with the survey editor and making it so components on the page erratically resize as content changed on the screen. Videos below.

Add a new page:

https://github.com/broadinstitute/juniper/assets/7257391/3608d15f-02da-4485-a8e9-6dd2b9e89b0b

Delete a page section:

https://github.com/broadinstitute/juniper/assets/7257391/f50cf7d6-bade-4529-be34-0b23f7baf47a

Move page sections:

https://github.com/broadinstitute/juniper/assets/7257391/79e83ab8-86e7-4b75-a13b-2bb64f7dcc50



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Start up admin + participant API servers and UIs
* Try adding a new page, confirm it shows up in the navbar after saving
* Confirm you can delete sections
* Confirm you can move sections around
* In general just try modifying as much state as possible in-between saves and confirm the final result after saving is as-expected