### PR TITLE
JN-720: Refactoring kit statuses

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/kit/KitRequest.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/kit/KitRequest.java
@@ -28,6 +28,6 @@ public class KitRequest extends BaseEntity {
      * JSON blob of the request state from DSM or another sample processor, kept to make sure we capture
      * any fields that don't happen to be stored directly in our model
      */
-    private String externalRequest;
-    private Instant externalRequestFetchedAt;
+    private String externalKit;
+    private Instant externalKitFetchedAt;
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/kit/KitRequest.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/kit/KitRequest.java
@@ -23,15 +23,11 @@ public class KitRequest extends BaseEntity {
      * In the future, we might decide to store separate fields, or maybe use the postgres jsonb type.
      */
     private String sentToAddress;
-    /**
-     * Status of the Juniper kit request. Since the Juniper and Pepper entities have related but separate lifecycles,
-     * we may need to track separate status. This will help Juniper know whether the kit is waiting on something to
-     * happen in Pepper or if action is needed on the Juniper side.
-     */
     private KitRequestStatus status;
     /**
-     * JSON blob of status from DSM
+     * JSON blob of the request state from DSM or another sample processor, kept to make sure we capture
+     * any fields that don't happen to be stored directly in our model
      */
-    private String dsmStatus;
-    private Instant dsmStatusFetchedAt;
+    private String externalRequest;
+    private Instant externalRequestFetchedAt;
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/kit/KitRequestStatus.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/kit/KitRequestStatus.java
@@ -1,9 +1,5 @@
 package bio.terra.pearl.core.model.kit;
 
-import bio.terra.pearl.core.service.kit.pepper.PepperKitRequest;
-
-import java.util.Set;
-
 /**
  * Kit status.  This mostly mimics PepperKitStatus (the statuses stored internally in Pepper), but with the addition of
  * "new" for kits that are recorded in juniper but do not exist in any external system yet, and "UNKNOWN" for the rare case

--- a/core/src/main/java/bio/terra/pearl/core/model/kit/KitRequestStatus.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/kit/KitRequestStatus.java
@@ -1,16 +1,13 @@
 package bio.terra.pearl.core.model.kit;
 
-import bio.terra.pearl.core.service.kit.pepper.PepperKitStatus;
+import bio.terra.pearl.core.service.kit.pepper.PepperKitRequest;
 
 import java.util.Set;
 
 /**
- * High-level, Juniper-centric kit status. Only needs to be specific enough for Juniper to decide how to interact with
- * Pepper. This is not intended to mirror all possible states in Pepper. For that, see
- * {@link PepperKitStatus#currentStatus}.
- *
- * CREATED --> IN_PROGRESS --> COMPLETE
- *                         \-> ERRORED
+ * Kit status.  This mostly mimics PepperKitStatus (the statuses stored internally in Pepper), but with the addition of
+ * "new" for kits that are recorded in juniper but do not exist in any external system yet, and "UNKNOWN" for the rare case
+ * where we receive a status from Pepper that we don't recognize.
  *
  * ERRORED kits should always have some error detail associated with them. However, the presence of error details does
  * not necessarily imply ERRORED. There may be transient errors while a kit is IN_PROGRESS that are resolved on the way
@@ -20,11 +17,12 @@ import java.util.Set;
  * by study staff.
  */
 public enum KitRequestStatus {
-    CREATED, // record created in Juniper database, usually followed almost immediately by IN_PROGRESS
-    IN_PROGRESS, // request sent to Pepper
-    COMPLETE, // Pepper returned a successful end state
-    FAILED; // Pepper returned a terminal error state
-
-    public static final Set<KitRequestStatus> NON_TERMINAL_STATES = Set.of(CREATED, IN_PROGRESS);
-    public static final Set<KitRequestStatus> TERMINAL_STATES = Set.of(COMPLETE, FAILED);
+    NEW,
+    CREATED,
+    QUEUED,
+    SENT,
+    RECEIVED,
+    ERRORED,
+    DEACTIVATED, // stopped -- no more processing/shipping will be done on this kit
+    UNKNOWN // for when we receive a status from Pepper that we don't recognize
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
@@ -81,10 +81,10 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
 
         // send kit request to DSM
         try {
-            PepperKitRequest dsmKitStatus = pepperDSMClient.sendKitRequest(studyShortcode, enrollee, kitRequest, pepperKitAddress);
+            PepperKit dsmKitStatus = pepperDSMClient.sendKitRequest(studyShortcode, enrollee, kitRequest, pepperKitAddress);
             // write out the PepperKitStatus as a string for storage
             String pepperRequestJson = objectMapper.writeValueAsString(dsmKitStatus);
-            kitRequest.setExternalRequest(pepperRequestJson);
+            kitRequest.setExternalKit(pepperRequestJson);
         } catch (PepperParseException e) {
             // response was successful, but we got unexpected format back from pepper
             // we want to log the error, but still continue on to saving the kit
@@ -145,12 +145,12 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
      * Do _NOT_ call this repeatedly for a collection of kits. Use a bulk operation instead to avoid overwhelming DSM.
      */
     @Transactional
-    public PepperKitRequest syncKitStatusFromPepper(UUID kitId) throws PepperParseException, PepperApiException {
+    public PepperKit syncKitStatusFromPepper(UUID kitId) throws PepperParseException, PepperApiException {
         KitRequest kitRequest = dao.find(kitId).orElseThrow(() -> new NotFoundException("Kit request not found"));
         var pepperKitStatus = pepperDSMClient.fetchKitStatus(kitId);
         try {
-            kitRequest.setExternalRequest(objectMapper.writeValueAsString(pepperKitStatus));
-            kitRequest.setExternalRequestFetchedAt(Instant.now());
+            kitRequest.setExternalKit(objectMapper.writeValueAsString(pepperKitStatus));
+            kitRequest.setExternalKitFetchedAt(Instant.now());
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Could not parse JSON response from DSM", e);
         }
@@ -181,10 +181,10 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
             // (Pepper doesn't have a concept of study environments, so all kits from a study are under the same code)
             // then update the statuses in Juniper for each environment
            try {
-               Collection<PepperKitRequest> pepperKitRequests = pepperDSMClient.fetchKitStatusByStudy(study.getShortcode());
+               Collection<PepperKit> pepperKits = pepperDSMClient.fetchKitStatusByStudy(study.getShortcode());
                // now find the environments for this study from the list of environments with kit types
                studyEnvs.stream().filter(studyEnv -> studyEnv.getStudyId().equals(study.getId())).forEach( studyEnv -> {
-                   syncKitStatusesForStudyEnv(study.getShortcode(), studyEnv.getEnvironmentName(), pepperKitRequests);
+                   syncKitStatusesForStudyEnv(study.getShortcode(), studyEnv.getEnvironmentName(), pepperKits);
                });
             } catch (PepperParseException | PepperApiException e) {
                 // if one sync fails, keep trying others in case the failure is just isolated unexpected data
@@ -195,16 +195,16 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
 
     @Transactional
     public void syncKitStatusesForStudyEnv(Study study, EnvironmentName environmentName) throws PepperParseException, PepperApiException {
-        Collection<PepperKitRequest> pepperKitRequests = pepperDSMClient.fetchKitStatusByStudy(study.getShortcode());
-        syncKitStatusesForStudyEnv(study.getShortcode(), environmentName, pepperKitRequests);
+        Collection<PepperKit> pepperKits = pepperDSMClient.fetchKitStatusByStudy(study.getShortcode());
+        syncKitStatusesForStudyEnv(study.getShortcode(), environmentName, pepperKits);
     }
 
-    private void syncKitStatusesForStudyEnv(String studyShortcode, EnvironmentName envName, Collection<PepperKitRequest> pepperKitRequests) throws PepperParseException, PepperApiException {
+    private void syncKitStatusesForStudyEnv(String studyShortcode, EnvironmentName envName, Collection<PepperKit> pepperKits) throws PepperParseException, PepperApiException {
         UUID studyEnvId = studyEnvironmentService.findByStudy(studyShortcode, envName)
                 .orElseThrow(() -> new NotFoundException("No matching study")).getId();
         var pepperStatusFetchedAt = Instant.now();
-        var pepperKitStatusByKitId = pepperKitRequests.stream().collect(
-                Collectors.toMap(PepperKitRequest::getJuniperKitId, Function.identity(),
+        var pepperKitStatusByKitId = pepperKits.stream().collect(
+                Collectors.toMap(PepperKit::getJuniperKitId, Function.identity(),
                         (kit1, kit2) -> !kit1.getCurrentStatus().equals("Deactivated") ? kit1 : kit2));
 
         studyEnvironmentService.find(studyEnvId).ifPresent(
@@ -271,15 +271,15 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
      * Saves updated kit status. This is called from a batch job, so exceptions are caught and logged instead of thrown
      * to allow the rest of the batch to be processed.
      */
-    private void saveKitStatus(KitRequest kit, PepperKitRequest pepperKitRequest, Instant pepperStatusFetchedAt) {
+    private void saveKitStatus(KitRequest kit, PepperKit pepperKit, Instant pepperStatusFetchedAt) {
         try {
-            kit.setExternalRequest(objectMapper.writeValueAsString(pepperKitRequest));
-            kit.setExternalRequestFetchedAt(pepperStatusFetchedAt);
-            kit.setStatus(PepperKitStatus.mapToKitRequestStatus(pepperKitRequest.getCurrentStatus()));
+            kit.setExternalKit(objectMapper.writeValueAsString(pepperKit));
+            kit.setExternalKitFetchedAt(pepperStatusFetchedAt);
+            kit.setStatus(PepperKitStatus.mapToKitRequestStatus(pepperKit.getCurrentStatus()));
             dao.update(kit);
         } catch (JsonProcessingException e) {
             logger.warn(
-                    "Unable to serialize status JSON for kit %s: %s".formatted(kit.getId(), pepperKitRequest.toString()),
+                    "Unable to serialize status JSON for kit %s: %s".formatted(kit.getId(), pepperKit.toString()),
                     e);
         }
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
@@ -81,10 +81,10 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
 
         // send kit request to DSM
         try {
-            PepperKitStatus dsmKitStatus = pepperDSMClient.sendKitRequest(studyShortcode, enrollee, kitRequest, pepperKitAddress);
+            PepperKitRequest dsmKitStatus = pepperDSMClient.sendKitRequest(studyShortcode, enrollee, kitRequest, pepperKitAddress);
             // write out the PepperKitStatus as a string for storage
-            var pepperStatusJson = objectMapper.writeValueAsString(dsmKitStatus);
-            kitRequest.setDsmStatus(pepperStatusJson);
+            String pepperRequestJson = objectMapper.writeValueAsString(dsmKitStatus);
+            kitRequest.setExternalRequest(pepperRequestJson);
         } catch (PepperParseException e) {
             // response was successful, but we got unexpected format back from pepper
             // we want to log the error, but still continue on to saving the kit
@@ -145,12 +145,12 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
      * Do _NOT_ call this repeatedly for a collection of kits. Use a bulk operation instead to avoid overwhelming DSM.
      */
     @Transactional
-    public PepperKitStatus syncKitStatusFromPepper(UUID kitId) throws PepperParseException, PepperApiException {
-        var kitRequest = dao.find(kitId).orElseThrow(() -> new NotFoundException("Kit request not found"));
+    public PepperKitRequest syncKitStatusFromPepper(UUID kitId) throws PepperParseException, PepperApiException {
+        KitRequest kitRequest = dao.find(kitId).orElseThrow(() -> new NotFoundException("Kit request not found"));
         var pepperKitStatus = pepperDSMClient.fetchKitStatus(kitId);
         try {
-            kitRequest.setDsmStatus(objectMapper.writeValueAsString(pepperKitStatus));
-            kitRequest.setDsmStatusFetchedAt(Instant.now());
+            kitRequest.setExternalRequest(objectMapper.writeValueAsString(pepperKitStatus));
+            kitRequest.setExternalRequestFetchedAt(Instant.now());
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Could not parse JSON response from DSM", e);
         }
@@ -181,10 +181,10 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
             // (Pepper doesn't have a concept of study environments, so all kits from a study are under the same code)
             // then update the statuses in Juniper for each environment
            try {
-               Collection<PepperKitStatus> pepperKitStatuses = pepperDSMClient.fetchKitStatusByStudy(study.getShortcode());
+               Collection<PepperKitRequest> pepperKitRequests = pepperDSMClient.fetchKitStatusByStudy(study.getShortcode());
                // now find the environments for this study from the list of environments with kit types
                studyEnvs.stream().filter(studyEnv -> studyEnv.getStudyId().equals(study.getId())).forEach( studyEnv -> {
-                   syncKitStatusesForStudyEnv(study.getShortcode(), studyEnv.getEnvironmentName(), pepperKitStatuses);
+                   syncKitStatusesForStudyEnv(study.getShortcode(), studyEnv.getEnvironmentName(), pepperKitRequests);
                });
             } catch (PepperParseException | PepperApiException e) {
                 // if one sync fails, keep trying others in case the failure is just isolated unexpected data
@@ -195,16 +195,16 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
 
     @Transactional
     public void syncKitStatusesForStudyEnv(Study study, EnvironmentName environmentName) throws PepperParseException, PepperApiException {
-        Collection<PepperKitStatus> pepperKitStatuses = pepperDSMClient.fetchKitStatusByStudy(study.getShortcode());
-        syncKitStatusesForStudyEnv(study.getShortcode(), environmentName, pepperKitStatuses);
+        Collection<PepperKitRequest> pepperKitRequests = pepperDSMClient.fetchKitStatusByStudy(study.getShortcode());
+        syncKitStatusesForStudyEnv(study.getShortcode(), environmentName, pepperKitRequests);
     }
 
-    private void syncKitStatusesForStudyEnv(String studyShortcode, EnvironmentName envName, Collection<PepperKitStatus> pepperKitStatuses) throws PepperParseException, PepperApiException {
+    private void syncKitStatusesForStudyEnv(String studyShortcode, EnvironmentName envName, Collection<PepperKitRequest> pepperKitRequests) throws PepperParseException, PepperApiException {
         UUID studyEnvId = studyEnvironmentService.findByStudy(studyShortcode, envName)
                 .orElseThrow(() -> new NotFoundException("No matching study")).getId();
         var pepperStatusFetchedAt = Instant.now();
-        var pepperKitStatusByKitId = pepperKitStatuses.stream().collect(
-                Collectors.toMap(PepperKitStatus::getJuniperKitId, Function.identity(),
+        var pepperKitStatusByKitId = pepperKitRequests.stream().collect(
+                Collectors.toMap(PepperKitRequest::getJuniperKitId, Function.identity(),
                         (kit1, kit2) -> !kit1.getCurrentStatus().equals("Deactivated") ? kit1 : kit2));
 
         studyEnvironmentService.find(studyEnvId).ifPresent(
@@ -227,11 +227,6 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
         return dao.findByStudyEnvironment(studyEnvironmentId);
     }
 
-    public List<KitRequest> findIncompleteKits(UUID studyEnvironmentId) {
-        return dao.findByStatus(
-                studyEnvironmentId,
-                List.of(KitRequestStatus.CREATED, KitRequestStatus.IN_PROGRESS));
-    }
 
     /**
      * Delete kits for an enrollee. Only for use by populate functions.
@@ -276,33 +271,19 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
      * Saves updated kit status. This is called from a batch job, so exceptions are caught and logged instead of thrown
      * to allow the rest of the batch to be processed.
      */
-    private void saveKitStatus(KitRequest kit, PepperKitStatus pepperKitStatus, Instant pepperStatusFetchedAt) {
+    private void saveKitStatus(KitRequest kit, PepperKitRequest pepperKitRequest, Instant pepperStatusFetchedAt) {
         try {
-            kit.setDsmStatus(objectMapper.writeValueAsString(pepperKitStatus));
-            kit.setDsmStatusFetchedAt(pepperStatusFetchedAt);
-            kit.setStatus(statusFromPepperCurrentStatus(pepperKitStatus.getCurrentStatus()));
+            kit.setExternalRequest(objectMapper.writeValueAsString(pepperKitRequest));
+            kit.setExternalRequestFetchedAt(pepperStatusFetchedAt);
+            kit.setStatus(PepperKitStatus.mapToKitRequestStatus(pepperKitRequest.getCurrentStatus()));
             dao.update(kit);
         } catch (JsonProcessingException e) {
             logger.warn(
-                    "Unable to serialize status JSON for kit %s: %s".formatted(kit.getId(), pepperKitStatus.toString()),
+                    "Unable to serialize status JSON for kit %s: %s".formatted(kit.getId(), pepperKitRequest.toString()),
                     e);
         }
     }
 
-    private KitRequestStatus statusFromPepperCurrentStatus(String currentStatus) {
-        if (currentStatus == null) {
-            return KitRequestStatus.CREATED;
-        } else {
-            var status = PepperKitStatus.Status.fromCurrentStatus(currentStatus);
-            if (PepperKitStatus.Status.isCompleted(status)) {
-                return KitRequestStatus.COMPLETE;
-            } else if (PepperKitStatus.Status.isFailed(status)) {
-                return KitRequestStatus.FAILED;
-            } else {
-                return KitRequestStatus.IN_PROGRESS;
-            }
-        }
-    }
 
     private final EnrolleeService enrolleeService;
     private final KitTypeDao kitTypeDao;

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClient.java
@@ -44,7 +44,7 @@ public class LivePepperDSMClient implements PepperDSMClient {
     }
 
     @Override
-    public PepperKitRequest sendKitRequest(String studyShortcode, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address)
+    public PepperKit sendKitRequest(String studyShortcode, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address)
     throws PepperApiException, PepperParseException {
         var request = buildAuthedPostRequest("shipKit", makeKitRequestBody(studyShortcode, enrollee, kitRequest, address));
         PepperKitStatusResponse response = retrieveAndDeserializeResponse(request, PepperKitStatusResponse.class);
@@ -56,7 +56,7 @@ public class LivePepperDSMClient implements PepperDSMClient {
     }
 
     @Override
-    public PepperKitRequest fetchKitStatus(UUID kitRequestId) throws PepperApiException, PepperParseException {
+    public PepperKit fetchKitStatus(UUID kitRequestId) throws PepperApiException, PepperParseException {
         var request = buildAuthedGetRequest("kitstatus/juniperKit/%s".formatted(kitRequestId));
         var response = retrieveAndDeserializeResponse(request, PepperKitStatusResponse.class);
         if (response.getKits().length != 1) {
@@ -67,7 +67,7 @@ public class LivePepperDSMClient implements PepperDSMClient {
     }
 
     @Override
-    public Collection<PepperKitRequest> fetchKitStatusByStudy(String studyShortcode) throws PepperApiException, PepperParseException {
+    public Collection<PepperKit> fetchKitStatusByStudy(String studyShortcode) throws PepperApiException, PepperParseException {
         var request = buildAuthedGetRequest("kitstatus/study/%s".formatted(makePepperStudyName(studyShortcode)));
         var response = retrieveAndDeserializeResponse(request, PepperKitStatusResponse.class);
         return Arrays.asList(response.getKits());

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClient.java
@@ -44,7 +44,7 @@ public class LivePepperDSMClient implements PepperDSMClient {
     }
 
     @Override
-    public PepperKitStatus sendKitRequest(String studyShortcode, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address)
+    public PepperKitRequest sendKitRequest(String studyShortcode, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address)
     throws PepperApiException, PepperParseException {
         var request = buildAuthedPostRequest("shipKit", makeKitRequestBody(studyShortcode, enrollee, kitRequest, address));
         PepperKitStatusResponse response = retrieveAndDeserializeResponse(request, PepperKitStatusResponse.class);
@@ -56,7 +56,7 @@ public class LivePepperDSMClient implements PepperDSMClient {
     }
 
     @Override
-    public PepperKitStatus fetchKitStatus(UUID kitRequestId) throws PepperApiException, PepperParseException {
+    public PepperKitRequest fetchKitStatus(UUID kitRequestId) throws PepperApiException, PepperParseException {
         var request = buildAuthedGetRequest("kitstatus/juniperKit/%s".formatted(kitRequestId));
         var response = retrieveAndDeserializeResponse(request, PepperKitStatusResponse.class);
         if (response.getKits().length != 1) {
@@ -67,7 +67,7 @@ public class LivePepperDSMClient implements PepperDSMClient {
     }
 
     @Override
-    public Collection<PepperKitStatus> fetchKitStatusByStudy(String studyShortcode) throws PepperApiException, PepperParseException {
+    public Collection<PepperKitRequest> fetchKitStatusByStudy(String studyShortcode) throws PepperApiException, PepperParseException {
         var request = buildAuthedGetRequest("kitstatus/study/%s".formatted(makePepperStudyName(studyShortcode)));
         var response = retrieveAndDeserializeResponse(request, PepperKitStatusResponse.class);
         return Arrays.asList(response.getKits());

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperDSMClient.java
@@ -17,7 +17,7 @@ public interface PepperDSMClient {
      * @return status result from Pepper
      * @throws PepperApiException on error from Pepper or failure to process the Pepper response
      */
-    PepperKitStatus sendKitRequest(String studyShortcode, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address) throws PepperApiException, PepperParseException;
-    PepperKitStatus fetchKitStatus(UUID kitRequestId) throws PepperApiException, PepperParseException;
-    Collection<PepperKitStatus> fetchKitStatusByStudy(String studyShortcode) throws PepperApiException, PepperParseException;
+    PepperKitRequest sendKitRequest(String studyShortcode, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address) throws PepperApiException, PepperParseException;
+    PepperKitRequest fetchKitStatus(UUID kitRequestId) throws PepperApiException, PepperParseException;
+    Collection<PepperKitRequest> fetchKitStatusByStudy(String studyShortcode) throws PepperApiException, PepperParseException;
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperDSMClient.java
@@ -17,7 +17,7 @@ public interface PepperDSMClient {
      * @return status result from Pepper
      * @throws PepperApiException on error from Pepper or failure to process the Pepper response
      */
-    PepperKitRequest sendKitRequest(String studyShortcode, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address) throws PepperApiException, PepperParseException;
-    PepperKitRequest fetchKitStatus(UUID kitRequestId) throws PepperApiException, PepperParseException;
-    Collection<PepperKitRequest> fetchKitStatusByStudy(String studyShortcode) throws PepperApiException, PepperParseException;
+    PepperKit sendKitRequest(String studyShortcode, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address) throws PepperApiException, PepperParseException;
+    PepperKit fetchKitStatus(UUID kitRequestId) throws PepperApiException, PepperParseException;
+    Collection<PepperKit> fetchKitStatusByStudy(String studyShortcode) throws PepperApiException, PepperParseException;
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperKit.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperKit.java
@@ -4,15 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
-import java.util.Set;
-
 /** holds kit request data as it is received from Pepper */
 @Getter @Setter
 @SuperBuilder @NoArgsConstructor
 @EqualsAndHashCode
 @ToString
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class PepperKitRequest {
+public class PepperKit {
     private String juniperKitId;
     private String currentStatus;
     private String dsmShippingLabel;

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperKitRequest.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperKitRequest.java
@@ -1,0 +1,31 @@
+package bio.terra.pearl.core.service.kit.pepper;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.util.Set;
+
+/** holds kit request data as it is received from Pepper */
+@Getter @Setter
+@SuperBuilder @NoArgsConstructor
+@EqualsAndHashCode
+@ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PepperKitRequest {
+    private String juniperKitId;
+    private String currentStatus;
+    private String dsmShippingLabel;
+    private String participantId; // Juniper enrollee shortcode
+    private String labelDate;
+    private String labelByEmail;
+    private String scanDate;
+    private String scanByEmail;
+    private String receiveDate;
+    private String trackingScanBy;
+    private String trackingNumber;
+    private String returnTrackingNumber;
+    private String errorMessage;
+    private String errorDate;
+    private Boolean error;
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperKitStatusResponse.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperKitStatusResponse.java
@@ -16,7 +16,7 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString
 public class PepperKitStatusResponse extends PepperResponse {
-    private PepperKitStatus[] kits;
+    private PepperKitRequest[] kits;
 
     /**
      * Minimally parses the given JSON as a PepperKitStatusResponse to extract the list of kits.

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperKitStatusResponse.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperKitStatusResponse.java
@@ -16,7 +16,7 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @ToString
 public class PepperKitStatusResponse extends PepperResponse {
-    private PepperKitRequest[] kits;
+    private PepperKit[] kits;
 
     /**
      * Minimally parses the given JSON as a PepperKitStatusResponse to extract the list of kits.

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/StubPepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/StubPepperDSMClient.java
@@ -34,7 +34,7 @@ public class StubPepperDSMClient implements PepperDSMClient {
     }
 
     @Override
-    public PepperKitRequest sendKitRequest(String studyShortcode, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address) {
+    public PepperKit sendKitRequest(String studyShortcode, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address) {
         log.info("STUB sending kit request");
         if (address.getCity().startsWith(BAD_ADDRESS_PREFIX) || address.getStreet1().startsWith(BAD_ADDRESS_PREFIX)) {
             throw new  PepperApiException(
@@ -47,7 +47,7 @@ public class StubPepperDSMClient implements PepperDSMClient {
                             .build(),
                     HttpStatus.BAD_REQUEST);
         }
-        PepperKitRequest status = PepperKitRequest.builder()
+        PepperKit status = PepperKit.builder()
                 .juniperKitId(kitRequest.getId().toString())
                 .dsmShippingLabel(UUID.randomUUID().toString())
                 .participantId(enrollee.getShortcode())
@@ -57,20 +57,20 @@ public class StubPepperDSMClient implements PepperDSMClient {
     }
 
     @Override
-    public PepperKitRequest fetchKitStatus(UUID kitRequestId) {
+    public PepperKit fetchKitStatus(UUID kitRequestId) {
         log.info("STUB fetching kit status");
-        return PepperKitRequest.builder()
+        return PepperKit.builder()
                 .juniperKitId(kitRequestId.toString())
                 .currentStatus("SENT")
                 .build();
     }
 
     @Override
-    public Collection<PepperKitRequest> fetchKitStatusByStudy(String studyShortcode) {
+    public Collection<PepperKit> fetchKitStatusByStudy(String studyShortcode) {
         log.info("STUB fetching status by study");
         var studyEnvironment = studyEnvironmentDao.findByStudy(studyShortcode, EnvironmentName.sandbox).get();
         return kitRequestService.findByStudyEnvironment(studyEnvironment.getId()).stream().map(kit -> {
-            PepperKitRequest status = PepperKitRequest.builder()
+            PepperKit status = PepperKit.builder()
                     .juniperKitId(kit.getId().toString())
                     .currentStatus(getNextStatus(kit))
                     .build();
@@ -91,7 +91,7 @@ public class StubPepperDSMClient implements PepperDSMClient {
     private String getNextStatus(KitRequest kit) {
         List<String> statusVals = MOCK_STATUS_SEQUENCE.stream().map(status -> status.pepperString).toList();
         try {
-            PepperKitRequest pepperStatus = objectMapper.readValue(kit.getExternalRequest(), PepperKitRequest.class);
+            PepperKit pepperStatus = objectMapper.readValue(kit.getExternalKit(), PepperKit.class);
             String currentStatus = pepperStatus.getCurrentStatus();
             int currentStatusIndex = statusVals.indexOf(currentStatus);
             int nextStatusIndex = (currentStatusIndex + 1) % statusVals.size();

--- a/core/src/main/resources/db/changelog/changesets/2023_11_30_kit_status.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2023_11_30_kit_status.yaml
@@ -1,0 +1,25 @@
+databaseChangeLog:
+  - changeSet:
+      id: kit_status
+      author: dbush
+      changes:
+        - sql:
+            sql:
+              update kit_request set status = (CASE 
+                WHEN cast(dsm_status AS json)->>'currentStatus' = 'kit without label' THEN 'CREATED'
+                WHEN cast(dsm_status AS json)->>'currentStatus' = 'queue' THEN 'QUEUED'
+                WHEN cast(dsm_status AS json)->>'currentStatus' = 'sent' THEN 'SENT'
+                WHEN cast(dsm_status AS json)->>'currentStatus' = 'received' THEN 'RECEIVED'
+                WHEN cast(dsm_status AS json)->>'currentStatus' = 'error' THEN 'ERRORED'
+                WHEN cast(dsm_status AS json)->>'currentStatus' = 'deactivated' THEN 'DEACTIVATED'
+                WHEN cast(dsm_status AS json)->>'currentStatus' = NULL THEN NULL
+                ELSE 'UNKNOWN'
+                END);
+        - renameColumn:
+            oldColumnName: dsm_status
+            newColumnName: external_request
+            tableName: kit_request
+        - renameColumn:
+            oldColumnName: dsm_status_fetched_at
+            newColumnName: external_request_fetched_at
+            tableName: kit_request

--- a/core/src/main/resources/db/changelog/changesets/2023_11_30_kit_status.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2023_11_30_kit_status.yaml
@@ -17,9 +17,9 @@ databaseChangeLog:
                 END);
         - renameColumn:
             oldColumnName: dsm_status
-            newColumnName: external_request
+            newColumnName: external_kit
             tableName: kit_request
         - renameColumn:
             oldColumnName: dsm_status_fetched_at
-            newColumnName: external_request_fetched_at
+            newColumnName: external_kit_fetched_at
             tableName: kit_request

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -149,6 +149,9 @@ databaseChangeLog:
   - include:
       file: changesets/2023_10_30_study_env_kit_type.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2023_11_30_kit_status.yaml
+      relativeToChangelogFile: true
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements
 # are atomic. When they are grouped in a changeset and one fails the changeset cannot be

--- a/core/src/test/java/bio/terra/pearl/core/dao/kit/KitRequestDaoTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/kit/KitRequestDaoTest.java
@@ -73,16 +73,16 @@ public class KitRequestDaoTest extends BaseSpringBootTest {
                 throw new RuntimeException(e);
             }
         };
-        var incompleteKits = Stream.of(KitRequestStatus.CREATED, KitRequestStatus.IN_PROGRESS).map(makeKit).toList();
-        var completeKits = Stream.of(KitRequestStatus.COMPLETE, KitRequestStatus.FAILED).map(makeKit).toList();
+        var incompleteKits = Stream.of(KitRequestStatus.CREATED, KitRequestStatus.SENT).map(makeKit).toList();
+        var completeKits = Stream.of(KitRequestStatus.RECEIVED, KitRequestStatus.ERRORED).map(makeKit).toList();
 
         // Act
         var fetchedIncompleteKits = kitRequestDao.findByStatus(
                 studyEnvironment.getId(),
-                List.of(KitRequestStatus.CREATED, KitRequestStatus.IN_PROGRESS));
+                List.of(KitRequestStatus.CREATED, KitRequestStatus.SENT));
         var fetchedCompleteKits = kitRequestDao.findByStatus(
                 studyEnvironment.getId(),
-                List.of(KitRequestStatus.COMPLETE, KitRequestStatus.FAILED));
+                List.of(KitRequestStatus.RECEIVED, KitRequestStatus.ERRORED));
 
         // Assert
         assertThat(fetchedIncompleteKits, containsInAnyOrder(incompleteKits.toArray()));

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
@@ -103,7 +103,7 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
         var kitRequest = kitRequestFactory.buildPersisted(getTestName(testInfo),
             enrollee.getId(), kitType.getId(), adminUser.getId());
 
-        var response = PepperKitRequest.builder()
+        var response = PepperKit.builder()
                 .juniperKitId(kitRequest.getId().toString())
                 .currentStatus("SENT")
                 .build();
@@ -132,7 +132,7 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
                 .creatingAdminUserId(adminUser.getId())
                 .enrolleeId(enrollee.getId())
                 .kitTypeId(kitType.getId())
-                .externalRequest("BOOM!")
+                .externalKit("BOOM!")
                 .build());
 
         // Act
@@ -179,15 +179,15 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
          *  - the first study has two kits, one in flight and one complete
          *  - the second study has one kit with an error
          */
-        var kitStatus1a = PepperKitRequest.builder()
+        var kitStatus1a = PepperKit.builder()
                 .juniperKitId(kitRequest1a.getId().toString())
                 .currentStatus(PepperKitStatus.SENT.pepperString)
                 .build();
-        var kitStatus1b = PepperKitRequest.builder()
+        var kitStatus1b = PepperKit.builder()
                 .juniperKitId(kitRequest1b.getId().toString())
                 .currentStatus(PepperKitStatus.RECEIVED.pepperString)
                 .build();
-        var kitStatus2 = PepperKitRequest.builder()
+        var kitStatus2 = PepperKit.builder()
                 .juniperKitId(kitRequest2.getId().toString())
                 .currentStatus(PepperKitStatus.ERRORED.pepperString)
                 .errorMessage("Something went wrong")
@@ -223,11 +223,11 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
         Mockito.verifyNoInteractions(mockPepperDSMClient);
     }
 
-    private void verifyKit(KitRequest kit, PepperKitRequest expectedDSMStatus, KitRequestStatus expectedStatus)
+    private void verifyKit(KitRequest kit, PepperKit expectedDSMStatus, KitRequestStatus expectedStatus)
             throws JsonProcessingException {
         var savedKit = kitRequestDao.find(kit.getId()).get();
         assertThat(savedKit.getStatus(), equalTo(expectedStatus));
-        assertThat(objectMapper.readValue(savedKit.getExternalRequest(), PepperKitRequest.class),
+        assertThat(objectMapper.readValue(savedKit.getExternalKit(), PepperKit.class),
                 equalTo(expectedDSMStatus));
     }
 

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientIntegrationTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientIntegrationTest.java
@@ -117,7 +117,7 @@ public class LivePepperDSMClientIntegrationTest extends BaseSpringBootTest {
 
         // Assert
         assertThat(statuses, not(statuses.isEmpty()));
-        assertThat(statuses, everyItem(where(PepperKitRequest::getJuniperKitId, notNullValue())));
+        assertThat(statuses, everyItem(where(PepperKit::getJuniperKitId, notNullValue())));
     }
 
     @Autowired

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientIntegrationTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientIntegrationTest.java
@@ -117,7 +117,7 @@ public class LivePepperDSMClientIntegrationTest extends BaseSpringBootTest {
 
         // Assert
         assertThat(statuses, not(statuses.isEmpty()));
-        assertThat(statuses, everyItem(where(PepperKitStatus::getJuniperKitId, notNullValue())));
+        assertThat(statuses, everyItem(where(PepperKitRequest::getJuniperKitId, notNullValue())));
     }
 
     @Autowired

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientTest.java
@@ -141,18 +141,18 @@ public class LivePepperDSMClientTest extends BaseSpringBootTest {
     @Transactional
     @Test
     public void testSendKitRequest() throws Exception {
-        PepperKitRequest kitStatus = PepperKitRequest.builder()
+        PepperKit kitStatus = PepperKit.builder()
                 .juniperKitId(kitRequest.getId().toString())
                 .currentStatus(PepperKitStatus.CREATED.pepperString)
                 .build();
         PepperKitStatusResponse mockResponse = PepperKitStatusResponse.builder()
                         .isError(false)
-                .kits(new PepperKitRequest[]{kitStatus})
+                .kits(new PepperKit[]{kitStatus})
                 .build();
 
         mockPepperResponse(HttpStatus.OK, objectMapper.writeValueAsString(mockResponse));
 
-        PepperKitRequest parsedResponse = client.sendKitRequest("testStudy", enrollee, kitRequest, address);
+        PepperKit parsedResponse = client.sendKitRequest("testStudy", enrollee, kitRequest, address);
 
         assertThat(parsedResponse.getCurrentStatus(), equalTo(PepperKitStatus.CREATED.pepperString));
         verifyRequestForPath("/shipKit");
@@ -162,10 +162,10 @@ public class LivePepperDSMClientTest extends BaseSpringBootTest {
     @Test
     public void testFetchKitStatus() throws Exception {
         // Arrange
-        PepperKitRequest kitStatus = PepperKitRequest.builder()
+        PepperKit kitStatus = PepperKit.builder()
                 .juniperKitId("testFetchKitStatusByStudy1")
                 .build();
-        PepperKitRequest[] kits = { kitStatus };
+        PepperKit[] kits = { kitStatus };
         var pepperResponse = PepperKitStatusResponse.builder()
                 .kits(kits)
                 .isError(false)
@@ -186,13 +186,13 @@ public class LivePepperDSMClientTest extends BaseSpringBootTest {
     @Test
     public void testFetchKitStatusByStudy() throws Exception {
         // Arrange
-        PepperKitRequest kitStatus1 = PepperKitRequest.builder()
+        PepperKit kitStatus1 = PepperKit.builder()
                 .juniperKitId("testFetchKitStatusByStudy_kit1")
                 .build();
-        PepperKitRequest kitStatus2 = PepperKitRequest.builder()
+        PepperKit kitStatus2 = PepperKit.builder()
                 .juniperKitId("testFetchKitStatusByStudy_kit2")
                 .build();
-        PepperKitRequest[] kits = { kitStatus1, kitStatus2 };
+        PepperKit[] kits = { kitStatus1, kitStatus2 };
         var pepperResponse = PepperKitStatusResponse.builder()
                 .kits(kits)
                 .isError(false)

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientTest.java
@@ -5,7 +5,6 @@ import bio.terra.pearl.core.factory.kit.KitRequestFactory;
 import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.participant.Enrollee;
-import bio.terra.pearl.core.service.kit.pepper.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -19,7 +18,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -143,20 +141,20 @@ public class LivePepperDSMClientTest extends BaseSpringBootTest {
     @Transactional
     @Test
     public void testSendKitRequest() throws Exception {
-        PepperKitStatus kitStatus = PepperKitStatus.builder()
+        PepperKitRequest kitStatus = PepperKitRequest.builder()
                 .juniperKitId(kitRequest.getId().toString())
-                .currentStatus(PepperKitStatus.Status.CREATED.currentStatus)
+                .currentStatus(PepperKitStatus.CREATED.pepperString)
                 .build();
         PepperKitStatusResponse mockResponse = PepperKitStatusResponse.builder()
                         .isError(false)
-                .kits(new PepperKitStatus[]{kitStatus})
+                .kits(new PepperKitRequest[]{kitStatus})
                 .build();
 
         mockPepperResponse(HttpStatus.OK, objectMapper.writeValueAsString(mockResponse));
 
-        PepperKitStatus parsedResponse = client.sendKitRequest("testStudy", enrollee, kitRequest, address);
+        PepperKitRequest parsedResponse = client.sendKitRequest("testStudy", enrollee, kitRequest, address);
 
-        assertThat(parsedResponse.getCurrentStatus(), equalTo(PepperKitStatus.Status.CREATED.currentStatus));
+        assertThat(parsedResponse.getCurrentStatus(), equalTo(PepperKitStatus.CREATED.pepperString));
         verifyRequestForPath("/shipKit");
     }
 
@@ -164,10 +162,10 @@ public class LivePepperDSMClientTest extends BaseSpringBootTest {
     @Test
     public void testFetchKitStatus() throws Exception {
         // Arrange
-        PepperKitStatus kitStatus = PepperKitStatus.builder()
+        PepperKitRequest kitStatus = PepperKitRequest.builder()
                 .juniperKitId("testFetchKitStatusByStudy1")
                 .build();
-        PepperKitStatus[] kits = { kitStatus };
+        PepperKitRequest[] kits = { kitStatus };
         var pepperResponse = PepperKitStatusResponse.builder()
                 .kits(kits)
                 .isError(false)
@@ -188,13 +186,13 @@ public class LivePepperDSMClientTest extends BaseSpringBootTest {
     @Test
     public void testFetchKitStatusByStudy() throws Exception {
         // Arrange
-        PepperKitStatus kitStatus1 = PepperKitStatus.builder()
+        PepperKitRequest kitStatus1 = PepperKitRequest.builder()
                 .juniperKitId("testFetchKitStatusByStudy_kit1")
                 .build();
-        PepperKitStatus kitStatus2 = PepperKitStatus.builder()
+        PepperKitRequest kitStatus2 = PepperKitRequest.builder()
                 .juniperKitId("testFetchKitStatusByStudy_kit2")
                 .build();
-        PepperKitStatus[] kits = { kitStatus1, kitStatus2 };
+        PepperKitRequest[] kits = { kitStatus1, kitStatus2 };
         var pepperResponse = PepperKitStatusResponse.builder()
                 .kits(kits)
                 .isError(false)

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/kit/KitRequestFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/kit/KitRequestFactory.java
@@ -6,7 +6,7 @@ import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.kit.KitRequestStatus;
 import bio.terra.pearl.core.model.kit.KitType;
-import bio.terra.pearl.core.service.kit.pepper.PepperKitRequest;
+import bio.terra.pearl.core.service.kit.pepper.PepperKit;
 import bio.terra.pearl.core.service.kit.pepper.PepperKitAddress;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -56,12 +56,12 @@ public class KitRequestFactory {
                 .kitTypeId(kitTypeId)
                 .build();
         var savedKitRequest = kitRequestDao.create(kitRequest);
-        var dsmStatus = PepperKitRequest.builder()
+        var dsmStatus = PepperKit.builder()
                 .currentStatus("kit without label")
                 .juniperKitId(savedKitRequest.getId().toString())
                 .build();
-        savedKitRequest.setExternalRequest(objectMapper.writeValueAsString(dsmStatus));
-        savedKitRequest.setExternalRequestFetchedAt(Instant.now());
+        savedKitRequest.setExternalKit(objectMapper.writeValueAsString(dsmStatus));
+        savedKitRequest.setExternalKitFetchedAt(Instant.now());
         return kitRequestDao.update(savedKitRequest);
     }
 }

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/kit/KitRequestFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/kit/KitRequestFactory.java
@@ -6,7 +6,7 @@ import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.kit.KitRequestStatus;
 import bio.terra.pearl.core.model.kit.KitType;
-import bio.terra.pearl.core.service.kit.pepper.PepperKitStatus;
+import bio.terra.pearl.core.service.kit.pepper.PepperKitRequest;
 import bio.terra.pearl.core.service.kit.pepper.PepperKitAddress;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -56,12 +56,12 @@ public class KitRequestFactory {
                 .kitTypeId(kitTypeId)
                 .build();
         var savedKitRequest = kitRequestDao.create(kitRequest);
-        var dsmStatus = PepperKitStatus.builder()
+        var dsmStatus = PepperKitRequest.builder()
                 .currentStatus("kit without label")
                 .juniperKitId(savedKitRequest.getId().toString())
                 .build();
-        savedKitRequest.setDsmStatus(objectMapper.writeValueAsString(dsmStatus));
-        savedKitRequest.setDsmStatusFetchedAt(Instant.now());
+        savedKitRequest.setExternalRequest(objectMapper.writeValueAsString(dsmStatus));
+        savedKitRequest.setExternalRequestFetchedAt(Instant.now());
         return kitRequestDao.update(savedKitRequest);
     }
 }

--- a/populate/src/main/java/bio/terra/pearl/populate/dto/kit/KitRequestPopDto.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/dto/kit/KitRequestPopDto.java
@@ -10,5 +10,5 @@ import lombok.Setter;
 public class KitRequestPopDto extends KitRequest {
     private String creatingAdminUsername;
     private String kitTypeName;
-    private JsonNode externalRequestJson;
+    private JsonNode externalKitJson;
 }

--- a/populate/src/main/java/bio/terra/pearl/populate/dto/kit/KitRequestPopDto.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/dto/kit/KitRequestPopDto.java
@@ -10,6 +10,5 @@ import lombok.Setter;
 public class KitRequestPopDto extends KitRequest {
     private String creatingAdminUsername;
     private String kitTypeName;
-    private String statusName;
-    private JsonNode dsmStatusJson;
+    private JsonNode externalRequestJson;
 }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
@@ -248,7 +248,7 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
                 .kitTypeId(kitType.getId())
                 .sentToAddress(objectMapper.writeValueAsString(sentToAddress))
                 .status(kitRequestPopDto.getStatus())
-                .externalKit(kitRequestPopDto.getExternalRequestJson().toString())
+                .externalKit(kitRequestPopDto.getExternalKitJson().toString())
                 .externalKitFetchedAt(Instant.now())
                 .build();
         kitRequest = kitRequestService.create(kitRequest);
@@ -419,10 +419,10 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
         popDto.getKitRequestDtos().forEach(kitDto -> {
             try {
                 KitRequestStatus kitRequestStatus = PopulateUtils.randomItem(Arrays.asList(KitRequestStatus.values()));
-                PepperKit pepperRequest = objectMapper.readValue(kitDto.getExternalRequestJson().toString(), PepperKit.class);
+                PepperKit pepperRequest = objectMapper.readValue(kitDto.getExternalKitJson().toString(), PepperKit.class);
                 pepperRequest.setCurrentStatus(kitRequestStatus.toString());
                 generateFakeDates(kitDto, kitRequestStatus, pepperRequest);
-                kitDto.setExternalRequestJson(objectMapper.valueToTree(pepperRequest));
+                kitDto.setExternalKitJson(objectMapper.valueToTree(pepperRequest));
             } catch (JsonProcessingException e) {
                 throw new RuntimeException(e);
             }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
@@ -21,7 +21,7 @@ import bio.terra.pearl.core.service.CascadeProperty;
 import bio.terra.pearl.core.service.consent.ConsentFormService;
 import bio.terra.pearl.core.service.consent.ConsentResponseService;
 import bio.terra.pearl.core.service.kit.KitRequestService;
-import bio.terra.pearl.core.service.kit.pepper.PepperKitRequest;
+import bio.terra.pearl.core.service.kit.pepper.PepperKit;
 import bio.terra.pearl.core.service.notification.NotificationConfigService;
 import bio.terra.pearl.core.service.notification.NotificationService;
 import bio.terra.pearl.core.service.participant.*;
@@ -248,8 +248,8 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
                 .kitTypeId(kitType.getId())
                 .sentToAddress(objectMapper.writeValueAsString(sentToAddress))
                 .status(kitRequestPopDto.getStatus())
-                .externalRequest(kitRequestPopDto.getExternalRequestJson().toString())
-                .externalRequestFetchedAt(Instant.now())
+                .externalKit(kitRequestPopDto.getExternalRequestJson().toString())
+                .externalKitFetchedAt(Instant.now())
                 .build();
         kitRequest = kitRequestService.create(kitRequest);
         if (kitRequestPopDto.getCreatedAt() != null) {
@@ -419,7 +419,7 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
         popDto.getKitRequestDtos().forEach(kitDto -> {
             try {
                 KitRequestStatus kitRequestStatus = PopulateUtils.randomItem(Arrays.asList(KitRequestStatus.values()));
-                PepperKitRequest pepperRequest = objectMapper.readValue(kitDto.getExternalRequestJson().toString(), PepperKitRequest.class);
+                PepperKit pepperRequest = objectMapper.readValue(kitDto.getExternalRequestJson().toString(), PepperKit.class);
                 pepperRequest.setCurrentStatus(kitRequestStatus.toString());
                 generateFakeDates(kitDto, kitRequestStatus, pepperRequest);
                 kitDto.setExternalRequestJson(objectMapper.valueToTree(pepperRequest));
@@ -429,7 +429,7 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
         });
     }
 
-    private static void generateFakeDates(KitRequestPopDto kitDto, KitRequestStatus status, PepperKitRequest pepperRequest) {
+    private static void generateFakeDates(KitRequestPopDto kitDto, KitRequestStatus status, PepperKit pepperRequest) {
         Instant recent = Instant.now();
         DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneId.systemDefault());
         switch (status) {

--- a/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
@@ -21,7 +21,7 @@ import bio.terra.pearl.core.service.CascadeProperty;
 import bio.terra.pearl.core.service.consent.ConsentFormService;
 import bio.terra.pearl.core.service.consent.ConsentResponseService;
 import bio.terra.pearl.core.service.kit.KitRequestService;
-import bio.terra.pearl.core.service.kit.pepper.PepperKitStatus;
+import bio.terra.pearl.core.service.kit.pepper.PepperKitRequest;
 import bio.terra.pearl.core.service.notification.NotificationConfigService;
 import bio.terra.pearl.core.service.notification.NotificationService;
 import bio.terra.pearl.core.service.participant.*;
@@ -242,15 +242,14 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
         var adminUser = adminUserDao.findByUsername(kitRequestPopDto.getCreatingAdminUsername()).get();
         var kitType = kitTypeDao.findByName(kitRequestPopDto.getKitTypeName()).get();
         var sentToAddress = KitRequestService.makePepperKitAddress(profile);
-        var kitRequestStatus = KitRequestStatus.valueOf(kitRequestPopDto.getStatusName());
         var kitRequest = KitRequest.builder()
                 .creatingAdminUserId(adminUser.getId())
                 .enrolleeId(enrollee.getId())
                 .kitTypeId(kitType.getId())
                 .sentToAddress(objectMapper.writeValueAsString(sentToAddress))
-                .status(kitRequestStatus)
-                .dsmStatus(kitRequestPopDto.getDsmStatusJson().toString())
-                .dsmStatusFetchedAt(Instant.now())
+                .status(kitRequestPopDto.getStatus())
+                .externalRequest(kitRequestPopDto.getExternalRequestJson().toString())
+                .externalRequestFetchedAt(Instant.now())
                 .build();
         kitRequest = kitRequestService.create(kitRequest);
         if (kitRequestPopDto.getCreatedAt() != null) {
@@ -419,46 +418,34 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
     private void populateKitRequests(EnrolleePopDto popDto) {
         popDto.getKitRequestDtos().forEach(kitDto -> {
             try {
-                var pepperStatus = objectMapper.readValue(kitDto.getDsmStatusJson().toString(), PepperKitStatus.class);
-                var status = PopulateUtils.randomItem(List.of("CREATED", "LABELED", "SCANNED", "RECEIVED"));
-                // Set appropriate statuses:
-                //   PepperKitStatus.currentStatus - status according to GP workflow in Pepper
-                //   KitRequestPopDto.statusName - status according to study staff workflow in Juniper
-                pepperStatus.setCurrentStatus(status);
-                switch (status) {
-                    case "CREATED" -> kitDto.setStatusName("CREATED");
-                    case "LABELED", "SCANNED" -> kitDto.setStatusName("IN_PROGRESS");
-                    case "RECEIVED" -> kitDto.setStatusName("COMPLETE");
-                    default -> {
-                        pepperStatus.setCurrentStatus("ERROR");
-                        kitDto.setStatus(KitRequestStatus.FAILED);
-                    }
-                }
-                generateFakeDates(kitDto, pepperStatus, status);
-                kitDto.setDsmStatusJson(objectMapper.valueToTree(pepperStatus));
+                KitRequestStatus kitRequestStatus = PopulateUtils.randomItem(Arrays.asList(KitRequestStatus.values()));
+                PepperKitRequest pepperRequest = objectMapper.readValue(kitDto.getExternalRequestJson().toString(), PepperKitRequest.class);
+                pepperRequest.setCurrentStatus(kitRequestStatus.toString());
+                generateFakeDates(kitDto, kitRequestStatus, pepperRequest);
+                kitDto.setExternalRequestJson(objectMapper.valueToTree(pepperRequest));
             } catch (JsonProcessingException e) {
                 throw new RuntimeException(e);
             }
         });
     }
 
-    private static void generateFakeDates(KitRequestPopDto kitDto, PepperKitStatus pepperStatus, String status) {
+    private static void generateFakeDates(KitRequestPopDto kitDto, KitRequestStatus status, PepperKitRequest pepperRequest) {
         Instant recent = Instant.now();
         DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneId.systemDefault());
         switch (status) {
             // Intentional fall-through to set all dates up to and including the date of `status`
-            case "RECEIVED":
+            case RECEIVED:
                 recent = recent.minus(PopulateUtils.randomInteger(1, 72), HOURS);
-                pepperStatus.setReceiveDate(formatter.format(recent));
-            case "SCANNED":
+                pepperRequest.setReceiveDate(formatter.format(recent));
+            case SENT:
                 recent = recent.minus(PopulateUtils.randomInteger(10, 30), DAYS);
-                pepperStatus.setScanDate(formatter.format(recent));
-                pepperStatus.setReturnTrackingNumber("1Z%s".formatted(PopulateUtils.randomString(12)));
-            case "LABELED":
+                pepperRequest.setScanDate(formatter.format(recent));
+                pepperRequest.setReturnTrackingNumber("1Z%s".formatted(PopulateUtils.randomString(12)));
+            case QUEUED:
                 recent = recent.minus(PopulateUtils.randomInteger(5, 7), DAYS);
-                pepperStatus.setLabelDate(formatter.format(recent));
-                pepperStatus.setTrackingNumber("1Z%s".formatted(PopulateUtils.randomString(12)));
-            case "CREATED":
+                pepperRequest.setLabelDate(formatter.format(recent));
+                pepperRequest.setTrackingNumber("1Z%s".formatted(PopulateUtils.randomString(12)));
+            case CREATED:
                 kitDto.setCreatedAt(recent.minus(PopulateUtils.randomInteger(12, 48), HOURS));
         }
     }

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
@@ -82,7 +82,7 @@
       "creatingAdminUsername": "staff@heartdemo.org",
       "kitTypeName": "SALIVA",
       "status": "CREATED",
-      "externalRequestJson": {
+      "externalKitJson": {
         "kitId": "11111111-2222-3333-4444-555555555555",
         "currentStatus": "kit without label",
         "labelDate": "2023-05-24",

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
@@ -81,8 +81,8 @@
     {
       "creatingAdminUsername": "staff@heartdemo.org",
       "kitTypeName": "SALIVA",
-      "statusName": "CREATED",
-      "dsmStatusJson": {
+      "status": "CREATED",
+      "externalRequestJson": {
         "kitId": "11111111-2222-3333-4444-555555555555",
         "currentStatus": "kit without label",
         "labelDate": "2023-05-24",

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/enrollees/jsalk.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/enrollees/jsalk.json
@@ -75,7 +75,7 @@
       "creatingAdminUsername": "staff@ourhealth.org",
       "kitTypeName": "SALIVA",
       "status": "CREATED",
-      "externalRequestJson": {
+      "externalKitJson": {
         "kitId": "11111111-2222-3333-4444-555555555555",
         "currentStatus": "kit without label",
         "labelDate": "2023-05-24",
@@ -98,7 +98,7 @@
       "creatingAdminUsername": "staff2@ourhealth.org",
       "kitTypeName": "SALIVA",
       "status": "DEACTIVATED",
-      "externalRequestJson": {
+      "externalKitJson": {
         "kitId": "11111111-2222-3333-4444-555555555556",
         "currentStatus": "deactivated",
         "labelDate": "2023-05-12",

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/enrollees/jsalk.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/enrollees/jsalk.json
@@ -74,8 +74,8 @@
     {
       "creatingAdminUsername": "staff@ourhealth.org",
       "kitTypeName": "SALIVA",
-      "statusName": "CREATED",
-      "dsmStatusJson": {
+      "status": "CREATED",
+      "externalRequestJson": {
         "kitId": "11111111-2222-3333-4444-555555555555",
         "currentStatus": "kit without label",
         "labelDate": "2023-05-24",
@@ -97,8 +97,8 @@
     {
       "creatingAdminUsername": "staff2@ourhealth.org",
       "kitTypeName": "SALIVA",
-      "statusName": "FAILED",
-      "dsmStatusJson": {
+      "status": "DEACTIVATED",
+      "externalRequestJson": {
         "kitId": "11111111-2222-3333-4444-555555555556",
         "currentStatus": "deactivated",
         "labelDate": "2023-05-12",
@@ -112,7 +112,7 @@
         "deactivationReason": "",
         "trackingNumbers": [],
         "returnTrackingNumber": "",
-        "errors": [],
+        "errors": ["Kit request was cancelled at request of participant"],
         "discardDate": "",
         "discardReason": ""
       }

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/enrollees/seed.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/enrollees/seed.json
@@ -96,7 +96,7 @@
     {
       "creatingAdminUsername": "staff@ourhealth.org",
       "kitTypeName": "SALIVA",
-      "statusName": "CREATED",
+      "status": "CREATED",
       "dsmStatusJson": {
         "kitId": "11111111-2222-3333-4444-555555555555",
         "currentStatus": "CREATED",

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -153,7 +153,7 @@ export type KitType = {
   description: string
 }
 
-export type PepperKitStatus = {
+export type PepperKit = {
   kitId: string,
   currentStatus: string,
   labelDate: string,
@@ -193,7 +193,7 @@ export type SiteImageMetadata = {
   version: number
 }
 
-const emptyPepperKitStatus: PepperKitStatus = {
+const emptyPepperKit: PepperKit = {
   kitId: '',
   currentStatus: '(unknown)',
   labelDate: '',
@@ -211,12 +211,12 @@ const emptyPepperKitStatus: PepperKitStatus = {
  * Therefore, this function will never raise an error and will always return an object that conforms to the
  * `PepperKitStatus` type.
  */
-function parsePepperKitStatus(json: string | undefined): PepperKitStatus {
+function parsePepperKitStatus(json: string | undefined): PepperKit {
   if (json) {
     try {
       const pepperStatus = JSON.parse(json)
       return {
-        ...emptyPepperKitStatus,
+        ...emptyPepperKit,
         ..._pick(pepperStatus,
           'juniperKitId', 'currentStatus', 'labelDate', 'scanDate', 'receiveDate', 'trackingNumber',
           'returnTrackingNumber', 'errorMessage')
@@ -225,7 +225,7 @@ function parsePepperKitStatus(json: string | undefined): PepperKitStatus {
       // ignore; fall-through to result for unexpected value
     }
   }
-  return emptyPepperKitStatus
+  return emptyPepperKit
 }
 
 export type KitRequest = {
@@ -235,8 +235,8 @@ export type KitRequest = {
   kitType: KitType,
   sentToAddress: string,
   status: string
-  externalRequest?: string
-  parsedExternalRequest?: PepperKitStatus
+  externalKit?: string
+  parsedExternalKit?: PepperKit
 }
 
 export type Config = {
@@ -695,7 +695,7 @@ export default {
     const url =`${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/enrollees/${enrolleeShortcode}`
     const response = await fetch(url, this.getGetInit())
     const enrollee: Enrollee = await this.processJsonResponse(response)
-    enrollee.kitRequests?.forEach(kit => { kit.parsedExternalRequest = parsePepperKitStatus(kit.externalRequest) })
+    enrollee.kitRequests?.forEach(kit => { kit.parsedExternalKit = parsePepperKitStatus(kit.externalKit) })
     return enrollee
   },
 
@@ -764,7 +764,7 @@ export default {
     const url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/kits`
     const response = await fetch(url, this.getGetInit())
     const kits: KitRequest[] = await this.processJsonResponse(response)
-    kits.forEach(kit => { kit.parsedExternalRequest = parsePepperKitStatus(kit.externalRequest) })
+    kits.forEach(kit => { kit.parsedExternalKit = parsePepperKitStatus(kit.externalKit) })
     return kits
   },
 
@@ -799,7 +799,7 @@ export default {
       body: JSON.stringify(enrolleeShortcodes)
     })
     const listResponse: KitRequestListResponse = await this.processJsonResponse(response)
-    listResponse.kitRequests.forEach(kit => { kit.parsedExternalRequest = parsePepperKitStatus(kit.externalRequest) })
+    listResponse.kitRequests.forEach(kit => { kit.parsedExternalKit = parsePepperKitStatus(kit.externalKit) })
     return listResponse
   },
 

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -235,8 +235,8 @@ export type KitRequest = {
   kitType: KitType,
   sentToAddress: string,
   status: string
-  dsmStatus?: string
-  pepperStatus?: PepperKitStatus
+  externalRequest?: string
+  parsedExternalRequest?: PepperKitStatus
 }
 
 export type Config = {
@@ -695,7 +695,7 @@ export default {
     const url =`${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/enrollees/${enrolleeShortcode}`
     const response = await fetch(url, this.getGetInit())
     const enrollee: Enrollee = await this.processJsonResponse(response)
-    enrollee.kitRequests?.forEach(kit => { kit.pepperStatus = parsePepperKitStatus(kit.dsmStatus) })
+    enrollee.kitRequests?.forEach(kit => { kit.parsedExternalRequest = parsePepperKitStatus(kit.externalRequest) })
     return enrollee
   },
 
@@ -764,7 +764,7 @@ export default {
     const url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/kits`
     const response = await fetch(url, this.getGetInit())
     const kits: KitRequest[] = await this.processJsonResponse(response)
-    kits.forEach(kit => { kit.pepperStatus = parsePepperKitStatus(kit.dsmStatus) })
+    kits.forEach(kit => { kit.parsedExternalRequest = parsePepperKitStatus(kit.externalRequest) })
     return kits
   },
 
@@ -799,7 +799,7 @@ export default {
       body: JSON.stringify(enrolleeShortcodes)
     })
     const listResponse: KitRequestListResponse = await this.processJsonResponse(response)
-    listResponse.kitRequests.forEach(kit => { kit.pepperStatus = parsePepperKitStatus(kit.dsmStatus) })
+    listResponse.kitRequests.forEach(kit => { kit.parsedExternalRequest = parsePepperKitStatus(kit.externalRequest) })
     return listResponse
   },
 

--- a/ui-admin/src/study/kits/KitList.test.tsx
+++ b/ui-admin/src/study/kits/KitList.test.tsx
@@ -48,7 +48,7 @@ function mockFetchKits() {
   jest.spyOn(Api, 'fetchKitsByStudyEnvironment').mockImplementation(() => {
     return Promise.resolve([mockKitRequest({
       enrollee: mockEnrollee(),
-      dsmStatus: '{"unexpected": "boom"}'
+      status: 'CREATED'
     })])
   })
 }

--- a/ui-admin/src/study/kits/KitList.tsx
+++ b/ui-admin/src/study/kits/KitList.tsx
@@ -238,7 +238,7 @@ function KitListView({ studyEnvContext, tab, kits, initialColumnVisibility }: {
     enableColumnFilter: false
   }, {
     header: 'Status',
-    accessorKey: 'parsedExternalRequest',
+    accessorKey: 'parsedExternalKit',
     cell: data => <KitStatusCell kitRequest={data.row.original} infoPlacement='left'/>,
     enableColumnFilter: false
   }]

--- a/ui-admin/src/study/participants/KitRequests.test.tsx
+++ b/ui-admin/src/study/participants/KitRequests.test.tsx
@@ -5,7 +5,7 @@ import { setupRouterTest } from 'test-utils/router-testing-utils'
 import { mockEnrollee, mockStudyEnvContext } from 'test-utils/mocking-utils'
 import { render, screen, waitFor } from '@testing-library/react'
 
-test('renders kit requsets', async () => {
+test('renders kit requests', async () => {
   const enrollee = mockEnrollee()
   const studyEnvContext = mockStudyEnvContext()
   const { RoutedComponent } = setupRouterTest(
@@ -15,6 +15,6 @@ test('renders kit requsets', async () => {
     expect(screen.getByText('Kit requests')).toBeInTheDocument()
   })
   expect(screen.getByText('Test kit')).toBeInTheDocument()
-  expect(screen.getByText('Kit Without Label')).toBeInTheDocument()
+  expect(screen.getByText('CREATED')).toBeInTheDocument()
   expect(screen.getByText('1234 Fake Street')).toBeInTheDocument()
 })

--- a/ui-admin/src/study/participants/KitRequests.tsx
+++ b/ui-admin/src/study/participants/KitRequests.tsx
@@ -38,8 +38,8 @@ const columns: ColumnDef<KitRequest, string>[] = [{
   cell: ({ row }) => <KitRequestAddress sentToAddressJson={row.original.sentToAddress}/>
 }, {
   header: 'DSM Status',
-  accessorKey: 'externalRequest',
-  cell: ({ row }) => <InfoPopup content={row.original.externalRequest} placement='left'/>
+  accessorKey: 'externalKit',
+  cell: ({ row }) => <InfoPopup content={row.original.externalKit} placement='left'/>
 }]
 
 /** Shows a list of all kit requests for an enrollee. */

--- a/ui-admin/src/study/participants/KitRequests.tsx
+++ b/ui-admin/src/study/participants/KitRequests.tsx
@@ -38,8 +38,8 @@ const columns: ColumnDef<KitRequest, string>[] = [{
   cell: ({ row }) => <KitRequestAddress sentToAddressJson={row.original.sentToAddress}/>
 }, {
   header: 'DSM Status',
-  accessorKey: 'dsmStatus',
-  cell: ({ row }) => <InfoPopup content={row.original.dsmStatus} placement='left'/>
+  accessorKey: 'externalRequest',
+  cell: ({ row }) => <InfoPopup content={row.original.externalRequest} placement='left'/>
 }]
 
 /** Shows a list of all kit requests for an enrollee. */

--- a/ui-admin/src/study/participants/KitStatusCell.tsx
+++ b/ui-admin/src/study/participants/KitStatusCell.tsx
@@ -12,7 +12,7 @@ export default function KitStatusCell(
   { kitRequest: KitRequest, infoPlacement?: Placement }
 ) {
   const infoTexts: Record<string, string> = {
-    'CREATED': 'Kit has not yet shipped',
+    'CREATED': 'Kit request received, has not yet shipped',
     'QUEUE': 'Shipping label has been printed',
     'SENT': 'Kit has been sent to the participant',
     'RECEIVED': 'Kit has been returned by the participant',
@@ -21,8 +21,8 @@ export default function KitStatusCell(
   }
   const currentStatus = kitRequest.status
   const info = currentStatus ? infoTexts[currentStatus] : ''
-  const errorMessage = kitRequest.parsedExternalRequest?.errorMessage ?
-      `: ${kitRequest.parsedExternalRequest.errorMessage}` : ''
+  const errorMessage = kitRequest.parsedExternalKit?.errorMessage ?
+      `: ${kitRequest.parsedExternalKit.errorMessage}` : ''
   const content = `${info}${errorMessage}`
   return <>
     {kitRequest.status}

--- a/ui-admin/src/study/participants/KitStatusCell.tsx
+++ b/ui-admin/src/study/participants/KitStatusCell.tsx
@@ -21,7 +21,8 @@ export default function KitStatusCell(
   }
   const currentStatus = kitRequest.status
   const info = currentStatus ? infoTexts[currentStatus] : ''
-  const errorMessage = kitRequest.parsedExternalRequest?.errorMessage ? `: ${kitRequest.parsedExternalRequest.errorMessage}` : ''
+  const errorMessage = kitRequest.parsedExternalRequest?.errorMessage ?
+      `: ${kitRequest.parsedExternalRequest.errorMessage}` : ''
   const content = `${info}${errorMessage}`
   return <>
     {kitRequest.status}

--- a/ui-admin/src/study/participants/KitStatusCell.tsx
+++ b/ui-admin/src/study/participants/KitStatusCell.tsx
@@ -12,19 +12,19 @@ export default function KitStatusCell(
   { kitRequest: KitRequest, infoPlacement?: Placement }
 ) {
   const infoTexts: Record<string, string> = {
-    'kit without label': 'Kit request has been received',
-    'queue': 'Shipping label has been printed',
-    'sent': 'Kit has been sent to the participant',
-    'received': 'Kit has been returned by the participant',
-    'error': 'There was a problem fulfilling this kit request',
-    'deactivated': 'Kit is deactivated'
+    'CREATED': 'Kit request has been received',
+    'QUEUE': 'Shipping label has been printed',
+    'SENT': 'Kit has been sent to the participant',
+    'RECEIVED': 'Kit has been returned by the participant',
+    'ERRORED': 'There was a problem fulfilling this kit request',
+    'DEACTIVATED': 'Kit is deactivated - no further processing will be done'
   }
-  const currentStatus = kitRequest.pepperStatus?.currentStatus
-  const info = currentStatus ? infoTexts[currentStatus.toLowerCase()] : ''
-  const errorMessage = kitRequest.pepperStatus?.errorMessage ? `: ${kitRequest.pepperStatus.errorMessage}` : ''
+  const currentStatus = kitRequest.status
+  const info = currentStatus ? infoTexts[currentStatus] : ''
+  const errorMessage = kitRequest.parsedExternalRequest?.errorMessage ? `: ${kitRequest.parsedExternalRequest.errorMessage}` : ''
   const content = `${info}${errorMessage}`
   return <>
-    {kitRequest.pepperStatus?.currentStatus}
+    {kitRequest.status}
     {info && <InfoPopup content={content} placement={infoPlacement}/>}
   </>
 }

--- a/ui-admin/src/study/participants/KitStatusCell.tsx
+++ b/ui-admin/src/study/participants/KitStatusCell.tsx
@@ -12,7 +12,7 @@ export default function KitStatusCell(
   { kitRequest: KitRequest, infoPlacement?: Placement }
 ) {
   const infoTexts: Record<string, string> = {
-    'CREATED': 'Kit request has been received',
+    'CREATED': 'Kit has not yet shipped',
     'QUEUE': 'Shipping label has been printed',
     'SENT': 'Kit has been sent to the participant',
     'RECEIVED': 'Kit has been returned by the participant',

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -207,24 +207,25 @@ export const mockKitType: () => KitType = () => ({
   description: 'Test sample collection kit'
 })
 
+/** returns a mock PepperKitStatus */
 export const mockExternalKitRequest = (): PepperKitStatus => {
   return {
     kitId: '',
-        currentStatus: 'Kit Without Label',
-      labelDate: '',
-      scanDate: '',
-      receiveDate: '',
-      trackingNumber: '',
-      returnTrackingNumber: '',
-      errorMessage: ''
+    currentStatus: 'Kit Without Label',
+    labelDate: '',
+    scanDate: '',
+    receiveDate: '',
+    trackingNumber: '',
+    returnTrackingNumber: '',
+    errorMessage: ''
   }
 }
 
 /** returns a mock kit request */
 export const mockKitRequest: (args?: {
   enrollee?: Enrollee,
-  dsmStatus?: string
-}) => KitRequest = ({ enrollee, dsmStatus } = {}) => ({
+  status?: string
+}) => KitRequest = ({ enrollee, status } = {}) => ({
   id: 'kitRequestId',
   createdAt: 1,
   enrollee,
@@ -240,7 +241,7 @@ export const mockKitRequest: (args?: {
     postalCode: '02138',
     country: 'US'
   }),
-  status: 'CREATED',
+  status: status || 'CREATED',
   externalRequest: JSON.stringify(mockExternalKitRequest()),
   parsedExternalRequest: mockExternalKitRequest()
 })

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -9,7 +9,7 @@ import {
   KitRequest,
   KitType,
   NotificationConfig,
-  ParticipantNote, PepperKitStatus,
+  ParticipantNote, PepperKit,
   Portal,
   PortalStudy, SiteImageMetadata,
   StudyEnvironmentConsent, SurveyResponse
@@ -208,7 +208,7 @@ export const mockKitType: () => KitType = () => ({
 })
 
 /** returns a mock PepperKitStatus */
-export const mockExternalKitRequest = (): PepperKitStatus => {
+export const mockExternalKitRequest = (): PepperKit => {
   return {
     kitId: '',
     currentStatus: 'Kit Without Label',
@@ -242,8 +242,8 @@ export const mockKitRequest: (args?: {
     country: 'US'
   }),
   status: status || 'CREATED',
-  externalRequest: JSON.stringify(mockExternalKitRequest()),
-  parsedExternalRequest: mockExternalKitRequest()
+  externalKit: JSON.stringify(mockExternalKitRequest()),
+  parsedExternalKit: mockExternalKitRequest()
 })
 
 /** returns a simple mock enrollee loosely based on the jsalk.json synthetic enrollee */

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -9,7 +9,7 @@ import {
   KitRequest,
   KitType,
   NotificationConfig,
-  ParticipantNote,
+  ParticipantNote, PepperKitStatus,
   Portal,
   PortalStudy, SiteImageMetadata,
   StudyEnvironmentConsent, SurveyResponse
@@ -207,6 +207,19 @@ export const mockKitType: () => KitType = () => ({
   description: 'Test sample collection kit'
 })
 
+export const mockExternalKitRequest = (): PepperKitStatus => {
+  return {
+    kitId: '',
+        currentStatus: 'Kit Without Label',
+      labelDate: '',
+      scanDate: '',
+      receiveDate: '',
+      trackingNumber: '',
+      returnTrackingNumber: '',
+      errorMessage: ''
+  }
+}
+
 /** returns a mock kit request */
 export const mockKitRequest: (args?: {
   enrollee?: Enrollee,
@@ -228,17 +241,8 @@ export const mockKitRequest: (args?: {
     country: 'US'
   }),
   status: 'CREATED',
-  externalRequest: dsmStatus,
-  parsedExternalRequest: {
-    kitId: '',
-    currentStatus: 'Kit Without Label',
-    labelDate: '',
-    scanDate: '',
-    receiveDate: '',
-    trackingNumber: '',
-    returnTrackingNumber: '',
-    errorMessage: ''
-  }
+  externalRequest: JSON.stringify(mockExternalKitRequest()),
+  parsedExternalRequest: mockExternalKitRequest()
 })
 
 /** returns a simple mock enrollee loosely based on the jsalk.json synthetic enrollee */

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -228,8 +228,8 @@ export const mockKitRequest: (args?: {
     country: 'US'
   }),
   status: 'CREATED',
-  dsmStatus,
-  pepperStatus: {
+  externalRequest: dsmStatus,
+  parsedExternalRequest: {
     kitId: '',
     currentStatus: 'Kit Without Label',
     labelDate: '',


### PR DESCRIPTION
#### DESCRIPTION

I started investigating including kit status into the participant data export, and using it to send reminders, and immediately got lost in the multiple layers of "statuses". So this PR is an effort to simplify and clean up our status code.  This has no functional changes except the addition of the "deactivated" tab (which was much easier to add as a result of this cleanup) 

The major change is that our KitRequestStatus is now a superset of statuses we get from Pepper, with a one-to-one mapping of statuses.  This enables our application logic to use the KitRequestStatus directly, instead of having to dive into the pepper data object.  I expect we will want to start extracting more fields like this from the pepper object as we add more admin capability.

<img width="1172" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/76d9b89f-eb4f-4227-bd3f-f8ebed6525d9">

This also does some minor prep for supporting non-Pepper manual kit tracking, by renaming KitRequest.dsmStatus to 'externalRequest' -- both so it's clear that's the representation of the entire request, and so that could represent state from somewhere other than pepper.

For the migration script, correctness of the status mapping is actually not that important to test (I lightly tested it locally), since the statuses will all be resynced nightly anyway, so the migration just ensures the data will look reasonable in the immediate aftermath of the release.   

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. Restart ApiAdminApp
2. repopulate OurHealth
3. go to `https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/kits/requested/created`
4. confirm you see two kits, one 'created', one 'deactivated'
5. refresh the kit statuses a few times, and confirm the kit statuses cycle appropriately.