### PR TITLE
[JN-689] Fix RAW_HTML page sections

### DIFF
--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
@@ -78,7 +78,7 @@ const HtmlPageView = ({
     newSectionArray[sectionIndex] = newSection
     htmlPage = {
       ...htmlPage,
-      sections: newSectionArray,
+      sections: newSectionArray
     }
     updatePage(htmlPage)
   }

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.tsx
@@ -71,13 +71,14 @@ const HtmlPageView = ({
     const newSection = {
       ...htmlPage.sections[sectionIndex],
       sectionType: updatedSection.sectionType,
-      sectionConfig: updatedSection.sectionConfig
+      sectionConfig: updatedSection.sectionConfig,
+      rawContent: updatedSection.rawContent
     }
     const newSectionArray = [...htmlPage.sections]
     newSectionArray[sectionIndex] = newSection
     htmlPage = {
       ...htmlPage,
-      sections: newSectionArray
+      sections: newSectionArray,
     }
     updatePage(htmlPage)
   }

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.test.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.test.tsx
@@ -5,6 +5,7 @@ import { mockHtmlPage, mockHtmlSection } from 'test-utils/mock-site-content'
 import HtmlSectionEditor from './HtmlSectionEditor'
 import userEvent from '@testing-library/user-event'
 import { sectionTemplates } from './sectionTemplates'
+import { SectionType } from '@juniper/ui-core'
 
 test('readOnly disables section type selection', async () => {
   const mockPage = mockHtmlPage()
@@ -155,4 +156,24 @@ test('invalid JSON disables moveSection buttons', async () => {
   //Assert
   expect(screen.getByLabelText('Move this section before the previous one')).toHaveAttribute('aria-disabled', 'true')
   expect(screen.getByLabelText('Move this section after the next one')).toHaveAttribute('aria-disabled', 'true')
+})
+
+test('RAW_HTML sections should load content from the rawContent field', async () => {
+  //Arrange
+  const mockSection = {
+    id: 'testSection',
+    sectionType: 'RAW_HTML' as SectionType,
+    rawContent: '<p>Test</p>'
+  }
+
+  const { RoutedComponent } = setupRouterTest(
+    <HtmlSectionEditor section={mockSection} readOnly={false}  allowTypeChange={false} updateSection={jest.fn()}
+      setSiteHasInvalidSection={jest.fn()} siteHasInvalidSection={false}/>)
+  render(RoutedComponent)
+
+  //Act
+  const input = screen.getByRole('textbox')
+
+  //Assert
+  expect(input).toHaveValue(mockSection.rawContent)
 })

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
@@ -63,7 +63,6 @@ const HtmlSectionEditor = ({
     setEditorValue(newEditorValue)
 
     if (section.sectionType === 'RAW_HTML') {
-      console.log(newEditorValue)
       updateSection({ ...section, rawContent: newEditorValue, sectionConfig: undefined })
     } else {
       try {

--- a/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlSectionEditor.tsx
@@ -45,26 +45,38 @@ const HtmlSectionEditor = ({
   const initial = SECTION_TYPES.find(sectionType => sectionType.value === section.sectionType)
   const [sectionTypeOpt, setSectionTypeOpt] = useState(initial)
 
-  const [editorValue, setEditorValue] = useState(() =>
-    JSON.stringify(JSON.parse(section?.sectionConfig ?? '{}'), null, 2))
+  const getSectionContent = (section: HtmlSection) => {
+    if (section.sectionType === 'RAW_HTML') {
+      return section.rawContent ?? ''
+    } else {
+      return JSON.stringify(JSON.parse(section?.sectionConfig ?? '{}'), null, 2)
+    }
+  }
+
+  const [editorValue, setEditorValue] = useState(getSectionContent(section))
 
   useEffect(() => {
-    setEditorValue(JSON.stringify(JSON.parse(section?.sectionConfig ?? '{}'), null, 2))
+    setEditorValue(getSectionContent(section))
   }, [section.sectionConfig])
 
   const handleEditorChange = (newEditorValue: string) => {
     setEditorValue(newEditorValue)
 
-    try {
-      JSON.parse(newEditorValue)
-      setSiteHasInvalidSection(false)
-      setSectionContainsErrors(false)
-      updateSection({ ...section, sectionConfig: newEditorValue })
-    } catch (e) {
-      setSiteHasInvalidSection(true)
-      setSectionContainsErrors(true)
-      // Note that we do not call updateSection here, as that would result in an invalid preview being shown.
-      // Instead, the preview will be based on the last valid config for this section.
+    if (section.sectionType === 'RAW_HTML') {
+      console.log(newEditorValue)
+      updateSection({ ...section, rawContent: newEditorValue, sectionConfig: undefined })
+    } else {
+      try {
+        JSON.parse(newEditorValue)
+        setSiteHasInvalidSection(false)
+        setSectionContainsErrors(false)
+        updateSection({ ...section, sectionConfig: newEditorValue, rawContent: undefined })
+      } catch (e) {
+        setSiteHasInvalidSection(true)
+        setSectionContainsErrors(true)
+        // Note that we do not call updateSection here, as that would result in an invalid preview being shown.
+        // Instead, the preview will be based on the last valid config for this section.
+      }
     }
   }
 


### PR DESCRIPTION
#### DESCRIPTION

This fixes RAW_HTML sections, which were incorrectly storing their value in the `sectionConfig` field rather than the `rawContent` field.


https://github.com/broadinstitute/juniper/assets/7257391/f5b8772f-db3c-4003-8f0e-c61c45781804



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Load admin UI site editor: https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/siteContent
* Add a RAW_HTML section and type in your favorite html
* Confirm you can save it and that it look correct on the admin preview and participant site