### PR TITLE
[JN-732] Add pdf support

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/site/SiteImageService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/site/SiteImageService.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class SiteImageService extends ImmutableEntityService<SiteImage, SiteImageDao> {
-    public static final List<String> ALLOWED_EXTENSIONS = Arrays.asList("png", "jpeg", "jpg", "svg", "gif", "webp", "ico");
+    public static final List<String> ALLOWED_EXTENSIONS = Arrays.asList("png", "jpeg", "jpg", "svg", "gif", "webp", "ico", "pdf");
     private PortalService portalService;
     public SiteImageService(SiteImageDao dao, @Lazy PortalService portalService) {
         super(dao);

--- a/ui-admin/src/portal/images/SiteImageList.test.tsx
+++ b/ui-admin/src/portal/images/SiteImageList.test.tsx
@@ -35,3 +35,19 @@ test('renders table with a clickable image', async () => {
   await userEvent.click(screen.getByTitle('show full-size preview'))
   await waitFor(() => expect(screen.getByAltText('full-size preview of testImage.png')).toBeInTheDocument())
 })
+
+test('does not render a preview for a non-image type', async () => {
+  jest.spyOn(Api, 'getPortalImages').mockImplementation(() => Promise.resolve([{
+    id: 'fakeId',
+    cleanFileName: 'testDoc.pdf',
+    version: 1,
+    createdAt: Date.now()
+  }]))
+  const { RoutedComponent } = setupRouterTest(
+    <SiteImageList portalContext={mockPortalContext()}
+      portalEnv={mockPortalEnvironment('sandbox')}/>)
+  render(RoutedComponent)
+  await waitFor(() => expect(screen.getByText('Showing 1 of 1 rows')).toBeInTheDocument())
+  expect(screen.getByText('testDoc.pdf')).toBeInTheDocument()
+  expect(screen.getByText('no preview')).toBeInTheDocument()
+})

--- a/ui-admin/src/portal/images/SiteImageList.tsx
+++ b/ui-admin/src/portal/images/SiteImageList.tsx
@@ -14,10 +14,11 @@ import { LoadedPortalContextT } from '../PortalProvider'
 import { useLoadingEffect } from 'api/api-utils'
 import TableClientPagination from 'util/TablePagination'
 import { Modal } from 'react-bootstrap'
-import SiteImageUploadModal from './SiteImageUploadModal'
+import SiteImageUploadModal, { allowedImageTypes } from './SiteImageUploadModal'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons'
-import { Button } from '../../components/forms/Button'
+import { Button } from 'components/forms/Button'
+import { renderPageHeader } from 'util/pageUtils'
 
 /** shows a list of images in a table */
 export default function SiteImageList({ portalContext, portalEnv }:
@@ -36,6 +37,9 @@ export default function SiteImageList({ portalContext, portalEnv }:
     setShowUploadModal(true)
   }
 
+  const supportsPreview = (image: SiteImageMetadata) => {
+    return allowedImageTypes.some(ext => image.cleanFileName.endsWith(ext))
+  }
 
   const columns: ColumnDef<SiteImageMetadata>[] = [{
     header: 'File name',
@@ -50,17 +54,19 @@ export default function SiteImageList({ portalContext, portalEnv }:
   }, {
     header: '',
     id: 'thumbnail',
-    cell: ({ row: { original: image } }) => <button onClick={() => setPreviewImage(image)}
-      style={{
-        minHeight: '44px', minWidth: '90px',
-        maxHeight: '44px', maxWidth: '90px'
-      }}
-      className="border-1 bg-white"
-      title="show full-size preview">
-      <img src={getImageUrl(portalContext.portal.shortcode, image.cleanFileName, image.version)}
-        style={{ maxHeight: '40px', maxWidth: '80px' }}
-      />
-    </button>
+    cell: ({ row: { original: image } }) => supportsPreview(image) ?
+      <button onClick={() => setPreviewImage(image)}
+        style={{
+          minHeight: '44px', minWidth: '90px',
+          maxHeight: '44px', maxWidth: '90px'
+        }}
+        className="border-1 bg-white"
+        title="show full-size preview">
+        <img src={getImageUrl(portalContext.portal.shortcode, image.cleanFileName, image.version)}
+          style={{ maxHeight: '40px', maxWidth: '80px' }}
+        />
+      </button> :
+      <span className="text-muted">no preview</span>
   }, {
     header: '',
     id: 'actions',
@@ -110,10 +116,11 @@ export default function SiteImageList({ portalContext, portalEnv }:
   }, [portalContext.portal.shortcode, portalEnv.environmentName])
 
 
-  return <div className="container p-3">
-    <h1 className="h4">Site images </h1>
-    <Button variant="secondary" onClick={() => setShowUploadModal(true)} >
-      <FontAwesomeIcon icon={faPlus}/> Add Image
+  return <div className="container-fluid px-4 py-2">
+    { renderPageHeader('Site Media')}
+    <Button onClick={() => setShowUploadModal(true)}
+      variant="light" className="border m-1">
+      <FontAwesomeIcon icon={faPlus} className="fa-lg"/> Upload
     </Button>
     <LoadingSpinner isLoading={isLoading}>
       {basicTableLayout(table)}

--- a/ui-admin/src/portal/images/SiteImageUploadModal.tsx
+++ b/ui-admin/src/portal/images/SiteImageUploadModal.tsx
@@ -10,9 +10,9 @@ import { LoadedPortalContextT } from '../PortalProvider'
 
 
 export const allowedImageTypes = ['gif', 'ico', 'jpeg', 'jpg', 'png', 'svg', 'webp']
-export const allowedApplicationTypes = ['pdf']
+export const allowedDocumentTypes = ['pdf']
 const FILE_TYPE_REGEX = new RegExp(
-  `^(?:image\\/(?:${allowedImageTypes.join('|')}))|(?:application\\/(?:${allowedApplicationTypes.join('|')}))$`
+  `^(?:image\\/(?:${allowedImageTypes.join('|')}))|(?:application\\/(?:${allowedDocumentTypes.join('|')}))$`
 )
 /** Renders a modal for an admin to submit a sample collection kit request. */
 export default function SiteImageUploadModal({
@@ -62,7 +62,7 @@ export default function SiteImageUploadModal({
     <Modal.Body>
       <form onSubmit={e => e.preventDefault()}>
         <div>
-          <p>Supported extensions are {[...allowedImageTypes, ...allowedApplicationTypes].join(', ')}.
+          <p>Supported extensions are {[...allowedImageTypes, ...allowedDocumentTypes].join(', ')}.
             Maximum size is 10MB</p>
           File:
           <div>

--- a/ui-admin/src/portal/images/SiteImageUploadModal.tsx
+++ b/ui-admin/src/portal/images/SiteImageUploadModal.tsx
@@ -9,7 +9,11 @@ import { Button } from 'components/forms/Button'
 import { LoadedPortalContextT } from '../PortalProvider'
 
 
-const FLE_TYPE_REGEX = /image\/(gif|ico|jpeg|jpg|png|svg|webp)/
+export const allowedImageTypes = ['gif', 'ico', 'jpeg', 'jpg', 'png', 'svg', 'webp']
+export const allowedApplicationTypes = ['pdf']
+const FILE_TYPE_REGEX = new RegExp(
+  `^(?:image\\/(?:${allowedImageTypes.join('|')}))|(?:application\\/(?:${allowedApplicationTypes.join('|')}))$`
+)
 /** Renders a modal for an admin to submit a sample collection kit request. */
 export default function SiteImageUploadModal({
   portalContext,
@@ -43,7 +47,7 @@ export default function SiteImageUploadModal({
   }
 
   const validationMessages = []
-  if (file && !file.type.match(FLE_TYPE_REGEX)) {
+  if (file && !file.type.match(FILE_TYPE_REGEX)) {
     validationMessages.push('This file extension is not supported.')
   }
   if (file && file.size > 10 * 1024 * 1024) {
@@ -53,14 +57,14 @@ export default function SiteImageUploadModal({
 
   return <Modal show={true} onHide={onDismiss}>
     <Modal.Header closeButton>
-      <Modal.Title>{existingImage ? 'Update' : 'Upload'} image</Modal.Title>
+      <Modal.Title>{existingImage ? 'Update' : 'Upload'} media</Modal.Title>
     </Modal.Header>
     <Modal.Body>
       <form onSubmit={e => e.preventDefault()}>
         <div>
-          <p>Supported extensions are gif, ico, jpeg, jpg, png, svg, and webp.
-                        Maximum size is 10MB</p>
-                    File:
+          <p>Supported extensions are {[...allowedImageTypes, ...allowedApplicationTypes].join(', ')}.
+            Maximum size is 10MB</p>
+          File:
           <div>
             { FileChooser }
             <span className="text-muted fst-italic ms-2">{file?.name}</span>

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -217,8 +217,8 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
             onClick={() => setShowDeletePageModal(!showAddPageModal)}>
             <FontAwesomeIcon icon={faTrash}/> Delete page
           </Button>
-          <Link to="../images" className="btn btn-light ms-auto border m-1">
-            <FontAwesomeIcon icon={faImage} className="fa-lg"/> Manage images
+          <Link to="../media" className="btn btn-light ms-auto border m-1">
+            <FontAwesomeIcon icon={faImage} className="fa-lg"/> Manage media
           </Link>
           { portalEnv.preRegSurveyId &&
             <Link to={'../forms/preReg'} className="btn btn-light border m-1">

--- a/ui-admin/src/study/StudyEnvironmentRouter.tsx
+++ b/ui-admin/src/study/StudyEnvironmentRouter.tsx
@@ -91,7 +91,7 @@ function StudyEnvironmentRouter({ study }: {study: Study}) {
       <Route path="participants/*" element={<ParticipantsRouter studyEnvContext={studyEnvContext}/>}/>
       <Route path="kits/*" element={<KitsRouter studyEnvContext={studyEnvContext}/>}/>
       <Route path="siteContent" element={<SiteContentLoader portalEnvContext={portalEnvContext}/>}/>
-      <Route path="images" element={<SiteImageList portalContext={portalContext} portalEnv={portalEnv}/>}/>
+      <Route path="media" element={<SiteImageList portalContext={portalContext} portalEnv={portalEnv}/>}/>
       <Route path="metrics" element={<StudyEnvMetricsView studyEnvContext={studyEnvContext}/>}/>
       <Route path="mailingList" element={<MailingListView portalContext={portalContext}
         portalEnv={portalEnv}/>}/>


### PR DESCRIPTION
#### DESCRIPTION

This adds pdf as an allowed filetype for the site file uploader. It also makes a few user-facing changes, like renaming "images" to "media" and changing some styling to be more consistent with other pages. 

Right now I only updated the "media" language where it was user facing. If we decide that media is the right word to use, it would make sense to propagate that language throughout the rest of our code. I just didn't want to be too quick to make that change before reaching consensus.

![Screenshot 2023-12-01 at 1 35 17 PM](https://github.com/broadinstitute/juniper/assets/7257391/e23b5159-a641-4a2f-8d1b-14bba31391c2)

![Screenshot 2023-12-01 at 1 34 56 PM](https://github.com/broadinstitute/juniper/assets/7257391/fd5bc8d2-1e99-4b9f-ad60-8272317c5943)


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Launch admin API and UI
* Try uploading a PDF: https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/media
* Verify that the regex still only supports image types + pdf
