### PR TITLE
[JN-735] Add study name to StudyEnvDiff view

### DIFF
--- a/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
@@ -19,7 +19,7 @@ export const emptyChangeSet: PortalEnvironmentChange = {
   studyEnvChanges: []
 }
 
-const emptyStudyEnvChange: StudyEnvironmentChange = {
+export const emptyStudyEnvChange: StudyEnvironmentChange = {
   studyShortcode: '',
   configChanges: [],
   preEnrollSurveyChanges: { changed: false },
@@ -81,7 +81,7 @@ type EnvironmentDiffProps = {
  * loads and displays the differences between two portal environments
  * */
 export default function PortalEnvDiffView(
-  { changeSet, destEnvName, applyChanges, sourceEnvName }: EnvironmentDiffProps) {
+  { changeSet, destEnvName, applyChanges, sourceEnvName, portal }: EnvironmentDiffProps) {
   const [selectedChanges, setSelectedChanges] = useState<PortalEnvironmentChange>(getDefaultPortalEnvChanges(changeSet))
 
   const updateSelectedStudyEnvChanges = (update: StudyEnvironmentChange) => {
@@ -160,7 +160,9 @@ export default function PortalEnvDiffView(
         {changeSet.studyEnvChanges.map(studyEnvChange => {
           const matchedChange = selectedChanges.studyEnvChanges
             .find(change => change.studyShortcode === studyEnvChange.studyShortcode) as StudyEnvironmentChange
-          return <StudyEnvDiff key={studyEnvChange.studyShortcode} studyEnvChange={studyEnvChange}
+          const studyName = portal.portalStudies.find(study =>
+            study.study.shortcode === studyEnvChange.studyShortcode)?.study.name || studyEnvChange.studyShortcode
+          return <StudyEnvDiff key={studyEnvChange.studyShortcode} studyName={studyName} studyEnvChange={studyEnvChange}
             selectedChanges={matchedChange} setSelectedChanges={updateSelectedStudyEnvChanges}/>
         })}
       </div>

--- a/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
@@ -160,8 +160,8 @@ export default function PortalEnvDiffView(
         {changeSet.studyEnvChanges.map(studyEnvChange => {
           const matchedChange = selectedChanges.studyEnvChanges
             .find(change => change.studyShortcode === studyEnvChange.studyShortcode) as StudyEnvironmentChange
-          const studyName = portal.portalStudies.find(study =>
-            study.study.shortcode === studyEnvChange.studyShortcode)?.study.name || studyEnvChange.studyShortcode
+          const studyName = portal.portalStudies.find(portalStudy =>
+            portalStudy.study.shortcode === studyEnvChange.studyShortcode)?.study.name || studyEnvChange.studyShortcode
           return <StudyEnvDiff key={studyEnvChange.studyShortcode} studyName={studyName} studyEnvChange={studyEnvChange}
             selectedChanges={matchedChange} setSelectedChanges={updateSelectedStudyEnvChanges}/>
         })}

--- a/ui-admin/src/portal/publish/StudyEnvDiff.test.tsx
+++ b/ui-admin/src/portal/publish/StudyEnvDiff.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import { emptyStudyEnvChange } from './PortalEnvDiffView'
 import StudyEnvDiff from './StudyEnvDiff'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 
 test('StudyEnvDiff renders the name of the study', () => {
-  const { getByText } = render(<StudyEnvDiff studyName="Test Study"
+  render(<StudyEnvDiff studyName="Test Study"
     studyEnvChange={emptyStudyEnvChange}
     selectedChanges={emptyStudyEnvChange}
     setSelectedChanges={jest.fn()}
   />)
-  expect(getByText('Test Study')).toBeInTheDocument()
+  expect(screen.getByText('Test Study')).toBeInTheDocument()
 })

--- a/ui-admin/src/portal/publish/StudyEnvDiff.test.tsx
+++ b/ui-admin/src/portal/publish/StudyEnvDiff.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { emptyStudyEnvChange } from './PortalEnvDiffView'
+import StudyEnvDiff from './StudyEnvDiff'
+import { render } from '@testing-library/react'
+
+test('StudyEnvDiff renders the name of the study', () => {
+  const { getByText } = render(<StudyEnvDiff studyName="Test Study"
+    studyEnvChange={emptyStudyEnvChange}
+    selectedChanges={emptyStudyEnvChange}
+    setSelectedChanges={jest.fn()}
+  />)
+  expect(getByText('Test Study')).toBeInTheDocument()
+})

--- a/ui-admin/src/portal/publish/StudyEnvDiff.tsx
+++ b/ui-admin/src/portal/publish/StudyEnvDiff.tsx
@@ -9,6 +9,7 @@ import {
 } from './diffComponents'
 
 type StudyEnvDiffProps = {
+  studyName: string,
   studyEnvChange: StudyEnvironmentChange,
   selectedChanges: StudyEnvironmentChange,
   setSelectedChanges: (update: StudyEnvironmentChange) => void
@@ -16,9 +17,9 @@ type StudyEnvDiffProps = {
 
 // TODO: Add JSDoc
 // eslint-disable-next-line jsdoc/require-jsdoc
-const StudyEnvDiff = ({ studyEnvChange, selectedChanges, setSelectedChanges }: StudyEnvDiffProps) => {
-  return <div className="px-3 mb-5">
-    <h2 className="h5">{studyEnvChange.studyShortcode}</h2>
+const StudyEnvDiff = ({ studyName, studyEnvChange, selectedChanges, setSelectedChanges }: StudyEnvDiffProps) => {
+  return <div className="px-3 my-2 py-2" style={{ backgroundColor: '#ededed' }}>
+    <h2 className="h5 pb-2">{studyName}</h2>
     <div className="my-1">
       <h3 className="h6">Environment config</h3>
       <div className="ms-4">

--- a/ui-admin/src/portal/publish/StudyEnvDiff.tsx
+++ b/ui-admin/src/portal/publish/StudyEnvDiff.tsx
@@ -17,7 +17,8 @@ type StudyEnvDiffProps = {
 // TODO: Add JSDoc
 // eslint-disable-next-line jsdoc/require-jsdoc
 const StudyEnvDiff = ({ studyEnvChange, selectedChanges, setSelectedChanges }: StudyEnvDiffProps) => {
-  return <div className="px-3">
+  return <div className="px-3 mb-5">
+    <h2 className="h5">{studyEnvChange.studyShortcode}</h2>
     <div className="my-1">
       <h3 className="h6">Environment config</h3>
       <div className="ms-4">


### PR DESCRIPTION
#### DESCRIPTION

This adds the study name and some visual separation to studies in the portal env diff view.

Before:
![Screenshot 2023-12-01 at 9 46 29 AM](https://github.com/broadinstitute/juniper/assets/7257391/7d910790-8421-487d-b901-fcf078dd3f57)


After:
![Screenshot 2023-12-01 at 9 45 52 AM](https://github.com/broadinstitute/juniper/assets/7257391/3a909f8b-71d6-4447-9dff-005c3811f993)


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Diff a portal with multiple studies, i.e. HeartHive https://localhost:3000/hearthive/studies/hh_registry/diff/sandbox/irb
Confirm that the 3 studies aren't all lumped together
