### PR TITLE
[JN-657] Handle HttpRequestMethodNotSupportedException properly

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -65,6 +65,7 @@ jobs:
             core/build/test-results/test/*.xml
             populate/build/test-results/test/*.xml
       - name: JUnit test report
+        # Generate a report if the tests fail or succeed, but not if the user cancels
         if: success() || failure()
         uses: dorny/test-reporter@v1
         with:

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -65,6 +65,7 @@ jobs:
             core/build/test-results/test/*.xml
             populate/build/test-results/test/*.xml
       - name: JUnit test report
+        if: success() || failure()
         uses: dorny/test-reporter@v1
         with:
           name: JUnit Tests

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandler.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandler.java
@@ -8,11 +8,13 @@ import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
+
 
 @Slf4j
 @RestControllerAdvice
@@ -56,7 +58,8 @@ public class GlobalExceptionHandler {
   @ExceptionHandler({
     NotFoundException.class,
     javax.ws.rs.NotFoundException.class,
-    bio.terra.pearl.core.service.exception.NotFoundException.class
+    bio.terra.pearl.core.service.exception.NotFoundException.class,
+    HttpRequestMethodNotSupportedException.class
   })
   public ResponseEntity<ErrorReport> notFoundExceptionHandler(Exception ex) {
     return buildErrorReport(ex, HttpStatus.NOT_FOUND, request);

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandler.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandler.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
-
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/GlobalExceptionHandler.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/GlobalExceptionHandler.java
@@ -54,10 +54,7 @@ public class GlobalExceptionHandler {
     return buildErrorReport(ex, HttpStatus.FORBIDDEN, request);
   }
 
-  @ExceptionHandler({
-    NotFoundException.class,
-    HttpRequestMethodNotSupportedException.class
-  })
+  @ExceptionHandler({NotFoundException.class, HttpRequestMethodNotSupportedException.class})
   public ResponseEntity<ErrorReport> notFoundExceptionHandler(Exception ex) {
     return buildErrorReport(ex, HttpStatus.NOT_FOUND, request);
   }

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/GlobalExceptionHandler.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.api.participant.controller;
 
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.InternalServerErrorException;
+import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.exception.ValidationException;
 import bio.terra.pearl.api.participant.model.ErrorReport;
@@ -10,6 +11,7 @@ import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -50,6 +52,14 @@ public class GlobalExceptionHandler {
   })
   public ResponseEntity<ErrorReport> authorizationExceptionHandler(Exception ex) {
     return buildErrorReport(ex, HttpStatus.FORBIDDEN, request);
+  }
+
+  @ExceptionHandler({
+    NotFoundException.class,
+    HttpRequestMethodNotSupportedException.class
+  })
+  public ResponseEntity<ErrorReport> notFoundExceptionHandler(Exception ex) {
+    return buildErrorReport(ex, HttpStatus.NOT_FOUND, request);
   }
 
   // catchall - internal server error


### PR DESCRIPTION
#### DESCRIPTION
Requests to valid endpoints using unsupported methods result in a HttpRequestMethodNotSupportedException. Instances of this are evident in the dev/demo logs: https://portal.azure.com/#@fad90753-2022-4456-9b0a-c7e5b934e408/blade/Microsoft_Azure_Monitoring_Logs/LogsBlade/source/Alerts.EmailLinks/scope/%7B%22resources%22%3A%5B%7B%22resourceId%22%3A%22%2Fsubscriptions%2F385ed569-ca04-4b97-97b4-677c8479585e%2FresourceGroups%2Fddp-aks-dev%2Fproviders%2FMicrosoft.OperationalInsights%2Fworkspaces%2Fddp-aks-dev-logs%22%7D%5D%7D/q/eJxNjsEKgzAQRO%2F9isVTC6GH3nMK3gqCei%2BSTNsISWST2gr9%2BEas6HXnzdtRwafOevA1POjwJXwSvCH4xJMcOo649TH4Y47L%2BXbKzPsJxoKcI0awTRNJSUVZ11VdbJao94q1wKPVUPlvpjZd1GtEetkUqTCXYdYNHHroRK11qO4qONd5I2jd1IQXawhq%2Fn25k4ll5w8%3D/prettify/1/timespan/2023-11-21T00%3a05%3a57.0000000Z%2f2023-11-21T00%3a10%3a57.0000000Z.

Juniper should return NOT_FOUND (404) or METHOD_NOT_ALLOWED (405), instead of 500, which triggers an alert. I chose NOT_FOUND since NOT_ALLOWED requires the response header to include a list of methods that *are* allowed for the endpoint, and that info embedded in the API layer. If that difference seems significant we can probably figure out how to get 405 working.

Also included here is an update to the 'Java CI' test report action, just since I noticed an issue for the test report for this PR. I can unbundle that if needed.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. Start ApiParticipantApp.
2. Using Curl, RestMan, etc., execute a GET request to http://localhost:8081/login. You should see an HTML page.
3. Execute a POST request to the same URL. You should see a 404 response, with an appropriate error message.
4. Check the ApiParticipantApp logs, observing GlobalExceptionHandler handling HttpRequestMethodNotSupportedException.
