### PR TITLE
[JN-624] Update participant B2C config for new OurHealth tenant

### DIFF
--- a/api-participant/src/main/resources/b2c-config.yml
+++ b/api-participant/src/main/resources/b2c-config.yml
@@ -1,9 +1,9 @@
 b2c:
   ourhealth:
-    tenantName: ddpdevb2c
-    clientId: 705c09dc-5cca-43d3-ae06-07de78bad29a
-    policyName: B2C_1A_ddp_participant_signup_signin_dev
-    changePasswordPolicyName: B2C_1A_ddp_participant_change_password_dev
+    tenantName: ourhealthdev
+    clientId: 206a23da-f303-4a9b-ad86-f51d1be51777
+    policyName: B2C_1A_DDP_participant_signup_signin_ourhealth-dev
+    changePasswordPolicyName: B2C_1A_DDP_participant_change_password_ourhealth-dev
   hearthive:
     tenantName: hearthivedev
     clientId: 8c778931-b7f6-4503-b30e-e975ab8ea615

--- a/api-participant/src/test/java/bio/terra/pearl/api/participant/config/B2CConfigurationServiceTest.java
+++ b/api-participant/src/test/java/bio/terra/pearl/api/participant/config/B2CConfigurationServiceTest.java
@@ -24,7 +24,7 @@ public class B2CConfigurationServiceTest {
     B2CPortalConfiguration b2cConfig = b2CService.getPortalConfiguration();
     notNull(b2cConfig, "b2cConfig should not be null");
     B2CPortalConfiguration.B2CProperties b2cProperties = b2cConfig.getPortalProperties("ourhealth");
-    assertThat(b2cProperties.getTenantName(), equalTo("ddpdevb2c"));
+    assertThat(b2cProperties.getTenantName(), equalTo("ourhealthdev"));
   }
 
   @Test


### PR DESCRIPTION
#### DESCRIPTION
Updates the local B2C configuration for OurHealth, since it is now a separate tenant. (Prior OurHealth was sharing a tenant with Juniper admin.)
Note: If you created test participants in the past, you need to re-join OurHealth to activate them again.


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. Start ApiParticipantApp.
2. Navigate to https://sandbox.ourhealth.localhost:3001.
3. Join the study, including email verification and login. All dialogs should have the OurHealth branding and the process should complete successfully.
