### PR TITLE
JN-647 implementing "acceptingEnrollment" flag

### DIFF
--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/StudyExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/StudyExtServiceTests.java
@@ -38,7 +38,7 @@ public class StudyExtServiceTests extends BaseSpringBootTest {
     AdminUser operator = adminUserFactory.buildPersisted(getTestName(testInfo), true);
     Portal portal = portalFactory.buildPersisted(getTestName(testInfo));
     for (EnvironmentName envName : EnvironmentName.values()) {
-        environmentFactory.buildPersisted(getTestName(testInfo), envName);
+      environmentFactory.buildPersisted(getTestName(testInfo), envName);
     }
     String newStudyShortcode = "newStudy" + RandomStringUtils.randomAlphabetic(5);
     StudyExtService.StudyCreationDto studyDto =

--- a/core/src/main/java/bio/terra/pearl/core/service/study/exception/StudyEnvConfigMissing.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/study/exception/StudyEnvConfigMissing.java
@@ -1,0 +1,5 @@
+package bio.terra.pearl.core.service.study.exception;
+
+/** throw if the invariant that all study environments must have a config is violated */
+public class StudyEnvConfigMissing extends RuntimeException {
+}

--- a/populate/src/main/resources/seed/portals/hearthive/studies/registry/study.json
+++ b/populate/src/main/resources/seed/portals/hearthive/studies/registry/study.json
@@ -13,7 +13,13 @@
         "passwordProtected": false,
         "password": "broad_institute",
         "initialized": true
-      }
+      },
+      "configuredConsentDtos": [
+        {
+          "consentStableId": "hh_registry_consent",
+          "consentVersion": 1
+        }
+      ]
     },
     {
       "environmentName": "irb",
@@ -31,13 +37,7 @@
         "passwordProtected": false,
         "password": "broad_institute",
         "initialized": false
-      },
-      "configuredConsentDtos": [
-        {
-          "consentStableId": "hh_registry_consent",
-          "consentVersion": 1
-        }
-      ]
+      }
     }
   ]
 }

--- a/ui-admin/src/study/StudySettings.test.tsx
+++ b/ui-admin/src/study/StudySettings.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react'
 
 import { StudyEnvConfigView } from './StudySettings'
 import { mockPortalContext, mockStudyEnvContext } from 'test-utils/mocking-utils'
-import { MockRegularUserProvider, MockSuperuserProvider } from 'test-utils/user-mocking-utils'
+import { MockSuperuserProvider } from 'test-utils/user-mocking-utils'
 import userEvent from '@testing-library/user-event'
 
 test('renders a study env. config', async () => {
@@ -33,14 +33,4 @@ test('updates a study env. config', async () => {
   await userEvent.type(input, 'newPass')
   expect(input).toHaveValue('newPass')
   expect(screen.getByText('Save study config')).toHaveAttribute('aria-disabled', 'false')
-})
-
-test('save disabled for non-superusers', async () => {
-  const portalContext = mockPortalContext()
-  const studyEnvContext = mockStudyEnvContext()
-  render(
-    <MockRegularUserProvider>
-      <StudyEnvConfigView portalContext={portalContext} studyEnvContext={studyEnvContext}/>
-    </MockRegularUserProvider>)
-  expect(screen.getByText('Save study config')).toHaveAttribute('aria-disabled', 'true')
 })

--- a/ui-admin/src/study/StudySettings.tsx
+++ b/ui-admin/src/study/StudySettings.tsx
@@ -6,13 +6,12 @@ import { PortalEnvironment } from '@juniper/ui-core'
 import { doApiLoad } from 'api/api-utils'
 import { Button } from 'components/forms/Button'
 import { set } from 'lodash/fp'
-import { useUser } from 'user/UserProvider'
 import Api from 'api/api'
 import { Store } from 'react-notifications-component'
 import { successNotification } from 'util/notifications'
 import LoadingSpinner from 'util/LoadingSpinner'
 import { renderPageHeader } from 'util/pageUtils'
-import InfoPopup from "../components/forms/InfoPopup";
+import InfoPopup from '../components/forms/InfoPopup'
 
 /** shows settings for both a study and its containing portal */
 export default function StudySettings({ studyEnvContext, portalContext }:
@@ -32,7 +31,6 @@ export default function StudySettings({ studyEnvContext, portalContext }:
 export function StudyEnvConfigView({ studyEnvContext, portalContext }:
                                        {studyEnvContext: StudyEnvContextT, portalContext: LoadedPortalContextT}) {
   const [config, setConfig] = useState(studyEnvContext.currentEnv.studyEnvironmentConfig)
-  const { user } = useUser()
   const [isLoading, setIsLoading] = useState(false)
   /** update a given field in the config */
   const updateConfig = (propName: string, value: string | boolean) => {
@@ -66,16 +64,16 @@ export function StudyEnvConfigView({ studyEnvContext, portalContext }:
     </div>
     <div>
       <label className="form-label">
-        accepting enrollment <InfoPopup content={`If not checked, this study will be hidden from participants, and
-        they will not be able to enroll.`}/>
+        accepting enrollment <InfoPopup content={`Uncheck this to hide the study from participants who have not
+        yet joined and prevent any further enrollments.`}/>
         <input type="checkbox" checked={config.passwordProtected} className="ms-2"
-               onChange={e => updateConfig('acceptingEnrollment', e.target.checked)}/>
+          onChange={e => updateConfig('acceptingEnrollment', e.target.checked)}/>
       </label>
     </div>
 
     <Button onClick={save}
-      variant="primary" disabled={!user.superuser || isLoading}
-      tooltip={user.superuser ? 'Save' : 'You do not have permission to edit these settings'}>
+      variant="primary" disabled={isLoading}
+      tooltip={'Save'}>
       {isLoading && <LoadingSpinner/>}
       {!isLoading && 'Save study config'}
     </Button>

--- a/ui-admin/src/study/StudySettings.tsx
+++ b/ui-admin/src/study/StudySettings.tsx
@@ -66,7 +66,7 @@ export function StudyEnvConfigView({ studyEnvContext, portalContext }:
       <label className="form-label">
         accepting enrollment <InfoPopup content={`Uncheck this to hide the study from participants who have not
         yet joined and prevent any further enrollments.`}/>
-        <input type="checkbox" checked={config.passwordProtected} className="ms-2"
+        <input type="checkbox" checked={config.acceptingEnrollment} className="ms-2"
           onChange={e => updateConfig('acceptingEnrollment', e.target.checked)}/>
       </label>
     </div>

--- a/ui-admin/src/study/StudySettings.tsx
+++ b/ui-admin/src/study/StudySettings.tsx
@@ -12,6 +12,7 @@ import { Store } from 'react-notifications-component'
 import { successNotification } from 'util/notifications'
 import LoadingSpinner from 'util/LoadingSpinner'
 import { renderPageHeader } from 'util/pageUtils'
+import InfoPopup from "../components/forms/InfoPopup";
 
 /** shows settings for both a study and its containing portal */
 export default function StudySettings({ studyEnvContext, portalContext }:
@@ -61,6 +62,14 @@ export function StudyEnvConfigView({ studyEnvContext, portalContext }:
       <label className="form-label">
         password <input type="text" className="form-control" value={config.password}
           onChange={e => updateConfig('password', e.target.value)}/>
+      </label>
+    </div>
+    <div>
+      <label className="form-label">
+        accepting enrollment <InfoPopup content={`If not checked, this study will be hidden from participants, and
+        they will not be able to enroll.`}/>
+        <input type="checkbox" checked={config.passwordProtected} className="ms-2"
+               onChange={e => updateConfig('acceptingEnrollment', e.target.checked)}/>
       </label>
     </div>
 

--- a/ui-core/src/participant/landing/sections/StepOverviewTemplate.tsx
+++ b/ui-core/src/participant/landing/sections/StepOverviewTemplate.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { SectionConfig } from '../../../types/landingPageConfig'
 import { getSectionStyle } from '../../util/styleUtils'
 import { withValidatedSectionConfig } from '../../util/withValidatedSectionConfig'
-import {requireOptionalArray, requireOptionalBoolean, requireOptionalString, requirePlainObject, requireString}
+import { requireOptionalArray, requireOptionalBoolean, requireOptionalString, requirePlainObject, requireString }
   from '../../util/validationUtils'
 
 import ConfiguredButton, { ButtonConfig, validateButtonConfig } from '../ConfiguredButton'
@@ -13,7 +13,7 @@ import { InlineMarkdown } from '../Markdown'
 
 import { TemplateComponentProps } from './templateUtils'
 import { useApiContext } from '../../../participant/ApiProvider'
-import classNames from "classnames";
+import classNames from 'classnames'
 
 type StepConfig = {
   image: MediaConfig,
@@ -44,7 +44,7 @@ const validateStepOverviewTemplateConfig = (config: SectionConfig): StepOverview
   const title = requireOptionalString(config, 'title', message)
   const steps = requireOptionalArray(config, 'steps', validateStepConfig, message)
   const showStepNumbers = requireOptionalBoolean(config, 'showStepNumbers', message)
-  return { buttons, steps, title, showStepNumbers}
+  return { buttons, steps, title, showStepNumbers }
 }
 
 type StepOverviewTemplateProps = TemplateComponentProps<StepOverviewTemplateConfig>
@@ -74,8 +74,8 @@ function StepOverviewTemplate(props: StepOverviewTemplateProps) {
       {
         _.map(steps, ({ image, duration, blurb }: StepConfig, i: number) => {
           return <div key={i}
-                      className={classNames("col-12 d-flex flex-column align-items-center mt-4",
-                          lgWidthClass)}>
+            className={classNames('col-12 d-flex flex-column align-items-center mt-4',
+              lgWidthClass)}>
             <div className="w-75 d-flex flex-column align-items-center align-items-lg-start">
               <ConfiguredMedia media={image} className="img-fluid p-3" style={{ maxWidth: '200px' }}/>
               { showStepNumbers && <p className="text-uppercase fs-5 fw-semibold mb-0">Step {i + 1}</p> }

--- a/ui-participant/src/Navbar.test.tsx
+++ b/ui-participant/src/Navbar.test.tsx
@@ -6,11 +6,11 @@ import {
   NavbarItemExternal,
   NavbarItemInternal,
   NavbarItemInternalAnchor,
-  NavbarItemMailingList
+  NavbarItemMailingList, PortalStudy
 } from 'api/api'
 import { setupRouterTest } from 'test-utils/router-testing-utils'
 
-import { CustomNavLink } from './Navbar'
+import { CustomNavLink, getMainJoinLink } from './Navbar'
 
 describe('CustomNavLink', () => {
   it('renders internal links', () => {
@@ -90,5 +90,73 @@ describe('CustomNavLink', () => {
     const modal = document.querySelector('.modal') as HTMLElement
     expect(link).toHaveAttribute('data-bs-toggle', 'modal')
     expect(link).toHaveAttribute('data-bs-target', `#${CSS.escape(modal.getAttribute('id') as string)}`)
+  })
+})
+
+describe('joinPath', () => {
+  it('joins the study if there is one study', () => {
+    const portalStudies = [{
+      study: {
+        shortcode: 'foo',
+        name: 'Foo',
+        studyEnvironments: [{
+          studyEnvironmentConfig: {
+            acceptingEnrollment: true
+          }
+        }]
+      }
+    }] as PortalStudy[]
+    const joinPath = getMainJoinLink(portalStudies)
+    expect(joinPath).toBe('/studies/foo/join')
+  })
+  it('joins the portal if there are two studies', () => {
+    const portalStudies = [{
+      study: {
+        shortcode: 'foo',
+        name: 'Foo',
+        studyEnvironments: [{
+          studyEnvironmentConfig: {
+            acceptingEnrollment: true
+          }
+        }]
+      }
+    }, {
+      study: {
+        shortcode: 'bar',
+        name: 'Bar',
+        studyEnvironments: [{
+          studyEnvironmentConfig: {
+            acceptingEnrollment: true
+          }
+        }]
+      }
+    }] as PortalStudy[]
+    const joinPath = getMainJoinLink(portalStudies)
+    expect(joinPath).toBe('/join')
+  })
+  it('joins the portal if only one study is accepting enrollment', () => {
+    const portalStudies = [{
+      study: {
+        shortcode: 'foo',
+        name: 'Foo',
+        studyEnvironments: [{
+          studyEnvironmentConfig: {
+            acceptingEnrollment: true
+          }
+        }]
+      }
+    }, {
+      study: {
+        shortcode: 'bar',
+        name: 'Bar',
+        studyEnvironments: [{
+          studyEnvironmentConfig: {
+            acceptingEnrollment: false
+          }
+        }]
+      }
+    }] as PortalStudy[]
+    const joinPath = getMainJoinLink(portalStudies)
+    expect(joinPath).toBe('/studies/foo/join')
   })
 })

--- a/ui-participant/src/Navbar.tsx
+++ b/ui-participant/src/Navbar.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useId, useRef } from 'react'
 import { Link, NavLink, useLocation } from 'react-router-dom'
 import { HashLink } from 'react-router-hash-link'
 
-import Api, { getEnvSpec, getImageUrl, NavbarItem } from 'api/api'
+import Api, {getEnvSpec, getImageUrl, NavbarItem, PortalStudy} from 'api/api'
 import { MailingListModal } from '@juniper/ui-core'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { useUser } from 'providers/UserProvider'
@@ -27,9 +27,9 @@ export default function Navbar(props: NavbarProps) {
   const { user, logoutUser } = useUser()
   const envSpec = getEnvSpec()
   const navLinks = localContent.navbarItems
-
-  const joinPath = portalEnv.portal.portalStudies.length === 1
-    ? `/studies/${portalEnv.portal.portalStudies[0].study.shortcode}/join`
+  const joinable = filterJoinableStudies(portalEnv.portal.portalStudies)
+  const joinPath = joinable.length === 1
+    ? `/studies/${joinable[0].study.shortcode}/join`
     : '/join'
 
   /** invoke B2C change password flow */
@@ -198,4 +198,9 @@ export function CustomNavLink({ navLink }: { navLink: NavbarItem }) {
     return <a href={navLink.href} className={navLinkClasses} target="_blank">{navLink.text}</a>
   }
   return <></>
+}
+
+export const filterJoinableStudies = (portalStudies: PortalStudy[]): PortalStudy[] => {
+  return portalStudies.filter(pStudy =>
+      pStudy.study.studyEnvironments[0].studyEnvironmentConfig.acceptingEnrollment)
 }

--- a/ui-participant/src/Navbar.tsx
+++ b/ui-participant/src/Navbar.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useId, useRef } from 'react'
 import { Link, NavLink, useLocation } from 'react-router-dom'
 import { HashLink } from 'react-router-hash-link'
 
-import Api, {getEnvSpec, getImageUrl, NavbarItem, PortalStudy} from 'api/api'
+import Api, { getEnvSpec, getImageUrl, NavbarItem, PortalStudy } from 'api/api'
 import { MailingListModal } from '@juniper/ui-core'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { useUser } from 'providers/UserProvider'
@@ -27,10 +27,6 @@ export default function Navbar(props: NavbarProps) {
   const { user, logoutUser } = useUser()
   const envSpec = getEnvSpec()
   const navLinks = localContent.navbarItems
-  const joinable = filterJoinableStudies(portalEnv.portal.portalStudies)
-  const joinPath = joinable.length === 1
-    ? `/studies/${joinable[0].study.shortcode}/join`
-    : '/join'
 
   /** invoke B2C change password flow */
   function doChangePassword() {
@@ -102,7 +98,7 @@ export default function Navbar(props: NavbarProps) {
                     'd-flex justify-content-center',
                     'mb-3 mb-lg-0 ms-lg-3'
                   )}
-                  to={joinPath}
+                  to={getMainJoinLink(portalEnv.portal.portalStudies)}
                 >
                   Join
                 </NavLink>
@@ -200,7 +196,18 @@ export function CustomNavLink({ navLink }: { navLink: NavbarItem }) {
   return <></>
 }
 
-export const filterJoinableStudies = (portalStudies: PortalStudy[]): PortalStudy[] => {
+/** the default join link -- will be rendered in the top right corner */
+export const getMainJoinLink = (portalStudies: PortalStudy[]) => {
+  const joinable = filterUnjoinableStudies(portalStudies)
+  /** if there's only one joinable study, link directly to it */
+  const joinPath = joinable.length === 1
+    ? `/studies/${joinable[0].study.shortcode}/join`
+    : '/join'
+  return joinPath
+}
+
+/** filters out studies that are not accepting enrollment */
+export const filterUnjoinableStudies = (portalStudies: PortalStudy[]): PortalStudy[] => {
   return portalStudies.filter(pStudy =>
-      pStudy.study.studyEnvironments[0].studyEnvironmentConfig.acceptingEnrollment)
+    pStudy.study.studyEnvironments[0].studyEnvironmentConfig.acceptingEnrollment)
 }

--- a/ui-participant/src/hub/HubPage.test.tsx
+++ b/ui-participant/src/hub/HubPage.test.tsx
@@ -17,7 +17,10 @@ jest.mock('../providers/PortalProvider', () => {
             name: 'Test Study',
             shortcode: 'STUDYSHORTCODE',
             studyEnvironments: [{
-              id: 'test-study-env-id'
+              id: 'test-study-env-id',
+              studyEnvironmentConfig: {
+                acceptingEnrollment: true
+              }
             }]
           }
         }]

--- a/ui-participant/src/hub/HubPage.tsx
+++ b/ui-participant/src/hub/HubPage.tsx
@@ -9,7 +9,7 @@ import { DocumentTitle } from 'util/DocumentTitle'
 import { userHasJoinedPortalStudy } from 'util/enrolleeUtils'
 
 import { HubMessageAlert, useHubUpdate } from './hubUpdates'
-import {filterJoinableStudies} from "../Navbar";
+import { filterUnjoinableStudies } from '../Navbar'
 
 
 /** renders the logged-in hub page */
@@ -20,8 +20,8 @@ export default function HubPage() {
   const hubUpdate = useHubUpdate()
   const [showMessage, setShowMessage] = useState(true)
 
-  const unjoinedStudies = filterJoinableStudies(portal.portalStudies)
-      .filter(pStudy => !userHasJoinedPortalStudy(pStudy, enrollees))
+  const unjoinedStudies = filterUnjoinableStudies(portal.portalStudies)
+    .filter(pStudy => !userHasJoinedPortalStudy(pStudy, enrollees))
   const hasUnjoinedStudies = unjoinedStudies.length > 0
   return (
     <>

--- a/ui-participant/src/hub/HubPage.tsx
+++ b/ui-participant/src/hub/HubPage.tsx
@@ -9,6 +9,7 @@ import { DocumentTitle } from 'util/DocumentTitle'
 import { userHasJoinedPortalStudy } from 'util/enrolleeUtils'
 
 import { HubMessageAlert, useHubUpdate } from './hubUpdates'
+import {filterJoinableStudies} from "../Navbar";
 
 
 /** renders the logged-in hub page */
@@ -19,7 +20,8 @@ export default function HubPage() {
   const hubUpdate = useHubUpdate()
   const [showMessage, setShowMessage] = useState(true)
 
-  const unjoinedStudies = portal.portalStudies.filter(pStudy => !userHasJoinedPortalStudy(pStudy, enrollees))
+  const unjoinedStudies = filterJoinableStudies(portal.portalStudies)
+      .filter(pStudy => !userHasJoinedPortalStudy(pStudy, enrollees))
   const hasUnjoinedStudies = unjoinedStudies.length > 0
   return (
     <>


### PR DESCRIPTION
#### DESCRIPTION

This adds business logic around the "acceptingEnrollment" studyEnvironmentConfig property, which was previously unused.  If a study is marked as not accepting enrollment, it is hidden from the dashboard and enrollment is also prohibited server-side.  This is intended for multi-study portals (such as HeartHive) where some studies will not open/close over time and/or not be ready for usage yet.  In the short term, this also lets the HeartHive dashboard be functional and do what we want while we take our time to implement proper admin-configurable participant dashboards.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. Redeploy ApiParticipantApp
2. repopulate hearthive `./scripts/populate_portal.sh hearthive`
3. go to https://sandbox.hearthive.localhost:3001/
4. confirm that the "join" link in the top right goes to `https://sandbox.hearthive.localhost:3001/studies/hh_registry/join` instead of just `https://sandbox.hearthive.localhost:3001/join`
5. Join. 
6. Confirm that you are auto-enrolled in the registry study, and that no other studies appear on your dashboard.

