### PR TITLE
[JN-708] updating Heart Hive email address

### DIFF
--- a/populate/src/main/resources/seed/portals/hearthive/portal.json
+++ b/populate/src/main/resources/seed/portals/hearthive/portal.json
@@ -1,5 +1,5 @@
 {
-  "name": "HeartHive",
+  "name": "The Heart Hive",
   "shortcode": "hearthive",
   "populateStudyFiles": [
     "studies/cardiomyopathy/study.json",
@@ -18,7 +18,8 @@
         "acceptingRegistration": true,
         "passwordProtected": false,
         "password": "broad_institute",
-        "initialized": true
+        "initialized": true,
+        "emailSourceAddress": "info@thehearthive.org"
       },
       "siteContentPopDto": {
         "populateFileName": "siteContent.json"
@@ -38,7 +39,8 @@
         "acceptingRegistration": true,
         "passwordProtected": false,
         "password": "broad_institute",
-        "initialized": false
+        "initialized": false,
+        "emailSourceAddress": "info@thehearthive.org"
       }
     },
     {
@@ -47,7 +49,8 @@
         "acceptingRegistration": true,
         "passwordProtected": false,
         "password": "broad_institute",
-        "initialized": false
+        "initialized": false,
+        "emailSourceAddress": "info@thehearthive.org"
       }
     }
   ],


### PR DESCRIPTION
#### DESCRIPTION

Updates the heart hive populate files to use the info@thehearthive.org mailing address.  I've already manually updated the demo and production portals to use this address

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1. repopulate hearthive. ./scripts/populate_portal.sh hearthive
2. go to https://localhost:3000/hearthive/studies/cmyop/env/sandbox/notificationContent
3. click the "study enrollment" notification
4. click "send test email" and then send
5. confirm the email you receive comes from "The Heart Hive" info@thehearthive.org
