### PR TITLE
JN-706 Notification config editing cleanups

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandler.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandler.java
@@ -1,10 +1,8 @@
 package bio.terra.pearl.api.admin.controller;
 
-import bio.terra.common.exception.BadRequestException;
-import bio.terra.common.exception.InternalServerErrorException;
-import bio.terra.common.exception.UnauthorizedException;
-import bio.terra.common.exception.ValidationException;
+import bio.terra.common.exception.*;
 import bio.terra.pearl.api.admin.model.ErrorReport;
+import bio.terra.pearl.core.service.exception.PermissionDeniedException;
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -38,11 +36,18 @@ public class GlobalExceptionHandler {
     return buildErrorReport(ex, HttpStatus.UNAUTHORIZED);
   }
 
-  @ExceptionHandler({
-    UnauthorizedException.class,
-  })
+  @ExceptionHandler({UnauthorizedException.class, PermissionDeniedException.class})
   public static ResponseEntity<ErrorReport> authorizationExceptionHandler(Exception ex) {
     return buildErrorReport(ex, HttpStatus.FORBIDDEN);
+  }
+
+  @ExceptionHandler({
+    NotFoundException.class,
+    javax.ws.rs.NotFoundException.class,
+    bio.terra.pearl.core.service.exception.NotFoundException.class
+  })
+  public static ResponseEntity<ErrorReport> notFoundExceptionHandler(Exception ex) {
+    return buildErrorReport(ex, HttpStatus.NOT_FOUND);
   }
 
   // catchall - internal server error
@@ -61,6 +66,10 @@ public class GlobalExceptionHandler {
     log.info("Global exception handler: " + causes, ex);
 
     return new ResponseEntity<>(
-        new ErrorReport().message(ex.getMessage()).statusCode(statusCode.value()), statusCode);
+        new ErrorReport()
+            .errorClass(ex.getClass().getName())
+            .message(ex.getMessage())
+            .statusCode(statusCode.value()),
+        statusCode);
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/notifications/NotificationConfigController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/notifications/NotificationConfigController.java
@@ -53,7 +53,7 @@ public class NotificationConfigController implements NotificationConfigApi {
             operator, portalShortcode, studyShortcode, environmentName, configId);
     return ResponseEntity.ok(
         configOpt.orElseThrow(
-            () -> new NotFoundException("a config with that id does not exist in this study")));
+            () -> new NotFoundException("A config with that id does not exist in this study")));
   }
 
   @Override

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/notifications/NotificationConfigController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/notifications/NotificationConfigController.java
@@ -6,6 +6,7 @@ import bio.terra.pearl.api.admin.service.notifications.NotificationConfigExtServ
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.notification.NotificationConfig;
+import bio.terra.pearl.core.service.exception.NotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Optional;
 import java.util.UUID;
@@ -50,7 +51,9 @@ public class NotificationConfigController implements NotificationConfigApi {
     Optional<NotificationConfig> configOpt =
         notificationConfigExtService.find(
             operator, portalShortcode, studyShortcode, environmentName, configId);
-    return ResponseEntity.of(configOpt.map(opt -> opt));
+    return ResponseEntity.ok(
+        configOpt.orElseThrow(
+            () -> new NotFoundException("a config with that id does not exist in this study")));
   }
 
   @Override

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -1386,6 +1386,8 @@ components:
       properties:
         message:
           type: string
+        errorClass:
+          type: string
         statusCode:
           type: integer
     PortalShallowDto:

--- a/core/src/main/java/bio/terra/pearl/core/service/portal/exception/PortalEnvironmentMissing.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/portal/exception/PortalEnvironmentMissing.java
@@ -1,5 +1,8 @@
 package bio.terra.pearl.core.service.portal.exception;
 
-/** throw if the invariant that all portals must have the sandbox/irb/live environments is violated */
-public class PortalEnvironmentMissing extends RuntimeException {
+/** throw if the invariant that all portals must have the sandbox/irb/live environments is violated
+ * Extends IllegalStateException rather than NoSuchElementException because this should never happen,
+ *  and if it does, it's likely because study creation/deletion is in-process
+ *  */
+public class PortalEnvironmentMissing extends IllegalStateException {
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/study/exception/StudyEnvironmentMissing.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/study/exception/StudyEnvironmentMissing.java
@@ -1,5 +1,9 @@
 package bio.terra.pearl.core.service.study.exception;
 
-/** throw if the invariant that all studies must have the sandbox/irb/live environments is violated */
-public class StudyEnvironmentMissing extends RuntimeException {
+/**
+ * throw if the invariant that all studies must have the sandbox/irb/live environments is violated.
+ * Extends IllegalStateException rather than NoSuchElementException because this should never happen,
+ * and if it does, it's likely because study creation/deletion is in-process
+ * */
+public class StudyEnvironmentMissing extends IllegalStateException {
 }

--- a/ui-admin/src/study/notifications/CreateNotificationConfigModal.tsx
+++ b/ui-admin/src/study/notifications/CreateNotificationConfigModal.tsx
@@ -22,7 +22,7 @@ const getDefaultConfig = (): NotificationConfig => {
     active: true,
     portalEnvironmentId: '',
     studyEnvironmentId: '',
-    afterMinutesIncomplete: 720 * 60,
+    afterMinutesIncomplete: 72 * 60,
     reminderIntervalMinutes: 72 * 60,
     maxNumReminders: 3,
     emailTemplate: {

--- a/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
+++ b/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
@@ -9,6 +9,9 @@ export default function EmailTemplateEditor({ emailTemplate, updateEmailTemplate
     emailTemplate: EmailTemplate, portalShortcode: string, updateEmailTemplate: (emailTemplate: EmailTemplate) => void
 }) {
   const emailEditorRef = useRef<EditorRef>(null)
+  // wrapper so that the unlayer event handler always accesses the latest state when updating
+  const emailTemplateRef = useRef(emailTemplate)
+  emailTemplateRef.current = emailTemplate
   const [activeTab, setActiveTab] = useState<string | null>('designer')
 
   const replacePlaceholders = (html: string) => {
@@ -28,7 +31,7 @@ export default function EmailTemplateEditor({ emailTemplate, updateEmailTemplate
       if (!emailEditorRef.current?.editor) { return }
       emailEditorRef.current.editor.exportHtml(data => {
         updateEmailTemplate({
-          ...emailTemplate,
+          ...emailTemplateRef.current,
           body: insertPlaceholders(data.html)
         })
       })

--- a/ui-admin/src/study/notifications/NotificationConfigView.tsx
+++ b/ui-admin/src/study/notifications/NotificationConfigView.tsx
@@ -98,13 +98,15 @@ export default function NotificationConfigView({ studyEnvContext, portalContext 
         updateEmailTemplate={updatedTemplate => setWorkingConfig(currentConfig => {
           // we have to use currentConfig since the template editor might call a stale version of this handler
           // due to the unlayer event listener setup
-          return {...currentConfig!,
-          emailTemplate: {
-            ...updatedTemplate,
-            id: undefined,
-            version: config ? config.emailTemplate.version + 1 : 1
+          return {
+            ...currentConfig!,
+            emailTemplate: {
+              ...updatedTemplate,
+              id: undefined,
+              version: config ? config.emailTemplate.version + 1 : 1
+            }
           }
-        }})}/>}
+        })}/>}
 
       <div className="d-flex justify-content-center">
         <button type="button" className="btn btn-primary" onClick={saveConfig}>Save</button>

--- a/ui-admin/src/study/notifications/NotificationConfigView.tsx
+++ b/ui-admin/src/study/notifications/NotificationConfigView.tsx
@@ -55,25 +55,25 @@ export default function NotificationConfigView({ studyEnvContext, portalContext 
       <NotificationConfigBaseForm config={workingConfig} setConfig={setWorkingConfig}/>
       { isTaskReminder(workingConfig) && <div>
         <div>
-          <label className="form-label">Remind after
+          <label className="form-label mt-3">Remind after
             <div className="d-flex align-items-center">
-              <input className="form-control me-2" type="number" value={workingConfig.afterMinutesIncomplete}
+              <input className="form-control me-2" type="number" value={workingConfig.afterMinutesIncomplete / 60}
                 onChange={e => setWorkingConfig(
-                  { ...workingConfig, afterMinutesIncomplete: parseInt(e.target.value) || 0 }
+                  { ...workingConfig, afterMinutesIncomplete: parseInt(e.target.value) * 60 || 0 }
                 )}/>
-              minutes
+              hours
             </div>
           </label>
         </div>
         <div>
           <label className="form-label">Repeat reminder after
             <div className="d-flex align-items-center">
-              <input className="form-control me-2" type="number" value={workingConfig.reminderIntervalMinutes}
+              <input className="form-control me-2" type="number" value={workingConfig.reminderIntervalMinutes / 60}
                 onChange={e => setWorkingConfig(
-                  { ...workingConfig, reminderIntervalMinutes: parseInt(e.target.value) || 0 }
+                  { ...workingConfig, reminderIntervalMinutes: parseInt(e.target.value) * 60 || 0 }
                 )}
               />
-              minutes</div>
+              hours</div>
           </label>
         </div>
         <div>
@@ -95,14 +95,16 @@ export default function NotificationConfigView({ studyEnvContext, portalContext 
 
       { hasTemplate && <EmailTemplateEditor emailTemplate={workingConfig.emailTemplate}
         portalShortcode={portal.shortcode}
-        updateEmailTemplate={updatedTemplate => setWorkingConfig({
-          ...workingConfig,
+        updateEmailTemplate={updatedTemplate => setWorkingConfig(currentConfig => {
+          // we have to use currentConfig since the template editor might call a stale version of this handler
+          // due to the unlayer event listener setup
+          return {...currentConfig!,
           emailTemplate: {
             ...updatedTemplate,
             id: undefined,
             version: config ? config.emailTemplate.version + 1 : 1
           }
-        })}/>}
+        }})}/>}
 
       <div className="d-flex justify-content-center">
         <button type="button" className="btn btn-primary" onClick={saveConfig}>Save</button>


### PR DESCRIPTION
#### DESCRIPTION
This cleans up a bunch of stuff from https://github.com/broadinstitute/juniper/pull/625

1. Reminder durations are in hours
2. Spacing between form fields are cleaner
3. NotFound exceptions are now explicitly handled
4. Our default exception mapper now includes the error class for better UX branching (not needed here, but will be useful for kit requests)
5. fixes bug where making changes to the email template would reset other form fields

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1. redeploy ApiAdminApp
2. go to https://localhost:3000/hearthive/studies/hh_registry/env/sandbox/notificationContent
3. create a notification config, confirm it saves and fields are all editable
4. go to https://localhost:3000/hearthive/studies/hh_registry/env/sandbox/notificationContent/configs/125cb80f-ca12-422f-8105-d2bd2734e215
5. confirm you get a reasonable 404 error message in the UI as below
<img width="705" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/cd329950-4ece-4710-9c94-e318f0236a4e">

