### PR TITLE
JN-688: adding other description to admin display

### DIFF
--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/enrollees/jsalk.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/enrollees/jsalk.json
@@ -45,7 +45,10 @@
         {"questionStableId": "oh_oh_basic_lastName", "stringValue": "Salk"},
         {"questionStableId": "oh_oh_basic_streetAddress", "stringValue": "415 Main Street"},
         {"questionStableId": "oh_oh_basic_mghPatient", "stringValue": "yes"},
-        {"questionStableId": "oh_oh_basic_dateOfBirth", "stringValue":  "11/12/1987"}
+        {"questionStableId": "oh_oh_basic_dateOfBirth", "stringValue":  "11/12/1987"},
+        {"questionStableId":"oh_oh_basic_birthSex", "stringValue": "other",
+          "otherDescription": "something else"
+        }
       ],
       "currentPageNo": 1,
       "complete": true,

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
@@ -31,6 +31,23 @@ describe('getDisplayValue', () => {
     expect(screen.getByText('option 2')).toBeTruthy()
   })
 
+  it('renders a free text other description', async () => {
+    const question: Question = {
+      isVisible: true,
+      choices: [{
+        text: 'option 1', value: 'option1Val'
+      }, {
+        text: 'option 2', value: 'option2Val'
+      }]
+    } as unknown as Question
+    const answer: Answer = {
+      stringValue: 'option2Val', questionStableId: 'testQ',
+      otherDescription: 'more detail'
+    } as Answer
+    render(<span>{getDisplayValue(answer, question)}</span>)
+    expect(screen.getByText('option 2 - more detail')).toBeTruthy()
+  })
+
   it('renders a choice array value', async () => {
     const question: Question = {
       isVisible: true,

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -126,6 +126,9 @@ export const getDisplayValue = (answer: Answer,
   if (answer.questionStableId.endsWith('signature')) {
     displayValue = <img src={answer.stringValue}/>
   }
+  if (answer.otherDescription) {
+    displayValue = `${displayValue} - ${answer.otherDescription}`
+  }
   return displayValue
 }
 


### PR DESCRIPTION
#### DESCRIPTION

Previously, free text other descriptions were not shown in the admin tool enrollee view (although they do appear in data export).  This fixes that.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. repopulate OurHealth
2. go to `https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants/OHSALK/surveys/oh_oh_basicInfo`
3. scroll down to see the "something else" now displayed alongside the birthSex "other" answer
<img width="999" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/88922060-b8bd-4ed9-b312-5f7d9cf37f53">
