### PR TITLE
[JN-629], [JN-630] Add consent form and preEnroll buttons

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConfiguredConsentController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConfiguredConsentController.java
@@ -43,7 +43,20 @@ public class ConfiguredConsentController implements ConfiguredConsentApi {
         objectMapper.convertValue(body, StudyEnvironmentConsent.class);
     var savedConfig =
         consentFormExtService.updateConfiguredConsent(
-            portalShortcode, environmentName, configuredForm, adminUser);
+            portalShortcode, environmentName, studyShortcode, configuredForm, adminUser);
+    return ResponseEntity.ok(savedConfig);
+  }
+
+  @Override
+  public ResponseEntity<Object> create(
+      String portalShortcode, String studyShortcode, String envName, Object body) {
+    AdminUser adminUser = authUtilService.requireAdminUser(request);
+    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
+    StudyEnvironmentConsent configuredForm =
+        objectMapper.convertValue(body, StudyEnvironmentConsent.class);
+    var savedConfig =
+        consentFormExtService.createConfiguredConsent(
+            portalShortcode, environmentName, studyShortcode, configuredForm, adminUser);
     return ResponseEntity.ok(savedConfig);
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConfiguredSurveyController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConfiguredSurveyController.java
@@ -44,7 +44,7 @@ public class ConfiguredSurveyController implements ConfiguredSurveyApi {
 
     StudyEnvironmentSurvey savedSes =
         surveyExtService.updateConfiguredSurvey(
-            portalShortcode, environmentName, configuredSurvey, adminUser);
+            portalShortcode, environmentName, studyShortcode, configuredSurvey, adminUser);
     return ResponseEntity.ok(savedSes);
   }
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConsentFormController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConsentFormController.java
@@ -39,4 +39,16 @@ public class ConsentFormController implements ConsentFormApi {
         consentFormExtService.createNewVersion(portalShortcode, consentForm, adminUser);
     return ResponseEntity.ok(savedConsent);
   }
+
+  @Override
+  public ResponseEntity<Object> create(String portalShortcode, String stableId, Object body) {
+    AdminUser adminUser = authUtilService.requireAdminUser(request);
+    ConsentForm consentForm = objectMapper.convertValue(body, ConsentForm.class);
+    if (!stableId.equals(consentForm.getStableId())) {
+      throw new IllegalArgumentException("form parameters don't match");
+    }
+    ConsentForm savedConsent =
+        consentFormExtService.create(portalShortcode, consentForm, adminUser);
+    return ResponseEntity.ok(savedConsent);
+  }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/ConsentFormExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/ConsentFormExtService.java
@@ -86,7 +86,7 @@ public class ConsentFormExtService {
     }
     if (!studyEnv.getId().equals(updatedObj.getStudyEnvironmentId())) {
       throw new IllegalArgumentException(
-              "Study environment id in request body does belong to this study");
+          "Study environment id in request body does belong to this study");
     }
     return studyEnv;
   }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/ConsentFormExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/ConsentFormExtService.java
@@ -6,9 +6,10 @@ import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.consent.ConsentForm;
 import bio.terra.pearl.core.model.consent.StudyEnvironmentConsent;
 import bio.terra.pearl.core.model.portal.Portal;
+import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.service.consent.ConsentFormService;
-import bio.terra.pearl.core.service.exception.PermissionDeniedException;
 import bio.terra.pearl.core.service.study.StudyEnvironmentConsentService;
+import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 
@@ -17,38 +18,76 @@ public class ConsentFormExtService {
   private AuthUtilService authUtilService;
   private ConsentFormService consentFormService;
   private StudyEnvironmentConsentService studyEnvironmentConsentService;
+  private StudyEnvironmentService studyEnvironmentService;
 
   public ConsentFormExtService(
       AuthUtilService authUtilService,
       ConsentFormService consentFormService,
-      StudyEnvironmentConsentService studyEnvironmentConsentService) {
+      StudyEnvironmentConsentService studyEnvironmentConsentService,
+      StudyEnvironmentService studyEnvironmentService) {
     this.authUtilService = authUtilService;
     this.consentFormService = consentFormService;
     this.studyEnvironmentConsentService = studyEnvironmentConsentService;
+    this.studyEnvironmentService = studyEnvironmentService;
   }
 
   public ConsentForm createNewVersion(
       String portalShortcode, ConsentForm consentForm, AdminUser user) {
-    if (!user.isSuperuser()) {
-      throw new PermissionDeniedException("You do not have permissions to perform this operation");
-    }
     Portal portal = authUtilService.authUserToPortal(user, portalShortcode);
     return consentFormService.createNewVersion(portal.getId(), consentForm);
+  }
+
+  public ConsentForm create(String portalShortcode, ConsentForm consentForm, AdminUser user) {
+    Portal portal = authUtilService.authUserToPortal(user, portalShortcode);
+    consentForm.setPortalId(portal.getId());
+    return consentFormService.create(consentForm);
   }
 
   public StudyEnvironmentConsent updateConfiguredConsent(
       String portalShortcode,
       EnvironmentName envName,
+      String studyShortcode,
       StudyEnvironmentConsent updatedObj,
       AdminUser user) {
-    authUtilService.authUserToPortal(user, portalShortcode);
-    if (!EnvironmentName.sandbox.equals(envName)) {
-      throw new IllegalArgumentException(
-          "Updates can only be made directly to the sandbox environment".formatted(envName));
-    }
+    authConfiguredConsentRequest(portalShortcode, envName, studyShortcode, updatedObj, user);
     StudyEnvironmentConsent existing =
         studyEnvironmentConsentService.find(updatedObj.getId()).get();
     BeanUtils.copyProperties(updatedObj, existing);
     return studyEnvironmentConsentService.update(existing);
+  }
+
+  public StudyEnvironmentConsent createConfiguredConsent(
+      String portalShortcode,
+      EnvironmentName envName,
+      String studyShortcode,
+      StudyEnvironmentConsent newObj,
+      AdminUser user) {
+    authConfiguredConsentRequest(portalShortcode, envName, studyShortcode, newObj, user);
+    return studyEnvironmentConsentService.create(newObj);
+  }
+
+  /**
+   * confirms the user has access to the study and that the consent belongs to that study, and that
+   * it's in the sandbox environment. Returns the study environment for which the change is being
+   * made in.
+   */
+  protected StudyEnvironment authConfiguredConsentRequest(
+      String portalShortcode,
+      EnvironmentName envName,
+      String studyShortcode,
+      StudyEnvironmentConsent updatedObj,
+      AdminUser user) {
+    authUtilService.authUserToStudy(user, portalShortcode, studyShortcode);
+    StudyEnvironment studyEnv = studyEnvironmentService.findByStudy(studyShortcode, envName).get();
+    if (!EnvironmentName.sandbox.equals(envName)
+        || !EnvironmentName.sandbox.equals(studyEnv.getEnvironmentName())) {
+      throw new IllegalArgumentException(
+          "Updates can only be made directly to the sandbox environment".formatted(envName));
+    }
+    if (!studyEnv.getId().equals(updatedObj.getStudyEnvironmentId())) {
+      throw new IllegalArgumentException(
+              "Study environment id in request body does belong to this study");
+    }
+    return studyEnv;
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/ConsentFormExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/ConsentFormExtService.java
@@ -70,6 +70,7 @@ public class ConsentFormExtService {
    * confirms the user has access to the study and that the consent belongs to that study, and that
    * it's in the sandbox environment. Returns the study environment for which the change is being
    * made in.
+   * @param updatedObj -- a StudyEnvironmentConsent object the user is requesting to create or modify
    */
   protected StudyEnvironment authConfiguredConsentRequest(
       String portalShortcode,
@@ -78,12 +79,11 @@ public class ConsentFormExtService {
       StudyEnvironmentConsent updatedObj,
       AdminUser user) {
     authUtilService.authUserToStudy(user, portalShortcode, studyShortcode);
-    StudyEnvironment studyEnv = studyEnvironmentService.findByStudy(studyShortcode, envName).get();
-    if (!EnvironmentName.sandbox.equals(envName)
-        || !EnvironmentName.sandbox.equals(studyEnv.getEnvironmentName())) {
+    if (!EnvironmentName.sandbox.equals(envName)) {
       throw new IllegalArgumentException(
-          "Updates can only be made directly to the sandbox environment".formatted(envName));
+              "Updates can only be made directly to the sandbox environment");
     }
+    StudyEnvironment studyEnv = studyEnvironmentService.findByStudy(studyShortcode, envName).get();
     if (!studyEnv.getId().equals(updatedObj.getStudyEnvironmentId())) {
       throw new IllegalArgumentException(
           "Study environment id in request body does belong to this study");

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/ConsentFormExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/ConsentFormExtService.java
@@ -70,7 +70,9 @@ public class ConsentFormExtService {
    * confirms the user has access to the study and that the consent belongs to that study, and that
    * it's in the sandbox environment. Returns the study environment for which the change is being
    * made in.
-   * @param updatedObj -- a StudyEnvironmentConsent object the user is requesting to create or modify
+   *
+   * @param updatedObj -- a StudyEnvironmentConsent object the user is requesting to create or
+   *     modify
    */
   protected StudyEnvironment authConfiguredConsentRequest(
       String portalShortcode,
@@ -81,7 +83,7 @@ public class ConsentFormExtService {
     authUtilService.authUserToStudy(user, portalShortcode, studyShortcode);
     if (!EnvironmentName.sandbox.equals(envName)) {
       throw new IllegalArgumentException(
-              "Updates can only be made directly to the sandbox environment");
+          "Updates can only be made directly to the sandbox environment");
     }
     StudyEnvironment studyEnv = studyEnvironmentService.findByStudy(studyShortcode, envName).get();
     if (!studyEnv.getId().equals(updatedObj.getStudyEnvironmentId())) {

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
@@ -4,7 +4,6 @@ import bio.terra.pearl.api.admin.service.AuthUtilService;
 import bio.terra.pearl.core.model.BaseEntity;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
-import bio.terra.pearl.core.model.consent.StudyEnvironmentConsent;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
@@ -139,7 +138,8 @@ public class SurveyExtService {
       EnvironmentName envName,
       UUID configuredSurveyId,
       AdminUser user) {
-    StudyEnvironmentSurvey configuredSurvey = studyEnvironmentSurveyService.find(configuredSurveyId).get();
+    StudyEnvironmentSurvey configuredSurvey =
+        studyEnvironmentSurveyService.find(configuredSurveyId).get();
     authConfiguredSurveyRequest(portalShortcode, envName, studyShortcode, configuredSurvey, user);
     studyEnvironmentSurveyService.deactivate(configuredSurveyId);
   }
@@ -170,26 +170,26 @@ public class SurveyExtService {
   }
 
   /**
-   * confirms the user has access to the study and that the configured survey belongs to that study, and that
-   * it's in the sandbox environment. Returns the study environment for which the change is being
-   * made in.
+   * confirms the user has access to the study and that the configured survey belongs to that study,
+   * and that it's in the sandbox environment. Returns the study environment for which the change is
+   * being made in.
    */
   protected StudyEnvironment authConfiguredSurveyRequest(
-          String portalShortcode,
-          EnvironmentName envName,
-          String studyShortcode,
-          StudyEnvironmentSurvey updatedObj,
-          AdminUser user) {
+      String portalShortcode,
+      EnvironmentName envName,
+      String studyShortcode,
+      StudyEnvironmentSurvey updatedObj,
+      AdminUser user) {
     authUtilService.authUserToStudy(user, portalShortcode, studyShortcode);
     StudyEnvironment studyEnv = studyEnvironmentService.findByStudy(studyShortcode, envName).get();
     if (!EnvironmentName.sandbox.equals(envName)
-            || !EnvironmentName.sandbox.equals(studyEnv.getEnvironmentName())) {
+        || !EnvironmentName.sandbox.equals(studyEnv.getEnvironmentName())) {
       throw new IllegalArgumentException(
-              "Updates can only be made directly to the sandbox environment".formatted(envName));
+          "Updates can only be made directly to the sandbox environment".formatted(envName));
     }
     if (!studyEnv.getId().equals(updatedObj.getStudyEnvironmentId())) {
       throw new IllegalArgumentException(
-              "Study environment id in request body does not belong to this study");
+          "Study environment id in request body does not belong to this study");
     }
     return studyEnv;
   }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
@@ -125,10 +125,6 @@ public class SurveyExtService {
       StudyEnvironmentSurvey surveyToConfigure,
       AdminUser user) {
     authConfiguredSurveyRequest(portalShortcode, envName, studyShortcode, surveyToConfigure, user);
-    if (!EnvironmentName.sandbox.equals(envName)) {
-      throw new IllegalArgumentException(
-          "Updates can only be made directly to the sandbox environment".formatted(envName));
-    }
     return studyEnvironmentSurveyService.create(surveyToConfigure);
   }
 

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -308,6 +308,41 @@ paths:
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/consentForms/{stableId}:
+    post:
+      summary: Saves a new consentForm with anew stableId as a new form -- will be assigned version 1
+      tags: [ consentForm ]
+      operationId: create
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: stableId, in: path, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content: { application/json: { schema: { type: object } } }
+      responses:
+        '200':
+          description: saved survey object
+          content: { application/json: { schema: { type: object } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/configuredConsents:
+    post:
+      summary: creates a configured consent for a study environment
+      tags: [ configuredConsent ]
+      operationId: create
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: studyShortcode, in: path, required: true, schema: { type: string } }
+        - { name: envName, in: path, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content: { application/json: { schema: { schema: { type: object } } } }
+      responses:
+        '200':
+          description: saved configuredConsent object
+          content: { application/json: { schema: { schema: { type: object } } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/configuredConsents/{configConsentId}:
     patch:
       summary: Updates a configured consent, such as by updating to a new version of the consent

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/ConsentFormExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/ConsentFormExtServiceTests.java
@@ -1,0 +1,111 @@
+package bio.terra.pearl.api.admin.service.forms;
+
+import bio.terra.pearl.api.admin.BaseSpringBootTest;
+import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
+import bio.terra.pearl.core.factory.admin.AdminUserFactory;
+import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.model.admin.PortalAdminUser;
+import bio.terra.pearl.core.model.consent.StudyEnvironmentConsent;
+import bio.terra.pearl.core.service.admin.PortalAdminUserService;
+import bio.terra.pearl.core.service.exception.NotFoundException;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+public class ConsentFormExtServiceTests extends BaseSpringBootTest {
+  @Autowired private AdminUserFactory adminUserFactory;
+  @Autowired private StudyEnvironmentFactory studyEnvironmentFactory;
+  @Autowired private ConsentFormExtService consentFormExtService;
+  @Autowired private PortalAdminUserService portalAdminUserService;
+
+  @Test
+  @Transactional
+  public void testUpdateConfiguredConsentAuth(TestInfo testInfo) {
+    AdminUser user = adminUserFactory.buildPersisted(getTestName(testInfo), false);
+    var envBundle = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.irb);
+
+    // auths to portal
+    Assertions.assertThrows(
+        NotFoundException.class,
+        () -> {
+          consentFormExtService.updateConfiguredConsent(
+              envBundle.getPortal().getShortcode(),
+              envBundle.getPortalEnv().getEnvironmentName(),
+              envBundle.getStudy().getShortcode(),
+              StudyEnvironmentConsent.builder()
+                  .consentFormId(UUID.randomUUID())
+                  .studyEnvironmentId(envBundle.getStudyEnv().getId())
+                  .build(),
+              user);
+        });
+
+    portalAdminUserService.create(
+        PortalAdminUser.builder()
+            .portalId(envBundle.getPortal().getId())
+            .adminUserId(user.getId())
+            .build());
+
+    // can't directly update IRB environment
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          consentFormExtService.updateConfiguredConsent(
+              envBundle.getPortal().getShortcode(),
+              envBundle.getPortalEnv().getEnvironmentName(),
+              envBundle.getStudy().getShortcode(),
+              StudyEnvironmentConsent.builder()
+                  .consentFormId(UUID.randomUUID())
+                  .studyEnvironmentId(envBundle.getStudyEnv().getId())
+                  .build(),
+              user);
+        });
+  }
+
+  @Test
+  @Transactional
+  public void testCreateConfiguredConsentAuth(TestInfo testInfo) {
+    AdminUser user = adminUserFactory.buildPersisted(getTestName(testInfo), false);
+    var envBundle =
+        studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.live);
+
+    // auths to portal
+    Assertions.assertThrows(
+        NotFoundException.class,
+        () -> {
+          consentFormExtService.createConfiguredConsent(
+              envBundle.getPortal().getShortcode(),
+              envBundle.getPortalEnv().getEnvironmentName(),
+              envBundle.getStudy().getShortcode(),
+              StudyEnvironmentConsent.builder()
+                  .consentFormId(UUID.randomUUID())
+                  .studyEnvironmentId(envBundle.getStudyEnv().getId())
+                  .build(),
+              user);
+        });
+
+    portalAdminUserService.create(
+        PortalAdminUser.builder()
+            .portalId(envBundle.getPortal().getId())
+            .adminUserId(user.getId())
+            .build());
+
+    // can't directly update Live environment
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          consentFormExtService.createConfiguredConsent(
+              envBundle.getPortal().getShortcode(),
+              envBundle.getPortalEnv().getEnvironmentName(),
+              envBundle.getStudy().getShortcode(),
+              StudyEnvironmentConsent.builder()
+                  .consentFormId(UUID.randomUUID())
+                  .studyEnvironmentId(envBundle.getStudyEnv().getId())
+                  .build(),
+              user);
+        });
+  }
+}

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/StudyEnvironmentFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/StudyEnvironmentFactory.java
@@ -70,7 +70,7 @@ public class StudyEnvironmentFactory {
     }
 
     public StudyEnvironmentBundle buildBundle(String testName, EnvironmentName envName) {
-        PortalEnvironment portalEnvironment = portalEnvironmentFactory.buildPersisted(testName);
+        PortalEnvironment portalEnvironment = portalEnvironmentFactory.buildPersisted(testName, envName);
         Study study = studyFactory.buildPersisted(portalEnvironment.getPortalId(), testName);
         StudyEnvironment studyEnvironment = buildPersisted(envName, study.getId(), testName);
         Portal portal = portalService.find(portalEnvironment.getPortalId()).get();

--- a/ui-admin/src/api/api-utils.tsx
+++ b/ui-admin/src/api/api-utils.tsx
@@ -3,8 +3,9 @@ import { failureNotification } from 'util/notifications'
 import { Store } from 'react-notifications-component'
 
 export type ApiErrorResponse = {
-    message: string,
-    statusCode: number
+  message: string,
+  error?: string
+  statusCode: number
 }
 
 const errorSuffix = 'If this error persists, please contact support@juniper.terra.bio'
@@ -26,7 +27,7 @@ export const defaultApiErrorHandle = (error: ApiErrorResponse,
   } else {
     Store.addNotification(failureNotification(<div>
       <div>{errorHeader}</div>
-      <div>{error.message}</div>
+      <div>{error.message ?? error.error}</div>
       <div>{errorSuffix}</div>
     </div>
     ))

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -571,7 +571,7 @@ export default {
   },
 
   async createConfiguredConsent(portalShortcode: string, studyShortcode: string, environmentName: string,
-                               configuredConsent: StudyEnvironmentConsent): Promise<StudyEnvironmentSurvey> {
+    configuredConsent: StudyEnvironmentConsent): Promise<StudyEnvironmentSurvey> {
     const url =`${API_ROOT}/portals/v1/${portalShortcode}/studies/${studyShortcode}` +
         `/env/${environmentName}/configuredConsents`
 

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -571,7 +571,7 @@ export default {
   },
 
   async createConfiguredConsent(portalShortcode: string, studyShortcode: string, environmentName: string,
-    configuredConsent: StudyEnvironmentConsent): Promise<StudyEnvironmentSurvey> {
+    configuredConsent: StudyEnvironmentConsent): Promise<StudyEnvironmentConsent> {
     const url =`${API_ROOT}/portals/v1/${portalShortcode}/studies/${studyShortcode}` +
         `/env/${environmentName}/configuredConsents`
 

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -547,6 +547,17 @@ export default {
     return await this.processJsonResponse(response)
   },
 
+  async createNewConsentForm(portalShortcode: string, consentForm: ConsentForm): Promise<ConsentForm> {
+    const url = `${API_ROOT}/portals/v1/${portalShortcode}/consentForms/`
+        + `${consentForm.stableId}`
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: this.getInitHeaders(),
+      body: JSON.stringify(consentForm)
+    })
+    return await this.processJsonResponse(response)
+  },
+
   async createNewConsentVersion(portalShortcode: string, consentForm: ConsentForm): Promise<ConsentForm> {
     const url = `${API_ROOT}/portals/v1/${portalShortcode}/consentForms/`
       + `${consentForm.stableId}/${consentForm.version}/newVersion`
@@ -555,6 +566,19 @@ export default {
       method: 'POST',
       headers: this.getInitHeaders(),
       body: JSON.stringify(consentForm)
+    })
+    return await this.processJsonResponse(response)
+  },
+
+  async createConfiguredConsent(portalShortcode: string, studyShortcode: string, environmentName: string,
+                               configuredConsent: StudyEnvironmentConsent): Promise<StudyEnvironmentSurvey> {
+    const url =`${API_ROOT}/portals/v1/${portalShortcode}/studies/${studyShortcode}` +
+        `/env/${environmentName}/configuredConsents`
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: this.getInitHeaders(),
+      body: JSON.stringify(configuredConsent)
     })
     return await this.processJsonResponse(response)
   },

--- a/ui-admin/src/study/StudyContent.tsx
+++ b/ui-admin/src/study/StudyContent.tsx
@@ -9,7 +9,8 @@ import { faEllipsisH } from '@fortawesome/free-solid-svg-icons'
 import ArchiveSurveyModal from './surveys/ArchiveSurveyModal'
 import DeleteSurveyModal from './surveys/DeleteSurveyModal'
 import { StudyEnvironmentSurvey } from '@juniper/ui-core'
-import CreateConsentModal from "./consents/CreateConsentModal";
+import CreateConsentModal from './consents/CreateConsentModal'
+import {Button, IconButton} from "../components/forms/Button";
 
 /** renders the main configuration page for a study environment */
 function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
@@ -87,10 +88,8 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
                       </Link>
                     </div>
                     { !isReadOnlyEnv && <div className="nav-item dropdown ms-1">
-                      <a className="btn btn-secondary ms-2" href="#" role="button" data-bs-toggle="dropdown"
-                         aria-expanded="false">
-                        <FontAwesomeIcon icon={faEllipsisH} className="fa-lg" title="configure survey menu"/>
-                      </a>
+                      <IconButton icon={faEllipsisH}  data-bs-toggle="dropdown"
+                                  aria-expanded="false" aria-label="configure survey menu"/>
                       <div className="dropdown-menu">
                         <ul className="list-unstyled">
                           <li>
@@ -118,11 +117,11 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
                 )
               })}
               <li>
-                <button className="btn btn-secondary" data-testid={'addSurvey'} onClick={() => {
+                <Button variant="secondary" data-testid={'addSurvey'} onClick={() => {
                   setShowCreateSurveyModal(!showCreateSurveyModal)
                 }}>
                   <FontAwesomeIcon icon={faPlus}/> Add
-                </button>
+                </Button>
               </li>
             </ul>
           </div>
@@ -139,7 +138,7 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
         selectedSurveyConfig={selectedSurveyConfig}
         onDismiss={() => setShowDeleteSurveyModal(false)}/> }
       { showCreateConsentModal && <CreateConsentModal studyEnvContext={studyEnvContext}
-                                                      onDismiss={() => setShowCreateConsentModal(false)}/>}
+        onDismiss={() => setShowCreateConsentModal(false)}/>}
       { !currentEnv.studyEnvironmentConfig.initialized && <div>Not yet initialized</div> }
     </div>
   </div>

--- a/ui-admin/src/study/StudyContent.tsx
+++ b/ui-admin/src/study/StudyContent.tsx
@@ -9,6 +9,7 @@ import { faEllipsisH } from '@fortawesome/free-solid-svg-icons'
 import ArchiveSurveyModal from './surveys/ArchiveSurveyModal'
 import DeleteSurveyModal from './surveys/DeleteSurveyModal'
 import { StudyEnvironmentSurvey } from '@juniper/ui-core'
+import CreateConsentModal from "./consents/CreateConsentModal";
 
 /** renders the main configuration page for a study environment */
 function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
@@ -21,6 +22,7 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
   const preEnrollSurvey = currentEnv.preEnrollSurvey
   const isReadOnlyEnv = !(currentEnv.environmentName === 'sandbox')
   const [showCreateSurveyModal, setShowCreateSurveyModal] = useState(false)
+  const [showCreateConsentModal, setShowCreateConsentModal] = useState(false)
   const [showArchiveSurveyModal, setShowArchiveSurveyModal] = useState(false)
   const [showDeleteSurveyModal, setShowDeleteSurveyModal] = useState(false)
   const [selectedSurveyConfig, setSelectedSurveyConfig] = useState<StudyEnvironmentSurvey>()
@@ -59,6 +61,13 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
                   </Link>
                 </li>
               }) }
+              <li>
+                <button className="btn btn-secondary" data-testid={'addConsent'} onClick={() => {
+                  setShowCreateConsentModal(!showCreateConsentModal)
+                }}>
+                  <FontAwesomeIcon icon={faPlus}/> Add
+                </button>
+              </li>
             </ul>
           </div>
         </li>
@@ -78,8 +87,9 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
                       </Link>
                     </div>
                     { !isReadOnlyEnv && <div className="nav-item dropdown ms-1">
-                      <a className="nav-link" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                        <FontAwesomeIcon icon={faEllipsisH} title="configure survey menu"/>
+                      <a className="btn btn-secondary ms-2" href="#" role="button" data-bs-toggle="dropdown"
+                         aria-expanded="false">
+                        <FontAwesomeIcon icon={faEllipsisH} className="fa-lg" title="configure survey menu"/>
                       </a>
                       <div className="dropdown-menu">
                         <ul className="list-unstyled">
@@ -119,18 +129,17 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
 
         </li>
       </ul> }
-      { <CreateSurveyModal studyEnvContext={studyEnvContext}
+      { showCreateSurveyModal && <CreateSurveyModal studyEnvContext={studyEnvContext}
         isReadOnlyEnv={isReadOnlyEnv}
-        show={showCreateSurveyModal}
-        setShow={setShowCreateSurveyModal}/> }
-      { selectedSurveyConfig && <ArchiveSurveyModal studyEnvContext={studyEnvContext}
+        onDismiss={() => setShowCreateSurveyModal(false)}/> }
+      { (showArchiveSurveyModal && selectedSurveyConfig) && <ArchiveSurveyModal studyEnvContext={studyEnvContext}
         selectedSurveyConfig={selectedSurveyConfig}
-        show={showArchiveSurveyModal}
-        setShow={setShowArchiveSurveyModal}/> }
-      { selectedSurveyConfig && <DeleteSurveyModal studyEnvContext={studyEnvContext}
+        onDismiss={() => setShowArchiveSurveyModal(false)}/> }
+      { (showDeleteSurveyModal && selectedSurveyConfig) && <DeleteSurveyModal studyEnvContext={studyEnvContext}
         selectedSurveyConfig={selectedSurveyConfig}
-        show={showDeleteSurveyModal}
-        setShow={setShowDeleteSurveyModal}/> }
+        onDismiss={() => setShowDeleteSurveyModal(false)}/> }
+      { showCreateConsentModal && <CreateConsentModal studyEnvContext={studyEnvContext}
+                                                      onDismiss={() => setShowCreateConsentModal(false)}/>}
       { !currentEnv.studyEnvironmentConfig.initialized && <div>Not yet initialized</div> }
     </div>
   </div>

--- a/ui-admin/src/study/StudyContent.tsx
+++ b/ui-admin/src/study/StudyContent.tsx
@@ -10,7 +10,7 @@ import ArchiveSurveyModal from './surveys/ArchiveSurveyModal'
 import DeleteSurveyModal from './surveys/DeleteSurveyModal'
 import { StudyEnvironmentSurvey } from '@juniper/ui-core'
 import CreateConsentModal from './consents/CreateConsentModal'
-import {Button, IconButton} from "../components/forms/Button";
+import { Button, IconButton } from '../components/forms/Button'
 
 /** renders the main configuration page for a study environment */
 function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
@@ -89,7 +89,7 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
                     </div>
                     { !isReadOnlyEnv && <div className="nav-item dropdown ms-1">
                       <IconButton icon={faEllipsisH}  data-bs-toggle="dropdown"
-                                  aria-expanded="false" aria-label="configure survey menu"/>
+                        aria-expanded="false" aria-label="configure survey menu"/>
                       <div className="dropdown-menu">
                         <ul className="list-unstyled">
                           <li>

--- a/ui-admin/src/study/StudyContent.tsx
+++ b/ui-admin/src/study/StudyContent.tsx
@@ -11,6 +11,7 @@ import DeleteSurveyModal from './surveys/DeleteSurveyModal'
 import { StudyEnvironmentSurvey } from '@juniper/ui-core'
 import CreateConsentModal from './consents/CreateConsentModal'
 import { Button, IconButton } from '../components/forms/Button'
+import CreatePreEnrollSurveyModal from './surveys/CreatePreEnrollSurveyModal'
 
 /** renders the main configuration page for a study environment */
 function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
@@ -26,6 +27,7 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
   const [showCreateConsentModal, setShowCreateConsentModal] = useState(false)
   const [showArchiveSurveyModal, setShowArchiveSurveyModal] = useState(false)
   const [showDeleteSurveyModal, setShowDeleteSurveyModal] = useState(false)
+  const [showCreatePreEnrollSurveyModal, setShowCreatePreEnrollModal] = useState(false)
   const [selectedSurveyConfig, setSelectedSurveyConfig] = useState<StudyEnvironmentSurvey>()
 
   currentEnv.configuredSurveys
@@ -41,11 +43,36 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
             <h6>Pre-enrollment questionnaire</h6>
           </div>
           <div className="flex-grow-1 p-3">
-            { preEnrollSurvey && <ul className="list-unstyled"><li>
-              <Link to={`preEnroll/${preEnrollSurvey.stableId}?readOnly=${isReadOnlyEnv}`}>
-                {preEnrollSurvey.name} <span className="detail">v{preEnrollSurvey.version}</span>
-              </Link>
-            </li></ul>}
+            { preEnrollSurvey && <ul className="list-unstyled">
+              <li className="d-flex align-items-center">
+                <Link to={`preEnroll/${preEnrollSurvey.stableId}?readOnly=${isReadOnlyEnv}`}>
+                  {preEnrollSurvey.name} <span className="detail">v{preEnrollSurvey.version}</span>
+                </Link>
+
+                { !isReadOnlyEnv && <div className="nav-item dropdown ms-1">
+                  <IconButton icon={faEllipsisH}  data-bs-toggle="dropdown"
+                    aria-expanded="false" aria-label="configure survey menu"/>
+                  <div className="dropdown-menu">
+                    <ul className="list-unstyled">
+                      <li>
+                        <button className="dropdown-item"
+                          onClick={() => alert('To remove a pre-enroll survey, contact support')}>
+                          Remove
+                        </button>
+                      </li>
+                    </ul>
+                  </div>
+                </div> }
+              </li>
+            </ul>}
+            { (!preEnrollSurvey && !isReadOnlyEnv) && <Button variant="secondary"
+              data-testid={'addPreEnroll'}
+              onClick={() => {
+                setShowCreatePreEnrollModal(!showCreatePreEnrollSurveyModal)
+              }}>
+              <FontAwesomeIcon icon={faPlus}/> Add
+            </Button>
+            }
           </div>
         </li>
         <li className="mb-3 bg-white">
@@ -63,11 +90,11 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
                 </li>
               }) }
               <li>
-                <button className="btn btn-secondary" data-testid={'addConsent'} onClick={() => {
+                { !isReadOnlyEnv && <button className="btn btn-secondary" data-testid={'addConsent'} onClick={() => {
                   setShowCreateConsentModal(!showCreateConsentModal)
                 }}>
                   <FontAwesomeIcon icon={faPlus}/> Add
-                </button>
+                </button> }
               </li>
             </ul>
           </div>
@@ -116,20 +143,18 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
                   </li>
                 )
               })}
-              <li>
+              {!isReadOnlyEnv && <li>
                 <Button variant="secondary" data-testid={'addSurvey'} onClick={() => {
                   setShowCreateSurveyModal(!showCreateSurveyModal)
                 }}>
                   <FontAwesomeIcon icon={faPlus}/> Add
                 </Button>
-              </li>
+              </li> }
             </ul>
           </div>
-
         </li>
       </ul> }
       { showCreateSurveyModal && <CreateSurveyModal studyEnvContext={studyEnvContext}
-        isReadOnlyEnv={isReadOnlyEnv}
         onDismiss={() => setShowCreateSurveyModal(false)}/> }
       { (showArchiveSurveyModal && selectedSurveyConfig) && <ArchiveSurveyModal studyEnvContext={studyEnvContext}
         selectedSurveyConfig={selectedSurveyConfig}
@@ -139,6 +164,8 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
         onDismiss={() => setShowDeleteSurveyModal(false)}/> }
       { showCreateConsentModal && <CreateConsentModal studyEnvContext={studyEnvContext}
         onDismiss={() => setShowCreateConsentModal(false)}/>}
+      { showCreatePreEnrollSurveyModal && <CreatePreEnrollSurveyModal studyEnvContext={studyEnvContext}
+        onDismiss={() => setShowCreatePreEnrollModal(false)}/> }
       { !currentEnv.studyEnvironmentConfig.initialized && <div>Not yet initialized</div> }
     </div>
   </div>

--- a/ui-admin/src/study/StudyContent.tsx
+++ b/ui-admin/src/study/StudyContent.tsx
@@ -53,7 +53,7 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
 
                 { !isReadOnlyEnv && <div className="nav-item dropdown ms-1">
                   <IconButton icon={faEllipsisH}  data-bs-toggle="dropdown"
-                    aria-expanded="false" aria-label="configure survey menu"/>
+                    aria-expanded="false" aria-label="configure pre-enroll menu"/>
                   <div className="dropdown-menu">
                     <ul className="list-unstyled">
                       <li>

--- a/ui-admin/src/study/StudyContent.tsx
+++ b/ui-admin/src/study/StudyContent.tsx
@@ -44,7 +44,7 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
           <div style={contentHeaderStyle}>
             <h6>Pre-enrollment questionnaire</h6>
           </div>
-          <div className="flex-grow-1 p-3">
+          <div className="flex-grow-1 pt-3">
             { preEnrollSurvey && <ul className="list-unstyled">
               <li className="d-flex align-items-center">
                 <Link to={`preEnroll/${preEnrollSurvey.stableId}?readOnly=${isReadOnlyEnv}`}>

--- a/ui-admin/src/study/consents/CreateConsentModal.test.tsx
+++ b/ui-admin/src/study/consents/CreateConsentModal.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import CreateConsentModal from './CreateConsentModal'
+import { mockStudyEnvContext } from 'test-utils/mocking-utils'
+import { setupRouterTest } from 'test-utils/router-testing-utils'
+import userEvent from '@testing-library/user-event'
+
+describe('CreateConsentModal', () => {
+  test('disables Create button when survey name and stable ID are blank', () => {
+    const studyEnvContext = mockStudyEnvContext()
+    const { RoutedComponent } = setupRouterTest(<CreateConsentModal
+      studyEnvContext={studyEnvContext}
+      onDismiss={jest.fn()}/>)
+    render(RoutedComponent)
+
+    const createButton = screen.getByText('Create')
+    expect(createButton).toBeDisabled()
+  })
+
+  test('enables Create button when survey name and stable ID are filled out', async () => {
+    const user = userEvent.setup()
+    const studyEnvContext = mockStudyEnvContext()
+    const { RoutedComponent } = setupRouterTest(<CreateConsentModal
+      studyEnvContext={studyEnvContext}
+      onDismiss={jest.fn()}/>)
+    render(RoutedComponent)
+
+    const surveyNameInput = screen.getByLabelText('Consent Name')
+    const surveyStableIdInput = screen.getByLabelText('Consent Stable ID')
+    await user.type(surveyNameInput, 'Test consent 123')
+    await user.type(surveyStableIdInput, 'test_consent_id')
+
+    const createButton = screen.getByText('Create')
+    expect(createButton).toBeEnabled()
+  })
+
+  test('should autofill the stable ID as the user fills in the survey name', async () => {
+    const user = userEvent.setup()
+    const studyEnvContext = mockStudyEnvContext()
+    const { RoutedComponent } = setupRouterTest(<CreateConsentModal
+      studyEnvContext={studyEnvContext}
+      onDismiss={jest.fn()}/>)
+    render(RoutedComponent)
+
+    await user.type(screen.getByLabelText('Consent Name'), 'Test Consent 1')
+
+    //Confirm that auto-fill stable ID worked
+    expect(screen.getByLabelText('Consent Stable ID')).toHaveValue('testConsent1')
+  })
+})

--- a/ui-admin/src/study/consents/CreateConsentModal.tsx
+++ b/ui-admin/src/study/consents/CreateConsentModal.tsx
@@ -1,0 +1,115 @@
+import React, {useContext, useState} from 'react'
+import {StudyEnvContextT} from "../StudyEnvironmentRouter";
+import {ConsentForm, StudyEnvironmentConsent, VersionedForm} from "@juniper/ui-core";
+import {PortalContext, PortalContextT} from "portal/PortalProvider";
+import {useNavigate} from "react-router-dom";
+import Api from "api/api";
+import {Store} from "react-notifications-component";
+import {failureNotification, successNotification} from "util/notifications";
+import Modal from "react-bootstrap/Modal";
+import InfoPopup from "components/forms/InfoPopup";
+import LoadingSpinner from "util/LoadingSpinner";
+import {generateStableId} from "util/pearlSurveyUtils";
+import {doApiLoad} from "../../api/api-utils";
+
+export default function CreateConsentModal({studyEnvContext, onDismiss}: {
+    studyEnvContext: StudyEnvContextT
+    onDismiss: () => void }) {
+    const [isLoading, setIsLoading] = useState(false)
+    const [consentName, setConsentName] = useState('')
+    const [consentStableId, setConsentStableId] = useState('')
+    const [enableAutofillStableId, setEnableAutofillStableId] = useState(true)
+
+    const portalContext = useContext(PortalContext) as PortalContextT
+    const navigate = useNavigate()
+
+
+    const attachConsentToEnv = async (createdConsent: ConsentForm) => {
+        await Api.createConfiguredConsent(studyEnvContext.portal.shortcode,
+            studyEnvContext.study.shortcode,
+            studyEnvContext.currentEnv.environmentName,
+            {
+                allowAdminEdit: true,
+                allowParticipantReedit: true,
+                allowParticipantStart: true,
+                id: '',
+                studyEnvironmentId: studyEnvContext.currentEnv.id,
+                consentForm: createdConsent,
+                consentFormId: createdConsent.id,
+                consentOrder: studyEnvContext.currentEnv.configuredConsents.length,
+                prepopulate: false
+            }
+        )
+        Store.addNotification(
+            successNotification(`Consent form added to ${studyEnvContext.currentEnv.environmentName}`))
+    }
+
+    const createConsent = async () => {
+        await doApiLoad(async () => {
+            const createdConsent = await Api.createNewConsentForm(studyEnvContext.portal.shortcode,
+                {
+                    createdAt: 0, id: '', lastUpdatedAt: 0, version: 1,
+                    content: '{"pages":[]}', name: consentName, stableId: consentStableId
+                }
+            )
+            Store.addNotification(successNotification('Consent form created'))
+
+            await attachConsentToEnv(createdConsent)
+
+            await portalContext.reloadPortal(studyEnvContext.portal.shortcode)
+            navigate(`consentForms/${consentStableId}`)
+            setIsLoading(false)
+            onDismiss()
+        }, {setIsLoading})
+    }
+    const clearFields = () => {
+        setConsentName('')
+        setConsentStableId('')
+        setEnableAutofillStableId(true)
+    }
+
+    return <Modal show={true} onHide={onDismiss}>
+        <Modal.Header closeButton>
+            <Modal.Title>Create New Consent Form</Modal.Title>
+            <div className="ms-4">
+                {studyEnvContext.study.name}: {studyEnvContext.currentEnv.environmentName}
+            </div>
+        </Modal.Header>
+        <Modal.Body>
+            <form onSubmit={e => e.preventDefault()}>
+                <label className="form-label" htmlFor="inputConsentName">Consent Name</label>
+                <input type="text" size={50} className="form-control" id="inputConsentName" value={consentName}
+                       onChange={event => {
+                           setConsentName(event.target.value)
+                           if (enableAutofillStableId) {
+                               setConsentStableId(generateStableId(event.target.value))
+                           }
+                       }}/>
+                <label className="form-label mt-3" htmlFor="inputConsentStableId">Consent Stable ID</label>
+                <InfoPopup content={`A stable and unique identifier for the consent. 
+                                      May be shown in exported datasets.`}/>
+                <input type="text" size={50} className="form-control" id="inputConsentStableId" value={consentStableId}
+                       onChange={event => {
+                           setConsentStableId(event.target.value)
+                           //Once the user has modified the stable ID on their own,
+                           // disable autofill in order to prevent overwriting
+                           setEnableAutofillStableId(false)
+                       }
+                       }/>
+            </form>
+        </Modal.Body>
+        <Modal.Footer>
+            <LoadingSpinner isLoading={isLoading}>
+                <button
+                    className="btn btn-primary"
+                    disabled={!consentName || !consentStableId}
+                    onClick={createConsent}
+                >Create</button>
+                <button className="btn btn-secondary" onClick={() => {
+                    onDismiss()
+                    clearFields()
+                }}>Cancel</button>
+            </LoadingSpinner>
+        </Modal.Footer>
+    </Modal>
+}

--- a/ui-admin/src/study/consents/CreateConsentModal.tsx
+++ b/ui-admin/src/study/consents/CreateConsentModal.tsx
@@ -10,8 +10,9 @@ import Modal from 'react-bootstrap/Modal'
 import InfoPopup from 'components/forms/InfoPopup'
 import LoadingSpinner from 'util/LoadingSpinner'
 import { generateStableId } from 'util/pearlSurveyUtils'
-import { doApiLoad } from '../../api/api-utils'
+import { doApiLoad } from 'api/api-utils'
 
+/** creates a new consent form for a study */
 export default function CreateConsentModal({ studyEnvContext, onDismiss }: {
     studyEnvContext: StudyEnvContextT
     onDismiss: () => void }) {

--- a/ui-admin/src/study/consents/CreateConsentModal.tsx
+++ b/ui-admin/src/study/consents/CreateConsentModal.tsx
@@ -1,115 +1,115 @@
-import React, {useContext, useState} from 'react'
-import {StudyEnvContextT} from "../StudyEnvironmentRouter";
-import {ConsentForm, StudyEnvironmentConsent, VersionedForm} from "@juniper/ui-core";
-import {PortalContext, PortalContextT} from "portal/PortalProvider";
-import {useNavigate} from "react-router-dom";
-import Api from "api/api";
-import {Store} from "react-notifications-component";
-import {failureNotification, successNotification} from "util/notifications";
-import Modal from "react-bootstrap/Modal";
-import InfoPopup from "components/forms/InfoPopup";
-import LoadingSpinner from "util/LoadingSpinner";
-import {generateStableId} from "util/pearlSurveyUtils";
-import {doApiLoad} from "../../api/api-utils";
+import React, { useContext, useState } from 'react'
+import { StudyEnvContextT } from '../StudyEnvironmentRouter'
+import { ConsentForm } from '@juniper/ui-core'
+import { PortalContext, PortalContextT } from 'portal/PortalProvider'
+import { useNavigate } from 'react-router-dom'
+import Api from 'api/api'
+import { Store } from 'react-notifications-component'
+import { successNotification } from 'util/notifications'
+import Modal from 'react-bootstrap/Modal'
+import InfoPopup from 'components/forms/InfoPopup'
+import LoadingSpinner from 'util/LoadingSpinner'
+import { generateStableId } from 'util/pearlSurveyUtils'
+import { doApiLoad } from '../../api/api-utils'
 
-export default function CreateConsentModal({studyEnvContext, onDismiss}: {
+export default function CreateConsentModal({ studyEnvContext, onDismiss }: {
     studyEnvContext: StudyEnvContextT
     onDismiss: () => void }) {
-    const [isLoading, setIsLoading] = useState(false)
-    const [consentName, setConsentName] = useState('')
-    const [consentStableId, setConsentStableId] = useState('')
-    const [enableAutofillStableId, setEnableAutofillStableId] = useState(true)
+  const [isLoading, setIsLoading] = useState(false)
+  const [consentName, setConsentName] = useState('')
+  const [consentStableId, setConsentStableId] = useState('')
+  const [enableAutofillStableId, setEnableAutofillStableId] = useState(true)
 
-    const portalContext = useContext(PortalContext) as PortalContextT
-    const navigate = useNavigate()
+  const portalContext = useContext(PortalContext) as PortalContextT
+  const navigate = useNavigate()
 
 
-    const attachConsentToEnv = async (createdConsent: ConsentForm) => {
-        await Api.createConfiguredConsent(studyEnvContext.portal.shortcode,
-            studyEnvContext.study.shortcode,
-            studyEnvContext.currentEnv.environmentName,
-            {
-                allowAdminEdit: true,
-                allowParticipantReedit: true,
-                allowParticipantStart: true,
-                id: '',
-                studyEnvironmentId: studyEnvContext.currentEnv.id,
-                consentForm: createdConsent,
-                consentFormId: createdConsent.id,
-                consentOrder: studyEnvContext.currentEnv.configuredConsents.length,
-                prepopulate: false
+  const attachConsentToEnv = async (createdConsent: ConsentForm) => {
+    await Api.createConfiguredConsent(studyEnvContext.portal.shortcode,
+      studyEnvContext.study.shortcode,
+      studyEnvContext.currentEnv.environmentName,
+      {
+        allowAdminEdit: true,
+        allowParticipantReedit: true,
+        allowParticipantStart: true,
+        id: '',
+        studyEnvironmentId: studyEnvContext.currentEnv.id,
+        consentForm: createdConsent,
+        consentFormId: createdConsent.id,
+        consentOrder: studyEnvContext.currentEnv.configuredConsents.length,
+        prepopulate: false
+      }
+    )
+    Store.addNotification(
+      successNotification(`Consent form added to ${studyEnvContext.currentEnv.environmentName}`))
+  }
+
+  const createConsent = async () => {
+    await doApiLoad(async () => {
+      const createdConsent = await Api.createNewConsentForm(studyEnvContext.portal.shortcode,
+        {
+          createdAt: 0, id: '', lastUpdatedAt: 0, version: 1,
+          content: '{"pages":[]}', name: consentName, stableId: consentStableId
+        }
+      )
+      Store.addNotification(successNotification('Consent form created'))
+
+      await attachConsentToEnv(createdConsent)
+
+      await portalContext.reloadPortal(studyEnvContext.portal.shortcode)
+      navigate(`consentForms/${consentStableId}`)
+      setIsLoading(false)
+      onDismiss()
+    }, { setIsLoading })
+  }
+  const clearFields = () => {
+    setConsentName('')
+    setConsentStableId('')
+    setEnableAutofillStableId(true)
+  }
+
+  return <Modal show={true} onHide={onDismiss}>
+    <Modal.Header closeButton>
+      <Modal.Title>Create New Consent Form</Modal.Title>
+      <div className="ms-4">
+        {studyEnvContext.study.name}: {studyEnvContext.currentEnv.environmentName}
+      </div>
+    </Modal.Header>
+    <Modal.Body>
+      <form onSubmit={e => e.preventDefault()}>
+        <label className="form-label" htmlFor="inputConsentName">Consent Name</label>
+        <input type="text" size={50} className="form-control" id="inputConsentName" value={consentName}
+          onChange={event => {
+            setConsentName(event.target.value)
+            if (enableAutofillStableId) {
+              setConsentStableId(generateStableId(event.target.value))
             }
-        )
-        Store.addNotification(
-            successNotification(`Consent form added to ${studyEnvContext.currentEnv.environmentName}`))
-    }
-
-    const createConsent = async () => {
-        await doApiLoad(async () => {
-            const createdConsent = await Api.createNewConsentForm(studyEnvContext.portal.shortcode,
-                {
-                    createdAt: 0, id: '', lastUpdatedAt: 0, version: 1,
-                    content: '{"pages":[]}', name: consentName, stableId: consentStableId
-                }
-            )
-            Store.addNotification(successNotification('Consent form created'))
-
-            await attachConsentToEnv(createdConsent)
-
-            await portalContext.reloadPortal(studyEnvContext.portal.shortcode)
-            navigate(`consentForms/${consentStableId}`)
-            setIsLoading(false)
-            onDismiss()
-        }, {setIsLoading})
-    }
-    const clearFields = () => {
-        setConsentName('')
-        setConsentStableId('')
-        setEnableAutofillStableId(true)
-    }
-
-    return <Modal show={true} onHide={onDismiss}>
-        <Modal.Header closeButton>
-            <Modal.Title>Create New Consent Form</Modal.Title>
-            <div className="ms-4">
-                {studyEnvContext.study.name}: {studyEnvContext.currentEnv.environmentName}
-            </div>
-        </Modal.Header>
-        <Modal.Body>
-            <form onSubmit={e => e.preventDefault()}>
-                <label className="form-label" htmlFor="inputConsentName">Consent Name</label>
-                <input type="text" size={50} className="form-control" id="inputConsentName" value={consentName}
-                       onChange={event => {
-                           setConsentName(event.target.value)
-                           if (enableAutofillStableId) {
-                               setConsentStableId(generateStableId(event.target.value))
-                           }
-                       }}/>
-                <label className="form-label mt-3" htmlFor="inputConsentStableId">Consent Stable ID</label>
-                <InfoPopup content={`A stable and unique identifier for the consent. 
+          }}/>
+        <label className="form-label mt-3" htmlFor="inputConsentStableId">Consent Stable ID</label>
+        <InfoPopup content={`A stable and unique identifier for the consent. 
                                       May be shown in exported datasets.`}/>
-                <input type="text" size={50} className="form-control" id="inputConsentStableId" value={consentStableId}
-                       onChange={event => {
-                           setConsentStableId(event.target.value)
-                           //Once the user has modified the stable ID on their own,
-                           // disable autofill in order to prevent overwriting
-                           setEnableAutofillStableId(false)
-                       }
-                       }/>
-            </form>
-        </Modal.Body>
-        <Modal.Footer>
-            <LoadingSpinner isLoading={isLoading}>
-                <button
-                    className="btn btn-primary"
-                    disabled={!consentName || !consentStableId}
-                    onClick={createConsent}
-                >Create</button>
-                <button className="btn btn-secondary" onClick={() => {
-                    onDismiss()
-                    clearFields()
-                }}>Cancel</button>
-            </LoadingSpinner>
-        </Modal.Footer>
-    </Modal>
+        <input type="text" size={50} className="form-control" id="inputConsentStableId" value={consentStableId}
+          onChange={event => {
+            setConsentStableId(event.target.value)
+            //Once the user has modified the stable ID on their own,
+            // disable autofill in order to prevent overwriting
+            setEnableAutofillStableId(false)
+          }
+          }/>
+      </form>
+    </Modal.Body>
+    <Modal.Footer>
+      <LoadingSpinner isLoading={isLoading}>
+        <button
+          className="btn btn-primary"
+          disabled={!consentName || !consentStableId}
+          onClick={createConsent}
+        >Create</button>
+        <button className="btn btn-secondary" onClick={() => {
+          onDismiss()
+          clearFields()
+        }}>Cancel</button>
+      </LoadingSpinner>
+    </Modal.Footer>
+  </Modal>
 }

--- a/ui-admin/src/study/surveys/ArchiveSurveyModal.test.tsx
+++ b/ui-admin/src/study/surveys/ArchiveSurveyModal.test.tsx
@@ -12,8 +12,7 @@ describe('ArchiveSurveyModal', () => {
     const studyEnvContext = mockStudyEnvContext()
     const { RoutedComponent } = setupRouterTest(<ArchiveSurveyModal
       studyEnvContext={studyEnvContext}
-      show={true}
-      setShow={jest.fn()}
+      onDismiss={jest.fn()}
       selectedSurveyConfig={mockConfiguredSurvey()}/>)
     render(RoutedComponent)
 

--- a/ui-admin/src/study/surveys/ArchiveSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/ArchiveSurveyModal.tsx
@@ -8,7 +8,7 @@ import { failureNotification } from '../../util/notifications'
 import { PortalContext, PortalContextT } from 'portal/PortalProvider'
 
 /** renders a modal that allows archiving a survey from the current study env */
-const ArchiveSurveyModal = ({studyEnvContext, selectedSurveyConfig, onDismiss}: {
+const ArchiveSurveyModal = ({ studyEnvContext, selectedSurveyConfig, onDismiss }: {
   studyEnvContext: StudyEnvContextT, selectedSurveyConfig: StudyEnvironmentSurvey,
   onDismiss: () => void }) => {
   const [isLoading, setIsLoading] = useState(false)

--- a/ui-admin/src/study/surveys/ArchiveSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/ArchiveSurveyModal.tsx
@@ -8,11 +8,9 @@ import { failureNotification } from '../../util/notifications'
 import { PortalContext, PortalContextT } from 'portal/PortalProvider'
 
 /** renders a modal that allows archiving a survey from the current study env */
-const ArchiveSurveyModal = ({
-  studyEnvContext, selectedSurveyConfig, show, setShow
-}: {
+const ArchiveSurveyModal = ({studyEnvContext, selectedSurveyConfig, onDismiss}: {
   studyEnvContext: StudyEnvContextT, selectedSurveyConfig: StudyEnvironmentSurvey,
-  show: boolean, setShow:  React.Dispatch<React.SetStateAction<boolean>> }) => {
+  onDismiss: () => void }) => {
   const [isLoading, setIsLoading] = useState(false)
 
   const portalContext = useContext(PortalContext) as PortalContextT
@@ -31,16 +29,12 @@ const ArchiveSurveyModal = ({
     ).catch(() =>
       Store.addNotification(failureNotification('Error removing survey'))
     )
-
-    setShow(false)
     await portalContext.reloadPortal(studyEnvContext.portal.shortcode)
     setIsLoading(false)
+    onDismiss()
   }
 
-  return <Modal show={show}
-    onHide={() => {
-      setShow(false)
-    }}>
+  return <Modal show={true} onHide={onDismiss}>
     <Modal.Header closeButton>
       <Modal.Title>Archive Survey</Modal.Title>
       <div className="ms-4">
@@ -68,9 +62,7 @@ const ArchiveSurveyModal = ({
           disabled={!canArchive}
           onClick={archiveSurvey}
         >Archive survey from {studyEnvContext.study.name}: {studyEnvContext.currentEnv.environmentName}</button>
-        <button className="btn btn-secondary" onClick={() => {
-          setShow(false)
-        }}>Cancel</button>
+        <button className="btn btn-secondary" onClick={onDismiss}>Cancel</button>
       </LoadingSpinner>
     </Modal.Footer>
   </Modal>

--- a/ui-admin/src/study/surveys/CreatePreEnrollSurveyModal.test.tsx
+++ b/ui-admin/src/study/surveys/CreatePreEnrollSurveyModal.test.tsx
@@ -1,15 +1,15 @@
 import { render, screen } from '@testing-library/react'
 import React from 'react'
-import CreateSurveyModal from './CreateSurveyModal'
 import { mockStudyEnvContext } from 'test-utils/mocking-utils'
 import { setupRouterTest } from 'test-utils/router-testing-utils'
 import userEvent from '@testing-library/user-event'
+import CreatePreEnrollSurveyModal from './CreatePreEnrollSurveyModal'
 
-describe('CreateSurveyModal', () => {
+describe('CreatePreEnrollSurveyModal', () => {
   test('disables Create button when survey name and stable ID are blank', () => {
     //Arrange
     const studyEnvContext = mockStudyEnvContext()
-    const { RoutedComponent } = setupRouterTest(<CreateSurveyModal
+    const { RoutedComponent } = setupRouterTest(<CreatePreEnrollSurveyModal
       studyEnvContext={studyEnvContext}
       onDismiss={jest.fn()}/>)
     render(RoutedComponent)
@@ -23,7 +23,7 @@ describe('CreateSurveyModal', () => {
     //Arrange
     const user = userEvent.setup()
     const studyEnvContext = mockStudyEnvContext()
-    const { RoutedComponent } = setupRouterTest(<CreateSurveyModal
+    const { RoutedComponent } = setupRouterTest(<CreatePreEnrollSurveyModal
       studyEnvContext={studyEnvContext}
       onDismiss={jest.fn()}/>)
     render(RoutedComponent)
@@ -43,7 +43,7 @@ describe('CreateSurveyModal', () => {
     //Arrange
     const user = userEvent.setup()
     const studyEnvContext = mockStudyEnvContext()
-    const { RoutedComponent } = setupRouterTest(<CreateSurveyModal
+    const { RoutedComponent } = setupRouterTest(<CreatePreEnrollSurveyModal
       studyEnvContext={studyEnvContext}
       onDismiss={jest.fn()}/>)
     render(RoutedComponent)

--- a/ui-admin/src/study/surveys/CreatePreEnrollSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreatePreEnrollSurveyModal.tsx
@@ -1,0 +1,80 @@
+import React, { useContext, useState } from 'react'
+import { StudyEnvContextT } from '../StudyEnvironmentRouter'
+import { PortalContext, PortalContextT } from 'portal/PortalProvider'
+import { useNavigate } from 'react-router-dom'
+import Api from 'api/api'
+import { Store } from 'react-notifications-component'
+import { successNotification } from 'util/notifications'
+import Modal from 'react-bootstrap/Modal'
+import InfoPopup from 'components/forms/InfoPopup'
+import LoadingSpinner from 'util/LoadingSpinner'
+import { useFormCreationNameFields } from './CreateSurveyModal'
+import { ApiErrorResponse, defaultApiErrorHandle, doApiLoad } from 'api/api-utils'
+
+/** dialog for adding a new PreEnrollment survey */
+export default function CreatePreEnrollSurveyModal({ studyEnvContext, onDismiss }:
+{studyEnvContext: StudyEnvContextT, onDismiss: () => void}) {
+  const [isLoading, setIsLoading] = useState(false)
+
+  const portalContext = useContext(PortalContext) as PortalContextT
+  const navigate = useNavigate()
+  const { formName, formStableId, clearFields, nameInput, stableIdInput } = useFormCreationNameFields()
+  const createSurvey =async () => {
+    await doApiLoad(async () => {
+      const createdSurvey = await Api.createNewSurvey(studyEnvContext.portal.shortcode,
+        {
+          createdAt: 0, id: '', lastUpdatedAt: 0, version: 1,
+          content: '{"pages":[]}', name: formName, stableId: formStableId
+        })
+      Store.addNotification(successNotification('Survey created'))
+      try {
+        await Api.updateStudyEnvironment(studyEnvContext.portal.shortcode,
+          studyEnvContext.study.shortcode,
+          studyEnvContext.currentEnv.environmentName,
+          {
+            ...studyEnvContext.currentEnv,
+            preEnrollSurveyId: createdSurvey.id
+          }
+        )
+      } catch (err) {
+        defaultApiErrorHandle(err as ApiErrorResponse, 'Error configuring survey: ')
+      }
+
+      await portalContext.reloadPortal(studyEnvContext.portal.shortcode)
+      navigate(`preEnroll/${formStableId}`)
+    }, { setIsLoading })
+    onDismiss()
+  }
+
+
+  return <Modal show={true} onHide={onDismiss}>
+    <Modal.Header closeButton>
+      <Modal.Title>Create PreEnrollment Survey</Modal.Title>
+      <div className="ms-4">
+        {studyEnvContext.study.name}: {studyEnvContext.currentEnv.environmentName}
+      </div>
+    </Modal.Header>
+    <Modal.Body>
+      <form onSubmit={e => e.preventDefault()}>
+        <label className="form-label" htmlFor="inputFormName">Survey Name</label>
+        { nameInput }
+        <label className="form-label mt-3" htmlFor="inputFormStableId">Survey Stable ID</label>
+        <InfoPopup content={'A stable and unique identifier for the form. May be shown in exported datasets.'}/>
+        { stableIdInput }
+      </form>
+    </Modal.Body>
+    <Modal.Footer>
+      <LoadingSpinner isLoading={isLoading}>
+        <button
+          className="btn btn-primary"
+          disabled={!formName || !formStableId}
+          onClick={createSurvey}
+        >Create</button>
+        <button className="btn btn-secondary" onClick={() => {
+          onDismiss()
+          clearFields()
+        }}>Cancel</button>
+      </LoadingSpinner>
+    </Modal.Footer>
+  </Modal>
+}

--- a/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
@@ -12,8 +12,7 @@ describe('CreateSurveyModal', () => {
     const { RoutedComponent } = setupRouterTest(<CreateSurveyModal
       studyEnvContext={studyEnvContext}
       isReadOnlyEnv={false}
-      show={true}
-      setShow={jest.fn()}/>)
+      onDismiss={jest.fn()}/>)
     render(RoutedComponent)
 
     //Assert
@@ -28,8 +27,7 @@ describe('CreateSurveyModal', () => {
     const { RoutedComponent } = setupRouterTest(<CreateSurveyModal
       studyEnvContext={studyEnvContext}
       isReadOnlyEnv={false}
-      show={true}
-      setShow={jest.fn()}/>)
+      onDismiss={jest.fn()}/>)
     render(RoutedComponent)
 
     //Act
@@ -50,8 +48,7 @@ describe('CreateSurveyModal', () => {
     const { RoutedComponent } = setupRouterTest(<CreateSurveyModal
       studyEnvContext={studyEnvContext}
       isReadOnlyEnv={false}
-      show={true}
-      setShow={jest.fn()}/>)
+      onDismiss={jest.fn()}/>)
     render(RoutedComponent)
 
     //Act

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -58,7 +58,7 @@ const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, onDismiss }: {study
         failureNotification(`Error configuring survey: ${err}`))
     }
     setIsLoading(false)
-      onDismiss()
+    onDismiss()
   }
   const clearFields = () => {
     setSurveyName('')

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -11,8 +11,8 @@ import InfoPopup from 'components/forms/InfoPopup'
 import { generateStableId } from 'util/pearlSurveyUtils'
 
 /** renders a modal that creates a new survey in a portal and configures it to the current study env */
-const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, show, setShow }: {studyEnvContext: StudyEnvContextT,
-  isReadOnlyEnv: boolean, show: boolean, setShow:  React.Dispatch<React.SetStateAction<boolean>> }) => {
+const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, onDismiss }: {studyEnvContext: StudyEnvContextT,
+  isReadOnlyEnv: boolean, onDismiss: () => void}) => {
   const [isLoading, setIsLoading] = useState(false)
   const [surveyName, setSurveyName] = useState('')
   const [surveyStableId, setSurveyStableId] = useState('')
@@ -57,9 +57,8 @@ const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, show, setShow }: {s
       Store.addNotification(
         failureNotification(`Error configuring survey: ${err}`))
     }
-
-    setShow(false)
     setIsLoading(false)
+      onDismiss()
   }
   const clearFields = () => {
     setSurveyName('')
@@ -67,11 +66,7 @@ const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, show, setShow }: {s
     setEnableAutofillStableId(true)
   }
 
-  return <Modal show={show}
-    onHide={() => {
-      setShow(false)
-      clearFields()
-    }}>
+  return <Modal show={true} onHide={onDismiss}>
     <Modal.Header closeButton>
       <Modal.Title>Create New Survey</Modal.Title>
       <div className="ms-4">
@@ -107,7 +102,7 @@ const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, show, setShow }: {s
           onClick={createSurvey}
         >Create</button>
         <button className="btn btn-secondary" onClick={() => {
-          setShow(false)
+          onDismiss()
           clearFields()
         }}>Cancel</button>
       </LoadingSpinner>

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -2,69 +2,56 @@ import React, { useContext, useState } from 'react'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
 import Modal from 'react-bootstrap/Modal'
 import LoadingSpinner from 'util/LoadingSpinner'
-import Api, { VersionedForm } from 'api/api'
 import { useNavigate } from 'react-router-dom'
-import { Store } from 'react-notifications-component'
-import { failureNotification } from 'util/notifications'
 import { PortalContext, PortalContextT } from 'portal/PortalProvider'
 import InfoPopup from 'components/forms/InfoPopup'
 import { generateStableId } from 'util/pearlSurveyUtils'
+import { ApiErrorResponse, defaultApiErrorHandle, doApiLoad } from '../../api/api-utils'
 
 /** renders a modal that creates a new survey in a portal and configures it to the current study env */
-const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, onDismiss }: {studyEnvContext: StudyEnvContextT,
-  isReadOnlyEnv: boolean, onDismiss: () => void}) => {
+const CreateSurveyModal = ({ studyEnvContext, onDismiss }:
+                               {studyEnvContext: StudyEnvContextT, onDismiss: () => void}) => {
   const [isLoading, setIsLoading] = useState(false)
-  const [surveyName, setSurveyName] = useState('')
-  const [surveyStableId, setSurveyStableId] = useState('')
-  const [enableAutofillStableId, setEnableAutofillStableId] = useState(true)
 
   const portalContext = useContext(PortalContext) as PortalContextT
   const navigate = useNavigate()
-
+  const { formName, formStableId, clearFields, nameInput, stableIdInput } = useFormCreationNameFields()
   const createSurvey = async () => {
-    setIsLoading(true)
-    const createdSurvey = await Api.createNewSurvey(studyEnvContext.portal.shortcode,
-      {
-        createdAt: 0, id: '', lastUpdatedAt: 0, version: 1,
-        content: '{"pages":[]}', name: surveyName, stableId: surveyStableId
-      }).catch(e =>
-      Store.addNotification(failureNotification(`Error creating survey: ${e.message}`))
-    ) as VersionedForm
-
-    try {
-      await Api.createConfiguredSurvey(studyEnvContext.portal.shortcode,
-        studyEnvContext.study.shortcode,
-        studyEnvContext.currentEnv.environmentName,
+    doApiLoad(async () => {
+      const createdSurvey = await Api.createNewSurvey(studyEnvContext.portal.shortcode,
         {
-          allowAdminEdit: true,
-          allowParticipantReedit: true,
-          allowParticipantStart: true,
-          id: '',
-          required: false,
-          prepopulate: false,
-          recurrenceIntervalDays: 0,
-          recur: false,
-          studyEnvironmentId: studyEnvContext.currentEnv.id,
-          survey: createdSurvey,
-          surveyId: createdSurvey.id,
-          surveyOrder: studyEnvContext.currentEnv.configuredSurveys.length
-        }
-      )
+          createdAt: 0, id: '', lastUpdatedAt: 0, version: 1,
+          content: '{"pages":[]}', name: formName, stableId: formStableId
+        })
+      try {
+        await Api.createConfiguredSurvey(studyEnvContext.portal.shortcode,
+          studyEnvContext.study.shortcode,
+          studyEnvContext.currentEnv.environmentName,
+          {
+            allowAdminEdit: true,
+            allowParticipantReedit: true,
+            allowParticipantStart: true,
+            id: '',
+            required: false,
+            prepopulate: false,
+            recurrenceIntervalDays: 0,
+            recur: false,
+            studyEnvironmentId: studyEnvContext.currentEnv.id,
+            survey: createdSurvey,
+            surveyId: createdSurvey.id,
+            surveyOrder: studyEnvContext.currentEnv.configuredSurveys.length
+          }
+        )
+      } catch (err) {
+        defaultApiErrorHandle(err as ApiErrorResponse, 'Error configuring survey: ')
+      }
 
       await portalContext.reloadPortal(studyEnvContext.portal.shortcode)
-      navigate(`surveys/${surveyStableId}?readOnly=${isReadOnlyEnv}`)
-    } catch (err) {
-      Store.addNotification(
-        failureNotification(`Error configuring survey: ${err}`))
-    }
-    setIsLoading(false)
-    onDismiss()
+      navigate(`surveys/${formStableId}`)
+      onDismiss()
+    }, { setIsLoading })
   }
-  const clearFields = () => {
-    setSurveyName('')
-    setSurveyStableId('')
-    setEnableAutofillStableId(true)
-  }
+
 
   return <Modal show={true} onHide={onDismiss}>
     <Modal.Header closeButton>
@@ -75,30 +62,18 @@ const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, onDismiss }: {study
     </Modal.Header>
     <Modal.Body>
       <form onSubmit={e => e.preventDefault()}>
-        <label className="form-label" htmlFor="inputSurveyName">Survey Name</label>
-        <input type="text" size={50} className="form-control" id="inputSurveyName" value={surveyName}
-          onChange={event => {
-            setSurveyName(event.target.value)
-            if (enableAutofillStableId) {
-              setSurveyStableId(generateStableId(event.target.value))
-            }
-          }}/>
-        <label className="form-label mt-3" htmlFor="inputSurveyStableId">Survey Stable ID</label>
+        <label className="form-label" htmlFor="inputFormName">Survey Name</label>
+        { nameInput }
+        <label className="form-label mt-3" htmlFor="inputFormStableId">Survey Stable ID</label>
         <InfoPopup content={'A stable and unique identifier for the survey. May be shown in exported datasets.'}/>
-        <input type="text" size={50} className="form-control" id="inputSurveyStableId" value={surveyStableId}
-          onChange={event => {
-            setSurveyStableId(event.target.value)
-            //Once the user has modified the stable ID on their own, disable autofill in order to prevent overwriting
-            setEnableAutofillStableId(false)
-          }
-          }/>
+        { stableIdInput }
       </form>
     </Modal.Body>
     <Modal.Footer>
       <LoadingSpinner isLoading={isLoading}>
         <button
           className="btn btn-primary"
-          disabled={!surveyName || !surveyStableId}
+          disabled={!formName || !formStableId}
           onClick={createSurvey}
         >Create</button>
         <button className="btn btn-secondary" onClick={() => {
@@ -111,3 +86,37 @@ const CreateSurveyModal = ({ studyEnvContext, isReadOnlyEnv, onDismiss }: {study
 }
 
 export default CreateSurveyModal
+
+/** hook for a form that sets a name and stableId */
+export const useFormCreationNameFields = () => {
+  const [formName, setFormName] = useState('')
+  const [formStableId, setFormStableId] = useState('')
+  const [enableAutofillStableId, setEnableAutofillStableId] = useState(true)
+
+  const clearFields = () => {
+    setFormName('')
+    setFormStableId('')
+    setEnableAutofillStableId(true)
+  }
+
+  const nameInput = <input type="text" size={50} className="form-control"
+    id="inputFormName" value={formName}
+    onChange={event => {
+      setFormName(event.target.value)
+      if (enableAutofillStableId) {
+        setFormStableId(generateStableId(event.target.value))
+      }
+    }}/>
+
+  const stableIdInput = <input type="text" size={50} className="form-control"
+    id="inputFormStableId" value={formStableId}
+    onChange={event => {
+      setFormStableId(event.target.value)
+      //Once the user has modified the stable ID on their own,
+      // disable autofill in order to prevent overwriting
+      setEnableAutofillStableId(false)
+    }
+    }/>
+
+  return { formName, formStableId, clearFields, nameInput, stableIdInput }
+}

--- a/ui-admin/src/study/surveys/DeleteSurveyModal.test.tsx
+++ b/ui-admin/src/study/surveys/DeleteSurveyModal.test.tsx
@@ -12,8 +12,7 @@ describe('DeleteSurveyModal', () => {
     const studyEnvContext = mockStudyEnvContext()
     const { RoutedComponent } = setupRouterTest(<DeleteSurveyModal
       studyEnvContext={studyEnvContext}
-      show={true}
-      setShow={jest.fn()}
+      onDismiss={jest.fn()}
       selectedSurveyConfig={mockConfiguredSurvey()}/>)
     render(RoutedComponent)
 

--- a/ui-admin/src/study/surveys/DeleteSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/DeleteSurveyModal.tsx
@@ -9,10 +9,9 @@ import { PortalContext, PortalContextT } from 'portal/PortalProvider'
 
 /** renders a modal that allows deleting a survey */
 const DeleteSurveyModal = ({
-  studyEnvContext, selectedSurveyConfig, show, setShow
+  studyEnvContext, selectedSurveyConfig, onDismiss
 }: {
-  studyEnvContext: StudyEnvContextT, selectedSurveyConfig: StudyEnvironmentSurvey,
-  show: boolean, setShow:  React.Dispatch<React.SetStateAction<boolean>> }) => {
+  studyEnvContext: StudyEnvContextT, selectedSurveyConfig: StudyEnvironmentSurvey, onDismiss: () => void}) => {
   const [isLoading, setIsLoading] = useState(false)
 
   const portalContext = useContext(PortalContext) as PortalContextT
@@ -29,16 +28,12 @@ const DeleteSurveyModal = ({
     ).catch(() =>
       Store.addNotification(failureNotification('Error deleting survey'))
     )
-
-    setShow(false)
     await portalContext.reloadPortal(studyEnvContext.portal.shortcode)
     setIsLoading(false)
+    onDismiss()
   }
 
-  return <Modal show={show}
-    onHide={() => {
-      setShow(false)
-    }}>
+  return <Modal show={true} onHide={onDismiss}>
     <Modal.Header closeButton>
       <Modal.Title>Delete Survey</Modal.Title>
       <div className="ms-4">
@@ -64,9 +59,7 @@ const DeleteSurveyModal = ({
           disabled={!canDelete}
           onClick={deleteSurvey}
         >Delete survey</button>
-        <button className="btn btn-secondary" onClick={() => {
-          setShow(false)
-        }}>Cancel</button>
+        <button className="btn btn-secondary" onClick={onDismiss}>Cancel</button>
       </LoadingSpinner>
     </Modal.Footer>
   </Modal>

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -151,6 +151,7 @@ export const mockConfiguredConsent = (): StudyEnvironmentConsent => {
   return {
     id: 'fakeGuid',
     consentFormId: 'consentId1',
+    studyEnvironmentId: 'studyEnvId1',
     consentOrder: 1,
     consentForm: mockConsentForm(),
     allowAdminEdit: false,

--- a/ui-core/src/types/study.ts
+++ b/ui-core/src/types/study.ts
@@ -43,6 +43,7 @@ export type StudyEnvironmentConsent = {
   id: string
   consentForm: ConsentForm
   consentFormId: string
+  studyEnvironmentId: string
   consentOrder: number
   allowAdminEdit: boolean
   allowParticipantStart: boolean


### PR DESCRIPTION
#### DESCRIPTION

This enables adding consent forms and pre-enrollment surveys to studies.  out of scope for this PR are removing/deactivating them.  This is almost entirely modeled after the survey infrastructure, and so this also updates some of the survey UX logic to match our latest modal patterns. 
<img width="322" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/bfe6193b-38db-45ae-ad03-044e2da1ed63">

<img width="587" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/6d454a6e-d954-4270-a561-f4b9d51d1d65">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy ApiAdminApp
2. populate HeartHive `./scripts/populate_portal.sh hearthive`
3. go to https://localhost:3000/hearthive/studies/pacing/env/sandbox/forms
4. try adding some consent forms.  Although it's not critical and out-of-scope to test, the participant flow should work with multiple consents (and it did when I quickly tested it) -- the participant shouldn't be able to access surveys until all consents are complete.
5. try adding a pre-enrollment survey