### PR TITLE
JN-654:  adding link branding color

### DIFF
--- a/ui-participant/src/index.scss
+++ b/ui-participant/src/index.scss
@@ -54,7 +54,7 @@ code {
 
 a {
   text-decoration: none;
-  color: var(--brand-color);
+  color: var(--brand-color, blue);
 }
 
 .App .navbar-nav {

--- a/ui-participant/src/index.scss
+++ b/ui-participant/src/index.scss
@@ -54,6 +54,7 @@ code {
 
 a {
   text-decoration: none;
+  color: var(--brand-color);
 }
 
 .App .navbar-nav {


### PR DESCRIPTION
#### DESCRIPTION

OurHealth participant site links were showing as blue instead their theme color.  This fixes that.  Adding @nawatts  as a reviewer, because this fix seems too obvious, and so I'm wondering if there's some complexity about the theme application that I'm missing, and why this wasn't already a style.

BEFORE
![image](https://github.com/broadinstitute/juniper/assets/2800795/4810bf6f-8b95-4824-bd88-4992b6d8987a)

NOW:
![image](https://github.com/broadinstitute/juniper/assets/2800795/bde94c44-12db-4f9e-98f8-d2c274275799)



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  Go to https://sandbox.ourhealth.localhost:3001/
2. confirm footer and other links show up as the theme color