### PR TITLE
[JN-657] Consolidate log handling in GlobalExceptionHandler

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandler.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandler.java
@@ -81,20 +81,20 @@ public class GlobalExceptionHandler {
             "%s%nRequest: %s %s %s",
             causes, request.getMethod(), request.getRequestURI(), statusCode.value());
 
-    switch (statusCode) {
-      case INTERNAL_SERVER_ERROR:
-        log.error(logString, ex);
-        break;
-      case BAD_REQUEST, UNAUTHORIZED, FORBIDDEN, NOT_FOUND:
-      default:
-        log.info(logString, ex);
-        break;
+    String message;
+    if (statusCode == HttpStatus.INTERNAL_SERVER_ERROR) {
+      log.error(logString, ex);
+      // don't share internal error messages with the client
+      message = "Internal server error";
+    } else {
+      log.info(logString, ex);
+      message = ex.getMessage();
     }
 
     return new ResponseEntity<>(
         new ErrorReport()
             .errorClass(ex.getClass().getName())
-            .message(ex.getMessage())
+            .message(message)
             .statusCode(statusCode.value()),
         statusCode);
   }

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandlerTest.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandlerTest.java
@@ -58,10 +58,16 @@ public class GlobalExceptionHandlerTest {
     request.setMethod("POST");
     request.setRequestURI("/api/portals/v1/portal1/studies");
     ResponseEntity<ErrorReport> errorReport =
+        GlobalExceptionHandler.buildErrorReport(nestedException, HttpStatus.BAD_REQUEST, request);
+    assertThat(errorReport.getStatusCode(), equalTo(HttpStatus.BAD_REQUEST));
+    assertThat(errorReport.getBody().getMessage(), equalTo("base exception"));
+
+    // we do not expose internal error exception messages to the client
+    errorReport =
         GlobalExceptionHandler.buildErrorReport(
             nestedException, HttpStatus.INTERNAL_SERVER_ERROR, request);
     assertThat(errorReport.getStatusCode(), equalTo(HttpStatus.INTERNAL_SERVER_ERROR));
-    assertThat(errorReport.getBody().getMessage(), equalTo("base exception"));
+    assertThat(errorReport.getBody().getMessage(), equalTo("Internal server error"));
     log.info("Global exception handler: " + errorReport);
   }
 

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/GlobalExceptionHandler.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/GlobalExceptionHandler.java
@@ -71,17 +71,17 @@ public class GlobalExceptionHandler {
             "%s%nRequest: %s %s %s",
             causes, request.getMethod(), request.getRequestURI(), statusCode.value());
 
-    switch (statusCode) {
-      case INTERNAL_SERVER_ERROR:
-        log.error(logString, ex);
-        break;
-      case BAD_REQUEST, UNAUTHORIZED, FORBIDDEN, NOT_FOUND:
-      default:
-        log.info(logString, ex);
-        break;
+    String message;
+    if (statusCode == HttpStatus.INTERNAL_SERVER_ERROR) {
+      log.error(logString, ex);
+      // don't share internal error messages with the client
+      message = "Internal server error";
+    } else {
+      log.info(logString, ex);
+      message = ex.getMessage();
     }
 
     return new ResponseEntity<>(
-        new ErrorReport().message(ex.getMessage()).statusCode(statusCode.value()), statusCode);
+        new ErrorReport().message(message).statusCode(statusCode.value()), statusCode);
   }
 }

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/GlobalExceptionHandler.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/GlobalExceptionHandler.java
@@ -20,7 +20,7 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-  private HttpServletRequest request;
+  private final HttpServletRequest request;
 
   public GlobalExceptionHandler(HttpServletRequest request) {
     this.request = request;
@@ -55,7 +55,6 @@ public class GlobalExceptionHandler {
   // catchall - internal server error
   @ExceptionHandler({InternalServerErrorException.class, Exception.class})
   public ResponseEntity<ErrorReport> internalErrorExceptionHandler(Exception ex) {
-    log.error("Exception caught by catch-all handler", ex);
     return buildErrorReport(ex, HttpStatus.INTERNAL_SERVER_ERROR, request);
   }
 
@@ -66,13 +65,21 @@ public class GlobalExceptionHandler {
     for (Throwable cause = ex.getCause(); cause != null; cause = cause.getCause()) {
       causes.append("\nCause: ").append(cause);
     }
-    log.info(
-        "{}\nRequest: {} {} {}",
-        causes,
-        request.getMethod(),
-        request.getRequestURI(),
-        statusCode.value(),
-        ex);
+
+    String logString =
+        String.format(
+            "%s%nRequest: %s %s %s",
+            causes, request.getMethod(), request.getRequestURI(), statusCode.value());
+
+    switch (statusCode) {
+      case INTERNAL_SERVER_ERROR:
+        log.error(logString, ex);
+        break;
+      case BAD_REQUEST, UNAUTHORIZED, FORBIDDEN, NOT_FOUND:
+      default:
+        log.info(logString, ex);
+        break;
+    }
 
     return new ResponseEntity<>(
         new ErrorReport().message(ex.getMessage()).statusCode(statusCode.value()), statusCode);


### PR DESCRIPTION
#### DESCRIPTION
Consolidates logging into a single place in GlobalExceptionHandler, ensuring consistent logging and providing a central place for future logging changes. This matters since Juniper alerting depends on the severity and structure of exception logging. (Also, I should have gotten this right in a prior PR.)


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. Run GlobalExceptionHandlerTest.
2. Observe the exception logging.
