### PR TITLE
[JN-616] Consistent page styling

### DIFF
--- a/ui-admin/src/components/forms/TextInput.tsx
+++ b/ui-admin/src/components/forms/TextInput.tsx
@@ -6,14 +6,15 @@ export type TextInputProps = Omit<JSX.IntrinsicElements['input'], 'onChange'> & 
   infoContent?: React.ReactNode,
   description?: string
   required?: boolean
-  label: string
+  label?: string
   labelClassname?: string,
+  placeholder?: string,
   onChange?: (value: string) => void
 }
 
 /** A text input with label and description. */
 export const TextInput = (props: TextInputProps) => {
-  const { infoContent, description, required, label, labelClassname, ...inputProps } = props
+  const { infoContent, description, required, label, labelClassname, placeholder, ...inputProps } = props
   const { className, disabled, id, value, onChange } = inputProps
 
   const generatedId = useId()
@@ -22,13 +23,13 @@ export const TextInput = (props: TextInputProps) => {
 
   return (
     <>
-      <label
+      {label && <label
         className={classNames('form-label', labelClassname)}
         htmlFor={inputId}
       >
         {label}
         {required && <span className="text-danger">*</span>}
-      </label>
+      </label>}
       {infoContent &&
         //@ts-ignore
         <InfoPopup content={infoContent}/>}
@@ -39,6 +40,7 @@ export const TextInput = (props: TextInputProps) => {
         aria-disabled={disabled}
         className={classNames('form-control', { disabled }, className, { 'is-invalid': required && value === '' })}
         disabled={undefined}
+        placeholder={placeholder}
         id={inputId}
         // Allow value to be undefined without triggering a React warning about uncontrolled input.
         value={value ?? ''}

--- a/ui-admin/src/portal/MailingListView.tsx
+++ b/ui-admin/src/portal/MailingListView.tsx
@@ -9,7 +9,7 @@ import {
   SortingState,
   useReactTable
 } from '@tanstack/react-table'
-import { basicTableLayout, IndeterminateCheckbox, RowVisibilityCount } from 'util/tableUtils'
+import { basicTableLayout, IndeterminateCheckbox, renderEmptyMessage, RowVisibilityCount } from 'util/tableUtils'
 import { currentIsoDate, instantToDateString, instantToDefaultString } from 'util/timeUtils'
 import { Button } from 'components/forms/Button'
 import { escapeCsvValue, saveBlobAsDownload } from 'util/downloadUtils'
@@ -132,9 +132,8 @@ export default function MailingListView({ portalContext, portalEnv }:
         </div>
       </div>
 
-      {basicTableLayout(table)}
-      { contacts.length === 0 &&
-        <span className="d-flex justify-content-center text-muted fst-italic">No contacts</span> }
+      { basicTableLayout(table) }
+      { renderEmptyMessage(contacts, 'No contacts') }
       { showDeleteConfirm && <Modal show={true} onHide={() => setShowDeleteConfirm(false)}>
         <Modal.Body>
           <div>Do you want to delete the <strong>{ numSelected }</strong> selected entries?</div>

--- a/ui-admin/src/portal/MailingListView.tsx
+++ b/ui-admin/src/portal/MailingListView.tsx
@@ -111,8 +111,8 @@ export default function MailingListView({ portalContext, portalEnv }:
   }
 
   return <div className="container-fluid px-4 py-2">
-    <div className="align-items-baseline d-flex mb-2">
-      <h2 className="text-center me-4 fw-bold">Mailing List</h2>
+    <div className="d-flex mb-2">
+      <h2 className="fw-bold">Mailing List</h2>
     </div>
     <LoadingSpinner isLoading={isLoading}>
       <div className="d-flex align-items-center justify-content-between">

--- a/ui-admin/src/portal/MailingListView.tsx
+++ b/ui-admin/src/portal/MailingListView.tsx
@@ -122,12 +122,12 @@ export default function MailingListView({ portalContext, portalEnv }:
         <div className="d-flex">
           <Button onClick={download}
             variant="light" className="border m-1" disabled={!numSelected}
-            tooltip={numSelected ? 'Download selected contacts' : 'you must select contacts to download'}>
+            tooltip={numSelected ? 'Download selected contacts' : 'You must select contacts to download'}>
             <FontAwesomeIcon icon={faDownload} className="fa-lg"/> Download
           </Button>
           <Button onClick={() => setShowDeleteConfirm(!showDeleteConfirm)}
             variant="light" className="border m-1" disabled={!numSelected}
-            tooltip={numSelected ? 'Remove selected contacts' : 'you must select contacts to remove'}>
+            tooltip={numSelected ? 'Remove selected contacts' : 'You must select contacts to remove'}>
             <FontAwesomeIcon icon={faTrash} className="fa-lg"/> Remove
           </Button>
         </div>

--- a/ui-admin/src/portal/MailingListView.tsx
+++ b/ui-admin/src/portal/MailingListView.tsx
@@ -9,7 +9,7 @@ import {
   SortingState,
   useReactTable
 } from '@tanstack/react-table'
-import { basicTableLayout, IndeterminateCheckbox } from 'util/tableUtils'
+import {basicTableLayout, IndeterminateCheckbox, RowVisibilityCount} from 'util/tableUtils'
 import { currentIsoDate, instantToDateString, instantToDefaultString } from 'util/timeUtils'
 import { Button } from 'components/forms/Button'
 import { escapeCsvValue, saveBlobAsDownload } from 'util/downloadUtils'
@@ -17,6 +17,8 @@ import { failureNotification, successNotification } from '../util/notifications'
 import { Store } from 'react-notifications-component'
 import Modal from 'react-bootstrap/Modal'
 import { useLoadingEffect } from '../api/api-utils'
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faDownload, faTrash} from "@fortawesome/free-solid-svg-icons";
 
 
 /** show the mailing list in table */
@@ -108,41 +110,51 @@ export default function MailingListView({ portalContext, portalEnv }:
     setShowDeleteConfirm(false)
   }
 
-  return <div className="container p-3">
-    <h1 className="h4">Mailing list </h1>
-    <LoadingSpinner isLoading={isLoading}>
-      <div className="d-flex align-items-center">
-        <div>
-          {numSelected} of {table.getPreFilteredRowModel().rows.length} selected
-        </div>
-        <Button onClick={download}
-          variant="secondary" disabled={!numSelected}
-          tooltip={numSelected ? 'Download selected contacts' : 'you must select contacts to download'}>
-          Download
-        </Button>
-        <Button onClick={() => setShowDeleteConfirm(!showDeleteConfirm)}
-          variant="secondary" disabled={!numSelected} className="ms-auto"
-          tooltip={numSelected ? 'Remove selected contacts' : 'you must select contacts to remove'}>
-          Remove
-        </Button>
+  return <div className="container-fluid pt-2">
+    <div className="row ps-3">
+      <div className="col-12 align-items-baseline d-flex mb-2">
+        <h2 className="text-center me-4 fw-bold">Mailing List</h2>
       </div>
+      <div className="col-12">
+        <LoadingSpinner isLoading={isLoading}>
+          <div className="d-flex align-items-center justify-content-between mx-3">
+            <div className="d-flex">
+              <RowVisibilityCount table={table}/>
+            </div>
+            <div className="d-flex">
+              <Button onClick={download}
+                variant="light" className="border m-1" disabled={!numSelected}
+                tooltip={numSelected ? 'Download selected contacts' : 'you must select contacts to download'}>
+                <FontAwesomeIcon icon={faDownload} className="fa-lg"/> Download
+              </Button>
+              <Button onClick={() => setShowDeleteConfirm(!showDeleteConfirm)}
+                variant="light" className="border m-1" disabled={!numSelected}
+                tooltip={numSelected ? 'Remove selected contacts' : 'you must select contacts to remove'}>
+                <FontAwesomeIcon icon={faTrash} className="fa-lg"/> Remove
+              </Button>
+            </div>
+          </div>
 
-      {basicTableLayout(table)}
-      { showDeleteConfirm && <Modal show={true} onHide={() => setShowDeleteConfirm(false)}>
-        <Modal.Body>
-          <div>Do you want to delete the <strong>{ numSelected }</strong> selected entries?</div>
+          {basicTableLayout(table)}
+          { contacts.length === 0 &&
+            <span className="d-flex justify-content-center text-muted fst-italic">No contacts</span> }
+          { showDeleteConfirm && <Modal show={true} onHide={() => setShowDeleteConfirm(false)}>
+            <Modal.Body>
+              <div>Do you want to delete the <strong>{ numSelected }</strong> selected entries?</div>
 
-          <div className="pt-3">This operation CANNOT BE UNDONE.</div>
-        </Modal.Body>
-        <Modal.Footer>
-          <button type="button" className="btn btn-danger" onClick={performDelete}>
-            Delete
-          </button>
-          <button type="button" className="btn btn-secondary" onClick={() => setShowDeleteConfirm(false)}>
-            Cancel
-          </button>
-        </Modal.Footer>
-      </Modal> }
-    </LoadingSpinner>
+              <div className="pt-3">This operation CANNOT BE UNDONE.</div>
+            </Modal.Body>
+            <Modal.Footer>
+              <button type="button" className="btn btn-danger" onClick={performDelete}>
+                Delete
+              </button>
+              <button type="button" className="btn btn-secondary" onClick={() => setShowDeleteConfirm(false)}>
+                Cancel
+              </button>
+            </Modal.Footer>
+          </Modal> }
+        </LoadingSpinner>
+      </div>
+    </div>
   </div>
 }

--- a/ui-admin/src/portal/MailingListView.tsx
+++ b/ui-admin/src/portal/MailingListView.tsx
@@ -9,7 +9,7 @@ import {
   SortingState,
   useReactTable
 } from '@tanstack/react-table'
-import {basicTableLayout, IndeterminateCheckbox, RowVisibilityCount} from 'util/tableUtils'
+import { basicTableLayout, IndeterminateCheckbox, RowVisibilityCount } from 'util/tableUtils'
 import { currentIsoDate, instantToDateString, instantToDefaultString } from 'util/timeUtils'
 import { Button } from 'components/forms/Button'
 import { escapeCsvValue, saveBlobAsDownload } from 'util/downloadUtils'
@@ -17,8 +17,8 @@ import { failureNotification, successNotification } from '../util/notifications'
 import { Store } from 'react-notifications-component'
 import Modal from 'react-bootstrap/Modal'
 import { useLoadingEffect } from '../api/api-utils'
-import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faDownload, faTrash} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faDownload, faTrash } from '@fortawesome/free-solid-svg-icons'
 
 
 /** show the mailing list in table */

--- a/ui-admin/src/portal/MailingListView.tsx
+++ b/ui-admin/src/portal/MailingListView.tsx
@@ -19,6 +19,7 @@ import Modal from 'react-bootstrap/Modal'
 import { useLoadingEffect } from '../api/api-utils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faDownload, faTrash } from '@fortawesome/free-solid-svg-icons'
+import { renderPageHeader } from 'util/pageUtils'
 
 
 /** show the mailing list in table */
@@ -111,9 +112,7 @@ export default function MailingListView({ portalContext, portalEnv }:
   }
 
   return <div className="container-fluid px-4 py-2">
-    <div className="d-flex mb-2">
-      <h2 className="fw-bold">Mailing List</h2>
-    </div>
+    { renderPageHeader('Mailing List') }
     <LoadingSpinner isLoading={isLoading}>
       <div className="d-flex align-items-center justify-content-between">
         <div className="d-flex">

--- a/ui-admin/src/portal/MailingListView.tsx
+++ b/ui-admin/src/portal/MailingListView.tsx
@@ -110,49 +110,47 @@ export default function MailingListView({ portalContext, portalEnv }:
     setShowDeleteConfirm(false)
   }
 
-  return <div className="container-fluid pt-2">
-    <div className="row px-3">
-      <div className="col-12 align-items-baseline d-flex mb-2">
-        <h2 className="text-center me-4 fw-bold">Mailing List</h2>
-      </div>
-      <LoadingSpinner isLoading={isLoading}>
-        <div className="d-flex align-items-center justify-content-between px-3">
-          <div className="d-flex">
-            <RowVisibilityCount table={table}/>
-          </div>
-          <div className="d-flex">
-            <Button onClick={download}
-              variant="light" className="border m-1" disabled={!numSelected}
-              tooltip={numSelected ? 'Download selected contacts' : 'you must select contacts to download'}>
-              <FontAwesomeIcon icon={faDownload} className="fa-lg"/> Download
-            </Button>
-            <Button onClick={() => setShowDeleteConfirm(!showDeleteConfirm)}
-              variant="light" className="border m-1" disabled={!numSelected}
-              tooltip={numSelected ? 'Remove selected contacts' : 'you must select contacts to remove'}>
-              <FontAwesomeIcon icon={faTrash} className="fa-lg"/> Remove
-            </Button>
-          </div>
-        </div>
-
-        {basicTableLayout(table)}
-        { contacts.length === 0 &&
-          <span className="d-flex justify-content-center text-muted fst-italic">No contacts</span> }
-        { showDeleteConfirm && <Modal show={true} onHide={() => setShowDeleteConfirm(false)}>
-          <Modal.Body>
-            <div>Do you want to delete the <strong>{ numSelected }</strong> selected entries?</div>
-
-            <div className="pt-3">This operation CANNOT BE UNDONE.</div>
-          </Modal.Body>
-          <Modal.Footer>
-            <button type="button" className="btn btn-danger" onClick={performDelete}>
-              Delete
-            </button>
-            <button type="button" className="btn btn-secondary" onClick={() => setShowDeleteConfirm(false)}>
-              Cancel
-            </button>
-          </Modal.Footer>
-        </Modal> }
-      </LoadingSpinner>
+  return <div className="container-fluid px-4 py-2">
+    <div className="align-items-baseline d-flex mb-2">
+      <h2 className="text-center me-4 fw-bold">Mailing List</h2>
     </div>
+    <LoadingSpinner isLoading={isLoading}>
+      <div className="d-flex align-items-center justify-content-between">
+        <div className="d-flex">
+          <RowVisibilityCount table={table}/>
+        </div>
+        <div className="d-flex">
+          <Button onClick={download}
+            variant="light" className="border m-1" disabled={!numSelected}
+            tooltip={numSelected ? 'Download selected contacts' : 'you must select contacts to download'}>
+            <FontAwesomeIcon icon={faDownload} className="fa-lg"/> Download
+          </Button>
+          <Button onClick={() => setShowDeleteConfirm(!showDeleteConfirm)}
+            variant="light" className="border m-1" disabled={!numSelected}
+            tooltip={numSelected ? 'Remove selected contacts' : 'you must select contacts to remove'}>
+            <FontAwesomeIcon icon={faTrash} className="fa-lg"/> Remove
+          </Button>
+        </div>
+      </div>
+
+      {basicTableLayout(table)}
+      { contacts.length === 0 &&
+        <span className="d-flex justify-content-center text-muted fst-italic">No contacts</span> }
+      { showDeleteConfirm && <Modal show={true} onHide={() => setShowDeleteConfirm(false)}>
+        <Modal.Body>
+          <div>Do you want to delete the <strong>{ numSelected }</strong> selected entries?</div>
+
+          <div className="pt-3">This operation CANNOT BE UNDONE.</div>
+        </Modal.Body>
+        <Modal.Footer>
+          <button type="button" className="btn btn-danger" onClick={performDelete}>
+            Delete
+          </button>
+          <button type="button" className="btn btn-secondary" onClick={() => setShowDeleteConfirm(false)}>
+            Cancel
+          </button>
+        </Modal.Footer>
+      </Modal> }
+    </LoadingSpinner>
   </div>
 }

--- a/ui-admin/src/portal/MailingListView.tsx
+++ b/ui-admin/src/portal/MailingListView.tsx
@@ -111,50 +111,48 @@ export default function MailingListView({ portalContext, portalEnv }:
   }
 
   return <div className="container-fluid pt-2">
-    <div className="row ps-3">
+    <div className="row px-3">
       <div className="col-12 align-items-baseline d-flex mb-2">
         <h2 className="text-center me-4 fw-bold">Mailing List</h2>
       </div>
-      <div className="col-12">
-        <LoadingSpinner isLoading={isLoading}>
-          <div className="d-flex align-items-center justify-content-between mx-3">
-            <div className="d-flex">
-              <RowVisibilityCount table={table}/>
-            </div>
-            <div className="d-flex">
-              <Button onClick={download}
-                variant="light" className="border m-1" disabled={!numSelected}
-                tooltip={numSelected ? 'Download selected contacts' : 'you must select contacts to download'}>
-                <FontAwesomeIcon icon={faDownload} className="fa-lg"/> Download
-              </Button>
-              <Button onClick={() => setShowDeleteConfirm(!showDeleteConfirm)}
-                variant="light" className="border m-1" disabled={!numSelected}
-                tooltip={numSelected ? 'Remove selected contacts' : 'you must select contacts to remove'}>
-                <FontAwesomeIcon icon={faTrash} className="fa-lg"/> Remove
-              </Button>
-            </div>
+      <LoadingSpinner isLoading={isLoading}>
+        <div className="d-flex align-items-center justify-content-between px-3">
+          <div className="d-flex">
+            <RowVisibilityCount table={table}/>
           </div>
+          <div className="d-flex">
+            <Button onClick={download}
+              variant="light" className="border m-1" disabled={!numSelected}
+              tooltip={numSelected ? 'Download selected contacts' : 'you must select contacts to download'}>
+              <FontAwesomeIcon icon={faDownload} className="fa-lg"/> Download
+            </Button>
+            <Button onClick={() => setShowDeleteConfirm(!showDeleteConfirm)}
+              variant="light" className="border m-1" disabled={!numSelected}
+              tooltip={numSelected ? 'Remove selected contacts' : 'you must select contacts to remove'}>
+              <FontAwesomeIcon icon={faTrash} className="fa-lg"/> Remove
+            </Button>
+          </div>
+        </div>
 
-          {basicTableLayout(table)}
-          { contacts.length === 0 &&
-            <span className="d-flex justify-content-center text-muted fst-italic">No contacts</span> }
-          { showDeleteConfirm && <Modal show={true} onHide={() => setShowDeleteConfirm(false)}>
-            <Modal.Body>
-              <div>Do you want to delete the <strong>{ numSelected }</strong> selected entries?</div>
+        {basicTableLayout(table)}
+        { contacts.length === 0 &&
+          <span className="d-flex justify-content-center text-muted fst-italic">No contacts</span> }
+        { showDeleteConfirm && <Modal show={true} onHide={() => setShowDeleteConfirm(false)}>
+          <Modal.Body>
+            <div>Do you want to delete the <strong>{ numSelected }</strong> selected entries?</div>
 
-              <div className="pt-3">This operation CANNOT BE UNDONE.</div>
-            </Modal.Body>
-            <Modal.Footer>
-              <button type="button" className="btn btn-danger" onClick={performDelete}>
-                Delete
-              </button>
-              <button type="button" className="btn btn-secondary" onClick={() => setShowDeleteConfirm(false)}>
-                Cancel
-              </button>
-            </Modal.Footer>
-          </Modal> }
-        </LoadingSpinner>
-      </div>
+            <div className="pt-3">This operation CANNOT BE UNDONE.</div>
+          </Modal.Body>
+          <Modal.Footer>
+            <button type="button" className="btn btn-danger" onClick={performDelete}>
+              Delete
+            </button>
+            <button type="button" className="btn btn-secondary" onClick={() => setShowDeleteConfirm(false)}>
+              Cancel
+            </button>
+          </Modal.Footer>
+        </Modal> }
+      </LoadingSpinner>
     </div>
   </div>
 }

--- a/ui-admin/src/portal/PortalEnvConfigView.tsx
+++ b/ui-admin/src/portal/PortalEnvConfigView.tsx
@@ -36,8 +36,9 @@ const PortalEnvConfigView = ({ portalContext, portalEnv }: PortalEnvConfigViewPr
       reloadPortal(portal.shortcode)
     }, { setIsLoading })
   }
-  return <form className="bg-white p-3">
-    <h2 className="h4">Website configuration ({portalContext.portal.name})</h2>
+
+  return <form className="bg-white">
+    <h4>Website configuration ({portalContext.portal.name})</h4>
     <p>Configure the accessibility of the landing page shown to all visitors, and sitewide properties</p>
     <div>
       <label className="form-label">

--- a/ui-admin/src/study/StudyContent.tsx
+++ b/ui-admin/src/study/StudyContent.tsx
@@ -9,6 +9,7 @@ import { faEllipsisH } from '@fortawesome/free-solid-svg-icons'
 import ArchiveSurveyModal from './surveys/ArchiveSurveyModal'
 import DeleteSurveyModal from './surveys/DeleteSurveyModal'
 import { StudyEnvironmentSurvey } from '@juniper/ui-core'
+import { renderPageHeader } from 'util/pageUtils'
 
 /** renders the main configuration page for a study environment */
 function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
@@ -31,9 +32,7 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
     .sort((a, b) => a.consentOrder - b.consentOrder)
 
   return <div className="container-fluid px-4 py-2">
-    <div className="d-flex mb-2">
-      <h2 className="fw-bold">Forms & Surveys</h2>
-    </div>
+    { renderPageHeader('Forms & Surveys') }
     <div className="col-12">
       { currentEnv.studyEnvironmentConfig.initialized && <ul className="list-unstyled">
         <li className="mb-3 bg-white">

--- a/ui-admin/src/study/StudyContent.tsx
+++ b/ui-admin/src/study/StudyContent.tsx
@@ -14,7 +14,7 @@ import { StudyEnvironmentSurvey } from '@juniper/ui-core'
 function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
   const { currentEnv } = studyEnvContext
   const contentHeaderStyle = {
-    padding: '1em 0 0 1em',
+    padding: '1em 0 0 0',
     borderBottom: '1px solid #f6f6f6'
   }
 
@@ -30,14 +30,17 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
   currentEnv.configuredConsents
     .sort((a, b) => a.consentOrder - b.consentOrder)
 
-  return <div className="container row">
-    <div className="col-12 p-3">
+  return <div className="container-fluid px-4 py-2">
+    <div className="d-flex mb-2">
+      <h2 className="fw-bold">Forms & Surveys</h2>
+    </div>
+    <div className="col-12">
       { currentEnv.studyEnvironmentConfig.initialized && <ul className="list-unstyled">
         <li className="mb-3 bg-white">
           <div style={contentHeaderStyle}>
             <h6>Pre-enrollment questionnaire</h6>
           </div>
-          <div className="flex-grow-1 p-3">
+          <div className="flex-grow-1 pt-3">
             { preEnrollSurvey && <ul className="list-unstyled"><li>
               <Link to={`preEnroll/${preEnrollSurvey.stableId}?readOnly=${isReadOnlyEnv}`}>
                 {preEnrollSurvey.name} <span className="detail">v{preEnrollSurvey.version}</span>
@@ -49,7 +52,7 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
           <div style={contentHeaderStyle}>
             <h6>Consent forms</h6>
           </div>
-          <div className="flex-grow-1 p-3">
+          <div className="flex-grow-1 pt-3">
             <ul className="list-unstyled">
               { currentEnv.configuredConsents.map((config, index) => {
                 const consentForm = config.consentForm
@@ -66,7 +69,7 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
           <div style={contentHeaderStyle}>
             <h6>Surveys</h6>
           </div>
-          <div className="flex-grow-1 p-3">
+          <div className="flex-grow-1 pt-3">
             <ul className="list-unstyled">
               { currentEnv.configuredSurveys.map((surveyConfig, index) => {
                 const survey = surveyConfig.survey

--- a/ui-admin/src/study/StudyContent.tsx
+++ b/ui-admin/src/study/StudyContent.tsx
@@ -14,7 +14,7 @@ import { StudyEnvironmentSurvey } from '@juniper/ui-core'
 function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
   const { currentEnv } = studyEnvContext
   const contentHeaderStyle = {
-    padding: '1em 0 0 0',
+    paddingTop: '1em',
     borderBottom: '1px solid #f6f6f6'
   }
 

--- a/ui-admin/src/study/StudySettings.tsx
+++ b/ui-admin/src/study/StudySettings.tsx
@@ -18,7 +18,11 @@ export default function StudySettings({ studyEnvContext, portalContext }:
   const portalEnv = portalContext.portal.portalEnvironments
     .find(env =>
       env.environmentName === studyEnvContext.currentEnv.environmentName) as PortalEnvironment
-  return <div className="ps-4">
+
+  return <div className="container-fluid px-4 py-2">
+    <div className="d-flex mb-2">
+      <h2 className="fw-bold">Site Settings</h2>
+    </div>
     <StudyEnvConfigView studyEnvContext={studyEnvContext} portalContext={portalContext}/>
     <PortalEnvConfigView portalEnv={portalEnv} portalContext={portalContext}/>
   </div>
@@ -45,7 +49,7 @@ export function StudyEnvConfigView({ studyEnvContext, portalContext }:
     }, { setIsLoading })
   }
 
-  return <form className="bg-white p-3 mb-5" onSubmit={e => e.preventDefault()}>
+  return <form className="bg-white mb-5" onSubmit={e => e.preventDefault()}>
     <h2 className="h4">{studyEnvContext.study.name} study configuration</h2>
     <p>Configure whether participants can access study content, such as surveys and consents.</p>
     <div>

--- a/ui-admin/src/study/StudySettings.tsx
+++ b/ui-admin/src/study/StudySettings.tsx
@@ -11,6 +11,7 @@ import Api from 'api/api'
 import { Store } from 'react-notifications-component'
 import { successNotification } from 'util/notifications'
 import LoadingSpinner from 'util/LoadingSpinner'
+import { renderPageHeader } from 'util/pageUtils'
 
 /** shows settings for both a study and its containing portal */
 export default function StudySettings({ studyEnvContext, portalContext }:
@@ -20,9 +21,7 @@ export default function StudySettings({ studyEnvContext, portalContext }:
       env.environmentName === studyEnvContext.currentEnv.environmentName) as PortalEnvironment
 
   return <div className="container-fluid px-4 py-2">
-    <div className="d-flex mb-2">
-      <h2 className="fw-bold">Site Settings</h2>
-    </div>
+    { renderPageHeader('Site Settings') }
     <StudyEnvConfigView studyEnvContext={studyEnvContext} portalContext={portalContext}/>
     <PortalEnvConfigView portalEnv={portalEnv} portalContext={portalContext}/>
   </div>

--- a/ui-admin/src/study/adminTasks/AdminTaskList.tsx
+++ b/ui-admin/src/study/adminTasks/AdminTaskList.tsx
@@ -128,7 +128,7 @@ taskData: AdminTaskListDto}) => {
     cell: info => renderStatusColumn(info.row.original)
   }, {
     header: 'Created',
-    accessorKey: 'createdAta',
+    accessorKey: 'createdAt',
     cell: info => instantToDefaultString(info.getValue() as number)
   }]
 

--- a/ui-admin/src/study/adminTasks/AdminTaskList.tsx
+++ b/ui-admin/src/study/adminTasks/AdminTaskList.tsx
@@ -93,8 +93,8 @@ export default function AdminTaskList({ studyEnvContext }: {studyEnvContext: Stu
   }
 
   return <div className="container-fluid px-4 py-2">
-    <div className="align-items-baseline d-flex mb-2">
-      <h2 className="text-center me-4 fw-bold">Tasks</h2>
+    <div className="d-flex mb-2">
+      <h2 className="fw-bold">Tasks</h2>
     </div>
     <LoadingSpinner isLoading={isLoading}>
       <MyTaskList studyEnvContext={studyEnvContext} taskData={taskData}/>

--- a/ui-admin/src/study/adminTasks/AdminTaskList.tsx
+++ b/ui-admin/src/study/adminTasks/AdminTaskList.tsx
@@ -92,14 +92,19 @@ export default function AdminTaskList({ studyEnvContext }: {studyEnvContext: Stu
     }
   }
 
-  return <div className="container p-3">
-    <LoadingSpinner isLoading={isLoading}>
-      <MyTaskList studyEnvContext={studyEnvContext} taskData={taskData}/>
-      <h2 className="h4 mt-5">All tasks</h2>
-      {basicTableLayout(allTasksTable)}
-    </LoadingSpinner>
-    { (showEditModal && selectedTask) && <AdminTaskEditModal task={selectedTask} users={users}
-      onDismiss={onDoneEditing} studyEnvContext={studyEnvContext}/> }
+  return <div className="container-fluid pt-2">
+    <div className="row ps-3">
+      <div className="col-12 align-items-baseline d-flex mb-2">
+        <h2 className="text-center me-4 fw-bold">Tasks</h2>
+      </div>
+      <LoadingSpinner isLoading={isLoading}>
+        <MyTaskList studyEnvContext={studyEnvContext} taskData={taskData}/>
+        <h4 className="mt-5">All tasks</h4>
+        {basicTableLayout(allTasksTable)}
+      </LoadingSpinner>
+      { (showEditModal && selectedTask) && <AdminTaskEditModal task={selectedTask} users={users}
+        onDismiss={onDoneEditing} studyEnvContext={studyEnvContext}/> }
+    </div>
   </div>
 }
 
@@ -123,7 +128,7 @@ taskData: AdminTaskListDto}) => {
     cell: info => renderStatusColumn(info.row.original)
   }, {
     header: 'Created',
-    accessorKey: 'createdAt',
+    accessorKey: 'createdAta',
     cell: info => instantToDefaultString(info.getValue() as number)
   }]
 
@@ -136,7 +141,7 @@ taskData: AdminTaskListDto}) => {
     getSortedRowModel: getSortedRowModel()
   })
   return <>
-    <h2 className="h4">My tasks</h2>
+    <h4>My tasks</h4>
     { !!myTasks.length && basicTableLayout(table)}
     { !myTasks.length && <div className="text-muted fst-italic mb-3">None</div> }
   </>

--- a/ui-admin/src/study/adminTasks/AdminTaskList.tsx
+++ b/ui-admin/src/study/adminTasks/AdminTaskList.tsx
@@ -21,6 +21,7 @@ import { faCheck, faEdit } from '@fortawesome/free-solid-svg-icons'
 import { useUser } from 'user/UserProvider'
 import { IconButton } from '../../components/forms/Button'
 import { AdminTaskEditModal } from './AdminTaskEditor'
+import { renderPageHeader } from 'util/pageUtils'
 
 
 /** show the lists of the user's tasks and all tasks */
@@ -93,12 +94,10 @@ export default function AdminTaskList({ studyEnvContext }: {studyEnvContext: Stu
   }
 
   return <div className="container-fluid px-4 py-2">
-    <div className="d-flex mb-2">
-      <h2 className="fw-bold">Tasks</h2>
-    </div>
+    { renderPageHeader('Tasks') }
     <LoadingSpinner isLoading={isLoading}>
       <MyTaskList studyEnvContext={studyEnvContext} taskData={taskData}/>
-      <h4 className="mt-5">All tasks</h4>
+      <h3 className="h4 mt-5">All tasks</h3>
       {basicTableLayout(allTasksTable)}
       { !taskData.tasks.length &&
         <span className="d-flex justify-content-center text-muted fst-italic">No tasks</span> }
@@ -141,7 +140,7 @@ taskData: AdminTaskListDto}) => {
     getSortedRowModel: getSortedRowModel()
   })
   return <>
-    <h4>My tasks</h4>
+    <h3 className="h4 mt-3">My tasks</h3>
     { basicTableLayout(table) }
     { !myTasks.length &&
       <span className="d-flex justify-content-center text-muted fst-italic">No tasks</span> }

--- a/ui-admin/src/study/adminTasks/AdminTaskList.tsx
+++ b/ui-admin/src/study/adminTasks/AdminTaskList.tsx
@@ -93,19 +93,17 @@ export default function AdminTaskList({ studyEnvContext }: {studyEnvContext: Stu
   }
 
   return <div className="container-fluid pt-2">
-    <div className="row ps-3">
+    <div className="row px-3">
       <div className="col-12 align-items-baseline d-flex mb-2">
         <h2 className="text-center me-4 fw-bold">Tasks</h2>
       </div>
-      <div className="col-12">
-        <LoadingSpinner isLoading={isLoading}>
-          <MyTaskList studyEnvContext={studyEnvContext} taskData={taskData}/>
-          <h4 className="mt-5">All tasks</h4>
-          {basicTableLayout(allTasksTable)}
-          { !taskData.tasks.length &&
-            <span className="d-flex justify-content-center text-muted fst-italic">No tasks</span> }
-        </LoadingSpinner>
-      </div>
+      <LoadingSpinner isLoading={isLoading}>
+        <MyTaskList studyEnvContext={studyEnvContext} taskData={taskData}/>
+        <h4 className="mt-5">All tasks</h4>
+        {basicTableLayout(allTasksTable)}
+        { !taskData.tasks.length &&
+          <span className="d-flex justify-content-center text-muted fst-italic">No tasks</span> }
+      </LoadingSpinner>
       { (showEditModal && selectedTask) && <AdminTaskEditModal task={selectedTask} users={users}
         onDismiss={onDoneEditing} studyEnvContext={studyEnvContext}/> }
     </div>

--- a/ui-admin/src/study/adminTasks/AdminTaskList.tsx
+++ b/ui-admin/src/study/adminTasks/AdminTaskList.tsx
@@ -92,21 +92,19 @@ export default function AdminTaskList({ studyEnvContext }: {studyEnvContext: Stu
     }
   }
 
-  return <div className="container-fluid pt-2">
-    <div className="row px-3">
-      <div className="col-12 align-items-baseline d-flex mb-2">
-        <h2 className="text-center me-4 fw-bold">Tasks</h2>
-      </div>
-      <LoadingSpinner isLoading={isLoading}>
-        <MyTaskList studyEnvContext={studyEnvContext} taskData={taskData}/>
-        <h4 className="mt-5">All tasks</h4>
-        {basicTableLayout(allTasksTable)}
-        { !taskData.tasks.length &&
-          <span className="d-flex justify-content-center text-muted fst-italic">No tasks</span> }
-      </LoadingSpinner>
-      { (showEditModal && selectedTask) && <AdminTaskEditModal task={selectedTask} users={users}
-        onDismiss={onDoneEditing} studyEnvContext={studyEnvContext}/> }
+  return <div className="container-fluid px-4 py-2">
+    <div className="align-items-baseline d-flex mb-2">
+      <h2 className="text-center me-4 fw-bold">Tasks</h2>
     </div>
+    <LoadingSpinner isLoading={isLoading}>
+      <MyTaskList studyEnvContext={studyEnvContext} taskData={taskData}/>
+      <h4 className="mt-5">All tasks</h4>
+      {basicTableLayout(allTasksTable)}
+      { !taskData.tasks.length &&
+        <span className="d-flex justify-content-center text-muted fst-italic">No tasks</span> }
+    </LoadingSpinner>
+    { (showEditModal && selectedTask) && <AdminTaskEditModal task={selectedTask} users={users}
+      onDismiss={onDoneEditing} studyEnvContext={studyEnvContext}/> }
   </div>
 }
 

--- a/ui-admin/src/study/adminTasks/AdminTaskList.tsx
+++ b/ui-admin/src/study/adminTasks/AdminTaskList.tsx
@@ -8,7 +8,7 @@ import {
   SortingState,
   useReactTable
 } from '@tanstack/react-table'
-import { basicTableLayout } from 'util/tableUtils'
+import { basicTableLayout, renderEmptyMessage } from 'util/tableUtils'
 import { instantToDateString, instantToDefaultString } from 'util/timeUtils'
 import { paramsFromContext, StudyEnvContextT, StudyEnvParams } from '../StudyEnvironmentRouter'
 import { useAdminUserContext } from 'providers/AdminUserProvider'
@@ -98,9 +98,8 @@ export default function AdminTaskList({ studyEnvContext }: {studyEnvContext: Stu
     <LoadingSpinner isLoading={isLoading}>
       <MyTaskList studyEnvContext={studyEnvContext} taskData={taskData}/>
       <h3 className="h4 mt-5">All tasks</h3>
-      {basicTableLayout(allTasksTable)}
-      { !taskData.tasks.length &&
-        <span className="d-flex justify-content-center text-muted fst-italic">No tasks</span> }
+      { basicTableLayout(allTasksTable) }
+      { renderEmptyMessage(taskData.tasks, 'No tasks') }
     </LoadingSpinner>
     { (showEditModal && selectedTask) && <AdminTaskEditModal task={selectedTask} users={users}
       onDismiss={onDoneEditing} studyEnvContext={studyEnvContext}/> }
@@ -142,8 +141,7 @@ taskData: AdminTaskListDto}) => {
   return <>
     <h3 className="h4 mt-3">My tasks</h3>
     { basicTableLayout(table) }
-    { !myTasks.length &&
-      <span className="d-flex justify-content-center text-muted fst-italic">No tasks</span> }
+    { renderEmptyMessage(myTasks, 'No tasks') }
   </>
 }
 

--- a/ui-admin/src/study/adminTasks/AdminTaskList.tsx
+++ b/ui-admin/src/study/adminTasks/AdminTaskList.tsx
@@ -97,11 +97,15 @@ export default function AdminTaskList({ studyEnvContext }: {studyEnvContext: Stu
       <div className="col-12 align-items-baseline d-flex mb-2">
         <h2 className="text-center me-4 fw-bold">Tasks</h2>
       </div>
-      <LoadingSpinner isLoading={isLoading}>
-        <MyTaskList studyEnvContext={studyEnvContext} taskData={taskData}/>
-        <h4 className="mt-5">All tasks</h4>
-        {basicTableLayout(allTasksTable)}
-      </LoadingSpinner>
+      <div className="col-12">
+        <LoadingSpinner isLoading={isLoading}>
+          <MyTaskList studyEnvContext={studyEnvContext} taskData={taskData}/>
+          <h4 className="mt-5">All tasks</h4>
+          {basicTableLayout(allTasksTable)}
+          { !taskData.tasks.length &&
+            <span className="d-flex justify-content-center text-muted fst-italic">No tasks</span> }
+        </LoadingSpinner>
+      </div>
       { (showEditModal && selectedTask) && <AdminTaskEditModal task={selectedTask} users={users}
         onDismiss={onDoneEditing} studyEnvContext={studyEnvContext}/> }
     </div>
@@ -142,8 +146,9 @@ taskData: AdminTaskListDto}) => {
   })
   return <>
     <h4>My tasks</h4>
-    { !!myTasks.length && basicTableLayout(table)}
-    { !myTasks.length && <div className="text-muted fst-italic mb-3">None</div> }
+    { basicTableLayout(table) }
+    { !myTasks.length &&
+      <span className="d-flex justify-content-center text-muted fst-italic">No tasks</span> }
   </>
 }
 

--- a/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
+++ b/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
@@ -18,7 +18,7 @@ import {
   basicTableLayout,
   checkboxColumnCell,
   ColumnVisibilityControl,
-  IndeterminateCheckbox,
+  IndeterminateCheckbox, renderEmptyMessage,
   RowVisibilityCount
 } from 'util/tableUtils'
 import LoadingSpinner from 'util/LoadingSpinner'
@@ -194,7 +194,6 @@ export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvCont
       </div>
     </div>
     { basicTableLayout(table, { filterable: true }) }
-    { enrollees.length === 0 &&
-      <span className="d-flex justify-content-center text-muted fst-italic">No participants</span> }
+    { renderEmptyMessage(enrollees, 'No participants') }
   </LoadingSpinner>
 }

--- a/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
+++ b/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
@@ -26,7 +26,7 @@ import { instantToDateString } from 'util/timeUtils'
 import RequestKitsModal from './RequestKitsModal'
 import { useLoadingEffect } from 'api/api-utils'
 import { enrolleeKitRequestPath } from '../participants/enrolleeView/EnrolleeView'
-import { Button } from '../../components/forms/Button'
+import { Button } from 'components/forms/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPaperPlane } from '@fortawesome/free-solid-svg-icons'
 

--- a/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
+++ b/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
@@ -14,12 +14,21 @@ import {
 
 import Api, { Enrollee } from 'api/api'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
-import { basicTableLayout, checkboxColumnCell, ColumnVisibilityControl, IndeterminateCheckbox } from 'util/tableUtils'
+import {
+  basicTableLayout,
+  checkboxColumnCell,
+  ColumnVisibilityControl,
+  IndeterminateCheckbox,
+  RowVisibilityCount
+} from 'util/tableUtils'
 import LoadingSpinner from 'util/LoadingSpinner'
 import { instantToDateString } from 'util/timeUtils'
 import RequestKitsModal from './RequestKitsModal'
 import { useLoadingEffect } from 'api/api-utils'
 import { enrolleeKitRequestPath } from '../participants/enrolleeView/EnrolleeView'
+import { Button } from '../../components/forms/Button'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faDownload, faPaperPlane } from '@fortawesome/free-solid-svg-icons'
 
 type EnrolleeRow = Enrollee & {
   taskCompletionStatus: Record<string, boolean>
@@ -165,30 +174,31 @@ export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvCont
     getFilteredRowModel: getFilteredRowModel()
   })
 
-  return <>
-    <LoadingSpinner isLoading={isLoading}>
-      <div className="d-flex align-items-center justify-content-between py-3">
-        <div className="d-flex align-items-center">
-          <span className="me-2">
-            {numSelected} of{' '}
-            {table.getPreFilteredRowModel().rows.length} selected
-          </span>
-          <span className="me-2">
-            <button className="btn btn-secondary"
-              onClick={() => { setShowRequestKitModal(true) }}
-              title={enableActionButtons ? 'Send sample collection kit' : 'Select at least one participant'}
-              aria-disabled={!enableActionButtons}>Send sample collection kit</button>
-          </span>
-          { showRequestKitModal && <RequestKitsModal
-            studyEnvContext={studyEnvContext}
-            onDismiss={() => setShowRequestKitModal(false)}
-            enrolleeShortcodes={enrolleesSelected}
-            onSubmit={onSubmit}/> }
+  return <div className="row">
+    <div className="col-12">
+      <LoadingSpinner isLoading={isLoading}>
+        <div className="d-flex align-items-center justify-content-between py-3">
+          <div className="d-flex align-items-center">
+            <RowVisibilityCount table={table}/>
+          </div>
+          <div className="d-flex">
+            <Button onClick={() => { setShowRequestKitModal(true) }}
+              variant="light" className="border m-1" disabled={!enableActionButtons}
+              tooltip={enableActionButtons ? 'Send sample collection kit' : 'Select at least one participant'}>
+              <FontAwesomeIcon icon={faPaperPlane} className="fa-lg"/> Send sample collection kit
+            </Button>
+            <ColumnVisibilityControl table={table}/>
+            { showRequestKitModal && <RequestKitsModal
+              studyEnvContext={studyEnvContext}
+              onDismiss={() => setShowRequestKitModal(false)}
+              enrolleeShortcodes={enrolleesSelected}
+              onSubmit={onSubmit}/> }
+          </div>
         </div>
-        <ColumnVisibilityControl table={table}/>
-      </div>
-      { basicTableLayout(table, { filterable: true }) }
-      { enrollees.length === 0 && <span className="text-muted fst-italic">No participants</span> }
-    </LoadingSpinner>
-  </>
+        { basicTableLayout(table, { filterable: true }) }
+        { enrollees.length === 0 &&
+          <span className="d-flex justify-content-center text-muted fst-italic">No participants</span> }
+      </LoadingSpinner>
+    </div>
+  </div>
 }

--- a/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
+++ b/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
@@ -175,7 +175,7 @@ export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvCont
   })
 
   return <LoadingSpinner isLoading={isLoading}>
-    <div className="d-flex align-items-center justify-content-between px-3">
+    <div className="d-flex align-items-center justify-content-between">
       <div className="d-flex align-items-center">
         <RowVisibilityCount table={table}/>
       </div>

--- a/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
+++ b/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
@@ -28,7 +28,7 @@ import { useLoadingEffect } from 'api/api-utils'
 import { enrolleeKitRequestPath } from '../participants/enrolleeView/EnrolleeView'
 import { Button } from '../../components/forms/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faDownload, faPaperPlane } from '@fortawesome/free-solid-svg-icons'
+import { faPaperPlane } from '@fortawesome/free-solid-svg-icons'
 
 type EnrolleeRow = Enrollee & {
   taskCompletionStatus: Record<string, boolean>
@@ -174,31 +174,27 @@ export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvCont
     getFilteredRowModel: getFilteredRowModel()
   })
 
-  return <div className="row">
-    <div className="col-12">
-      <LoadingSpinner isLoading={isLoading}>
-        <div className="d-flex align-items-center justify-content-between py-3">
-          <div className="d-flex align-items-center">
-            <RowVisibilityCount table={table}/>
-          </div>
-          <div className="d-flex">
-            <Button onClick={() => { setShowRequestKitModal(true) }}
-              variant="light" className="border m-1" disabled={!enableActionButtons}
-              tooltip={enableActionButtons ? 'Send sample collection kit' : 'Select at least one participant'}>
-              <FontAwesomeIcon icon={faPaperPlane} className="fa-lg"/> Send sample collection kit
-            </Button>
-            <ColumnVisibilityControl table={table}/>
-            { showRequestKitModal && <RequestKitsModal
-              studyEnvContext={studyEnvContext}
-              onDismiss={() => setShowRequestKitModal(false)}
-              enrolleeShortcodes={enrolleesSelected}
-              onSubmit={onSubmit}/> }
-          </div>
-        </div>
-        { basicTableLayout(table, { filterable: true }) }
-        { enrollees.length === 0 &&
-          <span className="d-flex justify-content-center text-muted fst-italic">No participants</span> }
-      </LoadingSpinner>
+  return <LoadingSpinner isLoading={isLoading}>
+    <div className="d-flex align-items-center justify-content-between px-3">
+      <div className="d-flex align-items-center">
+        <RowVisibilityCount table={table}/>
+      </div>
+      <div className="d-flex">
+        <Button onClick={() => { setShowRequestKitModal(true) }}
+          variant="light" className="border m-1" disabled={!enableActionButtons}
+          tooltip={enableActionButtons ? 'Send sample collection kit' : 'Select at least one participant'}>
+          <FontAwesomeIcon icon={faPaperPlane} className="fa-lg"/> Send sample collection kit
+        </Button>
+        <ColumnVisibilityControl table={table}/>
+        { showRequestKitModal && <RequestKitsModal
+          studyEnvContext={studyEnvContext}
+          onDismiss={() => setShowRequestKitModal(false)}
+          enrolleeShortcodes={enrolleesSelected}
+          onSubmit={onSubmit}/> }
+      </div>
     </div>
-  </div>
+    { basicTableLayout(table, { filterable: true }) }
+    { enrollees.length === 0 &&
+      <span className="d-flex justify-content-center text-muted fst-italic">No participants</span> }
+  </LoadingSpinner>
 }

--- a/ui-admin/src/study/kits/KitList.tsx
+++ b/ui-admin/src/study/kits/KitList.tsx
@@ -134,8 +134,8 @@ export default function KitList({ studyEnvContext }: { studyEnvContext: StudyEnv
   }
 
   return <LoadingSpinner isLoading={isLoading}>
-    <div className="container p-0 mt-2">
-      <div className="d-flex w-100 align-items-center" style={{ backgroundColor: '#ccc' }}>
+    <div className="container-fluid p-0 mt-2">
+      <div className="d-flex w-100 align-items-center mb-2" style={{ backgroundColor: '#ccc' }}>
         { statusTabs.map(tab => {
           const kits = kitsByStatus[tab.status] || []
           return <NavLink key={tab.key} to={tab.key} style={tabLinkStyle}>
@@ -249,5 +249,7 @@ function KitListView({ studyEnvContext, tab, kits, initialColumnVisibility }: {
       <ColumnVisibilityControl table={table}/>
     </div>
     {basicTableLayout(table, { filterable: true })}
+    { kits.length === 0 &&
+      <span className="d-flex justify-content-center text-muted fst-italic">No kits with status {tab}</span> }
   </>
 }

--- a/ui-admin/src/study/kits/KitList.tsx
+++ b/ui-admin/src/study/kits/KitList.tsx
@@ -11,7 +11,7 @@ import {
 import Api, { KitRequest } from 'api/api'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
 import LoadingSpinner from 'util/LoadingSpinner'
-import { basicTableLayout, ColumnVisibilityControl } from 'util/tableUtils'
+import { basicTableLayout, ColumnVisibilityControl, renderEmptyMessage } from 'util/tableUtils'
 import { instantToDateString, isoToInstant } from 'util/timeUtils'
 import { doApiLoad, useLoadingEffect } from 'api/api-utils'
 import { enrolleeKitRequestPath } from '../participants/enrolleeView/EnrolleeView'
@@ -248,8 +248,7 @@ function KitListView({ studyEnvContext, tab, kits, initialColumnVisibility }: {
     <div className="d-flex align-items-center justify-content-between">
       <ColumnVisibilityControl table={table}/>
     </div>
-    {basicTableLayout(table, { filterable: true })}
-    { kits.length === 0 &&
-      <span className="d-flex justify-content-center text-muted fst-italic">No kits with status {tab}</span> }
+    { basicTableLayout(table, { filterable: true }) }
+    { renderEmptyMessage(kits, `No kits with status ${tab}`) }
   </>
 }

--- a/ui-admin/src/study/kits/KitsRouter.tsx
+++ b/ui-admin/src/study/kits/KitsRouter.tsx
@@ -25,7 +25,7 @@ export default function KitsRouter({ studyEnvContext }: {studyEnvContext: StudyE
     </NavBreadcrumb>
     <div className="container-fluid px-4 py-2">
       <div className="d-flex mb-2">
-        <h2 className="h2 text-center me-4 fw-bold">Kits</h2>
+        <h2 className="fw-bold">Kits</h2>
       </div>
       <div className="d-flex w-100 mb-2" style={{ backgroundColor: '#ccc' }}>
         <NavLink to="eligible" style={tabLinkStyle}>

--- a/ui-admin/src/study/kits/KitsRouter.tsx
+++ b/ui-admin/src/study/kits/KitsRouter.tsx
@@ -23,26 +23,29 @@ export default function KitsRouter({ studyEnvContext }: {studyEnvContext: StudyE
     <NavBreadcrumb value={studyEnvContext.currentEnvPath}>
       <Link to={studyKitsPath(portalShortcode, studyShortcode, environmentName)}>kits</Link>
     </NavBreadcrumb>
-    <div className="container">
-      <div className="d-flex w-100" style={{ backgroundColor: '#ccc' }}>
-
-        <NavLink to="eligible" style={tabLinkStyle}>
-          <div className="py-3 px-5">
-            Eligible for kit
-          </div>
-        </NavLink>
-        <NavLink to="requested" style={tabLinkStyle}>
-          <div className="py-3 px-5">
-            Requested
-          </div>
-        </NavLink>
+    <div className="container-fluid pt-2">
+      <div className="row ps-3">
+        <div className="col-12 align-items-baseline d-flex mb-2">
+          <h2 className="h2 text-center me-4 fw-bold">Kits</h2>
+        </div>
+        <div className="d-flex w-100" style={{ backgroundColor: '#ccc' }}>
+          <NavLink to="eligible" style={tabLinkStyle}>
+            <div className="py-3 px-5">
+              Eligible for kit
+            </div>
+          </NavLink>
+          <NavLink to="requested" style={tabLinkStyle}>
+            <div className="py-3 px-5">
+              Requested
+            </div>
+          </NavLink>
+        </div>
+        <Routes>
+          <Route index element={<Navigate to='eligible' replace={true}/>}/>
+          <Route path="eligible" element={<KitEnrolleeSelection studyEnvContext={studyEnvContext}/>}/>
+          <Route path="requested/*" element={<KitList studyEnvContext={studyEnvContext}/>}/>
+        </Routes>
       </div>
-      <Routes>
-        <Route index element={<Navigate to='eligible' replace={true}/>}/>
-        <Route path="eligible" element={<KitEnrolleeSelection studyEnvContext={studyEnvContext}/>}/>
-        <Route path="requested/*" element={<KitList studyEnvContext={studyEnvContext}/>}/>
-      </Routes>
     </div>
-
   </>
 }

--- a/ui-admin/src/study/kits/KitsRouter.tsx
+++ b/ui-admin/src/study/kits/KitsRouter.tsx
@@ -23,29 +23,27 @@ export default function KitsRouter({ studyEnvContext }: {studyEnvContext: StudyE
     <NavBreadcrumb value={studyEnvContext.currentEnvPath}>
       <Link to={studyKitsPath(portalShortcode, studyShortcode, environmentName)}>kits</Link>
     </NavBreadcrumb>
-    <div className="container-fluid pt-2">
-      <div className="row px-3">
-        <div className="col-12 align-items-baseline d-flex mb-2">
-          <h2 className="h2 text-center me-4 fw-bold">Kits</h2>
-        </div>
-        <div className="d-flex w-100" style={{ backgroundColor: '#ccc' }}>
-          <NavLink to="eligible" style={tabLinkStyle}>
-            <div className="py-3 px-5">
-              Eligible for kit
-            </div>
-          </NavLink>
-          <NavLink to="requested" style={tabLinkStyle}>
-            <div className="py-3 px-5">
-              Requested
-            </div>
-          </NavLink>
-        </div>
-        <Routes>
-          <Route index element={<Navigate to='eligible' replace={true}/>}/>
-          <Route path="eligible" element={<KitEnrolleeSelection studyEnvContext={studyEnvContext}/>}/>
-          <Route path="requested/*" element={<KitList studyEnvContext={studyEnvContext}/>}/>
-        </Routes>
+    <div className="container-fluid px-4 py-2">
+      <div className="align-items-baseline d-flex mb-2">
+        <h2 className="h2 text-center me-4 fw-bold">Kits</h2>
       </div>
+      <div className="d-flex w-100 mb-2" style={{ backgroundColor: '#ccc' }}>
+        <NavLink to="eligible" style={tabLinkStyle}>
+          <div className="py-3 px-5">
+            Eligible for kit
+          </div>
+        </NavLink>
+        <NavLink to="requested" style={tabLinkStyle}>
+          <div className="py-3 px-5">
+            Requested
+          </div>
+        </NavLink>
+      </div>
+      <Routes>
+        <Route index element={<Navigate to='eligible' replace={true}/>}/>
+        <Route path="eligible" element={<KitEnrolleeSelection studyEnvContext={studyEnvContext}/>}/>
+        <Route path="requested/*" element={<KitList studyEnvContext={studyEnvContext}/>}/>
+      </Routes>
     </div>
   </>
 }

--- a/ui-admin/src/study/kits/KitsRouter.tsx
+++ b/ui-admin/src/study/kits/KitsRouter.tsx
@@ -24,7 +24,7 @@ export default function KitsRouter({ studyEnvContext }: {studyEnvContext: StudyE
       <Link to={studyKitsPath(portalShortcode, studyShortcode, environmentName)}>kits</Link>
     </NavBreadcrumb>
     <div className="container-fluid pt-2">
-      <div className="row ps-3">
+      <div className="row px-3">
         <div className="col-12 align-items-baseline d-flex mb-2">
           <h2 className="h2 text-center me-4 fw-bold">Kits</h2>
         </div>

--- a/ui-admin/src/study/kits/KitsRouter.tsx
+++ b/ui-admin/src/study/kits/KitsRouter.tsx
@@ -5,6 +5,7 @@ import { studyKitsPath } from 'portal/PortalRouter'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
 import KitEnrolleeSelection from './KitEnrolleeSelection'
 import KitList from './KitList'
+import { renderPageHeader } from 'util/pageUtils'
 
 /** Router for kit management screens. */
 export default function KitsRouter({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
@@ -24,9 +25,7 @@ export default function KitsRouter({ studyEnvContext }: {studyEnvContext: StudyE
       <Link to={studyKitsPath(portalShortcode, studyShortcode, environmentName)}>kits</Link>
     </NavBreadcrumb>
     <div className="container-fluid px-4 py-2">
-      <div className="d-flex mb-2">
-        <h2 className="fw-bold">Kits</h2>
-      </div>
+      { renderPageHeader('Kits') }
       <div className="d-flex w-100 mb-2" style={{ backgroundColor: '#ccc' }}>
         <NavLink to="eligible" style={tabLinkStyle}>
           <div className="py-3 px-5">

--- a/ui-admin/src/study/kits/KitsRouter.tsx
+++ b/ui-admin/src/study/kits/KitsRouter.tsx
@@ -24,7 +24,7 @@ export default function KitsRouter({ studyEnvContext }: {studyEnvContext: StudyE
       <Link to={studyKitsPath(portalShortcode, studyShortcode, environmentName)}>kits</Link>
     </NavBreadcrumb>
     <div className="container-fluid px-4 py-2">
-      <div className="align-items-baseline d-flex mb-2">
+      <div className="d-flex mb-2">
         <h2 className="h2 text-center me-4 fw-bold">Kits</h2>
       </div>
       <div className="d-flex w-100 mb-2" style={{ backgroundColor: '#ccc' }}>

--- a/ui-admin/src/study/metrics/StudyEnvMetricsView.tsx
+++ b/ui-admin/src/study/metrics/StudyEnvMetricsView.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { StudyEnvContextT } from '../StudyEnvironmentRouter'
 import MetricGraph from './MetricGraph'
+import { renderPageHeader } from 'util/pageUtils'
 
 export type MetricInfo = {
   name: string,
@@ -22,9 +23,7 @@ export default function StudyEnvMetricsView({ studyEnvContext }: {studyEnvContex
     return prev
   }, {})
   return <div className="container-fluid px-4 py-2">
-    <div className="d-flex mb-2">
-      <h2 className="fw-bold">Participant Analytics</h2>
-    </div>
+    { renderPageHeader('Participant Analytics') }
     <div className="row">
       <h4>{studyEnvContext.study.name} Summary
         <span className="fst-italic text-muted ms-3">({studyEnvContext.currentEnv.environmentName})</span>

--- a/ui-admin/src/study/metrics/StudyEnvMetricsView.tsx
+++ b/ui-admin/src/study/metrics/StudyEnvMetricsView.tsx
@@ -21,15 +21,20 @@ export default function StudyEnvMetricsView({ studyEnvContext }: {studyEnvContex
     prev[current.name] = current
     return prev
   }, {})
-  return <div className="container row justify-content-center">
-    <div className="col-md-8 p-4">
-      <h1 className="h4">{studyEnvContext.study.name} Summary
+  return <div className="container-fluid px-4 py-2">
+    <div className="d-flex mb-2">
+      <h2 className="fw-bold">Participant Analytics</h2>
+    </div>
+    <div className="row">
+      <h4>{studyEnvContext.study.name} Summary
         <span className="fst-italic text-muted ms-3">({studyEnvContext.currentEnv.environmentName})</span>
-      </h1>
-      <MetricGraph studyEnvContext={studyEnvContext} metricInfo={metricsByName['STUDY_ENROLLMENT']}/>
-      <MetricGraph studyEnvContext={studyEnvContext} metricInfo={metricsByName['STUDY_ENROLLEE_CONSENTED']}/>
-      <MetricGraph studyEnvContext={studyEnvContext} metricInfo={metricsByName['STUDY_REQUIRED_SURVEY_COMPLETION']}/>
-      <MetricGraph studyEnvContext={studyEnvContext} metricInfo={metricsByName['STUDY_SURVEY_COMPLETION']}/>
+      </h4>
+      <div className="mt-2">
+        <MetricGraph studyEnvContext={studyEnvContext} metricInfo={metricsByName['STUDY_ENROLLMENT']}/>
+        <MetricGraph studyEnvContext={studyEnvContext} metricInfo={metricsByName['STUDY_ENROLLEE_CONSENTED']}/>
+        <MetricGraph studyEnvContext={studyEnvContext} metricInfo={metricsByName['STUDY_REQUIRED_SURVEY_COMPLETION']}/>
+        <MetricGraph studyEnvContext={studyEnvContext} metricInfo={metricsByName['STUDY_SURVEY_COMPLETION']}/>
+      </div>
     </div>
   </div>
 }

--- a/ui-admin/src/study/notifications/NotificationContent.tsx
+++ b/ui-admin/src/study/notifications/NotificationContent.tsx
@@ -30,13 +30,16 @@ export default function NotificationContent({ studyEnvContext }: {studyEnvContex
     }
   }, [currentEnv.environmentName])
 
-  return <div className="container-fluid">
-    <div className="bg-white p-3 ps-5 row">
-      <div className="col-md-3 px-0 py-3 mh-100 bg-white border-end">
-        <h2 className="h5">Participant Notifications</h2>
-        <ul className="list-unstyled px-2">
+  return <div className="container-fluid px-4 py-2">
+    <div className="d-flex mb-2">
+      <h2 className="fw-bold">Emails & Notifications</h2>
+    </div>
+    <div className="row">
+      <div className="col-md-3 mh-100 bg-white border-end">
+        <h4>Participant Notifications</h4>
+        <ul className="list-unstyled p-2">
           { CONFIG_GROUPS.map(group => <li key={group.type}>
-            <h3 className="h6">{group.title}</h3>
+            <h6 className="pt-2">{group.title}</h6>
             <ul>
               { currentEnv.notificationConfigs
                 .filter(config => config.notificationType === group.type)

--- a/ui-admin/src/study/notifications/NotificationContent.tsx
+++ b/ui-admin/src/study/notifications/NotificationContent.tsx
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus'
 import { StudyEnvContextT } from '../StudyEnvironmentRouter'
 import NotificationConfigView from './NotificationConfigView'
+import { renderPageHeader } from 'util/pageUtils'
 
 const CONFIG_GROUPS = [
   { title: 'Event', type: 'EVENT' },
@@ -31,9 +32,7 @@ export default function NotificationContent({ studyEnvContext }: {studyEnvContex
   }, [currentEnv.environmentName])
 
   return <div className="container-fluid px-4 py-2">
-    <div className="d-flex mb-2">
-      <h2 className="fw-bold">Emails & Notifications</h2>
-    </div>
+    { renderPageHeader('Emails & Notifications') }
     <div className="row">
       <div className="col-md-3 mh-100 bg-white border-end">
         <h4>Participant Notifications</h4>

--- a/ui-admin/src/study/participants/datarepo/DatasetList.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetList.tsx
@@ -83,31 +83,29 @@ const DatasetList = ({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) =
   useEffect(() => {
     loadData()
   }, [studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName])
-  return <div className="container-fluid pt-2">
-    <div className="row px-3">
-      <div className="align-items-baseline d-flex mb-2">
-        <h2 className="text-center me-4 fw-bold">Terra Data Repo</h2>
-      </div>
-      <LoadingSpinner isLoading={isLoading}>
-        <div className="d-flex align-items-center justify-content-between px-3">
-          <h4>Datasets</h4>
-          { user.superuser &&
-              <Button onClick={() => setShowCreateDatasetModal(!showCreateDatasetModal)}
-                variant="light" className="border m-1"
-                aria-label="show or export to tdr modal">
-                <FontAwesomeIcon icon={faSquarePlus} className="fa-lg"/> Create dataset
-              </Button>
-          }
-        </div>
-        {basicTableLayout(datasetTable)}
-        { datasets.length === 0 &&
-          <span className="d-flex justify-content-center text-muted fst-italic">No datasets</span> }
-      </LoadingSpinner>
-      <CreateDatasetModal studyEnvContext={studyEnvContext}
-        show={showCreateDatasetModal}
-        setShow={setShowCreateDatasetModal}
-        loadDatasets={loadData}/>
+  return <div className="container-fluid px-4 py-2">
+    <div className="align-items-baseline d-flex mb-2">
+      <h2 className="text-center me-4 fw-bold">Terra Data Repo</h2>
     </div>
+    <LoadingSpinner isLoading={isLoading}>
+      <div className="d-flex align-items-center justify-content-between">
+        <h4>Datasets</h4>
+        { user.superuser &&
+            <Button onClick={() => setShowCreateDatasetModal(!showCreateDatasetModal)}
+              variant="light" className="border m-1"
+              aria-label="show or export to tdr modal">
+              <FontAwesomeIcon icon={faSquarePlus} className="fa-lg"/> Create dataset
+            </Button>
+        }
+      </div>
+      {basicTableLayout(datasetTable)}
+      { datasets.length === 0 &&
+        <span className="d-flex justify-content-center text-muted fst-italic">No datasets</span> }
+    </LoadingSpinner>
+    <CreateDatasetModal studyEnvContext={studyEnvContext}
+      show={showCreateDatasetModal}
+      setShow={setShowCreateDatasetModal}
+      loadDatasets={loadData}/>
   </div>
 }
 

--- a/ui-admin/src/study/participants/datarepo/DatasetList.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetList.tsx
@@ -19,6 +19,7 @@ import { useUser } from 'user/UserProvider'
 import CreateDatasetModal from './CreateDatasetModal'
 import { Button } from 'components/forms/Button'
 import { faSquarePlus } from '@fortawesome/free-solid-svg-icons'
+import { renderPageHeader } from 'util/pageUtils'
 
 const datasetColumns = (currentEnvPath: string): ColumnDef<DatasetDetails>[] => [{
   id: 'datasetName',
@@ -84,9 +85,7 @@ const DatasetList = ({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) =
     loadData()
   }, [studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName])
   return <div className="container-fluid px-4 py-2">
-    <div className="d-flex mb-2">
-      <h2 className="fw-bold">Terra Data Repo</h2>
-    </div>
+    { renderPageHeader('Terra Data Repo') }
     <LoadingSpinner isLoading={isLoading}>
       <div className="d-flex align-items-center justify-content-between">
         <h4>Datasets</h4>

--- a/ui-admin/src/study/participants/datarepo/DatasetList.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetList.tsx
@@ -5,7 +5,7 @@ import LoadingSpinner from 'util/LoadingSpinner'
 import { Store } from 'react-notifications-component'
 import { failureNotification } from 'util/notifications'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { instantToDefaultString } from '../../../util/timeUtils'
+import { instantToDefaultString } from 'util/timeUtils'
 import {
   ColumnDef,
   getCoreRowModel,
@@ -13,7 +13,7 @@ import {
   SortingState,
   useReactTable
 } from '@tanstack/react-table'
-import { basicTableLayout } from '../../../util/tableUtils'
+import { basicTableLayout, renderEmptyMessage } from 'util/tableUtils'
 import { Link } from 'react-router-dom'
 import { useUser } from 'user/UserProvider'
 import CreateDatasetModal from './CreateDatasetModal'
@@ -97,9 +97,8 @@ const DatasetList = ({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) =
             </Button>
         }
       </div>
-      {basicTableLayout(datasetTable)}
-      { datasets.length === 0 &&
-        <span className="d-flex justify-content-center text-muted fst-italic">No datasets</span> }
+      { basicTableLayout(datasetTable) }
+      { renderEmptyMessage(datasets, 'No datasets') }
     </LoadingSpinner>
     <CreateDatasetModal studyEnvContext={studyEnvContext}
       show={showCreateDatasetModal}

--- a/ui-admin/src/study/participants/datarepo/DatasetList.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetList.tsx
@@ -66,11 +66,6 @@ const DatasetList = ({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) =
     getSortedRowModel: getSortedRowModel()
   })
 
-  const contentHeaderStyle = {
-    padding: '1em 0 0 1em',
-    borderBottom: '1px solid #f6f6f6'
-  }
-
   const loadData = async () => {
     //Fetch datasets
     await Api.listDatasetsForStudyEnvironment(
@@ -87,30 +82,30 @@ const DatasetList = ({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) =
   useEffect(() => {
     loadData()
   }, [studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName])
-  return <div className="container-fluid py-3">
-    <h1 className="h3">Study Environment Datasets</h1>
-    { user.superuser &&
-        <button className="btn btn-secondary" onClick={() => setShowCreateDatasetModal(!showCreateDatasetModal)}
-          aria-label="show or hide export modal">
-          <FontAwesomeIcon icon={faPlus}/> Create new dataset
-        </button>
-    }
-    <CreateDatasetModal studyEnvContext={studyEnvContext}
-      show={showCreateDatasetModal}
-      setShow={setShowCreateDatasetModal}
-      loadDatasets={loadData}/>
-    <LoadingSpinner isLoading={isLoading}>
-      <div className="col-12 p-3">
-        <ul className="list-unstyled">
-          <li className="bg-white my-3">
-            <div style={contentHeaderStyle}>
-              <h6>Datasets</h6>
-            </div>
-            {basicTableLayout(datasetTable)}
-          </li>
-        </ul>
+  return <div className="container-fluid pt-2">
+    <div className="row ps-3">
+      <div className="col-12 align-items-baseline d-flex mb-2">
+        <h2 className="text-center me-4 fw-bold">Terra Data Repo</h2>
       </div>
-    </LoadingSpinner>
+      <h3>Datasets</h3>
+      {/*{ user.superuser &&*/}
+      {/*    <button className="btn btn-secondary" onClick={() => setShowCreateDatasetModal(!showCreateDatasetModal)}*/}
+      {/*      aria-label="show or hide export modal">*/}
+      {/*      <FontAwesomeIcon icon={faPlus}/> Create new dataset*/}
+      {/*    </button>*/}
+      {/*}*/}
+      <CreateDatasetModal studyEnvContext={studyEnvContext}
+        show={showCreateDatasetModal}
+        setShow={setShowCreateDatasetModal}
+        loadDatasets={loadData}/>
+      <div className="col-12">
+        <LoadingSpinner isLoading={isLoading}>
+          {basicTableLayout(datasetTable)}
+          { datasets.length === 0 &&
+            <span className="d-flex justify-content-center text-muted fst-italic">No datasets</span> }
+        </LoadingSpinner>
+      </div>
+    </div>
   </div>
 }
 

--- a/ui-admin/src/study/participants/datarepo/DatasetList.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetList.tsx
@@ -15,9 +15,10 @@ import {
 } from '@tanstack/react-table'
 import { basicTableLayout } from '../../../util/tableUtils'
 import { Link } from 'react-router-dom'
-import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus'
-import { useUser } from '../../../user/UserProvider'
+import { useUser } from 'user/UserProvider'
 import CreateDatasetModal from './CreateDatasetModal'
+import { Button } from 'components/forms/Button'
+import { faSquarePlus } from '@fortawesome/free-solid-svg-icons'
 
 const datasetColumns = (currentEnvPath: string): ColumnDef<DatasetDetails>[] => [{
   id: 'datasetName',
@@ -87,13 +88,20 @@ const DatasetList = ({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) =
       <div className="col-12 align-items-baseline d-flex mb-2">
         <h2 className="text-center me-4 fw-bold">Terra Data Repo</h2>
       </div>
-      <h3>Datasets</h3>
-      {/*{ user.superuser &&*/}
-      {/*    <button className="btn btn-secondary" onClick={() => setShowCreateDatasetModal(!showCreateDatasetModal)}*/}
-      {/*      aria-label="show or hide export modal">*/}
-      {/*      <FontAwesomeIcon icon={faPlus}/> Create new dataset*/}
-      {/*    </button>*/}
-      {/*}*/}
+      <div className="d-flex align-items-center justify-content-between">
+        <div className="d-flex">
+          <h4>Datasets</h4>
+        </div>
+        <div className="d-flex">
+          { user.superuser &&
+            <Button onClick={() => setShowCreateDatasetModal(!showCreateDatasetModal)}
+              variant="light" className="border m-1"
+              aria-label="show or export to tdr modal">
+              <FontAwesomeIcon icon={faSquarePlus} className="fa-lg"/> Create dataset
+            </Button>
+          }
+        </div>
+      </div>
       <CreateDatasetModal studyEnvContext={studyEnvContext}
         show={showCreateDatasetModal}
         setShow={setShowCreateDatasetModal}

--- a/ui-admin/src/study/participants/datarepo/DatasetList.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetList.tsx
@@ -84,8 +84,8 @@ const DatasetList = ({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) =
     loadData()
   }, [studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName])
   return <div className="container-fluid px-4 py-2">
-    <div className="align-items-baseline d-flex mb-2">
-      <h2 className="text-center me-4 fw-bold">Terra Data Repo</h2>
+    <div className="d-flex mb-2">
+      <h2 className="fw-bold">Terra Data Repo</h2>
     </div>
     <LoadingSpinner isLoading={isLoading}>
       <div className="d-flex align-items-center justify-content-between">

--- a/ui-admin/src/study/participants/datarepo/DatasetList.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetList.tsx
@@ -84,35 +84,29 @@ const DatasetList = ({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) =
     loadData()
   }, [studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName])
   return <div className="container-fluid pt-2">
-    <div className="row ps-3">
-      <div className="col-12 align-items-baseline d-flex mb-2">
+    <div className="row px-3">
+      <div className="align-items-baseline d-flex mb-2">
         <h2 className="text-center me-4 fw-bold">Terra Data Repo</h2>
       </div>
-      <div className="d-flex align-items-center justify-content-between">
-        <div className="d-flex">
+      <LoadingSpinner isLoading={isLoading}>
+        <div className="d-flex align-items-center justify-content-between px-3">
           <h4>Datasets</h4>
-        </div>
-        <div className="d-flex">
           { user.superuser &&
-            <Button onClick={() => setShowCreateDatasetModal(!showCreateDatasetModal)}
-              variant="light" className="border m-1"
-              aria-label="show or export to tdr modal">
-              <FontAwesomeIcon icon={faSquarePlus} className="fa-lg"/> Create dataset
-            </Button>
+              <Button onClick={() => setShowCreateDatasetModal(!showCreateDatasetModal)}
+                variant="light" className="border m-1"
+                aria-label="show or export to tdr modal">
+                <FontAwesomeIcon icon={faSquarePlus} className="fa-lg"/> Create dataset
+              </Button>
           }
         </div>
-      </div>
+        {basicTableLayout(datasetTable)}
+        { datasets.length === 0 &&
+          <span className="d-flex justify-content-center text-muted fst-italic">No datasets</span> }
+      </LoadingSpinner>
       <CreateDatasetModal studyEnvContext={studyEnvContext}
         show={showCreateDatasetModal}
         setShow={setShowCreateDatasetModal}
         loadDatasets={loadData}/>
-      <div className="col-12">
-        <LoadingSpinner isLoading={isLoading}>
-          {basicTableLayout(datasetTable)}
-          { datasets.length === 0 &&
-            <span className="d-flex justify-content-center text-muted fst-italic">No datasets</span> }
-        </LoadingSpinner>
-      </div>
     </div>
   </div>
 }

--- a/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
@@ -74,29 +74,27 @@ const ExportDataBrowser = ({ studyEnvContext }: {studyEnvContext: StudyEnvContex
   }, [studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName])
 
   return <div className="container-fluid pt-2">
-    <div className="row ps-3">
+    <div className="row px-3">
       <div className="col-12 align-items-baseline d-flex mb-2">
         <h2 className="text-center me-4 fw-bold">Data Export</h2>
       </div>
-      <div className="col-12">
-        <div className="d-flex align-items-center justify-content-between">
-          <div className="d-flex">
-            <span className="text-muted fst-italic">
-              (Transposed for readability, the actual export has participants as rows)
-            </span>
-          </div>
-          <div className="d-flex">
-            <Button onClick={() => setShowExportModal(!showExportModal)}
-              variant="light" className="border m-1"
-              aria-label="show or hide export modal">
-              <FontAwesomeIcon icon={faDownload} className="fa-lg"/> Download
-            </Button>
-          </div>
+      <div className="d-flex align-items-center justify-content-between px-3">
+        <div className="d-flex">
+          <span className="text-muted fst-italic">
+            (Transposed for readability, the actual export has participants as rows)
+          </span>
         </div>
-        <ExportDataControl studyEnvContext={studyEnvContext} show={showExportModal} setShow={setShowExportModal}/>
-        <LoadingSpinner isLoading={isLoading}/>
-        {!isLoading && basicTableLayout(table)}
+        <div className="d-flex">
+          <Button onClick={() => setShowExportModal(!showExportModal)}
+            variant="light" className="border m-1"
+            aria-label="show or hide export modal">
+            <FontAwesomeIcon icon={faDownload} className="fa-lg"/> Download
+          </Button>
+        </div>
       </div>
+      <ExportDataControl studyEnvContext={studyEnvContext} show={showExportModal} setShow={setShowExportModal}/>
+      <LoadingSpinner isLoading={isLoading}/>
+      {!isLoading && basicTableLayout(table)}
     </div>
   </div>
 }

--- a/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
@@ -73,29 +73,27 @@ const ExportDataBrowser = ({ studyEnvContext }: {studyEnvContext: StudyEnvContex
     setData(result)
   }, [studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName])
 
-  return <div className="container-fluid pt-2">
-    <div className="row px-3">
-      <div className="col-12 align-items-baseline d-flex mb-2">
-        <h2 className="text-center me-4 fw-bold">Data Export</h2>
-      </div>
-      <div className="d-flex align-items-center justify-content-between px-3">
-        <div className="d-flex">
-          <span className="text-muted fst-italic">
-            (Transposed for readability, the actual export has participants as rows)
-          </span>
-        </div>
-        <div className="d-flex">
-          <Button onClick={() => setShowExportModal(!showExportModal)}
-            variant="light" className="border m-1"
-            aria-label="show or hide export modal">
-            <FontAwesomeIcon icon={faDownload} className="fa-lg"/> Download
-          </Button>
-        </div>
-      </div>
-      <ExportDataControl studyEnvContext={studyEnvContext} show={showExportModal} setShow={setShowExportModal}/>
-      <LoadingSpinner isLoading={isLoading}/>
-      {!isLoading && basicTableLayout(table)}
+  return <div className="container-fluid px-4 py-2">
+    <div className="align-items-baseline d-flex mb-2">
+      <h2 className="text-center me-4 fw-bold">Data Export</h2>
     </div>
+    <div className="d-flex align-items-center justify-content-between">
+      <div className="d-flex">
+        <span className="text-muted fst-italic">
+          (Transposed for readability, the actual export has participants as rows)
+        </span>
+      </div>
+      <div className="d-flex">
+        <Button onClick={() => setShowExportModal(!showExportModal)}
+          variant="light" className="border m-1"
+          aria-label="show or hide export modal">
+          <FontAwesomeIcon icon={faDownload} className="fa-lg"/> Download
+        </Button>
+      </div>
+    </div>
+    <ExportDataControl studyEnvContext={studyEnvContext} show={showExportModal} setShow={setShowExportModal}/>
+    <LoadingSpinner isLoading={isLoading}/>
+    {!isLoading && basicTableLayout(table)}
   </div>
 }
 

--- a/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
@@ -15,6 +15,7 @@ import ExportDataControl from './ExportDataControl'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faDownload } from '@fortawesome/free-solid-svg-icons'
 import { useLoadingEffect } from 'api/api-utils'
+import {Button} from "../../../components/forms/Button";
 
 // TODO: Add JSDoc
 // eslint-disable-next-line jsdoc/require-jsdoc
@@ -72,18 +73,31 @@ const ExportDataBrowser = ({ studyEnvContext }: {studyEnvContext: StudyEnvContex
     setData(result)
   }, [studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName])
 
-  return <div className="container-fluid py-3">
-    <h1 className="h3">Data export preview</h1>
-    <span className="text-muted fst-italic">
-      (Transposed for readability, the actual export has participants as rows)
-    </span>
-    <button className="btn btn-secondary" onClick={() => setShowExportModal(!showExportModal)}
-      aria-label="show or hide export modal">
-      Download <FontAwesomeIcon icon={faDownload}/>
-    </button>
-    <ExportDataControl studyEnvContext={studyEnvContext} show={showExportModal} setShow={setShowExportModal}/>
-    <LoadingSpinner isLoading={isLoading}/>
-    {!isLoading && basicTableLayout(table)}
+  return <div className="container-fluid pt-2">
+    <div className="row ps-3">
+      <div className="col-12 align-items-baseline d-flex mb-2">
+        <h2 className="text-center me-4 fw-bold">Data Export</h2>
+      </div>
+      <div className="col-12">
+        <div className="d-flex align-items-center justify-content-between mx-3">
+          <div className="d-flex">
+            <span className="text-muted fst-italic">
+              (Transposed for readability, the actual export has participants as rows)
+            </span>
+          </div>
+          <div className="d-flex">
+            <Button onClick={() => setShowExportModal(!showExportModal)}
+              variant="light" className="border m-1"
+              aria-label="show or hide export modal">
+              <FontAwesomeIcon icon={faDownload} className="fa-lg"/> Download
+            </Button>
+          </div>
+        </div>
+        <ExportDataControl studyEnvContext={studyEnvContext} show={showExportModal} setShow={setShowExportModal}/>
+        <LoadingSpinner isLoading={isLoading}/>
+        {!isLoading && basicTableLayout(table)}
+      </div>
+    </div>
   </div>
 }
 

--- a/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
@@ -74,8 +74,8 @@ const ExportDataBrowser = ({ studyEnvContext }: {studyEnvContext: StudyEnvContex
   }, [studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName])
 
   return <div className="container-fluid px-4 py-2">
-    <div className="align-items-baseline d-flex mb-2">
-      <h2 className="text-center me-4 fw-bold">Data Export</h2>
+    <div className="d-flex mb-2">
+      <h2 className="fw-bold">Data Export</h2>
     </div>
     <div className="d-flex align-items-center justify-content-between">
       <div className="d-flex">

--- a/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
@@ -15,7 +15,7 @@ import ExportDataControl from './ExportDataControl'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faDownload } from '@fortawesome/free-solid-svg-icons'
 import { useLoadingEffect } from 'api/api-utils'
-import {Button} from "../../../components/forms/Button";
+import { Button } from 'components/forms/Button'
 
 // TODO: Add JSDoc
 // eslint-disable-next-line jsdoc/require-jsdoc
@@ -79,7 +79,7 @@ const ExportDataBrowser = ({ studyEnvContext }: {studyEnvContext: StudyEnvContex
         <h2 className="text-center me-4 fw-bold">Data Export</h2>
       </div>
       <div className="col-12">
-        <div className="d-flex align-items-center justify-content-between mx-3">
+        <div className="d-flex align-items-center justify-content-between">
           <div className="d-flex">
             <span className="text-muted fst-italic">
               (Transposed for readability, the actual export has participants as rows)

--- a/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
@@ -16,6 +16,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faDownload } from '@fortawesome/free-solid-svg-icons'
 import { useLoadingEffect } from 'api/api-utils'
 import { Button } from 'components/forms/Button'
+import { renderPageHeader } from 'util/pageUtils'
 
 // TODO: Add JSDoc
 // eslint-disable-next-line jsdoc/require-jsdoc
@@ -74,9 +75,7 @@ const ExportDataBrowser = ({ studyEnvContext }: {studyEnvContext: StudyEnvContex
   }, [studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName])
 
   return <div className="container-fluid px-4 py-2">
-    <div className="d-flex mb-2">
-      <h2 className="fw-bold">Data Export</h2>
-    </div>
+    { renderPageHeader('Data Export') }
     <div className="d-flex align-items-center justify-content-between">
       <div className="d-flex">
         <span className="text-muted fst-italic">

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -179,40 +179,36 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     .map(key => participantList[parseInt(key)].enrollee.shortcode)
 
   return <div className="ParticipantList container-fluid pt-2">
-    <div className="row ps-3">
-      <div className="col-12 align-items-baseline d-flex mb-2">
+    <div className="row px-3">
+      <div className="align-items-baseline d-flex mb-2">
         <h2 className="text-center me-4 fw-bold">Participant List</h2>
       </div>
-      <div className="col-12 align-items-baseline d-flex mb-3">
+      <div className="align-items-baseline d-flex mb-3">
         <FacetView facet={KEYWORD_FACET} facetValue={keywordFacetValue} updateValue={updateKeywordFacet}/>
       </div>
-      <div className="col-12">
-        <LoadingSpinner isLoading={isLoading}>
-          <div>
-            <div className="d-flex align-items-center justify-content-between mx-3">
-              <div className="d-flex">
-                <RowVisibilityCount table={table}/>
-              </div>
-              <div className="d-flex">
-                <Button onClick={() => setShowEmailModal(allowSendEmail)}
-                  variant="light" className="border m-1" disabled={!allowSendEmail}
-                  tooltip={allowSendEmail ? 'Send email' : 'Select at least one participant'}>
-                  <FontAwesomeIcon icon={faEnvelope} className="fa-lg"/> Send email
-                </Button>
-                <DownloadControl table={table} fileName={`${portal.shortcode}-ParticipantList-${currentIsoDate()}`}/>
-                <ColumnVisibilityControl table={table}/>
-                { showEmailModal && <AdHocEmailModal enrolleeShortcodes={enrolleesSelected}
-                  studyEnvContext={studyEnvContext}
-                  onDismiss={() => setShowEmailModal(false)}/> }
-              </div>
-            </div>
+      <LoadingSpinner isLoading={isLoading}>
+        <div className="d-flex align-items-center justify-content-between px-3">
+          <div className="d-flex">
+            <RowVisibilityCount table={table}/>
           </div>
-          { basicTableLayout(table, { filterable: true })}
-          { participantList.length === 0 &&
-            <span className="d-flex justify-content-center text-muted fst-italic">No participants</span> }
-          <TableClientPagination table={table} preferredNumRowsKey={preferredNumRowsKey}/>
-        </LoadingSpinner>
-      </div>
+          <div className="d-flex">
+            <Button onClick={() => setShowEmailModal(allowSendEmail)}
+              variant="light" className="border m-1" disabled={!allowSendEmail}
+              tooltip={allowSendEmail ? 'Send email' : 'Select at least one participant'}>
+              <FontAwesomeIcon icon={faEnvelope} className="fa-lg"/> Send email
+            </Button>
+            <DownloadControl table={table} fileName={`${portal.shortcode}-ParticipantList-${currentIsoDate()}`}/>
+            <ColumnVisibilityControl table={table}/>
+            { showEmailModal && <AdHocEmailModal enrolleeShortcodes={enrolleesSelected}
+              studyEnvContext={studyEnvContext}
+              onDismiss={() => setShowEmailModal(false)}/> }
+          </div>
+        </div>
+        { basicTableLayout(table, { filterable: true })}
+        { participantList.length === 0 &&
+          <span className="d-flex justify-content-center text-muted fst-italic">No participants</span> }
+        <TableClientPagination table={table} preferredNumRowsKey={preferredNumRowsKey}/>
+      </LoadingSpinner>
     </div>
   </div>
 }

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -179,8 +179,8 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     .map(key => participantList[parseInt(key)].enrollee.shortcode)
 
   return <div className="ParticipantList container-fluid px-4 py-2">
-    <div className="align-items-baseline d-flex mb-2">
-      <h2 className="text-center me-4 fw-bold">Participant List</h2>
+    <div className="d-flex mb-2">
+      <h2 className="fw-bold">Participant List</h2>
     </div>
     <div className="align-items-baseline d-flex mb-2">
       <FacetView facet={KEYWORD_FACET} facetValue={keywordFacetValue} updateValue={updateKeywordFacet}/>

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -17,7 +17,7 @@ import {
   basicTableLayout,
   ColumnVisibilityControl,
   DownloadControl,
-  IndeterminateCheckbox, RowVisibilityCount,
+  IndeterminateCheckbox, renderEmptyMessage, RowVisibilityCount,
   useRoutableTablePaging
 } from 'util/tableUtils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -202,9 +202,8 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
             onDismiss={() => setShowEmailModal(false)}/> }
         </div>
       </div>
-      { basicTableLayout(table, { filterable: true })}
-      { participantList.length === 0 &&
-        <span className="d-flex justify-content-center text-muted fst-italic">No participants</span> }
+      { basicTableLayout(table, { filterable: true }) }
+      { renderEmptyMessage(participantList, 'No participants') }
       <TableClientPagination table={table} preferredNumRowsKey={preferredNumRowsKey}/>
     </LoadingSpinner>
   </div>

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -183,7 +183,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
       <div className="align-items-baseline d-flex mb-2">
         <h2 className="text-center me-4 fw-bold">Participant List</h2>
       </div>
-      <div className="align-items-baseline d-flex mb-3">
+      <div className="align-items-baseline d-flex mb-2">
         <FacetView facet={KEYWORD_FACET} facetValue={keywordFacetValue} updateValue={updateKeywordFacet}/>
       </div>
       <LoadingSpinner isLoading={isLoading}>

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -17,7 +17,7 @@ import {
   basicTableLayout,
   ColumnVisibilityControl,
   DownloadControl,
-  IndeterminateCheckbox,
+  IndeterminateCheckbox, RowVisibilityCount,
   useRoutableTablePaging
 } from 'util/tableUtils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -181,7 +181,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
   return <div className="ParticipantList container-fluid pt-2">
     <div className="row ps-3">
       <div className="col-12 align-items-baseline d-flex mb-2">
-        <h2 className="h4 text-center me-4 fw-bold">Participant List</h2>
+        <h2 className="text-center me-4 fw-bold">Participant List</h2>
       </div>
       <div className="col-12 align-items-baseline d-flex mb-3">
         <FacetView facet={KEYWORD_FACET} facetValue={keywordFacetValue} updateValue={updateKeywordFacet}/>
@@ -191,14 +191,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
           <div>
             <div className="d-flex align-items-center justify-content-between mx-3">
               <div className="d-flex">
-                <span className="me-2">
-                  {numSelected} of{' '}
-                  {/* eslint-disable-next-line max-len */}
-                  {table.getPreFilteredRowModel().rows.length} selected ({table.getFilteredRowModel().rows.length} shown)
-                </span>
-                { showEmailModal && <AdHocEmailModal enrolleeShortcodes={enrolleesSelected}
-                  studyEnvContext={studyEnvContext}
-                  onDismiss={() => setShowEmailModal(false)}/> }
+                <RowVisibilityCount table={table}/>
               </div>
               <div className="d-flex">
                 <Button onClick={() => setShowEmailModal(allowSendEmail)}
@@ -208,10 +201,15 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
                 </Button>
                 <DownloadControl table={table} fileName={`${portal.shortcode}-ParticipantList-${currentIsoDate()}`}/>
                 <ColumnVisibilityControl table={table}/>
+                { showEmailModal && <AdHocEmailModal enrolleeShortcodes={enrolleesSelected}
+                  studyEnvContext={studyEnvContext}
+                  onDismiss={() => setShowEmailModal(false)}/> }
               </div>
             </div>
           </div>
           { basicTableLayout(table, { filterable: true })}
+          { participantList.length === 0 &&
+            <span className="d-flex justify-content-center text-muted fst-italic">No participants</span> }
           <TableClientPagination table={table} preferredNumRowsKey={preferredNumRowsKey}/>
         </LoadingSpinner>
       </div>

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -178,38 +178,36 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     .filter(key => rowSelection[key])
     .map(key => participantList[parseInt(key)].enrollee.shortcode)
 
-  return <div className="ParticipantList container-fluid pt-2">
-    <div className="row px-3">
-      <div className="align-items-baseline d-flex mb-2">
-        <h2 className="text-center me-4 fw-bold">Participant List</h2>
-      </div>
-      <div className="align-items-baseline d-flex mb-2">
-        <FacetView facet={KEYWORD_FACET} facetValue={keywordFacetValue} updateValue={updateKeywordFacet}/>
-      </div>
-      <LoadingSpinner isLoading={isLoading}>
-        <div className="d-flex align-items-center justify-content-between px-3">
-          <div className="d-flex">
-            <RowVisibilityCount table={table}/>
-          </div>
-          <div className="d-flex">
-            <Button onClick={() => setShowEmailModal(allowSendEmail)}
-              variant="light" className="border m-1" disabled={!allowSendEmail}
-              tooltip={allowSendEmail ? 'Send email' : 'Select at least one participant'}>
-              <FontAwesomeIcon icon={faEnvelope} className="fa-lg"/> Send email
-            </Button>
-            <DownloadControl table={table} fileName={`${portal.shortcode}-ParticipantList-${currentIsoDate()}`}/>
-            <ColumnVisibilityControl table={table}/>
-            { showEmailModal && <AdHocEmailModal enrolleeShortcodes={enrolleesSelected}
-              studyEnvContext={studyEnvContext}
-              onDismiss={() => setShowEmailModal(false)}/> }
-          </div>
-        </div>
-        { basicTableLayout(table, { filterable: true })}
-        { participantList.length === 0 &&
-          <span className="d-flex justify-content-center text-muted fst-italic">No participants</span> }
-        <TableClientPagination table={table} preferredNumRowsKey={preferredNumRowsKey}/>
-      </LoadingSpinner>
+  return <div className="ParticipantList container-fluid px-4 py-2">
+    <div className="align-items-baseline d-flex mb-2">
+      <h2 className="text-center me-4 fw-bold">Participant List</h2>
     </div>
+    <div className="align-items-baseline d-flex mb-2">
+      <FacetView facet={KEYWORD_FACET} facetValue={keywordFacetValue} updateValue={updateKeywordFacet}/>
+    </div>
+    <LoadingSpinner isLoading={isLoading}>
+      <div className="d-flex align-items-center justify-content-between">
+        <div className="d-flex">
+          <RowVisibilityCount table={table}/>
+        </div>
+        <div className="d-flex">
+          <Button onClick={() => setShowEmailModal(allowSendEmail)}
+            variant="light" className="border m-1" disabled={!allowSendEmail}
+            tooltip={allowSendEmail ? 'Send email' : 'Select at least one participant'}>
+            <FontAwesomeIcon icon={faEnvelope} className="fa-lg"/> Send email
+          </Button>
+          <DownloadControl table={table} fileName={`${portal.shortcode}-ParticipantList-${currentIsoDate()}`}/>
+          <ColumnVisibilityControl table={table}/>
+          { showEmailModal && <AdHocEmailModal enrolleeShortcodes={enrolleesSelected}
+            studyEnvContext={studyEnvContext}
+            onDismiss={() => setShowEmailModal(false)}/> }
+        </div>
+      </div>
+      { basicTableLayout(table, { filterable: true })}
+      { participantList.length === 0 &&
+        <span className="d-flex justify-content-center text-muted fst-italic">No participants</span> }
+      <TableClientPagination table={table} preferredNumRowsKey={preferredNumRowsKey}/>
+    </LoadingSpinner>
   </div>
 }
 

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -35,6 +35,7 @@ import { useLoadingEffect } from 'api/api-utils'
 import { FacetView, getUpdatedFacetValues } from './facets/EnrolleeSearchFacets'
 import TableClientPagination from 'util/TablePagination'
 import { Button } from 'components/forms/Button'
+import { renderPageHeader } from 'util/pageUtils'
 
 /** Shows a list of (for now) enrollees */
 function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
@@ -179,9 +180,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
     .map(key => participantList[parseInt(key)].enrollee.shortcode)
 
   return <div className="ParticipantList container-fluid px-4 py-2">
-    <div className="d-flex mb-2">
-      <h2 className="fw-bold">Participant List</h2>
-    </div>
+    { renderPageHeader('Participant List') }
     <div className="align-items-baseline d-flex mb-2">
       <FacetView facet={KEYWORD_FACET} facetValue={keywordFacetValue} updateValue={updateKeywordFacet}/>
     </div>

--- a/ui-admin/src/study/publishing/StudyPublishingView.tsx
+++ b/ui-admin/src/study/publishing/StudyPublishingView.tsx
@@ -18,7 +18,10 @@ const ENV_SORT_ORDER = ['sandbox', 'irb', 'live']
 export default function StudyPublishingView({ portal, studyShortcode }: {portal: Portal, studyShortcode: string}) {
   const sortedEnvs = portal.portalEnvironments.sort((pa, pb) =>
     ENV_SORT_ORDER.indexOf(pa.environmentName) - ENV_SORT_ORDER.indexOf(pb.environmentName))
-  return <div className="p-4 container">
+  return <div className="container-fluid px-4 py-2">
+    <div className="d-flex mb-2">
+      <h2 className="fw-bold">Publish Content</h2>
+    </div>
     <div className="row">
       <ul className="list-unstyled">
         { sortedEnvs.map(portalEnv => <li key={portalEnv.environmentName}>

--- a/ui-admin/src/study/publishing/StudyPublishingView.tsx
+++ b/ui-admin/src/study/publishing/StudyPublishingView.tsx
@@ -11,6 +11,7 @@ import Api from 'api/api'
 import { faExternalLink } from '@fortawesome/free-solid-svg-icons/faExternalLink'
 import { useConfig } from 'providers/ConfigProvider'
 import { studyEnvSiteContentPath } from '../StudyEnvironmentRouter'
+import { renderPageHeader } from 'util/pageUtils'
 
 
 const ENV_SORT_ORDER = ['sandbox', 'irb', 'live']
@@ -19,9 +20,7 @@ export default function StudyPublishingView({ portal, studyShortcode }: {portal:
   const sortedEnvs = portal.portalEnvironments.sort((pa, pb) =>
     ENV_SORT_ORDER.indexOf(pa.environmentName) - ENV_SORT_ORDER.indexOf(pb.environmentName))
   return <div className="container-fluid px-4 py-2">
-    <div className="d-flex mb-2">
-      <h2 className="fw-bold">Publish Content</h2>
-    </div>
+    { renderPageHeader('Publish Content') }
     <div className="row">
       <ul className="list-unstyled">
         { sortedEnvs.map(portalEnv => <li key={portalEnv.environmentName}>

--- a/ui-admin/src/user/PortalUserList.tsx
+++ b/ui-admin/src/user/PortalUserList.tsx
@@ -16,6 +16,7 @@ import CreateUserModal from './CreateUserModal'
 import { failureNotification } from '../util/notifications'
 import { Store } from 'react-notifications-component'
 import UserAction from './UserAction'
+import { Button } from 'components/forms/Button'
 
 // TODO: Add JSDoc
 // eslint-disable-next-line jsdoc/require-jsdoc
@@ -73,16 +74,27 @@ const PortalUserList = ({ portal }: {portal: Portal}) => {
   useEffect(() => {
     loadUsers()
   }, [])
-  return <div className="container p-3">
-    <h1 className="h4">All users </h1>
-    <button className="btn-secondary btn" onClick={() => setShowCreateModal(true)}>
-      <FontAwesomeIcon icon={faPlus}/> Create user
-    </button>
-    {showCreateModal && <CreateUserModal onDismiss={() => setShowCreateModal(false)} portals={[portal]}
-      userCreated={handleUserListChanged}/>}
-    <LoadingSpinner isLoading={isLoading}>
-      {basicTableLayout(table)}
-    </LoadingSpinner>
+  return <div className="container-fluid pt-2">
+    <div className="row px-3">
+      <div className="col-12 align-items-baseline d-flex mb-2">
+        <h2 className="text-center me-4 fw-bold">Manage Team</h2>
+      </div>
+      <div className="d-flex align-items-center justify-content-between px-3">
+        <div className="d-flex">
+          <h4>All users</h4>
+        </div>
+        <div className="d-flex">
+          <Button variant="light" className="border m-1" onClick={() => setShowCreateModal(true)}>
+            <FontAwesomeIcon icon={faPlus}/> Create user
+          </Button>
+        </div>
+      </div>
+      {showCreateModal && <CreateUserModal onDismiss={() => setShowCreateModal(false)} portals={[portal]}
+        userCreated={handleUserListChanged}/>}
+      <LoadingSpinner isLoading={isLoading}>
+        {basicTableLayout(table)}
+      </LoadingSpinner>
+    </div>
   </div>
 }
 

--- a/ui-admin/src/user/PortalUserList.tsx
+++ b/ui-admin/src/user/PortalUserList.tsx
@@ -92,6 +92,8 @@ const PortalUserList = ({ portal }: {portal: Portal}) => {
       userCreated={handleUserListChanged}/>}
     <LoadingSpinner isLoading={isLoading}>
       {basicTableLayout(table)}
+      { users.length === 0 &&
+        <span className="d-flex justify-content-center text-muted fst-italic">No users</span> }
     </LoadingSpinner>
   </div>
 }

--- a/ui-admin/src/user/PortalUserList.tsx
+++ b/ui-admin/src/user/PortalUserList.tsx
@@ -7,7 +7,7 @@ import {
   useReactTable
 } from '@tanstack/react-table'
 import Api, { AdminUser, Portal } from 'api/api'
-import { basicTableLayout } from 'util/tableUtils'
+import { basicTableLayout, renderEmptyMessage } from 'util/tableUtils'
 import { instantToDefaultString } from 'util/timeUtils'
 import LoadingSpinner from 'util/LoadingSpinner'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -90,9 +90,8 @@ const PortalUserList = ({ portal }: {portal: Portal}) => {
     {showCreateModal && <CreateUserModal onDismiss={() => setShowCreateModal(false)} portals={[portal]}
       userCreated={handleUserListChanged}/>}
     <LoadingSpinner isLoading={isLoading}>
-      {basicTableLayout(table)}
-      { users.length === 0 &&
-        <span className="d-flex justify-content-center text-muted fst-italic">No users</span> }
+      { basicTableLayout(table) }
+      { renderEmptyMessage(users, 'No users') }
     </LoadingSpinner>
   </div>
 }

--- a/ui-admin/src/user/PortalUserList.tsx
+++ b/ui-admin/src/user/PortalUserList.tsx
@@ -76,7 +76,7 @@ const PortalUserList = ({ portal }: {portal: Portal}) => {
   }, [])
   return <div className="container-fluid pt-2">
     <div className="row px-3">
-      <div className="col-12 align-items-baseline d-flex mb-2">
+      <div className="align-items-baseline d-flex mb-2">
         <h2 className="text-center me-4 fw-bold">Manage Team</h2>
       </div>
       <div className="d-flex align-items-center justify-content-between px-3">

--- a/ui-admin/src/user/PortalUserList.tsx
+++ b/ui-admin/src/user/PortalUserList.tsx
@@ -74,27 +74,25 @@ const PortalUserList = ({ portal }: {portal: Portal}) => {
   useEffect(() => {
     loadUsers()
   }, [])
-  return <div className="container-fluid pt-2">
-    <div className="row px-3">
-      <div className="align-items-baseline d-flex mb-2">
-        <h2 className="text-center me-4 fw-bold">Manage Team</h2>
-      </div>
-      <div className="d-flex align-items-center justify-content-between px-3">
-        <div className="d-flex">
-          <h4>All users</h4>
-        </div>
-        <div className="d-flex">
-          <Button variant="light" className="border m-1" onClick={() => setShowCreateModal(true)}>
-            <FontAwesomeIcon icon={faPlus}/> Create user
-          </Button>
-        </div>
-      </div>
-      {showCreateModal && <CreateUserModal onDismiss={() => setShowCreateModal(false)} portals={[portal]}
-        userCreated={handleUserListChanged}/>}
-      <LoadingSpinner isLoading={isLoading}>
-        {basicTableLayout(table)}
-      </LoadingSpinner>
+  return <div className="container-fluid px-4 py-2">
+    <div className="align-items-baseline d-flex mb-2">
+      <h2 className="text-center me-4 fw-bold">Manage Team</h2>
     </div>
+    <div className="d-flex align-items-center justify-content-between">
+      <div className="d-flex">
+        <h4>All users</h4>
+      </div>
+      <div className="d-flex">
+        <Button variant="light" className="border m-1" onClick={() => setShowCreateModal(true)}>
+          <FontAwesomeIcon icon={faPlus}/> Create user
+        </Button>
+      </div>
+    </div>
+    {showCreateModal && <CreateUserModal onDismiss={() => setShowCreateModal(false)} portals={[portal]}
+      userCreated={handleUserListChanged}/>}
+    <LoadingSpinner isLoading={isLoading}>
+      {basicTableLayout(table)}
+    </LoadingSpinner>
   </div>
 }
 

--- a/ui-admin/src/user/PortalUserList.tsx
+++ b/ui-admin/src/user/PortalUserList.tsx
@@ -75,8 +75,8 @@ const PortalUserList = ({ portal }: {portal: Portal}) => {
     loadUsers()
   }, [])
   return <div className="container-fluid px-4 py-2">
-    <div className="align-items-baseline d-flex mb-2">
-      <h2 className="text-center me-4 fw-bold">Manage Team</h2>
+    <div className="d-flex mb-2">
+      <h2 className="fw-bold">Manage Team</h2>
     </div>
     <div className="d-flex align-items-center justify-content-between">
       <div className="d-flex">

--- a/ui-admin/src/user/PortalUserList.tsx
+++ b/ui-admin/src/user/PortalUserList.tsx
@@ -17,6 +17,7 @@ import { failureNotification } from '../util/notifications'
 import { Store } from 'react-notifications-component'
 import UserAction from './UserAction'
 import { Button } from 'components/forms/Button'
+import { renderPageHeader } from 'util/pageUtils'
 
 // TODO: Add JSDoc
 // eslint-disable-next-line jsdoc/require-jsdoc
@@ -75,9 +76,7 @@ const PortalUserList = ({ portal }: {portal: Portal}) => {
     loadUsers()
   }, [])
   return <div className="container-fluid px-4 py-2">
-    <div className="d-flex mb-2">
-      <h2 className="fw-bold">Manage Team</h2>
-    </div>
+    { renderPageHeader('Manage Team') }
     <div className="d-flex align-items-center justify-content-between">
       <div className="d-flex">
         <h4>All users</h4>

--- a/ui-admin/src/user/UserList.tsx
+++ b/ui-admin/src/user/UserList.tsx
@@ -7,7 +7,7 @@ import {
   useReactTable
 } from '@tanstack/react-table'
 import Api, { AdminUser, Portal, PortalAdminUser } from 'api/api'
-import { basicTableLayout } from 'util/tableUtils'
+import { basicTableLayout, renderEmptyMessage }  from 'util/tableUtils'
 import { instantToDefaultString } from 'util/timeUtils'
 import LoadingSpinner from 'util/LoadingSpinner'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -97,9 +97,8 @@ const UserList = () => {
     {showCreateModal && <CreateUserModal onDismiss={() => setShowCreateModal(false)} portals={portals}
       userCreated={handleUserCreated}/>}
     <LoadingSpinner isLoading={isLoading}>
-      {basicTableLayout(table)}
-      { users.length === 0 &&
-        <span className="d-flex justify-content-center text-muted fst-italic">No users</span> }
+      { basicTableLayout(table) }
+      { renderEmptyMessage(users, 'No users') }
     </LoadingSpinner>
   </div>
 }

--- a/ui-admin/src/user/UserList.tsx
+++ b/ui-admin/src/user/UserList.tsx
@@ -87,8 +87,8 @@ const UserList = () => {
     loadAdminUsersAndPortals()
   }, [])
   return <div className="container-fluid px-4 py-2">
-    <div className="align-items-baseline d-flex mb-2">
-      <h2 className="text-center me-4 fw-bold">All Users</h2>
+    <div className="d-flex mb-2">
+      <h2 className="fw-bold">All Users</h2>
     </div>
     <div className="d-flex align-items-center justify-content-end">
       <Button variant="light" className="border m-1" onClick={() => setShowCreateModal(true)}>

--- a/ui-admin/src/user/UserList.tsx
+++ b/ui-admin/src/user/UserList.tsx
@@ -14,6 +14,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheck, faPlus } from '@fortawesome/free-solid-svg-icons'
 import CreateUserModal from './CreateUserModal'
 import { Button } from 'components/forms/Button'
+import { renderPageHeader } from 'util/pageUtils'
 
 /** lists all admin users */
 const UserList = () => {
@@ -87,9 +88,7 @@ const UserList = () => {
     loadAdminUsersAndPortals()
   }, [])
   return <div className="container-fluid px-4 py-2">
-    <div className="d-flex mb-2">
-      <h2 className="fw-bold">All Users</h2>
-    </div>
+    { renderPageHeader('All Users') }
     <div className="d-flex align-items-center justify-content-end">
       <Button variant="light" className="border m-1" onClick={() => setShowCreateModal(true)}>
         <FontAwesomeIcon icon={faPlus}/> Create user

--- a/ui-admin/src/user/UserList.tsx
+++ b/ui-admin/src/user/UserList.tsx
@@ -13,6 +13,7 @@ import LoadingSpinner from 'util/LoadingSpinner'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheck, faPlus } from '@fortawesome/free-solid-svg-icons'
 import CreateUserModal from './CreateUserModal'
+import { Button } from 'components/forms/Button'
 
 /** lists all admin users */
 const UserList = () => {
@@ -85,16 +86,22 @@ const UserList = () => {
   useEffect(() => {
     loadAdminUsersAndPortals()
   }, [])
-  return <div className="container p-3">
-    <h1 className="h4">All users </h1>
-    <button className="btn-secondary btn" onClick={() => setShowCreateModal(true)}>
-      <FontAwesomeIcon icon={faPlus}/> Create user
-    </button>
-    {showCreateModal && <CreateUserModal onDismiss={() => setShowCreateModal(false)} portals={portals}
-      userCreated={handleUserCreated}/>}
-    <LoadingSpinner isLoading={isLoading}>
-      {basicTableLayout(table)}
-    </LoadingSpinner>
+  return <div className="container-fluid pt-2">
+    <div className="px-1">
+      <div className="align-items-baseline d-flex mb-2">
+        <h2 className="text-center me-4 fw-bold">All Users</h2>
+      </div>
+      <div className="d-flex align-items-center justify-content-end px-3">
+        <Button variant="light" className="border m-1" onClick={() => setShowCreateModal(true)}>
+          <FontAwesomeIcon icon={faPlus}/> Create user
+        </Button>
+      </div>
+      {showCreateModal && <CreateUserModal onDismiss={() => setShowCreateModal(false)} portals={portals}
+        userCreated={handleUserCreated}/>}
+      <LoadingSpinner isLoading={isLoading}>
+        {basicTableLayout(table)}
+      </LoadingSpinner>
+    </div>
   </div>
 }
 

--- a/ui-admin/src/user/UserList.tsx
+++ b/ui-admin/src/user/UserList.tsx
@@ -86,22 +86,20 @@ const UserList = () => {
   useEffect(() => {
     loadAdminUsersAndPortals()
   }, [])
-  return <div className="container-fluid pt-2">
-    <div className="px-1">
-      <div className="align-items-baseline d-flex mb-2">
-        <h2 className="text-center me-4 fw-bold">All Users</h2>
-      </div>
-      <div className="d-flex align-items-center justify-content-end px-3">
-        <Button variant="light" className="border m-1" onClick={() => setShowCreateModal(true)}>
-          <FontAwesomeIcon icon={faPlus}/> Create user
-        </Button>
-      </div>
-      {showCreateModal && <CreateUserModal onDismiss={() => setShowCreateModal(false)} portals={portals}
-        userCreated={handleUserCreated}/>}
-      <LoadingSpinner isLoading={isLoading}>
-        {basicTableLayout(table)}
-      </LoadingSpinner>
+  return <div className="container-fluid px-4 py-2">
+    <div className="align-items-baseline d-flex mb-2">
+      <h2 className="text-center me-4 fw-bold">All Users</h2>
     </div>
+    <div className="d-flex align-items-center justify-content-end">
+      <Button variant="light" className="border m-1" onClick={() => setShowCreateModal(true)}>
+        <FontAwesomeIcon icon={faPlus}/> Create user
+      </Button>
+    </div>
+    {showCreateModal && <CreateUserModal onDismiss={() => setShowCreateModal(false)} portals={portals}
+      userCreated={handleUserCreated}/>}
+    <LoadingSpinner isLoading={isLoading}>
+      {basicTableLayout(table)}
+    </LoadingSpinner>
   </div>
 }
 

--- a/ui-admin/src/user/UserList.tsx
+++ b/ui-admin/src/user/UserList.tsx
@@ -99,6 +99,8 @@ const UserList = () => {
       userCreated={handleUserCreated}/>}
     <LoadingSpinner isLoading={isLoading}>
       {basicTableLayout(table)}
+      { users.length === 0 &&
+        <span className="d-flex justify-content-center text-muted fst-italic">No users</span> }
     </LoadingSpinner>
   </div>
 }

--- a/ui-admin/src/util/pageUtils.tsx
+++ b/ui-admin/src/util/pageUtils.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+
+/** renders a page header with the appropriate styling and spacing */
+export const renderPageHeader = (content: React.ReactNode) => {
+  return <div className="d-flex mb-2">
+    <h2 className="fw-bold">{content}</h2>
+  </div>
+}

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -4,11 +4,12 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCaretDown, faCaretUp, faCheck, faColumns, faDownload } from '@fortawesome/free-solid-svg-icons'
 import Select from 'react-select'
 import Modal from 'react-bootstrap/Modal'
-import { Button } from '../components/forms/Button'
+import { Button } from 'components/forms/Button'
 import { escapeCsvValue, saveBlobAsDownload } from './downloadUtils'
 import { instantToDefaultString } from './timeUtils'
 import { isEmpty } from 'lodash'
 import { useSearchParams } from 'react-router-dom'
+import { TextInput } from 'components/forms/TextInput'
 
 /**
  * Returns a debounced input react component
@@ -39,7 +40,14 @@ function DebouncedInput({
   }, [value])
 
   return (
-    <input {...props} value={value} style={{ height: 32 }} onChange={e => setValue(e.target.value)} />
+    <TextInput
+      label=""
+      placeholder={props.placeholder}
+      value={value}
+      onChange={v => {
+        setValue(v)
+      }}
+    />
   )
 }
 
@@ -94,18 +102,11 @@ function SelectFilter<A>({
       styles={{
         control: baseStyles => ({
           ...baseStyles,
-          width: 200,
-          height: 32,
-          minHeight: 32,
           fontWeight: 'normal'
         }),
         menu: baseStyles => ({
           ...baseStyles,
           fontWeight: 'normal'
-        }),
-        valueContainer: baseStyles => ({
-          ...baseStyles,
-          padding: '0 0.25rem'
         })
       }}
       value={selectedValue}

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -273,6 +273,25 @@ export function ColumnVisibilityControl<T>({ table }: {table: Table<T>}) {
 }
 
 /**
+ *
+ */
+export function RowVisibilityCount<T>({ table }: {table: Table<T>}) {
+  const numSelected = Object.keys(table.getState().rowSelection).length
+  const numPrefilteredRows = table.getPreFilteredRowModel().rows.length
+  const numFilteredRows = table.getFilteredRowModel().rows.length
+
+  if (numPrefilteredRows === numFilteredRows) {
+    return <span className="me-2">
+      {numSelected} of {numPrefilteredRows} selected
+    </span>
+  } else {
+    return <span className="me-2">
+      {numSelected} of {numPrefilteredRows} selected ({numFilteredRows} shown)
+    </span>
+  }
+}
+
+/**
  * Converts a cell value to an escaped string for csv export
  */
 function cellToCsvString(cellType: string, cellValue: unknown): string {

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -41,7 +41,6 @@ function DebouncedInput({
 
   return (
     <TextInput
-      label=""
       placeholder={props.placeholder}
       value={value}
       onChange={v => {
@@ -274,7 +273,8 @@ export function ColumnVisibilityControl<T>({ table }: {table: Table<T>}) {
 }
 
 /**
- *
+ * Returns a count of the total number of rows in the table, and the number of rows
+ * visible if a filter is applied
  */
 export function RowVisibilityCount<T>({ table }: {table: Table<T>}) {
   const numSelected = Object.keys(table.getState().rowSelection).length
@@ -282,13 +282,9 @@ export function RowVisibilityCount<T>({ table }: {table: Table<T>}) {
   const numFilteredRows = table.getFilteredRowModel().rows.length
 
   if (numPrefilteredRows === numFilteredRows) {
-    return <span className="me-2">
-      {numSelected} of {numPrefilteredRows} selected
-    </span>
+    return <span>{numSelected} of {numPrefilteredRows} selected</span>
   } else {
-    return <span className="me-2">
-      {numSelected} of {numPrefilteredRows} selected ({numFilteredRows} shown)
-    </span>
+    return <span>{numSelected} of {numPrefilteredRows} selected ({numFilteredRows} shown)</span>
   }
 }
 

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -289,6 +289,14 @@ export function RowVisibilityCount<T>({ table }: {table: Table<T>}) {
 }
 
 /**
+ * Renders a message if the table is empty
+ */
+export const renderEmptyMessage = (arr: unknown[], content: React.ReactNode) => {
+  if (arr.length > 0) { return null }
+  return <span className="d-flex justify-content-center text-muted fst-italic">{content}</span>
+}
+
+/**
  * Converts a cell value to an escaped string for csv export
  */
 function cellToCsvString(cellType: string, cellValue: unknown): string {


### PR DESCRIPTION
#### DESCRIPTION

There are a lot of UX tweaks in this PR- it touches every single top-level page that's represented in the sidebar (except for the Website editor). It's probably going to be a tedious review, sorry about that. :( The good news is that it's just style changes and there aren't any functional changes.  So you may be able to get away with skim-reviewing and then testing out locally. I also provided before/after screenshots of each page below in case that's helpful. See "Summary of changes" below to get an idea of what to look out for. Erin reviewed the screenshots below through "Tasks" and then gave me the green light to proceed with cleaning up the rest of the pages. There may still be some back-and-forth, but overall I expect the code to be fairly stable.

Eventually I may want to pull out some of the styles and page structure into some sort of `PageContainer` component, but for the purposes of this PR I just wanted to get things looking good. It was also a useful exercise to clean things up a bunch which makes it much easier to understand how our pages are structured in order to extract commonalities.

Summary of changes:

* Consistent header sizes and positioning for each modified page
* Consistent styling and padding for tables, etc
* Consistent button styling
* Consistent messaging when a rendered table is empty (sometimes the table was rendered with a "No rows" message, sometimes a table was not rendered at all, and sometimes it was rendered, but without the "No rows" message). This PR modifies every table table to still be rendered, but with a "No rows" message.
* Cleaned up a lot of the DOM which was often cluttered with extra divs, unnecessary redundant padding/margins, and conflicting styling (i.e. an `<h2>` restyled as an `h4`)
* Restyled the table column filters because they looked wonky and didn't use the same text input styling as all of our other inputs. The select filter was also not centered vertically (my fault from when I originally implemented it)

Participant List (left = before, right = after):
<img width="400" alt="participant_before" src="https://github.com/broadinstitute/juniper/assets/7257391/5a0cabe1-043f-4613-a0e0-85a97157dd2b"><img width="400" alt="participant_after" src="https://github.com/broadinstitute/juniper/assets/7257391/7dcd5e68-3817-48fd-9e87-8aced40a5555">

Kits:
<img width="400" alt="kits_before" src="https://github.com/broadinstitute/juniper/assets/7257391/078d1fd6-c1f6-4a82-8afc-8eb603994af1"><img width="400" alt="kits_after" src="https://github.com/broadinstitute/juniper/assets/7257391/afaf812a-375e-4a42-9a16-ad1a155120d3">

Manage Team:
<img width="400" alt="manage_team_before" src="https://github.com/broadinstitute/juniper/assets/7257391/ad1ef257-9a1e-4ff7-a851-2b079c1e29f6"><img width="400" alt="manage_team_after" src="https://github.com/broadinstitute/juniper/assets/7257391/e0b1ebbb-21d4-4e64-917a-41835bcbf244">

Data Export:
<img width="400" alt="data_export_before" src="https://github.com/broadinstitute/juniper/assets/7257391/27b2d6ae-568d-4a25-9c38-b1de7e46c516"><img width="400" alt="data_export_after" src="https://github.com/broadinstitute/juniper/assets/7257391/f64a7d4b-188f-45d5-8f0a-093e4a4e05a8">

Data Repo:
<img width="400" alt="data_repo_before" src="https://github.com/broadinstitute/juniper/assets/7257391/d0725794-8ca5-4f01-80e1-2e98bae158c4"><img width="400" alt="data_repo_after" src="https://github.com/broadinstitute/juniper/assets/7257391/8812a8e8-b0d8-4432-a951-312ca16fca67">

Mailing List:
<img width="400" alt="mailing_list_before" src="https://github.com/broadinstitute/juniper/assets/7257391/01adb4e5-b144-4d83-b1c9-e6c7c31003b8"><img width="400" alt="mailing_list_after" src="https://github.com/broadinstitute/juniper/assets/7257391/cdd00947-e767-47d5-b988-1e0abf317ba4">

Tasks:
<img width="400" alt="tasks_before" src="https://github.com/broadinstitute/juniper/assets/7257391/341f36b9-c092-4dfb-970a-18c19f561d43"><img width="400" alt="tasks_after" src="https://github.com/broadinstitute/juniper/assets/7257391/3ba42d02-6dcc-4080-83ae-75e74e1fa94f">

Participant Analytics:
<img width="400" alt="Screenshot 2023-10-24 at 5 36 43 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/fe89ecb9-aa5f-4156-afec-4dcf06f7c7fe"><img width="400" alt="Screenshot 2023-10-24 at 5 32 25 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/bc50401f-513a-4125-bc16-0e3ad0db2ed7">

Forms & Surveys:
<img width="400" alt="Screenshot 2023-10-24 at 5 36 51 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/59005f20-0714-4188-b66b-6d2a139eadb3"><img width="400" alt="Screenshot 2023-10-24 at 5 32 36 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/e4033bc8-2db8-46ec-b9ee-f8f6e3b52350">

Emails & Notifications:
<img width="400" alt="Screenshot 2023-10-24 at 5 36 56 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/54d91f26-bb30-484d-8115-f8f238434547"><img width="400" alt="Screenshot 2023-10-24 at 5 32 43 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/82b3dd76-e0c6-4c5e-a72a-4073205037a3">

Publish Content:
<img width="400" alt="Screenshot 2023-10-24 at 5 37 00 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/ac1825a9-1e15-4d9b-9a29-ec6d92a3b98c"><img width="400" alt="Screenshot 2023-10-24 at 5 32 46 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/13f60f74-da23-4a74-b69e-56166a103d1b">

Site Settings:
<img width="400" alt="Screenshot 2023-10-24 at 5 37 05 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/d4c8ae60-e95a-4821-a880-19069e26304d"><img width="400" alt="Screenshot 2023-10-24 at 5 32 50 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/ac8a90a4-543c-4fc5-a18a-b7f0fd0d2c97">



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

There isn't any new functionality here, so mainly you'll want to click around all of the modified pages to make sure that everything behaves correctly and that I haven't broken any buttons or dropped any components from pages entirely.