### PR TITLE
JN-706: Bringing the nav styling of PopulateRouteSelect and NotificationContent views up to that of EnrolleeView

### DIFF
--- a/ui-admin/src/populate/PopulateRouteSelect.tsx
+++ b/ui-admin/src/populate/PopulateRouteSelect.tsx
@@ -4,26 +4,41 @@ import PopulatePortalControl from './PopulatePortalControl'
 import PopulateSurveyControl from './PopulateSurveyControl'
 import PopulateSiteContentControl from './PopulateSiteContent'
 import PopulateAdminConfig from './PopulateAdminConfig'
+import { navDivStyle, navListItemStyle } from 'util/subNavStyles'
 
 /** shows links to the populate control panels, and handles the routing for them */
 export default function PopulateRouteSelect({ portalShortcode }: {portalShortcode?: string}) {
   /** styles links as bold if they are the current path */
-  const navStyleFunc = ({ isActive }: {isActive: boolean}) => {
-    return isActive ? { fontWeight: 'bold' } : {}
+  function getLinkCssClasses({ isActive }: { isActive: boolean }) {
+    return `${isActive ? "fw-bold" : ""} d-flex align-items-center`;
   }
 
   return <div className="container-fluid">
     <div className="bg-white p-3 ps-5 row">
       <div className="col-md-2 px-0 py-3 mh-100 bg-white border-end">
-        <h2 className="h4 px-3">Populate</h2>
-        <ul className="">
-          <li className="py-1"><NavLink to="portal" style={navStyleFunc}>Portal</NavLink></li>
-          <li className="py-1"><NavLink to="survey" style={navStyleFunc}>Survey</NavLink></li>
-          <li className="py-1">
-            <NavLink to="siteContent" style={navStyleFunc}>Site Content</NavLink>
-          </li>
-          <li className="py-1"><NavLink to="adminConfig" style={navStyleFunc}>Admin config</NavLink></li>
-        </ul>
+        <div className="d-flex">
+          <div style={navDivStyle}>
+            <ul className="list-unstyled">
+              <li style={navListItemStyle} className="ps-3">
+                <NavLink to="." className={getLinkCssClasses}>
+                  Populate
+                </NavLink>
+              </li>
+              <li style={navListItemStyle} className="ps-3">
+                <NavLink to="portal" className={getLinkCssClasses}>Portal</NavLink>
+              </li>
+              <li style={navListItemStyle} className="ps-3">
+                <NavLink to="survey" className={getLinkCssClasses}>Survey</NavLink>
+              </li>
+              <li style={navListItemStyle} className="ps-3">
+                <NavLink to="siteContent" className={getLinkCssClasses}>Site Content</NavLink>
+              </li>
+              <li style={navListItemStyle} className="ps-3">
+                <NavLink to="adminConfig" className={getLinkCssClasses}>Admin config</NavLink>
+              </li>
+            </ul>
+          </div>
+        </div>
       </div>
       <div className="col-md-6 py-3">
         <Routes>

--- a/ui-admin/src/populate/PopulateRouteSelect.tsx
+++ b/ui-admin/src/populate/PopulateRouteSelect.tsx
@@ -15,7 +15,7 @@ export default function PopulateRouteSelect({ portalShortcode }: {portalShortcod
 
   return <div className="container-fluid">
     <div className="bg-white p-3 ps-5 row">
-      <div className="col-md-2 px-0 py-3 mh-100 bg-white border-end">
+      <div className="col-md-2 px-0 py-3 mh-100 bg-white">
         <div className="d-flex">
           <div style={navDivStyle}>
             <ul className="list-unstyled">

--- a/ui-admin/src/populate/PopulateRouteSelect.tsx
+++ b/ui-admin/src/populate/PopulateRouteSelect.tsx
@@ -4,38 +4,29 @@ import PopulatePortalControl from './PopulatePortalControl'
 import PopulateSurveyControl from './PopulateSurveyControl'
 import PopulateSiteContentControl from './PopulateSiteContent'
 import PopulateAdminConfig from './PopulateAdminConfig'
-import { navDivStyle, navListItemStyle } from 'util/subNavStyles'
+import { navDivStyle, navLinkStyleFunc, navListItemStyle } from 'util/subNavStyles'
 import { renderPageHeader } from 'util/pageUtils'
 
 /** shows links to the populate control panels, and handles the routing for them */
 export default function PopulateRouteSelect({ portalShortcode }: {portalShortcode?: string}) {
-  /** styles links as bold if they are the current path */
-  function getLinkCssClasses({ isActive }: { isActive: boolean }) {
-    return `${isActive ? 'fw-bold' : ''} d-flex align-items-center`
-  }
-
   return <div className="container-fluid">
     { renderPageHeader('Populate') }
     <div className="d-flex">
-      <div className="bg-white p-3 ps-5 row">
-        <div className="col-md-2 px-0 py-3 mh-100 bg-white">
-          <div style={navDivStyle}>
-            <ul className="list-unstyled">
-              <li style={navListItemStyle} className="ps-3">
-                <NavLink to="portal" className={getLinkCssClasses}>Portal</NavLink>
-              </li>
-              <li style={navListItemStyle} className="ps-3">
-                <NavLink to="survey" className={getLinkCssClasses}>Survey</NavLink>
-              </li>
-              <li style={navListItemStyle} className="ps-3">
-                <NavLink to="siteContent" className={getLinkCssClasses}>Site Content</NavLink>
-              </li>
-              <li style={navListItemStyle} className="ps-3">
-                <NavLink to="adminConfig" className={getLinkCssClasses}>Admin config</NavLink>
-              </li>
-            </ul>
-          </div>
-        </div>
+      <div style={navDivStyle}>
+        <ul className="list-unstyled">
+          <li style={navListItemStyle} className="ps-3">
+            <NavLink to="portal" style={navLinkStyleFunc}>Portal</NavLink>
+          </li>
+          <li style={navListItemStyle} className="ps-3">
+            <NavLink to="survey" style={navLinkStyleFunc}>Survey</NavLink>
+          </li>
+          <li style={navListItemStyle} className="ps-3">
+            <NavLink to="siteContent" style={navLinkStyleFunc}>Site Content</NavLink>
+          </li>
+          <li style={navListItemStyle} className="ps-3">
+            <NavLink to="adminConfig" style={navLinkStyleFunc}>Admin config</NavLink>
+          </li>
+        </ul>
       </div>
       <div className="flex-grow-1 bg-white p-3">
         <Routes>

--- a/ui-admin/src/populate/PopulateRouteSelect.tsx
+++ b/ui-admin/src/populate/PopulateRouteSelect.tsx
@@ -10,7 +10,7 @@ import { navDivStyle, navListItemStyle } from 'util/subNavStyles'
 export default function PopulateRouteSelect({ portalShortcode }: {portalShortcode?: string}) {
   /** styles links as bold if they are the current path */
   function getLinkCssClasses({ isActive }: { isActive: boolean }) {
-    return `${isActive ? "fw-bold" : ""} d-flex align-items-center`;
+    return `${isActive ? 'fw-bold' : ''} d-flex align-items-center`
   }
 
   return <div className="container-fluid">

--- a/ui-admin/src/populate/PopulateRouteSelect.tsx
+++ b/ui-admin/src/populate/PopulateRouteSelect.tsx
@@ -5,6 +5,7 @@ import PopulateSurveyControl from './PopulateSurveyControl'
 import PopulateSiteContentControl from './PopulateSiteContent'
 import PopulateAdminConfig from './PopulateAdminConfig'
 import { navDivStyle, navListItemStyle } from 'util/subNavStyles'
+import { renderPageHeader } from 'util/pageUtils'
 
 /** shows links to the populate control panels, and handles the routing for them */
 export default function PopulateRouteSelect({ portalShortcode }: {portalShortcode?: string}) {
@@ -14,16 +15,12 @@ export default function PopulateRouteSelect({ portalShortcode }: {portalShortcod
   }
 
   return <div className="container-fluid">
-    <div className="bg-white p-3 ps-5 row">
-      <div className="col-md-2 px-0 py-3 mh-100 bg-white">
-        <div className="d-flex">
+    { renderPageHeader('Populate') }
+    <div className="d-flex">
+      <div className="bg-white p-3 ps-5 row">
+        <div className="col-md-2 px-0 py-3 mh-100 bg-white">
           <div style={navDivStyle}>
             <ul className="list-unstyled">
-              <li style={navListItemStyle} className="ps-3">
-                <NavLink to="." className={getLinkCssClasses}>
-                  Populate
-                </NavLink>
-              </li>
               <li style={navListItemStyle} className="ps-3">
                 <NavLink to="portal" className={getLinkCssClasses}>Portal</NavLink>
               </li>
@@ -40,7 +37,7 @@ export default function PopulateRouteSelect({ portalShortcode }: {portalShortcod
           </div>
         </div>
       </div>
-      <div className="col-md-6 py-3">
+      <div className="flex-grow-1 bg-white p-3">
         <Routes>
           <Route path="portal" element={<PopulatePortalControl/>}/>
           <Route path="survey"

--- a/ui-admin/src/study/notifications/NotificationContent.tsx
+++ b/ui-admin/src/study/notifications/NotificationContent.tsx
@@ -31,7 +31,7 @@ export default function NotificationContent({ studyEnvContext, portalContext }:
   const [showCreateModal, setShowCreateModal] = useState(false)
   /** styles links as bold if they are the current path */
   function getLinkCssClasses({ isActive }: { isActive: boolean }) {
-    return `${isActive ? "fw-bold" : ""} d-flex align-items-center`;
+    return `${isActive ? 'fw-bold' : ''} d-flex align-items-center`
   }
 
   const { isLoading, reload } = useLoadingEffect(async () => {
@@ -54,70 +54,68 @@ export default function NotificationContent({ studyEnvContext, portalContext }:
     setShowCreateModal(false)
   }
 
-  return (
-    <div className="container-fluid px-4 py-2">
-      {renderPageHeader("Participant email configuration")}
-      <div className="d-flex">
-        {isLoading && <LoadingSpinner/>}
-        {!isLoading && <div className="row">
-          <div className="col-md-3 mh-100 bg-white">
-            <div className="d-flex">
-              <div style={navDivStyle}>
-                <ul className="list-unstyled">
-                  <li style={navListItemStyle} className="ps-3">
-                    <NavLink to="." className={getLinkCssClasses}>
-                      Participant Notifications
-                    </NavLink>
+  return <div className="container-fluid px-4 py-2">
+    {renderPageHeader('Participant email configuration')}
+    <div className="d-flex">
+      {isLoading && <LoadingSpinner/>}
+      {!isLoading && <div className="row">
+        <div className="col-md-3 mh-100 bg-white">
+          <div className="d-flex">
+            <div style={navDivStyle}>
+              <ul className="list-unstyled">
+                <li style={navListItemStyle} className="ps-3">
+                  <NavLink to="." className={getLinkCssClasses}>
+                    Participant Notifications
+                  </NavLink>
+                </li>
+                {CONFIG_GROUPS.map(group => (
+                  <li style={navListItemStyle}>
+                    <CollapsableMenu header={group.title} headerClass="text-black" content={
+                      <ul className="list-unstyled p-2">
+                        {configList
+                          .filter(config => config.notificationType === group.type)
+                          .map(config => (
+                            <li key={config.id} className="mb-2">
+                              <div className="d-flex">
+                                <NavLink
+                                  to={`configs/${config.id}`}
+                                  className={getLinkCssClasses}
+                                >
+                                  <NotificationConfigTypeDisplay config={config} />
+                                  <span className="text-muted fst-italic">
+                                    {' '}
+                                    ({deliveryTypeDisplayMap[config.deliveryType]})
+                                  </span>
+                                </NavLink>
+                              </div>
+                            </li>
+                          ))}
+                      </ul>}/>
                   </li>
-                  {CONFIG_GROUPS.map((group) => (
-                    <li style={navListItemStyle}>
-                      <CollapsableMenu header={group.title} headerClass="text-black" content={
-                        <ul className="list-unstyled p-2">
-                          {configList
-                            .filter((config) => config.notificationType === group.type)
-                            .map((config) => (
-                              <li key={config.id} className="mb-2">
-                                <div className="d-flex">
-                                  <NavLink
-                                    to={`configs/${config.id}`}
-                                    className={getLinkCssClasses}
-                                  >
-                                    <NotificationConfigTypeDisplay config={config} />
-                                    <span className="text-muted fst-italic">
-                                      {" "}
-                                      ({deliveryTypeDisplayMap[config.deliveryType]})
-                                    </span>
-                                  </NavLink>
-                                </div>
-                              </li>
-                            ))}
-                        </ul>}/>
-                    </li>
-                  ))}
-                  <li style={navListItemStyle} className="ps-3">
-                    <button
-                      className="btn btn-secondary"
-                      onClick={() => setShowCreateModal(true)}
-                    >
-                      <FontAwesomeIcon icon={faPlus} /> Add
-                    </button>
-                  </li>
-                </ul>
-              </div>
+                ))}
+                <li style={navListItemStyle} className="ps-3">
+                  <button
+                    className="btn btn-secondary"
+                    onClick={() => setShowCreateModal(true)}
+                  >
+                    <FontAwesomeIcon icon={faPlus} /> Add
+                  </button>
+                </li>
+              </ul>
             </div>
           </div>
-        </div> }
-        <div className="flex-grow-1 bg-white p-3">
-          <Routes>
-            <Route path="configs/:configId"
-              element={<NotificationConfigView studyEnvContext={studyEnvContext} portalContext={portalContext}/>}/>
-          </Routes>
-          <Outlet/>
         </div>
-        { showCreateModal && <CreateNotificationConfigModal studyEnvParams={paramsFromContext(studyEnvContext)}
-          onDismiss={() => setShowCreateModal(false)} onCreate={onCreate}
-        /> }
+      </div> }
+      <div className="flex-grow-1 bg-white p-3">
+        <Routes>
+          <Route path="configs/:configId"
+            element={<NotificationConfigView studyEnvContext={studyEnvContext} portalContext={portalContext}/>}/>
+        </Routes>
+        <Outlet/>
       </div>
+      { showCreateModal && <CreateNotificationConfigModal studyEnvParams={paramsFromContext(studyEnvContext)}
+        onDismiss={() => setShowCreateModal(false)} onCreate={onCreate}
+      /> }
     </div>
-  );
+  </div>
 }

--- a/ui-admin/src/study/notifications/NotificationContent.tsx
+++ b/ui-admin/src/study/notifications/NotificationContent.tsx
@@ -68,37 +68,29 @@ export default function NotificationContent({ studyEnvContext, portalContext }:
                     Participant Notifications
                   </NavLink>
                 </li>
-                {CONFIG_GROUPS.map(group => (
-                  <li style={navListItemStyle}>
-                    <CollapsableMenu header={group.title} headerClass="text-black" content={
-                      <ul className="list-unstyled p-2">
-                        {configList
-                          .filter(config => config.notificationType === group.type)
-                          .map(config => (
-                            <li key={config.id} className="mb-2">
-                              <div className="d-flex">
-                                <NavLink
-                                  to={`configs/${config.id}`}
-                                  className={getLinkCssClasses}
-                                >
-                                  <NotificationConfigTypeDisplay config={config} />
-                                  <span className="text-muted fst-italic">
-                                    {' '}
-                                    ({deliveryTypeDisplayMap[config.deliveryType]})
-                                  </span>
-                                </NavLink>
-                              </div>
-                            </li>
-                          ))}
-                      </ul>}/>
-                  </li>
-                ))}
+                {CONFIG_GROUPS.map(group => <li style={navListItemStyle}>
+                  <CollapsableMenu header={group.title} headerClass="text-black" content={
+                    <ul className="list-unstyled p-2">
+                      { configList
+                        .filter(config => config.notificationType === group.type)
+                        .map(config => <li key={config.id} className="mb-2">
+                          <div className="d-flex">
+                            <NavLink to={`configs/${config.id}`} className={getLinkCssClasses}>
+                              <NotificationConfigTypeDisplay config={config} />
+                              <span className="text-muted fst-italic">
+                                {' '}
+                                ({deliveryTypeDisplayMap[config.deliveryType]})
+                              </span>
+                            </NavLink>
+                          </div>
+                        </li>
+                        ) }
+                    </ul>}
+                  />
+                </li>)}
                 <li style={navListItemStyle} className="ps-3">
-                  <button
-                    className="btn btn-secondary"
-                    onClick={() => setShowCreateModal(true)}
-                  >
-                    <FontAwesomeIcon icon={faPlus} /> Add
+                  <button className="btn btn-secondary" onClick={() => setShowCreateModal(true)}>
+                    <FontAwesomeIcon icon={faPlus}/> Add
                   </button>
                 </li>
               </ul>

--- a/ui-admin/src/study/notifications/NotificationContent.tsx
+++ b/ui-admin/src/study/notifications/NotificationContent.tsx
@@ -3,7 +3,7 @@ import { NavLink, Outlet, Route, Routes, useNavigate } from 'react-router-dom'
 import NotificationConfigTypeDisplay, { deliveryTypeDisplayMap } from './NotifcationConfigTypeDisplay'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus'
-import { StudyEnvContextT, paramsFromContext } from '../StudyEnvironmentRouter'
+import { paramsFromContext, StudyEnvContextT } from '../StudyEnvironmentRouter'
 import NotificationConfigView from './NotificationConfigView'
 import { renderPageHeader } from 'util/pageUtils'
 import { LoadedPortalContextT } from '../../portal/PortalProvider'
@@ -16,8 +16,8 @@ import { navDivStyle, navListItemStyle } from 'util/subNavStyles'
 import CollapsableMenu from 'navbar/CollapsableMenu'
 
 const CONFIG_GROUPS = [
-  { title: 'Event', type: 'EVENT' },
-  { title: 'Reminder', type: 'TASK_REMINDER' },
+  { title: 'Events', type: 'EVENT' },
+  { title: 'Participant Reminders', type: 'TASK_REMINDER' },
   { title: 'Ad-hoc', type: 'AD_HOC' }
 ]
 
@@ -56,10 +56,11 @@ export default function NotificationContent({ studyEnvContext, portalContext }:
 
   return (
     <div className="container-fluid px-4 py-2">
-      {renderPageHeader("Emails & Notifications")}
+      {renderPageHeader("Participant email configuration")}
       <div className="d-flex">
-        <div className="row">
-          <div className="col-md-3 mh-100 bg-white border-end">
+        {isLoading && <LoadingSpinner/>}
+        {!isLoading && <div className="row">
+          <div className="col-md-3 mh-100 bg-white">
             <div className="d-flex">
               <div style={navDivStyle}>
                 <ul className="list-unstyled">
@@ -71,8 +72,8 @@ export default function NotificationContent({ studyEnvContext, portalContext }:
                   {CONFIG_GROUPS.map((group) => (
                     <li style={navListItemStyle}>
                       <CollapsableMenu header={group.title} headerClass="text-black" content={
-                        <ul className="list-unstyled">
-                          {currentEnv.notificationConfigs
+                        <ul className="list-unstyled p-2">
+                          {configList
                             .filter((config) => config.notificationType === group.type)
                             .map((config) => (
                               <li key={config.id} className="mb-2">
@@ -96,7 +97,7 @@ export default function NotificationContent({ studyEnvContext, portalContext }:
                   <li style={navListItemStyle} className="ps-3">
                     <button
                       className="btn btn-secondary"
-                      onClick={() => alert("not yet implemented")}
+                      onClick={() => setShowCreateModal(true)}
                     >
                       <FontAwesomeIcon icon={faPlus} /> Add
                     </button>
@@ -105,7 +106,7 @@ export default function NotificationContent({ studyEnvContext, portalContext }:
               </div>
             </div>
           </div>
-        </div>
+        </div> }
         <div className="flex-grow-1 bg-white p-3">
           <Routes>
             <Route path="configs/:configId"

--- a/ui-admin/src/study/notifications/NotificationContent.tsx
+++ b/ui-admin/src/study/notifications/NotificationContent.tsx
@@ -55,46 +55,44 @@ export default function NotificationContent({ studyEnvContext, portalContext }:
   }
 
   return <div className="container-fluid px-4 py-2">
-    {renderPageHeader('Participant email configuration')}
+    { renderPageHeader('Participant email configuration') }
     <div className="d-flex">
       {isLoading && <LoadingSpinner/>}
       {!isLoading && <div className="row">
         <div className="col-md-3 mh-100 bg-white">
-          <div className="d-flex">
-            <div style={navDivStyle}>
-              <ul className="list-unstyled">
-                <li style={navListItemStyle} className="ps-3">
-                  <NavLink to="." className={getLinkCssClasses}>
-                    Participant Notifications
-                  </NavLink>
-                </li>
-                {CONFIG_GROUPS.map(group => <li style={navListItemStyle}>
-                  <CollapsableMenu header={group.title} headerClass="text-black" content={
-                    <ul className="list-unstyled p-2">
-                      { configList
-                        .filter(config => config.notificationType === group.type)
-                        .map(config => <li key={config.id} className="mb-2">
-                          <div className="d-flex">
-                            <NavLink to={`configs/${config.id}`} className={getLinkCssClasses}>
-                              <NotificationConfigTypeDisplay config={config} />
-                              <span className="text-muted fst-italic">
-                                {' '}
-                                ({deliveryTypeDisplayMap[config.deliveryType]})
-                              </span>
-                            </NavLink>
-                          </div>
-                        </li>
-                        ) }
-                    </ul>}
-                  />
-                </li>)}
-                <li style={navListItemStyle} className="ps-3">
-                  <button className="btn btn-secondary" onClick={() => setShowCreateModal(true)}>
-                    <FontAwesomeIcon icon={faPlus}/> Add
-                  </button>
-                </li>
-              </ul>
-            </div>
+          <div style={navDivStyle}>
+            <ul className="list-unstyled">
+              <li style={navListItemStyle} className="ps-3">
+                <NavLink to="." className={getLinkCssClasses}>
+                  Participant Notifications
+                </NavLink>
+              </li>
+              { CONFIG_GROUPS.map(group => <li style={navListItemStyle}>
+                <CollapsableMenu header={group.title} headerClass="text-black" content={
+                  <ul className="list-unstyled p-2">
+                    { configList
+                      .filter(config => config.notificationType === group.type)
+                      .map(config => <li key={config.id} className="mb-2">
+                        <div className="d-flex">
+                          <NavLink to={`configs/${config.id}`} className={getLinkCssClasses}>
+                            <NotificationConfigTypeDisplay config={config} />
+                            <span className="text-muted fst-italic">
+                              {' '}
+                              ({deliveryTypeDisplayMap[config.deliveryType]})
+                            </span>
+                          </NavLink>
+                        </div>
+                      </li>
+                      ) }
+                  </ul>}
+                />
+              </li>)}
+              <li style={navListItemStyle} className="ps-3">
+                <button className="btn btn-secondary" onClick={() => setShowCreateModal(true)}>
+                  <FontAwesomeIcon icon={faPlus}/> Add
+                </button>
+              </li>
+            </ul>
           </div>
         </div>
       </div> }

--- a/ui-admin/src/study/notifications/NotificationContent.tsx
+++ b/ui-admin/src/study/notifications/NotificationContent.tsx
@@ -70,11 +70,8 @@ export default function NotificationContent({ studyEnvContext, portalContext }:
                       .map(config => <li key={config.id} className="mb-2">
                         <div className="d-flex">
                           <NavLink to={`configs/${config.id}`} className={getLinkCssClasses}>
-                            <NotificationConfigTypeDisplay config={config} />
-                            <span className="text-muted fst-italic">
-                              {' '}
-                              ({deliveryTypeDisplayMap[config.deliveryType]})
-                            </span>
+                            <NotificationConfigTypeDisplay config={config}/>
+                            <span className="text-muted fst-italic"> ({deliveryTypeDisplayMap[config.deliveryType]})</span>
                           </NavLink>
                         </div>
                       </li>

--- a/ui-admin/src/study/notifications/NotificationContent.tsx
+++ b/ui-admin/src/study/notifications/NotificationContent.tsx
@@ -12,7 +12,7 @@ import Api from 'api/api'
 import { useLoadingEffect } from 'api/api-utils'
 import LoadingSpinner from 'util/LoadingSpinner'
 import CreateNotificationConfigModal from './CreateNotificationConfigModal'
-import { navDivStyle, navListItemStyle } from 'util/subNavStyles'
+import { navDivStyle, navLinkStyleFunc, navListItemStyle } from 'util/subNavStyles'
 import CollapsableMenu from 'navbar/CollapsableMenu'
 
 const CONFIG_GROUPS = [
@@ -29,10 +29,6 @@ export default function NotificationContent({ studyEnvContext, portalContext }:
   const [configList, setConfigList] = useState<NotificationConfig[]>([])
   const [previousEnv, setPreviousEnv] = useState<string>(currentEnv.environmentName)
   const [showCreateModal, setShowCreateModal] = useState(false)
-  /** styles links as bold if they are the current path */
-  function getLinkCssClasses({ isActive }: { isActive: boolean }) {
-    return `${isActive ? 'fw-bold' : ''} d-flex align-items-center`
-  }
 
   const { isLoading, reload } = useLoadingEffect(async () => {
     const configList = await Api.findNotificationConfigsForStudyEnv(portalContext.portal.shortcode,
@@ -58,35 +54,32 @@ export default function NotificationContent({ studyEnvContext, portalContext }:
     { renderPageHeader('Participant email configuration') }
     <div className="d-flex">
       {isLoading && <LoadingSpinner/>}
-      {!isLoading && <div className="row">
-        <div className="col-md-3 mh-100 bg-white">
-          <div style={navDivStyle}>
-            <ul className="list-unstyled">
-              { CONFIG_GROUPS.map(group => <li style={navListItemStyle}>
-                <CollapsableMenu header={group.title} headerClass="text-black" content={
-                  <ul className="list-unstyled p-2">
-                    { configList
-                      .filter(config => config.notificationType === group.type)
-                      .map(config => <li key={config.id} className="mb-2">
-                        <div className="d-flex">
-                          <NavLink to={`configs/${config.id}`} className={getLinkCssClasses}>
-                            <NotificationConfigTypeDisplay config={config}/>
-                            <span className="text-muted fst-italic"> ({deliveryTypeDisplayMap[config.deliveryType]})</span>
-                          </NavLink>
-                        </div>
-                      </li>
-                      ) }
-                  </ul>}
-                />
-              </li>)}
-              <li style={navListItemStyle} className="ps-3">
-                <button className="btn btn-secondary" onClick={() => setShowCreateModal(true)}>
-                  <FontAwesomeIcon icon={faPlus}/> Add
-                </button>
-              </li>
-            </ul>
-          </div>
-        </div>
+      {!isLoading && <div style={navDivStyle}>
+        <ul className="list-unstyled">
+          { CONFIG_GROUPS.map(group => <li style={navListItemStyle}>
+            <CollapsableMenu header={group.title} headerClass="text-black" content={
+              <ul className="list-unstyled p-2">
+                { configList
+                  .filter(config => config.notificationType === group.type)
+                  .map(config => <li key={config.id} className="mb-2">
+                    <div className="d-flex">
+                      <NavLink to={`configs/${config.id}`} style={navLinkStyleFunc}>
+                        <NotificationConfigTypeDisplay config={config}/>
+                        <span
+                          className="text-muted fst-italic"> ({deliveryTypeDisplayMap[config.deliveryType]})</span>
+                      </NavLink>
+                    </div>
+                  </li>
+                  ) }
+              </ul>}
+            />
+          </li>)}
+          <li style={navListItemStyle} className="ps-3">
+            <button className="btn btn-secondary" onClick={() => setShowCreateModal(true)}>
+              <FontAwesomeIcon icon={faPlus}/> Add
+            </button>
+          </li>
+        </ul>
       </div> }
       <div className="flex-grow-1 bg-white p-3">
         <Routes>

--- a/ui-admin/src/study/notifications/NotificationContent.tsx
+++ b/ui-admin/src/study/notifications/NotificationContent.tsx
@@ -74,11 +74,11 @@ export default function NotificationContent({ studyEnvContext, portalContext }:
               </ul>}
             />
           </li>)}
-          <li style={navListItemStyle} className="ps-3">
+          { currentEnv.environmentName == 'sandbox' && <li style={navListItemStyle} className="ps-3">
             <button className="btn btn-secondary" onClick={() => setShowCreateModal(true)}>
               <FontAwesomeIcon icon={faPlus}/> Add
             </button>
-          </li>
+          </li> }
         </ul>
       </div> }
       <div className="flex-grow-1 bg-white p-3">

--- a/ui-admin/src/study/notifications/NotificationContent.tsx
+++ b/ui-admin/src/study/notifications/NotificationContent.tsx
@@ -62,11 +62,6 @@ export default function NotificationContent({ studyEnvContext, portalContext }:
         <div className="col-md-3 mh-100 bg-white">
           <div style={navDivStyle}>
             <ul className="list-unstyled">
-              <li style={navListItemStyle} className="ps-3">
-                <NavLink to="." className={getLinkCssClasses}>
-                  Participant Notifications
-                </NavLink>
-              </li>
               { CONFIG_GROUPS.map(group => <li style={navListItemStyle}>
                 <CollapsableMenu header={group.title} headerClass="text-black" content={
                   <ul className="list-unstyled p-2">


### PR DESCRIPTION
#### DESCRIPTION
Updating the styling of the navigation bar of NotificationContent.tsx and PopulateRouteSelect.tsx. It now more closely matches that of EnrolleeView.tsx.

Here are screenshots showing the new UI:
![juniper-notification](https://github.com/broadinstitute/juniper/assets/426396/eeee7075-4628-4c0d-b4ac-fa4461140ff6)
![juniper-populate](https://github.com/broadinstitute/juniper/assets/426396/8d8963a4-175d-405c-995b-731e61c2321b)



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
Just navigate to either views and inspect the left-side navigation bar.
https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/notificationContent
https://localhost:3000/populate
