### PR TITLE
[JN-719] Delete pages

### DIFF
--- a/ui-admin/src/portal/siteContent/DeletePageModal.test.tsx
+++ b/ui-admin/src/portal/siteContent/DeletePageModal.test.tsx
@@ -6,41 +6,6 @@ import React from 'react'
 import { mockHtmlPage } from 'test-utils/mock-site-content'
 
 describe('DeletePageModal', () => {
-  test('disables Delete button when confirm string is not typed in', async () => {
-    //Arrange
-    const { RoutedComponent } = setupRouterTest(<DeletePageModal
-      onDismiss={jest.fn()}
-      deletePage={jest.fn()}
-      renderedPage={mockHtmlPage()}
-    />)
-
-    render(RoutedComponent)
-
-    //Assert
-    const deleteButton = screen.getByText('Delete')
-    expect(deleteButton).toBeDisabled()
-  })
-
-  test('enables Delete button when confirm string is typed in', async () => {
-    //Arrange
-    const { RoutedComponent } = setupRouterTest(<DeletePageModal
-      onDismiss={jest.fn()}
-      deletePage={jest.fn()}
-      renderedPage={mockHtmlPage()}
-    />)
-
-    render(RoutedComponent)
-
-    //Act
-    const confirmDeleteInput = screen.getByLabelText('Confirm by typing "delete example page" below.')
-    const deleteButton = screen.getByText('Delete')
-
-    await userEvent.type(confirmDeleteInput, 'delete example page')
-
-    //Assert
-    expect(deleteButton).toBeEnabled()
-  })
-
   test('Delete button calls deletePage with the page', async () => {
     //Arrange
     const mockDeletePageFn = jest.fn()
@@ -54,10 +19,8 @@ describe('DeletePageModal', () => {
     render(RoutedComponent)
 
     //Act
-    const confirmDeleteInput = screen.getByLabelText('Confirm by typing "delete example page" below.')
     const deleteButton = screen.getByText('Delete')
 
-    await userEvent.type(confirmDeleteInput, 'delete example page')
     await userEvent.click(deleteButton)
 
     //Assert

--- a/ui-admin/src/portal/siteContent/DeletePageModal.test.tsx
+++ b/ui-admin/src/portal/siteContent/DeletePageModal.test.tsx
@@ -1,0 +1,66 @@
+import userEvent from '@testing-library/user-event'
+import { setupRouterTest } from 'test-utils/router-testing-utils'
+import DeletePageModal from './DeletePageModal'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { mockHtmlPage } from 'test-utils/mock-site-content'
+
+describe('DeletePageModal', () => {
+  test('disables Delete button when confirm string is not typed in', async () => {
+    //Arrange
+    const { RoutedComponent } = setupRouterTest(<DeletePageModal
+      onDismiss={jest.fn()}
+      deletePage={jest.fn()}
+      renderedPage={mockHtmlPage()}
+    />)
+
+    render(RoutedComponent)
+
+    //Assert
+    const deleteButton = screen.getByText('Delete')
+    expect(deleteButton).toBeDisabled()
+  })
+
+  test('enables Delete button when confirm string is typed in', async () => {
+    //Arrange
+    const { RoutedComponent } = setupRouterTest(<DeletePageModal
+      onDismiss={jest.fn()}
+      deletePage={jest.fn()}
+      renderedPage={mockHtmlPage()}
+    />)
+
+    render(RoutedComponent)
+
+    //Act
+    const confirmDeleteInput = screen.getByLabelText('Confirm by typing "delete example page" below.')
+    const deleteButton = screen.getByText('Delete')
+
+    await userEvent.type(confirmDeleteInput, 'delete example page')
+
+    //Assert
+    expect(deleteButton).toBeEnabled()
+  })
+
+  test('Delete button calls deletePage with the page', async () => {
+    //Arrange
+    const mockDeletePageFn = jest.fn()
+    const mockPage = mockHtmlPage()
+    const { RoutedComponent } = setupRouterTest(<DeletePageModal
+      onDismiss={jest.fn()}
+      deletePage={mockDeletePageFn}
+      renderedPage={mockPage}
+    />)
+
+    render(RoutedComponent)
+
+    //Act
+    const confirmDeleteInput = screen.getByLabelText('Confirm by typing "delete example page" below.')
+    const deleteButton = screen.getByText('Delete')
+
+    await userEvent.type(confirmDeleteInput, 'delete example page')
+    await userEvent.click(deleteButton)
+
+    //Assert
+    expect(mockDeletePageFn).toHaveBeenCalledWith(mockPage)
+  })
+})

--- a/ui-admin/src/portal/siteContent/DeletePageModal.tsx
+++ b/ui-admin/src/portal/siteContent/DeletePageModal.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import Modal from 'react-bootstrap/Modal'
 import { HtmlPage } from '@juniper/ui-core'
 
-/** renders a modal allows the user to delete a page from the portal website */
+/** renders a modal for deleting pages from the portal website */
 const DeletePageModal = ({ renderedPage, deletePage, onDismiss }: {
   renderedPage: HtmlPage, deletePage: (page: HtmlPage) => void, onDismiss: () => void
 }) => {

--- a/ui-admin/src/portal/siteContent/DeletePageModal.tsx
+++ b/ui-admin/src/portal/siteContent/DeletePageModal.tsx
@@ -18,9 +18,6 @@ const DeletePageModal = ({ renderedPage, deletePage, onDismiss }: {
         Are you sure you want to delete the <strong>{renderedPage.title}</strong> page? Deleted pages
         can be restored from the website version history.
       </div>
-      <div className="mb-3">
-        Note that you must save your changes in the editor before your deletion will take effect.
-      </div>
     </Modal.Body>
     <Modal.Footer>
       <button

--- a/ui-admin/src/portal/siteContent/DeletePageModal.tsx
+++ b/ui-admin/src/portal/siteContent/DeletePageModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import Modal from 'react-bootstrap/Modal'
 import { HtmlPage } from '@juniper/ui-core'
 
@@ -6,13 +6,9 @@ import { HtmlPage } from '@juniper/ui-core'
 const DeletePageModal = ({ renderedPage, deletePage, onDismiss }: {
   renderedPage: HtmlPage, deletePage: (page: HtmlPage) => void, onDismiss: () => void
 }) => {
-  const [confirmDeletePage, setConfirmDeletePage] = useState('')
-  const deleteString = `delete ${renderedPage.title}`
-
   return <Modal show={true}
     onHide={() => {
       onDismiss()
-      setConfirmDeletePage('')
     }}>
     <Modal.Header closeButton>
       <Modal.Title>Delete Page</Modal.Title>
@@ -20,19 +16,15 @@ const DeletePageModal = ({ renderedPage, deletePage, onDismiss }: {
     <Modal.Body>
       <div className="mb-3">
         Are you sure you want to delete the <strong>{renderedPage.title}</strong> page? Deleted pages
-        can be restored from the website version history.</div>
-      <form onSubmit={e => e.preventDefault()}>
-        <label className="form-label">
-          Confirm by typing &quot;{deleteString}&quot; below.<br/>
-          <input type="text" size={50} className="form-control" id="inputPageRemoval" value={confirmDeletePage}
-            onChange={event => setConfirmDeletePage(event.target.value)}/>
-        </label>
-      </form>
+        can be restored from the website version history.
+      </div>
+      <div className="mb-3">
+        Note that you must save your changes in the editor before your deletion will take effect.
+      </div>
     </Modal.Body>
     <Modal.Footer>
       <button
         className="btn btn-primary"
-        disabled={confirmDeletePage.toLowerCase() !== deleteString.toLowerCase()}
         onClick={() => {
           deletePage(renderedPage)
           onDismiss()

--- a/ui-admin/src/portal/siteContent/DeletePageModal.tsx
+++ b/ui-admin/src/portal/siteContent/DeletePageModal.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react'
+import Modal from 'react-bootstrap/Modal'
+import { HtmlPage } from '@juniper/ui-core'
+
+/** renders a modal allows the user to delete a page from the portal website */
+const DeletePageModal = ({ renderedPage, deletePage, onDismiss }: {
+  renderedPage: HtmlPage, deletePage: (page: HtmlPage) => void, onDismiss: () => void
+}) => {
+  const [confirmDeletePage, setConfirmDeletePage] = useState('')
+  const deleteString = `delete ${renderedPage.title}`
+
+  return <Modal show={true}
+    onHide={() => {
+      onDismiss()
+      setConfirmDeletePage('')
+    }}>
+    <Modal.Header closeButton>
+      <Modal.Title>Delete Page</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>
+      <div className="mb-3">
+        Are you sure you want to delete the <strong>{renderedPage.title}</strong> page? Deleted pages
+        can be restored from the website version history.</div>
+      <form onSubmit={e => e.preventDefault()}>
+        <label className="form-label">
+          Confirm by typing &quot;{deleteString}&quot; below.<br/>
+          <input type="text" size={50} className="form-control" id="inputPageRemoval" value={confirmDeletePage}
+            onChange={event => setConfirmDeletePage(event.target.value)}/>
+        </label>
+      </form>
+    </Modal.Body>
+    <Modal.Footer>
+      <button
+        className="btn btn-primary"
+        disabled={confirmDeletePage.toLowerCase() !== deleteString.toLowerCase()}
+        onClick={() => {
+          deletePage(renderedPage)
+          onDismiss()
+        }}
+      >Delete</button>
+      <button className="btn btn-secondary" onClick={() => {
+        onDismiss()
+      }}>Cancel</button>
+    </Modal.Footer>
+  </Modal>
+}
+
+export default DeletePageModal

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.test.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.test.tsx
@@ -119,3 +119,17 @@ test('invalid site JSON disables page selector', async () => {
   const pageSelector = screen.getByLabelText('Select a page')
   expect(pageSelector).toBeDisabled()
 })
+
+test('delete page button is disabled when Landing page is selected', async () => {
+  //Arrange
+  const siteContent = mockSiteContent()
+  const { RoutedComponent } = setupRouterTest(
+    <SiteContentEditor siteContent={siteContent} previewApi={emptyApi} readOnly={false}
+      loadSiteContent={jest.fn()} createNewVersion={jest.fn()} switchToVersion={jest.fn()}
+      portalEnvContext={mockPortalEnvContext('sandbox')}/>)
+  render(RoutedComponent)
+
+  //Assert
+  const deletePageButton = screen.getByText('Delete page')
+  expect(deletePageButton).toHaveAttribute('aria-disabled', 'true')
+})

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -154,7 +154,7 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
     .map(navItem => ({ label: navItem.text, value: navItem.text }))
   pageOpts.unshift(landingPageOption)
 
-  const isLandingPage = selectedNavOpt.value === 'Landing page'
+  const isLandingPage = selectedNavOpt === landingPageOption
 
   return <div className="d-flex bg-white pb-5">
     <div className="d-flex flex-column flex-grow-1 mx-1 mb-1">

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { HtmlSection, NavbarItemInternal } from 'api/api'
 import Select from 'react-select'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faClipboard, faClockRotateLeft, faImage, faPlus } from '@fortawesome/free-solid-svg-icons'
+import { faClipboard, faClockRotateLeft, faImage, faPlus, faTrash } from '@fortawesome/free-solid-svg-icons'
 import HtmlPageEditView from './HtmlPageEditView'
 import {
   HtmlPage, LocalSiteContent, ApiProvider, SiteContent,
@@ -16,6 +16,7 @@ import CreatePreRegSurveyModal from '../CreatePreRegSurveyModal'
 import { PortalEnvContext } from '../PortalRouter'
 import ErrorBoundary from 'util/ErrorBoundary'
 import { Tab, Tabs } from 'react-bootstrap'
+import DeletePageModal from './DeletePageModal'
 
 type NavbarOption = {label: string, value: string}
 const landingPageOption = { label: 'Landing page', value: 'Landing page' }
@@ -43,6 +44,7 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
   const [workingContent, setWorkingContent] = useState<SiteContent>(initialContent)
   const [showVersionSelector, setShowVersionSelector] = useState(false)
   const [showAddPageModal, setShowAddPageModal] = useState(false)
+  const [showDeletePageModal, setShowDeletePageModal] = useState(false)
   const [showAddPreRegModal, setShowAddPreRegModal] = useState(false)
   const localContent = workingContent.localizedSiteContents.find(lsc => lsc.language === selectedLanguage)
   const [hasInvalidSection, setHasInvalidSection] = useState(false)
@@ -81,6 +83,25 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
     }
     updateLocalContent(updatedLocalContent)
     setSelectedNavOpt({ label: newNavBarItem.text, value: newNavBarItem.text || 'Landing page' })
+  }
+
+  const deletePage = (page: HtmlPage) => {
+    if (!localContent) {
+      return
+    }
+    const updatedNavBarItems = [...localContent.navbarItems]
+    const matchedNavItemIndex = navBarInternalItems.findIndex(navItem => navItem.htmlPage === page)
+    if (matchedNavItemIndex === -1) {
+      return
+    }
+    updatedNavBarItems.splice(matchedNavItemIndex, 1)
+    const updatedLocalContent = {
+      ...localContent,
+      navbarItems: updatedNavBarItems
+    }
+
+    updateLocalContent(updatedLocalContent)
+    setSelectedNavOpt(landingPageOption)
   }
 
   /** updates the global SiteContent object with the given HtmlPage, which may be associated with a navItem */
@@ -132,6 +153,8 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
   const pageOpts: {label: string, value: string}[] = navBarInternalItems
     .map(navItem => ({ label: navItem.text, value: navItem.text }))
   pageOpts.unshift(landingPageOption)
+
+  const isLandingPage = selectedNavOpt.value === 'Landing page'
 
   return <div className="d-flex bg-white pb-5">
     <div className="d-flex flex-column flex-grow-1 mx-1 mb-1">
@@ -187,6 +210,12 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
             disabled={readOnly || !isEditable || hasInvalidSection}
             onClick={() => setShowAddPageModal(!showAddPageModal)}>
             <FontAwesomeIcon icon={faPlus}/> Add page
+          </Button>
+          <Button className="btn btn-secondary"
+            tooltip={!isLandingPage ? 'Delete this page' : 'You cannot delete the landing page'}
+            disabled={readOnly || !isEditable || hasInvalidSection || isLandingPage}
+            onClick={() => setShowDeletePageModal(!showAddPageModal)}>
+            <FontAwesomeIcon icon={faTrash}/> Delete page
           </Button>
           <Link to="../images" className="btn btn-light ms-auto border m-1">
             <FontAwesomeIcon icon={faImage} className="fa-lg"/> Manage images
@@ -257,6 +286,10 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
         <AddPageModal portalEnv={portalEnv} portalShortcode={portalEnvContext.portal.shortcode}
           insertNewPage={insertNewPage}
           show={showAddPageModal} setShow={setShowAddPageModal}/>
+    }
+    { showDeletePageModal &&
+        <DeletePageModal renderedPage={pageToRender} deletePage={deletePage}
+          onDismiss={() => setShowDeletePageModal(false)}/>
     }
     { showAddPreRegModal &&
         <CreatePreRegSurveyModal portalEnvContext={portalEnvContext} onDismiss={() => setShowAddPreRegModal(false)}/>


### PR DESCRIPTION
#### DESCRIPTION

Not much to say about this one. You can delete pages now 🥳 You can't delete a landing page, but that doesn't seem like a desirable option anyway.

The modal in the video is not current and has been updated to look like this:
![Screenshot 2023-11-13 at 3 02 10 PM](https://github.com/broadinstitute/juniper/assets/7257391/563ba3ec-528c-4341-a30e-b503dd1d1dee)

https://github.com/broadinstitute/juniper/assets/7257391/da19941a-98f3-40fc-8b2a-cfacd54d9876


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Launch admin API + UI
* Populate ourhealth
* Go to the site content editor: https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/siteContent
* Try deleting pages (and note that you cannot delete a landing page)
* Save and confirm that the pages are deleted
