### PR TITLE
[JN-542] Provide template JSON when adding new sections

### DIFF
--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.test.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.test.tsx
@@ -4,6 +4,7 @@ import { setupRouterTest } from 'test-utils/router-testing-utils'
 import { mockHtmlPage } from 'test-utils/mock-site-content'
 import HtmlPageEditView from './HtmlPageEditView'
 import userEvent from '@testing-library/user-event'
+import { sectionTemplates } from './sectionTemplates'
 
 test('readOnly disables insert new section button', async () => {
   const mockPage = mockHtmlPage()
@@ -31,7 +32,7 @@ test('Insert Section button calls updatePage with a new blank HERO_WITH_IMAGE se
     ...mockPage,
     sections: [
       ...mockPage.sections,
-      { id: '', sectionType: 'HERO_WITH_IMAGE' }
+      { id: '', sectionType: 'HERO_WITH_IMAGE', sectionConfig: JSON.stringify(sectionTemplates['HERO_WITH_IMAGE']) }
     ]
   })
 })

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons'
-import { HtmlPage, HtmlSection, HtmlSectionView } from '@juniper/ui-core'
+import {HtmlPage, HtmlSection, HtmlSectionView, SectionType} from '@juniper/ui-core'
 import HtmlSectionEditor from './HtmlSectionEditor'
 import { Button } from 'components/forms/Button'
 import { sectionTemplates } from './sectionTemplates'
@@ -14,6 +14,12 @@ type HtmlPageViewProps = {
 
 /** Enables editing of a given page, showing the config and a preview for each section */
 const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => {
+  const DEFAULT_SECTION_TYPE = {
+    id: '',
+    sectionType: 'HERO_WITH_IMAGE' as SectionType,
+    sectionConfig: JSON.stringify(sectionTemplates['HERO_WITH_IMAGE'])
+  }
+
   //Inserts a new HtmlSection at the specified index on the page
   const insertNewSection = (sectionIndex: number, newSection: HtmlSection) => {
     const newSectionArray = [...htmlPage.sections]
@@ -31,10 +37,7 @@ const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => 
         aria-label={'Insert a blank section'}
         tooltip={'Insert a blank section'}
         disabled={readOnly}
-        onClick={() => insertNewSection(0, {
-          id: '', sectionType: 'HERO_WITH_IMAGE',
-          sectionConfig: JSON.stringify(sectionTemplates['HERO_WITH_IMAGE'])
-        })}>
+        onClick={() => insertNewSection(0, DEFAULT_SECTION_TYPE)}>
         <FontAwesomeIcon icon={faPlus}/> Insert section
       </Button>
     </div>
@@ -52,10 +55,7 @@ const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => 
             aria-label={'Insert a blank section'}
             tooltip={'Insert a blank section'}
             disabled={readOnly}
-            onClick={() => insertNewSection(index + 1, {
-              id: '', sectionType: 'HERO_WITH_IMAGE',
-              sectionConfig: JSON.stringify(sectionTemplates['HERO_WITH_IMAGE'])
-            })}>
+            onClick={() => insertNewSection(index + 1, DEFAULT_SECTION_TYPE)}>
             <FontAwesomeIcon icon={faPlus}/> Insert section
           </Button>
         </div>

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
@@ -4,6 +4,7 @@ import { faPlus } from '@fortawesome/free-solid-svg-icons'
 import { HtmlPage, HtmlSection, HtmlSectionView } from '@juniper/ui-core'
 import HtmlSectionEditor from './HtmlSectionEditor'
 import { Button } from 'components/forms/Button'
+import { sectionTemplates } from './sectionTemplates'
 
 type HtmlPageViewProps = {
   htmlPage: HtmlPage
@@ -30,7 +31,10 @@ const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => 
         aria-label={'Insert a blank section'}
         tooltip={'Insert a blank section'}
         disabled={readOnly}
-        onClick={() => insertNewSection(0, { id: '', sectionType: 'HERO_WITH_IMAGE' })}>
+        onClick={() => insertNewSection(0, {
+          id: '', sectionType: 'HERO_WITH_IMAGE',
+          sectionConfig: JSON.stringify(sectionTemplates['HERO_WITH_IMAGE'])
+        })}>
         <FontAwesomeIcon icon={faPlus}/> Insert section
       </Button>
     </div>
@@ -48,7 +52,10 @@ const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => 
             aria-label={'Insert a blank section'}
             tooltip={'Insert a blank section'}
             disabled={readOnly}
-            onClick={() => insertNewSection(index + 1, { id: '', sectionType: 'HERO_WITH_IMAGE' })}>
+            onClick={() => insertNewSection(index + 1, {
+              id: '', sectionType: 'HERO_WITH_IMAGE',
+              sectionConfig: JSON.stringify(sectionTemplates['HERO_WITH_IMAGE'])
+            })}>
             <FontAwesomeIcon icon={faPlus}/> Insert section
           </Button>
         </div>

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons'
-import {HtmlPage, HtmlSection, HtmlSectionView, SectionType} from '@juniper/ui-core'
+import { HtmlPage, HtmlSection, HtmlSectionView, SectionType } from '@juniper/ui-core'
 import HtmlSectionEditor from './HtmlSectionEditor'
 import { Button } from 'components/forms/Button'
 import { sectionTemplates } from './sectionTemplates'
@@ -31,7 +31,7 @@ const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => 
     updatePage(htmlPage)
   }
 
-  const renderAddSectionButton= (sectionIndex: number) => {
+  const renderAddSectionButton = (sectionIndex: number) => {
     return <div className="col-md-12 my-2" style={{ backgroundColor: '#eee' }}>
       <Button variant="secondary"
         aria-label={'Insert a blank section'}

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
@@ -31,16 +31,20 @@ const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => 
     updatePage(htmlPage)
   }
 
-  return <div>
-    <div className="col-md-12 my-2" style={{ backgroundColor: '#eee' }}>
+  const renderAddSectionButton= (sectionIndex: number) => {
+    return <div className="col-md-12 my-2" style={{ backgroundColor: '#eee' }}>
       <Button variant="secondary"
         aria-label={'Insert a blank section'}
         tooltip={'Insert a blank section'}
         disabled={readOnly}
-        onClick={() => insertNewSection(0, DEFAULT_SECTION_TYPE)}>
+        onClick={() => insertNewSection(sectionIndex, DEFAULT_SECTION_TYPE)}>
         <FontAwesomeIcon icon={faPlus}/> Insert section
       </Button>
     </div>
+  }
+
+  return <div>
+    { renderAddSectionButton(0) }
     {htmlPage.sections.map((section, index) => {
       return <div key={`${section.id}-${index}`} className="row g-0">
         <div className="col-md-4 p-2">
@@ -50,15 +54,7 @@ const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => 
         <div className="col-md-8">
           <HtmlSectionView section={section}/>
         </div>
-        <div className="col-md-12 my-2" style={{ backgroundColor: '#eee' }}>
-          <Button variant="secondary"
-            aria-label={'Insert a blank section'}
-            tooltip={'Insert a blank section'}
-            disabled={readOnly}
-            onClick={() => insertNewSection(index + 1, DEFAULT_SECTION_TYPE)}>
-            <FontAwesomeIcon icon={faPlus}/> Insert section
-          </Button>
-        </div>
+        { renderAddSectionButton(index + 1) }
       </div>
     })}
   </div>

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.test.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.test.tsx
@@ -4,6 +4,7 @@ import { setupRouterTest } from 'test-utils/router-testing-utils'
 import { mockHtmlPage, mockHtmlSection } from 'test-utils/mock-site-content'
 import HtmlSectionEditor from './HtmlSectionEditor'
 import userEvent from '@testing-library/user-event'
+import { sectionTemplates } from './sectionTemplates'
 
 test('readOnly disables section type selection', async () => {
   const mockPage = mockHtmlPage()
@@ -24,6 +25,34 @@ test('section type selection is enabled if the section type is unsaved', async (
       htmlPage={mockPage} updatePage={jest.fn}/>)
   render(RoutedComponent)
   expect(screen.getByLabelText('Select section type')).toBeEnabled()
+})
+
+test('switching section types sets the section config to the correct template', async () => {
+  //Arrange
+  const mockPage = mockHtmlPage()
+  const mockSection = mockPage.sections[0]
+  mockSection.id = ''
+  const mockUpdatePageFn = jest.fn()
+  const { RoutedComponent } = setupRouterTest(
+    <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={false}
+      htmlPage={mockPage} updatePage={mockUpdatePageFn}/>)
+  render(RoutedComponent)
+
+  //Act
+  const select = screen.getByLabelText('Select section type')
+  await userEvent.click(select)
+  const option = screen.getByText('FAQ')
+  await userEvent.click(option)
+
+  //Assert
+  expect(mockUpdatePageFn).toHaveBeenCalledWith({
+    ...mockPage,
+    sections: [{
+      ...mockSection,
+      sectionType: 'FAQ',
+      sectionConfig: JSON.stringify(sectionTemplates['FAQ'])
+    }]
+  })
 })
 
 test('DeleteSection button removes the section', async () => {

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
@@ -4,6 +4,7 @@ import Select from 'react-select'
 import { isEmpty } from 'lodash'
 import { IconButton } from 'components/forms/Button'
 import { faChevronDown, faChevronUp, faTimes } from '@fortawesome/free-solid-svg-icons'
+import { sectionTemplates } from './sectionTemplates'
 
 const SECTION_TYPES = [
   { label: 'FAQ', value: 'FAQ' },
@@ -96,8 +97,13 @@ const HtmlSectionEditor = ({
         isDisabled={readOnly || !isEmpty(section.id)}
         onChange={opt => {
           if (opt != undefined) {
+            const sectionTemplate = JSON.stringify(sectionTemplates[opt.label])
             setSectionTypeOpt(opt)
-            updateSection(sectionIndex, { ...section, sectionType: opt.value as SectionType })
+            updateSection(sectionIndex, {
+              ...section,
+              sectionType: opt.value as SectionType,
+              sectionConfig: sectionTemplate
+            })
           }
         }}/>
       <IconButton

--- a/ui-admin/src/portal/siteContent/sectionTemplates.ts
+++ b/ui-admin/src/portal/siteContent/sectionTemplates.ts
@@ -1,12 +1,140 @@
-//templates for all section types
-export const sectionTemplates = {
-  'faq': {
-    'title': '',
-    'questions': [
+/*
+ * This file contains template objects for each section type. These are used to populate
+ * the raw JSON section editor in the HtmlSectionEditor component. These templates aren't
+ * exhaustive; they do not provide every possible field for each section type, but they
+ * are a good starting point for creating new sections. Eventually we'll build a UI on
+ * top of this the raw JSON editor to make fields more configurable and easier to use.
+ */
+
+const templateImageConfig = {
+  cleanFileName: 'Enter cleanFileName here',
+  version: 1,
+  alt: 'Enter alt text here',
+  style: {
+    height: '40px'
+  }
+}
+
+const templatePhotoBio = {
+  image: { ...templateImageConfig },
+  name: 'Enter name here',
+  title: 'Enter title here',
+  blurb: 'Enter blurb here'
+}
+
+const templateSubgrid = {
+  title: 'Enter title here',
+  photoBios: [{
+    ...templatePhotoBio
+  }]
+}
+
+const templateMailingListButtonConfig = {
+  text: 'Join Mailing List',
+  type: 'mailingList'
+}
+
+const templateItemSection = {
+  title: 'Enter title here',
+  items: [{
+    ...templateMailingListButtonConfig
+  }]
+}
+
+const templateQuestion = {
+  question: 'Enter question here',
+  answer: 'Enter answer here'
+}
+
+export const sectionTemplates: Record<string, object> = {
+  'FAQ': {
+    title: 'Frequently Asked Questions',
+    blurb: 'Enter blurb here',
+    questions: [
       {
-        'question': '',
-        'answer': ''
+        ...templateQuestion
+      },
+      {
+        ...templateQuestion
+      }
+    ],
+    showToggleAllButton: true
+  },
+  'HERO_CENTERED': {
+    title: 'Enter title here',
+    blurb: 'Enter blurb here',
+    blurbAlign: 'center',
+    buttons: [
+      {
+        ...templateMailingListButtonConfig
       }
     ]
+  },
+  'HERO_WITH_IMAGE': {
+    title: 'Enter title here',
+    blurb: 'Enter blurb here',
+    fullWidth: true,
+    imagePosition: 'right',
+    buttons: [
+      {
+        ...templateMailingListButtonConfig
+      }
+    ],
+    logos: [
+      {
+        ...templateImageConfig
+      }
+    ]
+  },
+  'SOCIAL_MEDIA': {
+    twitterHandle: 'Enter Twitter handle here',
+    instagramHandle: 'Enter Instagram handle here',
+    facebookHandle: 'Enter Facebook handle here',
+    paddingBottom: 0
+  },
+  'STEP_OVERVIEW': {
+    title: 'Enter title here',
+    steps: [
+      {
+        blurb: 'Enter blurb here',
+        duration: '15-45 minutes',
+        image: {
+          ...templateImageConfig
+        }
+      }
+    ]
+  },
+  'PHOTO_BLURB_GRID': {
+    title: 'Enter title here',
+    subGrids: [
+      {
+        ...templateSubgrid
+      }
+    ]
+  },
+  'PARTICIPATION_DETAIL': {
+    actionButton: {
+      ...templateMailingListButtonConfig
+    },
+    blurb: 'Enter blurb here',
+    image: {
+      ...templateImageConfig
+    },
+    imagePosition: 'right',
+    stepNumberText: 'STEP 1',
+    timeIndication: '45+ minutes',
+    title: 'Enter title here'
+  },
+  'LINK_SECTIONS_FOOTER': {
+    itemSections: [
+      {
+        ...templateItemSection
+      }
+    ]
+  },
+  'BANNER_IMAGE': {
+    image: {
+      ...templateImageConfig
+    }
   }
 }

--- a/ui-admin/src/portal/siteContent/sectionTemplates.ts
+++ b/ui-admin/src/portal/siteContent/sectionTemplates.ts
@@ -1,0 +1,12 @@
+//templates for all section types
+export const sectionTemplates = {
+  'faq': {
+    'title': '',
+    'questions': [
+      {
+        'question': '',
+        'answer': ''
+      }
+    ]
+  }
+}

--- a/ui-admin/src/portal/siteContent/sectionTemplates.ts
+++ b/ui-admin/src/portal/siteContent/sectionTemplates.ts
@@ -3,7 +3,7 @@
  * the raw JSON section editor in the HtmlSectionEditor component. These templates aren't
  * exhaustive; they do not provide every possible field for each section type, but they
  * are a good starting point for creating new sections. Eventually we'll build a UI on
- * top of this the raw JSON editor to make fields more configurable and easier to use.
+ * top of this to make fields more configurable and easier to use.
  */
 
 const templateImageConfig = {

--- a/ui-admin/src/portal/siteContent/sectionTemplates.ts
+++ b/ui-admin/src/portal/siteContent/sectionTemplates.ts
@@ -74,6 +74,9 @@ export const sectionTemplates: Record<string, object> = {
     title: 'Enter title here',
     blurb: 'Enter blurb here',
     fullWidth: true,
+    image: {
+      ...templateImageConfig
+    },
     imagePosition: 'right',
     buttons: [
       {

--- a/ui-core/src/participant/landing/sections/FrequentlyAskedQuestionsTemplate.tsx
+++ b/ui-core/src/participant/landing/sections/FrequentlyAskedQuestionsTemplate.tsx
@@ -30,7 +30,7 @@ type FaqQuestion = {
   answer: string
 }
 
-type FrequentlyAskedQuestionsConfig = {
+export type FrequentlyAskedQuestionsConfig = {
   blurb?: string, //  text below the title
   questions: FaqQuestion[], // the questions
   showToggleAllButton?: boolean, // whether or not the show the expand/collapse button

--- a/ui-core/src/participant/landing/sections/FrequentlyAskedQuestionsTemplate.tsx
+++ b/ui-core/src/participant/landing/sections/FrequentlyAskedQuestionsTemplate.tsx
@@ -30,7 +30,7 @@ type FaqQuestion = {
   answer: string
 }
 
-export type FrequentlyAskedQuestionsConfig = {
+type FrequentlyAskedQuestionsConfig = {
   blurb?: string, //  text below the title
   questions: FaqQuestion[], // the questions
   showToggleAllButton?: boolean, // whether or not the show the expand/collapse button


### PR DESCRIPTION
#### DESCRIPTION

This improves the "Insert section" behavior by supplying default templates for each section type (except for `RAW_HTML`- I saw some TODO about looking into sanitization more so I figured I'd leave that out for the moment).

https://github.com/broadinstitute/juniper/assets/7257391/c2dd9468-3056-47fb-9a49-45dae9405fed

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Launch admin UI
* Add new sections in the site content editor: https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/siteContent
* Toggle types around and test that each section template works as expected

