### PR TITLE
[JN-628] updating populate forms to match OH prod

### DIFF
--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/basic.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/basic.json
@@ -143,20 +143,33 @@
           },
           {
             "type": "text",
-            "name": "oh_oh_basic_rawWeight",
-            "visibleIf": "{oh_oh_basic_weightUnit} notempty",
+            "name": "oh_oh_basic_rawWeightPounds",
+            "visibleIf": "{oh_oh_basic_weightUnit} = 'lbs'",
             "title": "Weight in {oh_oh_basic_weightUnit}",
             "isRequired": true,
             "validators": [
               {
                 "type": "regex",
-                "text": "Validation 1 fired",
-                "regex": "^[0-9]*$"
+                "text": "Enter a number between 1 and 1000. (Enter 1000 if you weigh more than that.)",
+                "regex": "^([1-9][0-9]{0,2}|1000)$"
               }
             ],
-            "inputType": "number",
-            "min": 0,
-            "max": 999
+            "inputType": "number"
+          },
+          {
+            "type": "text",
+            "name": "oh_oh_basic_rawWeightKilos",
+            "visibleIf": "{oh_oh_basic_weightUnit} = 'kg'",
+            "title": "Weight in {oh_oh_basic_weightUnit}",
+            "isRequired": true,
+            "validators": [
+              {
+                "type": "regex",
+                "text": "Enter a number between 1 and 500. (Enter 500 if you weigh more than that.)",
+                "regex": "^([1-9][0-9]?|[1-4]\\d\\d|500)$"
+              }
+            ],
+            "inputType": "number"
           },
           {
             "type": "radiogroup",
@@ -183,13 +196,11 @@
             "validators": [
               {
                 "type": "regex",
-                "text": "Validation 1 fired",
-                "regex": "^[0-9]*$"
+                "text": "Enter a number between 1 and 300.",
+                "regex": "^([1-9][0-9]?|[1-2]\\d\\d|300)$"
               }
             ],
-            "inputType": "number",
-            "min": 0,
-            "max": 500
+            "inputType": "number"
           },
           {
             "type": "text",
@@ -200,13 +211,11 @@
             "validators": [
               {
                 "type": "regex",
-                "text": "Validation 1 fired",
-                "regex": "^[0-9]*$"
+                "text": "Enter a number between 1 and 9.",
+                "regex": "^[1-9]$"
               }
             ],
-            "inputType": "number",
-            "min": 0,
-            "max": 9
+            "inputType": "number"
           },
           {
             "type": "text",
@@ -218,13 +227,11 @@
             "validators": [
               {
                 "type": "regex",
-                "text": "Validation 1 fired",
-                "regex": "^[0-9]*$"
+                "text": "Enter a number between 1 and 11. Half inches can be entered as .5 (example: 7.5).",
+                "regex": "^([0-9]|1[0-1])?(\\.5)?$"
               }
             ],
-            "inputType": "number",
-            "min": 0,
-            "max": 11
+            "inputType": "number"
           },
           {
             "name": "oh_oh_basic_birthSex",
@@ -2147,7 +2154,7 @@
       {
         "name": "oh_oh_basic_weight",
         "includeIntoResult": true,
-        "expression": "iif({oh_oh_basic_weightUnit} = 'lbs', {oh_oh_basic_rawWeight} * 0.453592, {oh_oh_basic_rawWeight} * 1)"
+        "expression": "iif({oh_oh_basic_weightUnit} = 'lbs', {oh_oh_basic_rawWeightPounds} * 0.453592, {oh_oh_basic_rawWeightKilos} * 1)"
       },
       {
         "name": "oh_oh_basic_height",

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/basic.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/basic.json
@@ -3,26 +3,63 @@
   "version": 1,
   "name": "The Basics",
   "footer": "Resources used for this survey:\n * All of Us\n * US2020 Census\n * NHANES\n * GenIUSS group (Gender Identity in U.S. Surveillance)\n * National Health Interview Survey (NHIS)\n * Behavioral Risk Factor Surveillance System (BRFSS)\n * NHCHC\n * OurHealth",
-  "answerMappings": [{
-    "questionStableId": "oh_oh_basic_firstName", "targetType": "PROFILE", "targetField": "givenName", "mapType": "STRING_TO_STRING"
-  },{
-    "questionStableId": "oh_oh_basic_lastName", "targetType": "PROFILE", "targetField": "familyName", "mapType": "STRING_TO_STRING"
-  },{
-    "questionStableId": "oh_oh_basic_streetAddress", "targetType": "PROFILE", "targetField": "mailingAddress.street1", "mapType": "STRING_TO_STRING"
-  },{
-    "questionStableId": "oh_oh_basic_city", "targetType": "PROFILE", "targetField": "mailingAddress.city", "mapType": "STRING_TO_STRING"
-  },{
-    "questionStableId": "oh_oh_basic_state", "targetType": "PROFILE", "targetField": "mailingAddress.state", "mapType": "STRING_TO_STRING"
-  },{
-    "questionStableId": "oh_oh_basic_zip", "targetType": "PROFILE", "targetField": "mailingAddress.postalCode", "mapType": "STRING_TO_STRING"
-  },{
-    "questionStableId": "oh_oh_basic_phoneNumber", "targetType": "PROFILE", "targetField": "phoneNumber", "mapType": "STRING_TO_STRING"
-  },{
-    "questionStableId": "oh_oh_basic_dateOfBirth", "targetType": "PROFILE", "targetField": "birthDate", "mapType": "STRING_TO_LOCAL_DATE",
-    "formatString": "MM/dd/yyyy"
-  },{
-    "questionStableId": "oh_oh_basic_birthSex", "targetType": "PROFILE", "targetField": "sexAtBirth", "mapType": "STRING_TO_STRING"
-  }],
+  "answerMappings": [
+    {
+      "questionStableId": "oh_oh_basic_firstName",
+      "targetType": "PROFILE",
+      "targetField": "givenName",
+      "mapType": "STRING_TO_STRING"
+    },
+    {
+      "questionStableId": "oh_oh_basic_lastName",
+      "targetType": "PROFILE",
+      "targetField": "familyName",
+      "mapType": "STRING_TO_STRING"
+    },
+    {
+      "questionStableId": "oh_oh_basic_streetAddress",
+      "targetType": "PROFILE",
+      "targetField": "mailingAddress.street1",
+      "mapType": "STRING_TO_STRING"
+    },
+    {
+      "questionStableId": "oh_oh_basic_city",
+      "targetType": "PROFILE",
+      "targetField": "mailingAddress.city",
+      "mapType": "STRING_TO_STRING"
+    },
+    {
+      "questionStableId": "oh_oh_basic_state",
+      "targetType": "PROFILE",
+      "targetField": "mailingAddress.state",
+      "mapType": "STRING_TO_STRING"
+    },
+    {
+      "questionStableId": "oh_oh_basic_zip",
+      "targetType": "PROFILE",
+      "targetField": "mailingAddress.postalCode",
+      "mapType": "STRING_TO_STRING"
+    },
+    {
+      "questionStableId": "oh_oh_basic_phoneNumber",
+      "targetType": "PROFILE",
+      "targetField": "phoneNumber",
+      "mapType": "STRING_TO_STRING"
+    },
+    {
+      "questionStableId": "oh_oh_basic_dateOfBirth",
+      "targetType": "PROFILE",
+      "targetField": "birthDate",
+      "mapType": "STRING_TO_LOCAL_DATE",
+      "formatString": "MM/dd/yyyy"
+    },
+    {
+      "questionStableId": "oh_oh_basic_birthSex",
+      "targetType": "PROFILE",
+      "targetField": "sexAtBirth",
+      "mapType": "STRING_TO_STRING"
+    }
+  ],
   "jsonContent": {
     "title": "The Basics",
     "showQuestionNumbers": "off",
@@ -106,33 +143,20 @@
           },
           {
             "type": "text",
-            "name": "oh_oh_basic_rawWeightPounds",
-            "visibleIf": "{oh_oh_basic_weightUnit} = 'lbs'",
+            "name": "oh_oh_basic_rawWeight",
+            "visibleIf": "{oh_oh_basic_weightUnit} notempty",
             "title": "Weight in {oh_oh_basic_weightUnit}",
             "isRequired": true,
             "validators": [
               {
                 "type": "regex",
-                "text": "Enter a number between 1 and 1000. (Enter 1000 if you weigh more than that.)",
-                "regex": "^([1-9][0-9]{0,2}|1000)$"
+                "text": "Validation 1 fired",
+                "regex": "^[0-9]*$"
               }
             ],
-            "inputType": "number"
-          },
-          {
-            "type": "text",
-            "name": "oh_oh_basic_rawWeightKilos",
-            "visibleIf": "{oh_oh_basic_weightUnit} = 'kg'",
-            "title": "Weight in {oh_oh_basic_weightUnit}",
-            "isRequired": true,
-            "validators": [
-              {
-                "type": "regex",
-                "text": "Enter a number between 1 and 500. (Enter 500 if you weigh more than that.)",
-                "regex": "^([1-9][0-9]?|[1-4]\\d\\d|500)$"
-              }
-            ],
-            "inputType": "number"
+            "inputType": "number",
+            "min": 0,
+            "max": 999
           },
           {
             "type": "radiogroup",
@@ -159,11 +183,13 @@
             "validators": [
               {
                 "type": "regex",
-                "text": "Enter a number between 1 and 300.",
-                "regex": "^([1-9][0-9]?|[1-2]\\d\\d|300)$"
+                "text": "Validation 1 fired",
+                "regex": "^[0-9]*$"
               }
             ],
-            "inputType": "number"
+            "inputType": "number",
+            "min": 0,
+            "max": 500
           },
           {
             "type": "text",
@@ -174,11 +200,13 @@
             "validators": [
               {
                 "type": "regex",
-                "text": "Enter a number between 1 and 9.",
-                "regex": "^[1-9]$"
+                "text": "Validation 1 fired",
+                "regex": "^[0-9]*$"
               }
             ],
-            "inputType": "number"
+            "inputType": "number",
+            "min": 0,
+            "max": 9
           },
           {
             "type": "text",
@@ -190,11 +218,13 @@
             "validators": [
               {
                 "type": "regex",
-                "text": "Enter a number between 1 and 11. Half inches can be entered as .5 (example: 7.5).",
-                "regex": "^([0-9]|1[0-1])?(\\.5)?$"
+                "text": "Validation 1 fired",
+                "regex": "^[0-9]*$"
               }
             ],
-            "inputType": "number"
+            "inputType": "number",
+            "min": 0,
+            "max": 11
           },
           {
             "name": "oh_oh_basic_birthSex",
@@ -2113,14 +2143,17 @@
         ]
       }
     ],
-    "calculatedValues": [{
-      "name": "oh_oh_basic_weight",
-      "includeIntoResult": true,
-      "expression": "iif({oh_oh_basic_weightUnit} = 'lbs', {oh_oh_basic_rawWeightPounds} * 0.453592, {oh_oh_basic_rawWeightKilos} * 1)"
-    },{
-      "name": "oh_oh_basic_height",
-      "includeIntoResult": true,
-      "expression": "iif({oh_oh_basic_heightUnit} = 'in', ({oh_oh_basic_rawHeightFeet} * 12 + {oh_oh_basic_rawHeightInches}) * 2.54, {oh_oh_basic_rawHeightCm} * 1)"
-    }]
+    "calculatedValues": [
+      {
+        "name": "oh_oh_basic_weight",
+        "includeIntoResult": true,
+        "expression": "iif({oh_oh_basic_weightUnit} = 'lbs', {oh_oh_basic_rawWeight} * 0.453592, {oh_oh_basic_rawWeight} * 1)"
+      },
+      {
+        "name": "oh_oh_basic_height",
+        "includeIntoResult": true,
+        "expression": "iif({oh_oh_basic_heightUnit} = 'in', ({oh_oh_basic_rawHeightFeet} * 12 + {oh_oh_basic_rawHeightInches}) * 2.54, {oh_oh_basic_rawHeightCm} * 1)"
+      }
+    ]
   }
 }

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/cardioHistory.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/cardioHistory.json
@@ -13,106 +13,406 @@
         "type": "dropdown",
         "title": "About how old were you when you were first told you had this condition? ",
         "choices": [
-          {"text": "0", "value": "0"},
-          {"text": "1", "value": "1"},
-          {"text": "2", "value": "2"},
-          {"text": "3", "value": "3"},
-          {"text": "4", "value": "4"},
-          {"text": "5", "value": "5"},
-          {"text": "6", "value": "6"},
-          {"text": "7", "value": "7"},
-          {"text": "8", "value": "8"},
-          {"text": "9", "value": "9"},
-          {"text": "10", "value": "10"},
-          {"text": "11", "value": "11"},
-          {"text": "12", "value": "12"},
-          {"text": "13", "value": "13"},
-          {"text": "14", "value": "14"},
-          {"text": "15", "value": "15"},
-          {"text": "16", "value": "16"},
-          {"text": "17", "value": "17"},
-          {"text": "18", "value": "18"},
-          {"text": "19", "value": "19"},
-          {"text": "20", "value": "20"},
-          {"text": "21", "value": "21"},
-          {"text": "22", "value": "22"},
-          {"text": "23", "value": "23"},
-          {"text": "24", "value": "24"},
-          {"text": "25", "value": "25"},
-          {"text": "26", "value": "26"},
-          {"text": "27", "value": "27"},
-          {"text": "28", "value": "28"},
-          {"text": "29", "value": "29"},
-          {"text": "30", "value": "30"},
-          {"text": "31", "value": "31"},
-          {"text": "32", "value": "32"},
-          {"text": "33", "value": "33"},
-          {"text": "34", "value": "34"},
-          {"text": "35", "value": "35"},
-          {"text": "36", "value": "36"},
-          {"text": "37", "value": "37"},
-          {"text": "38", "value": "38"},
-          {"text": "39", "value": "39"},
-          {"text": "40", "value": "40"},
-          {"text": "41", "value": "41"},
-          {"text": "42", "value": "42"},
-          {"text": "43", "value": "43"},
-          {"text": "44", "value": "44"},
-          {"text": "45", "value": "45"},
-          {"text": "46", "value": "46"},
-          {"text": "47", "value": "47"},
-          {"text": "48", "value": "48"},
-          {"text": "49", "value": "49"},
-          {"text": "50", "value": "50"},
-          {"text": "51", "value": "51"},
-          {"text": "52", "value": "52"},
-          {"text": "53", "value": "53"},
-          {"text": "54", "value": "54"},
-          {"text": "55", "value": "55"},
-          {"text": "56", "value": "56"},
-          {"text": "57", "value": "57"},
-          {"text": "58", "value": "58"},
-          {"text": "59", "value": "59"},
-          {"text": "60", "value": "60"},
-          {"text": "61", "value": "61"},
-          {"text": "62", "value": "62"},
-          {"text": "63", "value": "63"},
-          {"text": "64", "value": "64"},
-          {"text": "65", "value": "65"},
-          {"text": "66", "value": "66"},
-          {"text": "67", "value": "67"},
-          {"text": "68", "value": "68"},
-          {"text": "69", "value": "69"},
-          {"text": "70", "value": "70"},
-          {"text": "71", "value": "71"},
-          {"text": "72", "value": "72"},
-          {"text": "73", "value": "73"},
-          {"text": "74", "value": "74"},
-          {"text": "75", "value": "75"},
-          {"text": "76", "value": "76"},
-          {"text": "77", "value": "77"},
-          {"text": "78", "value": "78"},
-          {"text": "79", "value": "79"},
-          {"text": "80", "value": "80"},
-          {"text": "81", "value": "81"},
-          {"text": "82", "value": "82"},
-          {"text": "83", "value": "83"},
-          {"text": "84", "value": "84"},
-          {"text": "85", "value": "85"},
-          {"text": "86", "value": "86"},
-          {"text": "87", "value": "87"},
-          {"text": "88", "value": "88"},
-          {"text": "89", "value": "89"},
-          {"text": "90", "value": "90"},
-          {"text": "91", "value": "91"},
-          {"text": "92", "value": "92"},
-          {"text": "93", "value": "93"},
-          {"text": "94", "value": "94"},
-          {"text": "95", "value": "95"},
-          {"text": "96", "value": "96"},
-          {"text": "97", "value": "97"},
-          {"text": "98", "value": "98"},
-          {"text": "99", "value": "99"}
+          {
+            "text": "0",
+            "value": "0"
+          },
+          {
+            "text": "1",
+            "value": "1"
+          },
+          {
+            "text": "2",
+            "value": "2"
+          },
+          {
+            "text": "3",
+            "value": "3"
+          },
+          {
+            "text": "4",
+            "value": "4"
+          },
+          {
+            "text": "5",
+            "value": "5"
+          },
+          {
+            "text": "6",
+            "value": "6"
+          },
+          {
+            "text": "7",
+            "value": "7"
+          },
+          {
+            "text": "8",
+            "value": "8"
+          },
+          {
+            "text": "9",
+            "value": "9"
+          },
+          {
+            "text": "10",
+            "value": "10"
+          },
+          {
+            "text": "11",
+            "value": "11"
+          },
+          {
+            "text": "12",
+            "value": "12"
+          },
+          {
+            "text": "13",
+            "value": "13"
+          },
+          {
+            "text": "14",
+            "value": "14"
+          },
+          {
+            "text": "15",
+            "value": "15"
+          },
+          {
+            "text": "16",
+            "value": "16"
+          },
+          {
+            "text": "17",
+            "value": "17"
+          },
+          {
+            "text": "18",
+            "value": "18"
+          },
+          {
+            "text": "19",
+            "value": "19"
+          },
+          {
+            "text": "20",
+            "value": "20"
+          },
+          {
+            "text": "21",
+            "value": "21"
+          },
+          {
+            "text": "22",
+            "value": "22"
+          },
+          {
+            "text": "23",
+            "value": "23"
+          },
+          {
+            "text": "24",
+            "value": "24"
+          },
+          {
+            "text": "25",
+            "value": "25"
+          },
+          {
+            "text": "26",
+            "value": "26"
+          },
+          {
+            "text": "27",
+            "value": "27"
+          },
+          {
+            "text": "28",
+            "value": "28"
+          },
+          {
+            "text": "29",
+            "value": "29"
+          },
+          {
+            "text": "30",
+            "value": "30"
+          },
+          {
+            "text": "31",
+            "value": "31"
+          },
+          {
+            "text": "32",
+            "value": "32"
+          },
+          {
+            "text": "33",
+            "value": "33"
+          },
+          {
+            "text": "34",
+            "value": "34"
+          },
+          {
+            "text": "35",
+            "value": "35"
+          },
+          {
+            "text": "36",
+            "value": "36"
+          },
+          {
+            "text": "37",
+            "value": "37"
+          },
+          {
+            "text": "38",
+            "value": "38"
+          },
+          {
+            "text": "39",
+            "value": "39"
+          },
+          {
+            "text": "40",
+            "value": "40"
+          },
+          {
+            "text": "41",
+            "value": "41"
+          },
+          {
+            "text": "42",
+            "value": "42"
+          },
+          {
+            "text": "43",
+            "value": "43"
+          },
+          {
+            "text": "44",
+            "value": "44"
+          },
+          {
+            "text": "45",
+            "value": "45"
+          },
+          {
+            "text": "46",
+            "value": "46"
+          },
+          {
+            "text": "47",
+            "value": "47"
+          },
+          {
+            "text": "48",
+            "value": "48"
+          },
+          {
+            "text": "49",
+            "value": "49"
+          },
+          {
+            "text": "50",
+            "value": "50"
+          },
+          {
+            "text": "51",
+            "value": "51"
+          },
+          {
+            "text": "52",
+            "value": "52"
+          },
+          {
+            "text": "53",
+            "value": "53"
+          },
+          {
+            "text": "54",
+            "value": "54"
+          },
+          {
+            "text": "55",
+            "value": "55"
+          },
+          {
+            "text": "56",
+            "value": "56"
+          },
+          {
+            "text": "57",
+            "value": "57"
+          },
+          {
+            "text": "58",
+            "value": "58"
+          },
+          {
+            "text": "59",
+            "value": "59"
+          },
+          {
+            "text": "60",
+            "value": "60"
+          },
+          {
+            "text": "61",
+            "value": "61"
+          },
+          {
+            "text": "62",
+            "value": "62"
+          },
+          {
+            "text": "63",
+            "value": "63"
+          },
+          {
+            "text": "64",
+            "value": "64"
+          },
+          {
+            "text": "65",
+            "value": "65"
+          },
+          {
+            "text": "66",
+            "value": "66"
+          },
+          {
+            "text": "67",
+            "value": "67"
+          },
+          {
+            "text": "68",
+            "value": "68"
+          },
+          {
+            "text": "69",
+            "value": "69"
+          },
+          {
+            "text": "70",
+            "value": "70"
+          },
+          {
+            "text": "71",
+            "value": "71"
+          },
+          {
+            "text": "72",
+            "value": "72"
+          },
+          {
+            "text": "73",
+            "value": "73"
+          },
+          {
+            "text": "74",
+            "value": "74"
+          },
+          {
+            "text": "75",
+            "value": "75"
+          },
+          {
+            "text": "76",
+            "value": "76"
+          },
+          {
+            "text": "77",
+            "value": "77"
+          },
+          {
+            "text": "78",
+            "value": "78"
+          },
+          {
+            "text": "79",
+            "value": "79"
+          },
+          {
+            "text": "80",
+            "value": "80"
+          },
+          {
+            "text": "81",
+            "value": "81"
+          },
+          {
+            "text": "82",
+            "value": "82"
+          },
+          {
+            "text": "83",
+            "value": "83"
+          },
+          {
+            "text": "84",
+            "value": "84"
+          },
+          {
+            "text": "85",
+            "value": "85"
+          },
+          {
+            "text": "86",
+            "value": "86"
+          },
+          {
+            "text": "87",
+            "value": "87"
+          },
+          {
+            "text": "88",
+            "value": "88"
+          },
+          {
+            "text": "89",
+            "value": "89"
+          },
+          {
+            "text": "90",
+            "value": "90"
+          },
+          {
+            "text": "91",
+            "value": "91"
+          },
+          {
+            "text": "92",
+            "value": "92"
+          },
+          {
+            "text": "93",
+            "value": "93"
+          },
+          {
+            "text": "94",
+            "value": "94"
+          },
+          {
+            "text": "95",
+            "value": "95"
+          },
+          {
+            "text": "96",
+            "value": "96"
+          },
+          {
+            "text": "97",
+            "value": "97"
+          },
+          {
+            "text": "98",
+            "value": "98"
+          },
+          {
+            "text": "99",
+            "value": "99"
+          }
         ]
       },
       {
@@ -120,106 +420,406 @@
         "type": "dropdown",
         "title": "About how old were you when you had this procedure? ",
         "choices": [
-          {"text": "0", "value": "0"},
-          {"text": "1", "value": "1"},
-          {"text": "2", "value": "2"},
-          {"text": "3", "value": "3"},
-          {"text": "4", "value": "4"},
-          {"text": "5", "value": "5"},
-          {"text": "6", "value": "6"},
-          {"text": "7", "value": "7"},
-          {"text": "8", "value": "8"},
-          {"text": "9", "value": "9"},
-          {"text": "10", "value": "10"},
-          {"text": "11", "value": "11"},
-          {"text": "12", "value": "12"},
-          {"text": "13", "value": "13"},
-          {"text": "14", "value": "14"},
-          {"text": "15", "value": "15"},
-          {"text": "16", "value": "16"},
-          {"text": "17", "value": "17"},
-          {"text": "18", "value": "18"},
-          {"text": "19", "value": "19"},
-          {"text": "20", "value": "20"},
-          {"text": "21", "value": "21"},
-          {"text": "22", "value": "22"},
-          {"text": "23", "value": "23"},
-          {"text": "24", "value": "24"},
-          {"text": "25", "value": "25"},
-          {"text": "26", "value": "26"},
-          {"text": "27", "value": "27"},
-          {"text": "28", "value": "28"},
-          {"text": "29", "value": "29"},
-          {"text": "30", "value": "30"},
-          {"text": "31", "value": "31"},
-          {"text": "32", "value": "32"},
-          {"text": "33", "value": "33"},
-          {"text": "34", "value": "34"},
-          {"text": "35", "value": "35"},
-          {"text": "36", "value": "36"},
-          {"text": "37", "value": "37"},
-          {"text": "38", "value": "38"},
-          {"text": "39", "value": "39"},
-          {"text": "40", "value": "40"},
-          {"text": "41", "value": "41"},
-          {"text": "42", "value": "42"},
-          {"text": "43", "value": "43"},
-          {"text": "44", "value": "44"},
-          {"text": "45", "value": "45"},
-          {"text": "46", "value": "46"},
-          {"text": "47", "value": "47"},
-          {"text": "48", "value": "48"},
-          {"text": "49", "value": "49"},
-          {"text": "50", "value": "50"},
-          {"text": "51", "value": "51"},
-          {"text": "52", "value": "52"},
-          {"text": "53", "value": "53"},
-          {"text": "54", "value": "54"},
-          {"text": "55", "value": "55"},
-          {"text": "56", "value": "56"},
-          {"text": "57", "value": "57"},
-          {"text": "58", "value": "58"},
-          {"text": "59", "value": "59"},
-          {"text": "60", "value": "60"},
-          {"text": "61", "value": "61"},
-          {"text": "62", "value": "62"},
-          {"text": "63", "value": "63"},
-          {"text": "64", "value": "64"},
-          {"text": "65", "value": "65"},
-          {"text": "66", "value": "66"},
-          {"text": "67", "value": "67"},
-          {"text": "68", "value": "68"},
-          {"text": "69", "value": "69"},
-          {"text": "70", "value": "70"},
-          {"text": "71", "value": "71"},
-          {"text": "72", "value": "72"},
-          {"text": "73", "value": "73"},
-          {"text": "74", "value": "74"},
-          {"text": "75", "value": "75"},
-          {"text": "76", "value": "76"},
-          {"text": "77", "value": "77"},
-          {"text": "78", "value": "78"},
-          {"text": "79", "value": "79"},
-          {"text": "80", "value": "80"},
-          {"text": "81", "value": "81"},
-          {"text": "82", "value": "82"},
-          {"text": "83", "value": "83"},
-          {"text": "84", "value": "84"},
-          {"text": "85", "value": "85"},
-          {"text": "86", "value": "86"},
-          {"text": "87", "value": "87"},
-          {"text": "88", "value": "88"},
-          {"text": "89", "value": "89"},
-          {"text": "90", "value": "90"},
-          {"text": "91", "value": "91"},
-          {"text": "92", "value": "92"},
-          {"text": "93", "value": "93"},
-          {"text": "94", "value": "94"},
-          {"text": "95", "value": "95"},
-          {"text": "96", "value": "96"},
-          {"text": "97", "value": "97"},
-          {"text": "98", "value": "98"},
-          {"text": "99", "value": "99"}
+          {
+            "text": "0",
+            "value": "0"
+          },
+          {
+            "text": "1",
+            "value": "1"
+          },
+          {
+            "text": "2",
+            "value": "2"
+          },
+          {
+            "text": "3",
+            "value": "3"
+          },
+          {
+            "text": "4",
+            "value": "4"
+          },
+          {
+            "text": "5",
+            "value": "5"
+          },
+          {
+            "text": "6",
+            "value": "6"
+          },
+          {
+            "text": "7",
+            "value": "7"
+          },
+          {
+            "text": "8",
+            "value": "8"
+          },
+          {
+            "text": "9",
+            "value": "9"
+          },
+          {
+            "text": "10",
+            "value": "10"
+          },
+          {
+            "text": "11",
+            "value": "11"
+          },
+          {
+            "text": "12",
+            "value": "12"
+          },
+          {
+            "text": "13",
+            "value": "13"
+          },
+          {
+            "text": "14",
+            "value": "14"
+          },
+          {
+            "text": "15",
+            "value": "15"
+          },
+          {
+            "text": "16",
+            "value": "16"
+          },
+          {
+            "text": "17",
+            "value": "17"
+          },
+          {
+            "text": "18",
+            "value": "18"
+          },
+          {
+            "text": "19",
+            "value": "19"
+          },
+          {
+            "text": "20",
+            "value": "20"
+          },
+          {
+            "text": "21",
+            "value": "21"
+          },
+          {
+            "text": "22",
+            "value": "22"
+          },
+          {
+            "text": "23",
+            "value": "23"
+          },
+          {
+            "text": "24",
+            "value": "24"
+          },
+          {
+            "text": "25",
+            "value": "25"
+          },
+          {
+            "text": "26",
+            "value": "26"
+          },
+          {
+            "text": "27",
+            "value": "27"
+          },
+          {
+            "text": "28",
+            "value": "28"
+          },
+          {
+            "text": "29",
+            "value": "29"
+          },
+          {
+            "text": "30",
+            "value": "30"
+          },
+          {
+            "text": "31",
+            "value": "31"
+          },
+          {
+            "text": "32",
+            "value": "32"
+          },
+          {
+            "text": "33",
+            "value": "33"
+          },
+          {
+            "text": "34",
+            "value": "34"
+          },
+          {
+            "text": "35",
+            "value": "35"
+          },
+          {
+            "text": "36",
+            "value": "36"
+          },
+          {
+            "text": "37",
+            "value": "37"
+          },
+          {
+            "text": "38",
+            "value": "38"
+          },
+          {
+            "text": "39",
+            "value": "39"
+          },
+          {
+            "text": "40",
+            "value": "40"
+          },
+          {
+            "text": "41",
+            "value": "41"
+          },
+          {
+            "text": "42",
+            "value": "42"
+          },
+          {
+            "text": "43",
+            "value": "43"
+          },
+          {
+            "text": "44",
+            "value": "44"
+          },
+          {
+            "text": "45",
+            "value": "45"
+          },
+          {
+            "text": "46",
+            "value": "46"
+          },
+          {
+            "text": "47",
+            "value": "47"
+          },
+          {
+            "text": "48",
+            "value": "48"
+          },
+          {
+            "text": "49",
+            "value": "49"
+          },
+          {
+            "text": "50",
+            "value": "50"
+          },
+          {
+            "text": "51",
+            "value": "51"
+          },
+          {
+            "text": "52",
+            "value": "52"
+          },
+          {
+            "text": "53",
+            "value": "53"
+          },
+          {
+            "text": "54",
+            "value": "54"
+          },
+          {
+            "text": "55",
+            "value": "55"
+          },
+          {
+            "text": "56",
+            "value": "56"
+          },
+          {
+            "text": "57",
+            "value": "57"
+          },
+          {
+            "text": "58",
+            "value": "58"
+          },
+          {
+            "text": "59",
+            "value": "59"
+          },
+          {
+            "text": "60",
+            "value": "60"
+          },
+          {
+            "text": "61",
+            "value": "61"
+          },
+          {
+            "text": "62",
+            "value": "62"
+          },
+          {
+            "text": "63",
+            "value": "63"
+          },
+          {
+            "text": "64",
+            "value": "64"
+          },
+          {
+            "text": "65",
+            "value": "65"
+          },
+          {
+            "text": "66",
+            "value": "66"
+          },
+          {
+            "text": "67",
+            "value": "67"
+          },
+          {
+            "text": "68",
+            "value": "68"
+          },
+          {
+            "text": "69",
+            "value": "69"
+          },
+          {
+            "text": "70",
+            "value": "70"
+          },
+          {
+            "text": "71",
+            "value": "71"
+          },
+          {
+            "text": "72",
+            "value": "72"
+          },
+          {
+            "text": "73",
+            "value": "73"
+          },
+          {
+            "text": "74",
+            "value": "74"
+          },
+          {
+            "text": "75",
+            "value": "75"
+          },
+          {
+            "text": "76",
+            "value": "76"
+          },
+          {
+            "text": "77",
+            "value": "77"
+          },
+          {
+            "text": "78",
+            "value": "78"
+          },
+          {
+            "text": "79",
+            "value": "79"
+          },
+          {
+            "text": "80",
+            "value": "80"
+          },
+          {
+            "text": "81",
+            "value": "81"
+          },
+          {
+            "text": "82",
+            "value": "82"
+          },
+          {
+            "text": "83",
+            "value": "83"
+          },
+          {
+            "text": "84",
+            "value": "84"
+          },
+          {
+            "text": "85",
+            "value": "85"
+          },
+          {
+            "text": "86",
+            "value": "86"
+          },
+          {
+            "text": "87",
+            "value": "87"
+          },
+          {
+            "text": "88",
+            "value": "88"
+          },
+          {
+            "text": "89",
+            "value": "89"
+          },
+          {
+            "text": "90",
+            "value": "90"
+          },
+          {
+            "text": "91",
+            "value": "91"
+          },
+          {
+            "text": "92",
+            "value": "92"
+          },
+          {
+            "text": "93",
+            "value": "93"
+          },
+          {
+            "text": "94",
+            "value": "94"
+          },
+          {
+            "text": "95",
+            "value": "95"
+          },
+          {
+            "text": "96",
+            "value": "96"
+          },
+          {
+            "text": "97",
+            "value": "97"
+          },
+          {
+            "text": "98",
+            "value": "98"
+          },
+          {
+            "text": "99",
+            "value": "99"
+          }
         ]
       }
     ],
@@ -233,7 +833,7 @@
               {
                 "type": "html",
                 "name": "oh_oh_cardioHx_descriptionText",
-                "html": "<p>This survey asks questions about your Cardiometabolic Medical History. This is to better understand how it may affect health. It will take about 5-10 minutes to answer these questions. Please answer each question as honestly as possible. We are looking for your own answers, not what you think your doctors, family, or friends want you to say. Do not feel like you have to spend a long time on each question. The first answer that comes to you is usually the best one. </p>"
+                "html": "<p>This survey asks questions about your Cardiometabolic Medical History only. This is to better understand how it may affect health. The next survey will ask about other pertinent medical history. It will take about 5-10 minutes to answer these questions. Please answer each question as honestly as possible. We are looking for your own answers, not what you think your doctors, family, or friends want you to say. Do not feel like you have to spend a long time on each question. The first answer that comes to you is usually the best one. </p>"
               }
             ]
           },
@@ -253,12 +853,8 @@
             "title": "I am worried about my heart health.",
             "choices": [
               {
-                "text": "Yes, specifically about my heart",
-                "value": "yesSpecificallyAboutMyHeart"
-              },
-              {
-                "text": "Yes, in general",
-                "value": "yesInGeneral"
+                "text": "Yes",
+                "value": "yes"
               },
               {
                 "text": "No",
@@ -489,7 +1085,7 @@
             "title": "Coronary artery/coronary heart disease",
             "visibleIf": "{oh_oh_cardioHx_diagnosedHeartConditions} contains 'coronaryDisease'",
             "elements": [
-                            {
+              {
                 "name": "oh_oh_cardioHx_coronaryDiseaseAgeAtDx",
                 "questionTemplateName": "oh_oh_cardioHx_ageAboutAtDiagnosis"
               },
@@ -709,7 +1305,8 @@
             ]
           }
         ]
-      },{
+      },
+      {
         "elements": [
           {
             "type": "panel",
@@ -729,15 +1326,42 @@
             "noneValue": "none",
             "noneText": "None of the above",
             "choices": [
-              {"text": "Diabetes - Type 1", "value": "diabetesType1"},
-              {"text": "Diabetes - Type 2", "value": "diabetesType2"},
-              {"text": "Gestational diabetes", "value": "diabetesGestational"},
-              {"text": "Prediabetes", "value": "prediabetes"},
-              {"text": "Non-alcoholic Fatty Liver Disease (NAFLD/NASH)", "value": "nonAlcoholicFattyLiverDisease"},
-              {"text": "Obesity", "value": "obesity"},
-              {"text": "Polycystic Ovarian Syndrome (PCOS)", "value": "polycysticOvarianSyndrome"},
-              {"text": "Don't know", "value": "dontKnow"},
-              {"text": "Prefer not to answer", "value": "preferNoAnswer"}
+              {
+                "text": "Diabetes - Type 1",
+                "value": "diabetesType1"
+              },
+              {
+                "text": "Diabetes - Type 2",
+                "value": "diabetesType2"
+              },
+              {
+                "text": "Gestational diabetes",
+                "value": "diabetesGestational"
+              },
+              {
+                "text": "Prediabetes",
+                "value": "prediabetes"
+              },
+              {
+                "text": "Non-alcoholic Fatty Liver Disease (NAFLD/NASH)",
+                "value": "nonAlcoholicFattyLiverDisease"
+              },
+              {
+                "text": "Obesity",
+                "value": "obesity"
+              },
+              {
+                "text": "Polycystic Ovarian Syndrome (PCOS)",
+                "value": "polycysticOvarianSyndrome"
+              },
+              {
+                "text": "Don't know",
+                "value": "dontKnow"
+              },
+              {
+                "text": "Prefer not to answer",
+                "value": "preferNoAnswer"
+              }
             ]
           },
           {
@@ -809,10 +1433,22 @@
                 "type": "radiogroup",
                 "title": "In which of the following areas do you tend to store body fat?",
                 "choices": [
-                  {"text": "Abdomen/Stomach", "value": "abdomenStomach"},
-                  {"text": "Backside and thighs", "value": "backsideAndThighs"},
-                  {"text": "Arms and legs", "value": "armsAndLegs"},
-                  {"text": "Not sure", "value": "unsure"}
+                  {
+                    "text": "Abdomen/Stomach",
+                    "value": "abdomenStomach"
+                  },
+                  {
+                    "text": "Backside and thighs",
+                    "value": "backsideAndThighs"
+                  },
+                  {
+                    "text": "Arms and legs",
+                    "value": "armsAndLegs"
+                  },
+                  {
+                    "text": "Not sure",
+                    "value": "unsure"
+                  }
                 ]
               }
             ]
@@ -1134,7 +1770,8 @@
                     "value": "preferNoAnswer"
                   }
                 ]
-              },{
+              },
+              {
                 "name": "oh_oh_lifestyle_pregnancyConditions",
                 "type": "checkbox",
                 "title": "With any of these pregnancies, did a doctor or health care provider tell you that you had…?",
@@ -1142,17 +1779,50 @@
                 "noneValue": "none",
                 "noneText": "None of the above",
                 "choices": [
-                  {"text": "Gestational diabetes", "value": "gestationalDiabetes"},
-                  {"text": "Gestational hypertension", "value": "gestationalHypertension"},
-                  {"text": "Preeclampsia", "value": "preeclampsia"},
-                  {"text": "Eclampsia", "value": "eclampsia"},
-                  {"text": "Endometriosis", "value": "endometriosis"},
-                  {"text": "HELLP syndrome", "value": "hellpSyndrome"},
-                  {"text": "Peripartum cardiomyopathy", "value": "peripartumCardiomyopathy"},
-                  {"text": "Peripartum depression", "value": "peripartumDepression"},
-                  {"text": "Preterm labor", "value": "pretermLabor"},
-                  {"text": "Don't know", "value": "dontKnow"},
-                  {"text": "Prefer not to answer", "value": "preferNoAnswer"}
+                  {
+                    "text": "Gestational diabetes",
+                    "value": "gestationalDiabetes"
+                  },
+                  {
+                    "text": "Gestational hypertension",
+                    "value": "gestationalHypertension"
+                  },
+                  {
+                    "text": "Preeclampsia",
+                    "value": "preeclampsia"
+                  },
+                  {
+                    "text": "Eclampsia",
+                    "value": "eclampsia"
+                  },
+                  {
+                    "text": "Endometriosis",
+                    "value": "endometriosis"
+                  },
+                  {
+                    "text": "HELLP syndrome",
+                    "value": "hellpSyndrome"
+                  },
+                  {
+                    "text": "Peripartum cardiomyopathy",
+                    "value": "peripartumCardiomyopathy"
+                  },
+                  {
+                    "text": "Peripartum depression",
+                    "value": "peripartumDepression"
+                  },
+                  {
+                    "text": "Preterm labor",
+                    "value": "pretermLabor"
+                  },
+                  {
+                    "text": "Don't know",
+                    "value": "dontKnow"
+                  },
+                  {
+                    "text": "Prefer not to answer",
+                    "value": "preferNoAnswer"
+                  }
                 ]
               }
             ]
@@ -1162,10 +1832,22 @@
             "type": "radiogroup",
             "title": "Have you gone through or are you currently going through menopause? (Both natural and/or medical)",
             "choices": [
-              {"text": "Yes", "value": "yes"},
-              {"text": "No", "value": "no"},
-              {"text": "Don't know", "value": "dontKnow"},
-              {"text": "Prefer not to answer", "value": "preferNoAnswer"}
+              {
+                "text": "Yes",
+                "value": "yes"
+              },
+              {
+                "text": "No",
+                "value": "no"
+              },
+              {
+                "text": "Don't know",
+                "value": "dontKnow"
+              },
+              {
+                "text": "Prefer not to answer",
+                "value": "preferNoAnswer"
+              }
             ]
           },
           {
@@ -1186,8 +1868,8 @@
                     "value": "no"
                   },
                   {
-                    "text": "Sometimes regular, sometimes irregular",
-                    "value": "sometimesRegularSometimesIrregular"
+                    "text": "Occasionally",
+                    "value": "occasionally"
                   }
                 ]
               },

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/familyHistory.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/familyHistory.json
@@ -5,6 +5,7 @@
   "footer": "Unless otherwise mentioned, all questions are sourced from the All of Us research study.",
   "jsonContent": {
     "showQuestionNumbers": "off",
+    "clearInvisibleValues": "onHiddenContainer",
     "showProgressBar": "bottom",
     "questionTemplates": [
       {
@@ -12,107 +13,1687 @@
         "type": "dropdown",
         "title": "How old was this person when the heart attack occurred?",
         "choices": [
-          { "text": "I don't know", "value": "unknown" },
-          {"text": "0", "value": "0"},
-          {"text": "1", "value": "1"},
-          {"text": "2", "value": "2"},
-          {"text": "3", "value": "3"},
-          {"text": "4", "value": "4"},
-          {"text": "5", "value": "5"},
-          {"text": "6", "value": "6"},
-          {"text": "7", "value": "7"},
-          {"text": "8", "value": "8"},
-          {"text": "9", "value": "9"},
-          {"text": "10", "value": "10"},
-          {"text": "11", "value": "11"},
-          {"text": "12", "value": "12"},
-          {"text": "13", "value": "13"},
-          {"text": "14", "value": "14"},
-          {"text": "15", "value": "15"},
-          {"text": "16", "value": "16"},
-          {"text": "17", "value": "17"},
-          {"text": "18", "value": "18"},
-          {"text": "19", "value": "19"},
-          {"text": "20", "value": "20"},
-          {"text": "21", "value": "21"},
-          {"text": "22", "value": "22"},
-          {"text": "23", "value": "23"},
-          {"text": "24", "value": "24"},
-          {"text": "25", "value": "25"},
-          {"text": "26", "value": "26"},
-          {"text": "27", "value": "27"},
-          {"text": "28", "value": "28"},
-          {"text": "29", "value": "29"},
-          {"text": "30", "value": "30"},
-          {"text": "31", "value": "31"},
-          {"text": "32", "value": "32"},
-          {"text": "33", "value": "33"},
-          {"text": "34", "value": "34"},
-          {"text": "35", "value": "35"},
-          {"text": "36", "value": "36"},
-          {"text": "37", "value": "37"},
-          {"text": "38", "value": "38"},
-          {"text": "39", "value": "39"},
-          {"text": "40", "value": "40"},
-          {"text": "41", "value": "41"},
-          {"text": "42", "value": "42"},
-          {"text": "43", "value": "43"},
-          {"text": "44", "value": "44"},
-          {"text": "45", "value": "45"},
-          {"text": "46", "value": "46"},
-          {"text": "47", "value": "47"},
-          {"text": "48", "value": "48"},
-          {"text": "49", "value": "49"},
-          {"text": "50", "value": "50"},
-          {"text": "51", "value": "51"},
-          {"text": "52", "value": "52"},
-          {"text": "53", "value": "53"},
-          {"text": "54", "value": "54"},
-          {"text": "55", "value": "55"},
-          {"text": "56", "value": "56"},
-          {"text": "57", "value": "57"},
-          {"text": "58", "value": "58"},
-          {"text": "59", "value": "59"},
-          {"text": "60", "value": "60"},
-          {"text": "61", "value": "61"},
-          {"text": "62", "value": "62"},
-          {"text": "63", "value": "63"},
-          {"text": "64", "value": "64"},
-          {"text": "65", "value": "65"},
-          {"text": "66", "value": "66"},
-          {"text": "67", "value": "67"},
-          {"text": "68", "value": "68"},
-          {"text": "69", "value": "69"},
-          {"text": "70", "value": "70"},
-          {"text": "71", "value": "71"},
-          {"text": "72", "value": "72"},
-          {"text": "73", "value": "73"},
-          {"text": "74", "value": "74"},
-          {"text": "75", "value": "75"},
-          {"text": "76", "value": "76"},
-          {"text": "77", "value": "77"},
-          {"text": "78", "value": "78"},
-          {"text": "79", "value": "79"},
-          {"text": "80", "value": "80"},
-          {"text": "81", "value": "81"},
-          {"text": "82", "value": "82"},
-          {"text": "83", "value": "83"},
-          {"text": "84", "value": "84"},
-          {"text": "85", "value": "85"},
-          {"text": "86", "value": "86"},
-          {"text": "87", "value": "87"},
-          {"text": "88", "value": "88"},
-          {"text": "89", "value": "89"},
-          {"text": "90", "value": "90"},
-          {"text": "91", "value": "91"},
-          {"text": "92", "value": "92"},
-          {"text": "93", "value": "93"},
-          {"text": "94", "value": "94"},
-          {"text": "95", "value": "95"},
-          {"text": "96", "value": "96"},
-          {"text": "97", "value": "97"},
-          {"text": "98", "value": "98"},
-          {"text": "99", "value": "99"}
+          {
+            "text": "I don't know",
+            "value": "unknown"
+          },
+          {
+            "text": "0",
+            "value": "0"
+          },
+          {
+            "text": "1",
+            "value": "1"
+          },
+          {
+            "text": "2",
+            "value": "2"
+          },
+          {
+            "text": "3",
+            "value": "3"
+          },
+          {
+            "text": "4",
+            "value": "4"
+          },
+          {
+            "text": "5",
+            "value": "5"
+          },
+          {
+            "text": "6",
+            "value": "6"
+          },
+          {
+            "text": "7",
+            "value": "7"
+          },
+          {
+            "text": "8",
+            "value": "8"
+          },
+          {
+            "text": "9",
+            "value": "9"
+          },
+          {
+            "text": "10",
+            "value": "10"
+          },
+          {
+            "text": "11",
+            "value": "11"
+          },
+          {
+            "text": "12",
+            "value": "12"
+          },
+          {
+            "text": "13",
+            "value": "13"
+          },
+          {
+            "text": "14",
+            "value": "14"
+          },
+          {
+            "text": "15",
+            "value": "15"
+          },
+          {
+            "text": "16",
+            "value": "16"
+          },
+          {
+            "text": "17",
+            "value": "17"
+          },
+          {
+            "text": "18",
+            "value": "18"
+          },
+          {
+            "text": "19",
+            "value": "19"
+          },
+          {
+            "text": "20",
+            "value": "20"
+          },
+          {
+            "text": "21",
+            "value": "21"
+          },
+          {
+            "text": "22",
+            "value": "22"
+          },
+          {
+            "text": "23",
+            "value": "23"
+          },
+          {
+            "text": "24",
+            "value": "24"
+          },
+          {
+            "text": "25",
+            "value": "25"
+          },
+          {
+            "text": "26",
+            "value": "26"
+          },
+          {
+            "text": "27",
+            "value": "27"
+          },
+          {
+            "text": "28",
+            "value": "28"
+          },
+          {
+            "text": "29",
+            "value": "29"
+          },
+          {
+            "text": "30",
+            "value": "30"
+          },
+          {
+            "text": "31",
+            "value": "31"
+          },
+          {
+            "text": "32",
+            "value": "32"
+          },
+          {
+            "text": "33",
+            "value": "33"
+          },
+          {
+            "text": "34",
+            "value": "34"
+          },
+          {
+            "text": "35",
+            "value": "35"
+          },
+          {
+            "text": "36",
+            "value": "36"
+          },
+          {
+            "text": "37",
+            "value": "37"
+          },
+          {
+            "text": "38",
+            "value": "38"
+          },
+          {
+            "text": "39",
+            "value": "39"
+          },
+          {
+            "text": "40",
+            "value": "40"
+          },
+          {
+            "text": "41",
+            "value": "41"
+          },
+          {
+            "text": "42",
+            "value": "42"
+          },
+          {
+            "text": "43",
+            "value": "43"
+          },
+          {
+            "text": "44",
+            "value": "44"
+          },
+          {
+            "text": "45",
+            "value": "45"
+          },
+          {
+            "text": "46",
+            "value": "46"
+          },
+          {
+            "text": "47",
+            "value": "47"
+          },
+          {
+            "text": "48",
+            "value": "48"
+          },
+          {
+            "text": "49",
+            "value": "49"
+          },
+          {
+            "text": "50",
+            "value": "50"
+          },
+          {
+            "text": "51",
+            "value": "51"
+          },
+          {
+            "text": "52",
+            "value": "52"
+          },
+          {
+            "text": "53",
+            "value": "53"
+          },
+          {
+            "text": "54",
+            "value": "54"
+          },
+          {
+            "text": "55",
+            "value": "55"
+          },
+          {
+            "text": "56",
+            "value": "56"
+          },
+          {
+            "text": "57",
+            "value": "57"
+          },
+          {
+            "text": "58",
+            "value": "58"
+          },
+          {
+            "text": "59",
+            "value": "59"
+          },
+          {
+            "text": "60",
+            "value": "60"
+          },
+          {
+            "text": "61",
+            "value": "61"
+          },
+          {
+            "text": "62",
+            "value": "62"
+          },
+          {
+            "text": "63",
+            "value": "63"
+          },
+          {
+            "text": "64",
+            "value": "64"
+          },
+          {
+            "text": "65",
+            "value": "65"
+          },
+          {
+            "text": "66",
+            "value": "66"
+          },
+          {
+            "text": "67",
+            "value": "67"
+          },
+          {
+            "text": "68",
+            "value": "68"
+          },
+          {
+            "text": "69",
+            "value": "69"
+          },
+          {
+            "text": "70",
+            "value": "70"
+          },
+          {
+            "text": "71",
+            "value": "71"
+          },
+          {
+            "text": "72",
+            "value": "72"
+          },
+          {
+            "text": "73",
+            "value": "73"
+          },
+          {
+            "text": "74",
+            "value": "74"
+          },
+          {
+            "text": "75",
+            "value": "75"
+          },
+          {
+            "text": "76",
+            "value": "76"
+          },
+          {
+            "text": "77",
+            "value": "77"
+          },
+          {
+            "text": "78",
+            "value": "78"
+          },
+          {
+            "text": "79",
+            "value": "79"
+          },
+          {
+            "text": "80",
+            "value": "80"
+          },
+          {
+            "text": "81",
+            "value": "81"
+          },
+          {
+            "text": "82",
+            "value": "82"
+          },
+          {
+            "text": "83",
+            "value": "83"
+          },
+          {
+            "text": "84",
+            "value": "84"
+          },
+          {
+            "text": "85",
+            "value": "85"
+          },
+          {
+            "text": "86",
+            "value": "86"
+          },
+          {
+            "text": "87",
+            "value": "87"
+          },
+          {
+            "text": "88",
+            "value": "88"
+          },
+          {
+            "text": "89",
+            "value": "89"
+          },
+          {
+            "text": "90",
+            "value": "90"
+          },
+          {
+            "text": "91",
+            "value": "91"
+          },
+          {
+            "text": "92",
+            "value": "92"
+          },
+          {
+            "text": "93",
+            "value": "93"
+          },
+          {
+            "text": "94",
+            "value": "94"
+          },
+          {
+            "text": "95",
+            "value": "95"
+          },
+          {
+            "text": "96",
+            "value": "96"
+          },
+          {
+            "text": "97",
+            "value": "97"
+          },
+          {
+            "text": "98",
+            "value": "98"
+          },
+          {
+            "text": "99",
+            "value": "99"
+          }
+        ]
+      },
+      {
+        "name": "oh_oh_famHx_femaleCancer",
+        "type": "checkbox",
+        "title": "Cancer",
+        "showOtherItem": true,
+        "otherText": "Other cancer",
+        "otherPlaceholder": "Please specify",
+        "choices": [
+          {
+            "text": "Bladder cancer",
+            "value": "bladderCancer"
+          },
+          {
+            "text": "Blood or soft tissue cancer",
+            "value": "bloodOrSoftTissueCancer"
+          },
+          {
+            "text": "Bone cancer",
+            "value": "boneCancer"
+          },
+          {
+            "text": "Brain cancer",
+            "value": "brainCancer"
+          },
+          {
+            "text": "Breast cancer",
+            "value": "breastCancer"
+          },
+          {
+            "text": "Cervical cancer",
+            "value": "cervicalCancer"
+          },
+          {
+            "text": "Colon cancer/Rectal cancer",
+            "value": "colonCancerRectalCancer"
+          },
+          {
+            "text": "Endocrine cancer",
+            "value": "endocrineCancer"
+          },
+          {
+            "text": "Endometrial cancer",
+            "value": "endometrialCancer"
+          },
+          {
+            "text": "Esophageal cancer",
+            "value": "esophagealCancer"
+          },
+          {
+            "text": "Eye cancer",
+            "value": "eyeCancer"
+          },
+          {
+            "text": "Head and neck cancer",
+            "value": "headAndNeckCancer"
+          },
+          {
+            "text": "Kidney cancer",
+            "value": "kidneyCancer"
+          },
+          {
+            "text": "Lung cancer",
+            "value": "lungCancer"
+          },
+          {
+            "text": "Ovarian cancer",
+            "value": "ovarianCancer"
+          },
+          {
+            "text": "Pancreatic cancer",
+            "value": "pancreaticCancer"
+          },
+          {
+            "text": "Skin cancer",
+            "value": "skinCancer"
+          },
+          {
+            "text": "Stomach cancer",
+            "value": "stomachCancer"
+          },
+          {
+            "text": "Thyroid cancer",
+            "value": "thyroidCancer"
+          },
+          {
+            "text": "Don't know",
+            "value": "dontKnow"
+          },
+          {
+            "text": "Prefer not to answer",
+            "value": "preferNoAnswer"
+          }
+        ],
+        "showNoneItem": true,
+        "noneText": "None of the above",
+        "noneValue": "noneOfAbove",
+        "isRequired": true
+      },
+      {
+        "name": "oh_oh_famHx_allsexCancer",
+        "type": "checkbox",
+        "title": "Cancer",
+        "showOtherItem": true,
+        "otherText": "Other cancer",
+        "otherPlaceholder": "Please specify",
+        "choices": [
+          {
+            "text": "Bladder cancer",
+            "value": "bladderCancer"
+          },
+          {
+            "text": "Blood or soft tissue cancer",
+            "value": "bloodOrSoftTissueCancer"
+          },
+          {
+            "text": "Bone cancer",
+            "value": "boneCancer"
+          },
+          {
+            "text": "Brain cancer",
+            "value": "brainCancer"
+          },
+          {
+            "text": "Breast cancer",
+            "value": "breastCancer"
+          },
+          {
+            "text": "Cervical cancer",
+            "value": "cervicalCancer"
+          },
+          {
+            "text": "Colon cancer/Rectal cancer",
+            "value": "colonCancerRectalCancer"
+          },
+          {
+            "text": "Endocrine cancer",
+            "value": "endocrineCancer"
+          },
+          {
+            "text": "Endometrial cancer",
+            "value": "endometrialCancer"
+          },
+          {
+            "text": "Esophageal cancer",
+            "value": "esophagealCancer"
+          },
+          {
+            "text": "Eye cancer",
+            "value": "eyeCancer"
+          },
+          {
+            "text": "Head and neck cancer",
+            "value": "headAndNeckCancer"
+          },
+          {
+            "text": "Kidney cancer",
+            "value": "kidneyCancer"
+          },
+          {
+            "text": "Lung cancer",
+            "value": "lungCancer"
+          },
+          {
+            "text": "Ovarian cancer",
+            "value": "ovarianCancer"
+          },
+          {
+            "text": "Pancreatic cancer",
+            "value": "pancreaticCancer"
+          },
+          {
+            "text": "Prostate cancer",
+            "value": "prostateCancer"
+          },
+          {
+            "text": "Skin cancer",
+            "value": "skinCancer"
+          },
+          {
+            "text": "Stomach cancer",
+            "value": "stomachCancer"
+          },
+          {
+            "text": "Thyroid cancer",
+            "value": "thyroidCancer"
+          },
+          {
+            "text": "Don't know",
+            "value": "dontKnow"
+          },
+          {
+            "text": "Prefer not to answer",
+            "value": "preferNoAnswer"
+          }
+        ],
+        "showNoneItem": true,
+        "noneText": "None of the above",
+        "noneValue": "noneOfAbove",
+        "isRequired": true
+      },
+      {
+        "name": "oh_oh_famHx_maleCancer",
+        "type": "checkbox",
+        "title": "Cancer",
+        "showOtherItem": true,
+        "otherText": "Other cancer",
+        "otherPlaceholder": "Please specify",
+        "choices": [
+          {
+            "text": "Bladder cancer",
+            "value": "bladderCancer"
+          },
+          {
+            "text": "Blood or soft tissue cancer",
+            "value": "bloodOrSoftTissueCancer"
+          },
+          {
+            "text": "Bone cancer",
+            "value": "boneCancer"
+          },
+          {
+            "text": "Brain cancer",
+            "value": "brainCancer"
+          },
+          {
+            "text": "Breast cancer",
+            "value": "breastCancer"
+          },
+          {
+            "text": "Colon cancer/Rectal cancer",
+            "value": "colonCancerRectalCancer"
+          },
+          {
+            "text": "Endocrine cancer",
+            "value": "endocrineCancer"
+          },
+          {
+            "text": "Esophageal cancer",
+            "value": "esophagealCancer"
+          },
+          {
+            "text": "Eye cancer",
+            "value": "eyeCancer"
+          },
+          {
+            "text": "Head and neck cancer",
+            "value": "headAndNeckCancer"
+          },
+          {
+            "text": "Kidney cancer",
+            "value": "kidneyCancer"
+          },
+          {
+            "text": "Lung cancer",
+            "value": "lungCancer"
+          },
+          {
+            "text": "Pancreatic cancer",
+            "value": "pancreaticCancer"
+          },
+          {
+            "text": "Prostate cancer",
+            "value": "prostateCancer"
+          },
+          {
+            "text": "Skin cancer",
+            "value": "skinCancer"
+          },
+          {
+            "text": "Stomach cancer",
+            "value": "stomachCancer"
+          },
+          {
+            "text": "Thyroid cancer",
+            "value": "thyroidCancer"
+          },
+          {
+            "text": "Don't know",
+            "value": "dontKnow"
+          },
+          {
+            "text": "Prefer not to answer",
+            "value": "preferNoAnswer"
+          }
+        ],
+        "showNoneItem": true,
+        "noneText": "None of the above",
+        "noneValue": "noneOfAbove",
+        "isRequired": true
+      },
+      {
+        "name": "oh_oh_famHx_allsexHeartBlood",
+        "type": "checkbox",
+        "title": "Heart and blood conditions",
+        "showNoneItem": true,
+        "noneText": "None of the above",
+        "noneValue": "noneOfAbove",
+        "choices": [
+          {
+            "text": "Anemia",
+            "value": "anemia"
+          },
+          {
+            "text": "Abnormal heart rhythm",
+            "value": "abnormalHeartRhythm"
+          },
+          {
+            "text": "Atrial fibrillation (Afib) or Atrial flutter",
+            "value": "atrialFibrillation"
+          },
+          {
+            "text": "Bleeding disorder",
+            "value": "bleedingDisorder"
+          },
+          {
+            "text": "Coronary artery/coronary heart disease",
+            "value": "coronaryDisease"
+          },
+          {
+            "text": "Cardiac stent",
+            "value": "cardiacStent"
+          },
+          {
+            "text": "Coronary artery bypass surgery",
+            "value": "coronaryArteryBypassSurgery"
+          },
+          {
+            "text": "Heart attack",
+            "value": "heartAttack"
+          },
+          {
+            "text": "Heart failure",
+            "value": "heartFailure"
+          },
+          {
+            "text": "Heart valve disease",
+            "value": "heartValveDisease"
+          },
+          {
+            "text": "High cholesterol",
+            "value": "highCholesterol"
+          },
+          {
+            "text": "Hypertension (high blood pressure)",
+            "value": "hypertension"
+          },
+          {
+            "text": "Peripheral vascular disease",
+            "value": "peripheralVascularDisease"
+          },
+          {
+            "text": "Pulmonary embolism or deep vein thrombosis",
+            "value": "pulmonaryEmbolismOrDVT"
+          },
+          {
+            "text": "Sickle cell disease",
+            "value": "sickleCellDisease"
+          },
+          {
+            "text": "Stroke",
+            "value": "stroke"
+          },
+          {
+            "text": "Transient ischemic attacks (TIAs or mini-strokes)",
+            "value": "transientIschemicAttacks"
+          },
+          {
+            "text": "Sudden death/Cardiac arrest",
+            "value": "suddenDeathCardiacArrest"
+          },
+          {
+            "text": "Don't know",
+            "value": "dontKnow"
+          },
+          {
+            "text": "Prefer not to answer",
+            "value": "preferNoAnswer"
+          }
+        ],
+        "isRequired": true
+      },
+      {
+        "name": "oh_oh_famHx_sex",
+        "type": "dropdown",
+        "title": "What is the sex of this person? ",
+        "choices": [
+          {
+            "text": "Female",
+            "value": "female"
+          },
+          {
+            "text": "Male",
+            "value": "male"
+          },
+          {
+            "text": "Intersex",
+            "value": "intersedx"
+          },
+          {
+            "text": "Other",
+            "value": "other"
+          },
+          {
+            "text": "Prefer Not to Answer",
+            "value": "preferNotToAnswer"
+          }
+        ]
+      },
+      {
+        "name": "oh_oh_famHx_allsexDigestive",
+        "type": "checkbox",
+        "title": "Digestive conditions:",
+        "showNoneItem": true,
+        "noneText": "None of the above",
+        "noneValue": "noneOfAbove",
+        "choices": [
+          {
+            "text": "Acid reflux",
+            "value": "acidReflux"
+          },
+          {
+            "text": "Celiac disease",
+            "value": "celiacDisease"
+          },
+          {
+            "text": "Colon polyps",
+            "value": "colonPolyps"
+          },
+          {
+            "text": "Crohn’s disease",
+            "value": "crohnsDisease"
+          },
+          {
+            "text": "Diverticulitis/Diverticulosis",
+            "value": "diverticulitisDiverticulosis"
+          },
+          {
+            "text": "Gall stones",
+            "value": "gallStones"
+          },
+          {
+            "text": "Irritable bowel syndrome (IBS)",
+            "value": "irritableBowelSyndrome"
+          },
+          {
+            "text": "Liver condition (e.g., cirrhosis)",
+            "value": "liverCondition"
+          },
+          {
+            "text": "Pancreatitis",
+            "value": "pancreatitis"
+          },
+          {
+            "text": "Peptic (stomach) ulcers",
+            "value": "pepticStomachUlcers"
+          },
+          {
+            "text": "Ulcerative colitis",
+            "value": "ulcerativeColitis"
+          },
+          {
+            "text": "Don't know",
+            "value": "dontKnow"
+          },
+          {
+            "text": "Prefer not to answer",
+            "value": "preferNoAnswer"
+          }
+        ],
+        "isRequired": true
+      },
+      {
+        "name": "oh_oh_famHx_allsexHormone",
+        "type": "checkbox",
+        "title": "Hormone/endocrine conditions:",
+        "showNoneItem": true,
+        "noneText": "None of the above",
+        "noneValue": "noneOfAbove",
+        "choices": [
+          {
+            "text": "Hyperthyroidism",
+            "value": "hyperthyroidism"
+          },
+          {
+            "text": "Hypothyroidism",
+            "value": "hypothyroidism"
+          },
+          {
+            "text": "Prediabetes",
+            "value": "prediabetes"
+          },
+          {
+            "text": "Type 1 diabetes",
+            "value": "type1Diabetes"
+          },
+          {
+            "text": "Type 2 diabetes",
+            "value": "type2Diabetes"
+          },
+          {
+            "text": "Other/unknown diabetes",
+            "value": "otherUnknownDiabetes"
+          },
+          {
+            "text": "Don't know",
+            "value": "dontKnow"
+          },
+          {
+            "text": "Prefer not to answer",
+            "value": "preferNoAnswer"
+          }
+        ],
+        "isRequired": true
+      },
+      {
+        "name": "oh_oh_famHx_allsexKidneys",
+        "type": "checkbox",
+        "title": "Kidney conditions:",
+        "showNoneItem": true,
+        "noneText": "None of the above",
+        "noneValue": "noneOfAbove",
+        "choices": [
+          {
+            "text": "Kidney disease",
+            "value": "kidneyDisease"
+          },
+          {
+            "text": "Kidney stones",
+            "value": "kidneyStones"
+          },
+          {
+            "text": "Don't know",
+            "value": "dontKnow"
+          },
+          {
+            "text": "Prefer not to answer",
+            "value": "preferNoAnswer"
+          }
+        ],
+        "isRequired": true
+      },
+      {
+        "name": "oh_oh_famHx_allsexLung",
+        "type": "checkbox",
+        "title": "Lung conditions:",
+        "showNoneItem": true,
+        "noneText": "None of the above",
+        "noneValue": "noneOfAbove",
+        "choices": [
+          {
+            "text": "Asthma",
+            "value": "asthma"
+          },
+          {
+            "text": "Chronic lung disease (COPD, emphysema, or bronchitis)",
+            "value": "chronicLungDisease"
+          },
+          {
+            "text": "Sleep apnea",
+            "value": "sleepApnea"
+          },
+          {
+            "text": "Don't know",
+            "value": "dontKnow"
+          },
+          {
+            "text": "Prefer not to answer",
+            "value": "preferNoAnswer"
+          }
+        ],
+        "isRequired": true
+      },
+      {
+        "name": "oh_oh_famHx_allsexNervousSystem",
+        "type": "checkbox",
+        "title": "Brain and nervous system conditions:",
+        "showNoneItem": true,
+        "noneText": "None of the above",
+        "noneValue": "noneOfAbove",
+        "choices": [
+          {
+            "text": "Cerebral palsy",
+            "value": "cerebralPalsy"
+          },
+          {
+            "text": "Dementia (includes Alzheimer’s, vascular, etc.)",
+            "value": "dementia"
+          },
+          {
+            "text": "Epilepsy or seizure",
+            "value": "epilepsyOrSeizure"
+          },
+          {
+            "text": "Insomnia",
+            "value": "insomnia"
+          },
+          {
+            "text": "Migraine headaches",
+            "value": "migraineHeadaches"
+          },
+          {
+            "text": "Multiple sclerosis",
+            "value": "multipleSclerosis"
+          },
+          {
+            "text": "Muscular dystrophy (MD)",
+            "value": "muscularDystrophyMd"
+          },
+          {
+            "text": "Neuropathy",
+            "value": "neuropathy"
+          },
+          {
+            "text": "Parkinson’s disease",
+            "value": "parkinsonsDisease"
+          },
+          {
+            "text": "Don't know",
+            "value": "dontKnow"
+          },
+          {
+            "text": "Prefer not to answer",
+            "value": "preferNoAnswer"
+          }
+        ],
+        "isRequired": true
+      },
+      {
+        "name": "oh_oh_famHx_allsexMentalHealth",
+        "type": "checkbox",
+        "title": "Mental health or substance use conditions:",
+        "showNoneItem": true,
+        "noneText": "None of the above",
+        "noneValue": "noneOfAbove",
+        "choices": [
+          {
+            "text": "Alcohol use disorder",
+            "value": "alcoholUseDisorder"
+          },
+          {
+            "text": "Anxiety reaction/panic disorder",
+            "value": "anxietyReactionPanicDisorder"
+          },
+          {
+            "text": "Attention-deficit/hyperactivity disorder (ADHD)",
+            "value": "attentionDeficitHyperactivityDisorder"
+          },
+          {
+            "text": "Autism spectrum disorder",
+            "value": "autismSpectrumDisorder"
+          },
+          {
+            "text": "Bipolar disorder",
+            "value": "bipolarDisorder"
+          },
+          {
+            "text": "Depression",
+            "value": "depression"
+          },
+          {
+            "text": "Drug use disorder",
+            "value": "drugUseDisorder"
+          },
+          {
+            "text": "Eating disorder",
+            "value": "eatingDisorder"
+          },
+          {
+            "text": "Post-traumatic stress disorder (PTSD)",
+            "value": "postTraumaticStressDisorder"
+          },
+          {
+            "text": "Schizophrenia",
+            "value": "schizophrenia"
+          },
+          {
+            "text": "Don't know",
+            "value": "dontKnow"
+          },
+          {
+            "text": "Prefer not to answer",
+            "value": "preferNoAnswer"
+          }
+        ],
+        "isRequired": true
+      },
+      {
+        "name": "oh_oh_famHx_allsexBoneJointMuscle",
+        "type": "checkbox",
+        "title": "Bone, joint, and muscle conditions:",
+        "showNoneItem": true,
+        "noneText": "None of the above",
+        "noneValue": "noneOfAbove",
+        "choices": [
+          {
+            "text": "Carpal tunnel syndrome",
+            "value": "carpalTunnelSyndrome"
+          },
+          {
+            "text": "Fibromyalgia",
+            "value": "fibromyalgia"
+          },
+          {
+            "text": "Gout",
+            "value": "gout"
+          },
+          {
+            "text": "Osteoarthritis",
+            "value": "osteoarthritis"
+          },
+          {
+            "text": "Osteoporosis",
+            "value": "osteoporosis"
+          },
+          {
+            "text": "Pseudogout (CPPD)",
+            "value": "pseudogoutCppd"
+          },
+          {
+            "text": "Rheumatoid arthritis",
+            "value": "rheumatoidArthritis"
+          },
+          {
+            "text": "Spine, muscle, or bone disorders (non-cancer)",
+            "value": "spineMuscleOrBoneDisorders"
+          },
+          {
+            "text": "Systemic lupus",
+            "value": "systemicLupus"
+          },
+          {
+            "text": "Other arthritis, such as psoriatic arthritis and/or ankylosing spondylitis",
+            "value": "otherArthritis"
+          },
+          {
+            "text": "Don't know",
+            "value": "dontKnow"
+          },
+          {
+            "text": "Prefer not to answer",
+            "value": "preferNoAnswer"
+          }
+        ],
+        "isRequired": true
+      },
+      {
+        "name": "oh_oh_famHx_allsexHearingEye",
+        "type": "checkbox",
+        "title": "Hearing and eye conditions:",
+        "showNoneItem": true,
+        "noneText": "None of the above",
+        "noneValue": "noneOfAbove",
+        "choices": [
+          {
+            "text": "Cataracts",
+            "value": "cataracts"
+          },
+          {
+            "text": "Glaucoma",
+            "value": "glaucoma"
+          },
+          {
+            "text": "Macular degeneration",
+            "value": "macularDegeneration"
+          },
+          {
+            "text": "Myopia",
+            "value": "myopia"
+          },
+          {
+            "text": "Severe hearing loss or partial deafness in one or both ears",
+            "value": "severeHearingLoss"
+          },
+          {
+            "text": "Don't know",
+            "value": "dontKnow"
+          },
+          {
+            "text": "Prefer not to answer",
+            "value": "preferNoAnswer"
+          }
+        ],
+        "isRequired": true
+      },
+      {
+        "name": "oh_oh_famHx_femaleOtherConditions",
+        "type": "checkbox",
+        "title": "Other conditions:",
+        "showNoneItem": true,
+        "noneText": "None of the above",
+        "noneValue": "noneOfAbove",
+        "choices": [
+          {
+            "text": "Allergies",
+            "value": "allergies"
+          },
+          {
+            "text": "Endometriosis",
+            "value": "endometriosis"
+          },
+          {
+            "text": "Fibroids",
+            "value": "fibroids"
+          },
+          {
+            "text": "Obesity",
+            "value": "obesity"
+          },
+          {
+            "text": "Polycystic ovarian syndrome",
+            "value": "polycysticOvarianSyndrome"
+          },
+          {
+            "text": "Reactions to anesthesia (such as hyperthermia)",
+            "value": "reactionsToAnesthesia"
+          },
+          {
+            "text": "Skin condition (e.g., eczema, psoriasis, vitiligo)",
+            "value": "skinCondition"
+          },
+          {
+            "text": "Don't know",
+            "value": "dontKnow"
+          },
+          {
+            "text": "Prefer not to answer",
+            "value": "preferNoAnswer"
+          }
+        ],
+        "isRequired": true
+      },
+      {
+        "name": "oh_oh_famHx_maleOtherConditions",
+        "type": "checkbox",
+        "title": "Other conditions:",
+        "showNoneItem": true,
+        "noneText": "None of the above",
+        "noneValue": "noneOfAbove",
+        "choices": [
+          {
+            "text": "Allergies",
+            "value": "allergies"
+          },
+          {
+            "text": "Obesity",
+            "value": "obesity"
+          },
+          {
+            "text": "Reactions to anesthesia (such as hyperthermia)",
+            "value": "reactionsToAnesthesia"
+          },
+          {
+            "text": "Skin condition (e.g., eczema, psoriasis, vitiligo)",
+            "value": "skinCondition"
+          },
+          {
+            "text": "Don't know",
+            "value": "dontKnow"
+          },
+          {
+            "text": "Prefer not to answer",
+            "value": "preferNoAnswer"
+          }
+        ],
+        "isRequired": true
+      },
+      {
+        "name": "oh_oh_famHx_age",
+        "type": "dropdown",
+        "title": "What is the age of this person? ",
+        "choices": [
+          {
+            "text": "I don't know",
+            "value": "unknown"
+          },
+          {
+            "text": "0",
+            "value": "0"
+          },
+          {
+            "text": "1",
+            "value": "1"
+          },
+          {
+            "text": "2",
+            "value": "2"
+          },
+          {
+            "text": "3",
+            "value": "3"
+          },
+          {
+            "text": "4",
+            "value": "4"
+          },
+          {
+            "text": "5",
+            "value": "5"
+          },
+          {
+            "text": "6",
+            "value": "6"
+          },
+          {
+            "text": "7",
+            "value": "7"
+          },
+          {
+            "text": "8",
+            "value": "8"
+          },
+          {
+            "text": "9",
+            "value": "9"
+          },
+          {
+            "text": "10",
+            "value": "10"
+          },
+          {
+            "text": "11",
+            "value": "11"
+          },
+          {
+            "text": "12",
+            "value": "12"
+          },
+          {
+            "text": "13",
+            "value": "13"
+          },
+          {
+            "text": "14",
+            "value": "14"
+          },
+          {
+            "text": "15",
+            "value": "15"
+          },
+          {
+            "text": "16",
+            "value": "16"
+          },
+          {
+            "text": "17",
+            "value": "17"
+          },
+          {
+            "text": "18",
+            "value": "18"
+          },
+          {
+            "text": "19",
+            "value": "19"
+          },
+          {
+            "text": "20",
+            "value": "20"
+          },
+          {
+            "text": "21",
+            "value": "21"
+          },
+          {
+            "text": "22",
+            "value": "22"
+          },
+          {
+            "text": "23",
+            "value": "23"
+          },
+          {
+            "text": "24",
+            "value": "24"
+          },
+          {
+            "text": "25",
+            "value": "25"
+          },
+          {
+            "text": "26",
+            "value": "26"
+          },
+          {
+            "text": "27",
+            "value": "27"
+          },
+          {
+            "text": "28",
+            "value": "28"
+          },
+          {
+            "text": "29",
+            "value": "29"
+          },
+          {
+            "text": "30",
+            "value": "30"
+          },
+          {
+            "text": "31",
+            "value": "31"
+          },
+          {
+            "text": "32",
+            "value": "32"
+          },
+          {
+            "text": "33",
+            "value": "33"
+          },
+          {
+            "text": "34",
+            "value": "34"
+          },
+          {
+            "text": "35",
+            "value": "35"
+          },
+          {
+            "text": "36",
+            "value": "36"
+          },
+          {
+            "text": "37",
+            "value": "37"
+          },
+          {
+            "text": "38",
+            "value": "38"
+          },
+          {
+            "text": "39",
+            "value": "39"
+          },
+          {
+            "text": "40",
+            "value": "40"
+          },
+          {
+            "text": "41",
+            "value": "41"
+          },
+          {
+            "text": "42",
+            "value": "42"
+          },
+          {
+            "text": "43",
+            "value": "43"
+          },
+          {
+            "text": "44",
+            "value": "44"
+          },
+          {
+            "text": "45",
+            "value": "45"
+          },
+          {
+            "text": "46",
+            "value": "46"
+          },
+          {
+            "text": "47",
+            "value": "47"
+          },
+          {
+            "text": "48",
+            "value": "48"
+          },
+          {
+            "text": "49",
+            "value": "49"
+          },
+          {
+            "text": "50",
+            "value": "50"
+          },
+          {
+            "text": "51",
+            "value": "51"
+          },
+          {
+            "text": "52",
+            "value": "52"
+          },
+          {
+            "text": "53",
+            "value": "53"
+          },
+          {
+            "text": "54",
+            "value": "54"
+          },
+          {
+            "text": "55",
+            "value": "55"
+          },
+          {
+            "text": "56",
+            "value": "56"
+          },
+          {
+            "text": "57",
+            "value": "57"
+          },
+          {
+            "text": "58",
+            "value": "58"
+          },
+          {
+            "text": "59",
+            "value": "59"
+          },
+          {
+            "text": "60",
+            "value": "60"
+          },
+          {
+            "text": "61",
+            "value": "61"
+          },
+          {
+            "text": "62",
+            "value": "62"
+          },
+          {
+            "text": "63",
+            "value": "63"
+          },
+          {
+            "text": "64",
+            "value": "64"
+          },
+          {
+            "text": "65",
+            "value": "65"
+          },
+          {
+            "text": "66",
+            "value": "66"
+          },
+          {
+            "text": "67",
+            "value": "67"
+          },
+          {
+            "text": "68",
+            "value": "68"
+          },
+          {
+            "text": "69",
+            "value": "69"
+          },
+          {
+            "text": "70",
+            "value": "70"
+          },
+          {
+            "text": "71",
+            "value": "71"
+          },
+          {
+            "text": "72",
+            "value": "72"
+          },
+          {
+            "text": "73",
+            "value": "73"
+          },
+          {
+            "text": "74",
+            "value": "74"
+          },
+          {
+            "text": "75",
+            "value": "75"
+          },
+          {
+            "text": "76",
+            "value": "76"
+          },
+          {
+            "text": "77",
+            "value": "77"
+          },
+          {
+            "text": "78",
+            "value": "78"
+          },
+          {
+            "text": "79",
+            "value": "79"
+          },
+          {
+            "text": "80",
+            "value": "80"
+          },
+          {
+            "text": "81",
+            "value": "81"
+          },
+          {
+            "text": "82",
+            "value": "82"
+          },
+          {
+            "text": "83",
+            "value": "83"
+          },
+          {
+            "text": "84",
+            "value": "84"
+          },
+          {
+            "text": "85",
+            "value": "85"
+          },
+          {
+            "text": "86",
+            "value": "86"
+          },
+          {
+            "text": "87",
+            "value": "87"
+          },
+          {
+            "text": "88",
+            "value": "88"
+          },
+          {
+            "text": "89",
+            "value": "89"
+          },
+          {
+            "text": "90",
+            "value": "90"
+          },
+          {
+            "text": "91",
+            "value": "91"
+          },
+          {
+            "text": "92",
+            "value": "92"
+          },
+          {
+            "text": "93",
+            "value": "93"
+          },
+          {
+            "text": "94",
+            "value": "94"
+          },
+          {
+            "text": "95",
+            "value": "95"
+          },
+          {
+            "text": "96",
+            "value": "96"
+          },
+          {
+            "text": "97",
+            "value": "97"
+          },
+          {
+            "text": "98",
+            "value": "98"
+          },
+          {
+            "text": "99",
+            "value": "99"
+          }
         ]
       }
     ],
@@ -141,27 +1722,101 @@
           },
           {
             "name": "oh_oh_famHx_famKnowledge",
-            "type": "radiogroup",
-            "title": "How much do you know about illnesses or health problems of your parents, grandparents, brothers, sisters, and/or children?",
+            "type": "checkbox",
+            "title": "Please select the blood-related family members whose medical history you can provide.",
             "choices": [
               {
-                "text": "A lot",
-                "value": "aLot"
+                "text": "Mother",
+                "value": "mother"
               },
               {
-                "text": "Some",
-                "value": "some"
+                "text": "Father",
+                "value": "father"
               },
               {
-                "text": "None at all",
-                "value": "none"
+                "text": "Maternal Grandmother",
+                "value": "maternalGrandmother"
+              },
+              {
+                "text": "Maternal Grandfather",
+                "value": "maternalGrandfather"
+              },
+              {
+                "text": "Paternal Grandmother",
+                "value": "paternalGrandmother"
+              },
+              {
+                "text": "Paternal Grandfather",
+                "value": "paternalGrandfather"
+              },
+              {
+                "text": "Sibling(s)",
+                "value": "siblings"
+              },
+              {
+                "text": "Children",
+                "value": "children"
+              }
+            ],
+            "showNoneItem": true,
+            "noneText": "None of the above",
+            "noneValue": "noneOfAbove",
+            "isRequired": true
+          },
+          {
+            "name": "oh_oh_famHx_famKnowledge_numSiblings",
+            "type": "dropdown",
+            "title": "Please choose the number of siblings you are able to provide information about. If you have more than 4 siblings, please complete survey pages for the 4 siblings you know most about.",
+            "visibleIf": "{oh_oh_famHx_famKnowledge} contains 'siblings'",
+            "isRequired": true,
+            "choices": [
+              {
+                "text": "1",
+                "value": "1"
+              },
+              {
+                "text": "2",
+                "value": "2"
+              },
+              {
+                "text": "3",
+                "value": "3"
+              },
+              {
+                "text": "4",
+                "value": "4"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_famHx_famKnowledge_numChildren",
+            "type": "dropdown",
+            "title": "Please choose the number of biological children you are able to provide information about. If you have more than 4 children, please complete survey pages for the 4 children you know most about.",
+            "visibleIf": "{oh_oh_famHx_famKnowledge} contains 'children'",
+            "isRequired": true,
+            "choices": [
+              {
+                "text": "1",
+                "value": "1"
+              },
+              {
+                "text": "2",
+                "value": "2"
+              },
+              {
+                "text": "3",
+                "value": "3"
+              },
+              {
+                "text": "4",
+                "value": "4"
               }
             ]
           }
         ]
       },
       {
-        "visibleIf": "{oh_oh_famHx_famKnowledge} != 'none'",
+        "visibleIf": "{oh_oh_famHx_famKnowledge} != ['noneOfAbove']",
         "elements": [
           {
             "type": "panel",
@@ -169,18 +1824,22 @@
               {
                 "type": "html",
                 "name": "oh_oh_famHx_conditionIntro",
-                "html": "<h2>Family Cardiac History</h2><p>Please indicate if ANY of your parents, grandparents, brothers, sisters, and/or children have had any of the following. Think only of the people you are related to by blood. (Please select all that apply. If none of these apply, please skip.)</p>"
+                "html": "<h2>Family History of Premature Cardiac Disease</h2><p>Please indicate if ANY of your parents, grandparents, brothers, sisters, and/or children have had any of the following. Think only of the people you are related to by blood. (Please select all that apply. If none of these apply, please skip.)</p>"
               }
             ]
           },
           {
             "name": "oh_oh_famHx_suddenDeathUnexplained",
             "type": "checkbox",
-            "title": "Sudden, unexplained death, before the age of 50. (This does not include traumatic accidents, heart attacks, or heart failure.)",
+            "title": "Sudden, unexplained death, before the age of 50 due to non-cardiac related incidents, or those that were unexplained.",
             "showOtherItem": true,
-            "otherText": "Other",
+            "otherText": "Other Family Member",
             "otherPlaceholder": "Please specify",
             "choices": [
+              {
+                "text": "None of my blood-related family members have had this condition.",
+                "value": "none"
+              },
               {
                 "text": "Mother",
                 "value": "mother"
@@ -194,14 +1853,34 @@
                 "value": "sibling"
               },
               {
-                "text": "Grandparent",
-                "value": "grandparent"
-              },
-              {
                 "text": "Child",
                 "value": "child"
+              },
+              {
+                "text": "Maternal Grandmother",
+                "value": "maternalGrandmother"
+              },
+              {
+                "text": "Maternal Grandfather",
+                "value": "maternalGrandfather"
+              },
+              {
+                "text": "Paternal Grandmother",
+                "value": "paternalGrandmother"
+              },
+              {
+                "text": "Paternal Grandfather",
+                "value": "paternalGrandfather"
+              },
+              {
+                "text": "Prefer not to answer",
+                "value": "preferNotToAnswer"
               }
-            ]
+            ],
+            "showNoneItem": false,
+            "noneText": "None of the above",
+            "noneValue": "noneOfAbove",
+            "isRequired": true
           },
           {
             "type": "text",
@@ -236,22 +1915,52 @@
           {
             "type": "text",
             "inputType": "number",
-            "name": "oh_oh_famHx_suddenDeathUnexplainedGrandparentAge",
-            "size": "2",
-            "max": 50,
-            "min": 1,
-            "visibleIf": "{oh_oh_famHx_suddenDeathUnexplained} contains 'grandparent'",
-            "title": "What was your grandparent's age at death?"
-          },
-          {
-            "type": "text",
-            "inputType": "number",
             "name": "oh_oh_famHx_suddenDeathUnexplainedChildAge",
             "size": "2",
             "max": 50,
             "min": 1,
             "visibleIf": "{oh_oh_famHx_suddenDeathUnexplained} contains 'child'",
             "title": "What was your child's age at death?"
+          },
+          {
+            "type": "text",
+            "inputType": "number",
+            "name": "oh_oh_famHx_suddenDeathUnexplainedMaternalGrandmotherAge",
+            "size": "2",
+            "max": 50,
+            "min": 1,
+            "visibleIf": "{oh_oh_famHx_suddenDeathUnexplained} contains 'maternalGrandmother'",
+            "title": "What was your maternal grandmother's age at death?"
+          },
+          {
+            "type": "text",
+            "inputType": "number",
+            "name": "oh_oh_famHx_suddenDeathUnexplainedMaternalGrandfatherAge",
+            "size": "2",
+            "max": 50,
+            "min": 1,
+            "visibleIf": "{oh_oh_famHx_suddenDeathUnexplained} contains 'maternalGrandfather'",
+            "title": "What was your maternal grandfather's age at death?"
+          },
+          {
+            "type": "text",
+            "inputType": "number",
+            "name": "oh_oh_famHx_suddenDeathUnexplainedPaternalGrandmotherAge",
+            "size": "2",
+            "max": 50,
+            "min": 1,
+            "visibleIf": "{oh_oh_famHx_suddenDeathUnexplained} contains 'paternalGrandmother'",
+            "title": "What was your paternal grandmother's age at death?"
+          },
+          {
+            "type": "text",
+            "inputType": "number",
+            "name": "oh_oh_famHx_suddenDeathUnexplainedPaternalGrandfatherAge",
+            "size": "2",
+            "max": 50,
+            "min": 1,
+            "visibleIf": "{oh_oh_famHx_suddenDeathUnexplained} contains 'paternalGrandfather'",
+            "title": "What was your paternal grandfather's age at death?"
           },
           {
             "type": "text",
@@ -266,11 +1975,15 @@
           {
             "name": "oh_oh_famHx_suddenDeathHeart",
             "type": "checkbox",
-            "title": "Sudden death due to heart disease, before the age of 50. (This includes heart attack, heart failure, arrhythmia, etc.)",
+            "title": "Sudden death due to heart disease before the age of 50. (This includes heart attack, cardiac arrest, heart failure, arrhythmia, etc.)",
             "showOtherItem": true,
-            "otherText": "Other",
+            "otherText": "Other Family Member",
             "otherPlaceholder": "Please specify",
             "choices": [
+              {
+                "text": "None of my blood-related family members have had this condition.",
+                "value": "none"
+              },
               {
                 "text": "Mother",
                 "value": "mother"
@@ -284,14 +1997,30 @@
                 "value": "sibling"
               },
               {
-                "text": "Grandparent",
-                "value": "grandparent"
-              },
-              {
                 "text": "Child",
                 "value": "child"
+              },
+              {
+                "text": "Maternal Grandmother",
+                "value": "maternalGrandmother"
+              },
+              {
+                "text": "Maternal Grandfather",
+                "value": "maternalGrandfather"
+              },
+              {
+                "text": "Paternal Grandmother",
+                "value": "paternalGrandmother"
+              },
+              {
+                "text": "Paternal Grandfather",
+                "value": "paternalGrandfather"
               }
-            ]
+            ],
+            "showNoneItem": false,
+            "noneText": "None of the above",
+            "noneValue": "noneOfAbove",
+            "isRequired": true
           },
           {
             "type": "text",
@@ -325,16 +2054,6 @@
           },
           {
             "type": "text",
-            "name": "oh_oh_famHx_suddenDeathHeartGrandparentAge",
-            "inputType": "number",
-            "size": "2",
-            "max": 50,
-            "min": 1,
-            "visibleIf": "{oh_oh_famHx_suddenDeathHeart} contains 'grandparent'",
-            "title": "What was your grandparent's age at death?"
-          },
-          {
-            "type": "text",
             "name": "oh_oh_famHx_suddenDeathHeartChildAge",
             "inputType": "number",
             "size": "2",
@@ -342,6 +2061,46 @@
             "min": 1,
             "visibleIf": "{oh_oh_famHx_suddenDeathHeart} contains 'child'",
             "title": "What was your child's age at death?"
+          },
+          {
+            "type": "text",
+            "inputType": "number",
+            "name": "oh_oh_famHx_suddenDeathHeartMaternalGrandmotherAge",
+            "size": "2",
+            "max": 50,
+            "min": 1,
+            "visibleIf": "{oh_oh_famHx_suddenDeathHeart} contains 'maternalGrandmother'",
+            "title": "What was your maternal grandmother's age at death?"
+          },
+          {
+            "type": "text",
+            "inputType": "number",
+            "name": "oh_oh_famHx_suddenDeathHeartMaternalGrandfatherAge",
+            "size": "2",
+            "max": 50,
+            "min": 1,
+            "visibleIf": "{oh_oh_famHx_suddenDeathHeart} contains 'maternalGrandfather'",
+            "title": "What was your maternal grandfather's age at death?"
+          },
+          {
+            "type": "text",
+            "inputType": "number",
+            "name": "oh_oh_famHx_suddenDeathHeartPaternalGrandmotherAge",
+            "size": "2",
+            "max": 50,
+            "min": 1,
+            "visibleIf": "{oh_oh_famHx_suddenDeathHeart} contains 'paternalGrandmother'",
+            "title": "What was your paternal grandmother's age at death?"
+          },
+          {
+            "type": "text",
+            "inputType": "number",
+            "name": "oh_oh_famHx_suddenDeathHeartPaternalGrandfatherAge",
+            "size": "2",
+            "max": 50,
+            "min": 1,
+            "visibleIf": "{oh_oh_famHx_suddenDeathHeart} contains 'paternalGrandfather'",
+            "title": "What was your paternal grandfather's age at death?"
           },
           {
             "type": "text",
@@ -356,11 +2115,15 @@
           {
             "name": "oh_oh_famHx_heartAttackStroke",
             "type": "checkbox",
-            "title": "Heart attack or stroke before the age of 50",
+            "title": "Heart attack or stroke before the age of 50  that did not lead to death.",
             "showOtherItem": true,
             "otherText": "Other",
             "otherPlaceholder": "Please specify",
             "choices": [
+              {
+                "text": "None of my blood-related family members have had this condition.",
+                "value": "none"
+              },
               {
                 "text": "Mother",
                 "value": "mother"
@@ -374,14 +2137,30 @@
                 "value": "sibling"
               },
               {
-                "text": "Grandparent",
-                "value": "grandparent"
-              },
-              {
                 "text": "Child",
                 "value": "child"
+              },
+              {
+                "text": "Maternal Grandmother",
+                "value": "maternalGrandmother"
+              },
+              {
+                "text": "Maternal Grandfather",
+                "value": "maternalGrandfather"
+              },
+              {
+                "text": "Paternal Grandmother",
+                "value": "paternalGrandmother"
+              },
+              {
+                "text": "Paternal Grandfather",
+                "value": "paternalGrandfather"
               }
-            ]
+            ],
+            "showNoneItem": false,
+            "noneText": "None of the above",
+            "noneValue": "noneOfAbove",
+            "isRequired": true
           },
           {
             "type": "text",
@@ -415,16 +2194,6 @@
           },
           {
             "type": "text",
-            "name": "oh_oh_famHx_heartAttackStrokeGrandparentAge",
-            "inputType": "number",
-            "size": "2",
-            "max": 50,
-            "min": 1,
-            "visibleIf": "{oh_oh_famHx_heartAttackStroke} contains 'grandparent'",
-            "title": "What was your grandparent's age at the time of this event?"
-          },
-          {
-            "type": "text",
             "name": "oh_oh_famHx_heartAttackStrokeChildAge",
             "inputType": "number",
             "size": "2",
@@ -432,6 +2201,46 @@
             "min": 1,
             "visibleIf": "{oh_oh_famHx_heartAttackStroke} contains 'child'",
             "title": "What was your child's age at the time of this event?"
+          },
+          {
+            "type": "text",
+            "inputType": "number",
+            "name": "oh_oh_famHx_heartAttackStrokeMaternalGrandmotherAge",
+            "size": "2",
+            "max": 50,
+            "min": 1,
+            "visibleIf": "{oh_oh_famHx_heartAttackStroke} contains 'maternalGrandmother'",
+            "title": "What was your maternal grandmother's age at the time of this event?"
+          },
+          {
+            "type": "text",
+            "inputType": "number",
+            "name": "oh_oh_famHx_heartAttackStrokeMaternalGrandfatherAge",
+            "size": "2",
+            "max": 50,
+            "min": 1,
+            "visibleIf": "{oh_oh_famHx_heartAttackStroke} contains 'maternalGrandfather'",
+            "title": "What was your maternal grandfather's age at the time of this event?"
+          },
+          {
+            "type": "text",
+            "inputType": "number",
+            "name": "oh_oh_famHx_heartAttackStrokePaternalGrandmotherAge",
+            "size": "2",
+            "max": 50,
+            "min": 1,
+            "visibleIf": "{oh_oh_famHx_heartAttackStroke} contains 'paternalGrandmother'",
+            "title": "What was your paternal grandmother's age at the time of this event?"
+          },
+          {
+            "type": "text",
+            "inputType": "number",
+            "name": "oh_oh_famHx_heartAttackStrokePaternalGrandfatherAge",
+            "size": "2",
+            "max": 50,
+            "min": 1,
+            "visibleIf": "{oh_oh_famHx_heartAttackStroke} contains 'paternalGrandfather'",
+            "title": "What was your paternal grandfather's age at the time of this event?"
           },
           {
             "type": "text",
@@ -446,11 +2255,15 @@
           {
             "name": "oh_oh_famHx_stentOrBypass",
             "type": "checkbox",
-            "title": "Stent or bypass surgery before the age of 50",
+            "title": "Stent or bypass surgery before the age of 50.",
             "showOtherItem": true,
             "otherText": "Other",
             "otherPlaceholder": "Please specify",
             "choices": [
+              {
+                "text": "None of my blood-related family members have had this condition.",
+                "value": "none"
+              },
               {
                 "text": "Mother",
                 "value": "mother"
@@ -464,14 +2277,30 @@
                 "value": "sibling"
               },
               {
-                "text": "Grandparent",
-                "value": "grandparent"
-              },
-              {
                 "text": "Child",
                 "value": "child"
+              },
+              {
+                "text": "Maternal Grandmother",
+                "value": "maternalGrandmother"
+              },
+              {
+                "text": "Maternal Grandfather",
+                "value": "maternalGrandfather"
+              },
+              {
+                "text": "Paternal Grandmother",
+                "value": "paternalGrandmother"
+              },
+              {
+                "text": "Paternal Grandfather",
+                "value": "paternalGrandfather"
               }
-            ]
+            ],
+            "showNoneItem": false,
+            "noneText": "None of the above",
+            "noneValue": "noneOfAbove",
+            "isRequired": true
           },
           {
             "type": "text",
@@ -505,16 +2334,6 @@
           },
           {
             "type": "text",
-            "name": "oh_oh_famHx_stentOrBypassGrandparentAge",
-            "inputType": "number",
-            "size": "2",
-            "max": 50,
-            "min": 1,
-            "visibleIf": "{oh_oh_famHx_stentOrBypass} contains 'grandparent'",
-            "title": "What was your grandparent's age at the time of this event?"
-          },
-          {
-            "type": "text",
             "name": "oh_oh_famHx_stentOrBypassChildAge",
             "inputType": "number",
             "size": "2",
@@ -522,6 +2341,46 @@
             "min": 1,
             "visibleIf": "{oh_oh_famHx_stentOrBypass} contains 'child'",
             "title": "What was your child's age at the time of this event?"
+          },
+          {
+            "type": "text",
+            "inputType": "number",
+            "name": "oh_oh_famHx_stentOrBypassMaternalGrandmotherAge",
+            "size": "2",
+            "max": 50,
+            "min": 1,
+            "visibleIf": "{oh_oh_famHx_stentOrBypass} contains 'maternalGrandmother'",
+            "title": "What was your maternal grandmother's age at the time of this event?"
+          },
+          {
+            "type": "text",
+            "inputType": "number",
+            "name": "oh_oh_famHx_stentOrBypassMaternalGrandfatherAge",
+            "size": "2",
+            "max": 50,
+            "min": 1,
+            "visibleIf": "{oh_oh_famHx_stentOrBypass} contains 'maternalGrandfather'",
+            "title": "What was your maternal grandfather's age at the time of this event?"
+          },
+          {
+            "type": "text",
+            "inputType": "number",
+            "name": "oh_oh_famHx_stentOrBypassPaternalGrandmotherAge",
+            "size": "2",
+            "max": 50,
+            "min": 1,
+            "visibleIf": "{oh_oh_famHx_stentOrBypass} contains 'paternalGrandmother'",
+            "title": "What was your paternal grandmother's age at the time of this event?"
+          },
+          {
+            "type": "text",
+            "inputType": "number",
+            "name": "oh_oh_famHx_stentOrBypassPaternalGrandfatherAge",
+            "size": "2",
+            "max": 50,
+            "min": 1,
+            "visibleIf": "{oh_oh_famHx_stentOrBypass} contains 'paternalGrandfather'",
+            "title": "What was your paternal grandfather's age at the time of this event?"
           },
           {
             "type": "text",
@@ -534,8 +2393,9 @@
             "title": "What was your other relative's age at the time of this event?"
           }
         ]
-      },{
-        "visibleIf": "{oh_oh_famHx_famKnowledge} != 'none'",
+      },
+      {
+        "visibleIf": "{oh_oh_famHx_famKnowledge} contains 'mother'",
         "elements": [
           {
             "type": "panel",
@@ -546,233 +2406,65 @@
                 "html": "<h2>Your Mother’s Health</h2><p>Please indicate if your mother has ever been diagnosed with the following health conditions and/or health events. Think only of the person you are related to by blood. (Please select all that apply)</p>"
               }
             ]
-          },{
-          "name": "oh_oh_famHx_motherCancer",
-          "type": "checkbox",
-          "title": "Cancer",
-          "showOtherItem": true,
-          "otherText": "Other cancer",
-          "otherPlaceholder": "Please specify",
-          "choices": [
-            {"text": "Bladder cancer", "value": "bladderCancer"},
-            {"text": "Blood or soft tissue cancer", "value": "bloodOrSoftTissueCancer"},
-            {"text": "Bone cancer", "value": "boneCancer"},
-            {"text": "Brain cancer", "value": "brainCancer"},
-            {"text": "Breast cancer", "value": "breastCancer"},
-            {"text": "Cervical cancer", "value": "cervicalCancer"},
-            {"text": "Colon cancer/Rectal cancer", "value": "colonCancerRectalCancer"},
-            {"text": "Endocrine cancer", "value": "endocrineCancer"},
-            {"text": "Endometrial cancer", "value": "endometrialCancer"},
-            {"text": "Esophageal cancer", "value": "esophagealCancer"},
-            {"text": "Eye cancer", "value": "eyeCancer"},
-            {"text": "Head and neck cancer", "value": "headAndNeckCancer"},
-            {"text": "Kidney cancer", "value": "kidneyCancer"},
-            {"text": "Lung cancer", "value": "lungCancer"},
-            {"text": "Ovarian cancer", "value": "ovarianCancer"},
-            {"text": "Pancreatic cancer", "value": "pancreaticCancer"},
-            {"text": "Skin cancer", "value": "skinCancer"},
-            {"text": "Stomach cancer", "value": "stomachCancer"},
-            {"text": "Thyroid cancer", "value": "thyroidCancer"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_motherHeartBlood",
-          "type": "checkbox",
-          "title": "Heart and blood conditions",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Anemia", "value": "anemia"},
-            {"text": "Abnormal heart rhythm", "value": "abnormalHeartRhythm"},
-            {"text": "Atrial fibrillation (Afib) or Atrial flutter", "value": "atrialFibrillation"},
-            {"text": "Bleeding disorder", "value": "bleedingDisorder"},
-            {"text": "Coronary artery/coronary heart disease", "value": "coronaryDisease"},
-            {"text": "Cardiac stent", "value": "cardiacStent"},
-            {"text": "Coronary artery bypass surgery", "value": "coronaryArteryBypassSurgery"},
-            {"text": "Heart attack", "value": "heartAttack"},
-            {"text": "Heart failure", "value": "heartFailure"},
-            {"text": "Heart valve disease", "value": "heartValveDisease"},
-            {"text": "High cholesterol", "value": "highCholesterol"},
-            {"text": "Hypertension (high blood pressure)", "value": "hypertension"},
-            {"text": "Peripheral vascular disease", "value": "peripheralVascularDisease"},
-            {"text": "Pulmonary embolism or deep vein thrombosis", "value": "pulmonaryEmbolismOrDVT"},
-            {"text": "Sickle cell disease", "value": "sickleCellDisease"},
-            {"text": "Stroke", "value": "stroke"},
-            {"text": "Transient ischemic attacks (TIAs or mini-strokes)", "value": "transientIschemicAttacks"},
-            {"text": "Sudden death/Cardiac arrest", "value": "suddenDeathCardiacArrest"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_motherAgeAtHeartAttack",
-          "questionTemplateName": "oh_oh_famHx_ageAtHeartAttack",
-          "visibleIf": "{oh_oh_famHx_motherHeartBlood} contains 'heartAttack'"
-        },{
-          "name": "oh_oh_famHx_motherDisgestive",
-          "type": "checkbox",
-          "title": "Digestive conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Acid reflux", "value": "acidReflux"},
-            {"text": "Celiac disease", "value": "celiacDisease"},
-            {"text": "Colon polyps", "value": "colonPolyps"},
-            {"text": "Crohn’s disease", "value": "crohnsDisease"},
-            {"text": "Diverticulitis/Diverticulosis", "value": "diverticulitisDiverticulosis"},
-            {"text": "Gall stones", "value": "gallStones"},
-            {"text": "Irritable bowel syndrome (IBS)", "value": "irritableBowelSyndrome"},
-            {"text": "Liver condition (e.g., cirrhosis)", "value": "liverCondition"},
-            {"text": "Pancreatitis", "value": "pancreatitis"},
-            {"text": "Peptic (stomach) ulcers", "value": "pepticStomachUlcers"},
-            {"text": "Ulcerative colitis", "value": "ulcerativeColitis"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_motherHormone",
-          "type": "checkbox",
-          "title": "Hormone/endocrine conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Hyperthyroidism", "value": "hyperthyroidism"},
-            {"text": "Hypothyroidism", "value": "hypothyroidism"},
-            {"text": "Type 1 diabetes", "value": "type1Diabetes"},
-            {"text": "Type 2 diabetes", "value": "type2Diabetes"},
-            {"text": "Other/unknown diabetes", "value": "otherUnknownDiabetes"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_motherKidneys",
-          "type": "checkbox",
-          "title": "Kidney conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Kidney disease", "value": "kidneyDisease"},
-            {"text": "Kidney stones", "value": "kidneyStones"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_motherLung",
-          "type": "checkbox",
-          "title": "Lung conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Asthma", "value": "asthma"},
-            {"text": "Chronic lung disease (COPD, emphysema, or bronchitis)", "value": "chronicLungDisease"},
-            {"text": "Sleep apnea", "value": "sleepApnea"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_motherNervousSystem",
-          "type": "checkbox",
-          "title": "Brain and nervous system conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Cerebral palsy", "value": "cerebralPalsy"},
-            {"text": "Dementia (includes Alzheimer’s, vascular, etc.)", "value": "dementia"},
-            {"text": "Epilepsy or seizure", "value": "epilepsyOrSeizure"},
-            {"text": "Insomnia", "value": "insomnia"},
-            {"text": "Migraine headaches", "value": "migraineHeadaches"},
-            {"text": "Multiple sclerosis", "value": "multipleSclerosis"},
-            {"text": "Muscular dystrophy (MD)", "value": "muscularDystrophyMd"},
-            {"text": "Neuropathy", "value": "neuropathy"},
-            {"text": "Parkinson’s disease", "value": "parkinsonsDisease"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_motherMentalHealth",
-          "type": "checkbox",
-          "title": "Mental health or substance use conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Alcohol use disorder", "value": "alcoholUseDisorder"},
-            {"text": "Anxiety reaction/panic disorder", "value": "anxietyReactionPanicDisorder"},
-            {"text": "Attention-deficit/hyperactivity disorder (ADHD)", "value": "attentionDeficitHyperactivityDisorder"},
-            {"text": "Autism spectrum disorder", "value": "autismSpectrumDisorder"},
-            {"text": "Bipolar disorder", "value": "bipolarDisorder"},
-            {"text": "Depression", "value": "depression"},
-            {"text": "Drug use disorder", "value": "drugUseDisorder"},
-            {"text": "Eating disorder", "value": "eatingDisorder"},
-            {"text": "Post-traumatic stress disorder (PTSD)", "value": "postTraumaticStressDisorder"},
-            {"text": "Schizophrenia", "value": "schizophrenia"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_motherBoneJointMuscle",
-          "type": "checkbox",
-          "title": "Bone, joint, and muscle conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Carpal tunnel syndrome", "value": "carpalTunnelSyndrome"},
-            {"text": "Fibromyalgia", "value": "fibromyalgia"},
-            {"text": "Gout", "value": "gout"},
-            {"text": "Osteoarthritis", "value": "osteoarthritis"},
-            {"text": "Osteoporosis", "value": "osteoporosis"},
-            {"text": "Pseudogout (CPPD)", "value": "pseudogoutCppd"},
-            {"text": "Rheumatoid arthritis", "value": "rheumatoidArthritis"},
-            {"text": "Spine, muscle, or bone disorders (non-cancer)", "value": "spineMuscleOrBoneDisorders"},
-            {"text": "Systemic lupus", "value": "systemicLupus"},
-            {"text": "Other arthritis, such as psoriatic arthritis and/or ankylosing spondylitis", "value": "otherArthritis"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_motherHearingEye",
-          "type": "radiogroup",
-          "title": "Hearing and eye conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Cataracts", "value": "cataracts"},
-            {"text": "Glaucoma", "value": "glaucoma"},
-            {"text": "Macular degeneration", "value": "macularDegeneration"},
-            {"text": "Severe hearing loss or partial deafness in one or both ears", "value": "severeHearingLoss"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_motherOtherConditions",
-          "type": "checkbox",
-          "title": "Other conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Allergies", "value": "allergies"},
-            {"text": "Endometriosis", "value": "endometriosis"},
-            {"text": "Fibroids", "value": "fibroids"},
-            {"text": "Liver condition (e.g., cirrhosis)", "value": "liverCondition"},
-            {"text": "Obesity", "value": "obesity"},
-            {"text": "Polycystic ovarian syndrome", "value": "polycysticOvarianSyndrome"},
-            {"text": "Reactions to anesthesia (such as hyperthermia)", "value": "reactionsToAnesthesia"},
-            {"text": "Skin condition (e.g., eczema, psoriasis)", "value": "skinCondition"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        }]
-      },{
-        "visibleIf": "{oh_oh_famHx_famKnowledge} != 'none'",
+          },
+          {
+            "name": "oh_oh_famHx_motherAge",
+            "questionTemplateName": "oh_oh_famHx_age"
+          },
+          {
+            "name": "oh_oh_famHx_motherCancer",
+            "questionTemplateName": "oh_oh_famHx_femaleCancer"
+          },
+          {
+            "name": "oh_oh_famHx_motherHeartBlood",
+            "questionTemplateName": "oh_oh_famHx_allsexHeartBlood"
+          },
+          {
+            "name": "oh_oh_famHx_motherAgeAtHeartAttack",
+            "questionTemplateName": "oh_oh_famHx_ageAtHeartAttack",
+            "visibleIf": "{oh_oh_famHx_motherHeartBlood} contains 'heartAttack'",
+            "isRequired": true
+          },
+          {
+            "name": "oh_oh_famHx_motherDigestive",
+            "questionTemplateName": "oh_oh_famHx_allsexDigestive"
+          },
+          {
+            "name": "oh_oh_famHx_motherHormone",
+            "questionTemplateName": "oh_oh_famHx_allsexHormone"
+          },
+          {
+            "name": "oh_oh_famHx_motherKidneys",
+            "questionTemplateName": "oh_oh_famHx_allsexKidneys"
+          },
+          {
+            "name": "oh_oh_famHx_motherLung",
+            "questionTemplateName": "oh_oh_famHx_allsexLung"
+          },
+          {
+            "name": "oh_oh_famHx_motherNervousSystem",
+            "questionTemplateName": "oh_oh_famHx_allsexNervousSystem"
+          },
+          {
+            "name": "oh_oh_famHx_motherMentalHealth",
+            "questionTemplateName": "oh_oh_famHx_allsexMentalHealth"
+          },
+          {
+            "name": "oh_oh_famHx_motherBoneJointMuscle",
+            "questionTemplateName": "oh_oh_famHx_allsexBoneJointMuscle"
+          },
+          {
+            "name": "oh_oh_famHx_motherHearingEye",
+            "questionTemplateName": "oh_oh_famHx_allsexHearingEye"
+          },
+          {
+            "name": "oh_oh_famHx_motherOtherConditions",
+            "questionTemplateName": "oh_oh_famHx_femaleOtherConditions"
+          }
+        ]
+      },
+      {
+        "visibleIf": "{oh_oh_famHx_famKnowledge} contains 'father'",
         "elements": [
           {
             "type": "panel",
@@ -783,1226 +2475,922 @@
                 "html": "<h2>Your Father’s Health</h2><p>Please indicate if your father has ever been diagnosed with the following health conditions and/or health events. Think only of the person you are related to by blood. (Please select all that apply)</p>"
               }
             ]
-          },{
-          "name": "oh_oh_famHx_fatherCancer",
-          "type": "checkbox",
-          "title": "Cancer",
-          "showOtherItem": true,
-          "otherText": "Other cancer",
-          "otherPlaceholder": "Please specify",
-          "choices": [
-            {"text": "Bladder cancer", "value": "bladderCancer"},
-            {"text": "Blood or soft tissue cancer", "value": "bloodOrSoftTissueCancer"},
-            {"text": "Bone cancer", "value": "boneCancer"},
-            {"text": "Brain cancer", "value": "brainCancer"},
-            {"text": "Breast cancer", "value": "breastCancer"},
-            {"text": "Colon cancer/Rectal cancer", "value": "colonCancerRectalCancer"},
-            {"text": "Endocrine cancer", "value": "endocrineCancer"},
-            {"text": "Esophageal cancer", "value": "esophagealCancer"},
-            {"text": "Eye cancer", "value": "eyeCancer"},
-            {"text": "Head and neck cancer", "value": "headAndNeckCancer"},
-            {"text": "Kidney cancer", "value": "kidneyCancer"},
-            {"text": "Lung cancer", "value": "lungCancer"},
-            {"text": "Pancreatic cancer", "value": "pancreaticCancer"},
-            {"text": "Prostate cancer", "value": "prostateCancer"},
-            {"text": "Skin cancer", "value": "skinCancer"},
-            {"text": "Stomach cancer", "value": "stomachCancer"},
-            {"text": "Thyroid cancer", "value": "thyroidCancer"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_fatherHeartBlood",
-          "type": "checkbox",
-          "title": "Heart and blood conditions",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Anemia", "value": "anemia"},
-            {"text": "Abnormal heart rhythm", "value": "abnormalHeartRhythm"},
-            {"text": "Atrial fibrillation (Afib) or Atrial flutter", "value": "atrialFibrillation"},
-            {"text": "Bleeding disorder", "value": "bleedingDisorder"},
-            {"text": "Coronary artery/coronary heart disease", "value": "coronaryDisease"},
-            {"text": "Cardiac stent", "value": "cardiacStent"},
-            {"text": "Coronary artery bypass surgery", "value": "coronaryArteryBypassSurgery"},
-            {"text": "Heart attack", "value": "heartAttack"},
-            {"text": "Heart failure", "value": "heartFailure"},
-            {"text": "Heart valve disease", "value": "heartValveDisease"},
-            {"text": "High cholesterol", "value": "highCholesterol"},
-            {"text": "Hypertension (high blood pressure)", "value": "hypertension"},
-            {"text": "Peripheral vascular disease", "value": "peripheralVascularDisease"},
-            {"text": "Pulmonary embolism or deep vein thrombosis", "value": "pulmonaryEmbolismOrDVT"},
-            {"text": "Sickle cell disease", "value": "sickleCellDisease"},
-            {"text": "Stroke", "value": "stroke"},
-            {"text": "Transient ischemic attacks (TIAs or mini-strokes)", "value": "transientIschemicAttacks"},
-            {"text": "Sudden death/Cardiac arrest", "value": "suddenDeathCardiacArrest"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_fatherAgeAtHeartAttack",
-          "questionTemplateName": "oh_oh_famHx_ageAtHeartAttack",
-          "visibleIf": "{oh_oh_famHx_fatherHeartBlood} contains 'heartAttack'"
-        },{
-          "name": "oh_oh_famHx_fatherDisgestive",
-          "type": "checkbox",
-          "title": "Digestive conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Acid reflux", "value": "acidReflux"},
-            {"text": "Celiac disease", "value": "celiacDisease"},
-            {"text": "Colon polyps", "value": "colonPolyps"},
-            {"text": "Crohn’s disease", "value": "crohnsDisease"},
-            {"text": "Diverticulitis/Diverticulosis", "value": "diverticulitisDiverticulosis"},
-            {"text": "Gall stones", "value": "gallStones"},
-            {"text": "Irritable bowel syndrome (IBS)", "value": "irritableBowelSyndrome"},
-            {"text": "Liver condition (e.g., cirrhosis)", "value": "liverCondition"},
-            {"text": "Pancreatitis", "value": "pancreatitis"},
-            {"text": "Peptic (stomach) ulcers", "value": "pepticStomachUlcers"},
-            {"text": "Ulcerative colitis", "value": "ulcerativeColitis"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_fatherHormone",
-          "type": "checkbox",
-          "title": "Hormone/endocrine conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Hyperthyroidism", "value": "hyperthyroidism"},
-            {"text": "Hypothyroidism", "value": "hypothyroidism"},
-            {"text": "Type 1 diabetes", "value": "type1Diabetes"},
-            {"text": "Type 2 diabetes", "value": "type2Diabetes"},
-            {"text": "Other/unknown diabetes", "value": "otherUnknownDiabetes"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_fatherKidneys",
-          "type": "checkbox",
-          "title": "Kidney conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Kidney disease", "value": "kidneyDisease"},
-            {"text": "Kidney stones", "value": "kidneyStones"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_fatherLung",
-          "type": "checkbox",
-          "title": "Lung conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Asthma", "value": "asthma"},
-            {"text": "Chronic lung disease (COPD, emphysema, or bronchitis)", "value": "chronicLungDisease"},
-            {"text": "Sleep apnea", "value": "sleepApnea"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_fatherNervousSystem",
-          "type": "checkbox",
-          "title": "Brain and nervous system conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Cerebral palsy", "value": "cerebralPalsy"},
-            {"text": "Dementia (includes Alzheimer’s, vascular, etc.)", "value": "dementia"},
-            {"text": "Epilepsy or seizure", "value": "epilepsyOrSeizure"},
-            {"text": "Insomnia", "value": "insomnia"},
-            {"text": "Migraine headaches", "value": "migraineHeadaches"},
-            {"text": "Multiple sclerosis", "value": "multipleSclerosis"},
-            {"text": "Muscular dystrophy (MD)", "value": "muscularDystrophyMd"},
-            {"text": "Neuropathy", "value": "neuropathy"},
-            {"text": "Parkinson’s disease", "value": "parkinsonsDisease"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_fatherMentalHealth",
-          "type": "checkbox",
-          "title": "Mental health or substance use conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Alcohol use disorder", "value": "alcoholUseDisorder"},
-            {"text": "Anxiety reaction/panic disorder", "value": "anxietyReactionPanicDisorder"},
-            {"text": "Attention-deficit/hyperactivity disorder (ADHD)", "value": "attentionDeficitHyperactivityDisorder"},
-            {"text": "Autism spectrum disorder", "value": "autismSpectrumDisorder"},
-            {"text": "Bipolar disorder", "value": "bipolarDisorder"},
-            {"text": "Depression", "value": "depression"},
-            {"text": "Drug use disorder", "value": "drugUseDisorder"},
-            {"text": "Eating disorder", "value": "eatingDisorder"},
-            {"text": "Post-traumatic stress disorder (PTSD)", "value": "postTraumaticStressDisorder"},
-            {"text": "Schizophrenia", "value": "schizophrenia"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_fatherBoneJointMuscle",
-          "type": "checkbox",
-          "title": "Bone, joint, and muscle conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Carpal tunnel syndrome", "value": "carpalTunnelSyndrome"},
-            {"text": "Fibromyalgia", "value": "fibromyalgia"},
-            {"text": "Gout", "value": "gout"},
-            {"text": "Osteoarthritis", "value": "osteoarthritis"},
-            {"text": "Osteoporosis", "value": "osteoporosis"},
-            {"text": "Pseudogout (CPPD)", "value": "pseudogoutCppd"},
-            {"text": "Rheumatoid arthritis", "value": "rheumatoidArthritis"},
-            {"text": "Spine, muscle, or bone disorders (non-cancer)", "value": "spineMuscleOrBoneDisorders"},
-            {"text": "Systemic lupus", "value": "systemicLupus"},
-            {"text": "Other arthritis, such as psoriatic arthritis and/or ankylosing spondylitis", "value": "otherArthritis"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_fatherHearingEye",
-          "type": "radiogroup",
-          "title": "Hearing and eye conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Cataracts", "value": "cataracts"},
-            {"text": "Glaucoma", "value": "glaucoma"},
-            {"text": "Macular degeneration", "value": "macularDegeneration"},
-            {"text": "Severe hearing loss or partial deafness in one or both ears", "value": "severeHearingLoss"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_fatherOtherConditions",
-          "type": "checkbox",
-          "title": "Other conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Allergies", "value": "allergies"},
-            {"text": "Fibroids", "value": "fibroids"},
-            {"text": "Liver condition (e.g., cirrhosis)", "value": "liverCondition"},
-            {"text": "Obesity", "value": "obesity"},
-            {"text": "Reactions to anesthesia (such as hyperthermia)", "value": "reactionsToAnesthesia"},
-            {"text": "Skin condition (e.g., eczema, psoriasis)", "value": "skinCondition"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        }]
-      },{
-        "visibleIf": "{oh_oh_famHx_famKnowledge} != 'none'",
+          },
+          {
+            "name": "oh_oh_famHx_fatherAge",
+            "questionTemplateName": "oh_oh_famHx_age"
+          },
+          {
+            "name": "oh_oh_famHx_fatherCancer",
+            "questionTemplateName": "oh_oh_famHx_maleCancer"
+          },
+          {
+            "name": "oh_oh_famHx_fatherHeartBlood",
+            "questionTemplateName": "oh_oh_famHx_allsexHeartBlood"
+          },
+          {
+            "name": "oh_oh_famHx_fatherAgeAtHeartAttack",
+            "questionTemplateName": "oh_oh_famHx_ageAtHeartAttack",
+            "visibleIf": "{oh_oh_famHx_fatherHeartBlood} contains 'heartAttack'",
+            "isRequired": true
+          },
+          {
+            "name": "oh_oh_famHx_fatherDigestive",
+            "questionTemplateName": "oh_oh_famHx_allsexDigestive"
+          },
+          {
+            "name": "oh_oh_famHx_fatherHormone",
+            "questionTemplateName": "oh_oh_famHx_allsexHormone"
+          },
+          {
+            "name": "oh_oh_famHx_fatherKidneys",
+            "questionTemplateName": "oh_oh_famHx_allsexKidneys"
+          },
+          {
+            "name": "oh_oh_famHx_fatherLung",
+            "questionTemplateName": "oh_oh_famHx_allsexLung"
+          },
+          {
+            "name": "oh_oh_famHx_fatherNervousSystem",
+            "questionTemplateName": "oh_oh_famHx_allsexNervousSystem"
+          },
+          {
+            "name": "oh_oh_famHx_fatherMentalHealth",
+            "questionTemplateName": "oh_oh_famHx_allsexMentalHealth"
+          },
+          {
+            "name": "oh_oh_famHx_fatherBoneJointMuscle",
+            "questionTemplateName": "oh_oh_famHx_allsexBoneJointMuscle"
+          },
+          {
+            "name": "oh_oh_famHx_fatherHearingEye",
+            "questionTemplateName": "oh_oh_famHx_allsexHearingEye"
+          },
+          {
+            "name": "oh_oh_famHx_fatherOtherConditions",
+            "questionTemplateName": "oh_oh_famHx_maleOtherConditions"
+          }
+        ]
+      },
+      {
+        "visibleIf": "{oh_oh_famHx_famKnowledge} contains 'maternalGrandmother'",
         "elements": [
           {
             "type": "panel",
             "elements": [
               {
                 "type": "html",
-                "name": "siblingConditionsDescription",
-                "html": "<h2>Your Sibling’s Health</h2><p>Please indicate if your brothers and/or sisters [people with the same mother and/or father as you] has ever been diagnosed with the following health conditions and/or health events. Think only of those people you are related to by blood. If you have more than one sibling, check the box if any of your siblings have the condition. (Please select all that apply)</p>"
+                "name": "maternalGrandmotherConditionsDescription",
+                "html": "<h2>Your Maternal Grandmother’s Health</h2><p>Please indicate if your maternal grandmother has ever been diagnosed with the following health conditions and/or health events. Think only of the person you are related to by blood. (Please select all that apply)</p>"
               }
             ]
           },
           {
-            "name": "oh_oh_famHx_hasAnySiblings",
-            "type": "checkbox",
-            "title": " ",
-            "choices": [
-              {
-                "text": "I do not have any siblings.",
-                "value": "noSiblings"
-              }
-            ]
+            "name": "oh_oh_famHx_maternalGrandmotherAge",
+            "questionTemplateName": "oh_oh_famHx_age"
           },
+          {
+            "name": "oh_oh_famHx_maternalGrandmotherCancer",
+            "questionTemplateName": "oh_oh_famHx_femaleCancer"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandmotherHeartBlood",
+            "questionTemplateName": "oh_oh_famHx_allsexHeartBlood"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandmotherAgeAtHeartAttack",
+            "questionTemplateName": "oh_oh_famHx_ageAtHeartAttack",
+            "visibleIf": "{oh_oh_famHx_maternalGrandmotherHeartBlood} contains 'heartAttack'",
+            "isRequired": true
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandmotherDigestive",
+            "questionTemplateName": "oh_oh_famHx_allsexDigestive"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandmotherHormone",
+            "questionTemplateName": "oh_oh_famHx_allsexHormone"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandmotherKidneys",
+            "questionTemplateName": "oh_oh_famHx_allsexKidneys"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandmotherLung",
+            "questionTemplateName": "oh_oh_famHx_allsexLung"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandmotherNervousSystem",
+            "questionTemplateName": "oh_oh_famHx_allsexNervousSystem"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandmotherMentalHealth",
+            "questionTemplateName": "oh_oh_famHx_allsexMentalHealth"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandmotherBoneJointMuscle",
+            "questionTemplateName": "oh_oh_famHx_allsexBoneJointMuscle"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandmotherHearingEye",
+            "questionTemplateName": "oh_oh_famHx_allsexHearingEye"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandmotherOtherConditions",
+            "questionTemplateName": "oh_oh_famHx_femaleOtherConditions"
+          }
+        ]
+      },
+      {
+        "visibleIf": "{oh_oh_famHx_famKnowledge} contains 'maternalGrandfather'",
+        "elements": [
           {
             "type": "panel",
-            "visibleIf": "{oh_oh_famHx_hasAnySiblings} notcontains 'noSiblings'",
             "elements": [
               {
-              "name": "oh_oh_famHx_siblingCancer",
-              "type": "checkbox",
-              "title": "Cancer",
-              "showOtherItem": true,
-              "otherText": "Other cancer",
-              "otherPlaceholder": "Please specify",
-              "choices": [
-                {"text": "Bladder cancer", "value": "bladderCancer"},
-                {"text": "Blood or soft tissue cancer", "value": "bloodOrSoftTissueCancer"},
-                {"text": "Bone cancer", "value": "boneCancer"},
-                {"text": "Brain cancer", "value": "brainCancer"},
-                {"text": "Breast cancer", "value": "breastCancer"},
-                {"text": "Cervical cancer", "value": "cervicalCancer"},
-                {"text": "Colon cancer/Rectal cancer", "value": "colonCancerRectalCancer"},
-                {"text": "Endocrine cancer", "value": "endocrineCancer"},
-                {"text": "Endometrial cancer", "value": "endometrialCancer"},
-                {"text": "Esophageal cancer", "value": "esophagealCancer"},
-                {"text": "Eye cancer", "value": "eyeCancer"},
-                {"text": "Head and neck cancer", "value": "headAndNeckCancer"},
-                {"text": "Kidney cancer", "value": "kidneyCancer"},
-                {"text": "Lung cancer", "value": "lungCancer"},
-                {"text": "Ovarian cancer", "value": "ovarianCancer"},
-                {"text": "Pancreatic cancer", "value": "pancreaticCancer"},
-                {"text": "Prostate cancer", "value": "prostateCancer"},
-                {"text": "Skin cancer", "value": "skinCancer"},
-                {"text": "Stomach cancer", "value": "stomachCancer"},
-                {"text": "Thyroid cancer", "value": "thyroidCancer"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_siblingHeartBlood",
-              "type": "checkbox",
-              "title": "Heart and blood conditions",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Anemia", "value": "anemia"},
-                {"text": "Abnormal heart rhythm", "value": "abnormalHeartRhythm"},
-                {"text": "Atrial fibrillation (Afib) or Atrial flutter", "value": "atrialFibrillation"},
-                {"text": "Bleeding disorder", "value": "bleedingDisorder"},
-                {"text": "Coronary artery/coronary heart disease", "value": "coronaryDisease"},
-                {"text": "Cardiac stent", "value": "cardiacStent"},
-                {"text": "Coronary artery bypass surgery", "value": "coronaryArteryBypassSurgery"},
-                {"text": "Heart attack", "value": "heartAttack"},
-                {"text": "Heart failure", "value": "heartFailure"},
-                {"text": "Heart valve disease", "value": "heartValveDisease"},
-                {"text": "High cholesterol", "value": "highCholesterol"},
-                {"text": "Hypertension (high blood pressure)", "value": "hypertension"},
-                {"text": "Peripheral vascular disease", "value": "peripheralVascularDisease"},
-                {"text": "Pulmonary embolism or deep vein thrombosis", "value": "pulmonaryEmbolismOrDVT"},
-                {"text": "Sickle cell disease", "value": "sickleCellDisease"},
-                {"text": "Stroke", "value": "stroke"},
-                {"text": "Transient ischemic attacks (TIAs or mini-strokes)", "value": "transientIschemicAttacks"},
-                {"text": "Sudden death/Cardiac arrest", "value": "suddenDeathCardiacArrest"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_siblingAgeAtHeartAttack",
-              "questionTemplateName": "oh_oh_famHx_ageAtHeartAttack",
-              "visibleIf": "{oh_oh_famHx_siblingHeartBlood} contains 'heartAttack'"
-            },{
-              "name": "oh_oh_famHx_siblingDisgestive",
-              "type": "checkbox",
-              "title": "Digestive conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Acid reflux", "value": "acidReflux"},
-                {"text": "Celiac disease", "value": "celiacDisease"},
-                {"text": "Colon polyps", "value": "colonPolyps"},
-                {"text": "Crohn’s disease", "value": "crohnsDisease"},
-                {"text": "Diverticulitis/Diverticulosis", "value": "diverticulitisDiverticulosis"},
-                {"text": "Gall stones", "value": "gallStones"},
-                {"text": "Irritable bowel syndrome (IBS)", "value": "irritableBowelSyndrome"},
-                {"text": "Liver condition (e.g., cirrhosis)", "value": "liverCondition"},
-                {"text": "Pancreatitis", "value": "pancreatitis"},
-                {"text": "Peptic (stomach) ulcers", "value": "pepticStomachUlcers"},
-                {"text": "Ulcerative colitis", "value": "ulcerativeColitis"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_siblingHormone",
-              "type": "checkbox",
-              "title": "Hormone/endocrine conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Hyperthyroidism", "value": "hyperthyroidism"},
-                {"text": "Hypothyroidism", "value": "hypothyroidism"},
-                {"text": "Type 1 diabetes", "value": "type1Diabetes"},
-                {"text": "Type 2 diabetes", "value": "type2Diabetes"},
-                {"text": "Other/unknown diabetes", "value": "otherUnknownDiabetes"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_siblingKidneys",
-              "type": "checkbox",
-              "title": "Kidney conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Kidney disease", "value": "kidneyDisease"},
-                {"text": "Kidney stones", "value": "kidneyStones"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_siblingLung",
-              "type": "checkbox",
-              "title": "Lung conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Asthma", "value": "asthma"},
-                {"text": "Chronic lung disease (COPD, emphysema, or bronchitis)", "value": "chronicLungDisease"},
-                {"text": "Sleep apnea", "value": "sleepApnea"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_siblingNervousSystem",
-              "type": "checkbox",
-              "title": "Brain and nervous system conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Cerebral palsy", "value": "cerebralPalsy"},
-                {"text": "Dementia (includes Alzheimer’s, vascular, etc.)", "value": "dementia"},
-                {"text": "Epilepsy or seizure", "value": "epilepsyOrSeizure"},
-                {"text": "Insomnia", "value": "insomnia"},
-                {"text": "Migraine headaches", "value": "migraineHeadaches"},
-                {"text": "Multiple sclerosis", "value": "multipleSclerosis"},
-                {"text": "Muscular dystrophy (MD)", "value": "muscularDystrophyMd"},
-                {"text": "Neuropathy", "value": "neuropathy"},
-                {"text": "Parkinson’s disease", "value": "parkinsonsDisease"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_siblingMentalHealth",
-              "type": "checkbox",
-              "title": "Mental health or substance use conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Alcohol use disorder", "value": "alcoholUseDisorder"},
-                {"text": "Anxiety reaction/panic disorder", "value": "anxietyReactionPanicDisorder"},
-                {"text": "Attention-deficit/hyperactivity disorder (ADHD)", "value": "attentionDeficitHyperactivityDisorder"},
-                {"text": "Autism spectrum disorder", "value": "autismSpectrumDisorder"},
-                {"text": "Bipolar disorder", "value": "bipolarDisorder"},
-                {"text": "Depression", "value": "depression"},
-                {"text": "Drug use disorder", "value": "drugUseDisorder"},
-                {"text": "Eating disorder", "value": "eatingDisorder"},
-                {"text": "Post-traumatic stress disorder (PTSD)", "value": "postTraumaticStressDisorder"},
-                {"text": "Schizophrenia", "value": "schizophrenia"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_siblingBoneJointMuscle",
-              "type": "checkbox",
-              "title": "Bone, joint, and muscle conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Carpal tunnel syndrome", "value": "carpalTunnelSyndrome"},
-                {"text": "Fibromyalgia", "value": "fibromyalgia"},
-                {"text": "Gout", "value": "gout"},
-                {"text": "Osteoarthritis", "value": "osteoarthritis"},
-                {"text": "Osteoporosis", "value": "osteoporosis"},
-                {"text": "Pseudogout (CPPD)", "value": "pseudogoutCppd"},
-                {"text": "Rheumatoid arthritis", "value": "rheumatoidArthritis"},
-                {"text": "Spine, muscle, or bone disorders (non-cancer)", "value": "spineMuscleOrBoneDisorders"},
-                {"text": "Systemic lupus", "value": "systemicLupus"},
-                {"text": "Other arthritis, such as psoriatic arthritis and/or ankylosing spondylitis", "value": "otherArthritis"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_siblingHearingEye",
-              "type": "radiogroup",
-              "title": "Hearing and eye conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Cataracts", "value": "cataracts"},
-                {"text": "Glaucoma", "value": "glaucoma"},
-                {"text": "Macular degeneration", "value": "macularDegeneration"},
-                {"text": "Severe hearing loss or partial deafness in one or both ears", "value": "severeHearingLoss"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_siblingOtherConditions",
-              "type": "checkbox",
-              "title": "Other conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Allergies", "value": "allergies"},
-                {"text": "Endometriosis", "value": "endometriosis"},
-                {"text": "Fibroids", "value": "fibroids"},
-                {"text": "Liver condition (e.g., cirrhosis)", "value": "liverCondition"},
-                {"text": "Obesity", "value": "obesity"},
-                {"text": "Polycystic ovarian syndrome", "value": "polycysticOvarianSyndrome"},
-                {"text": "Reactions to anesthesia (such as hyperthermia)", "value": "reactionsToAnesthesia"},
-                {"text": "Skin condition (e.g., eczema, psoriasis)", "value": "skinCondition"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            }
-          ]
-         }
+                "type": "html",
+                "name": "maternalGrandfatherConditionsDescription",
+                "html": "<h2>Your Maternal Grandfather’s Health</h2><p>Please indicate if your maternal grandfather has ever been diagnosed with the following health conditions and/or health events. Think only of the person you are related to by blood. (Please select all that apply)</p>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandfatherAge",
+            "questionTemplateName": "oh_oh_famHx_age"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandfatherCancer",
+            "questionTemplateName": "oh_oh_famHx_maleCancer"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandfatherHeartBlood",
+            "questionTemplateName": "oh_oh_famHx_allsexHeartBlood"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandfatherAgeAtHeartAttack",
+            "questionTemplateName": "oh_oh_famHx_ageAtHeartAttack",
+            "visibleIf": "{oh_oh_famHx_maternalGrandfatherHeartBlood} contains 'heartAttack'",
+            "isRequired": true
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandfatherDigestive",
+            "questionTemplateName": "oh_oh_famHx_allsexDigestive"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandfatherHormone",
+            "questionTemplateName": "oh_oh_famHx_allsexHormone"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandfatherKidneys",
+            "questionTemplateName": "oh_oh_famHx_allsexKidneys"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandfatherLung",
+            "questionTemplateName": "oh_oh_famHx_allsexLung"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandfatherNervousSystem",
+            "questionTemplateName": "oh_oh_famHx_allsexNervousSystem"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandfatherMentalHealth",
+            "questionTemplateName": "oh_oh_famHx_allsexMentalHealth"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandfatherBoneJointMuscle",
+            "questionTemplateName": "oh_oh_famHx_allsexBoneJointMuscle"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandfatherHearingEye",
+            "questionTemplateName": "oh_oh_famHx_allsexHearingEye"
+          },
+          {
+            "name": "oh_oh_famHx_maternalGrandfatherOtherConditions",
+            "questionTemplateName": "oh_oh_famHx_maleOtherConditions"
+          }
         ]
-      },{
-        "visibleIf": "{oh_oh_famHx_famKnowledge} != 'none'",
-        "elements": [{
-          "type": "panel",
-          "elements": [
-            {
-              "type": "html",
-              "name": "daughterConditionsDescription",
-              "html": "<h2>Your Daughter’s Health</h2><p>Please indicate if your daughter(s) has ever been diagnosed with the following health conditions and/or health events. Think only of the person you are related to by blood. (select all that apply)</p>"
-            }
-          ]
-        },
-        {
-          "name": "oh_oh_famHx_hasAnyDaughters",
-          "type": "checkbox",
-          "title": " ",
-          "choices": [
-            {
-              "text": "I do not have any daughters.",
-              "value": "noDaughters"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "visibleIf": "{oh_oh_famHx_hasAnyDaughters} notcontains 'noDaughters'",
-          "elements": [
-            {
-              "name": "oh_oh_famHx_daughterCancer",
-              "type": "checkbox",
-              "title": "Cancer",
-              "showOtherItem": true,
-              "otherText": "Other cancer",
-              "otherPlaceholder": "Please specify",
-              "choices": [
-                {"text": "Bladder cancer", "value": "bladderCancer"},
-                {"text": "Blood or soft tissue cancer", "value": "bloodOrSoftTissueCancer"},
-                {"text": "Bone cancer", "value": "boneCancer"},
-                {"text": "Brain cancer", "value": "brainCancer"},
-                {"text": "Breast cancer", "value": "breastCancer"},
-                {"text": "Cervical cancer", "value": "cervicalCancer"},
-                {"text": "Colon cancer/Rectal cancer", "value": "colonCancerRectalCancer"},
-                {"text": "Endocrine cancer", "value": "endocrineCancer"},
-                {"text": "Endometrial cancer", "value": "endometrialCancer"},
-                {"text": "Esophageal cancer", "value": "esophagealCancer"},
-                {"text": "Eye cancer", "value": "eyeCancer"},
-                {"text": "Head and neck cancer", "value": "headAndNeckCancer"},
-                {"text": "Kidney cancer", "value": "kidneyCancer"},
-                {"text": "Lung cancer", "value": "lungCancer"},
-                {"text": "Ovarian cancer", "value": "ovarianCancer"},
-                {"text": "Pancreatic cancer", "value": "pancreaticCancer"},
-                {"text": "Skin cancer", "value": "skinCancer"},
-                {"text": "Stomach cancer", "value": "stomachCancer"},
-                {"text": "Thyroid cancer", "value": "thyroidCancer"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_daughterHeartBlood",
-              "type": "checkbox",
-              "title": "Heart and blood conditions",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Anemia", "value": "anemia"},
-                {"text": "Abnormal heart rhythm", "value": "anotherAbnormalHeartRhythm"},
-                {"text": "Atrial fibrillation (Afib) or Atrial flutter", "value": "atrialFibrillation"},
-                {"text": "Bleeding disorder", "value": "bleedingDisorder"},
-                {"text": "Coronary artery/coronary heart disease", "value": "coronaryDisease"},
-                {"text": "Cardiac stent", "value": "cardiacStent"},
-                {"text": "Coronary artery bypass surgery", "value": "coronaryArteryBypassSurgery"},
-                {"text": "Heart attack", "value": "heartAttack"},
-                {"text": "Heart failure", "value": "heartFailure"},
-                {"text": "Heart valve disease", "value": "heartValveDisease"},
-                {"text": "High cholesterol", "value": "highCholesterol"},
-                {"text": "Hypertension (high blood pressure)", "value": "hypertension"},
-                {"text": "Peripheral vascular disease", "value": "peripheralVascularDisease"},
-                {"text": "Pulmonary embolism or deep vein thrombosis", "value": "pulmonaryEmbolismOrDVT"},
-                {"text": "Sickle cell disease", "value": "sickleCellDisease"},
-                {"text": "Stroke", "value": "stroke"},
-                {"text": "Transient ischemic attacks (TIAs or mini-strokes)", "value": "transientIschemicAttacks"},
-                {"text": "Sudden death/Cardiac arrest", "value": "suddenDeathCardiacArrest"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_daughterAgeAtHeartAttack",
-              "questionTemplateName": "oh_oh_famHx_ageAtHeartAttack",
-              "visibleIf": "{oh_oh_famHx_daughterHeartBlood} contains 'heartAttack'"
-            },{
-              "name": "oh_oh_famHx_daughterDisgestive",
-              "type": "checkbox",
-              "title": "Digestive conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Acid reflux", "value": "acidReflux"},
-                {"text": "Celiac disease", "value": "celiacDisease"},
-                {"text": "Colon polyps", "value": "colonPolyps"},
-                {"text": "Crohn’s disease", "value": "crohnsDisease"},
-                {"text": "Diverticulitis/Diverticulosis", "value": "diverticulitisDiverticulosis"},
-                {"text": "Gall stones", "value": "gallStones"},
-                {"text": "Irritable bowel syndrome (IBS)", "value": "irritableBowelSyndrome"},
-                {"text": "Liver condition (e.g., cirrhosis)", "value": "liverCondition"},
-                {"text": "Pancreatitis", "value": "pancreatitis"},
-                {"text": "Peptic (stomach) ulcers", "value": "pepticStomachUlcers"},
-                {"text": "Ulcerative colitis", "value": "ulcerativeColitis"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_daughterHormone",
-              "type": "checkbox",
-              "title": "Hormone/endocrine conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Hyperthyroidism", "value": "hyperthyroidism"},
-                {"text": "Hypothyroidism", "value": "hypothyroidism"},
-                {"text": "Type 1 diabetes", "value": "type1Diabetes"},
-                {"text": "Type 2 diabetes", "value": "type2Diabetes"},
-                {"text": "Other/unknown diabetes", "value": "otherUnknownDiabetes"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_daughterKidneys",
-              "type": "checkbox",
-              "title": "Kidney conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Kidney disease", "value": "kidneyDisease"},
-                {"text": "Kidney stones", "value": "kidneyStones"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_daughterLung",
-              "type": "checkbox",
-              "title": "Lung conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Asthma", "value": "asthma"},
-                {"text": "Chronic lung disease (COPD, emphysema, or bronchitis)", "value": "chronicLungDisease"},
-                {"text": "Sleep apnea", "value": "sleepApnea"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_daughterNervousSystem",
-              "type": "checkbox",
-              "title": "Brain and nervous system conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Cerebral palsy", "value": "cerebralPalsy"},
-                {"text": "Dementia (includes Alzheimer’s, vascular, etc.)", "value": "dementia"},
-                {"text": "Epilepsy or seizure", "value": "epilepsyOrSeizure"},
-                {"text": "Insomnia", "value": "insomnia"},
-                {"text": "Migraine headaches", "value": "migraineHeadaches"},
-                {"text": "Multiple sclerosis", "value": "multipleSclerosis"},
-                {"text": "Muscular dystrophy (MD)", "value": "muscularDystrophyMd"},
-                {"text": "Neuropathy", "value": "neuropathy"},
-                {"text": "Parkinson’s disease", "value": "parkinsonsDisease"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_daughterMentalHealth",
-              "type": "checkbox",
-              "title": "Mental health or substance use conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Alcohol use disorder", "value": "alcoholUseDisorder"},
-                {"text": "Anxiety reaction/panic disorder", "value": "anxietyReactionPanicDisorder"},
-                {"text": "Attention-deficit/hyperactivity disorder (ADHD)", "value": "attentionDeficitHyperactivityDisorder"},
-                {"text": "Autism spectrum disorder", "value": "autismSpectrumDisorder"},
-                {"text": "Bipolar disorder", "value": "bipolarDisorder"},
-                {"text": "Depression", "value": "depression"},
-                {"text": "Drug use disorder", "value": "drugUseDisorder"},
-                {"text": "Eating disorder", "value": "eatingDisorder"},
-                {"text": "Post-traumatic stress disorder (PTSD)", "value": "postTraumaticStressDisorder"},
-                {"text": "Schizophrenia", "value": "schizophrenia"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_daughterBoneJointMuscle",
-              "type": "checkbox",
-              "title": "Bone, joint, and muscle conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Carpal tunnel syndrome", "value": "carpalTunnelSyndrome"},
-                {"text": "Fibromyalgia", "value": "fibromyalgia"},
-                {"text": "Gout", "value": "gout"},
-                {"text": "Osteoarthritis", "value": "osteoarthritis"},
-                {"text": "Osteoporosis", "value": "osteoporosis"},
-                {"text": "Pseudogout (CPPD)", "value": "pseudogoutCppd"},
-                {"text": "Rheumatoid arthritis", "value": "rheumatoidArthritis"},
-                {"text": "Spine, muscle, or bone disorders (non-cancer)", "value": "spineMuscleOrBoneDisorders"},
-                {"text": "Systemic lupus", "value": "systemicLupus"},
-                {"text": "Other arthritis, such as psoriatic arthritis and/or ankylosing spondylitis", "value": "otherArthritis"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_daughterHearingEye",
-              "type": "radiogroup",
-              "title": "Hearing and eye conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Cataracts", "value": "cataracts"},
-                {"text": "Glaucoma", "value": "glaucoma"},
-                {"text": "Macular degeneration", "value": "macularDegeneration"},
-                {"text": "Severe hearing loss or partial deafness in one or both ears", "value": "severeHearingLoss"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_daughterOtherConditions",
-              "type": "checkbox",
-              "title": "Other conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Allergies", "value": "allergies"},
-                {"text": "Endometriosis", "value": "endometriosis"},
-                {"text": "Fibroids", "value": "fibroids"},
-                {"text": "Liver condition (e.g., cirrhosis)", "value": "liverCondition"},
-                {"text": "Obesity", "value": "obesity"},
-                {"text": "Polycystic ovarian syndrome", "value": "polycysticOvarianSyndrome"},
-                {"text": "Reactions to anesthesia (such as hyperthermia)", "value": "reactionsToAnesthesia"},
-                {"text": "Skin condition (e.g., eczema, psoriasis)", "value": "skinCondition"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            }
-          ]
-        }
-      ]
-      },{
-        "visibleIf": "{oh_oh_famHx_famKnowledge} != 'none'",
-        "elements": [{
-          "type": "panel",
-          "elements": [
-            {
-              "type": "html",
-              "name": "sonConditionsDescription",
-              "html": "<h2>Your Son’s Health</h2><p>Please indicate if your son(s) has ever been diagnosed with the following health conditions and/or health events. Think only of the person you are related to by blood. (select all that apply)</p?"
-            }
-          ]
-        },{
-          "name": "oh_oh_famHx_hasAnySons",
-          "type": "checkbox",
-          "title": " ",
-          "choices": [
-            {
-              "text": "I do not have any sons.",
-              "value": "noSons"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "visibleIf": "{oh_oh_famHx_hasAnySons} notcontains 'noSons'",
-          "elements": [
-            {
-              "name": "oh_oh_famHx_sonCancer",
-              "type": "checkbox",
-              "title": "Cancer",
-              "showOtherItem": true,
-              "otherText": "Other cancer",
-              "otherPlaceholder": "Please specify",
-              "choices": [
-                {"text": "Bladder cancer", "value": "bladderCancer"},
-                {"text": "Blood or soft tissue cancer", "value": "bloodOrSoftTissueCancer"},
-                {"text": "Bone cancer", "value": "boneCancer"},
-                {"text": "Brain cancer", "value": "brainCancer"},
-                {"text": "Breast cancer", "value": "breastCancer"},
-                {"text": "Colon cancer/Rectal cancer", "value": "colonCancerRectalCancer"},
-                {"text": "Endocrine cancer", "value": "endocrineCancer"},
-                {"text": "Esophageal cancer", "value": "esophagealCancer"},
-                {"text": "Eye cancer", "value": "eyeCancer"},
-                {"text": "Head and neck cancer", "value": "headAndNeckCancer"},
-                {"text": "Kidney cancer", "value": "kidneyCancer"},
-                {"text": "Lung cancer", "value": "lungCancer"},
-                {"text": "Pancreatic cancer", "value": "pancreaticCancer"},
-                {"text": "Prostate cancer", "value": "prostateCancer"},
-                {"text": "Skin cancer", "value": "skinCancer"},
-                {"text": "Stomach cancer", "value": "stomachCancer"},
-                {"text": "Thyroid cancer", "value": "thyroidCancer"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_sonHeartBlood",
-              "type": "checkbox",
-              "title": "Heart and blood conditions",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Anemia", "value": "anemia"},
-                {"text": "Abnormal heart rhythm", "value": "abnormalHeartRhythm"},
-                {"text": "Atrial fibrillation (Afib) or Atrial flutter", "value": "atrialFibrillation"},
-                {"text": "Bleeding disorder", "value": "bleedingDisorder"},
-                {"text": "Coronary artery/coronary heart disease", "value": "coronaryDisease"},
-                {"text": "Cardiac stent", "value": "cardiacStent"},
-                {"text": "Coronary artery bypass surgery", "value": "coronaryArteryBypassSurgery"},
-                {"text": "Heart attack", "value": "heartAttack"},
-                {"text": "Heart failure", "value": "heartFailure"},
-                {"text": "Heart valve disease", "value": "heartValveDisease"},
-                {"text": "High cholesterol", "value": "highCholesterol"},
-                {"text": "Hypertension (high blood pressure)", "value": "hypertension"},
-                {"text": "Peripheral vascular disease", "value": "peripheralVascularDisease"},
-                {"text": "Pulmonary embolism or deep vein thrombosis", "value": "pulmonaryEmbolismOrDVT"},
-                {"text": "Sickle cell disease", "value": "sickleCellDisease"},
-                {"text": "Stroke", "value": "stroke"},
-                {"text": "Transient ischemic attacks (TIAs or mini-strokes)", "value": "transientIschemicAttacks"},
-                {"text": "Sudden death/Cardiac arrest", "value": "suddenDeathCardiacArrest"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_sonAgeAtHeartAttack",
-              "questionTemplateName": "oh_oh_famHx_ageAtHeartAttack",
-              "visibleIf": "{oh_oh_famHx_sonHeartBlood} contains 'heartAttack'"
-            },{
-              "name": "oh_oh_famHx_sonDisgestive",
-              "type": "checkbox",
-              "title": "Digestive conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Acid reflux", "value": "acidReflux"},
-                {"text": "Celiac disease", "value": "celiacDisease"},
-                {"text": "Colon polyps", "value": "colonPolyps"},
-                {"text": "Crohn’s disease", "value": "crohnsDisease"},
-                {"text": "Diverticulitis/Diverticulosis", "value": "diverticulitisDiverticulosis"},
-                {"text": "Gall stones", "value": "gallStones"},
-                {"text": "Irritable bowel syndrome (IBS)", "value": "irritableBowelSyndrome"},
-                {"text": "Liver condition (e.g., cirrhosis)", "value": "liverCondition"},
-                {"text": "Pancreatitis", "value": "pancreatitis"},
-                {"text": "Peptic (stomach) ulcers", "value": "pepticStomachUlcers"},
-                {"text": "Ulcerative colitis", "value": "ulcerativeColitis"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_sonHormone",
-              "type": "checkbox",
-              "title": "Hormone/endocrine conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Hyperthyroidism", "value": "hyperthyroidism"},
-                {"text": "Hypothyroidism", "value": "hypothyroidism"},
-                {"text": "Type 1 diabetes", "value": "type1Diabetes"},
-                {"text": "Type 2 diabetes", "value": "type2Diabetes"},
-                {"text": "Other/unknown diabetes", "value": "otherUnknownDiabetes"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_sonKidneys",
-              "type": "checkbox",
-              "title": "Kidney conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Kidney disease", "value": "kidneyDisease"},
-                {"text": "Kidney stones", "value": "kidneyStones"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_sonLung",
-              "type": "checkbox",
-              "title": "Lung conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Asthma", "value": "asthma"},
-                {"text": "Chronic lung disease (COPD, emphysema, or bronchitis)", "value": "chronicLungDisease"},
-                {"text": "Sleep apnea", "value": "sleepApnea"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_sonNervousSystem",
-              "type": "checkbox",
-              "title": "Brain and nervous system conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Cerebral palsy", "value": "cerebralPalsy"},
-                {"text": "Dementia (includes Alzheimer’s, vascular, etc.)", "value": "dementia"},
-                {"text": "Epilepsy or seizure", "value": "epilepsyOrSeizure"},
-                {"text": "Insomnia", "value": "insomnia"},
-                {"text": "Migraine headaches", "value": "migraineHeadaches"},
-                {"text": "Multiple sclerosis", "value": "multipleSclerosis"},
-                {"text": "Muscular dystrophy (MD)", "value": "muscularDystrophyMd"},
-                {"text": "Neuropathy", "value": "neuropathy"},
-                {"text": "Parkinson’s disease", "value": "parkinsonsDisease"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_sonMentalHealth",
-              "type": "checkbox",
-              "title": "Mental health or substance use conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Alcohol use disorder", "value": "alcoholUseDisorder"},
-                {"text": "Anxiety reaction/panic disorder", "value": "anxietyReactionPanicDisorder"},
-                {"text": "Attention-deficit/hyperactivity disorder (ADHD)", "value": "attentionDeficitHyperactivityDisorder"},
-                {"text": "Autism spectrum disorder", "value": "autismSpectrumDisorder"},
-                {"text": "Bipolar disorder", "value": "bipolarDisorder"},
-                {"text": "Depression", "value": "depression"},
-                {"text": "Drug use disorder", "value": "drugUseDisorder"},
-                {"text": "Eating disorder", "value": "eatingDisorder"},
-                {"text": "Post-traumatic stress disorder (PTSD)", "value": "postTraumaticStressDisorder"},
-                {"text": "Schizophrenia", "value": "schizophrenia"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_sonBoneJointMuscle",
-              "type": "checkbox",
-              "title": "Bone, joint, and muscle conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Carpal tunnel syndrome", "value": "carpalTunnelSyndrome"},
-                {"text": "Fibromyalgia", "value": "fibromyalgia"},
-                {"text": "Gout", "value": "gout"},
-                {"text": "Osteoarthritis", "value": "osteoarthritis"},
-                {"text": "Osteoporosis", "value": "osteoporosis"},
-                {"text": "Pseudogout (CPPD)", "value": "pseudogoutCppd"},
-                {"text": "Rheumatoid arthritis", "value": "rheumatoidArthritis"},
-                {"text": "Spine, muscle, or bone disorders (non-cancer)", "value": "spineMuscleOrBoneDisorders"},
-                {"text": "Systemic lupus", "value": "systemicLupus"},
-                {"text": "Other arthritis, such as psoriatic arthritis and/or ankylosing spondylitis", "value": "otherArthritis"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_sonHearingEye",
-              "type": "radiogroup",
-              "title": "Hearing and eye conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Cataracts", "value": "cataracts"},
-                {"text": "Glaucoma", "value": "glaucoma"},
-                {"text": "Macular degeneration", "value": "macularDegeneration"},
-                {"text": "Severe hearing loss or partial deafness in one or both ears", "value": "severeHearingLoss"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            },{
-              "name": "oh_oh_famHx_sonOtherConditions",
-              "type": "checkbox",
-              "title": "Other conditions:",
-              "showNoneItem": true,
-              "noneText": "None of the above",
-              "noneValue": "noneOfAbove",
-              "choices": [
-                {"text": "Allergies", "value": "allergies"},
-                {"text": "Fibroids", "value": "fibroids"},
-                {"text": "Liver condition (e.g., cirrhosis)", "value": "liverCondition"},
-                {"text": "Obesity", "value": "obesity"},
-                {"text": "Reactions to anesthesia (such as hyperthermia)", "value": "reactionsToAnesthesia"},
-                {"text": "Skin condition (e.g., eczema, psoriasis)", "value": "skinCondition"},
-                {"text": "Don't know", "value": "dontKnow"},
-                {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-              ]
-            }
-          ]
-        }
+      },
+      {
+        "visibleIf": "{oh_oh_famHx_famKnowledge} contains 'paternalGrandmother'",
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "paternalGrandmotherConditionsDescription",
+                "html": "<h2>Your Paternal Grandmother’s Health</h2><p>Please indicate if your paternal grandmother has ever been diagnosed with the following health conditions and/or health events. Think only of the person you are related to by blood. (Please select all that apply)</p>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandmotherAge",
+            "questionTemplateName": "oh_oh_famHx_age"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandmotherCancer",
+            "questionTemplateName": "oh_oh_famHx_femaleCancer"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandmotherHeartBlood",
+            "questionTemplateName": "oh_oh_famHx_allsexHeartBlood"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandmotherAgeAtHeartAttack",
+            "questionTemplateName": "oh_oh_famHx_ageAtHeartAttack",
+            "visibleIf": "{oh_oh_famHx_paternalGrandmotherHeartBlood} contains 'heartAttack'",
+            "isRequired": true
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandmotherDigestive",
+            "questionTemplateName": "oh_oh_famHx_allsexDigestive"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandmotherHormone",
+            "questionTemplateName": "oh_oh_famHx_allsexHormone"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandmotherKidneys",
+            "questionTemplateName": "oh_oh_famHx_allsexKidneys"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandmotherLung",
+            "questionTemplateName": "oh_oh_famHx_allsexLung"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandmotherNervousSystem",
+            "questionTemplateName": "oh_oh_famHx_allsexNervousSystem"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandmotherMentalHealth",
+            "questionTemplateName": "oh_oh_famHx_allsexMentalHealth"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandmotherBoneJointMuscle",
+            "questionTemplateName": "oh_oh_famHx_allsexBoneJointMuscle"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandmotherHearingEye",
+            "questionTemplateName": "oh_oh_famHx_allsexHearingEye"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandmotherOtherConditions",
+            "questionTemplateName": "oh_oh_famHx_femaleOtherConditions"
+          }
         ]
-      },{
-        "visibleIf": "{oh_oh_famHx_famKnowledge} != 'none'",
-        "elements": [{
-          "type": "panel",
-          "elements": [
-            {
-              "type": "html",
-              "name": "grandparentConditionsDescription",
-              "html": "<h2>Your Grandparents’ Health</h2><p>Please indicate if your grandparent(s) has ever been diagnosed with the following health conditions and/or health events. Think only of the person you are related to by blood. (select all that apply)</p>"
-            }
-          ]
-        },{
-          "name": "oh_oh_famHx_grandparentCancer",
-          "type": "checkbox",
-          "title": "Cancer",
-          "showOtherItem": true,
-          "otherText": "Other cancer",
-          "otherPlaceholder": "Please specify",
-          "choices": [
-            {"text": "Bladder cancer", "value": "bladderCancer"},
-            {"text": "Blood or tissue cancer", "value": "bloodOrSoftTissueCancer"},
-            {"text": "Bone cancer", "value": "boneCancer"},
-            {"text": "Brain cancer", "value": "brainCancer"},
-            {"text": "Breast cancer", "value": "breastCancer"},
-            {"text": "Cervical cancer", "value": "cervicalCancer"},
-            {"text": "Colon cancer/Rectal cancer", "value": "colonCancerRectalCancer"},
-            {"text": "Endocrine cancer", "value": "endocrineCancer"},
-            {"text": "Endometrial cancer", "value": "endometrialCancer"},
-            {"text": "Esophageal cancer", "value": "esophagealCancer"},
-            {"text": "Eye cancer", "value": "eyeCancer"},
-            {"text": "Head and neck cancer", "value": "headAndNeckCancer"},
-            {"text": "Kidney cancer", "value": "kidneyCancer"},
-            {"text": "Lung cancer", "value": "lungCancer"},
-            {"text": "Ovarian cancer", "value": "ovarianCancer"},
-            {"text": "Pancreatic cancer", "value": "pancreaticCancer"},
-            {"text": "Prostate cancer", "value": "prostateCancer"},
-            {"text": "Skin cancer", "value": "skinCancer"},
-            {"text": "Stomach cancer", "value": "stomachCancer"},
-            {"text": "Thyroid cancer", "value": "thyroidCancer"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_grandparentHeartBlood",
-          "type": "checkbox",
-          "title": "Heart and blood conditions",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Anemia", "value": "anemia"},
-            {"text": "Abnormal heart rhythm", "value": "abnormalHeartRhythm"},
-            {"text": "Atrial fibrillation (Afib) or Atrial flutter", "value": "atrialFibrillation"},
-            {"text": "Bleeding disorder", "value": "bleedingDisorder"},
-            {"text": "Coronary artery/coronary heart disease", "value": "coronaryDisease"},
-            {"text": "Cardiac stent", "value": "cardiacStent"},
-            {"text": "Coronary artery bypass surgery", "value": "coronaryArteryBypassSurgery"},
-            {"text": "Heart attack", "value": "heartAttack"},
-            {"text": "Heart failure", "value": "heartFailure"},
-            {"text": "Heart valve disease", "value": "heartValveDisease"},
-            {"text": "High cholesterol", "value": "highCholesterol"},
-            {"text": "Hypertension (high blood pressure)", "value": "hypertension"},
-            {"text": "Peripheral vascular disease", "value": "peripheralVascularDisease"},
-            {"text": "Pulmonary embolism or deep vein thrombosis", "value": "pulmonaryEmbolismOrDVT"},
-            {"text": "Sickle cell disease", "value": "sickleCellDisease"},
-            {"text": "Stroke", "value": "stroke"},
-            {"text": "Transient ischemic attacks (TIAs or mini-strokes)", "value": "transientIschemicAttacks"},
-            {"text": "Sudden death/Cardiac arrest", "value": "suddenDeathCardiacArrest"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_grandparentAgeAtHeartAttack",
-          "questionTemplateName": "oh_oh_famHx_ageAtHeartAttack",
-          "visibleIf": "{oh_oh_famHx_grandparentHeartBlood} contains 'heartAttack'"
-        },{
-          "name": "oh_oh_famHx_grandparentDisgestive",
-          "type": "checkbox",
-          "title": "Digestive conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Acid reflux", "value": "acidReflux"},
-            {"text": "Celiac disease", "value": "celiacDisease"},
-            {"text": "Colon polyps", "value": "colonPolyps"},
-            {"text": "Crohn’s disease", "value": "crohnsDisease"},
-            {"text": "Diverticulitis/Diverticulosis", "value": "diverticulitisDiverticulosis"},
-            {"text": "Gall stones", "value": "gallStones"},
-            {"text": "Irritable bowel syndrome (IBS)", "value": "irritableBowelSyndrome"},
-            {"text": "Liver condition (e.g., cirrhosis)", "value": "liverCondition"},
-            {"text": "Pancreatitis", "value": "pancreatitis"},
-            {"text": "Peptic (stomach) ulcers", "value": "pepticStomachUlcers"},
-            {"text": "Ulcerative colitis", "value": "ulcerativeColitis"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_grandparentHormone",
-          "type": "checkbox",
-          "title": "Hormone/endocrine conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Hyperthyroidism", "value": "hyperthyroidism"},
-            {"text": "Hypothyroidism", "value": "hypothyroidism"},
-            {"text": "Type 1 diabetes", "value": "type1Diabetes"},
-            {"text": "Type 2 diabetes", "value": "type2Diabetes"},
-            {"text": "Other/unknown diabetes", "value": "otherUnknownDiabetes"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_grandparentKidneys",
-          "type": "checkbox",
-          "title": "Kidney conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Kidney disease", "value": "kidneyDisease"},
-            {"text": "Kidney stones", "value": "kidneyStones"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_grandparentLung",
-          "type": "checkbox",
-          "title": "Lung conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Asthma", "value": "asthma"},
-            {"text": "Chronic lung disease (COPD, emphysema, or bronchitis)", "value": "chronicLungDisease"},
-            {"text": "Sleep apnea", "value": "sleepApnea"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_grandparentNervousSystem",
-          "type": "checkbox",
-          "title": "Brain and nervous system conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Cerebral palsy", "value": "cerebralPalsy"},
-            {"text": "Dementia (includes Alzheimer’s, vascular, etc.)", "value": "dementia"},
-            {"text": "Epilepsy or seizure", "value": "epilepsyOrSeizure"},
-            {"text": "Insomnia", "value": "insomnia"},
-            {"text": "Migraine headaches", "value": "migraineHeadaches"},
-            {"text": "Multiple sclerosis", "value": "multipleSclerosis"},
-            {"text": "Muscular dystrophy (MD)", "value": "muscularDystrophyMd"},
-            {"text": "Neuropathy", "value": "neuropathy"},
-            {"text": "Parkinson’s disease", "value": "parkinsonsDisease"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_grandparentMentalHealth",
-          "type": "checkbox",
-          "title": "Mental health or substance use conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Alcohol use disorder", "value": "alcoholUseDisorder"},
-            {"text": "Anxiety reaction/panic disorder", "value": "anxietyReactionPanicDisorder"},
-            {"text": "Attention-deficit/hyperactivity disorder (ADHD)", "value": "attentionDeficitHyperactivityDisorder"},
-            {"text": "Autism spectrum disorder", "value": "autismSpectrumDisorder"},
-            {"text": "Bipolar disorder", "value": "bipolarDisorder"},
-            {"text": "Depression", "value": "depression"},
-            {"text": "Drug use disorder", "value": "drugUseDisorder"},
-            {"text": "Eating disorder", "value": "eatingDisorder"},
-            {"text": "Post-traumatic stress disorder (PTSD)", "value": "postTraumaticStressDisorder"},
-            {"text": "Schizophrenia", "value": "schizophrenia"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_grandparentBoneJointMuscle",
-          "type": "checkbox",
-          "title": "Bone, joint, and muscle conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Carpal tunnel syndrome", "value": "carpalTunnelSyndrome"},
-            {"text": "Fibromyalgia", "value": "fibromyalgia"},
-            {"text": "Gout", "value": "gout"},
-            {"text": "Osteoarthritis", "value": "osteoarthritis"},
-            {"text": "Osteoporosis", "value": "osteoporosis"},
-            {"text": "Pseudogout (CPPD)", "value": "pseudogoutCppd"},
-            {"text": "Rheumatoid arthritis", "value": "rheumatoidArthritis"},
-            {"text": "Spine, muscle, or bone disorders (non-cancer)", "value": "spineMuscleOrBoneDisorders"},
-            {"text": "Systemic lupus", "value": "systemicLupus"},
-            {"text": "Other arthritis, such as psoriatic arthritis and/or ankylosing spondylitis", "value": "otherArthritis"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_grandparentHearingEye",
-          "type": "radiogroup",
-          "title": "Hearing and eye conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Cataracts", "value": "cataracts"},
-            {"text": "Glaucoma", "value": "glaucoma"},
-            {"text": "Macular degeneration", "value": "macularDegeneration"},
-            {"text": "Severe hearing loss or partial deafness in one or both ears", "value": "severeHearingLoss"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_famHx_grandparentOtherConditions",
-          "type": "checkbox",
-          "title": "Other conditions:",
-          "showNoneItem": true,
-          "noneText": "None of the above",
-          "noneValue": "noneOfAbove",
-          "choices": [
-            {"text": "Allergies", "value": "allergies"},
-            {"text": "Endometriosis", "value": "endometriosis"},
-            {"text": "Fibroids", "value": "fibroids"},
-            {"text": "Liver condition (e.g., cirrhosis)", "value": "liverCondition"},
-            {"text": "Obesity", "value": "obesity"},
-            {"text": "Polycystic ovarian syndrome", "value": "polycysticOvarianSyndrome"},
-            {"text": "Reactions to anesthesia (such as hyperthermia)", "value": "reactionsToAnesthesia"},
-            {"text": "Skin condition (e.g., eczema, psoriasis)", "value": "skinCondition"},
-            {"text": "Don't know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        }]
+      },
+      {
+        "visibleIf": "{oh_oh_famHx_famKnowledge} contains 'paternalGrandfather'",
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "paternalGrandfatherConditionsDescription",
+                "html": "<h2>Your Paternal Grandfather’s Health</h2><p>Please indicate if your paternal grandfather has ever been diagnosed with the following health conditions and/or health events. Think only of the person you are related to by blood. (Please select all that apply)</p>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandfatherAge",
+            "questionTemplateName": "oh_oh_famHx_age"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandfatherCancer",
+            "questionTemplateName": "oh_oh_famHx_maleCancer"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandfatherHeartBlood",
+            "questionTemplateName": "oh_oh_famHx_allsexHeartBlood"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandfatherAgeAtHeartAttack",
+            "questionTemplateName": "oh_oh_famHx_ageAtHeartAttack",
+            "visibleIf": "{oh_oh_famHx_paternalGrandfatherHeartBlood} contains 'heartAttack'",
+            "isRequired": true
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandfatherDigestive",
+            "questionTemplateName": "oh_oh_famHx_allsexDigestive"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandfatherHormone",
+            "questionTemplateName": "oh_oh_famHx_allsexHormone"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandfatherKidneys",
+            "questionTemplateName": "oh_oh_famHx_allsexKidneys"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandfatherLung",
+            "questionTemplateName": "oh_oh_famHx_allsexLung"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandfatherNervousSystem",
+            "questionTemplateName": "oh_oh_famHx_allsexNervousSystem"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandfatherMentalHealth",
+            "questionTemplateName": "oh_oh_famHx_allsexMentalHealth"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandfatherBoneJointMuscle",
+            "questionTemplateName": "oh_oh_famHx_allsexBoneJointMuscle"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandfatherHearingEye",
+            "questionTemplateName": "oh_oh_famHx_allsexHearingEye"
+          },
+          {
+            "name": "oh_oh_famHx_paternalGrandfatherOtherConditions",
+            "questionTemplateName": "oh_oh_famHx_maleOtherConditions"
+          }
+        ]
+      },
+      {
+        "visibleIf": "{oh_oh_famHx_famKnowledge_numSiblings} = '1' or {oh_oh_famHx_famKnowledge_numSiblings} = '2' or {oh_oh_famHx_famKnowledge_numSiblings} = '3' or {oh_oh_famHx_famKnowledge_numSiblings} = '4'",
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "sibling1ConditionsDescription",
+                "html": "<h2>Your First Sibling’s Health</h2><p>Please indicate if your first biological sibling [people with the same mother and/or father as you] has ever been diagnosed with the following health conditions and/or health events. Think only of the person you are related to by blood. (Please select all that apply)</p>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_famHx_sibling1_sex",
+            "questionTemplateName": "oh_oh_famHx_sex"
+          },
+          {
+            "name": "oh_oh_famHx_sibling1_age",
+            "questionTemplateName": "oh_oh_famHx_age"
+          },
+          {
+            "name": "oh_oh_famHx_sibling1Cancer",
+            "questionTemplateName": "oh_oh_famHx_allsexCancer"
+          },
+          {
+            "name": "oh_oh_famHx_sibling1HeartBlood",
+            "questionTemplateName": "oh_oh_famHx_allsexHeartBlood"
+          },
+          {
+            "name": "oh_oh_famHx_sibling1AgeAtHeartAttack",
+            "questionTemplateName": "oh_oh_famHx_ageAtHeartAttack",
+            "visibleIf": "{oh_oh_famHx_sibling1HeartBlood} contains 'heartAttack'",
+            "isRequired": true
+          },
+          {
+            "name": "oh_oh_famHx_sibling1Digestive",
+            "questionTemplateName": "oh_oh_famHx_allsexDigestive"
+          },
+          {
+            "name": "oh_oh_famHx_sibling1Hormone",
+            "questionTemplateName": "oh_oh_famHx_allsexHormone"
+          },
+          {
+            "name": "oh_oh_famHx_sibling1Kidneys",
+            "questionTemplateName": "oh_oh_famHx_allsexKidneys"
+          },
+          {
+            "name": "oh_oh_famHx_sibling1Lung",
+            "questionTemplateName": "oh_oh_famHx_allsexLung"
+          },
+          {
+            "name": "oh_oh_famHx_sibling1NervousSystem",
+            "questionTemplateName": "oh_oh_famHx_allsexNervousSystem"
+          },
+          {
+            "name": "oh_oh_famHx_sibling1MentalHealth",
+            "questionTemplateName": "oh_oh_famHx_allsexMentalHealth"
+          },
+          {
+            "name": "oh_oh_famHx_sibling1BoneJointMuscle",
+            "questionTemplateName": "oh_oh_famHx_allsexBoneJointMuscle"
+          },
+          {
+            "name": "oh_oh_famHx_sibling1HearingEye",
+            "questionTemplateName": "oh_oh_famHx_allsexHearingEye"
+          },
+          {
+            "name": "oh_oh_famHx_sibling1OtherConditions",
+            "questionTemplateName": "oh_oh_famHx_femaleOtherConditions"
+          }
+        ]
+      },
+      {
+        "visibleIf": "{oh_oh_famHx_famKnowledge_numSiblings} = '2' or {oh_oh_famHx_famKnowledge_numSiblings} = '3' or {oh_oh_famHx_famKnowledge_numSiblings} = '4'",
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "sibling2ConditionsDescription",
+                "html": "<h2>Your Second Sibling’s Health</h2><p>Please indicate if your second biological sibling [people with the same mother and/or father as you] has ever been diagnosed with the following health conditions and/or health events. Think only of the person you are related to by blood. (Please select all that apply)</p>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_famHx_sibling2_sex",
+            "questionTemplateName": "oh_oh_famHx_sex"
+          },
+          {
+            "name": "oh_oh_famHx_sibling2_age",
+            "questionTemplateName": "oh_oh_famHx_age"
+          },
+          {
+            "name": "oh_oh_famHx_sibling2Cancer",
+            "questionTemplateName": "oh_oh_famHx_allsexCancer"
+          },
+          {
+            "name": "oh_oh_famHx_sibling2HeartBlood",
+            "questionTemplateName": "oh_oh_famHx_allsexHeartBlood"
+          },
+          {
+            "name": "oh_oh_famHx_sibling2AgeAtHeartAttack",
+            "questionTemplateName": "oh_oh_famHx_ageAtHeartAttack",
+            "visibleIf": "{oh_oh_famHx_sibling2HeartBlood} contains 'heartAttack'",
+            "isRequired": true
+          },
+          {
+            "name": "oh_oh_famHx_sibling2Digestive",
+            "questionTemplateName": "oh_oh_famHx_allsexDigestive"
+          },
+          {
+            "name": "oh_oh_famHx_sibling2Hormone",
+            "questionTemplateName": "oh_oh_famHx_allsexHormone"
+          },
+          {
+            "name": "oh_oh_famHx_sibling2Kidneys",
+            "questionTemplateName": "oh_oh_famHx_allsexKidneys"
+          },
+          {
+            "name": "oh_oh_famHx_sibling2Lung",
+            "questionTemplateName": "oh_oh_famHx_allsexLung"
+          },
+          {
+            "name": "oh_oh_famHx_sibling2NervousSystem",
+            "questionTemplateName": "oh_oh_famHx_allsexNervousSystem"
+          },
+          {
+            "name": "oh_oh_famHx_sibling2MentalHealth",
+            "questionTemplateName": "oh_oh_famHx_allsexMentalHealth"
+          },
+          {
+            "name": "oh_oh_famHx_sibling2BoneJointMuscle",
+            "questionTemplateName": "oh_oh_famHx_allsexBoneJointMuscle"
+          },
+          {
+            "name": "oh_oh_famHx_sibling2HearingEye",
+            "questionTemplateName": "oh_oh_famHx_allsexHearingEye"
+          },
+          {
+            "name": "oh_oh_famHx_sibling2OtherConditions",
+            "questionTemplateName": "oh_oh_famHx_femaleOtherConditions"
+          }
+        ]
+      },
+      {
+        "visibleIf": "{oh_oh_famHx_famKnowledge_numSiblings} = '3' or {oh_oh_famHx_famKnowledge_numSiblings} = '4'",
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "sibling3ConditionsDescription",
+                "html": "<h2>Your Third Sibling’s Health</h2><p>Please indicate if your third biological sibling [people with the same mother and/or father as you] has ever been diagnosed with the following health conditions and/or health events. Think only of the person you are related to by blood. (Please select all that apply)</p>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_famHx_sibling3_sex",
+            "questionTemplateName": "oh_oh_famHx_sex"
+          },
+          {
+            "name": "oh_oh_famHx_sibling3_age",
+            "questionTemplateName": "oh_oh_famHx_age"
+          },
+          {
+            "name": "oh_oh_famHx_sibling3Cancer",
+            "questionTemplateName": "oh_oh_famHx_allsexCancer"
+          },
+          {
+            "name": "oh_oh_famHx_sibling3HeartBlood",
+            "questionTemplateName": "oh_oh_famHx_allsexHeartBlood"
+          },
+          {
+            "name": "oh_oh_famHx_sibling3AgeAtHeartAttack",
+            "questionTemplateName": "oh_oh_famHx_ageAtHeartAttack",
+            "visibleIf": "{oh_oh_famHx_sibling3HeartBlood} contains 'heartAttack'",
+            "isRequired": true
+          },
+          {
+            "name": "oh_oh_famHx_sibling3Digestive",
+            "questionTemplateName": "oh_oh_famHx_allsexDigestive"
+          },
+          {
+            "name": "oh_oh_famHx_sibling3Hormone",
+            "questionTemplateName": "oh_oh_famHx_allsexHormone"
+          },
+          {
+            "name": "oh_oh_famHx_sibling3Kidneys",
+            "questionTemplateName": "oh_oh_famHx_allsexKidneys"
+          },
+          {
+            "name": "oh_oh_famHx_sibling3Lung",
+            "questionTemplateName": "oh_oh_famHx_allsexLung"
+          },
+          {
+            "name": "oh_oh_famHx_sibling3NervousSystem",
+            "questionTemplateName": "oh_oh_famHx_allsexNervousSystem"
+          },
+          {
+            "name": "oh_oh_famHx_sibling3MentalHealth",
+            "questionTemplateName": "oh_oh_famHx_allsexMentalHealth"
+          },
+          {
+            "name": "oh_oh_famHx_sibling3BoneJointMuscle",
+            "questionTemplateName": "oh_oh_famHx_allsexBoneJointMuscle"
+          },
+          {
+            "name": "oh_oh_famHx_sibling3HearingEye",
+            "questionTemplateName": "oh_oh_famHx_allsexHearingEye"
+          },
+          {
+            "name": "oh_oh_famHx_sibling3OtherConditions",
+            "questionTemplateName": "oh_oh_famHx_femaleOtherConditions"
+          }
+        ]
+      },
+      {
+        "visibleIf": "{oh_oh_famHx_famKnowledge_numSiblings} = '4'",
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "sibling4ConditionsDescription",
+                "html": "<h2>Your Fourth Sibling’s Health</h2><p>Please indicate if your fourth biological sibling [people with the same mother and/or father as you] has ever been diagnosed with the following health conditions and/or health events. Think only of the person you are related to by blood. (Please select all that apply)</p>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_famHx_sibling4_sex",
+            "questionTemplateName": "oh_oh_famHx_sex"
+          },
+          {
+            "name": "oh_oh_famHx_sibling4_age",
+            "questionTemplateName": "oh_oh_famHx_age"
+          },
+          {
+            "name": "oh_oh_famHx_sibling4Cancer",
+            "questionTemplateName": "oh_oh_famHx_allsexCancer"
+          },
+          {
+            "name": "oh_oh_famHx_sibling4HeartBlood",
+            "questionTemplateName": "oh_oh_famHx_allsexHeartBlood"
+          },
+          {
+            "name": "oh_oh_famHx_sibling4AgeAtHeartAttack",
+            "questionTemplateName": "oh_oh_famHx_ageAtHeartAttack",
+            "visibleIf": "{oh_oh_famHx_sibling4HeartBlood} contains 'heartAttack'",
+            "isRequired": true
+          },
+          {
+            "name": "oh_oh_famHx_sibling4Digestive",
+            "questionTemplateName": "oh_oh_famHx_allsexDigestive"
+          },
+          {
+            "name": "oh_oh_famHx_sibling4Hormone",
+            "questionTemplateName": "oh_oh_famHx_allsexHormone"
+          },
+          {
+            "name": "oh_oh_famHx_sibling4Kidneys",
+            "questionTemplateName": "oh_oh_famHx_allsexKidneys"
+          },
+          {
+            "name": "oh_oh_famHx_sibling4Lung",
+            "questionTemplateName": "oh_oh_famHx_allsexLung"
+          },
+          {
+            "name": "oh_oh_famHx_sibling4NervousSystem",
+            "questionTemplateName": "oh_oh_famHx_allsexNervousSystem"
+          },
+          {
+            "name": "oh_oh_famHx_sibling4MentalHealth",
+            "questionTemplateName": "oh_oh_famHx_allsexMentalHealth"
+          },
+          {
+            "name": "oh_oh_famHx_sibling4BoneJointMuscle",
+            "questionTemplateName": "oh_oh_famHx_allsexBoneJointMuscle"
+          },
+          {
+            "name": "oh_oh_famHx_sibling4HearingEye",
+            "questionTemplateName": "oh_oh_famHx_allsexHearingEye"
+          },
+          {
+            "name": "oh_oh_famHx_sibling4OtherConditions",
+            "questionTemplateName": "oh_oh_famHx_femaleOtherConditions"
+          }
+        ]
+      },
+      {
+        "visibleIf": "{oh_oh_famHx_famKnowledge_numChildren} = '1' or {oh_oh_famHx_famKnowledge_numChildren} = '2' or {oh_oh_famHx_famKnowledge_numChildren} = '3' or {oh_oh_famHx_famKnowledge_numChildren} = '4'",
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "child1ConditionsDescription",
+                "html": "<h2>Your First Child’s Health</h2><p>Please indicate if your first biological child has ever been diagnosed with the following health conditions and/or health events. Think only of the person you are related to by blood. (Please select all that apply)</p>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_famHx_child1_sex",
+            "questionTemplateName": "oh_oh_famHx_sex"
+          },
+          {
+            "name": "oh_oh_famHx_child1_age",
+            "questionTemplateName": "oh_oh_famHx_age"
+          },
+          {
+            "name": "oh_oh_famHx_child1Cancer",
+            "questionTemplateName": "oh_oh_famHx_allsexCancer"
+          },
+          {
+            "name": "oh_oh_famHx_child1HeartBlood",
+            "questionTemplateName": "oh_oh_famHx_allsexHeartBlood"
+          },
+          {
+            "name": "oh_oh_famHx_child1AgeAtHeartAttack",
+            "questionTemplateName": "oh_oh_famHx_ageAtHeartAttack",
+            "visibleIf": "{oh_oh_famHx_child1HeartBlood} contains 'heartAttack'",
+            "isRequired": true
+          },
+          {
+            "name": "oh_oh_famHx_child1Digestive",
+            "questionTemplateName": "oh_oh_famHx_allsexDigestive"
+          },
+          {
+            "name": "oh_oh_famHx_child1Hormone",
+            "questionTemplateName": "oh_oh_famHx_allsexHormone"
+          },
+          {
+            "name": "oh_oh_famHx_child1Kidneys",
+            "questionTemplateName": "oh_oh_famHx_allsexKidneys"
+          },
+          {
+            "name": "oh_oh_famHx_child1Lung",
+            "questionTemplateName": "oh_oh_famHx_allsexLung"
+          },
+          {
+            "name": "oh_oh_famHx_child1NervousSystem",
+            "questionTemplateName": "oh_oh_famHx_allsexNervousSystem"
+          },
+          {
+            "name": "oh_oh_famHx_child1MentalHealth",
+            "questionTemplateName": "oh_oh_famHx_allsexMentalHealth"
+          },
+          {
+            "name": "oh_oh_famHx_child1BoneJointMuscle",
+            "questionTemplateName": "oh_oh_famHx_allsexBoneJointMuscle"
+          },
+          {
+            "name": "oh_oh_famHx_child1HearingEye",
+            "questionTemplateName": "oh_oh_famHx_allsexHearingEye"
+          },
+          {
+            "name": "oh_oh_famHx_child1OtherConditions",
+            "questionTemplateName": "oh_oh_famHx_femaleOtherConditions"
+          }
+        ]
+      },
+      {
+        "visibleIf": "{oh_oh_famHx_famKnowledge_numChildren} = '2' or {oh_oh_famHx_famKnowledge_numChildren} = '3' or {oh_oh_famHx_famKnowledge_numChildren} = '4'",
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "child2ConditionsDescription",
+                "html": "<h2>Your Second Child’s Health</h2><p>Please indicate if your second biological child has ever been diagnosed with the following health conditions and/or health events. Think only of the person you are related to by blood. (Please select all that apply)</p>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_famHx_child2_sex",
+            "questionTemplateName": "oh_oh_famHx_sex"
+          },
+          {
+            "name": "oh_oh_famHx_child2_age",
+            "questionTemplateName": "oh_oh_famHx_age"
+          },
+          {
+            "name": "oh_oh_famHx_child2Cancer",
+            "questionTemplateName": "oh_oh_famHx_allsexCancer"
+          },
+          {
+            "name": "oh_oh_famHx_child2HeartBlood",
+            "questionTemplateName": "oh_oh_famHx_allsexHeartBlood"
+          },
+          {
+            "name": "oh_oh_famHx_child2AgeAtHeartAttack",
+            "questionTemplateName": "oh_oh_famHx_ageAtHeartAttack",
+            "visibleIf": "{oh_oh_famHx_child2HeartBlood} contains 'heartAttack'",
+            "isRequired": true
+          },
+          {
+            "name": "oh_oh_famHx_child2Digestive",
+            "questionTemplateName": "oh_oh_famHx_allsexDigestive"
+          },
+          {
+            "name": "oh_oh_famHx_child2Hormone",
+            "questionTemplateName": "oh_oh_famHx_allsexHormone"
+          },
+          {
+            "name": "oh_oh_famHx_child2Kidneys",
+            "questionTemplateName": "oh_oh_famHx_allsexKidneys"
+          },
+          {
+            "name": "oh_oh_famHx_child2Lung",
+            "questionTemplateName": "oh_oh_famHx_allsexLung"
+          },
+          {
+            "name": "oh_oh_famHx_child2NervousSystem",
+            "questionTemplateName": "oh_oh_famHx_allsexNervousSystem"
+          },
+          {
+            "name": "oh_oh_famHx_child2MentalHealth",
+            "questionTemplateName": "oh_oh_famHx_allsexMentalHealth"
+          },
+          {
+            "name": "oh_oh_famHx_child2BoneJointMuscle",
+            "questionTemplateName": "oh_oh_famHx_allsexBoneJointMuscle"
+          },
+          {
+            "name": "oh_oh_famHx_child2HearingEye",
+            "questionTemplateName": "oh_oh_famHx_allsexHearingEye"
+          },
+          {
+            "name": "oh_oh_famHx_child12OtherConditions",
+            "questionTemplateName": "oh_oh_famHx_femaleOtherConditions"
+          }
+        ]
+      },
+      {
+        "visibleIf": "{oh_oh_famHx_famKnowledge_numChildren} = '3' or {oh_oh_famHx_famKnowledge_numChildren} = '4'",
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "child3ConditionsDescription",
+                "html": "<h2>Your Third Child’s Health</h2><p>Please indicate if your third biological child has ever been diagnosed with the following health conditions and/or health events. Think only of the person you are related to by blood. (Please select all that apply)</p>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_famHx_child3_sex",
+            "questionTemplateName": "oh_oh_famHx_sex"
+          },
+          {
+            "name": "oh_oh_famHx_child3_age",
+            "questionTemplateName": "oh_oh_famHx_age"
+          },
+          {
+            "name": "oh_oh_famHx_child3Cancer",
+            "questionTemplateName": "oh_oh_famHx_allsexCancer"
+          },
+          {
+            "name": "oh_oh_famHx_child3HeartBlood",
+            "questionTemplateName": "oh_oh_famHx_allsexHeartBlood"
+          },
+          {
+            "name": "oh_oh_famHx_child3AgeAtHeartAttack",
+            "questionTemplateName": "oh_oh_famHx_ageAtHeartAttack",
+            "visibleIf": "{oh_oh_famHx_child1HeartBlood} contains 'heartAttack'",
+            "isRequired": true
+          },
+          {
+            "name": "oh_oh_famHx_child3Digestive",
+            "questionTemplateName": "oh_oh_famHx_allsexDigestive"
+          },
+          {
+            "name": "oh_oh_famHx_child3Hormone",
+            "questionTemplateName": "oh_oh_famHx_allsexHormone"
+          },
+          {
+            "name": "oh_oh_famHx_child3Kidneys",
+            "questionTemplateName": "oh_oh_famHx_allsexKidneys"
+          },
+          {
+            "name": "oh_oh_famHx_child3Lung",
+            "questionTemplateName": "oh_oh_famHx_allsexLung"
+          },
+          {
+            "name": "oh_oh_famHx_child3NervousSystem",
+            "questionTemplateName": "oh_oh_famHx_allsexNervousSystem"
+          },
+          {
+            "name": "oh_oh_famHx_child3MentalHealth",
+            "questionTemplateName": "oh_oh_famHx_allsexMentalHealth"
+          },
+          {
+            "name": "oh_oh_famHx_child3BoneJointMuscle",
+            "questionTemplateName": "oh_oh_famHx_allsexBoneJointMuscle"
+          },
+          {
+            "name": "oh_oh_famHx_child3HearingEye",
+            "questionTemplateName": "oh_oh_famHx_allsexHearingEye"
+          },
+          {
+            "name": "oh_oh_famHx_child3OtherConditions",
+            "questionTemplateName": "oh_oh_famHx_femaleOtherConditions"
+          }
+        ]
+      },
+      {
+        "visibleIf": "{oh_oh_famHx_famKnowledge_numChildren} contains '4'",
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "child4ConditionsDescription",
+                "html": "<h2>Your Fourth Child’s Health</h2><p>Please indicate if your fourth biological child has ever been diagnosed with the following health conditions and/or health events. Think only of the person you are related to by blood. (Please select all that apply)</p>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_famHx_child4_sex",
+            "questionTemplateName": "oh_oh_famHx_sex"
+          },
+          {
+            "name": "oh_oh_famHx_child4_age",
+            "questionTemplateName": "oh_oh_famHx_age"
+          },
+          {
+            "name": "oh_oh_famHx_child4Cancer",
+            "questionTemplateName": "oh_oh_famHx_allsexCancer"
+          },
+          {
+            "name": "oh_oh_famHx_child4HeartBlood",
+            "questionTemplateName": "oh_oh_famHx_allsexHeartBlood"
+          },
+          {
+            "name": "oh_oh_famHx_child4AgeAtHeartAttack",
+            "questionTemplateName": "oh_oh_famHx_ageAtHeartAttack",
+            "visibleIf": "{oh_oh_famHx_child4HeartBlood} contains 'heartAttack'",
+            "isRequired": true
+          },
+          {
+            "name": "oh_oh_famHx_child4Digestive",
+            "questionTemplateName": "oh_oh_famHx_allsexDigestive"
+          },
+          {
+            "name": "oh_oh_famHx_child4Hormone",
+            "questionTemplateName": "oh_oh_famHx_allsexHormone"
+          },
+          {
+            "name": "oh_oh_famHx_child4Kidneys",
+            "questionTemplateName": "oh_oh_famHx_allsexKidneys"
+          },
+          {
+            "name": "oh_oh_famHx_child4Lung",
+            "questionTemplateName": "oh_oh_famHx_allsexLung"
+          },
+          {
+            "name": "oh_oh_famHx_child4NervousSystem",
+            "questionTemplateName": "oh_oh_famHx_allsexNervousSystem"
+          },
+          {
+            "name": "oh_oh_famHx_child4MentalHealth",
+            "questionTemplateName": "oh_oh_famHx_allsexMentalHealth"
+          },
+          {
+            "name": "oh_oh_famHx_child4BoneJointMuscle",
+            "questionTemplateName": "oh_oh_famHx_allsexBoneJointMuscle"
+          },
+          {
+            "name": "oh_oh_famHx_child4HearingEye",
+            "questionTemplateName": "oh_oh_famHx_allsexHearingEye"
+          },
+          {
+            "name": "oh_oh_famHx_child4OtherConditions",
+            "questionTemplateName": "oh_oh_famHx_femaleOtherConditions"
+          }
+        ]
       }
     ]
   }

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/lifestyle.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/lifestyle.json
@@ -11,724 +11,1857 @@
         "name": "oh_oh_lifestyle_numberRange",
         "type": "dropdown",
         "choices": [
-          {"text": "I don't know", "value": "unknown"},
-          {"text": "Prefer not to answer", "value": "preferNoAnswer"},
-          {"text": "0", "value": "0"},
-          {"text": "1", "value": "1"},
-          {"text": "2", "value": "2"},
-          {"text": "3", "value": "3"},
-          {"text": "4", "value": "4"},
-          {"text": "5", "value": "5"},
-          {"text": "6", "value": "6"},
-          {"text": "7", "value": "7"},
-          {"text": "8", "value": "8"},
-          {"text": "9", "value": "9"},
-          {"text": "10", "value": "10"},
-          {"text": "11", "value": "11"},
-          {"text": "12", "value": "12"},
-          {"text": "13", "value": "13"},
-          {"text": "14", "value": "14"},
-          {"text": "15", "value": "15"},
-          {"text": "16", "value": "16"},
-          {"text": "17", "value": "17"},
-          {"text": "18", "value": "18"},
-          {"text": "19", "value": "19"},
-          {"text": "20", "value": "20"},
-          {"text": "21", "value": "21"},
-          {"text": "22", "value": "22"},
-          {"text": "23", "value": "23"},
-          {"text": "24", "value": "24"},
-          {"text": "25", "value": "25"},
-          {"text": "26", "value": "26"},
-          {"text": "27", "value": "27"},
-          {"text": "28", "value": "28"},
-          {"text": "29", "value": "29"},
-          {"text": "30", "value": "30"},
-          {"text": "31", "value": "31"},
-          {"text": "32", "value": "32"},
-          {"text": "33", "value": "33"},
-          {"text": "34", "value": "34"},
-          {"text": "35", "value": "35"},
-          {"text": "36", "value": "36"},
-          {"text": "37", "value": "37"},
-          {"text": "38", "value": "38"},
-          {"text": "39", "value": "39"},
-          {"text": "40", "value": "40"},
-          {"text": "41", "value": "41"},
-          {"text": "42", "value": "42"},
-          {"text": "43", "value": "43"},
-          {"text": "44", "value": "44"},
-          {"text": "45", "value": "45"},
-          {"text": "46", "value": "46"},
-          {"text": "47", "value": "47"},
-          {"text": "48", "value": "48"},
-          {"text": "49", "value": "49"},
-          {"text": "50", "value": "50"},
-          {"text": "51", "value": "51"},
-          {"text": "52", "value": "52"},
-          {"text": "53", "value": "53"},
-          {"text": "54", "value": "54"},
-          {"text": "55", "value": "55"},
-          {"text": "56", "value": "56"},
-          {"text": "57", "value": "57"},
-          {"text": "58", "value": "58"},
-          {"text": "59", "value": "59"},
-          {"text": "60", "value": "60"},
-          {"text": "61", "value": "61"},
-          {"text": "62", "value": "62"},
-          {"text": "63", "value": "63"},
-          {"text": "64", "value": "64"},
-          {"text": "65", "value": "65"},
-          {"text": "66", "value": "66"},
-          {"text": "67", "value": "67"},
-          {"text": "68", "value": "68"},
-          {"text": "69", "value": "69"},
-          {"text": "70", "value": "70"},
-          {"text": "71", "value": "71"},
-          {"text": "72", "value": "72"},
-          {"text": "73", "value": "73"},
-          {"text": "74", "value": "74"},
-          {"text": "75", "value": "75"},
-          {"text": "76", "value": "76"},
-          {"text": "77", "value": "77"},
-          {"text": "78", "value": "78"},
-          {"text": "79", "value": "79"},
-          {"text": "80", "value": "80"},
-          {"text": "81", "value": "81"},
-          {"text": "82", "value": "82"},
-          {"text": "83", "value": "83"},
-          {"text": "84", "value": "84"},
-          {"text": "85", "value": "85"},
-          {"text": "86", "value": "86"},
-          {"text": "87", "value": "87"},
-          {"text": "88", "value": "88"},
-          {"text": "89", "value": "89"},
-          {"text": "90", "value": "90"},
-          {"text": "91", "value": "91"},
-          {"text": "92", "value": "92"},
-          {"text": "93", "value": "93"},
-          {"text": "94", "value": "94"},
-          {"text": "95", "value": "95"},
-          {"text": "96", "value": "96"},
-          {"text": "97", "value": "97"},
-          {"text": "98", "value": "98"},
-          {"text": "99", "value": "99"}
+          {
+            "text": "I don't know",
+            "value": "unknown"
+          },
+          {
+            "text": "Prefer not to answer",
+            "value": "preferNoAnswer"
+          },
+          {
+            "text": "0",
+            "value": "0"
+          },
+          {
+            "text": "1",
+            "value": "1"
+          },
+          {
+            "text": "2",
+            "value": "2"
+          },
+          {
+            "text": "3",
+            "value": "3"
+          },
+          {
+            "text": "4",
+            "value": "4"
+          },
+          {
+            "text": "5",
+            "value": "5"
+          },
+          {
+            "text": "6",
+            "value": "6"
+          },
+          {
+            "text": "7",
+            "value": "7"
+          },
+          {
+            "text": "8",
+            "value": "8"
+          },
+          {
+            "text": "9",
+            "value": "9"
+          },
+          {
+            "text": "10",
+            "value": "10"
+          },
+          {
+            "text": "11",
+            "value": "11"
+          },
+          {
+            "text": "12",
+            "value": "12"
+          },
+          {
+            "text": "13",
+            "value": "13"
+          },
+          {
+            "text": "14",
+            "value": "14"
+          },
+          {
+            "text": "15",
+            "value": "15"
+          },
+          {
+            "text": "16",
+            "value": "16"
+          },
+          {
+            "text": "17",
+            "value": "17"
+          },
+          {
+            "text": "18",
+            "value": "18"
+          },
+          {
+            "text": "19",
+            "value": "19"
+          },
+          {
+            "text": "20",
+            "value": "20"
+          },
+          {
+            "text": "21",
+            "value": "21"
+          },
+          {
+            "text": "22",
+            "value": "22"
+          },
+          {
+            "text": "23",
+            "value": "23"
+          },
+          {
+            "text": "24",
+            "value": "24"
+          },
+          {
+            "text": "25",
+            "value": "25"
+          },
+          {
+            "text": "26",
+            "value": "26"
+          },
+          {
+            "text": "27",
+            "value": "27"
+          },
+          {
+            "text": "28",
+            "value": "28"
+          },
+          {
+            "text": "29",
+            "value": "29"
+          },
+          {
+            "text": "30",
+            "value": "30"
+          },
+          {
+            "text": "31",
+            "value": "31"
+          },
+          {
+            "text": "32",
+            "value": "32"
+          },
+          {
+            "text": "33",
+            "value": "33"
+          },
+          {
+            "text": "34",
+            "value": "34"
+          },
+          {
+            "text": "35",
+            "value": "35"
+          },
+          {
+            "text": "36",
+            "value": "36"
+          },
+          {
+            "text": "37",
+            "value": "37"
+          },
+          {
+            "text": "38",
+            "value": "38"
+          },
+          {
+            "text": "39",
+            "value": "39"
+          },
+          {
+            "text": "40",
+            "value": "40"
+          },
+          {
+            "text": "41",
+            "value": "41"
+          },
+          {
+            "text": "42",
+            "value": "42"
+          },
+          {
+            "text": "43",
+            "value": "43"
+          },
+          {
+            "text": "44",
+            "value": "44"
+          },
+          {
+            "text": "45",
+            "value": "45"
+          },
+          {
+            "text": "46",
+            "value": "46"
+          },
+          {
+            "text": "47",
+            "value": "47"
+          },
+          {
+            "text": "48",
+            "value": "48"
+          },
+          {
+            "text": "49",
+            "value": "49"
+          },
+          {
+            "text": "50",
+            "value": "50"
+          },
+          {
+            "text": "51",
+            "value": "51"
+          },
+          {
+            "text": "52",
+            "value": "52"
+          },
+          {
+            "text": "53",
+            "value": "53"
+          },
+          {
+            "text": "54",
+            "value": "54"
+          },
+          {
+            "text": "55",
+            "value": "55"
+          },
+          {
+            "text": "56",
+            "value": "56"
+          },
+          {
+            "text": "57",
+            "value": "57"
+          },
+          {
+            "text": "58",
+            "value": "58"
+          },
+          {
+            "text": "59",
+            "value": "59"
+          },
+          {
+            "text": "60",
+            "value": "60"
+          },
+          {
+            "text": "61",
+            "value": "61"
+          },
+          {
+            "text": "62",
+            "value": "62"
+          },
+          {
+            "text": "63",
+            "value": "63"
+          },
+          {
+            "text": "64",
+            "value": "64"
+          },
+          {
+            "text": "65",
+            "value": "65"
+          },
+          {
+            "text": "66",
+            "value": "66"
+          },
+          {
+            "text": "67",
+            "value": "67"
+          },
+          {
+            "text": "68",
+            "value": "68"
+          },
+          {
+            "text": "69",
+            "value": "69"
+          },
+          {
+            "text": "70",
+            "value": "70"
+          },
+          {
+            "text": "71",
+            "value": "71"
+          },
+          {
+            "text": "72",
+            "value": "72"
+          },
+          {
+            "text": "73",
+            "value": "73"
+          },
+          {
+            "text": "74",
+            "value": "74"
+          },
+          {
+            "text": "75",
+            "value": "75"
+          },
+          {
+            "text": "76",
+            "value": "76"
+          },
+          {
+            "text": "77",
+            "value": "77"
+          },
+          {
+            "text": "78",
+            "value": "78"
+          },
+          {
+            "text": "79",
+            "value": "79"
+          },
+          {
+            "text": "80",
+            "value": "80"
+          },
+          {
+            "text": "81",
+            "value": "81"
+          },
+          {
+            "text": "82",
+            "value": "82"
+          },
+          {
+            "text": "83",
+            "value": "83"
+          },
+          {
+            "text": "84",
+            "value": "84"
+          },
+          {
+            "text": "85",
+            "value": "85"
+          },
+          {
+            "text": "86",
+            "value": "86"
+          },
+          {
+            "text": "87",
+            "value": "87"
+          },
+          {
+            "text": "88",
+            "value": "88"
+          },
+          {
+            "text": "89",
+            "value": "89"
+          },
+          {
+            "text": "90",
+            "value": "90"
+          },
+          {
+            "text": "91",
+            "value": "91"
+          },
+          {
+            "text": "92",
+            "value": "92"
+          },
+          {
+            "text": "93",
+            "value": "93"
+          },
+          {
+            "text": "94",
+            "value": "94"
+          },
+          {
+            "text": "95",
+            "value": "95"
+          },
+          {
+            "text": "96",
+            "value": "96"
+          },
+          {
+            "text": "97",
+            "value": "97"
+          },
+          {
+            "text": "98",
+            "value": "98"
+          },
+          {
+            "text": "99",
+            "value": "99"
+          }
         ]
       }
     ],
-    "pages": [{
-      "elements": [{
-        "type": "panel",
+    "pages": [
+      {
         "elements": [
           {
-            "type": "html",
-            "name": "oh_oh_lifestyleIntro",
-            "html": "<p>This survey asks questions about your lifestyle. This is to better understand how it may affect health. It will take about 5-10 minutes to answer these questions. Please answer each question as honestly as possible. We are looking for your own answers, not what you think your doctors, family, or friends want you to say. Do not feel like you have to spend a long time on each question. The first answer that comes to you is usually the best one.</p>"
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "oh_oh_lifestyleIntro",
+                "html": "<p>This survey asks questions about your lifestyle. This is to better understand how it may affect health. It will take about 5-10 minutes to answer these questions. Please answer each question as honestly as possible. We are looking for your own answers, not what you think your doctors, family, or friends want you to say. Do not feel like you have to spend a long time on each question. The first answer that comes to you is usually the best one.</p>"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "oh_oh_lifestyleVigorousActivityIntro",
+                "html": "<h2>Vigorous Activity</h2><p>Vigorous physical activities refer to activities that take hard physical effort and make you breathe much harder than normal. Think only about those physical activities that you did for at least 10 minutes at a time.</p>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_daysVigorousActivity",
+            "type": "radiogroup",
+            "title": "During the last 7 days, on how many days did you do vigorous physical activities like heavy lifting, aerobics, or fast bicycling?",
+            "choices": [
+              {
+                "text": "No vigorous physical activities",
+                "value": "none"
+              },
+              {
+                "text": "1 day",
+                "value": "1Day"
+              },
+              {
+                "text": "2 days",
+                "value": "2Days"
+              },
+              {
+                "text": "3 days",
+                "value": "3Days"
+              },
+              {
+                "text": "4 days",
+                "value": "4Days"
+              },
+              {
+                "text": "5 days",
+                "value": "5Days"
+              },
+              {
+                "text": "6 days",
+                "value": "6Days"
+              },
+              {
+                "text": "7 days",
+                "value": "7Days"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_vigorousActivityMinutes",
+            "type": "dropdown",
+            "visibleIf": "{oh_oh_lifestyle_daysVigorousActivity} != 'none'",
+            "title": "How many minutes did you usually spend doing vigorous physical activities on a typical day?",
+            "choices": [
+              {
+                "text": "Don't know / not sure",
+                "value": "dontKnowNotSure"
+              },
+              {
+                "text": "10",
+                "value": "10"
+              },
+              {
+                "text": "15",
+                "value": "15"
+              },
+              {
+                "text": "20",
+                "value": "20"
+              },
+              {
+                "text": "25",
+                "value": "25"
+              },
+              {
+                "text": "30",
+                "value": "30"
+              },
+              {
+                "text": "35",
+                "value": "35"
+              },
+              {
+                "text": "40",
+                "value": "40"
+              },
+              {
+                "text": "45",
+                "value": "45"
+              },
+              {
+                "text": "50",
+                "value": "50"
+              },
+              {
+                "text": "55",
+                "value": "55"
+              },
+              {
+                "text": "60",
+                "value": "60"
+              },
+              {
+                "text": "70",
+                "value": "70"
+              },
+              {
+                "text": "80",
+                "value": "80"
+              },
+              {
+                "text": "90",
+                "value": "90"
+              },
+              {
+                "text": "100",
+                "value": "100"
+              },
+              {
+                "text": "120",
+                "value": "120"
+              },
+              {
+                "text": "140",
+                "value": "140"
+              },
+              {
+                "text": "160",
+                "value": "160"
+              },
+              {
+                "text": "180",
+                "value": "180"
+              },
+              {
+                "text": "200",
+                "value": "200"
+              },
+              {
+                "text": "240",
+                "value": "240"
+              },
+              {
+                "text": "280",
+                "value": "280"
+              },
+              {
+                "text": "300+",
+                "value": "300"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "oh_oh_lifestyleModertateActivityIntro",
+                "html": "<h2>Moderate Activity</h2><p>Moderate physical activities refer to activities that take moderate physical effort and make you breathe somewhat harder than normal. Think only about those physical activities that you did for at least 10 minutes at a time. </p>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_daysModerateActivities",
+            "type": "radiogroup",
+            "title": "During the last 7 days, on how many days did you do moderate physical activities like carrying light loads, bicycling at a regular pace, or heavy yard work? Please do not include walking.",
+            "choices": [
+              {
+                "text": "No moderate physical activities",
+                "value": "none"
+              },
+              {
+                "text": "1 day",
+                "value": "1Day"
+              },
+              {
+                "text": "2 days",
+                "value": "2Days"
+              },
+              {
+                "text": "3 days",
+                "value": "3Days"
+              },
+              {
+                "text": "4 days",
+                "value": "4Days"
+              },
+              {
+                "text": "5 days",
+                "value": "5Days"
+              },
+              {
+                "text": "6 days",
+                "value": "6Days"
+              },
+              {
+                "text": "7 days",
+                "value": "7Days"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_moderateActivityMinutes",
+            "type": "dropdown",
+            "visibleIf": "{oh_oh_lifestyle_daysModerateActivities} != 'none'",
+            "title": "How many minutes did you usually spend doing moderate physical activities on one of those days?",
+            "choices": [
+              {
+                "text": "Don't know / not sure",
+                "value": "dontKnowNotSure"
+              },
+              {
+                "text": "10",
+                "value": "10"
+              },
+              {
+                "text": "15",
+                "value": "15"
+              },
+              {
+                "text": "20",
+                "value": "20"
+              },
+              {
+                "text": "25",
+                "value": "25"
+              },
+              {
+                "text": "30",
+                "value": "30"
+              },
+              {
+                "text": "35",
+                "value": "35"
+              },
+              {
+                "text": "40",
+                "value": "40"
+              },
+              {
+                "text": "45",
+                "value": "45"
+              },
+              {
+                "text": "50",
+                "value": "50"
+              },
+              {
+                "text": "55",
+                "value": "55"
+              },
+              {
+                "text": "60",
+                "value": "60"
+              },
+              {
+                "text": "70",
+                "value": "70"
+              },
+              {
+                "text": "80",
+                "value": "80"
+              },
+              {
+                "text": "90",
+                "value": "90"
+              },
+              {
+                "text": "100",
+                "value": "100"
+              },
+              {
+                "text": "120",
+                "value": "120"
+              },
+              {
+                "text": "140",
+                "value": "140"
+              },
+              {
+                "text": "160",
+                "value": "160"
+              },
+              {
+                "text": "180",
+                "value": "180"
+              },
+              {
+                "text": "200",
+                "value": "200"
+              },
+              {
+                "text": "240",
+                "value": "240"
+              },
+              {
+                "text": "280",
+                "value": "280"
+              },
+              {
+                "text": "300+",
+                "value": "300"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "oh_oh_lifestyleWalkingIntro",
+                "html": "<h2>Walking</h2><p>Think about the time you spent walking in the last 7 days. This includes at work and at home, walking to travel from place to place, and any other walking that you have done solely for recreation, sport, exercise, or leisure.</p>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_daysWalking",
+            "type": "radiogroup",
+            "title": "During the last 7 days, on how many days did you walk for at least 10 minutes at a time?",
+            "choices": [
+              {
+                "text": "No walking",
+                "value": "none"
+              },
+              {
+                "text": "1 day",
+                "value": "1Day"
+              },
+              {
+                "text": "2 days",
+                "value": "2Days"
+              },
+              {
+                "text": "3 days",
+                "value": "3Days"
+              },
+              {
+                "text": "4 days",
+                "value": "4Days"
+              },
+              {
+                "text": "5 days",
+                "value": "5Days"
+              },
+              {
+                "text": "6 days",
+                "value": "6Days"
+              },
+              {
+                "text": "7 days",
+                "value": "7Days"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_minutesWalking",
+            "type": "dropdown",
+            "visibleIf": "{oh_oh_lifestyle_daysWalking} != 'none'",
+            "title": "How many minutes did you usually spend doing walking on one of those days?",
+            "choices": [
+              {
+                "text": "Don't know / not sure",
+                "value": "dontKnowNotSure"
+              },
+              {
+                "text": "10",
+                "value": "10"
+              },
+              {
+                "text": "15",
+                "value": "15"
+              },
+              {
+                "text": "20",
+                "value": "20"
+              },
+              {
+                "text": "25",
+                "value": "25"
+              },
+              {
+                "text": "30",
+                "value": "30"
+              },
+              {
+                "text": "35",
+                "value": "35"
+              },
+              {
+                "text": "40",
+                "value": "40"
+              },
+              {
+                "text": "45",
+                "value": "45"
+              },
+              {
+                "text": "50",
+                "value": "50"
+              },
+              {
+                "text": "55",
+                "value": "55"
+              },
+              {
+                "text": "60",
+                "value": "60"
+              },
+              {
+                "text": "70",
+                "value": "70"
+              },
+              {
+                "text": "80",
+                "value": "80"
+              },
+              {
+                "text": "90",
+                "value": "90"
+              },
+              {
+                "text": "100",
+                "value": "100"
+              },
+              {
+                "text": "120",
+                "value": "120"
+              },
+              {
+                "text": "140",
+                "value": "140"
+              },
+              {
+                "text": "160",
+                "value": "160"
+              },
+              {
+                "text": "180",
+                "value": "180"
+              },
+              {
+                "text": "200",
+                "value": "200"
+              },
+              {
+                "text": "240",
+                "value": "240"
+              },
+              {
+                "text": "280",
+                "value": "280"
+              },
+              {
+                "text": "300+",
+                "value": "300"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "oh_oh_lifestyleSittingIntro",
+                "html": "<h2>Sitting</h2><p>Think about the time you spent sitting in the last 7 days. Include time spent at work, at home, while doing course work, and during leisure time. This may include time spent sitting at a desk, visiting friends, reading, or sitting/lying down to watch television.</p>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_timeSitting",
+            "type": "dropdown",
+            "title": "During the last 7 days, how much time did you spend sitting on a weekday? (In total)",
+            "choices": [
+              {
+                "text": "Don’t know / not sure",
+                "value": "dontKnowNotSure"
+              },
+              {
+                "text": "less than 30 minutes",
+                "value": "lessThan30Minutes"
+              },
+              {
+                "text": "30 minutes",
+                "value": "30Minutes"
+              },
+              {
+                "text": "1 hour",
+                "value": "1Hour"
+              },
+              {
+                "text": "90 minutes",
+                "value": "90Minutes"
+              },
+              {
+                "text": "2 hours",
+                "value": "2Hours"
+              },
+              {
+                "text": "3 hours",
+                "value": "3Hours"
+              },
+              {
+                "text": "4 hours",
+                "value": "4Hours"
+              },
+              {
+                "text": "5 hours",
+                "value": "5Hours"
+              },
+              {
+                "text": "6 hours",
+                "value": "6Hours"
+              },
+              {
+                "text": "7 hours",
+                "value": "7Hours"
+              },
+              {
+                "text": "8 hours",
+                "value": "8Hours"
+              },
+              {
+                "text": "9 hours",
+                "value": "9Hours"
+              },
+              {
+                "text": "10 hours",
+                "value": "10Hours"
+              },
+              {
+                "text": "11 hours",
+                "value": "11Hours"
+              },
+              {
+                "text": "12 hours",
+                "value": "12Hours"
+              }
+            ]
           }
         ]
-      }, {
-        "type": "panel",
+      },
+      {
         "elements": [
           {
-            "type": "html",
-            "name": "oh_oh_lifestyleVigorousActivityIntro",
-            "html": "<h2>Vigorous Activity</h2><p>Vigorous physical activities refer to activities that take hard physical effort and make you breathe much harder than normal. Think only about those physical activities that you did for at least 10 minutes at a time.</p>"
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "oh_oh_lifestyleSmokingIntro",
+                "html": "<h2>Smoking Habits</h2><p>The next questions will ask about your smoking habits, including cigarettes, bidis, electronic nicotine products, hookah/shisha, and paan with tobacco products. This will help researchers better understand how smoking affects health. As always, your answers are private.</p>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_smoke100cigs",
+            "type": "radiogroup",
+            "title": "Have you ever smoked the equivalent of at least 100 cigarettes in your life? Including bidis, hookah, or other forms of smoking? (There are 20 cigarettes in a pack.)",
+            "choices": [
+              {
+                "text": "Yes",
+                "value": "yes"
+              },
+              {
+                "text": "No",
+                "value": "no"
+              },
+              {
+                "text": "Don’t know",
+                "value": "dontKnow"
+              },
+              {
+                "text": "Prefer not to answer",
+                "value": "preferNoAnswer"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "visibleIf": "{oh_oh_lifestyle_smoke100cigs} = 'yes'",
+            "elements": [
+              {
+                "name": "oh_oh_lifestyle_smokingDays",
+                "type": "radiogroup",
+                "title": "Do you now smoke cigarettes every day, some days, or not at all?",
+                "choices": [
+                  {
+                    "text": "Every day",
+                    "value": "everyDay"
+                  },
+                  {
+                    "text": "Some days",
+                    "value": "someDays"
+                  },
+                  {
+                    "text": "Not at all",
+                    "value": "notAtAll"
+                  },
+                  {
+                    "text": "Don’t know",
+                    "value": "dontKnow"
+                  },
+                  {
+                    "text": "Prefer not to answer",
+                    "value": "preferNoAnswer"
+                  }
+                ]
+              },
+              {
+                "name": "oh_oh_lifestyle_ageSmokingStart",
+                "questionTemplateName": "oh_oh_lifestyle_numberRange",
+                "title": "How old were you when you first started regular cigarette smoking?"
+              },
+              {
+                "name": "oh_oh_lifestyle_attemptQuit",
+                "type": "radiogroup",
+                "title": "In the past, have you ever made a serious attempt to quit smoking? That is, have you stopped smoking for at least one day or longer because you were trying to quit?",
+                "choices": [
+                  {
+                    "text": "Yes",
+                    "value": "yes"
+                  },
+                  {
+                    "text": "No",
+                    "value": "no"
+                  },
+                  {
+                    "text": "Don’t know",
+                    "value": "dontKnow"
+                  },
+                  {
+                    "text": "Prefer not to answer",
+                    "value": "preferNoAnswer"
+                  }
+                ]
+              },
+              {
+                "name": "oh_oh_lifestyle_ageSmokingQuit",
+                "questionTemplateName": "oh_oh_lifestyle_numberRange",
+                "title": "If you have completely stopped smoking cigarettes, how old were you when you stopped?",
+                "visibleIf": "{oh_oh_lifestyle_attemptQuit} = 'yes'"
+              },
+              {
+                "name": "oh_oh_lifestyle_numberYearsSmoking",
+                "questionTemplateName": "oh_oh_lifestyle_numberRange",
+                "title": "How many years have you or did you smoke cigarettes?"
+              },
+              {
+                "name": "oh_oh_lifestyle_numberCigsDayNow",
+                "questionTemplateName": "oh_oh_lifestyle_numberRange",
+                "title": "On average, how many cigarettes do you smoke per day now? (There are 20 cigarettes in a pack.) "
+              },
+              {
+                "name": "oh_oh_lifestyle_numberCigsDayLife",
+                "questionTemplateName": "oh_oh_lifestyle_numberRange",
+                "title": "On average, over the entire time that you smoked, how many cigarettes did you smoke each day? (There are 20 cigarettes in a pack.)"
+              },
+              {
+                "name": "oh_oh_lifestyle_everSmokedBidi",
+                "type": "radiogroup",
+                "title": "Have you ever smoked a traditional “bidi” (“beedi”, “biri”), even one or two puffs?",
+                "choices": [
+                  {
+                    "text": "Yes",
+                    "value": "yes"
+                  },
+                  {
+                    "text": "No",
+                    "value": "no"
+                  },
+                  {
+                    "text": "Don’t know",
+                    "value": "dontKnow"
+                  },
+                  {
+                    "text": "Prefer not to answer",
+                    "value": "preferNoAnswer"
+                  }
+                ]
+              },
+              {
+                "name": "oh_oh_lifestyle_smokeBidiNow",
+                "type": "radiogroup",
+                "title": "Do you now smoke bidis… ",
+                "visibleIf": "{oh_oh_lifestyle_everSmokedBidi} = 'yes'",
+                "choices": [
+                  {
+                    "text": "Every day",
+                    "value": "everyDay"
+                  },
+                  {
+                    "text": "Some days",
+                    "value": "someDays"
+                  },
+                  {
+                    "text": "Not at all",
+                    "value": "notAtAll"
+                  },
+                  {
+                    "text": "Don’t know",
+                    "value": "dontKnow"
+                  },
+                  {
+                    "text": "Prefer not to answer",
+                    "value": "preferNoAnswer"
+                  }
+                ]
+              },
+              {
+                "name": "oh_oh_lifestyle_eNicotineEver",
+                "type": "radiogroup",
+                "title": "Have you ever used an electronic nicotine product, even one or two times? (Electronic nicotine products include e-cigarettes, vape pens, hookah pens, personal vaporizers and mods, e-cigars, e-pipes, and e-hookahs.)",
+                "choices": [
+                  {
+                    "text": "Yes",
+                    "value": "yes"
+                  },
+                  {
+                    "text": "No",
+                    "value": "no"
+                  },
+                  {
+                    "text": "Don’t know",
+                    "value": "dontKnow"
+                  },
+                  {
+                    "text": "Prefer not to answer",
+                    "value": "preferNoAnswer"
+                  }
+                ]
+              },
+              {
+                "name": "oh_oh_lifestyle_eNicotineNow",
+                "type": "radiogroup",
+                "title": "Do you now use electronic nicotine products…",
+                "visibleIf": "{oh_oh_lifestyle_eNicotineEver} = 'yes'",
+                "choices": [
+                  {
+                    "text": "Every day",
+                    "value": "everyDay"
+                  },
+                  {
+                    "text": "Some days",
+                    "value": "someDays"
+                  },
+                  {
+                    "text": "Not at all",
+                    "value": "notAtAll"
+                  },
+                  {
+                    "text": "Don’t know",
+                    "value": "dontKnow"
+                  },
+                  {
+                    "text": "Prefer not to answer",
+                    "value": "preferNoAnswer"
+                  }
+                ]
+              },
+              {
+                "name": "oh_oh_lifestyle_cigarEver",
+                "type": "radiogroup",
+                "title": "Have you ever smoked a traditional cigar, cigarillo, or filtered cigar, even one or two puffs?",
+                "choices": [
+                  {
+                    "text": "Yes",
+                    "value": "yes"
+                  },
+                  {
+                    "text": "No",
+                    "value": "no"
+                  },
+                  {
+                    "text": "Don’t know",
+                    "value": "dontKnow"
+                  },
+                  {
+                    "text": "Prefer not to answer",
+                    "value": "preferNoAnswer"
+                  }
+                ]
+              },
+              {
+                "name": "oh_oh_lifestyle_cigarNow",
+                "type": "radiogroup",
+                "title": "Do you now smoke a traditional cigar, cigarillo, or filtered cigar…",
+                "visibleIf": "{oh_oh_lifestyle_cigarEver} = 'yes'",
+                "choices": [
+                  {
+                    "text": "Every day",
+                    "value": "everyDay"
+                  },
+                  {
+                    "text": "Some days",
+                    "value": "someDays"
+                  },
+                  {
+                    "text": "Not at all",
+                    "value": "notAtAll"
+                  },
+                  {
+                    "text": "Don’t know",
+                    "value": "dontKnow"
+                  },
+                  {
+                    "text": "Prefer not to answer",
+                    "value": "preferNoAnswer"
+                  }
+                ]
+              },
+              {
+                "name": "oh_oh_lifestyle_hookahEver",
+                "type": "radiogroup",
+                "title": "Have you ever smoked tobacco in a hookah or shisha, even one or two puffs?",
+                "choices": [
+                  {
+                    "text": "Yes",
+                    "value": "yes"
+                  },
+                  {
+                    "text": "No",
+                    "value": "no"
+                  },
+                  {
+                    "text": "Don’t know",
+                    "value": "dontKnow"
+                  },
+                  {
+                    "text": "Prefer not to answer",
+                    "value": "preferNoAnswer"
+                  }
+                ]
+              },
+              {
+                "name": "oh_oh_lifestyle_hookahNow",
+                "type": "radiogroup",
+                "title": "Do you now smoke tobacco in a hookah or shisha…",
+                "visibleIf": "{oh_oh_lifestyle_hookahEver} = 'yes'",
+                "choices": [
+                  {
+                    "text": "Every day",
+                    "value": "everyDay"
+                  },
+                  {
+                    "text": "Some days",
+                    "value": "someDays"
+                  },
+                  {
+                    "text": "Not at all",
+                    "value": "notAtAll"
+                  },
+                  {
+                    "text": "Don’t know",
+                    "value": "dontKnow"
+                  },
+                  {
+                    "text": "Prefer not to answer",
+                    "value": "preferNoAnswer"
+                  }
+                ]
+              },
+              {
+                "name": "oh_oh_lifestyle_smokelessTobaccoEver",
+                "type": "radiogroup",
+                "title": "Have you ever used smokeless tobacco products, even one or two times? (Smokeless tobacco products include paan with tobacco products, dip, spit, and chewing tobacco.)",
+                "choices": [
+                  {
+                    "text": "Yes",
+                    "value": "yes"
+                  },
+                  {
+                    "text": "No",
+                    "value": "no"
+                  },
+                  {
+                    "text": "Don’t know",
+                    "value": "dontKnow"
+                  },
+                  {
+                    "text": "Prefer not to answer",
+                    "value": "preferNoAnswer"
+                  }
+                ]
+              },
+              {
+                "name": "oh_oh_lifestyle_smokelessTobaccoNow",
+                "type": "radiogroup",
+                "title": "Do you now use smokeless tobacco products… ",
+                "visibleIf": "{oh_oh_lifestyle_smokelessTobaccoEver} = 'yes'",
+                "choices": [
+                  {
+                    "text": "Every day",
+                    "value": "everyDay"
+                  },
+                  {
+                    "text": "Some days",
+                    "value": "someDays"
+                  },
+                  {
+                    "text": "Not at all",
+                    "value": "notAtAll"
+                  },
+                  {
+                    "text": "Don’t know",
+                    "value": "dontKnow"
+                  },
+                  {
+                    "text": "Prefer not to answer",
+                    "value": "preferNoAnswer"
+                  }
+                ]
+              }
+            ]
           }
         ]
-      },{
-        "name": "oh_oh_lifestyle_daysVigorousActivity",
-        "type": "radiogroup",
-        "title": "During the last 7 days, on how many days did you do vigorous physical activities like heavy lifting, digging, aerobics, or fast bicycling?",
-        "choices": [
-          {"text": "No vigorous physical activities", "value": "none"},
-          {"text": "1 day", "value": "1Day"},
-          {"text": "2 days", "value": "2Days"},
-          {"text": "3 days", "value": "3Days"},
-          {"text": "4 days", "value": "4Days"},
-          {"text": "5 days", "value": "5Days"},
-          {"text": "6 days", "value": "6Days"},
-          {"text": "7 days", "value": "7Days"}
-        ]
-      },{
-        "name": "oh_oh_lifestyle_vigorousActivityMinutes",
-        "type": "dropdown",
-        "visibleIf": "{oh_oh_lifestyle_daysVigorousActivity} != 'none'",
-        "title": "How many minutes did you usually spend doing vigorous physical activities on one of those days?",
-        "choices": [
-          {"text": "Don't know / not sure", "value": "dontKnowNotSure"},
-          {"text": "10", "value": "10"},
-          {"text": "15", "value": "15"},
-          {"text": "20", "value": "20"},
-          {"text": "25", "value": "25"},
-          {"text": "30", "value": "30"},
-          {"text": "35", "value": "35"},
-          {"text": "40", "value": "40"},
-          {"text": "45", "value": "45"},
-          {"text": "50", "value": "50"},
-          {"text": "55", "value": "55"},
-          {"text": "60", "value": "60"},
-          {"text": "70", "value": "70"},
-          {"text": "80", "value": "80"},
-          {"text": "90", "value": "90"},
-          {"text": "100", "value": "100"},
-          {"text": "120", "value": "120"},
-          {"text": "140", "value": "140"},
-          {"text": "160", "value": "160"},
-          {"text": "180", "value": "180"},
-          {"text": "200", "value": "200"},
-          {"text": "240", "value": "240"},
-          {"text": "280", "value": "280"},
-          {"text": "300+", "value": "300"}
-        ]
-      }, {
-        "type": "panel",
+      },
+      {
         "elements": [
           {
-            "type": "html",
-            "name": "oh_oh_lifestyleModertateActivityIntro",
-            "html": "<h2>Moderate Activity</h2><p>Moderate physical activities refer to activities that take moderate physical effort and make you breathe somewhat harder than normal. Think only about those physical activities that you did for at least 10 minutes at a time. </p>"
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "oh_oh_lifestyleDrinkingIntro",
+                "html": "<h2>Drinking Alcohol</h2><p>The next questions will ask about drinking alcohol. This includes coolers, beer, wine, champagne, liquor such as tequila, whiskey, rum, gin, vodka, scotch, or liqueurs, and also any other type of alcohol. This will help researchers better understand how alcohol affects health. As always, your answers are private.</p>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_everHadADrink",
+            "type": "radiogroup",
+            "title": "In your entire life, have you had at least 1 drink of any kind of alcohol, not counting small tastes or sips? (By a “drink,” we mean a can or bottle of beer, a glass of wine or a wine cooler, a shot of liquor, or a mixed drink with liquor in it.)",
+            "choices": [
+              {
+                "text": "Yes",
+                "value": "yes"
+              },
+              {
+                "text": "No",
+                "value": "no"
+              },
+              {
+                "text": "Prefer not to answer",
+                "value": "preferNoAnswer"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_drinkInLastYear",
+            "type": "radiogroup",
+            "title": "How often did you have a drink containing alcohol in the past year?",
+            "visibleIf": "{oh_oh_lifestyle_everHadADrink} = 'yes'",
+            "choices": [
+              {
+                "text": "Never",
+                "value": "never"
+              },
+              {
+                "text": "Monthly or less",
+                "value": "monthlyOrLess"
+              },
+              {
+                "text": "Two to four times a month",
+                "value": "twoToFourTimesAMonth"
+              },
+              {
+                "text": "Two to three times a week",
+                "value": "twoToThreeTimesAWeek"
+              },
+              {
+                "text": "Four or more times a week",
+                "value": "fourOrMoreTimesAWeek"
+              },
+              {
+                "text": "Prefer not to answer",
+                "value": "preferNoAnswer"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_drinksInADay",
+            "type": "radiogroup",
+            "title": "On a typical day when you drink, how many drinks do you have?",
+            "visibleIf": "{oh_oh_lifestyle_everHadADrink} = 'yes' and {oh_oh_lifestyle_drinkInLastYear} != 'never' and {oh_oh_lifestyle_drinkInLastYear} != 'preferNoAnswer' ",
+            "choices": [
+              {
+                "text": "1 or 2",
+                "value": "1or2"
+              },
+              {
+                "text": "3 or 4",
+                "value": "3or4"
+              },
+              {
+                "text": "5 or 6",
+                "value": "5or6"
+              },
+              {
+                "text": "7 to 9",
+                "value": "7to9"
+              },
+              {
+                "text": "10 or more",
+                "value": "10orMore"
+              },
+              {
+                "text": "Prefer not to answer",
+                "value": "preferNoAnswer"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_sixDrinksInOccasion",
+            "type": "radiogroup",
+            "title": "How often did you have six or more drinks on one occasion in the past year?",
+            "visibleIf": "{oh_oh_lifestyle_everHadADrink} = 'yes' and {oh_oh_lifestyle_drinkInLastYear} != 'never' and {oh_oh_lifestyle_drinkInLastYear} != 'preferNoAnswer' ",
+            "choices": [
+              {
+                "text": "Less than monthly",
+                "value": "lessThanMonthly"
+              },
+              {
+                "text": "Monthly",
+                "value": "monthly"
+              },
+              {
+                "text": "Weekly",
+                "value": "weekly"
+              },
+              {
+                "text": "Daily or almost daily",
+                "value": "dailyOrAlmostDaily"
+              },
+              {
+                "text": "Never in the last year",
+                "value": "neverInTheLastYear"
+              },
+              {
+                "text": "Prefer not to answer",
+                "value": "preferNoAnswer"
+              }
+            ]
           }
         ]
-      },{
-        "name": "oh_oh_lifestyle_daysModerateActivities",
-        "type": "radiogroup",
-        "title": "During the last 7 days, on how many days did you do moderate physical activities like carrying light loads, bicycling at a regular pace, or doubles tennis? Please do not include walking.",
-        "choices": [
-          {"text": "No moderate physical activities", "value": "none"},
-          {"text": "1 day", "value": "1Day"},
-          {"text": "2 days", "value": "2Days"},
-          {"text": "3 days", "value": "3Days"},
-          {"text": "4 days", "value": "4Days"},
-          {"text": "5 days", "value": "5Days"},
-          {"text": "6 days", "value": "6Days"},
-          {"text": "7 days", "value": "7Days"}
-        ]
-      },{
-        "name": "oh_oh_lifestyle_moderateActivityMinutes",
-        "type": "dropdown",
-        "visibleIf": "{oh_oh_lifestyle_daysModerateActivities} != 'none'",
-        "title": "How many minutes did you usually spend doing moderate physical activities on one of those days?",
-        "choices": [
-          {"text": "Don't know / not sure", "value": "dontKnowNotSure"},
-          {"text": "10", "value": "10"},
-          {"text": "15", "value": "15"},
-          {"text": "20", "value": "20"},
-          {"text": "25", "value": "25"},
-          {"text": "30", "value": "30"},
-          {"text": "35", "value": "35"},
-          {"text": "40", "value": "40"},
-          {"text": "45", "value": "45"},
-          {"text": "50", "value": "50"},
-          {"text": "55", "value": "55"},
-          {"text": "60", "value": "60"},
-          {"text": "70", "value": "70"},
-          {"text": "80", "value": "80"},
-          {"text": "90", "value": "90"},
-          {"text": "100", "value": "100"},
-          {"text": "120", "value": "120"},
-          {"text": "140", "value": "140"},
-          {"text": "160", "value": "160"},
-          {"text": "180", "value": "180"},
-          {"text": "200", "value": "200"},
-          {"text": "240", "value": "240"},
-          {"text": "280", "value": "280"},
-          {"text": "300+", "value": "300"}
-        ]
-      },{
-        "type": "panel",
+      },
+      {
         "elements": [
           {
-            "type": "html",
-            "name": "oh_oh_lifestyleWalkingIntro",
-            "html": "<h2>Walking</h2><p>Think about the time you spent walking in the last 7 days. This includes at work and at home, walking to travel from place to place, and any other walking that you have done solely for recreation, sport, exercise, or leisure.</p>"
-          }
-        ]
-      },{
-        "name": "oh_oh_lifestyle_daysWalking",
-        "type": "radiogroup",
-        "title": "During the last 7 days, on how many days did you walk for at least 10 minutes at a time?",
-        "choices": [
-          {"text": "No walking", "value": "none"},
-          {"text": "1 day", "value": "1Day"},
-          {"text": "2 days", "value": "2Days"},
-          {"text": "3 days", "value": "3Days"},
-          {"text": "4 days", "value": "4Days"},
-          {"text": "5 days", "value": "5Days"},
-          {"text": "6 days", "value": "6Days"},
-          {"text": "7 days", "value": "7Days"}
-        ]
-      },{
-        "name": "oh_oh_lifestyle_minutesWalking",
-        "type": "dropdown",
-        "visibleIf": "{oh_oh_lifestyle_daysWalking} != 'none'",
-        "title": "How many minutes did you usually spend doing walking on one of those days?",
-        "choices": [
-          {"text": "Don't know / not sure", "value": "dontKnowNotSure"},
-          {"text": "10", "value": "10"},
-          {"text": "15", "value": "15"},
-          {"text": "20", "value": "20"},
-          {"text": "25", "value": "25"},
-          {"text": "30", "value": "30"},
-          {"text": "35", "value": "35"},
-          {"text": "40", "value": "40"},
-          {"text": "45", "value": "45"},
-          {"text": "50", "value": "50"},
-          {"text": "55", "value": "55"},
-          {"text": "60", "value": "60"},
-          {"text": "70", "value": "70"},
-          {"text": "80", "value": "80"},
-          {"text": "90", "value": "90"},
-          {"text": "100", "value": "100"},
-          {"text": "120", "value": "120"},
-          {"text": "140", "value": "140"},
-          {"text": "160", "value": "160"},
-          {"text": "180", "value": "180"},
-          {"text": "200", "value": "200"},
-          {"text": "240", "value": "240"},
-          {"text": "280", "value": "280"},
-          {"text": "300+", "value": "300"}
-        ]
-      },{
-        "type": "panel",
-        "elements": [
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "oh_oh_lifestyleSubstancesIntro",
+                "html": "<h2>Other Substances</h2><p>Now we’d like to ask you about your experiences with medicines and other kinds of drugs. Some of the substances we’ll talk about are prescribed by a doctor (like pain medications). We only want to know if you have taken them for reasons or in doses other than prescribed. We understand that these are sensitive questions. You may choose not to answer them. However, by providing answers, you are helping researchers better understand how these substances affect health.</p>"
+              }
+            ]
+          },
           {
-            "type": "html",
-            "name": "oh_oh_lifestyleSittingIntro",
-            "html": "<h2>Sitting</h2><p>Think about the time you spent sitting in the last 7 days. Include time spent at work, at home, while doing course work, and during leisure time. This may include time spent sitting at a desk, visiting friends, reading, or sitting/lying down to watch television.</p>"
+            "name": "oh_oh_lifestyle_substanceUse",
+            "type": "checkbox",
+            "title": "In your LIFETIME, which of the following substances have you ever used?",
+            "showOtherItem": true,
+            "otherText": "Other",
+            "otherPlaceholder": "Please specify",
+            "showNoneItem": true,
+            "noneText": "None",
+            "choices": [
+              {
+                "text": "Marijuana (cannabis, pot, grass, hash, weed, bhaang, etc.)",
+                "value": "marijuana"
+              },
+              {
+                "text": "Cocaine (coke, crack, etc.)",
+                "value": "cocaine"
+              },
+              {
+                "text": "Prescription stimulants for non-medical reasons (Ritalin, Concerta, Dexedrine, Adderall, diet pills, etc.)",
+                "value": "prescriptionStimulants"
+              },
+              {
+                "text": "Other stimulants (methamphetamine, speed, crystal meth, ice, k2/spice, bath salts, etc.)",
+                "value": "otherStimulants"
+              },
+              {
+                "text": "Inhalants (nitrous oxide, glue, gas, paint thinner, etc.)",
+                "value": "inhalants"
+              },
+              {
+                "text": "Sedatives or sleeping pills for non-medical reasons (Valium, Serepax, Ativan, Xanax, Librium, Rohypnol, GHB, etc.)",
+                "value": "sedatives"
+              },
+              {
+                "text": "Hallucinogens (LSD, acid, mushrooms, PCP, Special K, ecstasy, etc.)",
+                "value": "hallucinogens"
+              },
+              {
+                "text": "Street opioids (heroin, opium, etc.)",
+                "value": "streetOpioids"
+              },
+              {
+                "text": "Prescription opioids for non-medical reasons (fentanyl, oxycodone [OxyContin, Percocet], hydrocodone [Vicodin], methadone, buprenorphine, etc.)",
+                "value": "prescriptionOpioids"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_marijuana3mos",
+            "type": "radiogroup",
+            "title": "In the PAST THREE MONTHS, how often have you used marijuana (cannabis, pot, grass, hash, bhaang, etc.)?",
+            "visibleIf": "{oh_oh_lifestyle_substanceUse} contains 'marijuana'",
+            "choices": [
+              {
+                "text": "Never",
+                "value": "never"
+              },
+              {
+                "text": "Once or twice",
+                "value": "onceOrTwice"
+              },
+              {
+                "text": "Monthly",
+                "value": "monthly"
+              },
+              {
+                "text": "Weekly",
+                "value": "weekly"
+              },
+              {
+                "text": "Daily or almost daily",
+                "value": "dailyOrAlmostDaily"
+              },
+              {
+                "text": "Prefer not to answer",
+                "value": "preferNoAnswer"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_cocaine3mos",
+            "type": "radiogroup",
+            "title": "In the PAST THREE MONTHS, how often have you used cocaine (coke, crack, etc.)?",
+            "visibleIf": "{oh_oh_lifestyle_substanceUse} contains 'cocaine'",
+            "choices": [
+              {
+                "text": "Never",
+                "value": "never"
+              },
+              {
+                "text": "Once or twice",
+                "value": "onceOrTwice"
+              },
+              {
+                "text": "Monthly",
+                "value": "monthly"
+              },
+              {
+                "text": "Weekly",
+                "value": "weekly"
+              },
+              {
+                "text": "Daily or almost daily",
+                "value": "dailyOrAlmostDaily"
+              },
+              {
+                "text": "Prefer not to answer",
+                "value": "preferNoAnswer"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_prescriptionStimulants3mos",
+            "type": "radiogroup",
+            "title": "In the PAST THREE MONTHS, how often have you used prescription stimulants for non-medical reasons (Vyvanse, Ritalin, Concerta, Dexedrine, Adderall, diet pills, etc.)",
+            "visibleIf": "{oh_oh_lifestyle_substanceUse} contains 'prescriptionStimulants'",
+            "choices": [
+              {
+                "text": "Never",
+                "value": "never"
+              },
+              {
+                "text": "Once or twice",
+                "value": "onceOrTwice"
+              },
+              {
+                "text": "Monthly",
+                "value": "monthly"
+              },
+              {
+                "text": "Weekly",
+                "value": "weekly"
+              },
+              {
+                "text": "Daily or almost daily",
+                "value": "dailyOrAlmostDaily"
+              },
+              {
+                "text": "Prefer not to answer",
+                "value": "preferNoAnswer"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_otherStimulants3mos",
+            "type": "radiogroup",
+            "title": "In the PAST THREE MONTHS, how often have you used other stimulants (methamphetamine, speed, crystal meth, ice, k2/spice, bath salts, etc.)",
+            "visibleIf": "{oh_oh_lifestyle_substanceUse} contains 'otherStimulants'",
+            "choices": [
+              {
+                "text": "Never",
+                "value": "never"
+              },
+              {
+                "text": "Once or twice",
+                "value": "onceOrTwice"
+              },
+              {
+                "text": "Monthly",
+                "value": "monthly"
+              },
+              {
+                "text": "Weekly",
+                "value": "weekly"
+              },
+              {
+                "text": "Daily or almost daily",
+                "value": "dailyOrAlmostDaily"
+              },
+              {
+                "text": "Prefer not to answer",
+                "value": "preferNoAnswer"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_inhalants3mos",
+            "type": "radiogroup",
+            "title": "In the PAST THREE MONTHS, how often have you used inhalants (nitrous oxide, glue, gas, paint thinner, etc.)",
+            "visibleIf": "{oh_oh_lifestyle_substanceUse} contains 'inhalants'",
+            "choices": [
+              {
+                "text": "Never",
+                "value": "never"
+              },
+              {
+                "text": "Once or twice",
+                "value": "onceOrTwice"
+              },
+              {
+                "text": "Monthly",
+                "value": "monthly"
+              },
+              {
+                "text": "Weekly",
+                "value": "weekly"
+              },
+              {
+                "text": "Daily or almost daily",
+                "value": "dailyOrAlmostDaily"
+              },
+              {
+                "text": "Prefer not to answer",
+                "value": "preferNoAnswer"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_sedatives3mos",
+            "type": "radiogroup",
+            "title": "In the PAST THREE MONTHS, how often have you used sedatives or sleeping pills for non-medical reasons (Valium, Serepax, Ativan, Xanax, Librium, Rohypnol, GHB, etc.)?",
+            "visibleIf": "{oh_oh_lifestyle_substanceUse} contains 'sedatives'",
+            "choices": [
+              {
+                "text": "Never",
+                "value": "never"
+              },
+              {
+                "text": "Once or twice",
+                "value": "onceOrTwice"
+              },
+              {
+                "text": "Monthly",
+                "value": "monthly"
+              },
+              {
+                "text": "Weekly",
+                "value": "weekly"
+              },
+              {
+                "text": "Daily or almost daily",
+                "value": "dailyOrAlmostDaily"
+              },
+              {
+                "text": "Prefer not to answer",
+                "value": "preferNoAnswer"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_hallucinogens3mos",
+            "type": "radiogroup",
+            "title": "In the PAST THREE MONTHS, how often have you used hallucinogens (LSD, acid, mushrooms, PCP, Special K, ecstasy, etc.)",
+            "visibleIf": "{oh_oh_lifestyle_substanceUse} contains 'hallucinogens'",
+            "choices": [
+              {
+                "text": "Never",
+                "value": "never"
+              },
+              {
+                "text": "Once or twice",
+                "value": "onceOrTwice"
+              },
+              {
+                "text": "Monthly",
+                "value": "monthly"
+              },
+              {
+                "text": "Weekly",
+                "value": "weekly"
+              },
+              {
+                "text": "Daily or almost daily",
+                "value": "dailyOrAlmostDaily"
+              },
+              {
+                "text": "Prefer not to answer",
+                "value": "preferNoAnswer"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_streetOpioids3mos",
+            "type": "radiogroup",
+            "title": "In the PAST THREE MONTHS, how often have you used street opioids (heroin, opium, etc.)?",
+            "visibleIf": "{oh_oh_lifestyle_substanceUse} contains 'streetOpioids'",
+            "choices": [
+              {
+                "text": "Never",
+                "value": "never"
+              },
+              {
+                "text": "Once or twice",
+                "value": "onceOrTwice"
+              },
+              {
+                "text": "Monthly",
+                "value": "monthly"
+              },
+              {
+                "text": "Weekly",
+                "value": "weekly"
+              },
+              {
+                "text": "Daily or almost daily",
+                "value": "dailyOrAlmostDaily"
+              },
+              {
+                "text": "Prefer not to answer",
+                "value": "preferNoAnswer"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_prescriptionOpioids3mos",
+            "type": "radiogroup",
+            "title": "In the PAST THREE MONTHS, how often have you used prescription opioids for non-medical reasons (fentanyl, oxycodone [OxyContin, Percocet], hydrocodone [Vicodin], methadone, buprenorphine, etc.)",
+            "visibleIf": "{oh_oh_lifestyle_substanceUse} contains 'prescriptionOpioids'",
+            "choices": [
+              {
+                "text": "Never",
+                "value": "never"
+              },
+              {
+                "text": "Once or twice",
+                "value": "onceOrTwice"
+              },
+              {
+                "text": "Monthly",
+                "value": "monthly"
+              },
+              {
+                "text": "Weekly",
+                "value": "weekly"
+              },
+              {
+                "text": "Daily or almost daily",
+                "value": "dailyOrAlmostDaily"
+              },
+              {
+                "text": "Prefer not to answer",
+                "value": "preferNoAnswer"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_lifestyle_otherDrugs3mos",
+            "type": "radiogroup",
+            "title": "In the PAST THREE MONTHS, how often have you used other drugs?",
+            "visibleIf": "{oh_oh_lifestyle_substanceUse} contains 'other'",
+            "choices": [
+              {
+                "text": "Never",
+                "value": "never"
+              },
+              {
+                "text": "Once or twice",
+                "value": "onceOrTwice"
+              },
+              {
+                "text": "Monthly",
+                "value": "monthly"
+              },
+              {
+                "text": "Weekly",
+                "value": "weekly"
+              },
+              {
+                "text": "Daily or almost daily",
+                "value": "dailyOrAlmostDaily"
+              },
+              {
+                "text": "Prefer not to answer",
+                "value": "preferNoAnswer"
+              }
+            ]
           }
         ]
-      },{
-        "name": "oh_oh_lifestyle_timeSitting",
-        "type": "dropdown",
-        "title": "During the last 7 days, how much time did you spend sitting on a weekday?",
-        "choices": [
-          {"text": "Don’t know / not sure", "value": "dontKnowNotSure"},
-          {"text": "less than 30 minutes", "value": "lessThan30Minutes"},
-          {"text": "30 minutes", "value": "30Minutes"},
-          {"text": "1 hour", "value": "1Hour"},
-          {"text": "90 minutes", "value": "90Minutes"},
-          {"text": "2 hours", "value": "2Hours"},
-          {"text": "3 hours", "value": "3Hours"},
-          {"text": "4 hours", "value": "4Hours"},
-          {"text": "5 hours", "value": "5Hours"},
-          {"text": "6 hours", "value": "6Hours"},
-          {"text": "7 hours", "value": "7Hours"},
-          {"text": "8 hours", "value": "8Hours"},
-          {"text": "9 hours", "value": "9Hours"},
-          {"text": "10 hours", "value": "10Hours"},
-          {"text": "11 hours", "value": "11Hours"},
-          {"text": "12 hours", "value": "12Hours"}
-        ]
-      }]
-    },{
-      "elements": [
-        {
-          "type": "panel",
-          "elements": [
-            {
-              "type": "html",
-              "name": "oh_oh_lifestyleSmokingIntro",
-              "html": "<h2>Smoking Habits</h2><p>The next questions will ask about your smoking habits, including cigarettes, bidis, electronic nicotine products, hookah/shisha, and paan with tobacco products. This will help researchers better understand how smoking affects health. As always, your answers are private.</p>"
-            }
-          ]
-        },
-        {
-          "name": "oh_oh_lifestyle_smoke100cigs",
-          "type": "radiogroup",
-          "title": "Have you ever smoked the equivalent of at least 100 cigarettes in your life? Including bidis, hookah, or other forms of smoking? (There are 20 cigarettes in a pack.)",
-          "choices": [
-            {"text": "Yes", "value": "yes"},
-            {"text": "No", "value": "no"},
-            {"text": "Don’t know", "value": "dontKnow"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "type": "panel",
-          "visibleIf": "{oh_oh_lifestyle_smoke100cigs} = 'yes'",
-          "elements": [{
-            "name": "oh_oh_lifestyle_smokingDays",
-            "type": "radiogroup",
-            "title": "Do you now smoke cigarettes every day, some days, or not at all?",
-            "choices": [
-              {"text": "Every day", "value": "everyDay"},
-              {"text": "Some days", "value": "someDays"},
-              {"text": "Not at all", "value": "notAtAll"},
-              {"text": "Don’t know", "value": "dontKnow"},
-              {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-            ]
-          },{
-            "name": "oh_oh_lifestyle_ageSmokingStart",
-            "questionTemplateName": "oh_oh_lifestyle_numberRange",
-            "title": "How old were you when you first started regular cigarette smoking?"
-          },{
-            "name": "oh_oh_lifestyle_attemptQuit",
-            "type": "radiogroup",
-            "title": "In the past, have you ever made a serious attempt to quit smoking? That is, have you stopped smoking for at least one day or longer because you were trying to quit?",
-            "choices": [
-              {"text": "Yes", "value": "yes"},
-              {"text": "No", "value": "no"},
-              {"text": "Don’t know", "value": "dontKnow"},
-              {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-            ]
-          },{
-            "name": "oh_oh_lifestyle_ageSmokingQuit",
-            "questionTemplateName": "oh_oh_lifestyle_numberRange",
-            "title": "If you have completely stopped smoking cigarettes, how old were you when you stopped?",
-            "visibleIf": "{oh_oh_lifestyle_attemptQuit} = 'yes'"
-          },{
-            "name": "oh_oh_lifestyle_numberYearsSmoking",
-            "questionTemplateName": "oh_oh_lifestyle_numberRange",
-            "title": "How many years have you or did you smoke cigarettes?"
-          },{
-            "name": "oh_oh_lifestyle_numberCigsDayNow",
-            "questionTemplateName": "oh_oh_lifestyle_numberRange",
-            "title": "On average, how many cigarettes do you smoke per day now? (There are 20 cigarettes in a pack.) "
-          },{
-            "name": "oh_oh_lifestyle_numberCigsDayLife",
-            "questionTemplateName": "oh_oh_lifestyle_numberRange",
-            "title": "On average, over the entire time that you smoked, how many cigarettes did you smoke each day? (There are 20 cigarettes in a pack.)"
-          },{
-            "name": "oh_oh_lifestyle_everSmokedBidi",
-            "type": "radiogroup",
-            "title": "Have you ever smoked a traditional “bidi” (“beedi”, “biri”), even one or two puffs?",
-            "choices": [
-              {"text": "Yes", "value": "yes"},
-              {"text": "No", "value": "no"},
-              {"text": "Don’t know", "value": "dontKnow"},
-              {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-            ]
-          },{
-            "name": "oh_oh_lifestyle_smokeBidiNow",
-            "type": "radiogroup",
-            "title": "Do you now smoke bidis… ",
-            "visibleIf": "{oh_oh_lifestyle_everSmokedBidi} = 'yes'",
-            "choices": [
-              {"text": "Every day", "value": "everyDay"},
-              {"text": "Some days", "value": "someDays"},
-              {"text": "Not at all", "value": "notAtAll"},
-              {"text": "Don’t know", "value": "dontKnow"},
-              {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-            ]
-          },{
-            "name": "oh_oh_lifestyle_eNicotineEver",
-            "type": "radiogroup",
-            "title": "Have you ever used an electronic nicotine product, even one or two times? (Electronic nicotine products include e-cigarettes, vape pens, hookah pens, personal vaporizers and mods, e-cigars, e-pipes, and e-hookahs.)",
-            "choices": [
-              {"text": "Yes", "value": "yes"},
-              {"text": "No", "value": "no"},
-              {"text": "Don’t know", "value": "dontKnow"},
-              {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-            ]
-          },{
-            "name": "oh_oh_lifestyle_eNicotineNow",
-            "type": "radiogroup",
-            "title": "Do you now use electronic nicotine products…",
-            "visibleIf": "{oh_oh_lifestyle_eNicotineEver} = 'yes'",
-            "choices": [
-              {"text": "Every day", "value": "everyDay"},
-              {"text": "Some days", "value": "someDays"},
-              {"text": "Not at all", "value": "notAtAll"},
-              {"text": "Don’t know", "value": "dontKnow"},
-              {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-            ]
-          },{
-            "name": "oh_oh_lifestyle_cigarEver",
-            "type": "radiogroup",
-            "title": "Have you ever smoked a traditional cigar, cigarillo, or filtered cigar, even one or two puffs?",
-            "choices": [
-              {"text": "Yes", "value": "yes"},
-              {"text": "No", "value": "no"},
-              {"text": "Don’t know", "value": "dontKnow"},
-              {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-            ]
-          },{
-            "name": "oh_oh_lifestyle_cigarNow",
-            "type": "radiogroup",
-            "title": "Do you now smoke a traditional cigar, cigarillo, or filtered cigar…",
-            "visibleIf": "{oh_oh_lifestyle_cigarEver} = 'yes'",
-            "choices": [
-              {"text": "Every day", "value": "everyDay"},
-              {"text": "Some days", "value": "someDays"},
-              {"text": "Not at all", "value": "notAtAll"},
-              {"text": "Don’t know", "value": "dontKnow"},
-              {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-            ]
-          },{
-            "name": "oh_oh_lifestyle_hookahEver",
-            "type": "radiogroup",
-            "title": "Have you ever smoked tobacco in a hookah or shisha, even one or two puffs?",
-            "choices": [
-              {"text": "Yes", "value": "yes"},
-              {"text": "No", "value": "no"},
-              {"text": "Don’t know", "value": "dontKnow"},
-              {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-            ]
-          },{
-            "name": "oh_oh_lifestyle_hookahNow",
-            "type": "radiogroup",
-            "title": "Do you now smoke tobacco in a hookah or shisha…",
-            "visibleIf": "{oh_oh_lifestyle_hookahEver} = 'yes'",
-            "choices": [
-              {"text": "Every day", "value": "everyDay"},
-              {"text": "Some days", "value": "someDays"},
-              {"text": "Not at all", "value": "notAtAll"},
-              {"text": "Don’t know", "value": "dontKnow"},
-              {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-            ]
-          },{
-            "name": "oh_oh_lifestyle_smokelessTobaccoEver",
-            "type": "radiogroup",
-            "title": "Have you ever used smokeless tobacco products, even one or two times? (Smokeless tobacco products include paan with tobacco products, dip, spit, and chewing tobacco.)",
-            "choices": [
-              {"text": "Yes", "value": "yes"},
-              {"text": "No", "value": "no"},
-              {"text": "Don’t know", "value": "dontKnow"},
-              {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-            ]
-          },{
-            "name": "oh_oh_lifestyle_smokelessTobaccoNow",
-            "type": "radiogroup",
-            "title": "Do you now use smokeless tobacco products… ",
-            "visibleIf": "{oh_oh_lifestyle_smokelessTobaccoEver} = 'yes'",
-            "choices": [
-              {"text": "Every day", "value": "everyDay"},
-              {"text": "Some days", "value": "someDays"},
-              {"text": "Not at all", "value": "notAtAll"},
-              {"text": "Don’t know", "value": "dontKnow"},
-              {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-            ]
-          }
-
-          ]
-        }
-      ]
-    },{
-      "elements": [
-        {
-          "type": "panel",
-          "elements": [
-            {
-              "type": "html",
-              "name": "oh_oh_lifestyleDrinkingIntro",
-              "html": "<h2>Drinking Alcohol</h2><p>The next questions will ask about drinking alcohol. This includes coolers, beer, wine, champagne, liquor such as tequila, whiskey, rum, gin, vodka, scotch, or liqueurs, and also any other type of alcohol. This will help researchers better understand how alcohol affects health. As always, your answers are private.</p>"
-            }
-          ]
-        },
-        {
-          "name": "oh_oh_lifestyle_everHadADrink",
-          "type": "radiogroup",
-          "title": "In your entire life, have you had at least 1 drink of any kind of alcohol, not counting small tastes or sips? (By a “drink,” we mean a can or bottle of beer, a glass of wine or a wine cooler, a shot of liquor, or a mixed drink with liquor in it.)",
-          "choices": [
-            {"text": "Yes", "value": "yes"},
-            {"text": "No", "value": "no"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_lifestyle_drinkInLastYear",
-          "type": "radiogroup",
-          "title": "How often did you have a drink containing alcohol in the past year?",
-          "visibleIf": "{oh_oh_lifestyle_everHadADrink} = 'yes'",
-          "choices": [
-            {"text": "Never", "value": "never"},
-            {"text": "Monthly or less", "value": "monthlyOrLess"},
-            {"text": "Two to four times a month", "value": "twoToFourTimesAMonth"},
-            {"text": "Two to three times a week", "value": "twoToThreeTimesAWeek"},
-            {"text": "Four or more times a week", "value": "fourOrMoreTimesAWeek"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_lifestyle_drinksInADay",
-          "type": "radiogroup",
-          "title": "On a typical day when you drink, how many drinks do you have?",
-          "visibleIf": "{oh_oh_lifestyle_everHadADrink} = 'yes' and {oh_oh_lifestyle_drinkInLastYear} != 'never' and {oh_oh_lifestyle_drinkInLastYear} != 'preferNoAnswer' ",
-          "choices": [
-            {"text": "1 or 2", "value": "1or2"},
-            {"text": "3 or 4", "value": "3or4"},
-            {"text": "5 or 6", "value": "5or6"},
-            {"text": "7 to 9", "value": "7to9"},
-            {"text": "10 or more", "value": "10orMore"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_lifestyle_sixDrinksInOccasion",
-          "type": "radiogroup",
-          "title": "How often did you have six or more drinks on one occasion in the past year?",
-          "visibleIf": "{oh_oh_lifestyle_everHadADrink} = 'yes' and {oh_oh_lifestyle_drinkInLastYear} != 'never' and {oh_oh_lifestyle_drinkInLastYear} != 'preferNoAnswer' ",
-          "choices": [
-            {"text": "Less than monthly", "value": "lessThanMonthly"},
-            {"text": "Monthly", "value": "monthly"},
-            {"text": "Weekly", "value": "weekly"},
-            {"text": "Daily or almost daily", "value": "dailyOrAlmostDaily"},
-            {"text": "Never in the last year", "value": "neverInTheLastYear"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        }
-      ]
-    },{
-      "elements": [
-        {
-          "type": "panel",
-          "elements": [
-            {
-              "type": "html",
-              "name": "oh_oh_lifestyleSubstancesIntro",
-              "html": "<h2>Other Substances</h2><p>Now we’d like to ask you about your experiences with medicines and other kinds of drugs. Some of the substances we’ll talk about are prescribed by a doctor (like pain medications). We only want to know if you have taken them for reasons or in doses other than prescribed. We understand that these are sensitive questions. You may choose not to answer them. However, by providing answers, you are helping researchers better understand how these substances affect health.</p>"
-            }
-          ]
-        },
-        {
-          "name": "oh_oh_lifestyle_substanceUse",
-          "type": "checkbox",
-          "title": "In your LIFETIME, which of the following substances have you ever used?",
-          "showOtherItem": true,
-          "otherText": "Other",
-          "otherPlaceholder": "Please specify",
-          "showNoneItem": true,
-          "noneText": "None",
-          "choices": [
-            {"text": "Marijuana (cannabis, pot, grass, hash, weed, bhaang, etc.)", "value": "marijuana"},
-            {"text": "Cocaine (coke, crack, etc.)", "value": "cocaine"},
-            {"text": "Prescription stimulants for non-medical reasons (Ritalin, Concerta, Dexedrine, Adderall, diet pills, etc.)", "value": "prescriptionStimulants"},
-            {"text": "Other stimulants (methamphetamine, speed, crystal meth, ice, k2/spice, bath salts, etc.)", "value": "otherStimulants"},
-            {"text": "Inhalants (nitrous oxide, glue, gas, paint thinner, etc.)", "value": "inhalants"},
-            {"text": "Sedatives or sleeping pills for non-medical reasons (Valium, Serepax, Ativan, Xanax, Librium, Rohypnol, GHB, etc.)", "value": "sedatives"},
-            {"text": "Hallucinogens (LSD, acid, mushrooms, PCP, Special K, ecstasy, etc.)", "value": "hallucinogens"},
-            {"text": "Street opioids (heroin, opium, etc.)", "value": "streetOpioids"},
-            {"text": "Prescription opioids for non-medical reasons (fentanyl, oxycodone [OxyContin, Percocet], hydrocodone [Vicodin], methadone, buprenorphine, etc.)", "value": "prescriptionOpioids"}
-          ]
-        },{
-          "name": "oh_oh_lifestyle_marijuana3mos",
-          "type": "radiogroup",
-          "title": "In the PAST THREE MONTHS, how often have you used marijuana (cannabis, pot, grass, hash, bhaang, etc.)?",
-          "visibleIf": "{oh_oh_lifestyle_substanceUse} contains 'marijuana'",
-          "choices": [
-            {"text": "Never", "value": "never"},
-            {"text": "Once or twice", "value": "onceOrTwice"},
-            {"text": "Monthly", "value": "monthly"},
-            {"text": "Weekly", "value": "weekly"},
-            {"text": "Daily or almost daily", "value": "dailyOrAlmostDaily"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_lifestyle_cocaine3mos",
-          "type": "radiogroup",
-          "title": "In the PAST THREE MONTHS, how often have you used cocaine (coke, crack, etc.)?",
-          "visibleIf": "{oh_oh_lifestyle_substanceUse} contains 'cocaine'",
-          "choices": [
-            {"text": "Never", "value": "never"},
-            {"text": "Once or twice", "value": "onceOrTwice"},
-            {"text": "Monthly", "value": "monthly"},
-            {"text": "Weekly", "value": "weekly"},
-            {"text": "Daily or almost daily", "value": "dailyOrAlmostDaily"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_lifestyle_prescriptionStimulants3mos",
-          "type": "radiogroup",
-          "title": "In the PAST THREE MONTHS, how often have you used prescription stimulants for non-medical reasons (Vyvanse, Ritalin, Concerta, Dexedrine, Adderall, diet pills, etc.)",
-          "visibleIf": "{oh_oh_lifestyle_substanceUse} contains 'prescriptionStimulants'",
-          "choices": [
-            {"text": "Never", "value": "never"},
-            {"text": "Once or twice", "value": "onceOrTwice"},
-            {"text": "Monthly", "value": "monthly"},
-            {"text": "Weekly", "value": "weekly"},
-            {"text": "Daily or almost daily", "value": "dailyOrAlmostDaily"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_lifestyle_otherStimulants3mos",
-          "type": "radiogroup",
-          "title": "In the PAST THREE MONTHS, how often have you used other stimulants (methamphetamine, speed, crystal meth, ice, k2/spice, bath salts, etc.)",
-          "visibleIf": "{oh_oh_lifestyle_substanceUse} contains 'otherStimulants'",
-          "choices": [
-            {"text": "Never", "value": "never"},
-            {"text": "Once or twice", "value": "onceOrTwice"},
-            {"text": "Monthly", "value": "monthly"},
-            {"text": "Weekly", "value": "weekly"},
-            {"text": "Daily or almost daily", "value": "dailyOrAlmostDaily"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_lifestyle_inhalants3mos",
-          "type": "radiogroup",
-          "title": "In the PAST THREE MONTHS, how often have you used inhalants (nitrous oxide, glue, gas, paint thinner, etc.)",
-          "visibleIf": "{oh_oh_lifestyle_substanceUse} contains 'inhalants'",
-          "choices": [
-            {"text": "Never", "value": "never"},
-            {"text": "Once or twice", "value": "onceOrTwice"},
-            {"text": "Monthly", "value": "monthly"},
-            {"text": "Weekly", "value": "weekly"},
-            {"text": "Daily or almost daily", "value": "dailyOrAlmostDaily"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_lifestyle_sedatives3mos",
-          "type": "radiogroup",
-          "title": "In the PAST THREE MONTHS, how often have you used sedatives or sleeping pills for non-medical reasons (Valium, Serepax, Ativan, Xanax, Librium, Rohypnol, GHB, etc.)?",
-          "visibleIf": "{oh_oh_lifestyle_substanceUse} contains 'sedatives'",
-          "choices": [
-            {"text": "Never", "value": "never"},
-            {"text": "Once or twice", "value": "onceOrTwice"},
-            {"text": "Monthly", "value": "monthly"},
-            {"text": "Weekly", "value": "weekly"},
-            {"text": "Daily or almost daily", "value": "dailyOrAlmostDaily"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_lifestyle_hallucinogens3mos",
-          "type": "radiogroup",
-          "title": "In the PAST THREE MONTHS, how often have you used hallucinogens (LSD, acid, mushrooms, PCP, Special K, ecstasy, etc.)",
-          "visibleIf": "{oh_oh_lifestyle_substanceUse} contains 'hallucinogens'",
-          "choices": [
-            {"text": "Never", "value": "never"},
-            {"text": "Once or twice", "value": "onceOrTwice"},
-            {"text": "Monthly", "value": "monthly"},
-            {"text": "Weekly", "value": "weekly"},
-            {"text": "Daily or almost daily", "value": "dailyOrAlmostDaily"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_lifestyle_streetOpioids3mos",
-          "type": "radiogroup",
-          "title": "In the PAST THREE MONTHS, how often have you used street opioids (heroin, opium, etc.)?",
-          "visibleIf": "{oh_oh_lifestyle_substanceUse} contains 'streetOpioids'",
-          "choices": [
-            {"text": "Never", "value": "never"},
-            {"text": "Once or twice", "value": "onceOrTwice"},
-            {"text": "Monthly", "value": "monthly"},
-            {"text": "Weekly", "value": "weekly"},
-            {"text": "Daily or almost daily", "value": "dailyOrAlmostDaily"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_lifestyle_prescriptionOpioids3mos",
-          "type": "radiogroup",
-          "title": "In the PAST THREE MONTHS, how often have you used prescription opioids for non-medical reasons (fentanyl, oxycodone [OxyContin, Percocet], hydrocodone [Vicodin], methadone, buprenorphine, etc.)",
-          "visibleIf": "{oh_oh_lifestyle_substanceUse} contains 'prescriptionOpioids'",
-          "choices": [
-            {"text": "Never", "value": "never"},
-            {"text": "Once or twice", "value": "onceOrTwice"},
-            {"text": "Monthly", "value": "monthly"},
-            {"text": "Weekly", "value": "weekly"},
-            {"text": "Daily or almost daily", "value": "dailyOrAlmostDaily"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        },{
-          "name": "oh_oh_lifestyle_otherDrugs3mos",
-          "type": "radiogroup",
-          "title": "In the PAST THREE MONTHS, how often have you used other drugs?",
-          "visibleIf": "{oh_oh_lifestyle_substanceUse} contains 'other'",
-          "choices": [
-            {"text": "Never", "value": "never"},
-            {"text": "Once or twice", "value": "onceOrTwice"},
-            {"text": "Monthly", "value": "monthly"},
-            {"text": "Weekly", "value": "weekly"},
-            {"text": "Daily or almost daily", "value": "dailyOrAlmostDaily"},
-            {"text": "Prefer not to answer", "value": "preferNoAnswer"}
-          ]
-        }
-      ]
-    }
+      }
     ]
   }
 }

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/medList.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/medList.json
@@ -75,7 +75,8 @@
                 "text": "I am not currently taking a statin",
                 "value": "none"
               }
-            ]
+            ],
+            "isRequired": true
           },
           {
             "name": "oh_oh_medList_atorvastatin",
@@ -103,7 +104,8 @@
                 "text": "Atorvastatin other dose",
                 "value": "atorvastatinOtherDose"
               }
-            ]
+            ],
+            "isRequired": true
           },
           {
             "name": "oh_oh_medList_rosuvastatin",
@@ -135,7 +137,8 @@
                 "text": "Rosuvastatin other dose",
                 "value": "rosuvastatinOtherDose"
               }
-            ]
+            ],
+            "isRequired": true
           },
           {
             "name": "oh_oh_medList_simvastatin",
@@ -167,7 +170,8 @@
                 "text": "Simvastatin other dose",
                 "value": "simvastatinOtherDose"
               }
-            ]
+            ],
+            "isRequired": true
           },
           {
             "name": "oh_oh_medList_pravastatin",
@@ -195,7 +199,8 @@
                 "text": "Pravastatin other dose",
                 "value": "pravastatinOtherDose"
               }
-            ]
+            ],
+            "isRequired": true
           },
           {
             "name": "oh_oh_medList_fluvastatin",
@@ -219,7 +224,8 @@
                 "text": "Fluvastatin other dose",
                 "value": "fluvastatinOtherDose"
               }
-            ]
+            ],
+            "isRequired": true
           },
           {
             "name": "oh_oh_medList_pitavastatin",
@@ -243,7 +249,8 @@
                 "text": "Other Pitavastatin dose",
                 "value": "otherPitavastatinDose"
               }
-            ]
+            ],
+            "isRequired": true
           },
           {
             "name": "oh_oh_medList_otherCholesterolMeds",
@@ -273,7 +280,12 @@
             ],
             "showNoneItem": true,
             "noneValue": "noneOfTheAbove",
-            "noneText": "I am not currently taking any of these medications"
+            "noneText": "I am not currently taking any of these medications",
+            "showOtherItem": true,
+            "otherText": "Other",
+            "otherPlaceholder": "Please specify",
+            "otherErrorText": "A description is required for choices of \"other\".",
+            "isRequired": true
           }
         ]
       },
@@ -317,7 +329,8 @@
             ],
             "showNoneItem": true,
             "noneValue": "none",
-            "noneText": "I am not currently taking an antiplatelet medication"
+            "noneText": "I am not currently taking an antiplatelet medication",
+            "isRequired": true
           },
           {
             "name": "oh_oh_medList_bloodThinners",
@@ -359,7 +372,8 @@
             ],
             "showNoneItem": true,
             "noneValue": "none",
-            "noneText": "I am not currently taking a blood thinner (anticoagulant) medication"
+            "noneText": "I am not currently taking a blood thinner (anticoagulant) medication",
+            "isRequired": true
           }
         ]
       },
@@ -408,10 +422,6 @@
               {
                 "text": "Sotalol",
                 "value": "sotalol"
-              },
-              {
-                "text": "Other beta blocker",
-                "value": "otherBetaBlocker"
               },
               {
                 "text": "Lisinopril",
@@ -516,7 +526,12 @@
             ],
             "showNoneItem": true,
             "noneValue": "noneOfTheAbove",
-            "noneText": "I am not currently taking any of these medications"
+            "noneText": "I am not currently taking any of these medications",
+            "showOtherItem": true,
+            "otherText": "Other",
+            "otherPlaceholder": "Please specify",
+            "otherErrorText": "A description is required for choices of \"other\".",
+            "isRequired": true
           }
         ]
       },
@@ -586,6 +601,10 @@
                 "value": "ertugliflozin"
               },
               {
+                "text": "Sotagliflozin (Inpefa)",
+                "value": "sotagliflozin"
+              },
+              {
                 "text": "Sitagliptin (Januvia)",
                 "value": "sitagliptin"
               },
@@ -624,15 +643,21 @@
             ],
             "showNoneItem": true,
             "noneValue": "noneOfTheAbove",
-            "noneText": "I am not currently taking any of these medications"
+            "noneText": "I am not currently taking any of these medications",
+            "showOtherItem": true,
+            "otherText": "Other",
+            "otherPlaceholder": "Please specify",
+            "otherErrorText": "A description is required for choices of \"other\".",
+            "isRequired": true
           }
         ]
-      }, {
+      },
+      {
         "elements": [
           {
             "name": "oh_oh_medList_otherMeds",
             "type": "medications",
-            "title": "List any additional medications below."
+            "title": "List any additional medications below, including any vitamins and supplements."
           }
         ]
       }

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/medicalHistory.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/medicalHistory.json
@@ -4,1786 +4,2810 @@
   "name": "Other Medical History",
   "footer": "Resources used for this survey:\n * All of Us\n * California Teacher’s Study (CTS)\n * Mike Honigberg, American Heart Association\n * OurHealth",
   "jsonContent": {
-  "title": "Other Medical History",
-  "showQuestionNumbers": "off",
-  "showProgressBar": "bottom",
-  "questionTemplates": [
-    {
-      "name": "oh_oh_medHx_ageAboutAtDiagnosis",
-      "type": "dropdown",
-      "title": "About how old were you when you were first told you had this condition? ",
-      "choices": [
-        {"text": "0", "value": "0"},
-        {"text": "1", "value": "1"},
-        {"text": "2", "value": "2"},
-        {"text": "3", "value": "3"},
-        {"text": "4", "value": "4"},
-        {"text": "5", "value": "5"},
-        {"text": "6", "value": "6"},
-        {"text": "7", "value": "7"},
-        {"text": "8", "value": "8"},
-        {"text": "9", "value": "9"},
-        {"text": "10", "value": "10"},
-        {"text": "11", "value": "11"},
-        {"text": "12", "value": "12"},
-        {"text": "13", "value": "13"},
-        {"text": "14", "value": "14"},
-        {"text": "15", "value": "15"},
-        {"text": "16", "value": "16"},
-        {"text": "17", "value": "17"},
-        {"text": "18", "value": "18"},
-        {"text": "19", "value": "19"},
-        {"text": "20", "value": "20"},
-        {"text": "21", "value": "21"},
-        {"text": "22", "value": "22"},
-        {"text": "23", "value": "23"},
-        {"text": "24", "value": "24"},
-        {"text": "25", "value": "25"},
-        {"text": "26", "value": "26"},
-        {"text": "27", "value": "27"},
-        {"text": "28", "value": "28"},
-        {"text": "29", "value": "29"},
-        {"text": "30", "value": "30"},
-        {"text": "31", "value": "31"},
-        {"text": "32", "value": "32"},
-        {"text": "33", "value": "33"},
-        {"text": "34", "value": "34"},
-        {"text": "35", "value": "35"},
-        {"text": "36", "value": "36"},
-        {"text": "37", "value": "37"},
-        {"text": "38", "value": "38"},
-        {"text": "39", "value": "39"},
-        {"text": "40", "value": "40"},
-        {"text": "41", "value": "41"},
-        {"text": "42", "value": "42"},
-        {"text": "43", "value": "43"},
-        {"text": "44", "value": "44"},
-        {"text": "45", "value": "45"},
-        {"text": "46", "value": "46"},
-        {"text": "47", "value": "47"},
-        {"text": "48", "value": "48"},
-        {"text": "49", "value": "49"},
-        {"text": "50", "value": "50"},
-        {"text": "51", "value": "51"},
-        {"text": "52", "value": "52"},
-        {"text": "53", "value": "53"},
-        {"text": "54", "value": "54"},
-        {"text": "55", "value": "55"},
-        {"text": "56", "value": "56"},
-        {"text": "57", "value": "57"},
-        {"text": "58", "value": "58"},
-        {"text": "59", "value": "59"},
-        {"text": "60", "value": "60"},
-        {"text": "61", "value": "61"},
-        {"text": "62", "value": "62"},
-        {"text": "63", "value": "63"},
-        {"text": "64", "value": "64"},
-        {"text": "65", "value": "65"},
-        {"text": "66", "value": "66"},
-        {"text": "67", "value": "67"},
-        {"text": "68", "value": "68"},
-        {"text": "69", "value": "69"},
-        {"text": "70", "value": "70"},
-        {"text": "71", "value": "71"},
-        {"text": "72", "value": "72"},
-        {"text": "73", "value": "73"},
-        {"text": "74", "value": "74"},
-        {"text": "75", "value": "75"},
-        {"text": "76", "value": "76"},
-        {"text": "77", "value": "77"},
-        {"text": "78", "value": "78"},
-        {"text": "79", "value": "79"},
-        {"text": "80", "value": "80"},
-        {"text": "81", "value": "81"},
-        {"text": "82", "value": "82"},
-        {"text": "83", "value": "83"},
-        {"text": "84", "value": "84"},
-        {"text": "85", "value": "85"},
-        {"text": "86", "value": "86"},
-        {"text": "87", "value": "87"},
-        {"text": "88", "value": "88"},
-        {"text": "89", "value": "89"},
-        {"text": "90", "value": "90"},
-        {"text": "91", "value": "91"},
-        {"text": "92", "value": "92"},
-        {"text": "93", "value": "93"},
-        {"text": "94", "value": "94"},
-        {"text": "95", "value": "95"},
-        {"text": "96", "value": "96"},
-        {"text": "97", "value": "97"},
-        {"text": "98", "value": "98"},
-        {"text": "99", "value": "99"}
-      ]
-    }
-  ],
-  "pages": [
-    {
-      "elements": [
-        {
-          "type": "panel",
-          "elements": [
-            {
-              "type": "html",
-              "name": "oh_oh_medHx_overallDescription",
-              "html": "<p>This survey asks questions about Other Medical History. This is to better understand how it may affect health. It will take about 5-10 minutes to answer these questions. Please answer each question as honestly as possible. We are looking for your own answers, not what you think your doctors, family, or friends want you to say. Do not feel like you have to spend a long time on each question. The first answer that comes to you is usually the best one.</p>"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "elements": [
-            {
-              "type": "html",
-              "name": "oh_oh_medHx_cancerHealthDescription",
-              "html": "<h2>Cancer Conditions</h2>"
-            }
-          ]
-        },
-        {
-          "name": "oh_oh_medHx_cancerTypes",
-          "type": "checkbox",
-          "title": "Has a doctor or health care provider ever told you that you have or had any of the following cancers? (select all that apply) ",
-          "choices": [
-            {
-              "text": "Bladder cancer",
-              "value": "bladderCancer"
-            },
-            {
-              "text": "Blood or soft tissue cancer",
-              "value": "bloodOrSoftTissueCancer"
-            },
-            {
-              "text": "Bone cancer",
-              "value": "boneCancer"
-            },
-            {
-              "text": "Brain cancer",
-              "value": "brainCancer"
-            },
-            {
-              "text": "Breast cancer",
-              "value": "breastCancer"
-            },
-            {
-              "text": "Cervical cancer",
-              "value": "cervicalCancer"
-            },
-            {
-              "text": "Colon cancer/Rectal cancer",
-              "value": "colonRectalCancer"
-            },
-            {
-              "text": "Endocrine cancer",
-              "value": "endocrineCancer"
-            },
-            {
-              "text": "Endometrial cancer",
-              "value": "endometrialCancer"
-            },
-            {
-              "text": "Esophageal cancer",
-              "value": "esophagealCancer"
-            },
-            {
-              "text": "Eye cancer",
-              "value": "eyeCancer"
-            },
-            {
-              "text": "Head and neck cancer",
-              "value": "headAndNeckCancer"
-            },
-            {
-              "text": "Kidney cancer",
-              "value": "kidneyCancer"
-            },
-            {
-              "text": "Lung cancer",
-              "value": "lungCancer"
-            },
-            {
-              "text": "Ovarian cancer",
-              "value": "ovarianCancer"
-            },
-            {
-              "text": "Pancreatic cancer",
-              "value": "pancreaticCancer"
-            },
-            {
-              "text": "Prostate cancer",
-              "value": "prostateCancer"
-            },
-            {
-              "text": "Skin cancer",
-              "value": "skinCancer"
-            },
-            {
-              "text": "Stomach cancer",
-              "value": "stomachCancer"
-            },
-            {
-              "text": "Thyroid cancer",
-              "value": "thyroidCancer"
-            },
-            {
-              "text": "Other cancer",
-              "value": "other"
-            },
-            {
-              "text": "I do not have cancer",
-              "value": "none"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Bladder cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'bladderCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_bladderCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Blood or soft tissue cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'bloodOrSoftTissueCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_bloodOrSoftTissueCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Bone cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'boneCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_boneCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Brain cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'brainCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_brainCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Breast cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'breastCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_breastCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Cervical cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'cervicalCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_cervicalCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Colon cancer/Rectal cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'colonRectalCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_colonRectalCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Endocrine cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'endocrineCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_endocrineCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Endometrial cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'endometrialCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_endometrialCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Esophageal cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'esophagealCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_esophagealCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Eye cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'eyeCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_eyeCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Head and neck cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'headAndNeckCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_headAndNeckCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Kidney cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'kidneyCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_kidneyCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Lung cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'lungCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_lungCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Ovarian cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'ovarianCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_ovarianCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Pancreatic cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'pancreaticCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_pancreaticCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Prostate cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'prostateCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_prostateCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Skin cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'skinCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_skinCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Stomach cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'stomachCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_stomachCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Thyroid cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'thyroidCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_thyroidCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Other cancer",
-          "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'other'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_otherCancerDescription",
-              "type": "text",
-              "title": "What is the other cancer?"
-            },
-            {
-              "name": "oh_oh_medHx_otherCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "elements": [
-        {
-          "type": "panel",
-          "elements": [
-            {
-              "type": "html",
-              "name": "oh_oh_medHx_digestiveDescription",
-              "html": "<h2>Digestive Conditions</h2>"
-            }
-          ]
-        },
-        {
-          "name": "oh_oh_medHx_digestiveConditionsDiagnoses",
-          "type": "checkbox",
-          "title": "Has a doctor or health care provider ever told you that you have…? (select all that apply) ",
-          "choices": [
-            {"text": "Acid reflux", "value": "acidReflux"},
-            {"text": "Bowel Obstruction", "value": "bowelObstruction"},
-            {"text": "Celiac disease", "value": "celiacDisease"},
-            {"text": "Colon polyps", "value": "colonPolyps"},
-            {"text": "Crohn’s disease", "value": "crohnsDisease"},
-            {"text": "Diverticulosis/diverticulitis", "value": "diverticulosisDiverticulitis"},
-            {"text": "Gallstones", "value": "gallStones"},
-            {"text": "Hemorrhoids", "value": "hemorrhoids"},
-            {"text": "Hernia", "value": "hernia"},
-            {"text": "Irritable bowel syndrome (IBS)", "value": "irritableBowelSyndrome"},
-            {"text": "Liver condition", "value": "liverCondition"},
-            {"text": "Pancreatitis", "value": "pancreatitis"},
-            {"text": "Peptic ulcers", "value": "pepticUlcers"},
-            {"text": "Ulcerative colitis", "value": "ulcerativeColitis"},
-            {"text": "Other digestive condition", "value": "otherDigestiveCondition"},
-            {"text": "I have no digestive condition", "value": "none"}
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Acid reflux",
-          "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'acidReflux'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_acidRefluxAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Bowel Obstruction",
-          "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'bowelObstruction'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_bowelObstructionAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Celiac disease",
-          "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'celiacDisease'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_celiacDiseaseAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Colon polyps",
-          "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'colonPolyps'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_colonPolypsAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Crohn’s disease",
-          "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'crohnsDisease'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_crohnsDiseaseAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Diverticulosis/diverticulitis",
-          "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'diverticulosisDiverticulitis'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_diverticulosisDiverticulitisAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Gallstones",
-          "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'gallStones'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_gallStonesAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Hemorrhoids",
-          "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'hemorrhoids'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_hemorrhoidsAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Hernia",
-          "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'hernia'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_herniaAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Irritable bowel syndrome (IBS)",
-          "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'irritableBowelSyndrome'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_irritableBowelSyndromeAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Liver condition",
-          "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'liverCondition'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_liverConditionAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            },
-            {
-              "name": "oh_oh_medHx_liverDiagnosedConditions",
-              "type": "checkbox",
-              "title": "Has a doctor or health care provider ever told you that you have…? (select all that apply) ",
-              "choices": [
-                {"text": "Cirrhosis of the Liver/Liver Failure", "value": "cirrhosisOrLiverFailure"},
-                {"text": "Non-alcoholic Fatty Liver Disease (NAFLD/NASH)", "value": "nonAlcFattyLiverDisease"},
-                {"text": "Liver cancer", "value": "liverCancer"},
-                {"text": "Hepatitis", "value": "hepatitis"}
-              ]
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Pancreatitis",
-          "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'pancreatitis'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_pancreatitisAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Peptic ulcers",
-          "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'pepticUlcers'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_pepticUlcersAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Ulcerative colitis",
-          "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'ulcerativeColitis'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_ulcerativeColitisAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Other digestive condition",
-          "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'otherDigestiveCondition'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_otherDigestiveConditionDescription",
-              "type": "text",
-              "title": "What is the other condition?"
-            },
-            {
-              "name": "oh_oh_medHx_otherDigestiveConditionAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "elements": [
-        {
-          "type": "panel",
-          "elements": [
-            {
-              "type": "html",
-              "name": "oh_oh_medHx_kidneyDescription",
-              "html": "<h2>Kidney Conditions</h2>"
-            }
-          ]
-        },
-        {
-          "name": "oh_oh_medHx_kidneyDiagnosedConditions",
-          "type": "checkbox",
-          "title": "Has a doctor or health care provider ever told you that you have…? (select all that apply) ",
-          "choices": [
-            {"text": "Acute kidney disease with no current dialysis", "value": "acuteKidneyDiseaseWithNoCurrentDialysis"},
-            {"text": "Kidney disease with dialysis", "value": "kidneyDiseaseWithDialysis"},
-            {"text": "Kidney disease without dialysis", "value": "kidneyDiseaseWithoutDialysis"},
-            {"text": "Kidney stones", "value": "kidneyStones"},
-            {"text": "Other kidney condition", "value": "otherKidneyCondition"},
-            {"text": "I have no kidney condition", "value": "iHaveNoKidneyCondition"}
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Acute kidney disease with no current dialysis",
-          "visibleIf": "{oh_oh_medHx_kidneyDiagnosedConditions} contains 'acuteKidneyDiseaseWithNoCurrentDialysis'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_acuteKidneyDiseaseWithNoCurrentDialysisAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Kidney disease with dialysis",
-          "visibleIf": "{oh_oh_medHx_kidneyDiagnosedConditions} contains 'kidneyDiseaseWithDialysis'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_kidneyDiseaseWithDialysisAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Kidney disease without dialysis",
-          "visibleIf": "{oh_oh_medHx_kidneyDiagnosedConditions} contains 'kidneyDiseaseWithoutDialysis'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_kidneyDiseaseWithoutDialysisAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Kidney stones",
-          "visibleIf": "{oh_oh_medHx_kidneyDiagnosedConditions} contains 'kidneyStones'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_kidneyStonesAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Other kidney condition",
-          "visibleIf": "{oh_oh_medHx_kidneyDiagnosedConditions} contains 'otherKidneyCondition'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_otherKidneyDescription",
-              "type": "text",
-              "title": "What is the other kidney condition?"
-            },
-            {
-              "name": "oh_oh_medHx_otherKidneyConditionAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "page5",
-      "elements": [
-        {
-          "type": "panel",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_endocrineDescription",
-              "type": "html",
-              "html": "<h2>Hormone/Endocrine Conditions</h2>"
-            }
-          ]
-        },
-        {
-          "name": "oh_oh_medHx_endocrineDiagnosedConditions",
-          "type": "checkbox",
-          "title": "Has a doctor or health care provider ever told you that you have…? (select all that apply) ",
-          "choices": [
-            {
-              "text": "Hyperthyroidism",
-              "value": "hyperthyroidism"
-            },
-            {
-              "text": "Hypothyroidism",
-              "value": "hypothyroidism"
-            },
-            {
-              "text": "Other/Unknown thyroid condition",
-              "value": "otherUnknownThyroidCondition"
-            },
-            {
-              "text": "Other hormone/endocrine condition",
-              "value": "otherHormoneEndocrineCondition"
-            },
-            {
-              "text": "I have no hormone/endocrine condition",
-              "value": "iHaveNoHormoneEndocrineCondition"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Hyperthyroidism",
-          "visibleIf": "{oh_oh_medHx_endocrineDiagnosedConditions} contains 'hyperthyroidism'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_hyperthyroidismAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Hypothyroidism",
-          "visibleIf": "{oh_oh_medHx_endocrineDiagnosedConditions} contains 'hypothyroidism'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_hypothyroidismAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Other/Unknown thyroid condition",
-          "visibleIf": "{oh_oh_medHx_endocrineDiagnosedConditions} contains 'otherUnknownThyroidCondition'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_otherUnknownThyroidConditionAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Other hormone/endocrine condition",
-          "visibleIf": "{oh_oh_medHx_endocrineDiagnosedConditions} contains 'otherHormoneEndocrineCondition'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_otherHormoneEndocrineConditionDescription",
-              "type": "text",
-              "title": "What is the other hormone/endocrine condition?"
-            },
-            {
-              "name": "oh_oh_medHx_otherHormoneEndocrineConditionAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "elements": [
-        {
-          "type": "panel",
-          "elements": [
-            {
-              "type": "html",
-              "name": "oh_oh_medHx_mentalHealthDescription",
-              "html": "<h2>Mental Health and Substance Use Conditions</h2>"
-            }
-          ]
-        },
-        {
-          "name": "oh_oh_medHx_mentalHealthDxConditions",
-          "type": "checkbox",
-          "title": "Has a doctor or health care provider ever told you that you have…? (select all that apply) ",
-          "choices": [
-            {"text": "Alcohol use disorder", "value": "alcoholUse"},
-            {"text": "Anxiety reaction/panic disorder", "value": "anxietyReactionPanic"},
-            {"text": "Attention-deficit/hyperactivity disorder (ADHD)", "value": "adhd"},
-            {"text": "Autism spectrum disorder", "value": "autismSpectrum"},
-            {"text": "Bipolar disorder", "value": "bipolar"},
-            {"text": "Depression", "value": "depression"},
-            {"text": "Drug use disorder", "value": "drugUse"},
-            {"text": "Eating disorder", "value": "eatingDisorder"},
-            {"text": "Post-traumatic stress disorder (PTSD)", "value": "ptsd"},
-            {"text": "Schizophrenia", "value": "schizophrenia"},
-            {"text": "Other mental health or substance use condition", "value": "other"},
-            {"text": "I have no mental health or substance use condition", "value": "none"}
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Alcohol use disorder",
-          "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'alcoholUse'",
-          "elements": [
-                        {
-              "name": "oh_oh_medHx_alcoholUseAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Anxiety reaction/panic disorder",
-          "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'anxietyReactionPanic'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_anxietyReactionPanicAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Attention-deficit/hyperactivity disorder (ADHD)",
-          "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'adhd'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_adhdAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Autism spectrum disorder",
-          "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'autismSpectrum'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_autismSpectrumAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Bipolar disorder",
-          "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'bipolar'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_bipolarAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Depression",
-          "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'depression'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_depressionAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Drug use disorder",
-          "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'drugUse'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_drugUseAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Eating disorder",
-          "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'eatingDisorder'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_eatingDisorderAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Post-traumatic stress disorder (PTSD)",
-          "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'ptsd'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_ptsdAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Schizophrenia",
-          "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'schizophrenia'",
-          "elements": [
-                        {
-              "name": "oh_oh_medHx_schizophreniaAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Other mental health or substance use condition",
-          "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'other'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_otherMentalHealthDescription",
-              "type": "text",
-              "title": "What is the other condition?"
-            },
-            {
-              "name": "oh_oh_medHx_otherMentalHealthAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "elements": [
-        {
-          "type": "panel",
-          "elements": [
-            {
-              "type": "html",
-              "name": "oh_oh_medHx_lungHealthDescription",
-              "html": "<h2>Lung Health</h2>"
-            }
-          ]
-        },
-        {
-          "name": "oh_oh_medHx_diagnosedLungConditions",
-          "type": "checkbox",
-          "title": "Has a doctor or health care provider ever told you that you have or had any of the following lung conditions? (select all that apply) ",
-          "choices": [
-            {"text": "Asthma", "value": "asthma"},
-            {"text": "Chronic Lung Disease", "value": "chronicLungDisease"},
-            {"text": "Sleep Apnea", "value": "sleepApnea"},
-            {"text": "Other lung condition", "value": "otherLung"},
-            {"text": "I have no lung condition", "value": "none"}
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Asthma",
-          "visibleIf": "{oh_oh_medHx_diagnosedLungConditions} contains 'asthma'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_asthmaAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Chronic Lung Disease",
-          "visibleIf": "{oh_oh_medHx_diagnosedLungConditions} contains 'chronicLungDisease'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_chronicLungDiseaseAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Sleep Apnea",
-          "visibleIf": "{oh_oh_medHx_diagnosedLungConditions} contains 'sleepApnea'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_sleepApneaAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Other lung condition",
-          "visibleIf": "{oh_oh_medHx_diagnosedLungConditions} contains 'otherLung'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_otherLungDescription",
-              "type": "text",
-              "title": "What is the other condition?"
-            },
-            {
-              "name": "oh_oh_medHx_otherLungAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "elements": [
-        {
-          "type": "panel",
-          "elements": [
-            {
-              "type": "html",
-              "name": "oh_oh_medHx_boneJointDiagnosedDescription",
-              "html": "<h2>Bone, Joint and Muscle Conditions</h2>"
-            }
-          ]
-        },
-        {
-          "name": "oh_oh_medHx_boneJointDiagnosedConditions",
-          "type": "checkbox",
-          "title": "Has a doctor or health care provider ever told you that you have…? (select all that apply) ",
-          "choices": [
-            {"text": "Carpal tunnel syndrome", "value": "carpalTunnelSyndrome"},
-            {"text": "Fibromyalgia", "value": "fibromyalgia"},
-            {"text": "Fractured/broken any bones in the last 5 years", "value": "fracturesInTheLast5Years"},
-            {"text": "Gout", "value": "gout"},
-            {"text": "Osteoarthritis", "value": "osteoarthritis"},
-            {"text": "Osteoporosis", "value": "osteoporosis"},
-            {"text": "Pseudogout", "value": "pseudogout"},
-            {"text": "Rheumatoid arthritis", "value": "rheumatoidArthritis"},
-            {"text": "Spine, muscle, or bone disorders (non-cancer)", "value": "spineMuscleOrBoneDisordersNonCancer"},
-            {"text": "Systemic lupus", "value": "systemicLupus"},
-            {"text": "Other arthritis, such as psoriatic arthritis and/or ankylosing spondylitis", "value": "otherArthritis"},
-            {"text": "Other bone, joint, or muscle condition", "value": "otherBoneJointOrMuscleCondition"},
-            {"text": "I have no bone, joint, or muscle condition", "value": "none"}
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Carpal tunnel syndrome",
-          "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'carpalTunnelSyndrome'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_carpalTunnelSyndromeAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Fibromyalgia",
-          "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'fibromyalgia'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_fibromyalgiaAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Fractured/broken any bones in the last 5 years",
-          "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'fracturesInTheLast5Years'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_fracturesInTheLast5YearsAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Gout",
-          "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'gout'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_goutAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Osteoarthritis",
-          "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'osteoarthritis'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_osteoarthritisAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Osteoporosis",
-          "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'osteoporosis'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_osteoporosisAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Pseudogout",
-          "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'pseudogout'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_pseudogoutAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Rheumatoid arthritis",
-          "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'rheumatoidArthritis'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_rheumatoidArthritisAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Spine, muscle, or bone disorders (non-cancer)",
-          "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'spineMuscleOrBoneDisordersNonCancer'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_spineMuscleOrBoneDisordersNonCancerAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Systemic lupus",
-          "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'systemicLupus'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_systemicLupusAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Other arthritis",
-          "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'otherArthritis'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_otherArthritisAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Other bone, joint, or muscle condition",
-          "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'otherBoneJointOrMuscleCondition'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_otherBoneJointOrMuscleConditionDescription",
-              "type": "text",
-              "title": "What is the other condition?"
-            },
-            {
-              "name": "oh_oh_medHx_otherBoneJointOrMuscleConditionAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "elements": [
-        {
-          "type": "panel",
-          "elements": [
-            {
-              "type": "html",
-              "name": "oh_oh_medHx_infectiousDiagnosedDescription",
-              "html": "<h2>Infectious Diseases</h2>"
-            }
-          ]
-        },
-        {
-          "name": "oh_oh_medHx_infectiousDiseasedDiagnosed",
-          "type": "checkbox",
-          "title": "Has a doctor or health care provider ever told you that you have…? (select all that apply) ",
-          "choices": [
-            {"text": "Chickenpox", "value": "chickenpox"},
-            {"text": "Chikungunya", "value": "chikungunya"},
-            {"text": "Chronic sinus infections", "value": "chronicSinusInfections"},
-            {"text": "COVID-19", "value": "covid19"},
-            {"text": "Dengue fever", "value": "dengueFever"},
-            {"text": "Hepatitis A", "value": "hepatitisA"},
-            {"text": "Hepatitis B", "value": "hepatitisB"},
-            {"text": "Hepatitis C", "value": "hepatitisC"},
-            {"text": "HIV/AIDS", "value": "hivAids"},
-            {"text": "Lyme disease", "value": "lymeDisease"},
-            {"text": "Malaria", "value": "malaria"},
-            {"text": "Recurrent urinary tract infections (uti)/bladder infections", "value": "recurrentUrinaryTractInfections"},
-            {"text": "Reoccurring yeast infection", "value": "reoccurringYeastInfection"},
-            {"text": "Severe acute respiratory syndrome (SARS)", "value": "sars"},
-            {"text": "Sexually transmitted infections (Gonorrhea, Syphilis, Chlamydia, HPV, or others)", "value": "sexuallyTransmittedInfections"},
-            {"text": "Shingles", "value": "shingles"},
-            {"text": "Tuberculosis", "value": "tuberculosis"},
-            {"text": "West Nile virus", "value": "westNileVirus"},
-            {"text": "Zika virus", "value": "zikaVirus"},
-            {"text": "Other infectious disease", "value": "other"},
-            {"text": "I have no infectious disease", "value": "none"}
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Chickenpox",
-          "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'chickenpox'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_chickenpoxAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Chikungunya",
-          "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'chikungunya'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_chikungunyaAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Chronic sinus infections",
-          "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'chronicSinusInfections'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_chronicSinusInfectionsAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "COVID-19",
-          "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'covid19'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_covid19AgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Dengue fever",
-          "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'dengueFever'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_dengueFeverAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Hepatitis A",
-          "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'hepatitisA'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_hepatitisAAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Hepatitis B",
-          "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'hepatitisB'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_hepatitisBAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Hepatitis C",
-          "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'hepatitisC'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_hepatitisCAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "HIV/AIDS",
-          "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'hivAids'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_hivAidsAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Lyme disease",
-          "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'lymeDisease'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_lymeDiseaseAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Malaria",
-          "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'malaria'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_malariaAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Recurrent urinary tract infections (uti)/bladder infections",
-          "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'recurrentUrinaryTractInfections'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_recurrentUrinaryTractInfectionsAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Reoccurring yeast infection",
-          "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'reoccurringYeastInfection'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_reoccurringYeastInfectionAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Severe acute respiratory syndrome (SARS)",
-          "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'sars'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_sarsAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Sexually transmitted infections (Gonorrhea, Syphilis, Chlamydia, HPV, or others)",
-          "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'sexuallyTransmittedInfections'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_sexuallyTransmittedInfectionsAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Shingles",
-          "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'shingles'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_shinglesAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Tuberculosis",
-          "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'tuberculosis'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_tuberculosisAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "West Nile virus",
-          "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'westNileVirus'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_westNileVirusAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Zika virus",
-          "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'zikaVirus'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_zikaVirusAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Other infectious disease",
-          "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'other'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_otherInfectiousDescription",
-              "type": "text",
-              "title": "What is the other condition?"
-            },
-            {
-              "name": "oh_oh_medHx_otherInfectiousAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        }
-      ]
-    },{
-      "elements": [
-        {
-          "type": "panel",
-          "elements": [
-            {
-              "type": "html",
-              "name": "oh_oh_medHx_nervousDiagnosedDescription",
-              "html": "<h2>Brain and Nervous System Conditions</h2>"
-            }
-          ]
-        },
-        {
-          "name": "oh_oh_medHx_nervousSystemDx",
-          "type": "checkbox",
-          "title": "Has a doctor or health care provider ever told you that you have…? (select all that apply) ",
-          "choices": [
-            {"text": "Cerebral palsy", "value": "cerebralPalsy"},
-            {"text": "Dementia", "value": "dementia"},
-            {"text": "Epilepsy or seizure", "value": "epilepsyOrSeizure"},
-            {"text": "Insomnia", "value": "insomnia"},
-            {"text": "Migraine headaches", "value": "migraineHeadaches"},
-            {"text": "Multiple sclerosis", "value": "multipleSclerosis"},
-            {"text": "Muscular dystrophy (MD)", "value": "muscularDystrophy"},
-            {"text": "Neuropathy", "value": "neuropathy"},
-            {"text": "Parkinson’s disease", "value": "parkinsonsDisease"},
-            {"text": "Other brain or nervous system condition", "value": "other"},
-            {"text": "I have no brain or nervous system condition", "value": "none"}
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Cerebral palsy",
-          "visibleIf": "{oh_oh_medHx_nervousSystemDx} contains 'cerebralPalsy'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_cerebralPalsyAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Dementia",
-          "visibleIf": "{oh_oh_medHx_nervousSystemDx} contains 'dementia'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_dementiaAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Epilepsy or seizure",
-          "visibleIf": "{oh_oh_medHx_nervousSystemDx} contains 'epilepsyOrSeizure'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_epilepsyOrSeizureAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Insomnia",
-          "visibleIf": "{oh_oh_medHx_nervousSystemDx} contains 'insomnia'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_insomniaAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Migraine headaches",
-          "visibleIf": "{oh_oh_medHx_nervousSystemDx} contains 'migraineHeadaches'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_migraineHeadachesAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Multiple sclerosis",
-          "visibleIf": "{oh_oh_medHx_nervousSystemDx} contains 'multipleSclerosis'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_multipleSclerosisAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Muscular dystrophy (MD)",
-          "visibleIf": "{oh_oh_medHx_nervousSystemDx} contains 'muscularDystrophy'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_muscularDystrophyAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Neuropathy",
-          "visibleIf": "{oh_oh_medHx_nervousSystemDx} contains 'neuropathy'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_neuropathyAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Parkinson’s disease",
-          "visibleIf": "{oh_oh_medHx_nervousSystemDx} contains 'parkinsonsDisease'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_parkinsonsDiseaseAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Other brain or nervous system condition",
-          "visibleIf": "{oh_oh_medHx_nervousSystemDx} contains 'other'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_otherNervousSystemDx",
-              "type": "text",
-              "title": "What is the other brain or nervous system condition?"
-            },
-            {
-              "name": "oh_oh_medHx_otherNervousAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        }
-      ]
-    },{
-      "elements": [
-        {
-          "type": "panel",
-          "elements": [
-            {
-              "type": "html",
-              "name": "oh_oh_medHx_hearingEyeDiagnosedDescription",
-              "html": "<h2>Hearing and Eye Conditions</h2>"
-            }
-          ]
-        },
-        {
-          "name": "oh_oh_medHx_hearingEyeDiagnosed",
-          "type": "checkbox",
-          "title": "Has a doctor or health care provider ever told you that you have any of the following hearing or vision problems? (select all that apply) ",
-          "choices": [
-            {"text": "Blindness, all causes", "value": "blindnessAllCauses"},
-            {"text": "Cataracts", "value": "cataracts"},
-            {"text": "Glaucoma", "value": "glaucoma"},
-            {"text": "Macular degeneration", "value": "macularDegeneration"},
-            {"text": "Severe hearing loss or partial deafness in one or both ears", "value": "severeHearingLoss"},
-            {"text": "Other hearing or eye condition", "value": "other"},
-            {"text": "I have no hearing or eye condition", "value": "none"}
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Blindness, all causes",
-          "visibleIf": "{oh_oh_medHx_hearingEyeDiagnosed} contains 'blindnessAllCauses'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_blindnessAllCausesAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Cataracts",
-          "visibleIf": "{oh_oh_medHx_hearingEyeDiagnosed} contains 'cataracts'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_cataractsAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Glaucoma",
-          "visibleIf": "{oh_oh_medHx_hearingEyeDiagnosed} contains 'glaucoma'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_glaucomaAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Macular degeneration",
-          "visibleIf": "{oh_oh_medHx_hearingEyeDiagnosed} contains 'macularDegeneration'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_macularDegenerationAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Severe hearing loss or partial deafness in one or both ears",
-          "visibleIf": "{oh_oh_medHx_hearingEyeDiagnosed} contains 'severeHearingLoss'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_severeHearingLossAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        },
-        {
-          "type": "panel",
-          "title": "Other hearing or eye condition",
-          "visibleIf": "{oh_oh_medHx_hearingEyeDiagnosed} contains 'other'",
-          "elements": [
-            {
-              "name": "oh_oh_medHx_otherHearingEyeDescription",
-              "type": "text",
-              "title": "What is the other hearing or eye condition?"
-            },
-            {
-              "name": "oh_oh_medHx_otherHearingEyeAgeAtDx",
-              "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
-            }
-          ]
-        }
-      ]
-    }
-  ]
-}
+    "title": "Other Medical History",
+    "showQuestionNumbers": "off",
+    "showProgressBar": "bottom",
+    "questionTemplates": [
+      {
+        "name": "oh_oh_medHx_ageAboutAtDiagnosis",
+        "type": "dropdown",
+        "title": "About how old were you when you were first told you had this condition? ",
+        "choices": [
+          {
+            "text": "0",
+            "value": "0"
+          },
+          {
+            "text": "1",
+            "value": "1"
+          },
+          {
+            "text": "2",
+            "value": "2"
+          },
+          {
+            "text": "3",
+            "value": "3"
+          },
+          {
+            "text": "4",
+            "value": "4"
+          },
+          {
+            "text": "5",
+            "value": "5"
+          },
+          {
+            "text": "6",
+            "value": "6"
+          },
+          {
+            "text": "7",
+            "value": "7"
+          },
+          {
+            "text": "8",
+            "value": "8"
+          },
+          {
+            "text": "9",
+            "value": "9"
+          },
+          {
+            "text": "10",
+            "value": "10"
+          },
+          {
+            "text": "11",
+            "value": "11"
+          },
+          {
+            "text": "12",
+            "value": "12"
+          },
+          {
+            "text": "13",
+            "value": "13"
+          },
+          {
+            "text": "14",
+            "value": "14"
+          },
+          {
+            "text": "15",
+            "value": "15"
+          },
+          {
+            "text": "16",
+            "value": "16"
+          },
+          {
+            "text": "17",
+            "value": "17"
+          },
+          {
+            "text": "18",
+            "value": "18"
+          },
+          {
+            "text": "19",
+            "value": "19"
+          },
+          {
+            "text": "20",
+            "value": "20"
+          },
+          {
+            "text": "21",
+            "value": "21"
+          },
+          {
+            "text": "22",
+            "value": "22"
+          },
+          {
+            "text": "23",
+            "value": "23"
+          },
+          {
+            "text": "24",
+            "value": "24"
+          },
+          {
+            "text": "25",
+            "value": "25"
+          },
+          {
+            "text": "26",
+            "value": "26"
+          },
+          {
+            "text": "27",
+            "value": "27"
+          },
+          {
+            "text": "28",
+            "value": "28"
+          },
+          {
+            "text": "29",
+            "value": "29"
+          },
+          {
+            "text": "30",
+            "value": "30"
+          },
+          {
+            "text": "31",
+            "value": "31"
+          },
+          {
+            "text": "32",
+            "value": "32"
+          },
+          {
+            "text": "33",
+            "value": "33"
+          },
+          {
+            "text": "34",
+            "value": "34"
+          },
+          {
+            "text": "35",
+            "value": "35"
+          },
+          {
+            "text": "36",
+            "value": "36"
+          },
+          {
+            "text": "37",
+            "value": "37"
+          },
+          {
+            "text": "38",
+            "value": "38"
+          },
+          {
+            "text": "39",
+            "value": "39"
+          },
+          {
+            "text": "40",
+            "value": "40"
+          },
+          {
+            "text": "41",
+            "value": "41"
+          },
+          {
+            "text": "42",
+            "value": "42"
+          },
+          {
+            "text": "43",
+            "value": "43"
+          },
+          {
+            "text": "44",
+            "value": "44"
+          },
+          {
+            "text": "45",
+            "value": "45"
+          },
+          {
+            "text": "46",
+            "value": "46"
+          },
+          {
+            "text": "47",
+            "value": "47"
+          },
+          {
+            "text": "48",
+            "value": "48"
+          },
+          {
+            "text": "49",
+            "value": "49"
+          },
+          {
+            "text": "50",
+            "value": "50"
+          },
+          {
+            "text": "51",
+            "value": "51"
+          },
+          {
+            "text": "52",
+            "value": "52"
+          },
+          {
+            "text": "53",
+            "value": "53"
+          },
+          {
+            "text": "54",
+            "value": "54"
+          },
+          {
+            "text": "55",
+            "value": "55"
+          },
+          {
+            "text": "56",
+            "value": "56"
+          },
+          {
+            "text": "57",
+            "value": "57"
+          },
+          {
+            "text": "58",
+            "value": "58"
+          },
+          {
+            "text": "59",
+            "value": "59"
+          },
+          {
+            "text": "60",
+            "value": "60"
+          },
+          {
+            "text": "61",
+            "value": "61"
+          },
+          {
+            "text": "62",
+            "value": "62"
+          },
+          {
+            "text": "63",
+            "value": "63"
+          },
+          {
+            "text": "64",
+            "value": "64"
+          },
+          {
+            "text": "65",
+            "value": "65"
+          },
+          {
+            "text": "66",
+            "value": "66"
+          },
+          {
+            "text": "67",
+            "value": "67"
+          },
+          {
+            "text": "68",
+            "value": "68"
+          },
+          {
+            "text": "69",
+            "value": "69"
+          },
+          {
+            "text": "70",
+            "value": "70"
+          },
+          {
+            "text": "71",
+            "value": "71"
+          },
+          {
+            "text": "72",
+            "value": "72"
+          },
+          {
+            "text": "73",
+            "value": "73"
+          },
+          {
+            "text": "74",
+            "value": "74"
+          },
+          {
+            "text": "75",
+            "value": "75"
+          },
+          {
+            "text": "76",
+            "value": "76"
+          },
+          {
+            "text": "77",
+            "value": "77"
+          },
+          {
+            "text": "78",
+            "value": "78"
+          },
+          {
+            "text": "79",
+            "value": "79"
+          },
+          {
+            "text": "80",
+            "value": "80"
+          },
+          {
+            "text": "81",
+            "value": "81"
+          },
+          {
+            "text": "82",
+            "value": "82"
+          },
+          {
+            "text": "83",
+            "value": "83"
+          },
+          {
+            "text": "84",
+            "value": "84"
+          },
+          {
+            "text": "85",
+            "value": "85"
+          },
+          {
+            "text": "86",
+            "value": "86"
+          },
+          {
+            "text": "87",
+            "value": "87"
+          },
+          {
+            "text": "88",
+            "value": "88"
+          },
+          {
+            "text": "89",
+            "value": "89"
+          },
+          {
+            "text": "90",
+            "value": "90"
+          },
+          {
+            "text": "91",
+            "value": "91"
+          },
+          {
+            "text": "92",
+            "value": "92"
+          },
+          {
+            "text": "93",
+            "value": "93"
+          },
+          {
+            "text": "94",
+            "value": "94"
+          },
+          {
+            "text": "95",
+            "value": "95"
+          },
+          {
+            "text": "96",
+            "value": "96"
+          },
+          {
+            "text": "97",
+            "value": "97"
+          },
+          {
+            "text": "98",
+            "value": "98"
+          },
+          {
+            "text": "99",
+            "value": "99"
+          }
+        ]
+      },
+      {
+        "name": "oh_oh_covid_ageAboutAtDiagnosis",
+        "type": "dropdown",
+        "title": "About how old were you when you were first diagnosed with COVID-19? ",
+        "choices": [
+          {
+            "text": "0",
+            "value": "0"
+          },
+          {
+            "text": "1",
+            "value": "1"
+          },
+          {
+            "text": "2",
+            "value": "2"
+          },
+          {
+            "text": "3",
+            "value": "3"
+          },
+          {
+            "text": "4",
+            "value": "4"
+          },
+          {
+            "text": "5",
+            "value": "5"
+          },
+          {
+            "text": "6",
+            "value": "6"
+          },
+          {
+            "text": "7",
+            "value": "7"
+          },
+          {
+            "text": "8",
+            "value": "8"
+          },
+          {
+            "text": "9",
+            "value": "9"
+          },
+          {
+            "text": "10",
+            "value": "10"
+          },
+          {
+            "text": "11",
+            "value": "11"
+          },
+          {
+            "text": "12",
+            "value": "12"
+          },
+          {
+            "text": "13",
+            "value": "13"
+          },
+          {
+            "text": "14",
+            "value": "14"
+          },
+          {
+            "text": "15",
+            "value": "15"
+          },
+          {
+            "text": "16",
+            "value": "16"
+          },
+          {
+            "text": "17",
+            "value": "17"
+          },
+          {
+            "text": "18",
+            "value": "18"
+          },
+          {
+            "text": "19",
+            "value": "19"
+          },
+          {
+            "text": "20",
+            "value": "20"
+          },
+          {
+            "text": "21",
+            "value": "21"
+          },
+          {
+            "text": "22",
+            "value": "22"
+          },
+          {
+            "text": "23",
+            "value": "23"
+          },
+          {
+            "text": "24",
+            "value": "24"
+          },
+          {
+            "text": "25",
+            "value": "25"
+          },
+          {
+            "text": "26",
+            "value": "26"
+          },
+          {
+            "text": "27",
+            "value": "27"
+          },
+          {
+            "text": "28",
+            "value": "28"
+          },
+          {
+            "text": "29",
+            "value": "29"
+          },
+          {
+            "text": "30",
+            "value": "30"
+          },
+          {
+            "text": "31",
+            "value": "31"
+          },
+          {
+            "text": "32",
+            "value": "32"
+          },
+          {
+            "text": "33",
+            "value": "33"
+          },
+          {
+            "text": "34",
+            "value": "34"
+          },
+          {
+            "text": "35",
+            "value": "35"
+          },
+          {
+            "text": "36",
+            "value": "36"
+          },
+          {
+            "text": "37",
+            "value": "37"
+          },
+          {
+            "text": "38",
+            "value": "38"
+          },
+          {
+            "text": "39",
+            "value": "39"
+          },
+          {
+            "text": "40",
+            "value": "40"
+          },
+          {
+            "text": "41",
+            "value": "41"
+          },
+          {
+            "text": "42",
+            "value": "42"
+          },
+          {
+            "text": "43",
+            "value": "43"
+          },
+          {
+            "text": "44",
+            "value": "44"
+          },
+          {
+            "text": "45",
+            "value": "45"
+          },
+          {
+            "text": "46",
+            "value": "46"
+          },
+          {
+            "text": "47",
+            "value": "47"
+          },
+          {
+            "text": "48",
+            "value": "48"
+          },
+          {
+            "text": "49",
+            "value": "49"
+          },
+          {
+            "text": "50",
+            "value": "50"
+          },
+          {
+            "text": "51",
+            "value": "51"
+          },
+          {
+            "text": "52",
+            "value": "52"
+          },
+          {
+            "text": "53",
+            "value": "53"
+          },
+          {
+            "text": "54",
+            "value": "54"
+          },
+          {
+            "text": "55",
+            "value": "55"
+          },
+          {
+            "text": "56",
+            "value": "56"
+          },
+          {
+            "text": "57",
+            "value": "57"
+          },
+          {
+            "text": "58",
+            "value": "58"
+          },
+          {
+            "text": "59",
+            "value": "59"
+          },
+          {
+            "text": "60",
+            "value": "60"
+          },
+          {
+            "text": "61",
+            "value": "61"
+          },
+          {
+            "text": "62",
+            "value": "62"
+          },
+          {
+            "text": "63",
+            "value": "63"
+          },
+          {
+            "text": "64",
+            "value": "64"
+          },
+          {
+            "text": "65",
+            "value": "65"
+          },
+          {
+            "text": "66",
+            "value": "66"
+          },
+          {
+            "text": "67",
+            "value": "67"
+          },
+          {
+            "text": "68",
+            "value": "68"
+          },
+          {
+            "text": "69",
+            "value": "69"
+          },
+          {
+            "text": "70",
+            "value": "70"
+          },
+          {
+            "text": "71",
+            "value": "71"
+          },
+          {
+            "text": "72",
+            "value": "72"
+          },
+          {
+            "text": "73",
+            "value": "73"
+          },
+          {
+            "text": "74",
+            "value": "74"
+          },
+          {
+            "text": "75",
+            "value": "75"
+          },
+          {
+            "text": "76",
+            "value": "76"
+          },
+          {
+            "text": "77",
+            "value": "77"
+          },
+          {
+            "text": "78",
+            "value": "78"
+          },
+          {
+            "text": "79",
+            "value": "79"
+          },
+          {
+            "text": "80",
+            "value": "80"
+          },
+          {
+            "text": "81",
+            "value": "81"
+          },
+          {
+            "text": "82",
+            "value": "82"
+          },
+          {
+            "text": "83",
+            "value": "83"
+          },
+          {
+            "text": "84",
+            "value": "84"
+          },
+          {
+            "text": "85",
+            "value": "85"
+          },
+          {
+            "text": "86",
+            "value": "86"
+          },
+          {
+            "text": "87",
+            "value": "87"
+          },
+          {
+            "text": "88",
+            "value": "88"
+          },
+          {
+            "text": "89",
+            "value": "89"
+          },
+          {
+            "text": "90",
+            "value": "90"
+          },
+          {
+            "text": "91",
+            "value": "91"
+          },
+          {
+            "text": "92",
+            "value": "92"
+          },
+          {
+            "text": "93",
+            "value": "93"
+          },
+          {
+            "text": "94",
+            "value": "94"
+          },
+          {
+            "text": "95",
+            "value": "95"
+          },
+          {
+            "text": "96",
+            "value": "96"
+          },
+          {
+            "text": "97",
+            "value": "97"
+          },
+          {
+            "text": "98",
+            "value": "98"
+          },
+          {
+            "text": "99",
+            "value": "99"
+          }
+        ]
+      }
+    ],
+    "pages": [
+      {
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "oh_oh_medHx_overallDescription",
+                "html": "<p>This survey asks questions about Other Medical History. This is to better understand how it may affect health. It will take about 5-10 minutes to answer these questions. Please answer each question as honestly as possible. We are looking for your own answers, not what you think your doctors, family, or friends want you to say. Do not feel like you have to spend a long time on each question. The first answer that comes to you is usually the best one.</p>"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "oh_oh_medHx_cancerHealthDescription",
+                "html": "<h2>Cancer Conditions</h2>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_medHx_cancerTypes",
+            "type": "checkbox",
+            "title": "Has a doctor or health care provider ever told you that you have or had any of the following cancers? (select all that apply) ",
+            "choices": [
+              {
+                "text": "Bladder cancer",
+                "value": "bladderCancer"
+              },
+              {
+                "text": "Blood or soft tissue cancer",
+                "value": "bloodOrSoftTissueCancer"
+              },
+              {
+                "text": "Bone cancer",
+                "value": "boneCancer"
+              },
+              {
+                "text": "Brain cancer",
+                "value": "brainCancer"
+              },
+              {
+                "text": "Breast cancer",
+                "value": "breastCancer"
+              },
+              {
+                "text": "Cervical cancer",
+                "value": "cervicalCancer"
+              },
+              {
+                "text": "Colon cancer/Rectal cancer",
+                "value": "colonRectalCancer"
+              },
+              {
+                "text": "Endocrine cancer",
+                "value": "endocrineCancer"
+              },
+              {
+                "text": "Endometrial cancer",
+                "value": "endometrialCancer"
+              },
+              {
+                "text": "Esophageal cancer",
+                "value": "esophagealCancer"
+              },
+              {
+                "text": "Eye cancer",
+                "value": "eyeCancer"
+              },
+              {
+                "text": "Head and neck cancer",
+                "value": "headAndNeckCancer"
+              },
+              {
+                "text": "Kidney cancer",
+                "value": "kidneyCancer"
+              },
+              {
+                "text": "Lung cancer",
+                "value": "lungCancer"
+              },
+              {
+                "text": "Ovarian cancer",
+                "value": "ovarianCancer"
+              },
+              {
+                "text": "Pancreatic cancer",
+                "value": "pancreaticCancer"
+              },
+              {
+                "text": "Prostate cancer",
+                "value": "prostateCancer"
+              },
+              {
+                "text": "Skin cancer",
+                "value": "skinCancer"
+              },
+              {
+                "text": "Stomach cancer",
+                "value": "stomachCancer"
+              },
+              {
+                "text": "Thyroid cancer",
+                "value": "thyroidCancer"
+              },
+              {
+                "text": "Other cancer",
+                "value": "other"
+              }
+            ],
+            "isRequired": true,
+            "showNoneItem": true,
+            "noneText": "I do not have cancer",
+            "noneValue": "none"
+          },
+          {
+            "type": "panel",
+            "title": "Bladder cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'bladderCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_bladderCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Blood or soft tissue cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'bloodOrSoftTissueCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_bloodOrSoftTissueCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Bone cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'boneCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_boneCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Brain cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'brainCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_brainCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Breast cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'breastCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_breastCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Cervical cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'cervicalCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_cervicalCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Colon cancer/Rectal cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'colonRectalCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_colonRectalCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Endocrine cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'endocrineCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_endocrineCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Endometrial cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'endometrialCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_endometrialCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Esophageal cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'esophagealCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_esophagealCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Eye cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'eyeCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_eyeCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Head and neck cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'headAndNeckCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_headAndNeckCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Kidney cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'kidneyCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_kidneyCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Lung cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'lungCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_lungCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Ovarian cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'ovarianCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_ovarianCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Pancreatic cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'pancreaticCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_pancreaticCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Prostate cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'prostateCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_prostateCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Skin cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'skinCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_skinCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Stomach cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'stomachCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_stomachCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Thyroid cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'thyroidCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_thyroidCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Other cancer",
+            "visibleIf": "{oh_oh_medHx_cancerTypes} contains 'other'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_otherCancerDescription",
+                "type": "text",
+                "title": "What is the other cancer?"
+              },
+              {
+                "name": "oh_oh_medHx_otherCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "oh_oh_medHx_digestiveDescription",
+                "html": "<h2>Digestive Conditions</h2>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_medHx_digestiveConditionsDiagnoses",
+            "type": "checkbox",
+            "title": "Has a doctor or health care provider ever told you that you have…? (select all that apply) ",
+            "choices": [
+              {
+                "text": "Acid reflux",
+                "value": "acidReflux"
+              },
+              {
+                "text": "Bowel Obstruction",
+                "value": "bowelObstruction"
+              },
+              {
+                "text": "Celiac disease",
+                "value": "celiacDisease"
+              },
+              {
+                "text": "Colon polyps",
+                "value": "colonPolyps"
+              },
+              {
+                "text": "Crohn’s disease",
+                "value": "crohnsDisease"
+              },
+              {
+                "text": "Diverticulosis/diverticulitis",
+                "value": "diverticulosisDiverticulitis"
+              },
+              {
+                "text": "Gallstones",
+                "value": "gallStones"
+              },
+              {
+                "text": "Hemorrhoids",
+                "value": "hemorrhoids"
+              },
+              {
+                "text": "Hernia",
+                "value": "hernia"
+              },
+              {
+                "text": "Irritable bowel syndrome (IBS)",
+                "value": "irritableBowelSyndrome"
+              },
+              {
+                "text": "Liver condition",
+                "value": "liverCondition"
+              },
+              {
+                "text": "Pancreatitis",
+                "value": "pancreatitis"
+              },
+              {
+                "text": "Peptic ulcers",
+                "value": "pepticUlcers"
+              },
+              {
+                "text": "Ulcerative colitis",
+                "value": "ulcerativeColitis"
+              },
+              {
+                "text": "Other digestive condition",
+                "value": "otherDigestiveCondition"
+              }
+            ],
+            "isRequired": true,
+            "showNoneItem": true,
+            "noneText": "I have no digestive condition",
+            "noneValue": "none"
+          },
+          {
+            "type": "panel",
+            "title": "Acid reflux",
+            "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'acidReflux'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_acidRefluxAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Bowel Obstruction",
+            "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'bowelObstruction'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_bowelObstructionAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Celiac disease",
+            "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'celiacDisease'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_celiacDiseaseAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Colon polyps",
+            "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'colonPolyps'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_colonPolypsAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Crohn’s disease",
+            "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'crohnsDisease'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_crohnsDiseaseAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Diverticulosis/diverticulitis",
+            "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'diverticulosisDiverticulitis'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_diverticulosisDiverticulitisAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Gallstones",
+            "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'gallStones'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_gallStonesAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Hemorrhoids",
+            "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'hemorrhoids'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_hemorrhoidsAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Hernia",
+            "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'hernia'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_herniaAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Irritable bowel syndrome (IBS)",
+            "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'irritableBowelSyndrome'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_irritableBowelSyndromeAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Liver condition",
+            "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'liverCondition'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_liverConditionAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              },
+              {
+                "name": "oh_oh_medHx_liverDiagnosedConditions",
+                "type": "checkbox",
+                "title": "Has a doctor or health care provider ever told you that you have…? (select all that apply) ",
+                "choices": [
+                  {
+                    "text": "Cirrhosis of the Liver/Liver Failure",
+                    "value": "cirrhosisOrLiverFailure"
+                  },
+                  {
+                    "text": "Non-alcoholic Fatty Liver Disease (NAFLD/NASH)",
+                    "value": "nonAlcFattyLiverDisease"
+                  },
+                  {
+                    "text": "Liver cancer",
+                    "value": "liverCancer"
+                  },
+                  {
+                    "text": "Hepatitis",
+                    "value": "hepatitis"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Pancreatitis",
+            "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'pancreatitis'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_pancreatitisAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Peptic ulcers",
+            "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'pepticUlcers'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_pepticUlcersAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Ulcerative colitis",
+            "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'ulcerativeColitis'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_ulcerativeColitisAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Other digestive condition",
+            "visibleIf": "{oh_oh_medHx_digestiveConditionsDiagnoses} contains 'otherDigestiveCondition'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_otherDigestiveConditionDescription",
+                "type": "text",
+                "title": "What is the other condition?"
+              },
+              {
+                "name": "oh_oh_medHx_otherDigestiveConditionAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "oh_oh_medHx_kidneyDescription",
+                "html": "<h2>Kidney Conditions</h2>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_medHx_kidneyDiagnosedConditions",
+            "type": "checkbox",
+            "title": "Has a doctor or health care provider ever told you that you have…? (select all that apply) ",
+            "choices": [
+              {
+                "text": "Acute kidney disease with no current dialysis",
+                "value": "acuteKidneyDiseaseWithNoCurrentDialysis"
+              },
+              {
+                "text": "Kidney disease with dialysis",
+                "value": "kidneyDiseaseWithDialysis"
+              },
+              {
+                "text": "Kidney disease without dialysis",
+                "value": "kidneyDiseaseWithoutDialysis"
+              },
+              {
+                "text": "Kidney stones",
+                "value": "kidneyStones"
+              },
+              {
+                "text": "Other kidney condition",
+                "value": "otherKidneyCondition"
+              }
+            ],
+            "isRequired": true,
+            "showNoneItem": true,
+            "noneText": "I have no kidney condition",
+            "noneValue": "iHaveNoKidneyCondition"
+          },
+          {
+            "type": "panel",
+            "title": "Acute kidney disease with no current dialysis",
+            "visibleIf": "{oh_oh_medHx_kidneyDiagnosedConditions} contains 'acuteKidneyDiseaseWithNoCurrentDialysis'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_acuteKidneyDiseaseWithNoCurrentDialysisAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Kidney disease with dialysis",
+            "visibleIf": "{oh_oh_medHx_kidneyDiagnosedConditions} contains 'kidneyDiseaseWithDialysis'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_kidneyDiseaseWithDialysisAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Kidney disease without dialysis",
+            "visibleIf": "{oh_oh_medHx_kidneyDiagnosedConditions} contains 'kidneyDiseaseWithoutDialysis'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_kidneyDiseaseWithoutDialysisAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Kidney stones",
+            "visibleIf": "{oh_oh_medHx_kidneyDiagnosedConditions} contains 'kidneyStones'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_kidneyStonesAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Other kidney condition",
+            "visibleIf": "{oh_oh_medHx_kidneyDiagnosedConditions} contains 'otherKidneyCondition'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_otherKidneyDescription",
+                "type": "text",
+                "title": "What is the other kidney condition?"
+              },
+              {
+                "name": "oh_oh_medHx_otherKidneyConditionAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "page5",
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_endocrineDescription",
+                "type": "html",
+                "html": "<h2>Hormone/Endocrine Conditions</h2>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_medHx_endocrineDiagnosedConditions",
+            "type": "checkbox",
+            "title": "Has a doctor or health care provider ever told you that you have…? (select all that apply) ",
+            "choices": [
+              {
+                "text": "Hyperthyroidism",
+                "value": "hyperthyroidism"
+              },
+              {
+                "text": "Hypothyroidism",
+                "value": "hypothyroidism"
+              },
+              {
+                "text": "Other/Unknown thyroid condition",
+                "value": "otherUnknownThyroidCondition"
+              },
+              {
+                "text": "Other hormone/endocrine condition",
+                "value": "otherHormoneEndocrineCondition"
+              }
+            ],
+            "isRequired": true,
+            "showNoneItem": true,
+            "noneText": "I have no hormone/endocrine condition",
+            "noneValue": "iHaveNoHormoneEndocrineCondition"
+          },
+          {
+            "type": "panel",
+            "title": "Hyperthyroidism",
+            "visibleIf": "{oh_oh_medHx_endocrineDiagnosedConditions} contains 'hyperthyroidism'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_hyperthyroidismAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Hypothyroidism",
+            "visibleIf": "{oh_oh_medHx_endocrineDiagnosedConditions} contains 'hypothyroidism'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_hypothyroidismAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Other/Unknown thyroid condition",
+            "visibleIf": "{oh_oh_medHx_endocrineDiagnosedConditions} contains 'otherUnknownThyroidCondition'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_otherUnknownThyroidConditionAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Other hormone/endocrine condition",
+            "visibleIf": "{oh_oh_medHx_endocrineDiagnosedConditions} contains 'otherHormoneEndocrineCondition'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_otherHormoneEndocrineConditionDescription",
+                "type": "text",
+                "title": "What is the other hormone/endocrine condition?"
+              },
+              {
+                "name": "oh_oh_medHx_otherHormoneEndocrineConditionAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "oh_oh_medHx_mentalHealthDescription",
+                "html": "<h2>Mental Health and Substance Use Conditions</h2>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_medHx_mentalHealthDxConditions",
+            "type": "checkbox",
+            "title": "Has a doctor or health care provider ever told you that you have…? (select all that apply) ",
+            "choices": [
+              {
+                "text": "Alcohol use disorder",
+                "value": "alcoholUse"
+              },
+              {
+                "text": "Anxiety reaction/panic disorder",
+                "value": "anxietyReactionPanic"
+              },
+              {
+                "text": "Attention-deficit/hyperactivity disorder (ADHD)",
+                "value": "adhd"
+              },
+              {
+                "text": "Autism spectrum disorder",
+                "value": "autismSpectrum"
+              },
+              {
+                "text": "Bipolar disorder",
+                "value": "bipolar"
+              },
+              {
+                "text": "Depression",
+                "value": "depression"
+              },
+              {
+                "text": "Drug use disorder",
+                "value": "drugUse"
+              },
+              {
+                "text": "Eating disorder",
+                "value": "eatingDisorder"
+              },
+              {
+                "text": "Post-traumatic stress disorder (PTSD)",
+                "value": "ptsd"
+              },
+              {
+                "text": "Schizophrenia",
+                "value": "schizophrenia"
+              },
+              {
+                "text": "Other mental health or substance use condition",
+                "value": "other"
+              }
+            ],
+            "isRequired": true,
+            "showNoneItem": true,
+            "noneText": "I have no mental health or substance use condition",
+            "noneValue": "none"
+          },
+          {
+            "type": "panel",
+            "title": "Alcohol use disorder",
+            "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'alcoholUse'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_alcoholUseAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Anxiety reaction/panic disorder",
+            "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'anxietyReactionPanic'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_anxietyReactionPanicAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Attention-deficit/hyperactivity disorder (ADHD)",
+            "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'adhd'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_adhdAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Autism spectrum disorder",
+            "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'autismSpectrum'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_autismSpectrumAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Bipolar disorder",
+            "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'bipolar'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_bipolarAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Depression",
+            "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'depression'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_depressionAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Drug use disorder",
+            "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'drugUse'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_drugUseAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Eating disorder",
+            "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'eatingDisorder'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_eatingDisorderAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Post-traumatic stress disorder (PTSD)",
+            "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'ptsd'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_ptsdAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Schizophrenia",
+            "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'schizophrenia'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_schizophreniaAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Other mental health or substance use condition",
+            "visibleIf": "{oh_oh_medHx_mentalHealthDxConditions} contains 'other'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_otherMentalHealthDescription",
+                "type": "text",
+                "title": "What is the other condition?"
+              },
+              {
+                "name": "oh_oh_medHx_otherMentalHealthAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "oh_oh_medHx_lungHealthDescription",
+                "html": "<h2>Lung Health</h2>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_medHx_diagnosedLungConditions",
+            "type": "checkbox",
+            "title": "Has a doctor or health care provider ever told you that you have or had any of the following lung conditions? (select all that apply) ",
+            "choices": [
+              {
+                "text": "Asthma",
+                "value": "asthma"
+              },
+              {
+                "text": "Chronic Lung Disease",
+                "value": "chronicLungDisease"
+              },
+              {
+                "text": "Sleep Apnea",
+                "value": "sleepApnea"
+              },
+              {
+                "text": "Other lung condition",
+                "value": "otherLung"
+              }
+            ],
+            "isRequired": true,
+            "showNoneItem": true,
+            "noneText": "I have no lung condition",
+            "noneValue": "none"
+          },
+          {
+            "type": "panel",
+            "title": "Asthma",
+            "visibleIf": "{oh_oh_medHx_diagnosedLungConditions} contains 'asthma'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_asthmaAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Chronic Lung Disease",
+            "visibleIf": "{oh_oh_medHx_diagnosedLungConditions} contains 'chronicLungDisease'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_chronicLungDiseaseAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Sleep Apnea",
+            "visibleIf": "{oh_oh_medHx_diagnosedLungConditions} contains 'sleepApnea'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_sleepApneaAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Other lung condition",
+            "visibleIf": "{oh_oh_medHx_diagnosedLungConditions} contains 'otherLung'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_otherLungDescription",
+                "type": "text",
+                "title": "What is the other condition?"
+              },
+              {
+                "name": "oh_oh_medHx_otherLungAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "oh_oh_medHx_boneJointDiagnosedDescription",
+                "html": "<h2>Bone, Joint, Skin, and Muscle Conditions</h2>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_medHx_boneJointDiagnosedConditions",
+            "type": "checkbox",
+            "title": "Has a doctor or health care provider ever told you that you have…? (select all that apply) ",
+            "choices": [
+              {
+                "text": "Carpal tunnel syndrome",
+                "value": "carpalTunnelSyndrome"
+              },
+              {
+                "text": "Fibromyalgia",
+                "value": "fibromyalgia"
+              },
+              {
+                "text": "Fractured/broken any bones in the last 5 years",
+                "value": "fracturesInTheLast5Years"
+              },
+              {
+                "text": "Gout",
+                "value": "gout"
+              },
+              {
+                "text": "Osteoarthritis",
+                "value": "osteoarthritis"
+              },
+              {
+                "text": "Osteoporosis",
+                "value": "osteoporosis"
+              },
+              {
+                "text": "Pseudogout",
+                "value": "pseudogout"
+              },
+              {
+                "text": "Rheumatoid arthritis",
+                "value": "rheumatoidArthritis"
+              },
+              {
+                "text": "Spine, muscle, or bone disorders (non-cancer)",
+                "value": "spineMuscleOrBoneDisordersNonCancer"
+              },
+              {
+                "text": "Systemic lupus",
+                "value": "systemicLupus"
+              },
+              {
+                "text": "Vitiligo",
+                "value": "vitiligo"
+              },
+              {
+                "text": "Other arthritis, such as psoriatic arthritis and/or ankylosing spondylitis",
+                "value": "otherArthritis"
+              },
+              {
+                "text": "Other bone, joint, skin, or muscle condition",
+                "value": "otherBoneJointOrMuscleCondition"
+              }
+            ],
+            "isRequired": true,
+            "showNoneItem": true,
+            "noneText": "I have no bone, joint, skin, or muscle condition",
+            "noneValue": "none"
+          },
+          {
+            "type": "panel",
+            "title": "Carpal tunnel syndrome",
+            "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'carpalTunnelSyndrome'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_carpalTunnelSyndromeAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Fibromyalgia",
+            "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'fibromyalgia'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_fibromyalgiaAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Fractured/broken any bones in the last 5 years",
+            "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'fracturesInTheLast5Years'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_fracturesInTheLast5YearsAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Gout",
+            "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'gout'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_goutAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Osteoarthritis",
+            "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'osteoarthritis'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_osteoarthritisAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Osteoporosis",
+            "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'osteoporosis'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_osteoporosisAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Pseudogout",
+            "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'pseudogout'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_pseudogoutAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Rheumatoid arthritis",
+            "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'rheumatoidArthritis'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_rheumatoidArthritisAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Spine, muscle, or bone disorders (non-cancer)",
+            "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'spineMuscleOrBoneDisordersNonCancer'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_spineMuscleOrBoneDisordersNonCancerAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Systemic lupus",
+            "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'systemicLupus'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_systemicLupusAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Vitiligo",
+            "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'vitiligo'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_vitiligoAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Other arthritis",
+            "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'otherArthritis'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_otherArthritisAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Other bone, joint, skin, or muscle condition",
+            "visibleIf": "{oh_oh_medHx_boneJointDiagnosedConditions} contains 'otherBoneJointOrMuscleCondition'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_otherBoneJointOrMuscleConditionDescription",
+                "type": "text",
+                "title": "What is the other condition?"
+              },
+              {
+                "name": "oh_oh_medHx_otherBoneJointOrMuscleConditionAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "oh_oh_medHx_infectiousDiagnosedDescription",
+                "html": "<h2>Infectious Diseases</h2>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_medHx_infectiousDiseasedDiagnosed",
+            "type": "checkbox",
+            "title": "Has a doctor or health care provider ever told you that you have…? (select all that apply) ",
+            "choices": [
+              {
+                "text": "Chickenpox",
+                "value": "chickenpox"
+              },
+              {
+                "text": "Chikungunya",
+                "value": "chikungunya"
+              },
+              {
+                "text": "Chronic sinus infections",
+                "value": "chronicSinusInfections"
+              },
+              {
+                "text": "COVID-19",
+                "value": "covid19"
+              },
+              {
+                "text": "Dengue fever",
+                "value": "dengueFever"
+              },
+              {
+                "text": "Hepatitis A",
+                "value": "hepatitisA"
+              },
+              {
+                "text": "Hepatitis B",
+                "value": "hepatitisB"
+              },
+              {
+                "text": "Hepatitis C",
+                "value": "hepatitisC"
+              },
+              {
+                "text": "HIV/AIDS",
+                "value": "hivAids"
+              },
+              {
+                "text": "Lyme disease",
+                "value": "lymeDisease"
+              },
+              {
+                "text": "Malaria",
+                "value": "malaria"
+              },
+              {
+                "text": "Recurrent urinary tract infections (uti)/bladder infections",
+                "value": "recurrentUrinaryTractInfections"
+              },
+              {
+                "text": "Reoccurring yeast infection",
+                "value": "reoccurringYeastInfection"
+              },
+              {
+                "text": "Severe acute respiratory syndrome (SARS)",
+                "value": "sars"
+              },
+              {
+                "text": "Sexually transmitted infections (Gonorrhea, Syphilis, Chlamydia, HPV, or others)",
+                "value": "sexuallyTransmittedInfections"
+              },
+              {
+                "text": "Shingles",
+                "value": "shingles"
+              },
+              {
+                "text": "Tuberculosis",
+                "value": "tuberculosis"
+              },
+              {
+                "text": "West Nile virus",
+                "value": "westNileVirus"
+              },
+              {
+                "text": "Zika virus",
+                "value": "zikaVirus"
+              },
+              {
+                "text": "Other infectious disease",
+                "value": "other"
+              }
+            ],
+            "isRequired": true,
+            "showNoneItem": true,
+            "noneText": "I have no infectious disease",
+            "noneValue": "none"
+          },
+          {
+            "type": "panel",
+            "title": "Chickenpox",
+            "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'chickenpox'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_chickenpoxAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Chikungunya",
+            "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'chikungunya'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_chikungunyaAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Chronic sinus infections",
+            "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'chronicSinusInfections'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_chronicSinusInfectionsAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "COVID-19",
+            "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'covid19'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_covid19AgeAtDx",
+                "questionTemplateName": "oh_oh_covid_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Dengue fever",
+            "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'dengueFever'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_dengueFeverAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Hepatitis A",
+            "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'hepatitisA'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_hepatitisAAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Hepatitis B",
+            "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'hepatitisB'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_hepatitisBAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Hepatitis C",
+            "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'hepatitisC'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_hepatitisCAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "HIV/AIDS",
+            "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'hivAids'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_hivAidsAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Lyme disease",
+            "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'lymeDisease'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_lymeDiseaseAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Malaria",
+            "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'malaria'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_malariaAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Recurrent urinary tract infections (uti)/bladder infections",
+            "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'recurrentUrinaryTractInfections'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_recurrentUrinaryTractInfectionsAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Reoccurring yeast infection",
+            "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'reoccurringYeastInfection'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_reoccurringYeastInfectionAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Severe acute respiratory syndrome (SARS)",
+            "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'sars'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_sarsAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Sexually transmitted infections (Gonorrhea, Syphilis, Chlamydia, HPV, or others)",
+            "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'sexuallyTransmittedInfections'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_sexuallyTransmittedInfectionsAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Shingles",
+            "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'shingles'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_shinglesAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Tuberculosis",
+            "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'tuberculosis'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_tuberculosisAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "West Nile virus",
+            "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'westNileVirus'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_westNileVirusAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Zika virus",
+            "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'zikaVirus'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_zikaVirusAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Other infectious disease",
+            "visibleIf": "{oh_oh_medHx_infectiousDiseasedDiagnosed} contains 'other'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_otherInfectiousDescription",
+                "type": "text",
+                "title": "What is the other condition?"
+              },
+              {
+                "name": "oh_oh_medHx_otherInfectiousAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "oh_oh_medHx_nervousDiagnosedDescription",
+                "html": "<h2>Brain and Nervous System Conditions</h2>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_medHx_nervousSystemDx",
+            "type": "checkbox",
+            "title": "Has a doctor or health care provider ever told you that you have…? (select all that apply) ",
+            "choices": [
+              {
+                "text": "Cerebral palsy",
+                "value": "cerebralPalsy"
+              },
+              {
+                "text": "Dementia",
+                "value": "dementia"
+              },
+              {
+                "text": "Epilepsy or seizure",
+                "value": "epilepsyOrSeizure"
+              },
+              {
+                "text": "Insomnia",
+                "value": "insomnia"
+              },
+              {
+                "text": "Migraine headaches",
+                "value": "migraineHeadaches"
+              },
+              {
+                "text": "Multiple sclerosis",
+                "value": "multipleSclerosis"
+              },
+              {
+                "text": "Muscular dystrophy (MD)",
+                "value": "muscularDystrophy"
+              },
+              {
+                "text": "Neuropathy",
+                "value": "neuropathy"
+              },
+              {
+                "text": "Parkinson’s disease",
+                "value": "parkinsonsDisease"
+              },
+              {
+                "text": "Other brain or nervous system condition",
+                "value": "other"
+              }
+            ],
+            "isRequired": true,
+            "showNoneItem": true,
+            "noneText": "I have no brain or nervous system condition",
+            "noneValue": "none"
+          },
+          {
+            "type": "panel",
+            "title": "Cerebral palsy",
+            "visibleIf": "{oh_oh_medHx_nervousSystemDx} contains 'cerebralPalsy'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_cerebralPalsyAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Dementia",
+            "visibleIf": "{oh_oh_medHx_nervousSystemDx} contains 'dementia'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_dementiaAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Epilepsy or seizure",
+            "visibleIf": "{oh_oh_medHx_nervousSystemDx} contains 'epilepsyOrSeizure'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_epilepsyOrSeizureAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Insomnia",
+            "visibleIf": "{oh_oh_medHx_nervousSystemDx} contains 'insomnia'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_insomniaAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Migraine headaches",
+            "visibleIf": "{oh_oh_medHx_nervousSystemDx} contains 'migraineHeadaches'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_migraineHeadachesAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Multiple sclerosis",
+            "visibleIf": "{oh_oh_medHx_nervousSystemDx} contains 'multipleSclerosis'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_multipleSclerosisAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Muscular dystrophy (MD)",
+            "visibleIf": "{oh_oh_medHx_nervousSystemDx} contains 'muscularDystrophy'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_muscularDystrophyAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Neuropathy",
+            "visibleIf": "{oh_oh_medHx_nervousSystemDx} contains 'neuropathy'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_neuropathyAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Parkinson’s disease",
+            "visibleIf": "{oh_oh_medHx_nervousSystemDx} contains 'parkinsonsDisease'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_parkinsonsDiseaseAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Other brain or nervous system condition",
+            "visibleIf": "{oh_oh_medHx_nervousSystemDx} contains 'other'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_otherNervousSystemDx",
+                "type": "text",
+                "title": "What is the other brain or nervous system condition?"
+              },
+              {
+                "name": "oh_oh_medHx_otherNervousAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "oh_oh_medHx_hearingEyeDiagnosedDescription",
+                "html": "<h2>Hearing and Eye Conditions</h2>"
+              }
+            ]
+          },
+          {
+            "name": "oh_oh_medHx_hearingEyeDiagnosed",
+            "type": "checkbox",
+            "title": "Has a doctor or health care provider ever told you that you have any of the following hearing or vision problems? (select all that apply) ",
+            "choices": [
+              {
+                "text": "Blindness, all causes",
+                "value": "blindnessAllCauses"
+              },
+              {
+                "text": "Cataracts",
+                "value": "cataracts"
+              },
+              {
+                "text": "Glaucoma",
+                "value": "glaucoma"
+              },
+              {
+                "text": "Macular degeneration",
+                "value": "macularDegeneration"
+              },
+              {
+                "text": "Myopia",
+                "value": "myopia"
+              },
+              {
+                "text": "Severe hearing loss or partial deafness in one or both ears",
+                "value": "severeHearingLoss"
+              },
+              {
+                "text": "Other hearing or eye condition",
+                "value": "other"
+              }
+            ],
+            "isRequired": true,
+            "showNoneItem": true,
+            "noneText": "I have no hearing or eye condition",
+            "noneValue": "none"
+          },
+          {
+            "type": "panel",
+            "title": "Blindness, all causes",
+            "visibleIf": "{oh_oh_medHx_hearingEyeDiagnosed} contains 'blindnessAllCauses'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_blindnessAllCausesAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Cataracts",
+            "visibleIf": "{oh_oh_medHx_hearingEyeDiagnosed} contains 'cataracts'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_cataractsAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Glaucoma",
+            "visibleIf": "{oh_oh_medHx_hearingEyeDiagnosed} contains 'glaucoma'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_glaucomaAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Macular degeneration",
+            "visibleIf": "{oh_oh_medHx_hearingEyeDiagnosed} contains 'macularDegeneration'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_macularDegenerationAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Myopia",
+            "visibleIf": "{oh_oh_medHx_hearingEyeDiagnosed} contains 'myopia'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_myopiaAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Severe hearing loss or partial deafness in one or both ears",
+            "visibleIf": "{oh_oh_medHx_hearingEyeDiagnosed} contains 'severeHearingLoss'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_severeHearingLossAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          },
+          {
+            "type": "panel",
+            "title": "Other hearing or eye condition",
+            "visibleIf": "{oh_oh_medHx_hearingEyeDiagnosed} contains 'other'",
+            "elements": [
+              {
+                "name": "oh_oh_medHx_otherHearingEyeDescription",
+                "type": "text",
+                "title": "What is the other hearing or eye condition?"
+              },
+              {
+                "name": "oh_oh_medHx_otherHearingEyeAgeAtDx",
+                "questionTemplateName": "oh_oh_medHx_ageAboutAtDiagnosis"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/ourHealthConsent.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/ourHealthConsent.json
@@ -3,198 +3,200 @@
   "stableId": "oh_oh_consent",
   "version": 1,
   "jsonContent":
-{
-  "logoPosition": "right",
-  "showQuestionNumbers": "off",
-  "showProgressBar": "bottom",
-  "calculatedValues": [
-    {
-      "name": "oh_oh_consent_signatureDate",
-      "expression": "iif({oh_oh_consent_signatureDate}, {oh_oh_consent_signatureDate}, currentDate())",
-      "includeIntoResult": true
-    },
-    {
-      "name": "oh_oh_consent_formattedSignatureDate",
-      "expression": "formatDate({oh_oh_consent_signatureDate})",
-      "includeIntoResult": true
-    }
-  ],
-  "pages": [
-    {
-      "name": "infoPage",
-      "elements": [
-        {
-          "type": "panel",
-          "elements": [
-            {
-              "type": "html",
-              "name": "mgbLogo",
-              "html": "<img alt='Mass General Brigham logo' src='/api/public/portals/v1/ourhealth/env/{portalEnvironmentName}/siteImages/1/mgb_logo.svg' style='margin-top:2rem' />"
-            },
-            {
-              "type": "html",
-              "name": "consentInfo1",
-              "html": "<h1 class='mt-4'>Research Consent Form<br><span class='h6'>Collection of Samples and Health Information for Research</span></h1><p><span class='fw-bold'>Research Tissue Bank</span> <span class='fw-bold'>Version</span>: February 2022</p><dl class='p-3 border border-dark'><div><dt class='d-inline'>Protocol Title: </dt><dd class='d-inline'>OurHealth</dd></div><div><dt class='d-inline'>Principal Investigator: </dt><dd class='d-inline'>Pradeep Natarajan, MD, MMSc</dd></div><div><dt class='d-inline'>Broad Institute Responsible Investigator: </dt><dd class='d-inline'>Pradeep Natarajan, MD, MMSc</dd></div><div><dt class='d-inline'>Description of Subject Population: </dt><dd class='d-inline'>South Asian individuals living in United States</dd></div></dl>"
-            },
-            {
-              "type": "html",
-              "name": "aboutThisForm",
-              "html": "<h2 class='my-4'>About this consent form</h2><p>Please read this form carefully and click “Next” when you are done to move on to the next section.</p><p>This form tells you important information about the collection and storage of samples for research. If you have questions about this study or the consent form at any time, please contact the OurHealth staff at <a href='tel:6177241240'>617-724-1240</a> or by email at <a href='mailto:info@ourhealthstudy.org'>info@ourhealthstudy.org</a>. If you decide to take part in this research study, you must sign this form, by typing and signing your name, to give your permission. We will email you a link to download a signed copy of this form to keep.</p>"
-            },
-            {
-              "type": "html",
-              "name": "keyPoints",
-              "html": "<h2 class='my-4'>Key Points</h2><p>We are asking you to be in this study because researchers at Mass General Brigham (Massachusetts General Hospital, Brigham & Women’s Hospital, and other Mass General Brigham institutions) are studying how genes and other factors affect the health of South Asians. To perform this research, we are asking you to provide your contact information, complete surveys, and provide a saliva sample to be stored for research purposes, including genetic testing.</p><p>The Broad Institute of MIT and Harvard’s Data Donation Platform (DDP), also known as Juniper, is the web-based participant platform being used by subjects to review, sign (by typing your name) the consent, and complete the surveys.</p><p>Taking part in this research study is voluntary. Your decision whether or not to participate <strong style='font-weight:normal;text-decoration:underline;'>will not affect your ability to get clinical care in any way</strong>. You may not directly benefit from participating in this study; however, your participation may help us better understand, treat, and even prevent diseases that may affect you, your family, and your community in the future.</p><p>The OurHealth staff is available at <a href='tel:6177241240'>617-724-1240</a> from Monday to Friday 9am – 5pm to assist with questions. You can also email the OurHealth staff at <a href='mailto:info@ourhealthstudy.org'>info@ourhealthstudy.org</a>. Pradeep Natarajan, MD, MMSc is the person in charge of this research study.</p><p>If you want to speak with someone not directly involved in this research study, please contact the Mass General Brigham internal review board (IRB). You can call them at <a href='tel:8572821900'>857-282-1900</a>. You can talk to them about your rights as a research subject, your concerns about the research, a complaint about the research, or any complaints about pressure to take part in or to continue in the research study.</p>"
-            },
-            {
-              "type": "html",
-              "name": "whatWillHappenIfYouTakePart",
-              "html": "<h2 class='my-4'>What will happen if you take part in this research sample biobank?</h2><ul><li>We will ask you if you have ever been a past or current patient within the Mass General Brigham system. If yes, we will look at your electronic health records now and, in the future, to update your health information (i.e., procedures, office visits, test results). A notation that you are taking part in this research study may be made in your electronic health record.  If no, we may contact you in the future to ask if you would be willing to sign any additional forms or documents that some hospitals or centers may require in order to share your electronic health records with us.</li><li>We will ask you for your contact information and mailing address. We will also ask you to complete surveys about your health and the health of your family. Additional survey(s) may become available during this study that you can choose to complete.</li><li>We will likely ask you to provide a sample of saliva at home—if so, we will use the address you provided to mail you a kit with detailed instructions on how to provide a saliva sample. We will ask you to send the saliva sample to us in a pre-stamped package that we will provide. We will study the cells from your saliva sample, including the genes found in the cells. No additional procedures will be required.</li><li>We will store your health information with your sample in a secure study database.</li><li>We may re-contact you in the future to get additional information or to ask if you are interested in joining other research studies.</li><li>The National Institutes of Health (NIH) and other organizations have developed central data (information) banks that analyze, collect, and share the information and results of certain types of genetic studies. Some (controlled-access) central data banks may store your genetic and medical information and provide the de-identified information to qualified researchers to use for further research. Other (open-access) data banks have de-identified data that are publicly viewable by anyone with internet access. We may share your de-identified information with other qualified researchers and central data banks. Therefore, you are providing your consent to share your results with these special data banks and other researchers, and have your information used for future research studies, including studies that have not yet been designed, studies involving diseases, and/or studies that may be for commercial purposes (such as the development or approval of new drugs). Your information will be de-identified and labeled only with a code number before it will be sent to central banks and other researchers. Your name and other information that could readily identify you will not be shared with central banks or other researchers. We will never sell your readily identifiable information to anyone under any circumstances.</li></ul>"
-            },
-            {
-              "type": "html",
-              "name": "whatTypeOfResearch",
-              "html": "<h2 class='my-4'>For what type of research will my samples be used?</h2><p>Your saliva sample contains cells with genetic information that can help us understand health and disease better. Your genes contain the instructions that tell our bodies how to grow and work. These instructions are referred to as your DNA. We know that certain changes in DNA can affect your health. For example,</p><ul><li>Certain DNA changes may increase or decrease the risk of developing specific health conditions like types of heart disease and some cancers.</li><li>Certain DNA changes may increase the risk of passing specific health conditions onto children, even if the parents don’t have those conditions.</li><li>Certain DNA changes may impact how certain medicines work and whether a person gets side effects after taking them.</li><li>Other DNA changes may tell us about things like where our ancestors may be from or how our bodies work.</li></ul><p>We will perform genetic testing on your saliva sample to learn about these changes, including but not limited to the following:</p><ul><li>Genome wide association analysis (GWAS) may be performed to identify genetic variants that are associated with a risk for a disease or condition. We may calculate a risk score based on genetic variants, called a “polygenic risk score”, to tell us about an increased or decreased risk for developing a certain disease or condition.</li><li>Whole genome sequencing may be performed to look at all or most of your genes to study links between disease and related disorders as well as many diseases or conditions.</li><li>Whole exome sequencing may be performed to look at only a portion of your genes that provide instructions, or code, for proteins, which are the building blocks of cells.</li></ul>"
-            },
-            {
-              "type": "html",
-              "name": "willIGetResults",
-              "html": "<h2 class='my-4'>Will I get results of research done using my samples?</h2><p>OurHealth aims to check DNA (genetic variants) for certain kinds of changes as described above. We do not intend to return research genetic results to subjects. It is likely that you will never be contacted with individual genetic research results.</p><p>However, there may be times when researchers are analyzing your electronic health record and DNA and discover information that may be medically important to you. If experts from OurHealth decide that the research results from your samples are of high medical importance, we may attempt to contact you to give you these results because of the following:</p><ul><li>Single DNA changes in some genes are related to health conditions that may require action by your clinical care team.  In these cases, there may be a possible intervention to decrease risk of developing the condition or to prevent the condition from progressing.</li><li>Many DNA changes can contribute to the development of a disease. Researchers are now looking at how the total number of changes across the genome are associated with an increased or decreased risk of developing a disease, also call a “polygenic risk score”. In these cases, there may be intervention to decrease risk of developing the condition or to prevent the condition from progressing, especially for those who are at the highest risk.</li></ul><p>If we contact you about research genetic results, we will ask if you wish to know about the results before we share them. We will emphasize that all research results should be validated by a clinical [Clinical Laboratory Improvement Amendments (CLIA)] genetic test. This should be arranged in consultation with your clinical provider, and the OurHealth study will not be responsible for costs incurred from repeat testing in a CLIA-certified lab. You can choose whether you want to know about these results or not. In any cases where you do not want to know about these results, they will not be disclosed to you, your family, or your provider. If you do want to know about these results, a genetic counselor will disclose and explain the results.</p><p>You may receive a newsletter or other information that will tell you about the research discoveries from OurHealth. This newsletter will not identify you or describe any of your individual results. You can opt out of receiving this newsletter at any time by sending an email to <a href='mailto:info@ourhealthstudy.org'>info@ourhealthstudy.org</a>.</p><p>We may publish what we learn in medical journals. In the future, when research results are published, they may show that South Asians are at an increased or decreased risk of developing a disease. These results will not identify you or describe any of your individual results.</p>"
-            },
-            {
-              "type": "html",
-              "name": "whatAreTheBenefits",
-              "html": "<h2 class='my-4'>What are the benefits to me?</h2><p>You will likely <strong style='font-weight:normal;text-decoration:underline;'>not receive any direct personal health benefits</strong> from research conducted on your information in this study.</p>"
-            },
-            {
-              "type": "html",
-              "name": "willIBePaid",
-              "html": "<h2 class='my-4'>Will I be paid for my samples?</h2><p>You will not receive payment for your sample(s).</p>"
-            },
-            {
-              "type": "html",
-              "name": "whatAreTheCosts",
-              "html": "<h2 class='my-4'>What are the costs to me to take part in the research tissue bank?</h2><p>There are no costs to participate in OurHealth.</p>"
-            },
-            {
-              "type": "html",
-              "name": "howIsInfoStored",
-              "html": "<h2 class='my-4'>How are my samples and health information stored in the Biobank?</h2><p>Staff at the Broad Institute’s Genomics Platform will assign your sample a code number and store it in a freezer. They will not keep your name or other information that could identify you with your sample. They will use the code number to connect your sample to your health information that is stored in a secure computer database. The computer database is protected with a password. Only staff at the Genomics Platform will know the computer database password.</p>"
-            },
-            {
-              "type": "html",
-              "name": "whichResearchesCanUse",
-              "html": "<h2 class='my-4'>Which researchers can use your samples and what information about you can they have?</h2><ul><li>Researchers from Mass General Brigham institutions listed on this IRB application will be allowed to work with your identified data and samples if they have approval from the Mass General Brigham IRB.</li><li>Your de-identified (coded) samples and health information may be shared with researchers at Mass General Brigham institutions, researchers at non-Mass General Brigham institutions or with for profit companies that are working with Mass General Brigham researchers.</li><li>Your samples will not be sold for profit; however, we may use your samples and information to develop new products or medical tests to be sold. Mass General Brigham and researchers may benefit if this happens. However, neither you nor your family will receive any payment if your samples and information are used for this purpose.</li></ul>"
-            },
-            {
-              "type": "html",
-              "name": "howLongWillSamplesBeKept",
-              "html": "<h2 class='my-4'>How long will the Biobank keep my samples and information?</h2><p>The code linking your samples to your health information may be kept indefinitely so that your samples and updated health information may be used for research in the future.</p>"
-            },
-            {
-              "type": "html",
-              "name": "canIStop",
-              "html": "<h2 class='my-4'>Can you stop allowing your samples and information to be stored and used for research?</h2><p>You have a right to withdraw your permission at any time. If you do, your samples and your information will be destroyed. However, it will not be possible to destroy samples and information that have already been given to researchers in some cases. If you decide to withdraw your permission, please contact the OurHealth staff by phone, <a href='tel:6177241240'>617-724-1240</a>, by email at <a href='mailto:info@ourhealthstudy.org'>info@ourhealthstudy.org</a>, or by mail at 185 Cambridge Street, 5.236, Boston, MA 02114.</p>"
-            },
-            {
-              "type": "html",
-              "name": "whatAreTheRisks",
-              "html": "<h2 style='margin-top:2rem;'>What are the risks?</h2><ul><li>The main risk of allowing us to store and use your samples and certain limited health information for research is a potential loss of privacy. We will protect your privacy by labeling your samples and information only with a code, using secure data encryption on the storage database, and keeping the key to the code in a password protected database.</li><li>There are federal laws and state protections that can help protect your privacy. The Federal law, known as the Genetic Information Nondiscrimination Act (GINA), protects you from genetic discrimination. GINA generally makes it illegal for health insurance companies, group health plans, and most employers to discriminate against you based on your genetic information. However, this law does not protect you against genetic discrimination by companies that sell life insurance, disability insurance, or long-term care insurance.</li><li>We do not think that there will be further risks to your privacy by sharing your samples and other information with other researchers at Mass General Brigham or by sharing your de-identified information with central data (information) banks that analyze, collect, and share the information and results of certain types of genetic studies.</li><li>As scientists learn more about DNA changes, it is possible that our understanding of their health impact will change over time. We might learn that a DNA change is more or less likely to cause a health problem in the future. If this happens with a result you have received, we may update you. You can always reach out to the OurHealth staff by phone (<a href='tel:6177241240'>617-724-1240</a>) or by email at <a href='mailto:info@ourhealthstudy.org'>info@ourhealthstudy.org</a>.</li><li>Taking part in a genetic study may bring unexpected information to light which could have a negative impact on you, your family or other relationships. You can reduce this risk by choosing not to participate or to not accept results in the event that they are offered to you.</li></ul>"
-            },
-            {
-              "type": "html",
-              "name": "whatHappensIfInjured",
-              "html": "<h2 class='my-4'>What happens if you are injured as a result of taking part in this research study?</h2><p>Injuries sometimes happen in research even when no one is at fault. There are no plans to pay you or give you other compensation for an injury, should one occur. However, you are not giving up any of your legal rights by signing this form.</p>"
-            },
-            {
-              "type": "html",
-              "name": "howWillPrivacyBeProtected",
-              "html": "<h2 class='my-4'>If you take part in this research study, how will we protect your privacy?</h2><p>Federal law requires Mass General Brigham to protect the privacy of health information and related information that identifies you. We refer to this information simply as “identifiable information.” The same federal laws that protect your health information will protect your research information.</p><p>In addition to Mass General Brigham researchers listed on this IRB application, the following people or groups may be able to see, use, and share your identifiable health information from the research:</p><ul><li>The Mass General Brigham IRB that oversees the project and the Mass General Brigham research quality improvement programs.</li><li>People from organizations that provide independent accreditation and oversight of hospitals and research.</li><li>People or organizations that we hire to do work for us, such as data storage companies, insurers, and lawyers, Federal and state agencies (such as the Food and Drug Administration, the Department of Health and Human Services, the National Institutes of Health, and other US or foreign government bodies that oversee or review research).</li></ul><p>We share your identifiable health information only when we must, and we ask anyone who receives it from us to protect your privacy.</p>"
-            },
-            {
-              "type": "html",
-              "name": "privacyRights",
-              "html": "<h2 class='my-4'>Your Privacy Rights</h2><p>You have the right not to sign this form that allows us to use and share your health information for research; however, if you don’t sign it, you can’t take part in this research study.</p>"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "name": "documentationOfConsentPage",
-      "elements": [
-        {
-          "type": "panel",
-          "elements": [
-            {
-              "type": "html",
-              "name": "documentationOfConsent",
-              "html": "<h1 class='mb-4' style='margin-top:2rem;'>Documentation of Consent</h1><p>This is what I agree to:</p><ol><li>You can perform (or work with others to perform) genomic or molecular tests on my saliva sample and store the sample(s) until this research study is complete.</li><li>You can store the answers that I provide in study surveys until this research study is complete.</li><li>You can study and share the results of the genomic or molecular tests, survey responses, and my health information with established public databases (e.g., NIH data portals) and with other qualified researchers in a manner that does not include my name, or any other information that could be used to readily identify me, to be used by other qualified researchers to perform future research studies, including studies that have not yet been designed, studies for diseases other than cancer, and studies that may be for commercial purposes.</li><li>You can use the results of studying my saliva sample and my health information for future research studies, including studies that have not yet been designed, studies for any disease, and/or studies that may be for commercial purposes.</li><li>You can contact me in the future for reasons related to this research study.</li></ol>"
-            }
-          ]
-        },
-        {
-          "type": "radiogroup",
-          "name": "oh_oh_consent_agree",
-          "title": "Do you agree to the above?",
-          "titleLocation": "hidden",
-          "isRequired": true,
-          "choices": [
-            {
-              "value": "agree",
-              "text": "I agree"
-            },
-            {
-              "value": "doNotAgree",
-              "text": "I do not agree"
-            }
-          ],
-          "validators": [{
-            "type": "expression",
-            "text": "You must agree in order to take part in the study.",
-            "expression": "{oh_oh_consent_agree} = 'agree'"
-          }]
-        }
-      ]
-    },
-    {
-      "name": "signaturePage",
-      "elements": [
-        {
-          "type": "panel",
-          "elements": [
-            {
-              "type": "html",
-              "name": "statementOfPerson",
-              "html": "<h1 class='mb-4' style='margin-top:2rem;'>Statement of Person Giving Informed Consent and Authorization</h1><p>My full typed name below indicates:</p><ul><li>I have had enough time to read the consent and think about agreeing to participate in this study.</li><li>I have had all of my questions answered to my satisfaction.</li><li>I am willing to participate in this research study.</li><li>I have been told that my participation is voluntary and if I decide not to participate it will have no impact on my medical care.</li><li>I have been told that if I decide to participate now, I can decide to stop being in the study at any time. </li><li>I acknowledge that a copy of the signed consent form will be sent to my email address</li></ul>"
-            }
-          ]
-        },
-        {
-          "type": "text",
-          "isRequired": true,
-          "name": "oh_oh_consent_legalName",
-          "title": "Full legal name"
-        },
-        {
-          "type": "panel",
-          "elements": [
-            {
-              "type": "html",
-              "name": "signatureDateDisplay",
-              "html": "<p style='padding-top:2rem;margin:0;'><span style='font-weight:600;'>Today's date</span>: {oh_oh_consent_formattedSignatureDate}.</p>"
-            }
-          ]
-        },
-        {
-          "type": "signaturepad",
-          "isRequired": true,
-          "name": "oh_oh_consent_signature",
-          "title": "Signature of Subject",
-          "description": "I give my consent to take part in this research study and agree to allow my health information to be used and shared as described above."
-        }
-      ]
-    }
-  ]
-}
+  {
+    "logoPosition": "right",
+    "showQuestionNumbers": "off",
+    "showProgressBar": "bottom",
+    "calculatedValues": [
+      {
+        "name": "oh_oh_consent_signatureDate",
+        "expression": "iif({oh_oh_consent_signatureDate}, {oh_oh_consent_signatureDate}, currentDate())",
+        "includeIntoResult": true
+      },
+      {
+        "name": "oh_oh_consent_formattedSignatureDate",
+        "expression": "formatDate({oh_oh_consent_signatureDate})",
+        "includeIntoResult": true
+      }
+    ],
+    "pages": [
+      {
+        "name": "infoPage",
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "mgbLogo",
+                "html": "<img alt='Mass General Brigham logo' src='/api/public/portals/v1/ourhealth/env/{portalEnvironmentName}/siteImages/1/mgb_logo.svg' style='margin-top:2rem' />"
+              },
+              {
+                "type": "html",
+                "name": "consentInfo1",
+                "html": "<h1 class='mt-4'>Research Consent Form<br><span class='h6'>Collection of Samples and Health Information for Research</span></h1><p><span class='fw-bold'>Research Tissue Bank</span> <span class='fw-bold'>Version</span>: February 2022</p><dl class='p-3 border border-dark'><div><dt class='d-inline'>Protocol Title: </dt><dd class='d-inline'>OurHealth</dd></div><div><dt class='d-inline'>Principal Investigator: </dt><dd class='d-inline'>Pradeep Natarajan, MD, MMSc</dd></div><div><dt class='d-inline'>Broad Institute Responsible Investigator: </dt><dd class='d-inline'>Pradeep Natarajan, MD, MMSc</dd></div><div><dt class='d-inline'>Description of Subject Population: </dt><dd class='d-inline'>South Asian individuals living in United States</dd></div></dl>"
+              },
+              {
+                "type": "html",
+                "name": "aboutThisForm",
+                "html": "<h2 class='my-4'>About this consent form</h2><p>Please read this form carefully and click “Next” when you are done to move on to the next section.</p><p>This form tells you important information about the collection and storage of samples for research. If you have questions about this study or the consent form at any time, please contact the OurHealth staff at <a href='tel:6177241240'>617-724-1240</a> or by email at <a href='mailto:info@ourhealthstudy.org'>info@ourhealthstudy.org</a>. If you decide to take part in this research study, you must sign this form, by typing and signing your name, to give your permission. We will email you a link to download a signed copy of this form to keep.</p>"
+              },
+              {
+                "type": "html",
+                "name": "keyPoints",
+                "html": "<h2 class='my-4'>Key Points</h2><p>We are asking you to be in this study because researchers at Mass General Brigham (Massachusetts General Hospital, Brigham & Women’s Hospital, and other Mass General Brigham institutions) are studying how genes and other factors affect the health of South Asians. To perform this research, we are asking you to provide your contact information, complete surveys, and provide a saliva sample to be stored for research purposes, including genetic testing.</p><p>The Broad Institute of MIT and Harvard’s Data Donation Platform (DDP), also known as Juniper, is the web-based participant platform being used by subjects to review, sign (by typing your name) the consent, and complete the surveys.</p><p>Taking part in this research study is voluntary. Your decision whether or not to participate <strong style='font-weight:normal;text-decoration:underline;'>will not affect your ability to get clinical care in any way</strong>. You may not directly benefit from participating in this study; however, your participation may help us better understand, treat, and even prevent diseases that may affect you, your family, and your community in the future.</p><p>The OurHealth staff is available at <a href='tel:6177241240'>617-724-1240</a> from Monday to Friday 9am – 5pm to assist with questions. You can also email the OurHealth staff at <a href='mailto:info@ourhealthstudy.org'>info@ourhealthstudy.org</a>. Pradeep Natarajan, MD, MMSc is the person in charge of this research study.</p><p>If you want to speak with someone not directly involved in this research study, please contact the Mass General Brigham internal review board (IRB). You can call them at <a href='tel:8572821900'>857-282-1900</a>. You can talk to them about your rights as a research subject, your concerns about the research, a complaint about the research, or any complaints about pressure to take part in or to continue in the research study.</p>"
+              },
+              {
+                "type": "html",
+                "name": "whatWillHappenIfYouTakePart",
+                "html": "<h2 class='my-4'>What will happen if you take part in this research sample biobank?</h2><ul><li>We will ask you if you have ever been a past or current patient within the Mass General Brigham system. If yes, we will look at your electronic health records now and, in the future, to update your health information (i.e., procedures, office visits, test results). A notation that you are taking part in this research study may be made in your electronic health record.  If no, we may contact you in the future to ask if you would be willing to sign any additional forms or documents that some hospitals or centers may require in order to share your electronic health records with us.</li><li>We will ask you for your contact information and mailing address. We will also ask you to complete surveys about your health and the health of your family. Additional survey(s) may become available during this study that you can choose to complete.</li><li>We will likely ask you to provide a sample of saliva at home—if so, we will use the address you provided to mail you a kit with detailed instructions on how to provide a saliva sample. We will ask you to send the saliva sample to us in a pre-stamped package that we will provide. We will study the cells from your saliva sample, including the genes found in the cells. No additional procedures will be required.</li><li>We will store your health information with your sample in a secure study database.</li><li>We may re-contact you in the future to get additional information or to ask if you are interested in joining other research studies.</li><li>The National Institutes of Health (NIH) and other organizations have developed central data (information) banks that analyze, collect, and share the information and results of certain types of genetic studies. Some (controlled-access) central data banks may store your genetic and medical information and provide the de-identified information to qualified researchers to use for further research. Other (open-access) data banks have de-identified data that are publicly viewable by anyone with internet access. We may share your de-identified information with other qualified researchers and central data banks. Therefore, you are providing your consent to share your results with these special data banks and other researchers, and have your information used for future research studies, including studies that have not yet been designed, studies involving diseases, and/or studies that may be for commercial purposes (such as the development or approval of new drugs). Your information will be de-identified and labeled only with a code number before it will be sent to central banks and other researchers. Your name and other information that could readily identify you will not be shared with central banks or other researchers. We will never sell your readily identifiable information to anyone under any circumstances.</li></ul>"
+              },
+              {
+                "type": "html",
+                "name": "whatTypeOfResearch",
+                "html": "<h2 class='my-4'>For what type of research will my samples be used?</h2><p>Your saliva sample contains cells with genetic information that can help us understand health and disease better. Your genes contain the instructions that tell our bodies how to grow and work. These instructions are referred to as your DNA. We know that certain changes in DNA can affect your health. For example,</p><ul><li>Certain DNA changes may increase or decrease the risk of developing specific health conditions like types of heart disease and some cancers.</li><li>Certain DNA changes may increase the risk of passing specific health conditions onto children, even if the parents don’t have those conditions.</li><li>Certain DNA changes may impact how certain medicines work and whether a person gets side effects after taking them.</li><li>Other DNA changes may tell us about things like where our ancestors may be from or how our bodies work.</li></ul><p>We will perform genetic testing on your saliva sample to learn about these changes, including but not limited to the following:</p><ul><li>Genome wide association analysis (GWAS) may be performed to identify genetic variants that are associated with a risk for a disease or condition. We may calculate a risk score based on genetic variants, called a “polygenic risk score”, to tell us about an increased or decreased risk for developing a certain disease or condition.</li><li>Whole genome sequencing may be performed to look at all or most of your genes to study links between disease and related disorders as well as many diseases or conditions.</li><li>Whole exome sequencing may be performed to look at only a portion of your genes that provide instructions, or code, for proteins, which are the building blocks of cells.</li></ul>"
+              },
+              {
+                "type": "html",
+                "name": "willIGetResults",
+                "html": "<h2 class='my-4'>Will I get results of research done using my samples?</h2><p>OurHealth aims to check DNA (genetic variants) for certain kinds of changes as described above. We do not intend to return research genetic results to subjects. It is likely that you will never be contacted with individual genetic research results.</p><p>However, there may be times when researchers are analyzing your electronic health record and DNA and discover information that may be medically important to you. If experts from OurHealth decide that the research results from your samples are of high medical importance, we may attempt to contact you to give you these results because of the following:</p><ul><li>Single DNA changes in some genes are related to health conditions that may require action by your clinical care team.  In these cases, there may be a possible intervention to decrease risk of developing the condition or to prevent the condition from progressing.</li><li>Many DNA changes can contribute to the development of a disease. Researchers are now looking at how the total number of changes across the genome are associated with an increased or decreased risk of developing a disease, also call a “polygenic risk score”. In these cases, there may be intervention to decrease risk of developing the condition or to prevent the condition from progressing, especially for those who are at the highest risk.</li></ul><p>If we contact you about research genetic results, we will ask if you wish to know about the results before we share them. We will emphasize that all research results should be validated by a clinical [Clinical Laboratory Improvement Amendments (CLIA)] genetic test. This should be arranged in consultation with your clinical provider, and the OurHealth study will not be responsible for costs incurred from repeat testing in a CLIA-certified lab. You can choose whether you want to know about these results or not. In any cases where you do not want to know about these results, they will not be disclosed to you, your family, or your provider. If you do want to know about these results, a genetic counselor will disclose and explain the results.</p><p>You may receive a newsletter or other information that will tell you about the research discoveries from OurHealth. This newsletter will not identify you or describe any of your individual results. You can opt out of receiving this newsletter at any time by sending an email to <a href='mailto:info@ourhealthstudy.org'>info@ourhealthstudy.org</a>.</p><p>We may publish what we learn in medical journals. In the future, when research results are published, they may show that South Asians are at an increased or decreased risk of developing a disease. These results will not identify you or describe any of your individual results.</p>"
+              },
+              {
+                "type": "html",
+                "name": "myBenefits",
+                "html": "<h2 class='my-4'>What are the benefits to me?</h2><p>You will likely <strong style='font-weight:normal;text-decoration:underline;'>not receive any direct personal health benefits</strong> from research conducted on your information in this study.</p>"
+              },
+              {
+                "type": "html",
+                "name": "willIBePaid",
+                "html": "<h2 class='my-4'>Will I be paid for my samples?</h2><p>You will not receive payment for your sample(s).</p>"
+              },
+              {
+                "type": "html",
+                "name": "whatAreTheCosts",
+                "html": "<h2 class='my-4'>What are the costs to me to take part in the research tissue bank?</h2><p>There are no costs to participate in OurHealth.</p>"
+              },
+              {
+                "type": "html",
+                "name": "howIsInfoStored",
+                "html": "<h2 class='my-4'>How are my samples and health information stored in the Biobank?</h2><p>Staff at the Broad Institute’s Genomics Platform will assign your sample a code number and store it in a freezer. They will not keep your name or other information that could identify you with your sample. They will use the code number to connect your sample to your health information that is stored in a secure computer database. The computer database is protected with a password. Only staff at the Genomics Platform will know the computer database password.</p>"
+              },
+              {
+                "type": "html",
+                "name": "whichResearchesCanUse",
+                "html": "<h2 class='my-4'>Which researchers can use your samples and what information about you can they have?</h2><ul><li>Researchers from Mass General Brigham institutions listed on this IRB application will be allowed to work with your identified data and samples if they have approval from the Mass General Brigham IRB.</li><li>Your de-identified (coded) samples and health information may be shared with researchers at Mass General Brigham institutions, researchers at non-Mass General Brigham institutions or with for profit companies that are working with Mass General Brigham researchers.</li><li>Your samples will not be sold for profit; however, we may use your samples and information to develop new products or medical tests to be sold. Mass General Brigham and researchers may benefit if this happens. However, neither you nor your family will receive any payment if your samples and information are used for this purpose.</li></ul>"
+              },
+              {
+                "type": "html",
+                "name": "howLongWillSamplesBeKept",
+                "html": "<h2 class='my-4'>How long will the Biobank keep my samples and information?</h2><p>The code linking your samples to your health information may be kept indefinitely so that your samples and updated health information may be used for research in the future.</p>"
+              },
+              {
+                "type": "html",
+                "name": "canIStop",
+                "html": "<h2 class='my-4'>Can you stop allowing your samples and information to be stored and used for research?</h2><p>You have a right to withdraw your permission at any time. If you do, your samples and your information will be destroyed. However, it will not be possible to destroy samples and information that have already been given to researchers in some cases. If you decide to withdraw your permission, please contact the OurHealth staff by phone, <a href='tel:6177241240'>617-724-1240</a>, by email at <a href='mailto:info@ourhealthstudy.org'>info@ourhealthstudy.org</a>, or by mail at 185 Cambridge Street, 5.236, Boston, MA 02114.</p>"
+              },
+              {
+                "type": "html",
+                "name": "whatAreTheRisks",
+                "html": "<h2 style='margin-top:2rem;'>What are the risks?</h2><ul><li>The main risk of allowing us to store and use your samples and certain limited health information for research is a potential loss of privacy. We will protect your privacy by labeling your samples and information only with a code, using secure data encryption on the storage database, and keeping the key to the code in a password protected database.</li><li>There are federal laws and state protections that can help protect your privacy. The Federal law, known as the Genetic Information Nondiscrimination Act (GINA), protects you from genetic discrimination. GINA generally makes it illegal for health insurance companies, group health plans, and most employers to discriminate against you based on your genetic information. However, this law does not protect you against genetic discrimination by companies that sell life insurance, disability insurance, or long-term care insurance.</li><li>We do not think that there will be further risks to your privacy by sharing your samples and other information with other researchers at Mass General Brigham or by sharing your de-identified information with central data (information) banks that analyze, collect, and share the information and results of certain types of genetic studies.</li><li>As scientists learn more about DNA changes, it is possible that our understanding of their health impact will change over time. We might learn that a DNA change is more or less likely to cause a health problem in the future. If this happens with a result you have received, we may update you. You can always reach out to the OurHealth staff by phone (<a href='tel:6177241240'>617-724-1240</a>) or by email at <a href='mailto:info@ourhealthstudy.org'>info@ourhealthstudy.org</a>.</li><li>Taking part in a genetic study may bring unexpected information to light which could have a negative impact on you, your family or other relationships. You can reduce this risk by choosing not to participate or to not accept results in the event that they are offered to you.</li></ul>"
+              },
+              {
+                "type": "html",
+                "name": "whatHappensIfInjured",
+                "html": "<h2 class='my-4'>What happens if you are injured as a result of taking part in this research study?</h2><p>Injuries sometimes happen in research even when no one is at fault. There are no plans to pay you or give you other compensation for an injury, should one occur. However, you are not giving up any of your legal rights by signing this form.</p>"
+              },
+              {
+                "type": "html",
+                "name": "howWillPrivacyBeProtected",
+                "html": "<h2 class='my-4'>If you take part in this research study, how will we protect your privacy?</h2><p>Federal law requires Mass General Brigham to protect the privacy of health information and related information that identifies you. We refer to this information simply as “identifiable information.” The same federal laws that protect your health information will protect your research information.</p><p>In addition to Mass General Brigham researchers listed on this IRB application, the following people or groups may be able to see, use, and share your identifiable health information from the research:</p><ul><li>The Mass General Brigham IRB that oversees the project and the Mass General Brigham research quality improvement programs.</li><li>People from organizations that provide independent accreditation and oversight of hospitals and research.</li><li>People or organizations that we hire to do work for us, such as data storage companies, insurers, and lawyers, Federal and state agencies (such as the Food and Drug Administration, the Department of Health and Human Services, the National Institutes of Health, and other US or foreign government bodies that oversee or review research).</li></ul><p>We share your identifiable health information only when we must, and we ask anyone who receives it from us to protect your privacy.</p>"
+              },
+              {
+                "type": "html",
+                "name": "privacyRights",
+                "html": "<h2 class='my-4'>Your Privacy Rights</h2><p>You have the right not to sign this form that allows us to use and share your health information for research; however, if you don’t sign it, you can’t take part in this research study.</p>"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "documentationOfConsentPage",
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "documentationOfConsent",
+                "html": "<h1 class='mb-4' style='margin-top:2rem;'>Documentation of Consent</h1><p>This is what I agree to:</p><ol><li>You can perform (or work with others to perform) genomic or molecular tests on my saliva sample and store the sample(s) until this research study is complete.</li><li>You can store the answers that I provide in study surveys until this research study is complete.</li><li>You can study and share the results of the genomic or molecular tests, survey responses, and my health information with established public databases (e.g., NIH data portals) and with other qualified researchers in a manner that does not include my name, or any other information that could be used to readily identify me, to be used by other qualified researchers to perform future research studies, including studies that have not yet been designed, studies for diseases other than cancer, and studies that may be for commercial purposes.</li><li>You can use the results of studying my saliva sample and my health information for future research studies, including studies that have not yet been designed, studies for any disease, and/or studies that may be for commercial purposes.</li><li>You can contact me in the future for reasons related to this research study.</li></ol>"
+              }
+            ]
+          },
+          {
+            "type": "radiogroup",
+            "name": "oh_oh_consent_agree",
+            "title": "Do you agree to the above?",
+            "titleLocation": "hidden",
+            "isRequired": true,
+            "choices": [
+              {
+                "value": "agree",
+                "text": "I agree"
+              },
+              {
+                "value": "doNotAgree",
+                "text": "I do not agree"
+              }
+            ],
+            "validators": [
+              {
+                "type": "expression",
+                "text": "You must agree in order to take part in the study.",
+                "expression": "{oh_oh_consent_agree} = 'agree'"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "signaturePage",
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "statementOfPerson",
+                "html": "<h1 class='mb-4' style='margin-top:2rem;'>Statement of Person Giving Informed Consent and Authorization</h1><p>My full typed name below indicates:</p><ul><li>I have had enough time to read the consent and think about agreeing to participate in this study.</li><li>I have had all of my questions answered to my satisfaction.</li><li>I am willing to participate in this research study.</li><li>I have been told that my participation is voluntary and if I decide not to participate it will have no impact on my medical care.</li><li>I have been told that if I decide to participate now, I can decide to stop being in the study at any time. </li><li>I acknowledge that a copy of the signed consent form will be available to me via my Participant Dashboard.</li></ul>"
+              }
+            ]
+          },
+          {
+            "type": "text",
+            "isRequired": true,
+            "name": "oh_oh_consent_legalName",
+            "title": "Full legal name"
+          },
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "signatureDateDisplay",
+                "html": "<p style='padding-top:2rem;margin:0;'><span style='font-weight:600;'>Today's date</span>: {oh_oh_consent_formattedSignatureDate}.</p>"
+              }
+            ]
+          },
+          {
+            "type": "signaturepad",
+            "isRequired": true,
+            "name": "oh_oh_consent_signature",
+            "title": "Signature of Subject",
+            "description": "I give my consent to take part in this research study and agree to allow my health information to be used and shared as described above."
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/populate/src/test/java/bio/terra/pearl/populate/SurveyPopulatorTests.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/SurveyPopulatorTests.java
@@ -66,7 +66,7 @@ public class SurveyPopulatorTests extends BaseSpringBootTest {
         assertThat(fetchedSurvey.getAnswerMappings().size(), greaterThan(0));
 
         var questionDefs = surveyQuestionDefinitionDao.findAllBySurveyId(fetchedSurvey.getId());
-        assertThat(questionDefs, hasSize(53));
+        assertThat(questionDefs, hasSize(52));
     }
 
     @Test

--- a/populate/src/test/java/bio/terra/pearl/populate/SurveyPopulatorTests.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/SurveyPopulatorTests.java
@@ -66,7 +66,7 @@ public class SurveyPopulatorTests extends BaseSpringBootTest {
         assertThat(fetchedSurvey.getAnswerMappings().size(), greaterThan(0));
 
         var questionDefs = surveyQuestionDefinitionDao.findAllBySurveyId(fetchedSurvey.getId());
-        assertThat(questionDefs, hasSize(52));
+        assertThat(questionDefs, hasSize(53));
     }
 
     @Test


### PR DESCRIPTION
#### DESCRIPTION

This updates our dev populate forms to match OurHealth production, to enable more accurate local troubleshooting/testing.  I'm not sure it's worth reviewing the code -- the whitespace differences make it impossible, and the incoming code is just pasted direct from OurHealth prod, so it's the authoritative version.
@denniscunningham were your height/weight question validation updates deployed to production?  I think we talked about it, but I don't know if anyone ever actually updated the forms in prod--it looks like they were not--that might have gotten lost in the shuffle when Jeff left.

Since this project started I've had a dream that we could just download an entire study/portal configuration direct from prod, and either spin it up locally or check it into source with a couple of clicks.  I don't actually think that would take too much effort, and now that we have multiple customers, it would be increasingly valuable.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. repopulate OurHealth
2. confirm it still appears
