### PR TITLE
JN-718: enabling study staff withdrawal

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeExtService.java
@@ -7,7 +7,6 @@ import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.EnrolleeSearchResult;
 import bio.terra.pearl.core.model.participant.WithdrawnEnrollee;
 import bio.terra.pearl.core.model.workflow.DataChangeRecord;
-import bio.terra.pearl.core.service.exception.PermissionDeniedException;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.participant.WithdrawnEnrolleeService;
 import bio.terra.pearl.core.service.participant.search.EnrolleeSearchService;
@@ -78,9 +77,6 @@ public class EnrolleeExtService {
 
   public WithdrawnEnrollee withdrawEnrollee(AdminUser user, String enroleeShortcode)
       throws JsonProcessingException {
-    if (!user.isSuperuser()) {
-      throw new PermissionDeniedException("Not authoried to withdraw participants");
-    }
     Enrollee enrollee = authUtilService.authAdminUserToEnrollee(user, enroleeShortcode);
     return withdrawnEnrolleeService.withdrawEnrollee(enrollee);
   }

--- a/ui-admin/src/study/participants/enrolleeView/AdvancedOptions.test.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/AdvancedOptions.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { setupRouterTest } from 'test-utils/router-testing-utils'
+import { mockEnrollee, mockParticipantNote, mockStudyEnvContext } from 'test-utils/mocking-utils'
+import { mockAdminUser } from 'test-utils/user-mocking-utils'
+import { render, screen } from '@testing-library/react'
+import { ParticipantNote } from 'api/api'
+import AdvancedOptions from './AdvancedOptions'
+import userEvent from '@testing-library/user-event'
+
+test('disables withdraw unless specific confirmation', async () => {
+  const enrollee = mockEnrollee()
+  const { RoutedComponent } = setupRouterTest(
+    <AdvancedOptions enrollee={enrollee} studyEnvContext={mockStudyEnvContext()}/>)
+  render(RoutedComponent)
+  expect(screen.getByText('Withdraw')).toBeInTheDocument()
+  expect(screen.getByText('Withdraw')).toHaveAttribute('aria-disabled', 'true')
+
+  await userEvent.type(screen.getByRole('textbox'),
+        `withdraw ${enrollee.profile.givenName} ${enrollee.profile.familyName}`)
+  expect(screen.getByText('Withdraw')).toHaveAttribute('aria-disabled', 'false')
+})

--- a/ui-admin/src/study/participants/enrolleeView/AdvancedOptions.test.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/AdvancedOptions.test.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import { setupRouterTest } from 'test-utils/router-testing-utils'
-import { mockEnrollee, mockParticipantNote, mockStudyEnvContext } from 'test-utils/mocking-utils'
-import { mockAdminUser } from 'test-utils/user-mocking-utils'
+import { mockEnrollee, mockStudyEnvContext } from 'test-utils/mocking-utils'
 import { render, screen } from '@testing-library/react'
-import { ParticipantNote } from 'api/api'
 import AdvancedOptions from './AdvancedOptions'
 import userEvent from '@testing-library/user-event'
 

--- a/ui-admin/src/study/participants/enrolleeView/AdvancedOptions.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/AdvancedOptions.tsx
@@ -1,32 +1,27 @@
 import React, { useState } from 'react'
 import Api, { Enrollee } from 'api/api'
-import { StudyEnvContextT } from '../../StudyEnvironmentRouter'
-import { useUser } from 'user/UserProvider'
-import { failureNotification, successNotification } from 'util/notifications'
+import { participantListPath, StudyEnvContextT } from '../../StudyEnvironmentRouter'
+import { successNotification } from 'util/notifications'
 import { Store } from 'react-notifications-component'
 import { useNavigate } from 'react-router-dom'
+import { doApiLoad } from 'api/api-utils'
+import { Button } from 'components/forms/Button'
 
 /** shows not-commonly-used enrollee functionality */
 export default function AdvancedOptions({ enrollee, studyEnvContext }:
 {enrollee: Enrollee, studyEnvContext: StudyEnvContextT}) {
   const [shortcodeConfirm, setShortcodeConfirm] = useState('')
-  const { user } = useUser()
   const navigate = useNavigate()
   const withdrawString = `withdraw ${enrollee.profile.givenName} ${enrollee.profile.familyName}`
   const canWithdraw = shortcodeConfirm === withdrawString
   const doWithdraw = async () => {
-    if (!user.superuser) {
-      Store.addNotification(failureNotification('you are not authorized to withdraw participants'))
-      return
-    }
-    try {
+    doApiLoad(async () => {
       await Api.withdrawEnrollee(studyEnvContext.portal.shortcode, studyEnvContext.study.shortcode,
         studyEnvContext.currentEnv.environmentName, enrollee.shortcode)
       Store.addNotification(successNotification('withdrawal succeeded'))
-      navigate(studyEnvContext.currentEnvPath)
-    } catch (e) {
-      Store.addNotification(failureNotification('withdrawal failed'))
-    }
+      navigate(participantListPath(studyEnvContext.portal.shortcode, studyEnvContext.study.shortcode,
+        studyEnvContext.currentEnv.environmentName))
+    })
   }
   return <div className="p4">
     <form onSubmit={e => e.preventDefault()}>
@@ -40,7 +35,8 @@ export default function AdvancedOptions({ enrollee, studyEnvContext }:
             onChange={e => setShortcodeConfirm(e.target.value)}/>
         </label>
       </div>
-      <button type="button" className="btn btn-primary" onClick={doWithdraw} disabled={!canWithdraw}>Withdraw</button>
+      <Button variant="primary" className="btn btn-primary"
+        onClick={doWithdraw} disabled={!canWithdraw}>Withdraw</Button>
     </form>
 
   </div>


### PR DESCRIPTION
#### DESCRIPTION

OurHealth needs to be able to withdraw some soft-launch participants.  This removes the superuser limitation on withdrawing participants.  This also cleans up the component to match latest patterns


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy apiAdminApp
2. log in to admin tool using development mode as `staff@ourhealth.org`
3. go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants/OHNEWB/withdrawal
4. type in the confirmation, and click withdraw
5. confirm the participant is withdrawn