### PR TITLE
JN-646 analysis friendly export UX polish

### DIFF
--- a/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
@@ -76,13 +76,13 @@ const ExportDataBrowser = ({ studyEnvContext }: {studyEnvContext: StudyEnvContex
 
   return <div className="container-fluid px-4 py-2">
     { renderPageHeader('Data Export') }
-    <div className="d-flex align-items-center justify-content-between">
-      <div className="d-flex">
-        <span className="text-muted fst-italic">
+    <div className="align-items-center justify-content-between">
+      <div>
+        <span className="text-muted fst-italic px-2">
           (Transposed for readability, the actual export has participants as rows)
         </span>
       </div>
-      <div className="d-flex">
+      <div >
         <Button onClick={() => setShowExportModal(!showExportModal)}
           variant="light" className="border m-1"
           aria-label="show or hide export modal">

--- a/ui-admin/src/study/participants/export/ExportDataControl.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataControl.tsx
@@ -82,7 +82,7 @@ const ExportDataControl = ({ studyEnvContext, show, setShow }: {studyEnvContext:
           <span className="fw-bold">Data format</span><br/>
           <label className="me-3">
             <input type="radio" name="humanReadable" value="true" checked={humanReadable}
-              onChange={humanReadableChanged} className="me-1" disabled={true}/> Human-readable
+              onChange={humanReadableChanged} className="me-1"/> Human-readable
           </label>
           <label>
             <input type="radio" name="humanReadable" value="false" checked={!humanReadable}


### PR DESCRIPTION
#### DESCRIPTION

Moving "Download" button to directly under the title, since that's the primary action for the page.  This also fixes the bug where you couldn't switch back to human-readable format
![image](https://github.com/broadinstitute/juniper/assets/2800795/93450c42-d4fd-4660-b59d-6ec85265219b)


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/export/dataBrowser
2. confirm the "Download" button is directly under the title, and not lost to the right of the screen
3. click "Download"
4. confirm you can switch back and forth between human/analysis-friendly