### PR TITLE
[JN-657] Add request info to exception logging

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandler.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandler.java
@@ -71,7 +71,13 @@ public class GlobalExceptionHandler {
     for (Throwable cause = ex.getCause(); cause != null; cause = cause.getCause()) {
       causes.append("\nCause: ").append(cause);
     }
-    log.info("{}\nRequest: {} {}", causes, request.getMethod(), request.getRequestURI(), ex);
+    log.info(
+        "{}\nRequest: {} {} {}",
+        causes,
+        request.getMethod(),
+        request.getRequestURI(),
+        statusCode.value(),
+        ex);
 
     return new ResponseEntity<>(
         new ErrorReport().message(ex.getMessage()).statusCode(statusCode.value()), statusCode);

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandler.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.exception.ValidationException;
 import bio.terra.pearl.api.admin.model.ErrorReport;
 import com.auth0.jwt.exceptions.JWTDecodeException;
+import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +20,12 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+  private HttpServletRequest request;
+
+  public GlobalExceptionHandler(HttpServletRequest request) {
+    this.request = request;
+  }
+
   @ExceptionHandler({
     MethodArgumentNotValidException.class,
     MethodArgumentTypeMismatchException.class,
@@ -27,38 +34,44 @@ public class GlobalExceptionHandler {
     ValidationException.class,
     BadRequestException.class
   })
-  public static ResponseEntity<ErrorReport> badRequestExceptionHandler(Exception ex) {
-    return buildErrorReport(ex, HttpStatus.BAD_REQUEST);
+  public ResponseEntity<ErrorReport> badRequestExceptionHandler(Exception ex) {
+    return buildErrorReport(ex, HttpStatus.BAD_REQUEST, request);
+  }
+
+  public static ResponseEntity<ErrorReport> badRequestHandler(
+      Exception ex, HttpServletRequest request) {
+    return buildErrorReport(ex, HttpStatus.BAD_REQUEST, request);
   }
 
   @ExceptionHandler({
     JWTDecodeException.class,
   })
-  public static ResponseEntity<ErrorReport> authenticationExceptionHandler(Exception ex) {
-    return buildErrorReport(ex, HttpStatus.UNAUTHORIZED);
+  public ResponseEntity<ErrorReport> authenticationExceptionHandler(Exception ex) {
+    return buildErrorReport(ex, HttpStatus.UNAUTHORIZED, request);
   }
 
   @ExceptionHandler({
     UnauthorizedException.class,
   })
-  public static ResponseEntity<ErrorReport> authorizationExceptionHandler(Exception ex) {
-    return buildErrorReport(ex, HttpStatus.FORBIDDEN);
+  public ResponseEntity<ErrorReport> authorizationExceptionHandler(Exception ex) {
+    return buildErrorReport(ex, HttpStatus.FORBIDDEN, request);
   }
 
   // catchall - internal server error
   @ExceptionHandler({InternalServerErrorException.class, Exception.class})
-  public static ResponseEntity<ErrorReport> internalErrorExceptionHandler(Exception ex) {
+  public ResponseEntity<ErrorReport> internalErrorExceptionHandler(Exception ex) {
     log.error("Exception caught by catch-all handler", ex);
-    return buildErrorReport(ex, HttpStatus.INTERNAL_SERVER_ERROR);
+    return buildErrorReport(ex, HttpStatus.INTERNAL_SERVER_ERROR, request);
   }
 
   protected static ResponseEntity<ErrorReport> buildErrorReport(
-      Throwable ex, HttpStatus statusCode) {
+      Throwable ex, HttpStatus statusCode, HttpServletRequest request) {
+
     StringBuilder causes = new StringBuilder("Exception: ").append(ex);
     for (Throwable cause = ex.getCause(); cause != null; cause = cause.getCause()) {
       causes.append("\nCause: ").append(cause);
     }
-    log.info("Global exception handler: " + causes, ex);
+    log.info("{}\nRequest: {} {}", causes, request.getMethod(), request.getRequestURI(), ex);
 
     return new ResponseEntity<>(
         new ErrorReport().message(ex.getMessage()).statusCode(statusCode.value()), statusCode);

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/admin/AdminUserController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/admin/AdminUserController.java
@@ -44,7 +44,7 @@ public class AdminUserController implements AdminUserApi {
 
   @ExceptionHandler(ValidationException.class)
   public ResponseEntity<ErrorReport> handleValidationException(ValidationException e) {
-    return GlobalExceptionHandler.badRequestExceptionHandler(e);
+    return GlobalExceptionHandler.badRequestHandler(e, request);
   }
 
   @Override

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/kit/KitController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/kit/KitController.java
@@ -49,7 +49,7 @@ public class KitController implements KitApi {
 
   @ExceptionHandler(PepperApiException.class)
   public ResponseEntity<ErrorReport> handlePepperApiException(PepperApiException e) {
-    return GlobalExceptionHandler.badRequestExceptionHandler(e);
+    return GlobalExceptionHandler.badRequestHandler(e, request);
   }
 
   @Override

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandlerTest.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandlerTest.java
@@ -29,6 +29,7 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -53,8 +54,12 @@ public class GlobalExceptionHandlerTest {
   @Test
   void testBuildErrorReport() {
     Exception nestedException = new Exception("base exception", new Exception("root cause"));
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setMethod("POST");
+    request.setRequestURI("/api/portals/v1/portal1/studies");
     ResponseEntity<ErrorReport> errorReport =
-        GlobalExceptionHandler.buildErrorReport(nestedException, HttpStatus.INTERNAL_SERVER_ERROR);
+        GlobalExceptionHandler.buildErrorReport(
+            nestedException, HttpStatus.INTERNAL_SERVER_ERROR, request);
     assertThat(errorReport.getStatusCode(), equalTo(HttpStatus.INTERNAL_SERVER_ERROR));
     assertThat(errorReport.getBody().getMessage(), equalTo("base exception"));
     log.info("Global exception handler: " + errorReport);

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/GlobalExceptionHandler.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/GlobalExceptionHandler.java
@@ -66,7 +66,13 @@ public class GlobalExceptionHandler {
     for (Throwable cause = ex.getCause(); cause != null; cause = cause.getCause()) {
       causes.append("\nCause: ").append(cause);
     }
-    log.info("{}\nRequest: {} {}", causes, request.getMethod(), request.getRequestURI(), ex);
+    log.info(
+        "{}\nRequest: {} {} {}",
+        causes,
+        request.getMethod(),
+        request.getRequestURI(),
+        statusCode.value(),
+        ex);
 
     return new ResponseEntity<>(
         new ErrorReport().message(ex.getMessage()).statusCode(statusCode.value()), statusCode);


### PR DESCRIPTION
#### DESCRIPTION
For all exceptions handled by the GlobalExceptionHandler, logs exception information with the associated request. This makes troubleshooting via logs and alerts a lot easier.


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. Run ApiAdminApp.
2. Goto https://localhost:3000/
3. Do an operation via the UI that will cause an exception. (I like creating a study with an existing shortcode.)
4. Observe the exception logging. It should include request information (method, URI).

