### PR TITLE
[JN-682] add tabs to site content editor

### DIFF
--- a/ui-admin/src/portal/siteContent/SiteContentEditor.test.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.test.tsx
@@ -52,3 +52,17 @@ test('readOnly hides save button', async () => {
   expect(screen.getByText('Landing page')).toBeInTheDocument()
   expect(screen.queryByText('Save')).not.toBeInTheDocument()
 })
+
+test('clicking on the Preview tab shows full page preview', async () => {
+  const siteContent = mockSiteContent()
+  const { RoutedComponent } = setupRouterTest(
+    <SiteContentEditor siteContent={siteContent} previewApi={emptyApi} readOnly={false}
+      loadSiteContent={jest.fn()} createNewVersion={jest.fn()} portalShortcode="foo"
+      switchToVersion={jest.fn()}
+      portalEnv={mockPortalEnvironment('sandbox')}/>)
+  render(RoutedComponent)
+
+  await userEvent.click(screen.getByText('Preview'))
+  expect(screen.queryByText('Insert section')).not.toBeInTheDocument()
+  expect(screen.queryByText('we are the best')).toBeInTheDocument()
+})

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -1,14 +1,16 @@
 import React, { useState } from 'react'
-import { NavbarItemInternal, PortalEnvironment } from 'api/api'
+import { HtmlSection, NavbarItemInternal, PortalEnvironment } from 'api/api'
 import Select from 'react-select'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faClockRotateLeft, faImage, faPlus } from '@fortawesome/free-solid-svg-icons'
 import HtmlPageEditView from './HtmlPageEditView'
-import { HtmlPage, LocalSiteContent, ApiProvider, SiteContent, ApiContextT } from '@juniper/ui-core'
+import { HtmlPage, LocalSiteContent, ApiProvider, SiteContent, ApiContextT, HtmlSectionView } from '@juniper/ui-core'
 import { Link } from 'react-router-dom'
 import SiteContentVersionSelector from './SiteContentVersionSelector'
-import { Button } from '../../components/forms/Button'
+import { Button } from 'components/forms/Button'
 import AddPageModal from './AddPageModal'
+import ErrorBoundary from 'util/ErrorBoundary'
+import { Tab, Tabs } from 'react-bootstrap'
 
 type NavbarOption = {label: string, value: string}
 const landingPageOption = { label: 'Landing page', value: 'Landing page' }
@@ -31,6 +33,7 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
     portalEnv, loadSiteContent, switchToVersion, createNewVersion, readOnly
   } = props
   const selectedLanguage = 'en'
+  const [activeTab, setActiveTab] = useState<string | null>('designer')
   const [selectedNavOpt, setSelectedNavOpt] = useState<NavbarOption>(landingPageOption)
   const [workingContent, setWorkingContent] = useState<SiteContent>(siteContent)
   const [showVersionSelector, setShowVersionSelector] = useState(false)
@@ -160,12 +163,41 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
         </div>
 
       </div>
-      <div>
-        {pageToRender &&
-          <ApiProvider api={previewApi}>
-            <HtmlPageEditView htmlPage={pageToRender} readOnly={readOnly}
-              updatePage={page => updatePage(page, currentNavBarItem?.text)}/>
-          </ApiProvider>}
+      <div className="d-flex flex-column flex-grow-1 mt-2">
+        <Tabs
+          activeKey={activeTab ?? undefined}
+          className="mb-1"
+          mountOnEnter
+          unmountOnExit
+          onSelect={setActiveTab}
+        >
+          <Tab
+            eventKey="designer"
+            title="Designer"
+          >
+            <ErrorBoundary>
+              <div>
+                {pageToRender &&
+                    <ApiProvider api={previewApi}>
+                      <HtmlPageEditView htmlPage={pageToRender} readOnly={readOnly}
+                        updatePage={page => updatePage(page, currentNavBarItem?.text)}/>
+                    </ApiProvider>}
+              </div>
+            </ErrorBoundary>
+          </Tab>
+          <Tab
+            eventKey="preview"
+            title="Preview"
+          >
+            <ErrorBoundary>
+              <ApiProvider api={previewApi}>
+                { pageToRender.sections.map((section: HtmlSection) =>
+                  <HtmlSectionView section={section} key={section.id}/>)
+                }
+              </ApiProvider>
+            </ErrorBoundary>
+          </Tab>
+        </Tabs>
       </div>
     </div>
     { showVersionSelector &&


### PR DESCRIPTION
#### DESCRIPTION

This just adds 2 tabs to the content editor, which allows you to preview the entire page without the "Insert section.." buttons breaking up the page flow. 

I'm splitting this out from the other site content editor improvements because I want to at least make sure this quick and low-risk improvement can get into todays release. I might be able to sneak the improved invalid JSON handling into today's release too, but that'll be as part of another PR and I'd give it a 50/50 shot.

![Screenshot 2023-10-30 at 8 27 42 AM](https://github.com/broadinstitute/juniper/assets/7257391/28db1cf8-a29f-437a-8fc0-3e1b385bfedc)


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Start up admin UI + API
* Test that the full preview loads when you click on the Preview tab, and that live edits are shown: https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/siteContent