### PR TITLE
[JN-665] Adding asset fingerprint fallback to participant site

### DIFF
--- a/api-participant/build.gradle
+++ b/api-participant/build.gradle
@@ -47,15 +47,42 @@ dependencies {
 }
 
 task copyWebApp(type: Copy) {
+    dependsOn(rootProject.bundleParticipantUI)
     from "$rootDir/ui-participant/build"
     into "$rootDir/api-participant/build/resources/main/static"
 }
 
-// for now, only jib depends on copyWebApp, so that a npm rebuild/install will not be triggered for
-// development redeploys.  this means to deploy locally with the static assets in place you'll
-// need to run the copyWebApp task yourself
-copyWebApp.dependsOn(rootProject.bundleParticipantUI)
-jibDockerBuild.dependsOn('copyWebApp')
+// creates copies of the fingerprinted js files without the asset fingerprint.
+task createUnfingerprintedJs(type: Copy) {
+    dependsOn('copyWebApp')
+    dependsOn('processResources')
+    from "$rootDir/api-participant/build/resources/main/static/static/js"
+    into "$rootDir/api-participant/build/resources/main/static/static/js"
+    rename("main.([0-9a-f]{8}).js", "main.js")
+    rename('(.*).([0-9a-f]{8}).chunk.js', '$1.chunk.js')
+}
+
+// creates copies of the fingerprinted CSS files without the asset fingerprint
+task createUnfingerprintedCss(type: Copy) {
+    dependsOn('copyWebApp')
+    dependsOn('processResources')
+    from "$rootDir/api-participant/build/resources/main/static/static/css"
+    into "$rootDir/api-participant/build/resources/main/static/static/css"
+    rename("main.*.css", "main.css")
+}
+
+// See comment in PublicApiController.java for why we want unfingerprinted versions of assets.  We still keep the fingerprinted
+// versions for reference to help in determining which version of a file the server *actually* has
+task createUnfingerprintedAssets() {
+    dependsOn('createUnfingerprintedJs')
+    dependsOn('createUnfingerprintedCss')
+}
+
+// for now, only jib depends on copyWebApp (via createUnfingerprintedAssets),
+// so that a npm rebuild/install will not be triggered for development redeploys.
+// this means to deploy locally with the static assets in place you'll
+// need to run the copyWebApp task yourself from the repo root with ./gradlew api-participant:copyWebApp
+jibDockerBuild.dependsOn('createUnfingerprintedAssets')
 
 test {
     useJUnitPlatform ()

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PublicApiController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PublicApiController.java
@@ -149,14 +149,14 @@ public class PublicApiController implements PublicApi {
    * new pod which has a different asset fingerprint, and thus returns 404. This obviously opens the
    * door for obscure bugs relating to a user having different versions of different frontend assets
    * on the same page. This is reasonably safe for us now, though, since main.js is typically the
-   * only asset that changes between versions -- the majority of our css is inlined, and our JS chunks
-   * are for things like the privacy policy that are rarely used/updated. And the fingerprints are
-   * still included in index.html, so the fingerprints still do their job of preventing unwanted
-   * browser caching.
+   * only asset that changes between versions -- the majority of our css is inlined, and our JS
+   * chunks are for things like the privacy policy that are rarely used/updated. And the
+   * fingerprints are still included in index.html, so the fingerprints still do their job of
+   * preventing unwanted browser caching.
    *
-   * We're willing to temporarily accept the risk of possibly odd behavior in exchange for
-   * the site not appearing as down during deploys. Eventually, we should upgrade our
-   * deployment/hosting infrastructure to solve this problem in a more robust way
+   * <p>We're willing to temporarily accept the risk of possibly odd behavior in exchange for the
+   * site not appearing as down during deploys. Eventually, we should upgrade our deployment/hosting
+   * infrastructure to solve this problem in a more robust way
    */
   @GetMapping(value = "/static/js/main.{hash}.js")
   public String getFingerprintedJs() {

--- a/api-participant/src/test/java/bio/terra/pearl/api/participant/api/PublicApiControllerTest.java
+++ b/api-participant/src/test/java/bio/terra/pearl/api/participant/api/PublicApiControllerTest.java
@@ -85,6 +85,27 @@ class PublicApiControllerTest {
   }
 
   @Test
+  void testHandlesMismatchedJSFingerprint() throws Exception {
+    this.mockMvc
+        .perform(get("/static/js/main.12345678.js"))
+        .andExpect(forwardedUrl("/static/js/main.js"));
+  }
+
+  @Test
+  void testHandlesMismatchedCSSFingerprint() throws Exception {
+    this.mockMvc
+        .perform(get("/static/css/main.12345678.css"))
+        .andExpect(forwardedUrl("/static/css/main.css"));
+  }
+
+  @Test
+  void testHandlesMismatchedJsChunkFingerprint() throws Exception {
+    this.mockMvc
+        .perform(get("/static/js/111.12345678.chunk.js"))
+        .andExpect(forwardedUrl("/static/js/111.chunk.js"));
+  }
+
+  @Test
   void testResourceGets() throws Exception {
     // confirm image paths are not forwarded to index
     this.mockMvc.perform(get("/foo/bar/image.png")).andExpect(status().isNotFound());


### PR DESCRIPTION
#### DESCRIPTION

We had a problem where rolling deploys was causing the site to appear unavailable as requests for js assets 404'ed due to the request being served by a pod with a different version of the fingerprinted asset. Investigation into devOps-side ways of solving this problem (blue/green deployments, sticky load balancer pods, static asset hosting, etc..) suggested they would all involve more time and moving parts than we are comfortable spending right now, and likely introduce more risk than we want given our recent and upcoming launches.  See https://broadinstitute.slack.com/archives/CADM7MZ35/p1698759809580049 for some discussion

 So as a temporary band-aid, this updates our application servers to fallback to serving the js/css assets they have, even if the fingerprint doesn't match.  

This bandaid is reasonably safe for us now, though, since main.js is typically the only asset that changes between versions -- the majority of our css is inlined, and our JS chunks are for things like the privacy policy that are rarely used/updated. And the fingerprints are still included in index.html, so the fingerprints still do their job of preventing unwanted browser caching.  And it's certainly better than the alternative of the site always being down for 5-10mins during deploys.

My current thinking is that this change should get us at least  through the holidays, and then in Jan/Feb we can look at more robust devOps solutions. 

Also, I only included this band-aid on the participant side, since participant site availability is way more important than admin site availability.  


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1.  Clean out any existing built assets: from the repo root, run `./gradlew api-participant:clean`
2. Run the task to build and place all the assets for the participant server:  from the repo root , run `./gradlew api-participant:jibDockerBuild`
3. Restart your ApiParticipantApp (either intelliJ or `./gradlew api-participant:bootRun`)
4. in your browser, go to http://localhost:8081/static/js/main.11111111.js
5. confirm you get Javascript served to you, despite that asset name not existing in the built assets included in `api-participant/build/resources/main/static/static/js`