### PR TITLE
JN-746 fixing consent history display

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConsentFormController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConsentFormController.java
@@ -29,6 +29,20 @@ public class ConsentFormController implements ConsentFormApi {
   }
 
   @Override
+  public ResponseEntity<Object> get(String portalShortcode, String stableId, Integer version) {
+    AdminUser adminUser = authUtilService.requireAdminUser(request);
+    ConsentForm form = consentFormExtService.get(portalShortcode, stableId, version, adminUser);
+    return ResponseEntity.ok(form);
+  }
+
+  @Override
+  public ResponseEntity<Object> getAllVersions(String portalShortcode, String stableId) {
+    AdminUser adminUser = authUtilService.requireAdminUser(request);
+    return ResponseEntity.ok(
+        consentFormExtService.listVersions(portalShortcode, stableId, adminUser));
+  }
+
+  @Override
   public ResponseEntity<Object> newVersion(String portalShortcode, String stableId, Object body) {
     AdminUser adminUser = authUtilService.requireAdminUser(request);
     ConsentForm consentForm = objectMapper.convertValue(body, ConsentForm.class);

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/ConsentFormExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/ConsentFormExtService.java
@@ -10,6 +10,7 @@ import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.service.consent.ConsentFormService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentConsentService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
+import java.util.List;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 
@@ -41,6 +42,25 @@ public class ConsentFormExtService {
     Portal portal = authUtilService.authUserToPortal(user, portalShortcode);
     consentForm.setPortalId(portal.getId());
     return consentFormService.create(consentForm);
+  }
+
+  public ConsentForm get(
+      String portalShortcode, String stableId, int version, AdminUser adminUser) {
+    Portal portal = authUtilService.authUserToPortal(adminUser, portalShortcode);
+    ConsentForm form = authUtilService.authConsentFormToPortal(portal, stableId, version);
+    return form;
+  }
+
+  public List<ConsentForm> listVersions(
+      String portalShortcode, String stableId, AdminUser adminUser) {
+    Portal portal = authUtilService.authUserToPortal(adminUser, portalShortcode);
+    // This is used to populate the version selector in the admin UI. It's not necessary
+    // to return the surveys with any content or answer mappings, the response will
+    // be too large. Instead, just get the individual versions as content is needed.
+    List<ConsentForm> forms = consentFormService.findByStableIdNoContent(stableId);
+    List<ConsentForm> formsInPortal =
+        forms.stream().filter(form -> portal.getId().equals(form.getPortalId())).toList();
+    return formsInPortal;
   }
 
   public StudyEnvironmentConsent updateConfiguredConsent(

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -182,19 +182,6 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/surveys/{stableId}:
-    get:
-      summary: gets all versions of the requested survey
-      tags: [ survey ]
-      operationId: getAllVersions
-      parameters:
-        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
-        - { name: stableId, in: path, required: true, schema: { type: string } }
-      responses:
-        '200':
-          description: list of survey version metadata
-          content: { application/json: { schema: { type: object } } }
-        '500':
-          $ref: '#/components/responses/ServerError'
     delete:
       summary: deletes the specified survey, will fail if the survey has any responses or is in use by a non-sandbox environment
       tags: [ survey ]
@@ -205,6 +192,20 @@ paths:
       responses:
         '204':
           description: No Content
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/surveys/{stableId}/metadata:
+    get:
+      summary: gets metadata for all versions of the requested survey
+      tags: [ survey ]
+      operationId: getAllVersions
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: stableId, in: path, required: true, schema: { type: string } }
+      responses:
+        '200':
+          description: list of survey version metadata
+          content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/surveys:
@@ -291,6 +292,21 @@ paths:
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
+
+  /api/portals/v1/{portalShortcode}/consentForms/{stableId}/metadata:
+    get:
+      summary: gets metadata for all versions of the requested form
+      tags: [ consentForm ]
+      operationId: getAllVersions
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: stableId, in: path, required: true, schema: { type: string } }
+      responses:
+        '200':
+          description: list of consentForm version metadata
+          content: { application/json: { schema: { type: object } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/consentForms/{stableId}/{version}:
     get:
       summary: gets the requested form
@@ -307,19 +323,6 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/consentForms/{stableId}:
-    get:
-      summary: gets all versions of the requested form
-      tags: [ consentForm ]
-      operationId: getAllVersions
-      parameters:
-        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
-        - { name: stableId, in: path, required: true, schema: { type: string } }
-      responses:
-        '200':
-          description: list of consentForm version metadata
-          content: { application/json: { schema: { type: object } } }
-        '500':
-          $ref: '#/components/responses/ServerError'
     post:
       summary: Saves a new consentForm with anew stableId as a new form -- will be assigned version 1
       tags: [ consentForm ]

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -291,6 +291,51 @@ paths:
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/consentForms/{stableId}/{version}:
+    get:
+      summary: gets the requested form
+      tags: [ consentForm ]
+      operationId: get
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: stableId, in: path, required: true, schema: { type: string } }
+        - { name: version, in: path, required: true, schema: { type: integer } }
+      responses:
+        '200':
+          description: consentForm object
+          content: { application/json: { schema: { type: object } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/consentForms/{stableId}:
+    get:
+      summary: gets all versions of the requested form
+      tags: [ consentForm ]
+      operationId: getAllVersions
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: stableId, in: path, required: true, schema: { type: string } }
+      responses:
+        '200':
+          description: list of consentForm version metadata
+          content: { application/json: { schema: { type: object } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
+    post:
+      summary: Saves a new consentForm with anew stableId as a new form -- will be assigned version 1
+      tags: [ consentForm ]
+      operationId: create
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: stableId, in: path, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content: { application/json: { schema: { type: object } } }
+      responses:
+        '200':
+          description: saved consentForm object
+          content: { application/json: { schema: { type: object } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/consentForms/{stableId}/{version}/newVersion:
     post:
       summary: Saves the consentForm as a new version
@@ -304,24 +349,7 @@ paths:
         content: { application/json: { schema: { type: object } } }
       responses:
         '200':
-          description: saved survey object
-          content: { application/json: { schema: { type: object } } }
-        '500':
-          $ref: '#/components/responses/ServerError'
-  /api/portals/v1/{portalShortcode}/consentForms/{stableId}:
-    post:
-      summary: Saves a new consentForm with anew stableId as a new form -- will be assigned version 1
-      tags: [ consentForm ]
-      operationId: create
-      parameters:
-        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
-        - { name: stableId, in: path, required: true, schema: { type: string } }
-      requestBody:
-        required: true
-        content: { application/json: { schema: { type: object } } }
-      responses:
-        '200':
-          description: saved survey object
+          description: saved consentForm object
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/MockAuthServiceAlwaysRejects.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/MockAuthServiceAlwaysRejects.java
@@ -7,7 +7,7 @@ import bio.terra.pearl.core.service.exception.PermissionDeniedException;
 
 public class MockAuthServiceAlwaysRejects extends AuthUtilService {
   public MockAuthServiceAlwaysRejects() {
-    super(null, null, null, null, null, null, consentFormService);
+    super(null, null, null, null, null, null, null);
   }
 
   @Override

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/MockAuthServiceAlwaysRejects.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/MockAuthServiceAlwaysRejects.java
@@ -7,7 +7,7 @@ import bio.terra.pearl.core.service.exception.PermissionDeniedException;
 
 public class MockAuthServiceAlwaysRejects extends AuthUtilService {
   public MockAuthServiceAlwaysRejects() {
-    super(null, null, null, null, null, null);
+    super(null, null, null, null, null, null, consentFormService);
   }
 
   @Override

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/AuthUtilServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/AuthUtilServiceTests.java
@@ -10,9 +10,12 @@ import bio.terra.pearl.core.factory.portal.PortalFactory;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.admin.PortalAdminUser;
 import bio.terra.pearl.core.model.portal.Portal;
+import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.service.admin.PortalAdminUserService;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.portal.PortalService;
+import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,5 +76,23 @@ public class AuthUtilServiceTests extends BaseSpringBootTest {
             adminUserFactory.builder("authAdminToPortalAllowsSuperUser").superuser(true));
     Portal portal = portalFactory.buildPersisted("authAdminToPortalAllowsSuperUser");
     assertThat(authUtilService.authUserToPortal(user, portal.getShortcode()), notNullValue());
+  }
+
+  @Test
+  public void testVerifyObjToPortal() {
+    Portal portal = Portal.builder().id(UUID.randomUUID()).build();
+    Assertions.assertThrows(
+        NotFoundException.class,
+        () -> {
+          authUtilService.verifyObjInPortal(portal, Optional.of(new Survey()));
+        });
+    Assertions.assertThrows(
+        NotFoundException.class,
+        () -> {
+          authUtilService.verifyObjInPortal(portal, Optional.empty());
+        });
+
+    Survey survey = Survey.builder().portalId(portal.getId()).build();
+    authUtilService.verifyObjInPortal(portal, Optional.of(survey));
   }
 }

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/ConsentFormExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/ConsentFormExtServiceTests.java
@@ -1,14 +1,23 @@
 package bio.terra.pearl.api.admin.service.forms;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
 import bio.terra.pearl.api.admin.BaseSpringBootTest;
 import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
 import bio.terra.pearl.core.factory.admin.AdminUserFactory;
+import bio.terra.pearl.core.factory.consent.ConsentFormFactory;
+import bio.terra.pearl.core.factory.portal.PortalFactory;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.admin.PortalAdminUser;
+import bio.terra.pearl.core.model.consent.ConsentForm;
 import bio.terra.pearl.core.model.consent.StudyEnvironmentConsent;
+import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.service.admin.PortalAdminUserService;
 import bio.terra.pearl.core.service.exception.NotFoundException;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -21,6 +30,26 @@ public class ConsentFormExtServiceTests extends BaseSpringBootTest {
   @Autowired private StudyEnvironmentFactory studyEnvironmentFactory;
   @Autowired private ConsentFormExtService consentFormExtService;
   @Autowired private PortalAdminUserService portalAdminUserService;
+  @Autowired private ConsentFormFactory consentFormFactory;
+  @Autowired private PortalFactory portalFactory;
+
+  @Test
+  @Transactional
+  public void testListVersions(TestInfo testInfo) {
+    AdminUser user = adminUserFactory.buildPersisted(getTestName(testInfo), true);
+
+    Portal portal = portalFactory.buildPersisted(getTestName(testInfo));
+    var builder =
+        consentFormFactory.builderWithDependencies(getTestName(testInfo)).portalId(portal.getId());
+    ConsentForm form = consentFormFactory.buildPersisted(builder);
+
+    List<ConsentForm> forms =
+        consentFormExtService.listVersions(portal.getShortcode(), form.getStableId(), user);
+    assertThat(forms.get(0), equalTo(form));
+
+    forms = consentFormExtService.listVersions(portal.getShortcode(), "doesNotExist", user);
+    assertThat(forms, hasSize(0));
+  }
 
   @Test
   @Transactional

--- a/core/src/main/java/bio/terra/pearl/core/dao/consent/ConsentFormDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/consent/ConsentFormDao.java
@@ -6,6 +6,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import bio.terra.pearl.core.model.survey.Survey;
 import org.jdbi.v3.core.Jdbi;
 import org.springframework.stereotype.Component;
 
@@ -31,6 +33,16 @@ public class ConsentFormDao extends BaseVersionedJdbiDao<ConsentForm> {
 
     public List<ConsentForm> findByPortalId(UUID portalId) {
         return findAllByProperty("portal_id", portalId);
+    }
+
+    public List<ConsentForm> findByStableIdNoContent(String stableId) {
+        List<ConsentForm> forms = jdbi.withHandle(handle ->
+                handle.createQuery("select id, name, created_at, last_updated_at, version, stable_id, portal_id from consent_form where stable_id = :stableId;")
+                        .bind("stableId", stableId)
+                        .mapTo(clazz)
+                        .list()
+        );
+        return forms;
     }
 
     public int getNextVersion(String stableId) {

--- a/core/src/main/java/bio/terra/pearl/core/model/PortalAttached.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/PortalAttached.java
@@ -1,0 +1,7 @@
+package bio.terra.pearl.core.model;
+
+import java.util.UUID;
+
+public interface PortalAttached {
+    public UUID getPortalId();
+}

--- a/core/src/main/java/bio/terra/pearl/core/model/consent/ConsentForm.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/consent/ConsentForm.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.model.consent;
 
 import bio.terra.pearl.core.model.BaseEntity;
+import bio.terra.pearl.core.model.PortalAttached;
 import bio.terra.pearl.core.model.Versioned;
 import java.util.UUID;
 import lombok.Builder;
@@ -14,7 +15,7 @@ import lombok.experimental.SuperBuilder;
 @Setter
 @NoArgsConstructor
 @SuperBuilder
-public class ConsentForm extends BaseEntity implements Versioned {
+public class ConsentForm extends BaseEntity implements Versioned, PortalAttached {
     private String stableId;
     @Builder.Default
     private int version = 1;

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/Survey.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/Survey.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.model.survey;
 
 import bio.terra.pearl.core.model.BaseEntity;
+import bio.terra.pearl.core.model.PortalAttached;
 import bio.terra.pearl.core.model.Versioned;
 import java.util.ArrayList;
 import java.util.List;
@@ -12,7 +13,7 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Getter @Setter @NoArgsConstructor @SuperBuilder
-public class Survey extends BaseEntity implements Versioned {
+public class Survey extends BaseEntity implements Versioned, PortalAttached {
     private String stableId;
     @Builder.Default
     private int version = 1;

--- a/core/src/main/java/bio/terra/pearl/core/service/consent/ConsentFormService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/consent/ConsentFormService.java
@@ -26,6 +26,10 @@ public class ConsentFormService extends VersionedEntityService<ConsentForm, Cons
         }
     }
 
+    public List<ConsentForm> findByStableIdNoContent(String stableId) {
+        return dao.findByStableIdNoContent(stableId);
+    }
+
     @Transactional
     public ConsentForm createNewVersion(UUID portalId, ConsentForm consentForm) {
         ConsentForm newConsent = new ConsentForm();

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/consent/ConsentFormFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/consent/ConsentFormFactory.java
@@ -28,6 +28,10 @@ public class ConsentFormFactory {
         return builder(testName);
     }
 
+    public ConsentForm buildPersisted(ConsentForm.ConsentFormBuilder builder) {
+        return consentFormService.create(builder.build());
+    }
+
     public ConsentForm buildPersisted(String testName) {
         return consentFormService.create(builderWithDependencies(testName).build());
     }

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -556,12 +556,12 @@ export default {
 
   async getConsentFormVersions(portalShortcode: string, stableId: string): Promise<Survey[]> {
     const response = await fetch(`${API_ROOT}/portals/v1/${portalShortcode}/consentForms/${stableId}`,
-        this.getGetInit())
+      this.getGetInit())
     return await this.processJsonResponse(response)
   },
 
   async updateConfiguredConsent(portalShortcode: string, studyShortcode: string, environmentName: string,
-                                configuredConsent: StudyEnvironmentConsent): Promise<StudyEnvironmentConsent> {
+    configuredConsent: StudyEnvironmentConsent): Promise<StudyEnvironmentConsent> {
     const url =`${API_ROOT}/portals/v1/${portalShortcode}/studies/${studyShortcode}` +
         `/env/${environmentName}/configuredConsents/${configuredConsent.id}`
 

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -555,7 +555,7 @@ export default {
   },
 
   async getConsentFormVersions(portalShortcode: string, stableId: string): Promise<Survey[]> {
-    const response = await fetch(`${API_ROOT}/portals/v1/${portalShortcode}/consentForms/${stableId}`,
+    const response = await fetch(`${API_ROOT}/portals/v1/${portalShortcode}/consentForms/${stableId}/metadata`,
       this.getGetInit())
     return await this.processJsonResponse(response)
   },
@@ -632,7 +632,8 @@ export default {
   },
 
   async getSurveyVersions(portalShortcode: string, stableId: string): Promise<Survey[]> {
-    const response = await fetch(`${API_ROOT}/portals/v1/${portalShortcode}/surveys/${stableId}`, this.getGetInit())
+    const response = await fetch(`${API_ROOT}/portals/v1/${portalShortcode}/surveys/${stableId}/metadata`,
+      this.getGetInit())
     return await this.processJsonResponse(response)
   },
 

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -548,6 +548,31 @@ export default {
     return await this.processJsonResponse(response)
   },
 
+  async getConsentForm(portalShortcode: string, stableId: string, version: number): Promise<Survey> {
+    const url = `${API_ROOT}/portals/v1/${portalShortcode}/consentForms/${stableId}/${version}`
+    const response = await fetch(url, this.getGetInit())
+    return await this.processJsonResponse(response)
+  },
+
+  async getConsentFormVersions(portalShortcode: string, stableId: string): Promise<Survey[]> {
+    const response = await fetch(`${API_ROOT}/portals/v1/${portalShortcode}/consentForms/${stableId}`,
+        this.getGetInit())
+    return await this.processJsonResponse(response)
+  },
+
+  async updateConfiguredConsent(portalShortcode: string, studyShortcode: string, environmentName: string,
+                                configuredConsent: StudyEnvironmentConsent): Promise<StudyEnvironmentConsent> {
+    const url =`${API_ROOT}/portals/v1/${portalShortcode}/studies/${studyShortcode}` +
+        `/env/${environmentName}/configuredConsents/${configuredConsent.id}`
+
+    const response = await fetch(url, {
+      method: 'PATCH',
+      headers: this.getInitHeaders(),
+      body: JSON.stringify(configuredConsent)
+    })
+    return await this.processJsonResponse(response)
+  },
+
   async createNewConsentForm(portalShortcode: string, consentForm: ConsentForm): Promise<ConsentForm> {
     const url = `${API_ROOT}/portals/v1/${portalShortcode}/consentForms/`
         + `${consentForm.stableId}`
@@ -644,19 +669,6 @@ export default {
       method: 'PATCH',
       headers: this.getInitHeaders(),
       body: JSON.stringify(configuredSurvey)
-    })
-    return await this.processJsonResponse(response)
-  },
-
-  async updateConfiguredConsent(portalShortcode: string, studyShortcode: string, environmentName: string,
-    configuredConsent: StudyEnvironmentConsent): Promise<StudyEnvironmentConsent> {
-    const url =`${API_ROOT}/portals/v1/${portalShortcode}/studies/${studyShortcode}` +
-      `/env/${environmentName}/configuredConsents/${configuredConsent.id}`
-
-    const response = await fetch(url, {
-      method: 'PATCH',
-      headers: this.getInitHeaders(),
-      body: JSON.stringify(configuredConsent)
     })
     return await this.processJsonResponse(response)
   },

--- a/ui-admin/src/study/StudyEnvironmentRouter.tsx
+++ b/ui-admin/src/study/StudyEnvironmentRouter.tsx
@@ -118,6 +118,7 @@ function StudyEnvironmentRouter({ study }: {study: Study}) {
         </Route>
         <Route path="consentForms">
           <Route path=":consentStableId">
+            <Route path=":version" element={<ConsentView studyEnvContext={studyEnvContext}/>}/>
             <Route index element={<ConsentView studyEnvContext={studyEnvContext}/>}/>
           </Route>
           <Route path="*" element={<div>Unknown consent page</div>}/>

--- a/ui-admin/src/study/surveys/ConsentView.tsx
+++ b/ui-admin/src/study/surveys/ConsentView.tsx
@@ -11,8 +11,8 @@ import Api, {
 
 import { failureNotification, successNotification } from 'util/notifications'
 import SurveyEditorView from './SurveyEditorView'
-import {useLoadingEffect} from "../../api/api-utils";
-import LoadingSpinner from "../../util/LoadingSpinner";
+import { useLoadingEffect } from '../../api/api-utils'
+import LoadingSpinner from '../../util/LoadingSpinner'
 
 /** Handles logic for updating study environment surveys */
 function RawConsentView({ studyEnvContext, consent, readOnly = false }:
@@ -99,7 +99,7 @@ function ConsentView({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
   const [searchParams] = useSearchParams()
   const isReadOnly = searchParams.get('readOnly') === 'true'
   const configuredForm = currentEnv.configuredConsents
-      .find(s => s.consentForm.stableId === consentStableId)?.consentForm
+    .find(s => s.consentForm.stableId === consentStableId)?.consentForm
   const appliedVersion = version || configuredForm?.version
   if (!consentStableId) {
     return <span>you need to specify the stableId of the consentForm</span>
@@ -110,11 +110,11 @@ function ConsentView({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
   }
 
   const { isLoading, form } = useLoadedConsentForm(studyEnvContext.portal.shortcode,
-      consentStableId, appliedVersion)
+    consentStableId, appliedVersion)
   return <>
     { isLoading && <LoadingSpinner/> }
     { !isLoading && form && <RawConsentView studyEnvContext={studyEnvContext}
-                                            consent={form} readOnly={isReadOnly}/> }
+      consent={form} readOnly={isReadOnly}/> }
   </>
 }
 

--- a/ui-admin/src/study/surveys/ConsentView.tsx
+++ b/ui-admin/src/study/surveys/ConsentView.tsx
@@ -55,6 +55,7 @@ function RawConsentView({ studyEnvContext, consent, readOnly = false }:
       readOnly={readOnly}
       onCancel={() => navigate(studyEnvFormsPath(portal.shortcode, study.shortcode, currentEnv.environmentName))}
       onSave={createNewVersion}
+      isConsentForm={true}
     />
   )
 }

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -32,7 +32,7 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
     readOnly = false,
     onCancel,
     onSave,
-      isConsentForm
+    isConsentForm
   } = props
 
   const FORM_DRAFT_KEY = getFormDraftKey({ form: currentForm })

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -21,6 +21,7 @@ type SurveyEditorViewProps = {
   readOnly?: boolean
   onCancel: () => void
   onSave: (update: { content: string }) => Promise<void>
+  isConsentForm?: boolean
 }
 
 /** renders a survey for editing/viewing */
@@ -30,7 +31,8 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
     currentForm,
     readOnly = false,
     onCancel,
-    onSave
+    onSave,
+      isConsentForm
   } = props
 
   const FORM_DRAFT_KEY = getFormDraftKey({ form: currentForm })
@@ -195,7 +197,8 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
           setVisibleVersionPreviews={setVisibleVersionPreviews}
           stableId={currentForm.stableId}
           setShow={setShowVersionSelector}
-          show={showVersionSelector}/>
+          show={showVersionSelector}
+          isConsentForm={isConsentForm}/>
         }
       </div>
       <FormContentEditor

--- a/ui-admin/src/study/surveys/SurveyView.tsx
+++ b/ui-admin/src/study/surveys/SurveyView.tsx
@@ -66,7 +66,7 @@ function RawSurveyView({ studyEnvContext, survey, readOnly = false }:
 
 /** loads a survey and associated data (e.g. answer mappings) */
 export const useLoadedSurvey = (portalShortcode: string, stableId: string, version: number) => {
-  const [survey, setSurvey] = useState<Survey | undefined>()
+  const [survey, setSurvey] = useState<Survey>()
 
   /** load the survey from the server to get answer mappings and ensure we've got the latest content */
   const { isLoading } = useLoadingEffect(async () => {

--- a/ui-admin/src/study/surveys/VersionSelector.tsx
+++ b/ui-admin/src/study/surveys/VersionSelector.tsx
@@ -13,25 +13,35 @@ import { useLoadingEffect } from '../../api/api-utils'
 /** component for selecting versions of a form */
 export default function VersionSelector({
   studyEnvContext, stableId, show, setShow,
-  visibleVersionPreviews, setVisibleVersionPreviews
+  visibleVersionPreviews, setVisibleVersionPreviews, isConsentForm = false
 }:
                                           {studyEnvContext: StudyEnvContextT, stableId: string,
                                             show: boolean, setShow: (show: boolean) => void
                                             visibleVersionPreviews: VersionedForm[],
-                                            setVisibleVersionPreviews: (versions: VersionedForm[]) => void}) {
+                                            setVisibleVersionPreviews: (versions: VersionedForm[]) => void,
+                                          isConsentForm?: boolean}) {
   const [versionList, setVersionList] = useState<VersionedForm[]>([])
   const [selectedVersion, setSelectedVersion] = useState<number>()
   const selectId = useId()
 
   const { isLoading } = useLoadingEffect(async () => {
-    const result = await Api.getSurveyVersions(studyEnvContext.portal.shortcode, stableId)
+    let result
+    if (isConsentForm) {
+      result = await Api.getConsentFormVersions(studyEnvContext.portal.shortcode, stableId)
+    } else {
+      result = await Api.getSurveyVersions(studyEnvContext.portal.shortcode, stableId)
+    }
     setVersionList(result.sort((a, b) => b.version - a.version))
   }, [stableId])
 
-  function loadVersion(version: number) {
-    Api.getSurvey(studyEnvContext.portal.shortcode, stableId, version).then(result => {
-      setVisibleVersionPreviews([...visibleVersionPreviews, result])
-    })
+  async function loadVersion(version: number) {
+    let result
+    if (isConsentForm) {
+      result = await Api.getConsentForm(studyEnvContext.portal.shortcode, stableId, version)
+    } else {
+      result = await Api.getSurvey(studyEnvContext.portal.shortcode, stableId, version)
+    }
+    setVisibleVersionPreviews([...visibleVersionPreviews, result])
   }
 
   const versionOpts = versionList.map(formVersion => ({

--- a/ui-admin/src/study/surveys/VersionSelector.tsx
+++ b/ui-admin/src/study/surveys/VersionSelector.tsx
@@ -86,7 +86,7 @@ export default function VersionSelector({
         studyEnvContext.portal.shortcode,
         studyEnvContext.study.shortcode,
         studyEnvContext.currentEnv.environmentName
-      )}/surveys/${stableId}/${selectedVersion}?readOnly=true`}
+      )}/${isConsentForm ? 'consentForms' : 'surveys'}/${stableId}/${selectedVersion}?readOnly=true`}
       className="btn btn-secondary"
       aria-disabled={!selectedVersion}
       style={{ pointerEvents: selectedVersion ? undefined : 'none' }}


### PR DESCRIPTION
#### DESCRIPTION

The consent form version selector was never wired up, and Rachel from HeartHive needs it to get back to a previous version of one of their consents.  So this adds the needed endpoints and updates the version selector to be able to load either consents or surveys.  It also updates the consent form editor to fetch the consent from the server, rather than relying on the portal 'god object'

<img width="909" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/d2e5f2bc-c3d9-4ce0-af55-3637fd5b8fb3">

This adds a new interface "PortalAttached" to enable some auth code sharing.  

There definitely is some room to more cleanly factor the UI code--I don't like the "isConsentForm" boolean.  I suspect the better approach will be to break the Api object into modules, and then the controls will just pass in the Api module for forms/surveys as needed, and that will enable a lot more code sharing between the consent and survey editors.  But that's a bit beyond the scope of this PR.  

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to `https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/forms/consentForms/oh_oh_consent?readOnly=false`
2. make a trivial change to the form, and save it
3. click the "history" button
4. confirm the past version is available, and can be previewed