### PR TITLE
[JN-681]. syncing all kit statuses

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/StubPepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/StubPepperDSMClient.java
@@ -86,9 +86,18 @@ public class StubPepperDSMClient implements PepperDSMClient {
         }).toList();
     }
 
+    protected List<PepperKitStatus.Status> MOCK_STATUS_SEQUENCE = List.of(
+            PepperKitStatus.Status.CREATED,
+            PepperKitStatus.Status.QUEUED,
+            PepperKitStatus.Status.SENT,
+            PepperKitStatus.Status.RECEIVED,
+            PepperKitStatus.Status.ERRORED,
+            PepperKitStatus.Status.DEACTIVATED
+    );
+
     /** helper to get the next status for a kit */
     private String getNextStatus(KitRequest kit) {
-        List<String> statusVals = Arrays.stream(PepperKitStatus.Status.values()).map(status -> status.currentStatus).toList();
+        List<String> statusVals = MOCK_STATUS_SEQUENCE.stream().map(status -> status.currentStatus).toList();
         try {
             PepperKitStatus pepperStatus = objectMapper.readValue(kit.getDsmStatus(), PepperKitStatus.class);
             String currentStatus = pepperStatus.getCurrentStatus();

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/StubPepperDSMClientTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/StubPepperDSMClientTest.java
@@ -66,7 +66,7 @@ class StubPepperDSMClientTest extends BaseSpringBootTest {
         assertThat(kitStatuses.size(), equalTo(1));
         var kitStatus = kitStatuses.stream().findFirst().get();
         assertThat(kitStatus.getJuniperKitId(), equalTo(kit.getId().toString()));
-        assertThat(kitStatus.getCurrentStatus(), equalTo("SENT"));
+        assertThat(kitStatus.getCurrentStatus(), equalTo("queue"));
     }
 
     @Autowired

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/kit/KitRequestFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/kit/KitRequestFactory.java
@@ -57,7 +57,7 @@ public class KitRequestFactory {
                 .build();
         var savedKitRequest = kitRequestDao.create(kitRequest);
         var dsmStatus = PepperKitStatus.builder()
-                .currentStatus("CREATED")
+                .currentStatus("kit without label")
                 .juniperKitId(savedKitRequest.getId().toString())
                 .build();
         savedKitRequest.setDsmStatus(objectMapper.writeValueAsString(dsmStatus));

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
@@ -84,6 +84,7 @@
       "statusName": "CREATED",
       "dsmStatusJson": {
         "kitId": "11111111-2222-3333-4444-555555555555",
+        "currentStatus": "kit without label",
         "labelDate": "2023-05-24",
         "scanDate": "2023-05-24",
         "receiveDate": "2023-05-24",

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/enrollees/jsalk.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/enrollees/jsalk.json
@@ -74,8 +74,31 @@
       "statusName": "CREATED",
       "dsmStatusJson": {
         "kitId": "11111111-2222-3333-4444-555555555555",
-        "currentStatus": "CREATED",
+        "currentStatus": "kit without label",
         "labelDate": "2023-05-24",
+        "scanDate": "",
+        "receiveDate": "",
+        "scannedByEmail": "",
+        "receivedByEmail": "",
+        "labeledByEmail": "",
+        "deactivationDate": "",
+        "deactivatedBy": "",
+        "deactivationReason": "",
+        "trackingNumbers": [],
+        "returnTrackingNumber": "",
+        "errors": [],
+        "discardDate": "",
+        "discardReason": ""
+      }
+    },
+    {
+      "creatingAdminUsername": "staff2@ourhealth.org",
+      "kitTypeName": "SALIVA",
+      "statusName": "FAILED",
+      "dsmStatusJson": {
+        "kitId": "11111111-2222-3333-4444-555555555556",
+        "currentStatus": "deactivated",
+        "labelDate": "2023-05-12",
         "scanDate": "",
         "receiveDate": "",
         "scannedByEmail": "",


### PR DESCRIPTION
#### DESCRIPTION

Previously, we only synched active kits.  Now we sync all kits.  IIRC Brian was worried synching all kits would send too many DB requests if we synched every kit every time.  We can address that concern later if the sync becomes too slow by implementing a bulk update.   This also updates the stubClient to progress the status of kits, so that you can see what kit statuses look like as they move through the application. 

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  redeploy ApiAdminApp
2. repopulate ourhealth
3. go to `https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/kits/requested`
4. confirm you see two kits, one created, one with issues
5. click the "Refresh" button.  
6. confirm the deactivated kit (previously under "issues"), is now under "created"