### PR TITLE
JN-698: case insensitive login

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/CurrentUnauthedUserService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/CurrentUnauthedUserService.java
@@ -1,6 +1,5 @@
 package bio.terra.pearl.api.admin.service;
 
-import bio.terra.pearl.core.dao.admin.AdminUserDao;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.admin.AdminUserWithPermissions;
 import bio.terra.pearl.core.service.admin.AdminUserService;
@@ -10,7 +9,6 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class CurrentUnauthedUserService {
@@ -22,13 +20,14 @@ public class CurrentUnauthedUserService {
 
   public Optional<AdminUserWithPermissions> unauthedLogin(String username) {
     Optional<AdminUserWithPermissions> userOpt =
-            adminUserService.findByUsernameWithPermissions(username);
-    userOpt.ifPresent(userWithPermissions -> {
-      AdminUser user = userWithPermissions.user();
-      user.setToken(generateFakeJwtToken(username));
-      user.setLastLogin(Instant.now());
-      adminUserService.update(user);
-    });
+        adminUserService.findByUsernameWithPermissions(username);
+    userOpt.ifPresent(
+        userWithPermissions -> {
+          AdminUser user = userWithPermissions.user();
+          user.setToken(generateFakeJwtToken(username));
+          user.setLastLogin(Instant.now());
+          adminUserService.update(user);
+        });
     return userOpt;
   }
 
@@ -51,7 +50,7 @@ public class CurrentUnauthedUserService {
     userOpt.ifPresent(
         user -> {
           user.setToken(null);
-            adminUserService.update(user);
+          adminUserService.update(user);
         });
   }
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/CurrentUserService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/CurrentUserService.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.api.admin.service;
 
 import bio.terra.pearl.core.dao.admin.AdminUserDao;
 import bio.terra.pearl.core.model.admin.AdminUserWithPermissions;
+import bio.terra.pearl.core.service.admin.AdminUserService;
 import com.auth0.jwt.JWT;
 import java.time.Instant;
 import java.util.Optional;
@@ -10,10 +11,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class CurrentUserService {
-  private AdminUserDao adminUserDao;
+  private AdminUserService adminUserService;
 
-  public CurrentUserService(AdminUserDao adminUserDao) {
-    this.adminUserDao = adminUserDao;
+  public CurrentUserService(AdminUserService adminUserService) {
+    this.adminUserService = adminUserService;
   }
 
   public Optional<AdminUserWithPermissions> tokenLogin(String token) {
@@ -21,12 +22,11 @@ public class CurrentUserService {
     userWithPermsOpt.ifPresent(
         userWithPerms -> {
           userWithPerms.user().setLastLogin(Instant.now());
-          adminUserDao.update(userWithPerms.user());
+          adminUserService.update(userWithPerms.user());
         });
     return userWithPermsOpt;
   }
 
-  @Transactional
   public Optional<AdminUserWithPermissions> refresh(String token) {
     return loadByToken(token);
   }
@@ -34,7 +34,7 @@ public class CurrentUserService {
   protected Optional<AdminUserWithPermissions> loadByToken(String token) {
     var decodedJWT = JWT.decode(token);
     var email = decodedJWT.getClaim("email").asString();
-    return adminUserDao.findByUsernameWithPermissions(email);
+    return adminUserService.findByUsernameWithPermissions(email);
   }
 
   public void logout(String token) {

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/CurrentUserService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/CurrentUserService.java
@@ -1,13 +1,11 @@
 package bio.terra.pearl.api.admin.service;
 
-import bio.terra.pearl.core.dao.admin.AdminUserDao;
 import bio.terra.pearl.core.model.admin.AdminUserWithPermissions;
 import bio.terra.pearl.core.service.admin.AdminUserService;
 import com.auth0.jwt.JWT;
 import java.time.Instant;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class CurrentUserService {

--- a/core/src/main/java/bio/terra/pearl/core/dao/admin/AdminUserDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/admin/AdminUserDao.java
@@ -24,11 +24,17 @@ public class AdminUserDao extends BaseMutableJdbiDao<AdminUser> {
     }
 
     public Optional<AdminUser> findByUsername(String username) {
-        return findByProperty("username", username);
+        return jdbi.withHandle(handle ->
+                handle.createQuery("select * from " + tableName + " where lower(username) = :username;")
+                        .bind("username", username.toLowerCase())
+                        .mapTo(clazz)
+                        .findOne()
+        );
     }
 
+    /** does a case-insensitive search for the username */
     public Optional<AdminUserWithPermissions> findByUsernameWithPermissions(String username) {
-        Optional<AdminUser> userOpt = findByProperty("username", username);
+        Optional<AdminUser> userOpt = findByUsername(username);
         if (userOpt.isPresent()) {
             return loadWithPermissions(userOpt.get());
         }

--- a/core/src/test/java/bio/terra/pearl/core/service/admin/AdminUserServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/admin/AdminUserServiceTests.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,6 +55,20 @@ public class AdminUserServiceTests extends BaseSpringBootTest {
 
         adminUserService.delete(savedUser.getId(), CascadeProperty.EMPTY_SET);
         assertThat(adminUserService.findByUsername(user.getUsername()).isEmpty(), equalTo(true));
+    }
+
+    @Test
+    @Transactional
+    public void testCaseInsensitiveLookup() {
+        AdminUser user = adminUserFactory.builder("testAdminUserCrud")
+                .username("MixedCaseName@test.co" + RandomStringUtils.randomNumeric(3))
+                .build();
+        adminUserService.create(user);
+
+        assertThat(adminUserService.findByUsername(user.getUsername()).isPresent(), is(true));
+        assertThat(adminUserService.findByUsername(user.getUsername().toUpperCase()).isPresent(), is(true));
+        assertThat(adminUserService.findByUsername(user.getUsername().toLowerCase()).isPresent(), is(true));
+        assertThat(adminUserService.findByUsername(user.getUsername() + "x").isPresent(), is(false));
     }
 
     @Test


### PR DESCRIPTION
#### DESCRIPTION

Upgrades admin logins to be case-insensitive.  Surprisingly difficult to find authoritative information on Microsoft acocunt settings, I suspect because there are about a billion different microsoft credential systems.  But I think we're relatively safe here because (1) The major MS account sources (Outlook, Windows) are case-insensitive and (2) MS admin accounts should generally be within a company domain.  So, e.g. while it might be theoretically possible for some obscure active directory mode to enable`someone@mgh.org` and `someONE@mgh.org` to be different accounts, that's a pretty narrow attack vector, since the attacker would still need admin access to the `mgh.org` OAuth provider to make that account. 

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. Redeploy apiAdminApp
2. login in development mode as both `dbush@broadinstitue.org`  and `DBush@broadinstitute.org`, and observe successes.