### PR TITLE
[JN-611] removing brian and katie from default users

### DIFF
--- a/populate/src/main/java/bio/terra/pearl/populate/service/BaseSeedPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/BaseSeedPopulator.java
@@ -26,8 +26,7 @@ public class BaseSeedPopulator {
     private KitTypePopulator kitTypePopulator;
 
     public static final List<String> ADMIN_USERS_TO_POPULATE =
-            Arrays.asList("adminUsers/dbush.json", "adminUsers/breilly.json",
-                    "adminUsers/myanaman.json", "adminUsers/kkaratza.json",
+            Arrays.asList("adminUsers/dbush.json", "adminUsers/myanaman.json",
                     "adminUsers/jkorte.json", "adminUsers/egwozdz.json",
                     "adminUsers/mflinn.json", "adminUsers/nwatts.json",
                     "adminUsers/mbemis.json", "adminUsers/cunningh.json",

--- a/populate/src/main/resources/seed/adminUsers/breilly.json
+++ b/populate/src/main/resources/seed/adminUsers/breilly.json
@@ -1,4 +1,0 @@
-{
-  "username": "breilly@broadinstitute.org",
-  "superuser": true
-}

--- a/populate/src/main/resources/seed/adminUsers/kkaratza.json
+++ b/populate/src/main/resources/seed/adminUsers/kkaratza.json
@@ -1,4 +1,0 @@
-{
-  "username": "kkaratza@broadinstitute.org",
-  "superuser": true
-}


### PR DESCRIPTION
#### DESCRIPTION

Removing folks no longer on the team from the default populate

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. nuke local database with `./local-dev/run_postgres.sh start`
2. restart ApiAdminApp, confirm seed users populate, without Brian and Katie

