### PR TITLE
JN-741 Deselect participants when successfully requesting sample kits

### DIFF
--- a/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
+++ b/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
@@ -69,10 +69,12 @@ export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvCont
     setEnrollees(enrolleeRows)
   }, [studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName])
 
-  const onSubmit = async (success: boolean) => {
+  const onSubmit = async (anyKitWasCreated: boolean) => {
     setShowRequestKitModal(false)
     reload()
-    if (success) {
+    if (anyKitWasCreated) {
+      /** if any kits were created, that changes the filter state of the table
+       and could result in hidden items still being selected. Clear the selections to be safe */
       table.toggleAllRowsSelected(false)
     }
   }

--- a/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
+++ b/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
@@ -69,9 +69,12 @@ export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvCont
     setEnrollees(enrolleeRows)
   }, [studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName])
 
-  const onSubmit = async () => {
+  const onSubmit = async (success: boolean) => {
     setShowRequestKitModal(false)
     reload()
+    if (success) {
+      table.toggleAllRowsSelected(false)
+    }
   }
   const enrolleesSelected = Object.keys(rowSelection)
     .filter(key => rowSelection[key])

--- a/ui-admin/src/study/kits/RequestKitsModal.tsx
+++ b/ui-admin/src/study/kits/RequestKitsModal.tsx
@@ -18,13 +18,14 @@ export default function RequestKitsModal({
     studyEnvContext: StudyEnvContextT,
     onDismiss: () => void,
     enrolleeShortcodes: string[],
-    onSubmit: () => void }) {
+    onSubmit: (success: boolean) => void }) {
   const { portal, study, currentEnv } = studyEnvContext
   const [isLoading, setIsLoading] = useState(false)
 
   const { kitType, KitSelect } = useKitTypeSelect(paramsFromContext(studyEnvContext))
   const handleSubmit = async () => {
     doApiLoad(async () => {
+      let success = false
       const response = await Api.requestKits(portal.shortcode, study.shortcode, currentEnv.environmentName,
         enrolleeShortcodes, kitType)
       if (response.exceptions.length) {
@@ -37,8 +38,9 @@ export default function RequestKitsModal({
         Store.addNotification(successNotification(
                     `${response.kitRequests.length} kit requests created`
         ))
+        success = true
       }
-      onSubmit()
+      onSubmit(success)
     }, { setIsLoading })
   }
   const kitPluralized = pluralize('kit', enrolleeShortcodes.length)

--- a/ui-admin/src/study/kits/RequestKitsModal.tsx
+++ b/ui-admin/src/study/kits/RequestKitsModal.tsx
@@ -18,14 +18,13 @@ export default function RequestKitsModal({
     studyEnvContext: StudyEnvContextT,
     onDismiss: () => void,
     enrolleeShortcodes: string[],
-    onSubmit: (success: boolean) => void }) {
+    onSubmit: (anyKitWasCreated: boolean) => void }) {
   const { portal, study, currentEnv } = studyEnvContext
   const [isLoading, setIsLoading] = useState(false)
 
   const { kitType, KitSelect } = useKitTypeSelect(paramsFromContext(studyEnvContext))
   const handleSubmit = async () => {
     doApiLoad(async () => {
-      let success = false
       const response = await Api.requestKits(portal.shortcode, study.shortcode, currentEnv.environmentName,
         enrolleeShortcodes, kitType)
       if (response.exceptions.length) {
@@ -38,9 +37,8 @@ export default function RequestKitsModal({
         Store.addNotification(successNotification(
                     `${response.kitRequests.length} kit requests created`
         ))
-        success = true
       }
-      onSubmit(success)
+      onSubmit(!!response.kitRequests.length)
     }, { setIsLoading })
   }
   const kitPluralized = pluralize('kit', enrolleeShortcodes.length)


### PR DESCRIPTION
#### DESCRIPTION
If any kits have been successfully requested for participants, it will now deselect all participants from the KitEnrolleeSelection view. If none were successful, the current selection will be maintained


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
Go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/kits/eligible
and select one or more participants and click "Send sample collection kit". In the modal that appears, press "Request Kits". If a kit was sent successfully, the table should have no one selected. If no kits were successful, it should keep the selection
