### PR TITLE
[JN-699] fixing study prefix formatter

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportData.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportData.java
@@ -6,11 +6,13 @@ import bio.terra.pearl.core.model.survey.Answer;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
 import java.util.List;
+
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
-@Getter @Setter @Builder
+@Getter @Setter @Builder @AllArgsConstructor
 public class EnrolleeExportData {
     private Enrollee enrollee;
     private Profile profile;

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/SurveyFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/SurveyFormatter.java
@@ -13,8 +13,6 @@ import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static java.util.stream.Collectors.groupingBy;
 
@@ -83,7 +81,7 @@ public class SurveyFormatter implements ExportFormatter {
             return header + OTHER_DESCRIPTION_KEY_SUFFIX;
         } else if (itemExportInfo.getQuestionStableId() != null) {
             // for now, strip the prefixes to aid in readability.  Once we have multi-source surveys, we can revisit this.
-            String cleanStableId = stripStudyPrefixes(itemExportInfo.getQuestionStableId());
+            String cleanStableId = stripStudyAndSurveyPrefixes(itemExportInfo.getQuestionStableId());
             header = ExportFormatUtils.getColumnKey(moduleExportInfo.getModuleName(), cleanStableId);
             if (itemExportInfo.isSplitOptionsIntoColumns()) {
                 header += ExportFormatUtils.COLUMN_NAME_DELIMITER + choice.stableId();
@@ -104,7 +102,7 @@ public class SurveyFormatter implements ExportFormatter {
         if (isOtherDescription) {
             return OTHER_DESCRIPTION_HEADER;
         }
-        return ExportFormatUtils.camelToWordCase(stripStudyPrefixes(itemExportInfo.getQuestionStableId()));
+        return ExportFormatUtils.camelToWordCase(stripStudyAndSurveyPrefixes(itemExportInfo.getQuestionStableId()));
     }
 
     public ModuleExportInfo getModuleExportInfo(ExportOptions exportOptions, String stableId, List<Survey> surveys,
@@ -135,11 +133,14 @@ public class SurveyFormatter implements ExportFormatter {
                 .build();
     }
 
-    protected String stripStudyPrefixes(String stableId) {
-        if (stableId.lastIndexOf("_") < 0) {
+    /** strip out study and survey prefixes.  so e.g. "oh_oh_famHx_question1" becomes "question1" */
+    public static String stripStudyAndSurveyPrefixes(String stableId) {
+        // if there are >= 3 underscores, filter out everything before the third underscore
+        int thirdUnderscoreIndex = StringUtils.ordinalIndexOf(stableId, "_", 3);
+        if (thirdUnderscoreIndex < 0) {
             return stableId;
         }
-        return stableId.substring(stableId.lastIndexOf('_') + 1);
+        return stableId.substring(thirdUnderscoreIndex + 1);
     }
 
     /**

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/EnrolleeFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/EnrolleeFormatterTests.java
@@ -1,6 +1,7 @@
-package bio.terra.pearl.core.service.export;
+package bio.terra.pearl.core.service.export.formatters;
 
 import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.service.export.EnrolleeExportData;
 import bio.terra.pearl.core.service.export.formatters.EnrolleeFormatter;
 import bio.terra.pearl.core.service.export.instance.ExportOptions;
 import bio.terra.pearl.core.service.export.instance.ModuleExportInfo;

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ProfileFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ProfileFormatterTests.java
@@ -1,7 +1,8 @@
-package bio.terra.pearl.core.service.export;
+package bio.terra.pearl.core.service.export.formatters;
 
 import bio.terra.pearl.core.model.participant.MailingAddress;
 import bio.terra.pearl.core.model.participant.Profile;
+import bio.terra.pearl.core.service.export.EnrolleeExportData;
 import bio.terra.pearl.core.service.export.formatters.ProfileFormatter;
 import bio.terra.pearl.core.service.export.instance.ExportOptions;
 import bio.terra.pearl.core.service.export.instance.ModuleExportInfo;

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/SurveyFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/SurveyFormatterTests.java
@@ -1,10 +1,11 @@
-package bio.terra.pearl.core.service.export;
+package bio.terra.pearl.core.service.export.formatters;
 
 import bio.terra.pearl.core.BaseSpringBootTest;
 import bio.terra.pearl.core.model.survey.Answer;
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.model.survey.SurveyQuestionDefinition;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
+import bio.terra.pearl.core.service.export.EnrolleeExportData;
 import bio.terra.pearl.core.service.export.formatters.SurveyFormatter;
 import bio.terra.pearl.core.service.export.instance.ExportOptions;
 import bio.terra.pearl.core.service.export.instance.ItemExportInfo;
@@ -155,6 +156,14 @@ public class SurveyFormatterTests extends BaseSpringBootTest {
         exportOptions = ExportOptions.builder().splitOptionsIntoColumns(false).stableIdsForOptions(true).build();
         valueMap = generateAnswerMap(questionDef, multiselectBoth, exportOptions);
         assertThat(valueMap.get("oh_surveyA.oh_surveyA_q1"), equalTo("red"));
+    }
+
+    @Test
+    public void testStripStudyAndSurveyPrefixes() {
+        assertThat(SurveyFormatter.stripStudyAndSurveyPrefixes("oh_oh_famHx_someQuestion"), equalTo("someQuestion"));
+        assertThat(SurveyFormatter.stripStudyAndSurveyPrefixes("oh_oh_famHx_someQuestion_suffix"), equalTo("someQuestion_suffix"));
+        assertThat(SurveyFormatter.stripStudyAndSurveyPrefixes("nonStandardPrefix_someQuestion"), equalTo("nonStandardPrefix_someQuestion"));
+        assertThat(SurveyFormatter.stripStudyAndSurveyPrefixes("someQuestion"), equalTo("someQuestion"));
     }
 
     /** helper for testing generation of answer maps values for a single question-answer pair */


### PR DESCRIPTION
#### DESCRIPTION

This was the cause of the support email Romit sent yesterday -- Shriie had created some questions with underscores in their stableIds, and then our formatter was stripping them out.

I've created a ticket in the next sprint to re-evaluate our prefixing strategy.  I suspect given the changes in our self-service model we want to scrap it altogether.  Once we decide that strategy, the UX should enforce it

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1. Go to a PR that is soon to be opened syncing OurHealth's current production surveys to populate
2. repopulate ourHealth
3. go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/export/dataBrowser
4. confirm you can find a column called `oh_oh_famHx.sibling1_sex` in the export column list
