### PR TITLE
[JN-683] Section editor now allows typing invalid JSON

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/site/LocalizedSiteContentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/site/LocalizedSiteContentService.java
@@ -35,6 +35,7 @@ public class LocalizedSiteContentService extends ImmutableEntityService<Localize
         if (localSite.getFooterSection() != null) {
             HtmlSection footer = htmlSectionDao.create(localSite.getFooterSection());
             localSite.setFooterSectionId(footer.getId());
+            localSite.setFooterSection(footer);
         }
         LocalizedSiteContent savedSite = dao.create(localSite);
         for (int i = 0; i < localSite.getNavbarItems().size(); i++) {
@@ -52,6 +53,7 @@ public class LocalizedSiteContentService extends ImmutableEntityService<Localize
             dao.setLandingPageId(savedSite.getId(), landingPage.getId());
         }
         savedSite.setLandingPage(landingPage);
+        savedSite.setFooterSection(localSite.getFooterSection());
         return savedSite;
     }
 

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.test.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.test.tsx
@@ -10,7 +10,7 @@ test('readOnly disables insert new section button', async () => {
   const mockPage = mockHtmlPage()
   const { RoutedComponent } = setupRouterTest(
     <HtmlPageEditView htmlPage={mockPage} readOnly={true} updatePage={jest.fn()}
-      setSiteInvalid={jest.fn()} siteInvalid={false}/>)
+      setSiteInvalid={jest.fn()} siteInvalid={false} footerSection={undefined} updateFooter={jest.fn()}/>)
   render(RoutedComponent)
   expect(screen.getAllByLabelText('Insert a blank section')[0]).toHaveAttribute('aria-disabled', 'true')
 })
@@ -21,7 +21,7 @@ test('Insert Section button calls updatePage with a new blank HERO_WITH_IMAGE se
   const mockUpdatePageFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
     <HtmlPageEditView htmlPage={mockPage} readOnly={false} updatePage={mockUpdatePageFn}
-      setSiteInvalid={jest.fn()} siteInvalid={false}/>)
+      setSiteInvalid={jest.fn()} siteInvalid={false} footerSection={undefined} updateFooter={jest.fn()}/>)
   render(RoutedComponent)
 
   //Act
@@ -43,7 +43,7 @@ test('invalid JSON disables Insert Section button', async () => {
   const mockPage = mockHtmlPage()
   const { RoutedComponent } = setupRouterTest(
     <HtmlPageEditView htmlPage={mockPage} readOnly={false} updatePage={jest.fn()}
-      setSiteInvalid={jest.fn()} siteInvalid={true}/>)
+      setSiteInvalid={jest.fn()} siteInvalid={true} footerSection={undefined} updateFooter={jest.fn()}/>)
   render(RoutedComponent)
   const sectionButtons= await screen.findAllByLabelText('Insert a blank section')
 

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.test.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.test.tsx
@@ -10,7 +10,7 @@ test('readOnly disables insert new section button', async () => {
   const mockPage = mockHtmlPage()
   const { RoutedComponent } = setupRouterTest(
     <HtmlPageEditView htmlPage={mockPage} readOnly={true} updatePage={jest.fn()}
-      setSiteInvalid={jest.fn()} siteInvalid={false} footerSection={undefined} updateFooter={jest.fn()}/>)
+                      setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false} footerSection={undefined} updateFooter={jest.fn()}/>)
   render(RoutedComponent)
   expect(screen.getAllByLabelText('Insert a blank section')[0]).toHaveAttribute('aria-disabled', 'true')
 })
@@ -21,7 +21,7 @@ test('Insert Section button calls updatePage with a new blank HERO_WITH_IMAGE se
   const mockUpdatePageFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
     <HtmlPageEditView htmlPage={mockPage} readOnly={false} updatePage={mockUpdatePageFn}
-      setSiteInvalid={jest.fn()} siteInvalid={false} footerSection={undefined} updateFooter={jest.fn()}/>)
+                      setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false} footerSection={undefined} updateFooter={jest.fn()}/>)
   render(RoutedComponent)
 
   //Act
@@ -43,7 +43,7 @@ test('invalid JSON disables Insert Section button', async () => {
   const mockPage = mockHtmlPage()
   const { RoutedComponent } = setupRouterTest(
     <HtmlPageEditView htmlPage={mockPage} readOnly={false} updatePage={jest.fn()}
-      setSiteInvalid={jest.fn()} siteInvalid={true} footerSection={undefined} updateFooter={jest.fn()}/>)
+                      setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={true} footerSection={undefined} updateFooter={jest.fn()}/>)
   render(RoutedComponent)
   const sectionButtons= await screen.findAllByLabelText('Insert a blank section')
 

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.test.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.test.tsx
@@ -38,3 +38,16 @@ test('Insert Section button calls updatePage with a new blank HERO_WITH_IMAGE se
     ]
   })
 })
+
+test('invalid JSON disables Insert Section button', async () => {
+  const mockPage = mockHtmlPage()
+  const { RoutedComponent } = setupRouterTest(
+    <HtmlPageEditView htmlPage={mockPage} readOnly={false} updatePage={jest.fn()}
+      setSiteInvalid={jest.fn()} siteInvalid={true}/>)
+  render(RoutedComponent)
+  const sectionButtons= await screen.findAllByLabelText('Insert a blank section')
+
+  sectionButtons.forEach(button => {
+    expect(button).toHaveAttribute('aria-disabled', 'true')
+  })
+})

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.test.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.test.tsx
@@ -9,7 +9,8 @@ import { sectionTemplates } from './sectionTemplates'
 test('readOnly disables insert new section button', async () => {
   const mockPage = mockHtmlPage()
   const { RoutedComponent } = setupRouterTest(
-    <HtmlPageEditView htmlPage={mockPage} readOnly={true} updatePage={jest.fn()}/>)
+    <HtmlPageEditView htmlPage={mockPage} readOnly={true} updatePage={jest.fn()}
+      setSiteInvalid={jest.fn()} siteInvalid={false}/>)
   render(RoutedComponent)
   expect(screen.getAllByLabelText('Insert a blank section')[0]).toHaveAttribute('aria-disabled', 'true')
 })
@@ -19,7 +20,8 @@ test('Insert Section button calls updatePage with a new blank HERO_WITH_IMAGE se
   const mockPage = mockHtmlPage()
   const mockUpdatePageFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
-    <HtmlPageEditView htmlPage={mockPage} readOnly={false} updatePage={mockUpdatePageFn}/>)
+    <HtmlPageEditView htmlPage={mockPage} readOnly={false} updatePage={mockUpdatePageFn}
+      setSiteInvalid={jest.fn()} siteInvalid={false}/>)
   render(RoutedComponent)
 
   //Act

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.test.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.test.tsx
@@ -9,8 +9,8 @@ import { sectionTemplates } from './sectionTemplates'
 test('readOnly disables insert new section button', async () => {
   const mockPage = mockHtmlPage()
   const { RoutedComponent } = setupRouterTest(
-    <HtmlPageEditView htmlPage={mockPage} readOnly={true} updatePage={jest.fn()}
-                      setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false} footerSection={undefined} updateFooter={jest.fn()}/>)
+    <HtmlPageEditView htmlPage={mockPage} readOnly={true} updatePage={jest.fn()} setSiteHasInvalidSection={jest.fn()}
+      siteHasInvalidSection={false} footerSection={undefined} updateFooter={jest.fn()}/>)
   render(RoutedComponent)
   expect(screen.getAllByLabelText('Insert a blank section')[0]).toHaveAttribute('aria-disabled', 'true')
 })
@@ -21,7 +21,8 @@ test('Insert Section button calls updatePage with a new blank HERO_WITH_IMAGE se
   const mockUpdatePageFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
     <HtmlPageEditView htmlPage={mockPage} readOnly={false} updatePage={mockUpdatePageFn}
-                      setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false} footerSection={undefined} updateFooter={jest.fn()}/>)
+      setSiteHasInvalidSection={jest.fn()}
+      siteHasInvalidSection={false} footerSection={undefined} updateFooter={jest.fn()}/>)
   render(RoutedComponent)
 
   //Act
@@ -42,8 +43,8 @@ test('Insert Section button calls updatePage with a new blank HERO_WITH_IMAGE se
 test('invalid JSON disables Insert Section button', async () => {
   const mockPage = mockHtmlPage()
   const { RoutedComponent } = setupRouterTest(
-    <HtmlPageEditView htmlPage={mockPage} readOnly={false} updatePage={jest.fn()}
-                      setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={true} footerSection={undefined} updateFooter={jest.fn()}/>)
+    <HtmlPageEditView htmlPage={mockPage} readOnly={false} updatePage={jest.fn()} setSiteHasInvalidSection={jest.fn()}
+      siteHasInvalidSection={true} footerSection={undefined} updateFooter={jest.fn()}/>)
   render(RoutedComponent)
   const sectionButtons= await screen.findAllByLabelText('Insert a blank section')
 

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
@@ -9,11 +9,13 @@ import { sectionTemplates } from './sectionTemplates'
 type HtmlPageViewProps = {
   htmlPage: HtmlPage
   readOnly: boolean
+  siteInvalid: boolean
+  setSiteInvalid: (invalid: boolean) => void
   updatePage: (page: HtmlPage) => void
 }
 
 /** Enables editing of a given page, showing the config and a preview for each section */
-const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => {
+const HtmlPageView = ({ htmlPage, readOnly, siteInvalid, setSiteInvalid, updatePage }: HtmlPageViewProps) => {
   const DEFAULT_SECTION_TYPE = {
     id: '',
     sectionType: 'HERO_WITH_IMAGE' as SectionType,
@@ -36,7 +38,7 @@ const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => 
       <Button variant="secondary"
         aria-label={'Insert a blank section'}
         tooltip={'Insert a blank section'}
-        disabled={readOnly}
+        disabled={readOnly || siteInvalid}
         onClick={() => insertNewSection(sectionIndex, DEFAULT_SECTION_TYPE)}>
         <FontAwesomeIcon icon={faPlus}/> Insert section
       </Button>
@@ -48,8 +50,8 @@ const HtmlPageView = ({ htmlPage, updatePage, readOnly }: HtmlPageViewProps) => 
     {htmlPage.sections.map((section, index) => {
       return <div key={`${section.id}-${index}`} className="row g-0">
         <div className="col-md-4 p-2">
-          <HtmlSectionEditor updatePage={updatePage} htmlPage={htmlPage}
-            section={section} sectionIndex={index} readOnly={readOnly}/>
+          <HtmlSectionEditor updatePage={updatePage} htmlPage={htmlPage} setSiteInvalid={setSiteInvalid}
+            siteInvalid={siteInvalid} section={section} sectionIndex={index} readOnly={readOnly}/>
         </div>
         <div className="col-md-8">
           <HtmlSectionView section={section}/>

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
@@ -9,8 +9,8 @@ import { sectionTemplates } from './sectionTemplates'
 type HtmlPageViewProps = {
   htmlPage: HtmlPage
   readOnly: boolean
-  siteInvalid: boolean
-  setSiteInvalid: (invalid: boolean) => void
+  siteHasInvalidSection: boolean
+  setSiteHasInvalidSection: (invalid: boolean) => void
   footerSection?: HtmlSection
   updateFooter: (section?: HtmlSection) => void
   updatePage: (page: HtmlPage) => void
@@ -18,7 +18,7 @@ type HtmlPageViewProps = {
 
 /** Enables editing of a given page, showing the config and a preview for each section */
 const HtmlPageView = ({
-  htmlPage, readOnly, siteInvalid, setSiteInvalid, footerSection, updateFooter, updatePage
+  htmlPage, readOnly, siteHasInvalidSection, setSiteHasInvalidSection, footerSection, updateFooter, updatePage
 }: HtmlPageViewProps) => {
   const DEFAULT_SECTION_TYPE = {
     id: '',
@@ -45,7 +45,7 @@ const HtmlPageView = ({
       sections: newSectionArray
     }
     //When the site content is invalid, users can only delete the invalid section. So it's safe to reset this flag
-    setSiteInvalid(false)
+    setSiteHasInvalidSection(false)
 
     updatePage(htmlPage)
   }
@@ -87,7 +87,7 @@ const HtmlPageView = ({
       <Button variant="secondary"
         aria-label={'Insert a blank section'}
         tooltip={'Insert a blank section'}
-        disabled={readOnly || siteInvalid}
+        disabled={readOnly || siteHasInvalidSection}
         onClick={() => insertNewSection(sectionIndex, DEFAULT_SECTION_TYPE)}>
         <FontAwesomeIcon icon={faPlus}/> Insert section
       </Button>
@@ -99,9 +99,9 @@ const HtmlPageView = ({
     {htmlPage.sections.map((section, index) => {
       return <div key={`${section.id}-${index}`} className="row g-0">
         <div className="col-md-4 px-2 pb-2">
-          <HtmlSectionEditor updateSection={updateSection(index)} setSiteInvalid={setSiteInvalid}
+          <HtmlSectionEditor updateSection={updateSection(index)} setSiteHasInvalidSection={setSiteHasInvalidSection}
             moveSection={moveSection(index)} removeSection={removeSection(index)} allowTypeChange={section.id === ''}
-            siteInvalid={siteInvalid} section={section} readOnly={readOnly}/>
+            siteHasInvalidSection={siteHasInvalidSection} section={section} readOnly={readOnly}/>
         </div>
         <div className="col-md-8">
           <HtmlSectionView section={section}/>
@@ -111,10 +111,11 @@ const HtmlPageView = ({
     })}
     { footerSection && <div className="row g-0">
       <div className="col-md-4 px-2 pb-2 mb-2">
-        <HtmlSectionEditor setSiteInvalid={setSiteInvalid} allowTypeChange={false}
+        <HtmlSectionEditor setSiteHasInvalidSection={setSiteHasInvalidSection} allowTypeChange={false}
           //These are undefined because we do not allow the user to move or remove the footer section
           moveSection={undefined} removeSection={() => updateFooter(undefined)}
-          siteInvalid={siteInvalid} section={footerSection} updateSection={updateFooter} readOnly={readOnly}/>
+          siteHasInvalidSection={siteHasInvalidSection} section={footerSection}
+          updateSection={updateFooter} readOnly={readOnly}/>
       </div>
       <div className="col-md-8">
         <HtmlSectionView section={footerSection}/>
@@ -124,7 +125,7 @@ const HtmlPageView = ({
       <Button variant="secondary"
         aria-label={'Insert a footer'}
         tooltip={'Insert a footer'}
-        disabled={readOnly || siteInvalid}
+        disabled={readOnly || siteHasInvalidSection}
         onClick={() => updateFooter({
           id: '',
           sectionType: 'LINK_SECTIONS_FOOTER' as SectionType,

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.test.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.test.tsx
@@ -11,7 +11,7 @@ test('readOnly disables section type selection', async () => {
   const mockSection = mockPage.sections[0]
   const { RoutedComponent } = setupRouterTest(
     <HtmlSectionEditor updateSection={jest.fn} section={mockSection} readOnly={true} allowTypeChange={true}
-      setSiteInvalid={jest.fn()} siteInvalid={false}/>)
+                       setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
   render(RoutedComponent)
   expect(screen.getByLabelText('Select section type')).toBeDisabled()
 })
@@ -22,7 +22,7 @@ test('section type selection is enabled if the section type is unsaved', async (
   mockSection.id = ''
   const { RoutedComponent } = setupRouterTest(
     <HtmlSectionEditor section={mockSection} readOnly={false} allowTypeChange={true}
-      updateSection={jest.fn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
+                       updateSection={jest.fn} setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
   render(RoutedComponent)
   expect(screen.getByLabelText('Select section type')).toBeEnabled()
 })
@@ -35,7 +35,7 @@ test('switching section types sets the section config to the correct template', 
   const mockUpdateSectionFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
     <HtmlSectionEditor section={mockSection} readOnly={false} allowTypeChange={true}
-      updateSection={mockUpdateSectionFn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
+                       updateSection={mockUpdateSectionFn} setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
   render(RoutedComponent)
 
   //Act
@@ -59,7 +59,7 @@ test('DeleteSection button removes the section', async () => {
   const mockDeleteFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
     <HtmlSectionEditor section={mockSection} readOnly={false} allowTypeChange={false}
-      updateSection={jest.fn()} removeSection={mockDeleteFn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
+                       updateSection={jest.fn()} removeSection={mockDeleteFn} setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
   render(RoutedComponent)
 
   //Act
@@ -83,7 +83,7 @@ test('MoveSectionUp button allows reordering', async () => {
   const mockMoveSectionFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
     <HtmlSectionEditor section={mockSection} readOnly={false} allowTypeChange={false}
-      updateSection={jest.fn} moveSection={mockMoveSectionFn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
+                       updateSection={jest.fn} moveSection={mockMoveSectionFn} setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
   render(RoutedComponent)
 
   //Act
@@ -107,7 +107,7 @@ test('MoveSectionDown button allows reordering', async () => {
   const mockMoveSectionFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
     <HtmlSectionEditor section={mockSection} readOnly={false} updateSection={jest.fn}
-      allowTypeChange={false} moveSection={mockMoveSectionFn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
+                       allowTypeChange={false} moveSection={mockMoveSectionFn} setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
   render(RoutedComponent)
 
   //Act
@@ -125,7 +125,7 @@ test('invalid JSON shows an error around the textbox', async () => {
   const mockUpdateSectionFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
     <HtmlSectionEditor section={mockSection} readOnly={false} allowTypeChange={false}
-      updateSection={mockUpdateSectionFn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
+                       updateSection={mockUpdateSectionFn} setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
   render(RoutedComponent)
 
   //Act
@@ -144,7 +144,7 @@ test('invalid JSON disables moveSection buttons', async () => {
   const mockUpdateSectionFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
     <HtmlSectionEditor section={mockSection} readOnly={false} moveSection={jest.fn()} removeSection={jest.fn()}
-      allowTypeChange={false} updateSection={mockUpdateSectionFn} setSiteInvalid={jest.fn()} siteInvalid={true}/>)
+                       allowTypeChange={false} updateSection={mockUpdateSectionFn} setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={true}/>)
   render(RoutedComponent)
 
   //Act

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.test.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.test.tsx
@@ -11,7 +11,7 @@ test('readOnly disables section type selection', async () => {
   const mockSection = mockPage.sections[0]
   const { RoutedComponent } = setupRouterTest(
     <HtmlSectionEditor updateSection={jest.fn} section={mockSection} readOnly={true} allowTypeChange={true}
-                       setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
+      setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
   render(RoutedComponent)
   expect(screen.getByLabelText('Select section type')).toBeDisabled()
 })
@@ -22,7 +22,7 @@ test('section type selection is enabled if the section type is unsaved', async (
   mockSection.id = ''
   const { RoutedComponent } = setupRouterTest(
     <HtmlSectionEditor section={mockSection} readOnly={false} allowTypeChange={true}
-                       updateSection={jest.fn} setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
+      updateSection={jest.fn} setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
   render(RoutedComponent)
   expect(screen.getByLabelText('Select section type')).toBeEnabled()
 })
@@ -34,8 +34,8 @@ test('switching section types sets the section config to the correct template', 
   mockSection.id = ''
   const mockUpdateSectionFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
-    <HtmlSectionEditor section={mockSection} readOnly={false} allowTypeChange={true}
-                       updateSection={mockUpdateSectionFn} setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
+    <HtmlSectionEditor section={mockSection} readOnly={false} allowTypeChange={true} updateSection={mockUpdateSectionFn}
+      setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
   render(RoutedComponent)
 
   //Act
@@ -58,8 +58,8 @@ test('DeleteSection button removes the section', async () => {
   const mockSection = mockPage.sections[0]
   const mockDeleteFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
-    <HtmlSectionEditor section={mockSection} readOnly={false} allowTypeChange={false}
-                       updateSection={jest.fn()} removeSection={mockDeleteFn} setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
+    <HtmlSectionEditor section={mockSection} readOnly={false} allowTypeChange={false} updateSection={jest.fn()}
+      removeSection={mockDeleteFn} setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
   render(RoutedComponent)
 
   //Act
@@ -82,8 +82,8 @@ test('MoveSectionUp button allows reordering', async () => {
   const mockSection = mockPage.sections[1]
   const mockMoveSectionFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
-    <HtmlSectionEditor section={mockSection} readOnly={false} allowTypeChange={false}
-                       updateSection={jest.fn} moveSection={mockMoveSectionFn} setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
+    <HtmlSectionEditor section={mockSection} readOnly={false} allowTypeChange={false} updateSection={jest.fn}
+      moveSection={mockMoveSectionFn} setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
   render(RoutedComponent)
 
   //Act
@@ -106,8 +106,8 @@ test('MoveSectionDown button allows reordering', async () => {
   const mockSection = mockPage.sections[0]
   const mockMoveSectionFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
-    <HtmlSectionEditor section={mockSection} readOnly={false} updateSection={jest.fn}
-                       allowTypeChange={false} moveSection={mockMoveSectionFn} setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
+    <HtmlSectionEditor section={mockSection} readOnly={false} updateSection={jest.fn} allowTypeChange={false}
+      moveSection={mockMoveSectionFn} setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
   render(RoutedComponent)
 
   //Act
@@ -125,7 +125,7 @@ test('invalid JSON shows an error around the textbox', async () => {
   const mockUpdateSectionFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
     <HtmlSectionEditor section={mockSection} readOnly={false} allowTypeChange={false}
-                       updateSection={mockUpdateSectionFn} setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
+      updateSection={mockUpdateSectionFn} setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
   render(RoutedComponent)
 
   //Act
@@ -144,7 +144,8 @@ test('invalid JSON disables moveSection buttons', async () => {
   const mockUpdateSectionFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
     <HtmlSectionEditor section={mockSection} readOnly={false} moveSection={jest.fn()} removeSection={jest.fn()}
-                       allowTypeChange={false} updateSection={mockUpdateSectionFn} setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={true}/>)
+      allowTypeChange={false} updateSection={mockUpdateSectionFn}
+      setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={true}/>)
   render(RoutedComponent)
 
   //Act

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.test.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.test.tsx
@@ -10,8 +10,8 @@ test('readOnly disables section type selection', async () => {
   const mockPage = mockHtmlPage()
   const mockSection = mockPage.sections[0]
   const { RoutedComponent } = setupRouterTest(
-    <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={true}
-      htmlPage={mockPage} updatePage={jest.fn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
+    <HtmlSectionEditor updateSection={jest.fn} section={mockSection} readOnly={true} allowTypeChange={true}
+      setSiteInvalid={jest.fn()} siteInvalid={false}/>)
   render(RoutedComponent)
   expect(screen.getByLabelText('Select section type')).toBeDisabled()
 })
@@ -21,8 +21,8 @@ test('section type selection is enabled if the section type is unsaved', async (
   const mockSection = mockPage.sections[0]
   mockSection.id = ''
   const { RoutedComponent } = setupRouterTest(
-    <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={false}
-      htmlPage={mockPage} updatePage={jest.fn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
+    <HtmlSectionEditor section={mockSection} readOnly={false} allowTypeChange={true}
+      updateSection={jest.fn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
   render(RoutedComponent)
   expect(screen.getByLabelText('Select section type')).toBeEnabled()
 })
@@ -32,10 +32,10 @@ test('switching section types sets the section config to the correct template', 
   const mockPage = mockHtmlPage()
   const mockSection = mockPage.sections[0]
   mockSection.id = ''
-  const mockUpdatePageFn = jest.fn()
+  const mockUpdateSectionFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
-    <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={false}
-      htmlPage={mockPage} updatePage={mockUpdatePageFn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
+    <HtmlSectionEditor section={mockSection} readOnly={false} allowTypeChange={true}
+      updateSection={mockUpdateSectionFn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
   render(RoutedComponent)
 
   //Act
@@ -45,13 +45,10 @@ test('switching section types sets the section config to the correct template', 
   await userEvent.click(option)
 
   //Assert
-  expect(mockUpdatePageFn).toHaveBeenCalledWith({
-    ...mockPage,
-    sections: [{
-      ...mockSection,
-      sectionType: 'FAQ',
-      sectionConfig: JSON.stringify(sectionTemplates['FAQ'])
-    }]
+  expect(mockUpdateSectionFn).toHaveBeenCalledWith({
+    ...mockSection,
+    sectionType: 'FAQ',
+    sectionConfig: JSON.stringify(sectionTemplates['FAQ'])
   })
 })
 
@@ -59,10 +56,10 @@ test('DeleteSection button removes the section', async () => {
   //Arrange
   const mockPage = mockHtmlPage()
   const mockSection = mockPage.sections[0]
-  const mockUpdatePageFn = jest.fn()
+  const mockDeleteFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
-    <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={false}
-      htmlPage={mockPage} updatePage={mockUpdatePageFn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
+    <HtmlSectionEditor section={mockSection} readOnly={false} allowTypeChange={false}
+      updateSection={jest.fn()} removeSection={mockDeleteFn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
   render(RoutedComponent)
 
   //Act
@@ -70,10 +67,7 @@ test('DeleteSection button removes the section', async () => {
   await userEvent.click(deleteButton)
 
   //Assert
-  expect(mockUpdatePageFn).toHaveBeenCalledWith({
-    ...mockPage,
-    sections: []
-  })
+  expect(mockDeleteFn).toHaveBeenCalled()
 })
 
 test('MoveSectionUp button allows reordering', async () => {
@@ -86,10 +80,10 @@ test('MoveSectionUp button allows reordering', async () => {
     ]
   }
   const mockSection = mockPage.sections[1]
-  const mockUpdatePageFn = jest.fn()
+  const mockMoveSectionFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
-    <HtmlSectionEditor sectionIndex={1} section={mockSection} readOnly={false}
-      htmlPage={mockPage} updatePage={mockUpdatePageFn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
+    <HtmlSectionEditor section={mockSection} readOnly={false} allowTypeChange={false}
+      updateSection={jest.fn} moveSection={mockMoveSectionFn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
   render(RoutedComponent)
 
   //Act
@@ -97,10 +91,7 @@ test('MoveSectionUp button allows reordering', async () => {
   await userEvent.click(moveUpButton)
 
   //Assert
-  expect(mockUpdatePageFn).toHaveBeenCalledWith({
-    ...mockPage,
-    sections: [mockPage.sections[1], mockPage.sections[0]]
-  })
+  expect(mockMoveSectionFn).toHaveBeenCalledWith('up')
 })
 
 test('MoveSectionDown button allows reordering', async () => {
@@ -113,10 +104,10 @@ test('MoveSectionDown button allows reordering', async () => {
     ]
   }
   const mockSection = mockPage.sections[0]
-  const mockUpdatePageFn = jest.fn()
+  const mockMoveSectionFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
-    <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={false}
-      htmlPage={mockPage} updatePage={mockUpdatePageFn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
+    <HtmlSectionEditor section={mockSection} readOnly={false} updateSection={jest.fn}
+      allowTypeChange={false} moveSection={mockMoveSectionFn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
   render(RoutedComponent)
 
   //Act
@@ -124,20 +115,17 @@ test('MoveSectionDown button allows reordering', async () => {
   await userEvent.click(moveDownButton)
 
   //Assert
-  expect(mockUpdatePageFn).toHaveBeenCalledWith({
-    ...mockPage,
-    sections: [mockPage.sections[1], mockPage.sections[0]]
-  })
+  expect(mockMoveSectionFn).toHaveBeenCalledWith('down')
 })
 
 test('invalid JSON shows an error around the textbox', async () => {
   //Arrange
   const mockPage = mockHtmlPage()
   const mockSection = mockPage.sections[0]
-  const mockUpdatePageFn = jest.fn()
+  const mockUpdateSectionFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
-    <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={false}
-      htmlPage={mockPage} updatePage={mockUpdatePageFn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
+    <HtmlSectionEditor section={mockSection} readOnly={false} allowTypeChange={false}
+      updateSection={mockUpdateSectionFn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
   render(RoutedComponent)
 
   //Act
@@ -145,7 +133,7 @@ test('invalid JSON shows an error around the textbox', async () => {
   await userEvent.type(input, '{\\\\}}') //testing-library requires escaping, this equates to "}"
 
   //Assert
-  expect(mockUpdatePageFn).not.toHaveBeenCalled()
+  expect(mockUpdateSectionFn).not.toHaveBeenCalled()
   expect(input).toHaveClass('is-invalid')
 })
 
@@ -153,10 +141,10 @@ test('invalid JSON disables moveSection buttons', async () => {
   //Arrange
   const mockPage = mockHtmlPage()
   const mockSection = mockPage.sections[0]
-  const mockUpdatePageFn = jest.fn()
+  const mockUpdateSectionFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
-    <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={false}
-      htmlPage={mockPage} updatePage={mockUpdatePageFn} setSiteInvalid={jest.fn()} siteInvalid={true}/>)
+    <HtmlSectionEditor section={mockSection} readOnly={false} moveSection={jest.fn()} removeSection={jest.fn()}
+      allowTypeChange={false} updateSection={mockUpdateSectionFn} setSiteInvalid={jest.fn()} siteInvalid={true}/>)
   render(RoutedComponent)
 
   //Act
@@ -164,7 +152,6 @@ test('invalid JSON disables moveSection buttons', async () => {
   await userEvent.type(input, '{\\\\}}') //testing-library requires escaping, this equates to "}"
 
   //Assert
-  expect(screen.getByLabelText('Delete this section')).toHaveAttribute('aria-disabled', 'false')
   expect(screen.getByLabelText('Move this section before the previous one')).toHaveAttribute('aria-disabled', 'true')
   expect(screen.getByLabelText('Move this section after the next one')).toHaveAttribute('aria-disabled', 'true')
 })

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.test.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen, waitFor} from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import React from 'react'
 import { setupRouterTest } from 'test-utils/router-testing-utils'
 import { mockHtmlPage, mockHtmlSection } from 'test-utils/mock-site-content'

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.test.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.test.tsx
@@ -11,7 +11,7 @@ test('readOnly disables section type selection', async () => {
   const mockSection = mockPage.sections[0]
   const { RoutedComponent } = setupRouterTest(
     <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={true}
-      htmlPage={mockPage} updatePage={jest.fn}/>)
+      htmlPage={mockPage} updatePage={jest.fn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
   render(RoutedComponent)
   expect(screen.getByLabelText('Select section type')).toBeDisabled()
 })
@@ -22,7 +22,7 @@ test('section type selection is enabled if the section type is unsaved', async (
   mockSection.id = ''
   const { RoutedComponent } = setupRouterTest(
     <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={false}
-      htmlPage={mockPage} updatePage={jest.fn}/>)
+      htmlPage={mockPage} updatePage={jest.fn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
   render(RoutedComponent)
   expect(screen.getByLabelText('Select section type')).toBeEnabled()
 })
@@ -35,7 +35,7 @@ test('switching section types sets the section config to the correct template', 
   const mockUpdatePageFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
     <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={false}
-      htmlPage={mockPage} updatePage={mockUpdatePageFn}/>)
+      htmlPage={mockPage} updatePage={mockUpdatePageFn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
   render(RoutedComponent)
 
   //Act
@@ -62,7 +62,7 @@ test('DeleteSection button removes the section', async () => {
   const mockUpdatePageFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
     <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={false}
-      htmlPage={mockPage} updatePage={mockUpdatePageFn}/>)
+      htmlPage={mockPage} updatePage={mockUpdatePageFn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
   render(RoutedComponent)
 
   //Act
@@ -89,7 +89,7 @@ test('MoveSectionUp button allows reordering', async () => {
   const mockUpdatePageFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
     <HtmlSectionEditor sectionIndex={1} section={mockSection} readOnly={false}
-      htmlPage={mockPage} updatePage={mockUpdatePageFn}/>)
+      htmlPage={mockPage} updatePage={mockUpdatePageFn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
   render(RoutedComponent)
 
   //Act
@@ -116,7 +116,7 @@ test('MoveSectionDown button allows reordering', async () => {
   const mockUpdatePageFn = jest.fn()
   const { RoutedComponent } = setupRouterTest(
     <HtmlSectionEditor sectionIndex={0} section={mockSection} readOnly={false}
-      htmlPage={mockPage} updatePage={mockUpdatePageFn}/>)
+      htmlPage={mockPage} updatePage={mockUpdatePageFn} setSiteInvalid={jest.fn()} siteInvalid={false}/>)
   render(RoutedComponent)
 
   //Act

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
@@ -27,8 +27,8 @@ const HtmlSectionEditor = ({
   removeSection,
   moveSection,
   section,
-  siteInvalid,
-  setSiteInvalid,
+  siteHasInvalidSection,
+  setSiteHasInvalidSection,
   allowTypeChange,
   readOnly
 }: {
@@ -36,8 +36,8 @@ const HtmlSectionEditor = ({
   removeSection?: () => void
   moveSection?: (direction: 'up' | 'down') => void
   section: HtmlSection
-  siteInvalid: boolean
-  setSiteInvalid: (invalid: boolean) => void
+  siteHasInvalidSection: boolean
+  setSiteHasInvalidSection: (invalid: boolean) => void
   allowTypeChange: boolean
   readOnly: boolean
 }) => {
@@ -57,11 +57,11 @@ const HtmlSectionEditor = ({
 
     try {
       JSON.parse(newEditorValue)
-      setSiteInvalid(false)
+      setSiteHasInvalidSection(false)
       setSectionContainsErrors(false)
       updateSection({ ...section, sectionConfig: newEditorValue })
     } catch (e) {
-      setSiteInvalid(true)
+      setSiteHasInvalidSection(true)
       setSectionContainsErrors(true)
       // Note that we do not call updateSection here, as that would result in an invalid preview being shown.
       // Instead, the preview will be based on the last valid config for this section.
@@ -75,9 +75,9 @@ const HtmlSectionEditor = ({
         onChange={opt => {
           if (opt != undefined) {
             if (sectionContainsErrors) {
-              //If the user is changing the section that had errors, then we can clear the siteInvalid flag
+              //If the user is changing the section that had errors, then we can clear the siteHasInvalidSection flag
               //because it will now be using a valid default template.
-              setSiteInvalid(false)
+              setSiteHasInvalidSection(false)
               setSectionContainsErrors(false)
             }
             const sectionTemplate = JSON.stringify(sectionTemplates[opt.label])
@@ -92,7 +92,7 @@ const HtmlSectionEditor = ({
       { moveSection && <IconButton
         aria-label="Move this section before the previous one"
         className="ms-2"
-        disabled={readOnly || siteInvalid}
+        disabled={readOnly || siteHasInvalidSection}
         icon={faChevronUp}
         variant="light"
         onClick={() => moveSection('up')}
@@ -100,7 +100,7 @@ const HtmlSectionEditor = ({
       { moveSection && <IconButton
         aria-label="Move this section after the next one"
         className="ms-2"
-        disabled={readOnly || siteInvalid}
+        disabled={readOnly || siteHasInvalidSection}
         icon={faChevronDown}
         variant="light"
         onClick={() => moveSection('down')}
@@ -108,14 +108,14 @@ const HtmlSectionEditor = ({
       { removeSection && <IconButton
         aria-label="Delete this section"
         className="ms-2"
-        disabled={readOnly || (siteInvalid && !sectionContainsErrors)}
+        disabled={readOnly || (siteHasInvalidSection && !sectionContainsErrors)}
         icon={faTimes}
         variant="light"
         onClick={() => removeSection()}
       /> }
     </div>
     <textarea value={editorValue} style={{ height: 'calc(100% - 2em)', width: '100%', minHeight: '300px' }}
-      disabled={readOnly || (siteInvalid && !sectionContainsErrors)}
+      disabled={readOnly || (siteHasInvalidSection && !sectionContainsErrors)}
       className={classNames('w-100 flex-grow-1 form-control font-monospace',
         { 'is-invalid': sectionContainsErrors })}
       onChange={e => {

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
@@ -101,13 +101,14 @@ const HtmlSectionEditor = ({
 
     try {
       JSON.parse(newEditorValue)
-      setSectionContainsErrors(false)
       setSiteInvalid(false)
+      setSectionContainsErrors(false)
       updateSection(sectionIndex, { ...section, sectionConfig: newEditorValue })
     } catch (e) {
       setSiteInvalid(true)
       setSectionContainsErrors(true)
-      // Note that we do not call updateSection here, as that would result in an invalid preview being shown
+      // Note that we do not call updateSection here, as that would result in an invalid preview being shown.
+      // Instead, the preview will be based on the last valid config for this section.
     }
   }
 
@@ -120,7 +121,12 @@ const HtmlSectionEditor = ({
         isDisabled={readOnly || !isEmpty(section.id)}
         onChange={opt => {
           if (opt != undefined) {
-            setSiteInvalid(false)
+            if (sectionContainsErrors) {
+              //If the user is changing the section that had errors, then we can clear the siteInvalid flag
+              //because it will now be using a valid default template.
+              setSiteInvalid(false)
+              setSectionContainsErrors(false)
+            }
             const sectionTemplate = JSON.stringify(sectionTemplates[opt.label])
             setSectionTypeOpt(opt)
             updateSection(sectionIndex, {

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.test.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.test.tsx
@@ -5,7 +5,7 @@ import { setupRouterTest } from 'test-utils/router-testing-utils'
 import { render, screen, waitFor } from '@testing-library/react'
 import { emptyApi, mockSiteContent } from 'test-utils/mock-site-content'
 import userEvent from '@testing-library/user-event'
-import { mockPortalEnvContext } from 'test-utils/mocking-utils'
+import {mockPortalEnvContext, mockPortalEnvironment} from 'test-utils/mocking-utils'
 
 test('enables live-preview text editing', async () => {
   const siteContent = mockSiteContent()
@@ -71,9 +71,8 @@ test('invalid site JSON disables Save button', async () => {
   const siteContent = mockSiteContent()
   const { RoutedComponent } = setupRouterTest(
     <SiteContentEditor siteContent={siteContent} previewApi={emptyApi} readOnly={false}
-      loadSiteContent={jest.fn()} createNewVersion={jest.fn()} portalShortcode="foo"
-      switchToVersion={jest.fn()}
-      portalEnv={mockPortalEnvironment('sandbox')}/>)
+      loadSiteContent={jest.fn()} createNewVersion={jest.fn()}
+      switchToVersion={jest.fn()} portalEnvContext={mockPortalEnvContext('sandbox')}/>)
   render(RoutedComponent)
 
   //Act
@@ -89,9 +88,9 @@ test('invalid site JSON disables Add Page button', async () => {
   const siteContent = mockSiteContent()
   const { RoutedComponent } = setupRouterTest(
     <SiteContentEditor siteContent={siteContent} previewApi={emptyApi} readOnly={false}
-      loadSiteContent={jest.fn()} createNewVersion={jest.fn()} portalShortcode="foo"
+      loadSiteContent={jest.fn()} createNewVersion={jest.fn()}
       switchToVersion={jest.fn()}
-      portalEnv={mockPortalEnvironment('sandbox')}/>)
+      portalEnvContext={mockPortalEnvContext('sandbox')}/>)
   render(RoutedComponent)
 
   //Act
@@ -108,8 +107,8 @@ test('invalid site JSON disables page selector', async () => {
   const siteContent = mockSiteContent()
   const { RoutedComponent } = setupRouterTest(
     <SiteContentEditor siteContent={siteContent} previewApi={emptyApi} readOnly={false}
-      loadSiteContent={jest.fn()} createNewVersion={jest.fn()} portalShortcode="foo" switchToVersion={jest.fn()}
-      portalEnv={mockPortalEnvironment('sandbox')}/>)
+      loadSiteContent={jest.fn()} createNewVersion={jest.fn()} switchToVersion={jest.fn()}
+      portalEnvContext={mockPortalEnvContext('sandbox')}/>)
   render(RoutedComponent)
 
   //Act

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.test.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.test.tsx
@@ -65,3 +65,58 @@ test('clicking on the Preview tab shows full page preview', async () => {
   expect(screen.queryByText('Insert section')).not.toBeInTheDocument()
   expect(screen.queryByText('we are the best')).toBeInTheDocument()
 })
+
+test('invalid site JSON disables Save button', async () => {
+  //Arrange
+  const siteContent = mockSiteContent()
+  const { RoutedComponent } = setupRouterTest(
+    <SiteContentEditor siteContent={siteContent} previewApi={emptyApi} readOnly={false}
+      loadSiteContent={jest.fn()} createNewVersion={jest.fn()} portalShortcode="foo"
+      switchToVersion={jest.fn()}
+      portalEnv={mockPortalEnvironment('sandbox')}/>)
+  render(RoutedComponent)
+
+  //Act
+  const sectionInput = screen.getByRole('textbox')
+  await userEvent.type(sectionInput, '{\\\\}}') //testing-library requires escaping, this equates to "}"
+
+  //Assert
+  expect(screen.queryByText('Save')).toHaveAttribute('aria-disabled', 'true')
+})
+
+test('invalid site JSON disables Add Page button', async () => {
+  //Arrange
+  const siteContent = mockSiteContent()
+  const { RoutedComponent } = setupRouterTest(
+    <SiteContentEditor siteContent={siteContent} previewApi={emptyApi} readOnly={false}
+      loadSiteContent={jest.fn()} createNewVersion={jest.fn()} portalShortcode="foo"
+      switchToVersion={jest.fn()}
+      portalEnv={mockPortalEnvironment('sandbox')}/>)
+  render(RoutedComponent)
+
+  //Act
+  const sectionInput = screen.getByRole('textbox')
+  await userEvent.type(sectionInput, '{\\\\}}') //testing-library requires escaping, this equates to "}"
+
+  //Assert
+  const addPageButton = screen.getByText('Add page')
+  expect(addPageButton).toHaveAttribute('aria-disabled', 'true')
+})
+
+test('invalid site JSON disables page selector', async () => {
+  //Arrange
+  const siteContent = mockSiteContent()
+  const { RoutedComponent } = setupRouterTest(
+    <SiteContentEditor siteContent={siteContent} previewApi={emptyApi} readOnly={false}
+      loadSiteContent={jest.fn()} createNewVersion={jest.fn()} portalShortcode="foo" switchToVersion={jest.fn()}
+      portalEnv={mockPortalEnvironment('sandbox')}/>)
+  render(RoutedComponent)
+
+  //Act
+  const sectionInput = screen.getByRole('textbox')
+  await userEvent.type(sectionInput, '{\\\\}}') //testing-library requires escaping, this equates to "}"
+
+  //Assert
+  const pageSelector = screen.getByLabelText('Select a page')
+  expect(pageSelector).toBeDisabled()
+})

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.test.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.test.tsx
@@ -5,7 +5,7 @@ import { setupRouterTest } from 'test-utils/router-testing-utils'
 import { render, screen, waitFor } from '@testing-library/react'
 import { emptyApi, mockSiteContent } from 'test-utils/mock-site-content'
 import userEvent from '@testing-library/user-event'
-import { mockPortalEnvContext, mockPortalEnvironment } from 'test-utils/mocking-utils'
+import { mockPortalEnvContext } from 'test-utils/mocking-utils'
 
 test('enables live-preview text editing', async () => {
   const siteContent = mockSiteContent()

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.test.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.test.tsx
@@ -5,7 +5,7 @@ import { setupRouterTest } from 'test-utils/router-testing-utils'
 import { render, screen, waitFor } from '@testing-library/react'
 import { emptyApi, mockSiteContent } from 'test-utils/mock-site-content'
 import userEvent from '@testing-library/user-event'
-import {mockPortalEnvContext, mockPortalEnvironment} from 'test-utils/mocking-utils'
+import { mockPortalEnvContext, mockPortalEnvironment } from 'test-utils/mocking-utils'
 
 test('enables live-preview text editing', async () => {
   const siteContent = mockSiteContent()

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -4,7 +4,10 @@ import Select from 'react-select'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faClipboard, faClockRotateLeft, faImage, faPlus } from '@fortawesome/free-solid-svg-icons'
 import HtmlPageEditView from './HtmlPageEditView'
-import { HtmlPage, LocalSiteContent, ApiProvider, SiteContent, ApiContextT, HtmlSectionView } from '@juniper/ui-core'
+import {
+  HtmlPage, LocalSiteContent, ApiProvider, SiteContent,
+  ApiContextT, HtmlSectionView, SiteFooter
+} from '@juniper/ui-core'
 import { Link } from 'react-router-dom'
 import SiteContentVersionSelector from './SiteContentVersionSelector'
 import { Button } from 'components/forms/Button'
@@ -108,6 +111,18 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
     }
     updateLocalContent(updatedLocalContent)
   }
+
+  const updateFooter = (footer?: HtmlSection) => {
+    if (!localContent) {
+      return
+    }
+    const updatedLocalContent = {
+      ...localContent,
+      footerSection: footer
+    }
+    updateLocalContent(updatedLocalContent)
+  }
+
   const isEditable = !readOnly && portalEnv.environmentName === 'sandbox'
 
   const currentNavBarItem = selectedNavOpt.value ? navBarInternalItems
@@ -118,7 +133,7 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
     .map(navItem => ({ label: navItem.text, value: navItem.text }))
   pageOpts.unshift(landingPageOption)
 
-  return <div className="d-flex bg-white">
+  return <div className="d-flex bg-white pb-5">
     <div className="d-flex flex-column flex-grow-1 mx-1 mb-1">
       <div className="d-flex p-2 align-items-center">
         <div className="d-flex flex-grow-1">
@@ -208,6 +223,7 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
                     <ApiProvider api={previewApi}>
                       <HtmlPageEditView htmlPage={pageToRender} readOnly={readOnly}
                         siteInvalid={siteInvalid} setSiteInvalid={setSiteInvalid}
+                        footerSection={localContent.footerSection} updateFooter={updateFooter}
                         updatePage={page => updatePage(page, currentNavBarItem?.text)}/>
                     </ApiProvider>}
               </div>
@@ -223,6 +239,7 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
                 { pageToRender.sections.map((section: HtmlSection) =>
                   <HtmlSectionView section={section} key={section.id}/>)
                 }
+                <SiteFooter footerSection={localContent.footerSection}/>
               </ApiProvider>
             </ErrorBoundary>
           </Tab>

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -161,7 +161,7 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
       <div className="px-2">
         <div className="d-flex flex-grow-1 mb-1">
           <div style={{ width: 250 }}>
-            <Select options={pageOpts} value={selectedNavOpt} isDisabled={siteInvalid}
+            <Select options={pageOpts} value={selectedNavOpt} isDisabled={siteInvalid} aria-label={'Select a page'}
               onChange={e => {
                 setSelectedNavOpt(e ?? landingPageOption)
               }}/>

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -48,11 +48,6 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
   }
   const navBarInternalItems = localContent.navbarItems
     .filter((navItem): navItem is NavbarItemInternal => navItem.itemType === 'INTERNAL')
-  //
-  // useEffect(() => {
-  //   const invalidSections = document.querySelectorAll('.is-invalid')
-  //   setSiteInvalid(invalidSections.length > 0)
-  // }, [workingContent])
 
   /** updates the global SiteContent object with the given LocalSiteContent */
   const updateLocalContent = (localContent: LocalSiteContent) => {
@@ -87,7 +82,6 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
 
   /** updates the global SiteContent object with the given HtmlPage, which may be associated with a navItem */
   const updatePage = (page: HtmlPage, navItemText?: string) => {
-    console.log('updatePage', page, navItemText)
     if (!localContent) {
       return
     }
@@ -167,14 +161,14 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
       <div className="px-2">
         <div className="d-flex flex-grow-1 mb-1">
           <div style={{ width: 250 }}>
-            <Select options={pageOpts} value={selectedNavOpt}
+            <Select options={pageOpts} value={selectedNavOpt} isDisabled={siteInvalid}
               onChange={e => {
                 setSelectedNavOpt(e ?? landingPageOption)
               }}/>
           </div>
           <Button className="btn btn-secondary"
             tooltip={'Add a new page'}
-            disabled={readOnly || !isEditable}
+            disabled={readOnly || !isEditable || siteInvalid}
             onClick={() => setShowAddPageModal(!showAddPageModal)}>
             <FontAwesomeIcon icon={faPlus}/> Add page
           </Button>
@@ -206,12 +200,14 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
           <Tab
             eventKey="designer"
             title="Designer"
+            disabled={siteInvalid}
           >
             <ErrorBoundary>
               <div>
                 {pageToRender &&
                     <ApiProvider api={previewApi}>
                       <HtmlPageEditView htmlPage={pageToRender} readOnly={readOnly}
+                        siteInvalid={siteInvalid} setSiteInvalid={setSiteInvalid}
                         updatePage={page => updatePage(page, currentNavBarItem?.text)}/>
                     </ApiProvider>}
               </div>
@@ -220,6 +216,7 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
           <Tab
             eventKey="preview"
             title="Preview"
+            disabled={siteInvalid}
           >
             <ErrorBoundary>
               <ApiProvider api={previewApi}>

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -34,18 +34,25 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
   } = props
   const { portalEnv } = portalEnvContext
   const selectedLanguage = 'en'
+  const initialContent = siteContent
   const [activeTab, setActiveTab] = useState<string | null>('designer')
   const [selectedNavOpt, setSelectedNavOpt] = useState<NavbarOption>(landingPageOption)
-  const [workingContent, setWorkingContent] = useState<SiteContent>(siteContent)
+  const [workingContent, setWorkingContent] = useState<SiteContent>(initialContent)
   const [showVersionSelector, setShowVersionSelector] = useState(false)
   const [showAddPageModal, setShowAddPageModal] = useState(false)
   const [showAddPreRegModal, setShowAddPreRegModal] = useState(false)
   const localContent = workingContent.localizedSiteContents.find(lsc => lsc.language === selectedLanguage)
+  const [siteInvalid, setSiteInvalid] = useState(false)
   if (!localContent) {
     return <div>no content for language {selectedLanguage}</div>
   }
   const navBarInternalItems = localContent.navbarItems
     .filter((navItem): navItem is NavbarItemInternal => navItem.itemType === 'INTERNAL')
+  //
+  // useEffect(() => {
+  //   const invalidSections = document.querySelectorAll('.is-invalid')
+  //   setSiteInvalid(invalidSections.length > 0)
+  // }, [workingContent])
 
   /** updates the global SiteContent object with the given LocalSiteContent */
   const updateLocalContent = (localContent: LocalSiteContent) => {
@@ -80,6 +87,7 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
 
   /** updates the global SiteContent object with the given HtmlPage, which may be associated with a navItem */
   const updatePage = (page: HtmlPage, navItemText?: string) => {
+    console.log('updatePage', page, navItemText)
     if (!localContent) {
       return
     }
@@ -134,7 +142,17 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
         {
           isEditable && <div className="d-flex flex-grow-1">
             <Button className="ms-auto me-md-2" variant="primary"
-              disabled={readOnly}
+              disabled={readOnly || siteInvalid || (initialContent === workingContent)}
+              tooltipPlacement={'left'}
+              tooltip={(() => {
+                if (initialContent === workingContent) {
+                  return 'Site is unchanged. Make changes to save.'
+                }
+                if (siteInvalid) {
+                  return 'Site is invalid. Correct to save.'
+                }
+                return 'Save changes'
+              })()}
               onClick={() => createNewVersion(workingContent)}>
                   Save
             </Button>

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -45,7 +45,7 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
   const [showAddPageModal, setShowAddPageModal] = useState(false)
   const [showAddPreRegModal, setShowAddPreRegModal] = useState(false)
   const localContent = workingContent.localizedSiteContents.find(lsc => lsc.language === selectedLanguage)
-  const [siteInvalid, setSiteInvalid] = useState(false)
+  const [hasInvalidSection, setHasInvalidSection] = useState(false)
   if (!localContent) {
     return <div>no content for language {selectedLanguage}</div>
   }
@@ -151,13 +151,13 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
         {
           isEditable && <div className="d-flex flex-grow-1">
             <Button className="ms-auto me-md-2" variant="primary"
-              disabled={readOnly || siteInvalid || (initialContent === workingContent)}
+              disabled={readOnly || hasInvalidSection || (initialContent === workingContent)}
               tooltipPlacement={'left'}
               tooltip={(() => {
                 if (initialContent === workingContent) {
                   return 'Site is unchanged. Make changes to save.'
                 }
-                if (siteInvalid) {
+                if (hasInvalidSection) {
                   return 'Site is invalid. Correct to save.'
                 }
                 return 'Save changes'
@@ -176,14 +176,15 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
       <div className="px-2">
         <div className="d-flex flex-grow-1 mb-1">
           <div style={{ width: 250 }}>
-            <Select options={pageOpts} value={selectedNavOpt} isDisabled={siteInvalid} aria-label={'Select a page'}
+            <Select options={pageOpts} value={selectedNavOpt}
+              isDisabled={hasInvalidSection} aria-label={'Select a page'}
               onChange={e => {
                 setSelectedNavOpt(e ?? landingPageOption)
               }}/>
           </div>
           <Button className="btn btn-secondary"
             tooltip={'Add a new page'}
-            disabled={readOnly || !isEditable || siteInvalid}
+            disabled={readOnly || !isEditable || hasInvalidSection}
             onClick={() => setShowAddPageModal(!showAddPageModal)}>
             <FontAwesomeIcon icon={faPlus}/> Add page
           </Button>
@@ -215,14 +216,14 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
           <Tab
             eventKey="designer"
             title="Designer"
-            disabled={siteInvalid}
+            disabled={hasInvalidSection}
           >
             <ErrorBoundary>
               <div>
                 {pageToRender &&
                     <ApiProvider api={previewApi}>
                       <HtmlPageEditView htmlPage={pageToRender} readOnly={readOnly}
-                        siteInvalid={siteInvalid} setSiteInvalid={setSiteInvalid}
+                        siteHasInvalidSection={hasInvalidSection} setSiteHasInvalidSection={setHasInvalidSection}
                         footerSection={localContent.footerSection} updateFooter={updateFooter}
                         updatePage={page => updatePage(page, currentNavBarItem?.text)}/>
                     </ApiProvider>}
@@ -232,7 +233,7 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
           <Tab
             eventKey="preview"
             title="Preview"
-            disabled={siteInvalid}
+            disabled={hasInvalidSection}
           >
             <ErrorBoundary>
               <ApiProvider api={previewApi}>

--- a/ui-admin/src/portal/siteContent/sectionTemplates.ts
+++ b/ui-admin/src/portal/siteContent/sectionTemplates.ts
@@ -34,10 +34,18 @@ const templateMailingListButtonConfig = {
   type: 'mailingList'
 }
 
+const templateLinkConfig = {
+  text: 'Enter text here',
+  href: 'Enter link here'
+}
+
 const templateItemSection = {
   title: 'Enter title here',
   items: [{
-    ...templateMailingListButtonConfig
+    ...templateLinkConfig
+  },
+  {
+    ...templateLinkConfig
   }]
 }
 
@@ -130,6 +138,12 @@ export const sectionTemplates: Record<string, object> = {
   },
   'LINK_SECTIONS_FOOTER': {
     itemSections: [
+      {
+        ...templateItemSection
+      },
+      {
+        ...templateItemSection
+      },
       {
         ...templateItemSection
       }

--- a/ui-core/src/index.ts
+++ b/ui-core/src/index.ts
@@ -14,6 +14,7 @@ export * from './surveyUtils'
 export * from './waitForImages'
 
 export * from './participant/landing/sections/HtmlSectionView'
+export * from './participant/landing/sections/SiteFooter'
 export * from './participant/landing/Markdown'
 export * from './participant/landing/MailingListModal'
 export * from './participant/landing/MailingListForm'

--- a/ui-core/src/participant/landing/sections/SiteFooter.tsx
+++ b/ui-core/src/participant/landing/sections/SiteFooter.tsx
@@ -1,0 +1,36 @@
+import classNames from 'classnames'
+import { HtmlSectionView } from './HtmlSectionView'
+import { Link } from 'react-router-dom'
+import React from 'react'
+import { HtmlSection } from 'src/types/landingPageConfig'
+
+/**
+ * Returns a siteFooter section for use in the Participant UI and Admin UI site previews
+ */
+export function SiteFooter({ footerSection }: { footerSection?: HtmlSection }) {
+  const hasFooter = !!footerSection
+
+  return <footer>
+    <div
+      className={classNames('row mx-0 d-flex justify-content-center', { 'pt-5': hasFooter })}
+    >
+      <div className="col-12 col-lg-8 px-0">
+        {footerSection && (
+          <HtmlSectionView section={footerSection}/>
+        )}
+        <div className="row mx-0">
+          <div
+            className={classNames('col-12', { 'border-top border-secondary': hasFooter })}
+            style={{
+              paddingTop: '2rem', paddingBottom: '2rem',
+              marginTop: hasFooter ? '6rem' : 0
+            }}
+          >
+            <Link to="/privacy">Privacy Policy</Link>
+            <Link to="/terms/participant" style={{ marginLeft: '2rem' }}>Terms of Use</Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer>
+}

--- a/ui-participant/src/landing/LandingPage.tsx
+++ b/ui-participant/src/landing/LandingPage.tsx
@@ -1,7 +1,6 @@
-import classNames from 'classnames'
 import React, { useEffect, useRef } from 'react'
-import { Link, Outlet, useLocation, useSearchParams } from 'react-router-dom'
-import { LocalSiteContent, MailingListModal, HtmlSectionView } from '@juniper/ui-core'
+import { Outlet, useLocation, useSearchParams } from 'react-router-dom'
+import { LocalSiteContent, MailingListModal, SiteFooter } from '@juniper/ui-core'
 import _uniqueId from 'lodash/uniqueId'
 import Navbar from '../Navbar'
 import * as bootstrap from 'bootstrap'
@@ -36,37 +35,13 @@ function LandingPageView({ localContent }: { localContent: LocalSiteContent }) {
     modal.show()
   }, [])
 
-  const hasFooter = !!localContent.footerSection
-
   return <div className="LandingPage">
     <div className="container-fluid bg-white min-vh-100 d-flex flex-column p-0">
       <Navbar />
       <main className="flex-grow-1">
         <Outlet/>
       </main>
-      <footer>
-        <div
-          className={classNames('row mx-0 d-flex justify-content-center', { 'pt-5': hasFooter })}
-        >
-          <div className="col-12 col-lg-8 px-0">
-            {localContent.footerSection && (
-              <HtmlSectionView section={localContent.footerSection}/>
-            )}
-            <div className="row mx-0">
-              <div
-                className={classNames('col-12', { 'border-top border-secondary': hasFooter })}
-                style={{
-                  paddingTop: '2rem', paddingBottom: '2rem',
-                  marginTop: hasFooter ? '6rem' : 0
-                }}
-              >
-                <Link to="/privacy">Privacy Policy</Link>
-                <Link to="/terms/participant" style={{ marginLeft: '2rem' }}>Terms of Use</Link>
-              </div>
-            </div>
-          </div>
-        </div>
-      </footer>
+      <SiteFooter footerSection={localContent.footerSection}/>
       <MailingListModal id={mailingListModalId.current} />
     </div>
   </div>


### PR DESCRIPTION
#### DESCRIPTION

I'm not 100% thrilled with how this turned out, but it was the least invasive way of allowing for invalid JSON to be typed during section editing. Ideally we'll have a UI slapped on top of this textbox so hopefully this won't live forever. I tried a couple of other approaches that followed a cleaner hierarchy of which component should own the validation, but they all ended up being pretty gnarly when it came down to actual implementation.

The implementation of this final approach disables a lot of functionality until a user has corrected their invalid JSON (add page, insert section, move section, etc). Because newly-inserted sections don't yet have IDs and section indexes can easily change, it was pretty difficult to accurately keep track of which sections were actually invalid after moving them around or changing pages. Disabling that functionality adds enough guardrails where it becomes much easier to manage.

https://github.com/broadinstitute/juniper/assets/7257391/4c555c52-97fa-40ea-ae58-30771308d6ab

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Launch admin UI + API
* Edit a section and type in some invalid JSON. Ensure that there is no possible way to save the page with that invalid section
* Ensure that section previews are still working
* Make sure that no functionality is inadvertently disabled even when JSON is valid