### PR TITLE
JN-646 Analysis-friendly export

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/survey/QuestionChoice.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/QuestionChoice.java
@@ -1,3 +1,7 @@
 package bio.terra.pearl.core.model.survey;
 
-public record QuestionChoice(String stableId, String text) { }
+import lombok.Builder;
+
+public record QuestionChoice(String stableId, String text) {
+    @Builder public QuestionChoice {}
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoExportService.java
@@ -223,8 +223,8 @@ public class DataRepoExportService {
 
             TsvExporter tsvExporter = new TsvExporter(moduleExportInfos, enrolleeMaps);
 
-            tsvExporter.applyToEveryColumn((moduleExportInfo, itemExportInfo, isOtherDescription) -> tdrColumns.add(new TdrColumn(
-                    DataRepoExportUtils.juniperToDataRepoColumnName(moduleExportInfo.getFormatter().getColumnKey(moduleExportInfo, itemExportInfo, isOtherDescription, null)),
+            tsvExporter.applyToEveryColumn((moduleExportInfo, itemExportInfo, choice, isOtherDescription) -> tdrColumns.add(new TdrColumn(
+                    DataRepoExportUtils.juniperToDataRepoColumnName(moduleExportInfo.getFormatter().getColumnKey(moduleExportInfo, itemExportInfo, choice, isOtherDescription)),
                     DataRepoExportUtils.juniperToDataRepoColumnType(itemExportInfo.getDataType())
                 )
             ));

--- a/core/src/main/java/bio/terra/pearl/core/service/export/ExcelExporter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/ExcelExporter.java
@@ -58,16 +58,6 @@ public class ExcelExporter extends BaseExporter {
         });
     }
 
-    /**
-     * we don't need to worry about escaping any characters, we just need to replace null with empty string
-     */
-    protected String sanitizeValue(String value) {
-        if (value == null) {
-            value = StringUtils.EMPTY;
-        }
-        return value;
-    }
-
     protected String getSheetName() {
         return SHEET_NAME;
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/TsvExporter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/TsvExporter.java
@@ -48,10 +48,8 @@ public class TsvExporter extends BaseExporter {
      * @param value the value to sanitize
      * @return the sanitized value, suitable for including in a tsv
      */
-    protected String sanitizeValue(String value) {
-        if (value == null) {
-            value = StringUtils.EMPTY;
-        }
+    protected String sanitizeValue(String value, String nullValueString) {
+        value = super.sanitizeValue(value, nullValueString);
         // first replace double quotes with single '
         String sanitizedValue = value.replace("\"", "'");
         // then quote the whole string if needed

--- a/core/src/main/java/bio/terra/pearl/core/service/export/instance/ExportOptions.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/instance/ExportOptions.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.service.export.instance;
 
 import bio.terra.pearl.core.service.export.ExportFileFormat;
+import lombok.Builder;
 
 public record ExportOptions (boolean splitOptionsIntoColumns, boolean stableIdsForOptions, boolean onlyIncludeMostRecent,
                              ExportFileFormat fileFormat,
@@ -8,4 +9,7 @@ public record ExportOptions (boolean splitOptionsIntoColumns, boolean stableIdsF
     public ExportOptions() {
         this(false, false, true, ExportFileFormat.TSV, null);
     }
+
+    @Builder
+    public ExportOptions {}
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeExportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeExportServiceTests.java
@@ -25,6 +25,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 
+/**
+ * Tests for the EnrolleeExportService.  Note that end-to-end tests for the export service are in the
+ * Populate tests, as those provide more realistic testing of the export against simulated submitted data
+ */
 public class EnrolleeExportServiceTests extends BaseSpringBootTest {
     @Autowired
     private StudyEnvironmentFactory studyEnvironmentFactory;

--- a/core/src/test/java/bio/terra/pearl/core/service/export/SurveyFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/SurveyFormatterTests.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.core.service.export;
 
+import bio.terra.pearl.core.BaseSpringBootTest;
 import bio.terra.pearl.core.model.survey.Answer;
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.model.survey.SurveyQuestionDefinition;
@@ -7,7 +8,7 @@ import bio.terra.pearl.core.model.survey.SurveyResponse;
 import bio.terra.pearl.core.service.export.formatters.SurveyFormatter;
 import bio.terra.pearl.core.service.export.instance.ExportOptions;
 import bio.terra.pearl.core.service.export.instance.ItemExportInfo;
-import bio.terra.pearl.core.service.export.instance.ModuleExportInfo;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.HashMap;
@@ -16,70 +17,163 @@ import java.util.Map;
 import java.util.UUID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+
+import org.apache.commons.math3.analysis.function.Exp;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class SurveyFormatterTests {
+public class SurveyFormatterTests extends BaseSpringBootTest {
     @Autowired
     ObjectMapper objectMapper;
     @Test
     public void testToStringMap() throws Exception {
-        Survey survey = Survey.builder()
-                .id(UUID.randomUUID())
-                .stableId("oh_surveyA")
-                .version(1)
-                .build();
+        Survey testSurvey =  Survey.builder().id(UUID.randomUUID()).stableId("oh_surveyA").version(1).build();
         SurveyQuestionDefinition questionDef = SurveyQuestionDefinition.builder()
                 .questionStableId("oh_surveyA_q1")
                 .questionType("text")
                 .exportOrder(1)
                 .build();
         var moduleExportInfo = new SurveyFormatter(objectMapper)
-                .getModuleExportInfo(new ExportOptions(), "oh_surveyA", List.of(survey), List.of(questionDef));
-        SurveyResponse response = SurveyResponse.builder()
+                .getModuleExportInfo(new ExportOptions(), "oh_surveyA", List.of(testSurvey), List.of(questionDef));
+        SurveyResponse testResponse = SurveyResponse.builder()
                 .id(UUID.randomUUID())
-                .surveyId(survey.getId())
-                .build();
+                .surveyId(testSurvey.getId()).build();
         Answer answer = Answer.builder()
-                .surveyStableId(survey.getStableId())
+                .surveyStableId(testSurvey.getStableId())
                 .questionStableId("oh_surveyA_q1")
-                .surveyResponseId(response.getId())
+                .surveyResponseId(testResponse.getId())
                 .stringValue("easyValue")
                 .build();
         EnrolleeExportData enrolleeExportData = new EnrolleeExportData(null, null,
-                List.of(answer), null, List.of(response));
+                List.of(answer), null, List.of(testResponse));
         Map<String, String> valueMap = moduleExportInfo.toStringMap(enrolleeExportData);
 
         assertThat(valueMap.get("oh_surveyA.oh_surveyA_q1"), equalTo("easyValue"));
         assertThat(valueMap.get("oh_surveyA.complete"), equalTo("false"));
-
-
     }
 
+    @Test
     public void testAddAnswerToMapHandlesMissingVersion() throws Exception {
-        Survey survey = Survey.builder()
-                .id(UUID.randomUUID())
-                .stableId("oh_surveyA")
-                .version(1)
-                .build();
         SurveyQuestionDefinition questionDef = SurveyQuestionDefinition.builder()
                 .questionStableId("oh_surveyA_q1")
                 .questionType("text")
                 .exportOrder(1)
                 .build();
-        SurveyFormatter surveyFormatter = new SurveyFormatter(objectMapper);
-        var moduleExportInfo = surveyFormatter
-                .getModuleExportInfo(new ExportOptions(), "oh_surveyA", List.of(survey), List.of(questionDef));
-        ItemExportInfo itemExportInfo = moduleExportInfo.getItems().get(0);
-        Map<String, String> valueMap = new HashMap<>();
         Answer answerToMissingSurvey = Answer.builder()
                         .questionStableId("oh_surveyA_q1")
                         .surveyStableId("oh_surveyA")
                         .surveyVersion(18)
                         .stringValue("test123").build();
-        Map<String, List<Answer>> answerMap = Map.of("oh_surveyA_q1", List.of(answerToMissingSurvey));
-        surveyFormatter.addAnswersToMap(moduleExportInfo, itemExportInfo, answerMap, valueMap);
-
+        Map<String, String> valueMap = generateAnswerMap(questionDef, answerToMissingSurvey, new ExportOptions());
         assertThat(valueMap.get("oh_surveyA.oh_surveyA_q1"), equalTo("test123"));
     }
+
+    @Test
+    public void testAddAnswerToMapStableIdForOption() throws Exception {
+        SurveyQuestionDefinition questionDef = SurveyQuestionDefinition.builder()
+                .questionStableId("oh_surveyA_q1")
+                .questionType("radiogroup")
+                .exportOrder(1)
+                .allowMultiple(false)
+                .choices("""
+                    [{"stableId":"red","text":"Red label"},{"stableId":"blue","text":"Blue label"}]
+                    """)
+                .build();
+        Answer singleSelect = Answer.builder()
+                .questionStableId("oh_surveyA_q1")
+                .surveyStableId("oh_surveyA")
+                .surveyVersion(1)
+                .stringValue("red").build();
+        ExportOptions exportOptions = ExportOptions.builder().stableIdsForOptions(true).build();
+        Map<String, String> valueMap = generateAnswerMap(questionDef, singleSelect, exportOptions);
+        assertThat(valueMap.get("oh_surveyA.oh_surveyA_q1"), equalTo("red"));
+
+        exportOptions = ExportOptions.builder().stableIdsForOptions(false).build();
+        valueMap = generateAnswerMap(questionDef, singleSelect, exportOptions);
+        assertThat(valueMap.get("oh_surveyA.oh_surveyA_q1"), equalTo("Red label"));
+    }
+
+    @Test
+    public void testAddAnswerToMapMultiselectBothSelected() throws Exception {
+        SurveyQuestionDefinition questionDef = SurveyQuestionDefinition.builder()
+                .questionStableId("oh_surveyA_q1")
+                .questionType("checkbox")
+                .exportOrder(1)
+                .allowMultiple(true)
+                .choices("""
+                    [{"stableId":"red","text":"Red label"},{"stableId":"blue","text":"Blue label"}]
+                    """)
+                .build();
+        Answer multiselectBoth = Answer.builder()
+                .questionStableId("oh_surveyA_q1")
+                .surveyStableId("oh_surveyA")
+                .surveyVersion(1)
+                .objectValue("""
+                        ["red", "blue"]
+                        """).build();
+        ExportOptions exportOptions = ExportOptions.builder().splitOptionsIntoColumns(true).build();
+        Map<String, String> valueMap = generateAnswerMap(questionDef, multiselectBoth, exportOptions);
+        assertThat(valueMap.get("oh_surveyA.oh_surveyA_q1.red"), equalTo("1"));
+        assertThat(valueMap.get("oh_surveyA.oh_surveyA_q1.blue"), equalTo("1"));
+
+        exportOptions = ExportOptions.builder().splitOptionsIntoColumns(false).build();
+        valueMap = generateAnswerMap(questionDef, multiselectBoth, exportOptions);
+        assertThat(valueMap.get("oh_surveyA.oh_surveyA_q1"), equalTo("Red label, Blue label"));
+
+        exportOptions = ExportOptions.builder().splitOptionsIntoColumns(false).stableIdsForOptions(true).build();
+        valueMap = generateAnswerMap(questionDef, multiselectBoth, exportOptions);
+        assertThat(valueMap.get("oh_surveyA.oh_surveyA_q1"), equalTo("red, blue"));
+    }
+
+    @Test
+    public void testAddAnswerToMapOneSelected() throws Exception {
+        SurveyQuestionDefinition questionDef = SurveyQuestionDefinition.builder()
+                .questionStableId("oh_surveyA_q1")
+                .questionType("checkbox")
+                .exportOrder(1)
+                .allowMultiple(true)
+                .choices("""
+                    [{"stableId":"red","text":"Red label"},{"stableId":"blue","text":"Blue label"}]
+                    """)
+                .build();
+        Answer multiselectBoth = Answer.builder()
+                .questionStableId("oh_surveyA_q1")
+                .surveyStableId("oh_surveyA")
+                .surveyVersion(1)
+                .objectValue("""
+                        ["red"]
+                        """).build();
+        ExportOptions exportOptions = ExportOptions.builder().splitOptionsIntoColumns(true).build();
+        Map<String, String> valueMap = generateAnswerMap(questionDef, multiselectBoth, exportOptions);
+        assertThat(valueMap.get("oh_surveyA.oh_surveyA_q1.red"), equalTo("1"));
+        assertThat(valueMap.get("oh_surveyA.oh_surveyA_q1.blue"), equalTo(null));
+
+        exportOptions = ExportOptions.builder().splitOptionsIntoColumns(false).build();
+        valueMap = generateAnswerMap(questionDef, multiselectBoth, exportOptions);
+        assertThat(valueMap.get("oh_surveyA.oh_surveyA_q1"), equalTo("Red label"));
+
+        exportOptions = ExportOptions.builder().splitOptionsIntoColumns(false).stableIdsForOptions(true).build();
+        valueMap = generateAnswerMap(questionDef, multiselectBoth, exportOptions);
+        assertThat(valueMap.get("oh_surveyA.oh_surveyA_q1"), equalTo("red"));
+    }
+
+    /** helper for testing generation of answer maps values for a single question-answer pair */
+    private Map<String, String> generateAnswerMap(SurveyQuestionDefinition question, Answer answer, ExportOptions exportOptions) throws JsonProcessingException {
+        Map<String, String> valueMap = new HashMap<>();
+        Survey testSurvey =  Survey.builder()
+                .id(UUID.randomUUID())
+                .stableId("oh_surveyA")
+                .version(1)
+                .build();
+        SurveyFormatter surveyFormatter = new SurveyFormatter(objectMapper);
+        var moduleExportInfo = surveyFormatter
+                .getModuleExportInfo(exportOptions, "oh_surveyA", List.of(testSurvey), List.of(question));
+        ItemExportInfo itemExportInfo = moduleExportInfo.getItems().stream().filter(
+                itemInfo -> "oh_surveyA_q1".equals(itemInfo.getQuestionStableId())
+        ).findFirst().get();
+        Map<String, List<Answer>> answerMap = Map.of("oh_surveyA_q1", List.of(answer));
+        surveyFormatter.addAnswersToMap(moduleExportInfo, itemExportInfo, answerMap, valueMap);
+        return valueMap;
+    }
+
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/export/TsvExporterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/TsvExporterTests.java
@@ -1,10 +1,14 @@
 package bio.terra.pearl.core.service.export;
 
+import bio.terra.pearl.core.BaseSpringBootTest;
+import bio.terra.pearl.core.model.survey.QuestionChoice;
 import bio.terra.pearl.core.service.export.formatters.ProfileFormatter;
+import bio.terra.pearl.core.service.export.formatters.SurveyFormatter;
 import bio.terra.pearl.core.service.export.instance.ItemExportInfo;
 import bio.terra.pearl.core.service.export.instance.ModuleExportInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -12,7 +16,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class TsvExporterTests {
+public class TsvExporterTests extends BaseSpringBootTest {
     @Autowired
     ObjectMapper objectMapper;
     @Test
@@ -27,10 +31,39 @@ public class TsvExporterTests {
         Map<String, String> valueMap = Map.of("test1.field1", "blahblah",
                 "test1.field2", "bloblob");
         TsvExporter exporter = new TsvExporter(List.of(profileModuleInfo), List.of(valueMap));
+        String outString = getExportResult(List.of(valueMap), List.of(profileModuleInfo));
+        assertThat(outString, equalTo("test1.field1\ttest1.field2\nField 1\tField 2\nblahblah\tbloblob\n"));
+    }
+
+    @Test
+    public void testSplitColumnsExport() throws Exception {
+        var profileModuleInfo = ModuleExportInfo.builder()
+                .moduleName("test1")
+                .formatter(new SurveyFormatter(objectMapper)) // use the profile formatter since it's just a basic bean format
+                .items(List.of(
+                        ItemExportInfo.builder()
+                                .baseColumnKey("survey.q1")
+                                .allowMultiple(true)
+                                .splitOptionsIntoColumns(true)
+                                .questionStableId("q1")
+                                .choices(List.of(
+                                        new QuestionChoice("choice1","Choice 1"),
+                                        new QuestionChoice("choice2","Choice 2"),
+                                        new QuestionChoice("choice3","Choice 3")
+                                ))
+                                .build()
+                )).build();
+        Map<String, String> valueMap = Map.of("survey.q1.choice1", "1",
+                "survey.q1.choice3", "1");
+        String outString = getExportResult(List.of(valueMap), List.of(profileModuleInfo));
+        assertThat(outString, equalTo("test1.q1.choice1\ttest1.q1.choice2\ttest1.q1.choice3\nChoice 1\tChoice 2\tChoice 3\n1\t0\t1\n"));
+    }
+
+    private String getExportResult(List<Map<String, String>> valueMaps, List<ModuleExportInfo> moduleExportInfos) throws IOException {
+        TsvExporter exporter = new TsvExporter(moduleExportInfos, valueMaps);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         exporter.export(baos);
         baos.close();
-        String outString = baos.toString();
-        assertThat(outString, equalTo("test1.field1\ttest1.field2\nField 1\tField 2\nblahblah\tbloblob\n"));
+        return baos.toString();
     }
 }

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateOurhealthTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateOurhealthTest.java
@@ -112,7 +112,8 @@ public class PopulateOurhealthTest extends BasePopulatePortalsTest {
     }
 
     private void checkExportContent(UUID sandboxEnvironmentId) throws Exception {
-        ExportOptions options = new ExportOptions(false, false, true, ExportFileFormat.TSV, null);
+        // test the analysis-friendly export as that is the most important for data integrity, and the least visible via admin tool
+        ExportOptions options = new ExportOptions(true, true, true, ExportFileFormat.TSV, null);
         List<ModuleExportInfo> moduleInfos = enrolleeExportService.generateModuleInfos(options, sandboxEnvironmentId);
         List<Map<String, String>> exportData = enrolleeExportService.generateExportMaps(sandboxEnvironmentId, moduleInfos, options.limit());
 
@@ -121,7 +122,10 @@ public class PopulateOurhealthTest extends BasePopulatePortalsTest {
                 .findFirst().get();
         assertThat(jsalkMap.get("profile.mailingAddress.street1"), equalTo("415 Main Street"));
         assertThat(jsalkMap.get("oh_oh_cardioHx.oh_oh_cardioHx_worriedHeartHealth"),
-                equalTo("Yes, specifically about my heart"));
+                equalTo("yesSpecificallyAboutMyHeart"));
+        assertThat(jsalkMap.get("oh_oh_cardioHx.oh_oh_cardioHx_diagnosedHeartConditions.bleedingDisorder"), equalTo("1"));
+        assertThat(jsalkMap.get("oh_oh_cardioHx.oh_oh_cardioHx_diagnosedHeartConditions.anemia"), equalTo("1"));
+        assertThat(jsalkMap.get("oh_oh_cardioHx.oh_oh_cardioHx_diagnosedHeartConditions.cardiacArrest"), equalTo(null));
     }
 
     private void checkDataDictionary(UUID portalId, UUID sandboxEnvironmentId) throws Exception {

--- a/ui-admin/src/study/participants/export/ExportDataControl.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataControl.tsx
@@ -86,7 +86,7 @@ const ExportDataControl = ({ studyEnvContext, show, setShow }: {studyEnvContext:
           </label>
           <label>
             <input type="radio" name="humanReadable" value="false" checked={!humanReadable}
-              onChange={humanReadableChanged} className="me-1" disabled={true}/> Analysis-friendly
+              onChange={humanReadableChanged} className="me-1"/> Analysis-friendly
           </label>
         </div>
         <div className="py-2">


### PR DESCRIPTION
#### DESCRIPTION

Adds support for the analysis-friendly export of multi-select questions, with a separate column for each choice.  See https://broad-juniper.zendesk.com/hc/en-us/articles/18259824756123-Participant-List-Export-details for a description with examples.  

I'm sure I'm late to the game, but I finally set up Github copilot and used it while I was coding this.  Overall it was 'meh' but there were two places where it wrote entire reasonably complex and correct lines for me after I just typed 3-4 characters.  Bonus points to any reviewer who can identify those lines :)

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy ApiAdminApp
2. go to `localhost:3000/ourhealth/studies/ourheart/env/live/export/dataBrowser`
3. select 'Download'
4. choose 'analysis-friendly' format
5. downlaod
6. confirm the data exports and multiselect questions are rendered as columns.  (`oh_oh_cardioHx_diagnosedHeartConditions` should show 1s for JOSALK)
