### PR TITLE
[JN-543] upload image function

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/SiteImageController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/SiteImageController.java
@@ -5,7 +5,7 @@ import bio.terra.pearl.api.admin.service.AuthUtilService;
 import bio.terra.pearl.api.admin.service.siteContent.SiteImageExtService;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.site.SiteImage;
-import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.io.IOException;
 import java.net.URLConnection;
 import java.util.Optional;
@@ -22,17 +22,14 @@ public class SiteImageController implements SiteImageApi {
   private AuthUtilService authUtilService;
   private HttpServletRequest request;
   private SiteImageExtService siteImageExtService;
-  private ObjectMapper objectMapper;
 
   public SiteImageController(
       AuthUtilService authUtilService,
       HttpServletRequest request,
-      SiteImageExtService siteImageExtService,
-      ObjectMapper objectMapper) {
+      SiteImageExtService siteImageExtService) {
     this.authUtilService = authUtilService;
     this.request = request;
     this.siteImageExtService = siteImageExtService;
-    this.objectMapper = objectMapper;
   }
 
   /**

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/SiteImageController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/SiteImageController.java
@@ -5,7 +5,6 @@ import bio.terra.pearl.api.admin.service.AuthUtilService;
 import bio.terra.pearl.api.admin.service.siteContent.SiteImageExtService;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.site.SiteImage;
-
 import java.io.IOException;
 import java.net.URLConnection;
 import java.util.Optional;

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/SiteImageController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/SiteImageController.java
@@ -5,6 +5,8 @@ import bio.terra.pearl.api.admin.service.AuthUtilService;
 import bio.terra.pearl.api.admin.service.siteContent.SiteImageExtService;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.site.SiteImage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.net.URLConnection;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
@@ -13,20 +15,24 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.multipart.MultipartFile;
 
 @Controller
 public class SiteImageController implements SiteImageApi {
   private AuthUtilService authUtilService;
   private HttpServletRequest request;
   private SiteImageExtService siteImageExtService;
+  private ObjectMapper objectMapper;
 
   public SiteImageController(
       AuthUtilService authUtilService,
       HttpServletRequest request,
-      SiteImageExtService siteImageExtService) {
+      SiteImageExtService siteImageExtService,
+      ObjectMapper objectMapper) {
     this.authUtilService = authUtilService;
     this.request = request;
     this.siteImageExtService = siteImageExtService;
+    this.objectMapper = objectMapper;
   }
 
   /**
@@ -46,6 +52,19 @@ public class SiteImageController implements SiteImageApi {
   public ResponseEntity<Object> list(String portalShortcode) {
     AdminUser operator = authUtilService.requireAdminUser(request);
     return ResponseEntity.ok(siteImageExtService.list(portalShortcode, operator));
+  }
+
+  @Override
+  public ResponseEntity<Object> upload(
+      String portalShortcode, String uploadFileName, Integer version, MultipartFile image) {
+    AdminUser operator = authUtilService.requireAdminUser(request);
+    try {
+      byte[] imageData = image.getBytes();
+      return ResponseEntity.ok(
+          siteImageExtService.upload(portalShortcode, uploadFileName, imageData, operator));
+    } catch (IOException e) {
+      throw new IllegalArgumentException("could not read image data");
+    }
   }
 
   private ResponseEntity<Resource> convertToResourceResponse(Optional<SiteImage> imageOpt) {

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/siteContent/SiteImageExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/siteContent/SiteImageExtService.java
@@ -46,6 +46,7 @@ public class SiteImageExtService {
             .version(version)
             .data(imageData)
             .uploadFileName(uploadFileName)
+            .cleanFileName(cleanFileName)
             .build();
     // the create method handles cleaning and converting the uploadFileName to a cleanFileName
     return siteImageService.create(image);

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/siteContent/SiteImageExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/siteContent/SiteImageExtService.java
@@ -34,4 +34,20 @@ public class SiteImageExtService {
     authUtilService.authUserToPortal(operator, portalShortcode);
     return siteImageService.findMetadataByPortal(portalShortcode);
   }
+
+  public SiteImage upload(
+      String portalShortcode, String uploadFileName, byte[] imageData, AdminUser operator) {
+    authUtilService.authUserToPortal(operator, portalShortcode);
+    String cleanFileName = SiteImageService.cleanFileName(uploadFileName);
+    int version = siteImageService.getNextVersion(cleanFileName, portalShortcode);
+    SiteImage image =
+        SiteImage.builder()
+            .portalShortcode(portalShortcode)
+            .version(version)
+            .data(imageData)
+            .uploadFileName(uploadFileName)
+            .build();
+    // the create method handles cleaning and converting the uploadFileName to a cleanFileName
+    return siteImageService.create(image);
+  }
 }

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -1139,6 +1139,30 @@ paths:
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/siteImages/upload/{uploadFileName}/{version}:
+    post:
+      summary: upload an image
+      tags: [ siteImage ]
+      operationId: upload
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: uploadFileName, in: path, required: true, schema: { type: string } }
+        - { name: version, in: path, required: true, schema: { type: integer } }
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                image:
+                  type: string
+                  format: binary
+      responses:
+        '200':
+          description: image data
+          content: { application/json: { schema: { type: object } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/public/portals/v1/{portalShortcode}/env/{envName}/siteImages/{version}/{cleanFileName}:
     get:
       summary: Returns the binary image data for the image of the given shortcode

--- a/api-admin/src/main/resources/application.yml
+++ b/api-admin/src/main/resources/application.yml
@@ -94,6 +94,11 @@ spring:
       ddl-auto: update
     open-in-view: true
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
 hibernate:
   packages-to-scan: bio.terra.pearl.core.model
 

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/siteContent/SiteImageExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/siteContent/SiteImageExtServiceTests.java
@@ -6,6 +6,7 @@ import bio.terra.pearl.core.factory.portal.PortalFactory;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.service.exception.NotFoundException;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +37,8 @@ public class SiteImageExtServiceTests extends BaseSpringBootTest {
     Assertions.assertThrows(
         NotFoundException.class,
         () -> {
-          siteImageExtService.upload(portal.getShortcode(), "blah", "blah".getBytes(), operator);
+          siteImageExtService.upload(
+              portal.getShortcode(), "blah", "blah".getBytes(StandardCharsets.UTF_8), operator);
         });
   }
 }

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/siteContent/SiteImageExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/siteContent/SiteImageExtServiceTests.java
@@ -8,7 +8,6 @@ import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,13 +18,25 @@ public class SiteImageExtServiceTests extends BaseSpringBootTest {
 
   @Test
   @Transactional
-  public void imageListAuthsToPortal(TestInfo testInfo) {
-    AdminUser user = adminUserFactory.buildPersisted("imageListAuthsToPortal", false);
+  public void imageListAuthsToPortal() {
+    AdminUser operator = adminUserFactory.buildPersisted("imageListAuthsToPortal", false);
     Portal portal = portalFactory.buildPersisted("imageListAuthsToPortal");
     Assertions.assertThrows(
         NotFoundException.class,
         () -> {
-          siteImageExtService.list(portal.getShortcode(), user);
+          siteImageExtService.list(portal.getShortcode(), operator);
+        });
+  }
+
+  @Test
+  @Transactional
+  public void uploadAuthsToPortal() {
+    AdminUser operator = adminUserFactory.buildPersisted("uploadAuthsToPortal", false);
+    Portal portal = portalFactory.buildPersisted("uploadAuthsToPortal");
+    Assertions.assertThrows(
+        NotFoundException.class,
+        () -> {
+          siteImageExtService.upload(portal.getShortcode(), "blah", "blah".getBytes(), operator);
         });
   }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/site/NavbarItemService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/site/NavbarItemService.java
@@ -26,7 +26,9 @@ public class NavbarItemService extends ImmutableEntityService<NavbarItem, Navbar
             htmlPage = htmlPageService.create(htmlPage);
             item.setHtmlPageId(htmlPage.getId());
         }
-        return dao.create(item);
+        item = dao.create(item);
+        item.setHtmlPage(htmlPage);
+        return item;
     }
 
     public void deleteByLocalSiteId(UUID localSiteId, Set<CascadeProperty> cascades) {

--- a/core/src/main/java/bio/terra/pearl/core/service/site/SiteImageService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/site/SiteImageService.java
@@ -40,6 +40,7 @@ public class SiteImageService extends ImmutableEntityService<SiteImage, SiteImag
 
     @Override
     public SiteImage create(SiteImage image) {
+
         if (!isAllowedFileName(image.getUploadFileName())) {
             throw new IllegalArgumentException("Allowed extensions are: " +
                     ALLOWED_EXTENSIONS.stream().collect(Collectors.joining(", ")));

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -483,6 +483,21 @@ export default {
     return await this.processJsonResponse(response)
   },
 
+  async uploadPortalImage(portalShortcode: string, uploadFileName: string, version: number, file: File):
+      Promise<SiteImageMetadata> {
+    const url = `${API_ROOT}/portals/v1/${portalShortcode}/siteImages/upload/${uploadFileName}/${version}`
+    const headers = this.getInitHeaders()
+    delete headers['Content-Type'] // browsers will auto-add the correct type for the multipart file
+    const formData = new FormData()
+    formData.append('file', file)
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: formData
+    })
+    return await this.processJsonResponse(response)
+  },
+
   async getSurvey(portalShortcode: string, stableId: string, version: number): Promise<Survey> {
     const url = `${API_ROOT}/portals/v1/${portalShortcode}/surveys/${stableId}/${version}`
     const response = await fetch(url, this.getGetInit())

--- a/ui-admin/src/portal/images/SiteImageList.tsx
+++ b/ui-admin/src/portal/images/SiteImageList.tsx
@@ -99,6 +99,7 @@ export default function SiteImageList({ portalContext, portalEnv }:
 
   const onSubmitUpload = () => {
     reload()
+    setUpdatingImage(undefined)
     setShowUploadModal(false)
   }
 
@@ -125,7 +126,10 @@ export default function SiteImageList({ portalContext, portalEnv }:
         previewImage.version)} alt={`full-size preview of ${previewImage.cleanFileName}`}/>
     </Modal> }
     { showUploadModal && <SiteImageUploadModal portalContext={portalContext}
-      onDismiss={() => setShowUploadModal(false)}
+      onDismiss={() => {
+        setShowUploadModal(false)
+        setUpdatingImage(undefined)
+      }}
       existingImage={updatingImage}
       onSubmit={onSubmitUpload}/> }
   </div>

--- a/ui-admin/src/portal/images/SiteImageUploadModal.test.tsx
+++ b/ui-admin/src/portal/images/SiteImageUploadModal.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+
+import { setupRouterTest } from 'test-utils/router-testing-utils'
+import { render, screen, waitFor } from '@testing-library/react'
+import { mockPortalContext, mockSiteImage } from 'test-utils/mocking-utils'
+import Api from 'api/api'
+import userEvent from '@testing-library/user-event'
+import SiteImageUploadModal, { cleanFileName } from './SiteImageUploadModal'
+import { Store } from 'react-notifications-component'
+
+
+test('upload is disabled until file chosen', async () => {
+  const file = new File(['hello'], 'hello.png', { type: 'image/png' })
+  const { RoutedComponent } = setupRouterTest(
+    <SiteImageUploadModal portalContext={mockPortalContext()} onDismiss={jest.fn()} onSubmit={jest.fn()}/>)
+  render(RoutedComponent)
+  expect(screen.getByText('Upload')).toHaveAttribute('aria-disabled', 'true')
+  const fileInput = screen.getByTestId('fileInput') as HTMLInputElement
+  await userEvent.upload(fileInput, file)
+  expect(screen.getByText('Upload')).toHaveAttribute('aria-disabled', 'false')
+})
+
+test('file name shown to user is cleaned', async () => {
+  const file = new File(['hello'], 'Hello ^&stuff.png', { type: 'image/png' })
+  const { RoutedComponent } = setupRouterTest(
+    <SiteImageUploadModal portalContext={mockPortalContext()} onDismiss={jest.fn()} onSubmit={jest.fn()}/>)
+  render(RoutedComponent)
+  const fileInput = screen.getByTestId('fileInput') as HTMLInputElement
+  await userEvent.upload(fileInput, file)
+  expect(screen.getByLabelText('Name:')).toHaveValue('hello_stuff.png')
+})
+
+test('upload api is called on submit', async () => {
+  const uploadSpy = jest.spyOn(Api, 'uploadPortalImage')
+    .mockImplementation(() => Promise.resolve(mockSiteImage()))
+  jest.spyOn(Store, 'addNotification').mockImplementation(jest.fn())
+  const file = new File(['databits'], 'hello.png', { type: 'image/png' })
+  const portalContext = mockPortalContext()
+  const { RoutedComponent } = setupRouterTest(
+    <SiteImageUploadModal portalContext={portalContext} onDismiss={jest.fn()} onSubmit={jest.fn()}/>)
+  render(RoutedComponent)
+  const fileInput = screen.getByTestId('fileInput') as HTMLInputElement
+  await userEvent.upload(fileInput, file)
+  userEvent.click(screen.getByText('Upload'))
+  await waitFor(() => expect(uploadSpy)
+    .toHaveBeenCalledWith(portalContext.portal.shortcode, file.name, 1, file))
+})
+
+test('cleanFileName handles names', async () => {
+  expect(cleanFileName('hello.png')).toBe('hello.png')
+})
+
+test('cleanFileName downcases uppercase', async () => {
+  expect(cleanFileName('Hello.png')).toBe('hello.png')
+})
+
+test('cleanFileName replaces spaces with underscore', async () => {
+  expect(cleanFileName('He llo.png')).toBe('he_llo.png')
+})
+
+test('cleanFileName removes special chars', async () => {
+  expect(cleanFileName('He$$$#@$%llo.png')).toBe('hello.png')
+})
+
+

--- a/ui-admin/src/portal/images/SiteImageUploadModal.tsx
+++ b/ui-admin/src/portal/images/SiteImageUploadModal.tsx
@@ -8,6 +8,8 @@ import { Store } from 'react-notifications-component'
 import { Button } from 'components/forms/Button'
 import { LoadedPortalContextT } from '../PortalProvider'
 
+
+const FLE_TYPE_REGEX = /image\/(gif|ico|jpeg|jpg|png|svg|webp)/
 /** Renders a modal for an admin to submit a sample collection kit request. */
 export default function SiteImageUploadModal({
   portalContext,
@@ -40,6 +42,15 @@ export default function SiteImageUploadModal({
     }, { setIsLoading })
   }
 
+  const validationMessages = []
+  if (file && !file.type.match(FLE_TYPE_REGEX)) {
+    validationMessages.push('This file extension is not supported.')
+  }
+  if (file && file.size > 10 * 1024 * 1024) {
+    validationMessages.push('File size exceeds the 10MB limit.')
+  }
+  const enableSubmit = file && fileName && !validationMessages.length
+
   return <Modal show={true} onHide={onDismiss}>
     <Modal.Header closeButton>
       <Modal.Title>{existingImage ? 'Update' : 'Upload'} image</Modal.Title>
@@ -54,6 +65,7 @@ export default function SiteImageUploadModal({
             { FileChooser }
             <span className="text-muted fst-italic ms-2">{file?.name}</span>
           </div>
+          { validationMessages.map(msg => <div className='text-danger'>{msg}</div>)}
         </div>
         <label className="mt-3 mb-2 form-label">
                     Name:
@@ -68,7 +80,7 @@ export default function SiteImageUploadModal({
     <Modal.Footer>
       <LoadingSpinner isLoading={isLoading}>
         <button className='btn btn-secondary' onClick={onDismiss}>Cancel</button>
-        <Button variant="primary" disabled={!file || !fileName} onClick={uploadImage}>Upload</Button>
+        <Button variant="primary" disabled={!enableSubmit} onClick={uploadImage}>Upload</Button>
       </LoadingSpinner>
     </Modal.Footer>
   </Modal>

--- a/ui-admin/src/portal/images/SiteImageUploadModal.tsx
+++ b/ui-admin/src/portal/images/SiteImageUploadModal.tsx
@@ -1,0 +1,121 @@
+import React, { ChangeEvent, useRef, useState } from 'react'
+import { Modal } from 'react-bootstrap'
+import Api, { SiteImageMetadata } from 'api/api'
+import { doApiLoad } from 'api/api-utils'
+import LoadingSpinner from 'util/LoadingSpinner'
+import { successNotification } from 'util/notifications'
+import { Store } from 'react-notifications-component'
+import { Button } from 'components/forms/Button'
+import { LoadedPortalContextT } from '../PortalProvider'
+
+/** Renders a modal for an admin to submit a sample collection kit request. */
+export default function SiteImageUploadModal({
+  portalContext,
+  onDismiss, onSubmit,
+  existingImage
+}: {
+    portalContext: LoadedPortalContextT,
+    onDismiss: () => void,
+    existingImage?: SiteImageMetadata,
+    onSubmit: () => void }) {
+  const [isLoading, setIsLoading] = useState(false)
+
+  const [fileName, setFileName] = useState(existingImage?.cleanFileName ?? '')
+
+  const handleFileChange = (newFile: File) => {
+    // only autofill the name field if this is a new image
+    if (!existingImage) {
+      setFileName(cleanFileName(newFile.name))
+    }
+  }
+
+  const { file, FileChooser } = useFileUploadButton(handleFileChange)
+  const uploadImage = () => {
+    if (!file) { return }
+    const version = existingImage?.version ? existingImage.version + 1 : 1
+    doApiLoad(async () => {
+      await Api.uploadPortalImage(portalContext.portal.shortcode, fileName, version, file)
+      Store.addNotification(successNotification('image saved'))
+      onSubmit()
+    }, { setIsLoading })
+  }
+
+  return <Modal show={true} onHide={onDismiss}>
+    <Modal.Header closeButton>
+      <Modal.Title>{existingImage ? 'Update' : 'Upload'} image</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>
+      <form onSubmit={e => e.preventDefault()}>
+        <div>
+          <p>Supported extensions are gif, ico, jpeg, jpg, png, svg, and webp.
+                        Maximum size is 10MB</p>
+                    File:
+          <div>
+            { FileChooser }
+            <span className="text-muted fst-italic ms-2">{file?.name}</span>
+          </div>
+        </div>
+        <label className="mt-3 mb-2 form-label">
+                    Name:
+          <input type="text" className="form-control" readOnly={!!existingImage}
+            onChange={e => setFileName(cleanFileName(e.target.value))} value={fileName}/>
+        </label>
+        <p>File names must be lowercase,
+                    and cannot contain special characters other than dashes or underscores.</p>
+
+      </form>
+    </Modal.Body>
+    <Modal.Footer>
+      <LoadingSpinner isLoading={isLoading}>
+        <button className='btn btn-secondary' onClick={onDismiss}>Cancel</button>
+        <Button variant="primary" disabled={!file || !fileName} onClick={uploadImage}>Upload</Button>
+      </LoadingSpinner>
+    </Modal.Footer>
+  </Modal>
+}
+
+// type for file chooser events -- see https://github.com/microsoft/TypeScript/issues/31816
+type FileEvent = ChangeEvent<HTMLInputElement> & {
+    target: EventTarget & { files: FileList };
+};
+
+/** hook for a file chooser that uses our theming.  It's impossible to style the system file chooser, so the
+ * recommended path is to hide it and render our own.  */
+const useFileUploadButton = (onFileChange: (file: File) => void) => {
+  const hiddenFileInput = useRef<HTMLInputElement>(null)
+  const [file, setFile] = useState<File>()
+
+  const handleFileChange = (event: FileEvent) => {
+    setFile(event.target.files[0])
+    onFileChange(event.target.files[0])
+  }
+
+  const handleClick = () => {
+    if (hiddenFileInput.current) {
+      hiddenFileInput.current.click()
+    }
+  }
+
+  return {
+    FileChooser: <span>
+      <Button variant="primary" outline={true} onClick={handleClick}>
+                    Choose file
+      </Button>
+      <input type="file" data-testid="fileInput"
+        onChange={handleFileChange} ref={hiddenFileInput} style={{ display: 'none' }}/>
+    </span>,
+    file
+  }
+}
+
+/**
+ * A cleanFileName is a portal-scoped-unique, URL-safe identifier.
+ * cleanFileName is the upload filename with whitespace replaced with _,
+ * stripped of special characters and whitespace except "." "_" or "-", then lowercased.
+ * See SiteImageService.java for the server-side implementation of this
+ */
+export const cleanFileName = (fileName: string) => {
+  return fileName.toLowerCase()
+    .replaceAll(/\s/g, '_')
+    .replaceAll(/[^a-z\d._-]/g, '')
+}

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -11,7 +11,7 @@ import {
   NotificationConfig,
   ParticipantNote,
   Portal,
-  PortalStudy,
+  PortalStudy, SiteImageMetadata,
   StudyEnvironmentConsent, SurveyResponse
 } from 'api/api'
 import { Survey } from '@juniper/ui-core/build/types/forms'
@@ -372,5 +372,14 @@ export const mockAnswer = (): Answer => {
     surveyVersion: 1,
     stringValue: 'foo',
     questionStableId: 'question1'
+  }
+}
+/** mock siteImageMetadata */
+export const mockSiteImage = (): SiteImageMetadata => {
+  return {
+    id: 'image1',
+    createdAt: Date.now(),
+    cleanFileName: 'fileName.png',
+    version: 1
   }
 }


### PR DESCRIPTION
DESCRIPTION
This adds an "Add image" and "update" buttons on the image manager which allow a user to upload files.
image
The "update" buttons will upload a new version of the existing image. To see the update in the website, the user will then have to change the image version in the siteContent

TO TEST: (simple manual steps for confirming core behavior -- used for pre-release checks)
redeploy ApiAdminApp
go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/images
click "add Image"
choose an image file to upload
click upload
confirm the updated image can be found in the image list