### PR TITLE
JN-745: fixing study settings bug

### DIFF
--- a/ui-admin/src/portal/PortalEnvConfigView.test.tsx
+++ b/ui-admin/src/portal/PortalEnvConfigView.test.tsx
@@ -22,6 +22,29 @@ test('renders a portal env. config', async () => {
     .toBe(envConfig.acceptingRegistration)
 })
 
+test('changes state when portal env changes', async () => {
+  const portalContext = mockPortalContext()
+  const portalEnv = portalContext.portal?.portalEnvironments[0] as PortalEnvironment
+  const envConfig = portalEnv.portalEnvironmentConfig
+  const { rerender } = render(<MockSuperuserProvider>
+    <PortalEnvConfigView portalContext={portalContext} portalEnv={portalEnv}/>
+  </MockSuperuserProvider>)
+
+  expect(screen.getByLabelText('password')).toHaveValue(envConfig.password)
+  const differentEnv = {
+    ...portalEnv,
+    portalEnvironmentConfig: {
+      ...portalEnv.portalEnvironmentConfig,
+      password: 'newPass3'
+    },
+    environmentName: 'irb'
+  }
+  rerender(<MockSuperuserProvider>
+    <PortalEnvConfigView portalContext={portalContext} portalEnv={differentEnv}/>
+  </MockSuperuserProvider>)
+  expect(screen.getByLabelText('password')).toHaveValue('newPass3')
+})
+
 test('updates a portal env. config', async () => {
   const portalContext = mockPortalContext()
   const portalEnv = portalContext.portal?.portalEnvironments[0] as PortalEnvironment

--- a/ui-admin/src/portal/PortalEnvConfigView.tsx
+++ b/ui-admin/src/portal/PortalEnvConfigView.tsx
@@ -8,6 +8,7 @@ import { set } from 'lodash/fp'
 import { LoadedPortalContextT } from './PortalProvider'
 import { doApiLoad } from 'api/api-utils'
 import LoadingSpinner from '../util/LoadingSpinner'
+import useUpdateEffect from '../util/useUpdateEffect'
 
 
 type PortalEnvConfigViewProps = {
@@ -27,6 +28,9 @@ const PortalEnvConfigView = ({ portalContext, portalEnv }: PortalEnvConfigViewPr
   const updateConfig = (propName: string, value: string | boolean) => {
     setConfig(set(propName, value))
   }
+  useUpdateEffect(() => {
+    setConfig(portalEnv.portalEnvironmentConfig)
+  }, [portalContext.portal.shortcode, portalEnv.environmentName])
   /** saves any changes to the server */
   const save = async (e: React.MouseEvent) => {
     e.preventDefault()
@@ -48,7 +52,7 @@ const PortalEnvConfigView = ({ portalContext, portalEnv }: PortalEnvConfigViewPr
     </div>
     <div>
       <label className="form-label">
-      password <input type="text" className="form-control" value={config.password}
+      password <input type="text" className="form-control" value={config.password ?? ''}
           onChange={e => updateConfig('password', e.target.value)}/>
       </label>
     </div>
@@ -62,14 +66,14 @@ const PortalEnvConfigView = ({ portalContext, portalEnv }: PortalEnvConfigViewPr
     <div>
       <label className="form-label">
       participant hostname
-        <input type="text" className="form-control" value={config.participantHostname}
+        <input type="text" className="form-control" value={config.participantHostname ?? ''}
           onChange={e => updateConfig('participantHostname', e.target.value)}/>
       </label>
     </div>
     <div>
       <label className="form-label">
       Email source address
-        <input type="text" className="form-control" value={config.emailSourceAddress}
+        <input type="text" className="form-control" value={config.emailSourceAddress ?? ''}
           onChange={e => updateConfig('emailSourceAddress', e.target.value)}/>
       </label>
     </div>

--- a/ui-admin/src/study/StudySettings.test.tsx
+++ b/ui-admin/src/study/StudySettings.test.tsx
@@ -20,6 +20,31 @@ test('renders a study env. config', async () => {
     .toBe(expectedConfig.passwordProtected)
 })
 
+test('updates display when study env. changes', async () => {
+  const portalContext = mockPortalContext()
+  const studyEnvContext = mockStudyEnvContext()
+  const expectedConfig = studyEnvContext.currentEnv.studyEnvironmentConfig
+  const { rerender } = render(<MockSuperuserProvider>
+    <StudyEnvConfigView portalContext={portalContext} studyEnvContext={studyEnvContext}/>
+  </MockSuperuserProvider>)
+  expect(screen.getByLabelText('password')).toHaveValue(expectedConfig.password)
+  const differentEnvContext = {
+    ...studyEnvContext,
+    currentEnv: {
+      ...studyEnvContext.currentEnv,
+      studyEnvironmentConfig: {
+        ...studyEnvContext.currentEnv.studyEnvironmentConfig,
+        password: 'newPass3'
+      },
+      environmentName: 'irb'
+    }
+  }
+  rerender(<MockSuperuserProvider>
+    <StudyEnvConfigView portalContext={portalContext} studyEnvContext={differentEnvContext}/>
+  </MockSuperuserProvider>)
+  expect(screen.getByLabelText('password')).toHaveValue('newPass3')
+})
+
 test('updates a study env. config', async () => {
   const portalContext = mockPortalContext()
   const studyEnvContext = mockStudyEnvContext()
@@ -34,3 +59,4 @@ test('updates a study env. config', async () => {
   expect(input).toHaveValue('newPass')
   expect(screen.getByText('Save study config')).toHaveAttribute('aria-disabled', 'false')
 })
+

--- a/ui-admin/src/study/StudySettings.tsx
+++ b/ui-admin/src/study/StudySettings.tsx
@@ -12,6 +12,7 @@ import { successNotification } from 'util/notifications'
 import LoadingSpinner from 'util/LoadingSpinner'
 import { renderPageHeader } from 'util/pageUtils'
 import InfoPopup from '../components/forms/InfoPopup'
+import useUpdateEffect from '../util/useUpdateEffect'
 
 /** shows settings for both a study and its containing portal */
 export default function StudySettings({ studyEnvContext, portalContext }:
@@ -37,6 +38,10 @@ export function StudyEnvConfigView({ studyEnvContext, portalContext }:
     setConfig(set(propName, value))
   }
 
+  useUpdateEffect(() => {
+    setConfig(studyEnvContext.currentEnv.studyEnvironmentConfig)
+  }, [studyEnvContext.currentEnv.environmentName, studyEnvContext.study.shortcode])
+
   /** saves any changes to the server */
   const save = async () => {
     doApiLoad(async () => {
@@ -58,7 +63,7 @@ export function StudyEnvConfigView({ studyEnvContext, portalContext }:
     </div>
     <div>
       <label className="form-label">
-        password <input type="text" className="form-control" value={config.password}
+        password <input type="text" className="form-control" value={config.password ?? ''}
           onChange={e => updateConfig('password', e.target.value)}/>
       </label>
     </div>


### PR DESCRIPTION
#### DESCRIPTION

Previously, changing the environment on the Study Settings page could leave stale values populated in the form.  This is because we weren't clearing the form state when the environment or study changed, and also because sometimes we were passing `undefined` as the value to text fields, which results in it becoming an uncontrolled field.

This was my first time using the `rerender` function in react tests -- this let me easily test how the component behaves when rerendered with different props.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. repopulate OurHealth. `./scripts/populate_portal.sh ourhealth`
2. go to `https://localhost:3000/ourhealth/studies/ourheart/env/live/settings`
3. note the "Email source address" (the bottom-most form field) is empty
4. switch the environment to 'sandbox' 
5. confirm the "Email source address" now shows "info@ourhealthstudy.org"
