### PR TITLE
JN-725: editing the nav logo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17851,6 +17851,15 @@
         }
       }
     },
+    "node_modules/react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -22684,6 +22693,7 @@
         "query-string": "^7.1.3",
         "react": "^18.2.0",
         "react-bootstrap": "^2.8.0",
+        "react-colorful": "^5.6.1",
         "react-contenteditable": "^3.3.6",
         "react-dom": "^18.2.0",
         "react-email-editor": "^1.7.9",
@@ -25468,6 +25478,7 @@
         "query-string": "^7.1.3",
         "react": "^18.2.0",
         "react-bootstrap": "^2.8.0",
+        "react-colorful": "^5.6.1",
         "react-contenteditable": "^3.3.6",
         "react-dom": "^18.2.0",
         "react-email-editor": "^1.7.9",
@@ -36939,6 +36950,12 @@
         "uncontrollable": "^7.2.1",
         "warning": "^4.0.3"
       }
+    },
+    "react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "requires": {}
     },
     "react-dev-utils": {
       "version": "12.0.1",

--- a/ui-admin/src/portal/images/SiteImageList.tsx
+++ b/ui-admin/src/portal/images/SiteImageList.tsx
@@ -87,7 +87,6 @@ export default function SiteImageList({ portalContext, portalEnv }:
   })
 
 
-
   const onSubmitUpload = () => {
     reload()
     setUpdatingImage(undefined)

--- a/ui-admin/src/portal/images/SiteImageList.tsx
+++ b/ui-admin/src/portal/images/SiteImageList.tsx
@@ -86,16 +86,7 @@ export default function SiteImageList({ portalContext, portalEnv }:
     getSortedRowModel: getSortedRowModel()
   })
 
-  /** Only show the most recent version of a given image in the list */
-  const filterPriorVersions = (imageList: SiteImageMetadata[]) => {
-    const latestVersions: Record<string, SiteImageMetadata> = {}
-    imageList.forEach(image => {
-      if (image.version > (latestVersions[image.cleanFileName]?.version ?? -1)) {
-        latestVersions[image.cleanFileName] = image
-      }
-    })
-    return Object.values(latestVersions)
-  }
+
 
   const onSubmitUpload = () => {
     reload()
@@ -106,6 +97,7 @@ export default function SiteImageList({ portalContext, portalEnv }:
 
   const { isLoading, reload } = useLoadingEffect(async () => {
     const result = await Api.getPortalImages(portalContext.portal.shortcode)
+    /** Only show the most recent version of a given image in the list */
     setImages(filterPriorVersions(result))
   }, [portalContext.portal.shortcode, portalEnv.environmentName])
 
@@ -133,4 +125,15 @@ export default function SiteImageList({ portalContext, portalEnv }:
       existingImage={updatingImage}
       onSubmit={onSubmitUpload}/> }
   </div>
+}
+
+/** Return an array of only the most recent of each image version */
+export const filterPriorVersions = (imageList: SiteImageMetadata[]): SiteImageMetadata[] => {
+  const latestVersions: Record<string, SiteImageMetadata> = {}
+  imageList.forEach(image => {
+    if (image.version > (latestVersions[image.cleanFileName]?.version ?? -1)) {
+      latestVersions[image.cleanFileName] = image
+    }
+  })
+  return Object.values(latestVersions)
 }

--- a/ui-admin/src/portal/siteContent/AddPageModal.test.tsx
+++ b/ui-admin/src/portal/siteContent/AddPageModal.test.tsx
@@ -9,8 +9,7 @@ describe('AddPageModal', () => {
   test('disables Create button when title and path aren\'t filled out', async () => {
     //Arrange
     const { RoutedComponent } = setupRouterTest(<AddPageModal
-      show={true}
-      setShow={jest.fn()}
+      onDismiss={jest.fn()}
       insertNewPage={jest.fn()}
       portalEnv={mockPortalEnvironment('sandbox')}
       portalShortcode={'test'}
@@ -26,8 +25,7 @@ describe('AddPageModal', () => {
   test('enables Create button when title and path are filled out', async () => {
     //Arrange
     const { RoutedComponent } = setupRouterTest(<AddPageModal
-      show={true}
-      setShow={jest.fn()}
+      onDismiss={jest.fn()}
       insertNewPage={jest.fn()}
       portalEnv={mockPortalEnvironment('sandbox')}
       portalShortcode={'test'}
@@ -51,8 +49,7 @@ describe('AddPageModal', () => {
     //Arrange
     const mockInsertNewPageFn = jest.fn()
     const { RoutedComponent } = setupRouterTest(<AddPageModal
-      show={true}
-      setShow={jest.fn()}
+      onDismiss={jest.fn()}
       insertNewPage={mockInsertNewPageFn}
       portalEnv={mockPortalEnvironment('sandbox')}
       portalShortcode={'test'}

--- a/ui-admin/src/portal/siteContent/AddPageModal.tsx
+++ b/ui-admin/src/portal/siteContent/AddPageModal.tsx
@@ -5,9 +5,9 @@ import Api from 'api/api'
 import { useConfig } from 'providers/ConfigProvider'
 
 /** renders a modal that adds a new page to the site */
-const AddPageModal = ({ portalEnv, portalShortcode, insertNewPage, show, setShow }: {
+const AddPageModal = ({ portalEnv, portalShortcode, insertNewPage, onDismiss }: {
   portalEnv: PortalEnvironment, portalShortcode: string, insertNewPage: (page: HtmlPage) => void,
-  show: boolean, setShow:  React.Dispatch<React.SetStateAction<boolean>>
+  onDismiss: () => void
 }) => {
   const zoneConfig = useConfig()
 
@@ -20,7 +20,7 @@ const AddPageModal = ({ portalEnv, portalShortcode, insertNewPage, show, setShow
       path: pagePath,
       sections: []
     })
-    setShow(false)
+    onDismiss()
   }
 
   const clearFields = () => {
@@ -31,10 +31,9 @@ const AddPageModal = ({ portalEnv, portalShortcode, insertNewPage, show, setShow
   const portalUrl = Api.getParticipantLink(portalEnv.portalEnvironmentConfig, zoneConfig.participantUiHostname,
     portalShortcode, portalEnv.environmentName)
 
-  return <Modal show={show}
-    onHide={() => {
-      setShow(false)
+  return <Modal onHide={() => {
       clearFields()
+      onDismiss()
     }}>
     <Modal.Header closeButton>
       <Modal.Title>Add New Page</Modal.Title>
@@ -67,7 +66,7 @@ const AddPageModal = ({ portalEnv, portalShortcode, insertNewPage, show, setShow
         onClick={addPage}
       >Create</button>
       <button className="btn btn-secondary" onClick={() => {
-        setShow(false)
+        onDismiss()
         clearFields()
       }}>Cancel</button>
     </Modal.Footer>

--- a/ui-admin/src/portal/siteContent/AddPageModal.tsx
+++ b/ui-admin/src/portal/siteContent/AddPageModal.tsx
@@ -31,10 +31,10 @@ const AddPageModal = ({ portalEnv, portalShortcode, insertNewPage, onDismiss }: 
   const portalUrl = Api.getParticipantLink(portalEnv.portalEnvironmentConfig, zoneConfig.participantUiHostname,
     portalShortcode, portalEnv.environmentName)
 
-  return <Modal onHide={() => {
-      clearFields()
-      onDismiss()
-    }}>
+  return <Modal show={true} onHide={() => {
+    clearFields()
+    onDismiss()
+  }}>
     <Modal.Header closeButton>
       <Modal.Title>Add New Page</Modal.Title>
     </Modal.Header>

--- a/ui-admin/src/portal/siteContent/BrandingModal.test.tsx
+++ b/ui-admin/src/portal/siteContent/BrandingModal.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+
+import { render, screen, waitFor } from '@testing-library/react'
+import { mockLocalSiteContent } from 'test-utils/mock-site-content'
+import Api from 'api/api'
+import BrandingModal from './BrandingModal'
+import userEvent from '@testing-library/user-event'
+import { select } from 'react-select-event'
+
+describe('BrandingModal', () => {
+  test('branding color is updatable', async () => {
+    jest.spyOn(Api, 'getPortalImages').mockResolvedValue([])
+    const updateSpy = jest.fn()
+    render(<BrandingModal portalShortcode="test"
+      onDismiss={jest.fn()}
+      updateLocalContent={updateSpy}
+      localContent={{
+        ...mockLocalSiteContent(),
+        primaryBrandColor: '#ff0000'
+      }}/>)
+    await waitFor(() => expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument())
+    expect(screen.getByTitle('color preview')).toHaveStyle('background-color: #ff0000')
+    await userEvent.clear(screen.getByLabelText('Primary Brand Color'))
+    await userEvent.type(screen.getByLabelText('Primary Brand Color'), '#00ff00')
+    await userEvent.click(screen.getByText('Ok'))
+    expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({ primaryBrandColor: '#00ff00' }))
+  })
+
+  test('nav logo is updatable', async () => {
+    jest.spyOn(Api, 'getPortalImages').mockResolvedValue([{
+      cleanFileName: 'test2.png', version: 1, id: 'teest', createdAt: 0
+    }])
+    const updateSpy = jest.fn()
+    render(<BrandingModal portalShortcode="test"
+      onDismiss={jest.fn()}
+      updateLocalContent={updateSpy}
+      localContent={{
+        ...mockLocalSiteContent(),
+        primaryBrandColor: '#ff0000'
+      }}/>)
+    await waitFor(() => expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument())
+    await select(screen.getByLabelText('Navbar logo'), 'test2.png')
+    await userEvent.click(screen.getByText('Ok'))
+    expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({ navLogoCleanFileName: 'test2.png' }))
+  })
+})

--- a/ui-admin/src/portal/siteContent/BrandingModal.tsx
+++ b/ui-admin/src/portal/siteContent/BrandingModal.tsx
@@ -1,79 +1,87 @@
-import React, {useState} from 'react'
-import {LocalSiteContent} from "@juniper/ui-core";
-import Modal from "react-bootstrap/Modal";
-import {useLoadingEffect} from "../../api/api-utils";
-import Api, {getImageUrl, SiteImageMetadata} from "../../api/api";
-import {filterPriorVersions} from "../images/SiteImageList";
-import useReactSingleSelect from "../../util/react-select-utils";
-import LoadingSpinner from "../../util/LoadingSpinner";
-import Select from "react-select";
+import React, { useState } from 'react'
+import { LocalSiteContent } from '@juniper/ui-core'
+import Modal from 'react-bootstrap/Modal'
+import { useLoadingEffect } from 'api/api-utils'
+import Api, { getImageUrl, SiteImageMetadata } from 'api/api'
+import { filterPriorVersions } from '../images/SiteImageList'
+import useReactSingleSelect from 'util/react-select-utils'
+import LoadingSpinner from 'util/LoadingSpinner'
+import Select from 'react-select'
+import InfoPopup from 'components/forms/InfoPopup'
 
 const imageOptionLabel = (image: SiteImageMetadata, portalShortcode: string) => <div>
-    {image.cleanFileName} <img style={{maxHeight: '1.5em'}}
-                               src={getImageUrl(portalShortcode, image!.cleanFileName, image!.version)}/>
+  {image.cleanFileName} <img style={{ maxHeight: '1.5em' }}
+    src={getImageUrl(portalShortcode, image!.cleanFileName, image!.version)}/>
 </div>
 
-export default function BrandingModal({onDismiss, localContent, updateLocalContent, portalShortcode}: {
+/** controls for primary color and nav logo */
+export default function BrandingModal({ onDismiss, localContent, updateLocalContent, portalShortcode }: {
     onDismiss: () => void, localContent: LocalSiteContent, updateLocalContent: (newContent: LocalSiteContent) => void,
     portalShortcode: string
 }) {
-    const [images, setImages] = React.useState<SiteImageMetadata[]>([])
-    const [selectedNavLogo, setSelectedNavLogo] = useState<SiteImageMetadata>()
+  const [images, setImages] = React.useState<SiteImageMetadata[]>([])
+  const [selectedNavLogo, setSelectedNavLogo] = useState<SiteImageMetadata>()
 
-    const {selectInputId, selectedOption, options, onChange} = useReactSingleSelect(
-        images,
-        image => ({label: imageOptionLabel(image, portalShortcode), value: image}),
-        setSelectedNavLogo, selectedNavLogo)
+  const { selectInputId, selectedOption, options, onChange } = useReactSingleSelect(
+    images,
+    image => ({ label: imageOptionLabel(image, portalShortcode), value: image }),
+    setSelectedNavLogo, selectedNavLogo)
 
-    const { isLoading: isImageListLoading, reload } = useLoadingEffect(async () => {
-        const result = await Api.getPortalImages(portalShortcode)
-        /** Only show the most recent version of a given image in the list */
-        const imageList = filterPriorVersions(result).sort((a, b) => a.cleanFileName.localeCompare(b.cleanFileName))
-        setImages(imageList)
-        setSelectedNavLogo(imageList.find(image => image.cleanFileName === localContent.navLogoCleanFileName))
-    }, [portalShortcode])
+  const { isLoading: isImageListLoading } = useLoadingEffect(async () => {
+    const result = await Api.getPortalImages(portalShortcode)
+    /** Only show the most recent version of a given image in the list */
+    const imageList = filterPriorVersions(result).sort((a, b) => a.cleanFileName.localeCompare(b.cleanFileName))
+    setImages(imageList)
+    setSelectedNavLogo(imageList.find(image => image.cleanFileName === localContent.navLogoCleanFileName))
+  }, [portalShortcode])
 
-    const [color, setColor] = useState(localContent.primaryBrandColor)
+  const [color, setColor] = useState(localContent.primaryBrandColor)
 
-   return <Modal show={true}
-                       onHide={() => {
-                           onDismiss()
-                       }}>
-        <Modal.Header closeButton>
-            <Modal.Title>Branding</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-            <form onSubmit={e => e.preventDefault()}>
-                <label htmlFor="inputPageTitle">Navbar logo</label>
-                <LoadingSpinner isLoading={isImageListLoading}>
-                    <Select inputId={selectInputId} options={options} value={selectedOption} onChange={onChange}/>
-                </LoadingSpinner>
-                <label htmlFor="colorInput" className="mt-3">Primary Brand Color
-                    <span className="px-2 ms-3" style={{backgroundColor: color}}/>
-                </label>
-                <input type="text" className="form-control" id="colorInput"
-                       value={color}
-                       onChange={event => {
-                           setColor(event.target.value)
-                       }}/>
+  return <Modal show={true}
+    onHide={() => {
+      onDismiss()
+    }}>
+    <Modal.Header closeButton>
+      <Modal.Title>Branding</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>
+      <form onSubmit={e => e.preventDefault()}>
+        <label htmlFor={selectInputId}>Navbar logo</label>
+        <InfoPopup content={`The logo that appears in the top left corner of the participant navbar`}/>
+        <LoadingSpinner isLoading={isImageListLoading}>
+          <Select inputId={selectInputId} options={options} value={selectedOption} onChange={onChange}/>
+        </LoadingSpinner>
+        <label htmlFor="colorInput" className="mt-3">Primary Brand Color</label>
+        <InfoPopup content={<span>
+          Color for links and action buttons for participants. This should be
+          specified as a CSS color string, either hex (<code>#33aabb</code>) or RGB (<code>rgb(25,180,100)</code>)
+        </span>}/>
+        <div className="d-flex">
+          <input type="text" className="form-control" id="colorInput"
+            value={color}
+            onChange={event => {
+              setColor(event.target.value)
+            }}/>
+          <span className="px-4 ms-2" style={{ backgroundColor: color }} title="color preview"/>
+        </div>
 
 
-            </form>
-        </Modal.Body>
-        <Modal.Footer>
-            <button
-                className="btn btn-primary"
-                onClick={() => {
-                    updateLocalContent({
-                        ...localContent,
-                        primaryBrandColor: color,
-                        navLogoCleanFileName: selectedNavLogo?.cleanFileName ?? '',
-                        navLogoVersion: selectedNavLogo?.version ?? 0
-                    })
-                    onDismiss()
-                }}
-            >Ok</button>
-            <button className="btn btn-secondary" onClick={onDismiss}>Cancel</button>
-        </Modal.Footer>
-    </Modal>
+      </form>
+    </Modal.Body>
+    <Modal.Footer>
+      <button
+        className="btn btn-primary"
+        onClick={() => {
+          updateLocalContent({
+            ...localContent,
+            primaryBrandColor: color,
+            navLogoCleanFileName: selectedNavLogo?.cleanFileName ?? '',
+            navLogoVersion: selectedNavLogo?.version ?? 0
+          })
+          onDismiss()
+        }}
+      >Ok</button>
+      <button className="btn btn-secondary" onClick={onDismiss}>Cancel</button>
+    </Modal.Footer>
+  </Modal>
 }

--- a/ui-admin/src/portal/siteContent/BrandingModal.tsx
+++ b/ui-admin/src/portal/siteContent/BrandingModal.tsx
@@ -1,0 +1,79 @@
+import React, {useState} from 'react'
+import {LocalSiteContent} from "@juniper/ui-core";
+import Modal from "react-bootstrap/Modal";
+import {useLoadingEffect} from "../../api/api-utils";
+import Api, {getImageUrl, SiteImageMetadata} from "../../api/api";
+import {filterPriorVersions} from "../images/SiteImageList";
+import useReactSingleSelect from "../../util/react-select-utils";
+import LoadingSpinner from "../../util/LoadingSpinner";
+import Select from "react-select";
+
+const imageOptionLabel = (image: SiteImageMetadata, portalShortcode: string) => <div>
+    {image.cleanFileName} <img style={{maxHeight: '1.5em'}}
+                               src={getImageUrl(portalShortcode, image!.cleanFileName, image!.version)}/>
+</div>
+
+export default function BrandingModal({onDismiss, localContent, updateLocalContent, portalShortcode}: {
+    onDismiss: () => void, localContent: LocalSiteContent, updateLocalContent: (newContent: LocalSiteContent) => void,
+    portalShortcode: string
+}) {
+    const [images, setImages] = React.useState<SiteImageMetadata[]>([])
+    const [selectedNavLogo, setSelectedNavLogo] = useState<SiteImageMetadata>()
+
+    const {selectInputId, selectedOption, options, onChange} = useReactSingleSelect(
+        images,
+        image => ({label: imageOptionLabel(image, portalShortcode), value: image}),
+        setSelectedNavLogo, selectedNavLogo)
+
+    const { isLoading: isImageListLoading, reload } = useLoadingEffect(async () => {
+        const result = await Api.getPortalImages(portalShortcode)
+        /** Only show the most recent version of a given image in the list */
+        const imageList = filterPriorVersions(result).sort((a, b) => a.cleanFileName.localeCompare(b.cleanFileName))
+        setImages(imageList)
+        setSelectedNavLogo(imageList.find(image => image.cleanFileName === localContent.navLogoCleanFileName))
+    }, [portalShortcode])
+
+    const [color, setColor] = useState(localContent.primaryBrandColor)
+
+   return <Modal show={true}
+                       onHide={() => {
+                           onDismiss()
+                       }}>
+        <Modal.Header closeButton>
+            <Modal.Title>Branding</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+            <form onSubmit={e => e.preventDefault()}>
+                <label htmlFor="inputPageTitle">Navbar logo</label>
+                <LoadingSpinner isLoading={isImageListLoading}>
+                    <Select inputId={selectInputId} options={options} value={selectedOption} onChange={onChange}/>
+                </LoadingSpinner>
+                <label htmlFor="colorInput" className="mt-3">Primary Brand Color
+                    <span className="px-2 ms-3" style={{backgroundColor: color}}/>
+                </label>
+                <input type="text" className="form-control" id="colorInput"
+                       value={color}
+                       onChange={event => {
+                           setColor(event.target.value)
+                       }}/>
+
+
+            </form>
+        </Modal.Body>
+        <Modal.Footer>
+            <button
+                className="btn btn-primary"
+                onClick={() => {
+                    updateLocalContent({
+                        ...localContent,
+                        primaryBrandColor: color,
+                        navLogoCleanFileName: selectedNavLogo?.cleanFileName ?? '',
+                        navLogoVersion: selectedNavLogo?.version ?? 0
+                    })
+                    onDismiss()
+                }}
+            >Ok</button>
+            <button className="btn btn-secondary" onClick={onDismiss}>Cancel</button>
+        </Modal.Footer>
+    </Modal>
+}

--- a/ui-admin/src/portal/siteContent/DeletePageModal.tsx
+++ b/ui-admin/src/portal/siteContent/DeletePageModal.tsx
@@ -27,9 +27,7 @@ const DeletePageModal = ({ renderedPage, deletePage, onDismiss }: {
           onDismiss()
         }}
       >Delete</button>
-      <button className="btn btn-secondary" onClick={() => {
-        onDismiss()
-      }}>Cancel</button>
+      <button className="btn btn-secondary" onClick={onDismiss}>Cancel</button>
     </Modal.Footer>
   </Modal>
 }

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react'
-import { HtmlSection, NavbarItemInternal } from 'api/api'
+import Api, { HtmlSection, NavbarItemInternal } from 'api/api'
 import Select from 'react-select'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import {faClipboard, faClockRotateLeft, faImage, faPalette, faPlus, faTrash} from '@fortawesome/free-solid-svg-icons'
+import { faClipboard, faClockRotateLeft, faImage, faPalette, faPlus, faTrash } from '@fortawesome/free-solid-svg-icons'
 import HtmlPageEditView from './HtmlPageEditView'
 import {
   HtmlPage, LocalSiteContent, ApiProvider, SiteContent,
@@ -17,12 +17,10 @@ import { PortalEnvContext } from '../PortalRouter'
 import ErrorBoundary from 'util/ErrorBoundary'
 import { Tab, Tabs } from 'react-bootstrap'
 import DeletePageModal from './DeletePageModal'
-import BrandingModal from "./BrandingModal";
-import Api from "../../api/api";
-import {faExternalLink} from "@fortawesome/free-solid-svg-icons/faExternalLink";
-import {useConfig} from "../../providers/ConfigProvider";
-import Modal from "react-bootstrap/Modal";
-import LoadingSpinner from "../../util/LoadingSpinner";
+import BrandingModal from './BrandingModal'
+import { faExternalLink } from '@fortawesome/free-solid-svg-icons/faExternalLink'
+import { useConfig } from '../../providers/ConfigProvider'
+import Modal from 'react-bootstrap/Modal'
 
 type NavbarOption = {label: string, value: string}
 const landingPageOption = { label: 'Landing page', value: 'Landing page' }
@@ -157,13 +155,13 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
     if (hasInvalidSection || (initialContent !== workingContent)) {
       setShowUnsavedPreviewModal(true)
     } else {
-        showParticipantView()
+      showParticipantView()
     }
   }
 
   const showParticipantView = () => {
     const url = Api.getParticipantLink(portalEnv.portalEnvironmentConfig, zoneConfig.participantUiHostname,
-        portalEnvContext.portal.shortcode, portalEnv.environmentName)
+      portalEnvContext.portal.shortcode, portalEnv.environmentName)
     window.open(url, '_blank')
   }
 
@@ -244,7 +242,7 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
             <FontAwesomeIcon icon={faTrash}/> Delete page
           </Button>
           <Button variant="light"  className="ms-auto  border m-1" tooltip={''}
-                  onClick={() => setShowBrandingModal(true)}
+            onClick={() => setShowBrandingModal(true)}
           >
             <FontAwesomeIcon icon={faPalette} className="fa-lg"/> Branding
           </Button>
@@ -327,7 +325,7 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
     }
     { showBrandingModal &&
         <BrandingModal onDismiss={() => setShowBrandingModal(false)} localContent={localContent}
-        updateLocalContent={updateLocalContent} portalShortcode={portalEnvContext.portal.shortcode}/>
+          updateLocalContent={updateLocalContent} portalShortcode={portalEnvContext.portal.shortcode}/>
     }
     { showUnsavedPreviewModal &&
         <Modal show={true} onHide={() => setShowUnsavedPreviewModal(false)}>
@@ -336,8 +334,9 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
           </Modal.Body>
           <Modal.Footer>
             <button className="btn btn-primary" onClick={() => {
-                  showParticipantView()
-                  setShowUnsavedPreviewModal(false)}}>
+              showParticipantView()
+              setShowUnsavedPreviewModal(false)
+            }}>
               Launch participant view in new tab
             </button>
             <button className="btn btn-secondary" onClick={() => setShowUnsavedPreviewModal(false)}>Cancel</button>

--- a/ui-admin/src/study/CreateNewStudyModal.tsx
+++ b/ui-admin/src/study/CreateNewStudyModal.tsx
@@ -17,13 +17,13 @@ export default function CreateNewStudyModal({ onDismiss }: {onDismiss: () => voi
   const { portalList, reload } = useNavContext()
   const [studyName, setStudyName] = useState('')
   const [studyShortcode, setStudyShortcode] = useState('')
-  const [selectedPortal, setSelectedPortal] = useState<Portal>()
+  const [selectedPortal, setSelectedPortal] = useState<Portal | undefined>(portalList[0])
   const { onChange, options, selectedOption, selectInputId } =
         useReactSingleSelect(
           portalList,
           (portal: Portal) => ({ label: portal.name, value: portal }),
           setSelectedPortal,
-          portalList[0])
+          selectedPortal)
 
   const [isLoading, setIsLoading] = useState(false)
   const createStudy = async () => {

--- a/ui-admin/src/study/CreateNewStudyModal.tsx
+++ b/ui-admin/src/study/CreateNewStudyModal.tsx
@@ -20,10 +20,10 @@ export default function CreateNewStudyModal({ onDismiss }: {onDismiss: () => voi
   const [selectedPortal, setSelectedPortal] = useState<Portal>()
   const { onChange, options, selectedOption, selectInputId } =
         useReactSingleSelect(
-            portalList,
-            (portal: Portal) => ({ label: portal.name, value: portal }),
-            setSelectedPortal,
-            portalList[0])
+          portalList,
+          (portal: Portal) => ({ label: portal.name, value: portal }),
+          setSelectedPortal,
+          portalList[0])
 
   const [isLoading, setIsLoading] = useState(false)
   const createStudy = async () => {

--- a/ui-admin/src/study/CreateNewStudyModal.tsx
+++ b/ui-admin/src/study/CreateNewStudyModal.tsx
@@ -17,8 +17,13 @@ export default function CreateNewStudyModal({ onDismiss }: {onDismiss: () => voi
   const { portalList, reload } = useNavContext()
   const [studyName, setStudyName] = useState('')
   const [studyShortcode, setStudyShortcode] = useState('')
-  const { onChange, options, selectedItem: selectedPortal, selectedOption, selectInputId } =
-        useReactSingleSelect(portalList, (portal: Portal) => ({ label: portal.name, value: portal }), portalList[0])
+  const [selectedPortal, setSelectedPortal] = useState<Portal>()
+  const { onChange, options, selectedOption, selectInputId } =
+        useReactSingleSelect(
+            portalList,
+            (portal: Portal) => ({ label: portal.name, value: portal }),
+            setSelectedPortal,
+            portalList[0])
 
   const [isLoading, setIsLoading] = useState(false)
   const createStudy = async () => {

--- a/ui-admin/src/util/react-select-utils.ts
+++ b/ui-admin/src/util/react-select-utils.ts
@@ -1,4 +1,4 @@
-import { useId, useState } from 'react'
+import { useId } from 'react'
 
 /**
  * helper function for setting up an accessible react-select component, returns the currently selected item, and a

--- a/ui-admin/src/util/react-select-utils.ts
+++ b/ui-admin/src/util/react-select-utils.ts
@@ -12,14 +12,13 @@ import { useId, useState } from 'react'
  *
  * */
 export default function useReactSingleSelect<T>(items: T[],
-  labelFunction: (i: T) => {label: string, value: T},
-  initialValue?: T) {
-  const [selectedItem, setSelectedItem] = useState(initialValue)
+  labelFunction: (i: T) => {label: React.ReactNode, value: T},
+  setSelectedItem: (i?: T) => void, selectedItem?: T) {
   const options = items.map(labelFunction)
   const selectedValue = selectedItem ? labelFunction(selectedItem).value : undefined
   const selectedOption = options.find(opt => opt.value === selectedValue)
   const selectInputId = useId()
 
-  const onChange = (opt: {label: string, value: T} | null) => setSelectedItem(opt?.value)
-  return { onChange, options, selectedItem, selectedOption, selectInputId }
+  const onChange = (opt: {label: React.ReactNode, value: T} | null) => setSelectedItem(opt?.value)
+  return { onChange, options, selectedOption, selectInputId }
 }

--- a/ui-admin/src/util/react-select-utils.ts
+++ b/ui-admin/src/util/react-select-utils.ts
@@ -1,4 +1,4 @@
-import { useId } from 'react'
+import { Dispatch, SetStateAction, useId } from 'react'
 
 /**
  * helper function for setting up an accessible react-select component, returns the currently selected item, and a
@@ -13,7 +13,7 @@ import { useId } from 'react'
  * */
 export default function useReactSingleSelect<T>(items: T[],
   labelFunction: (i: T) => {label: React.ReactNode, value: T},
-  setSelectedItem: (i?: T) => void, selectedItem?: T) {
+  setSelectedItem: Dispatch<SetStateAction<T | undefined>>, selectedItem?: T) {
   const options = items.map(labelFunction)
   const selectedValue = selectedItem ? labelFunction(selectedItem).value : undefined
   const selectedOption = options.find(opt => opt.value === selectedValue)


### PR DESCRIPTION
#### DESCRIPTION
This enables editing of the nav logo and the primary brand color from the SiteContentEditor
<img width="1182" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/3d876758-8cc3-4fd5-9a03-cce83d703117">
Clicking the "Branding" button pulls up a dialog
<img width="517" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/9a6c37f6-bcb0-4a8f-8456-9701e3600e09">

This is bare-bones, no error-checking, mainly intended for internal use when setting up a study just so we don't have to go to the database.  I thought about a color picker for brand color, but I'm not sure it would actually be used -- AFAIK all our past customers already had a brand color (or Erin chose one), and so exact typing is strongly preferred to picking.  

To make testing easier, I added a link to the participant view from the SiteContentEditor.  If you press it with unsaved changes, an alert pops up letting you know that the preview will not show unsaved changes.

<img width="581" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/4cfef1cc-ba7b-44f2-818e-fb61352466a4">

This SiteContent editor is starting to get very noisy, I suspect it doesn't have room for many more controls before it will need some consolidation/rearrangement

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. Go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/siteContent
2. click the "Branding" button
3. edit the primary brand color, updating it to, say, `#33bb44`
4. pick a different nav logo image
5. click 'ok'
6. save 
7. click the participant view link
8. confirm the new primary brand color and logo is reflected in the UI