### PR TITLE
JN-752: clean js tests

### DIFF
--- a/ui-admin/src/forms/FormContentEditor.test.tsx
+++ b/ui-admin/src/forms/FormContentEditor.test.tsx
@@ -13,12 +13,12 @@ const formContent: string = JSON.stringify({
 
 describe('FormContentEditor', () => {
   it('should trap FormDesigner errors in an ErrorBoundary', () => {
-    // Arrange
+    // avoid cluttering the console with the error message from the expected error
+    jest.spyOn(console, 'error').mockImplementation(jest.fn())
     const { container } = render(<FormContentEditor
       initialContent={formContent} visibleVersionPreviews={[]} readOnly={false} onChange={jest.fn()}
     />)
 
-    // Assert
     // Our custom ErrorBoundary text
     expect(container).toHaveTextContent('Something went wrong')
     // JSON Editor and Preview tabs should still be visible

--- a/ui-admin/src/portal/MailingListView.test.tsx
+++ b/ui-admin/src/portal/MailingListView.test.tsx
@@ -20,6 +20,8 @@ const contacts: MailingListContact[] = [{
 }]
 
 test('renders a mailing list', async () => {
+  // avoid cluttering the console with the info messages from the table creation
+  jest.spyOn(console, 'info').mockImplementation(jest.fn())
   jest.spyOn(Api, 'fetchMailingList').mockImplementation(() => Promise.resolve(contacts))
   const portalContext = mockPortalContext()
   const portalEnv = portalContext.portal.portalEnvironments[0]

--- a/ui-admin/src/study/notifications/NotificationContent.test.tsx
+++ b/ui-admin/src/study/notifications/NotificationContent.test.tsx
@@ -33,6 +33,8 @@ test('renders routable config list', async () => {
   ]
   jest.spyOn(Api, 'findNotificationConfigsForStudyEnv')
     .mockImplementation(() => Promise.resolve(notificationConfigs))
+  jest.spyOn(Api, 'findNotificationConfig')
+    .mockImplementation(jest.fn())
 
   const { RoutedComponent, router } =
       setupRouterTest(<>

--- a/ui-admin/src/study/notifications/NotificationContent.tsx
+++ b/ui-admin/src/study/notifications/NotificationContent.tsx
@@ -56,7 +56,7 @@ export default function NotificationContent({ studyEnvContext, portalContext }:
       {isLoading && <LoadingSpinner/>}
       {!isLoading && <div style={navDivStyle}>
         <ul className="list-unstyled">
-          { CONFIG_GROUPS.map(group => <li style={navListItemStyle}>
+          { CONFIG_GROUPS.map(group => <li style={navListItemStyle} key={group.title}>
             <CollapsableMenu header={group.title} headerClass="text-black" content={
               <ul className="list-unstyled p-2">
                 { configList

--- a/ui-admin/src/study/participants/datarepo/DatasetDashboard.test.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetDashboard.test.tsx
@@ -30,6 +30,8 @@ jest.mock('react-router-dom', () => ({
 }))
 
 test('renders a link to TDR if the dataset successful created', async () => {
+  // avoid cluttering the console with the info messages from the table creation
+  jest.spyOn(console, 'info').mockImplementation(jest.fn())
   const studyEnvContext = mockStudyEnvContext()
 
   const { RoutedComponent } = setupRouterTest(<DatasetDashboard studyEnvContext={studyEnvContext}/>)

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeView.test.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeView.test.tsx
@@ -7,6 +7,7 @@ import { render, screen, within } from '@testing-library/react'
 
 
 test('renders survey links for configured surveys', async () => {
+  jest.spyOn(window, 'alert').mockImplementation(jest.fn())
   const studyEnvContext = mockStudyEnvContext()
   const enrollee = mockEnrollee()
 
@@ -20,6 +21,7 @@ test('renders survey links for configured surveys', async () => {
 })
 
 test('renders survey taken badges', async () => {
+  jest.spyOn(window, 'alert').mockImplementation(jest.fn())
   const studyEnvContext = mockStudyEnvContext()
   const enrollee = mockEnrollee()
   enrollee.surveyResponses.push({
@@ -43,6 +45,7 @@ test('renders survey taken badges', async () => {
 
 
 test('renders consent links for configured consents', async () => {
+  jest.spyOn(window, 'alert').mockImplementation(jest.fn())
   const studyEnvContext = mockStudyEnvContext()
   const enrollee = mockEnrollee()
 
@@ -56,6 +59,7 @@ test('renders consent links for configured consents', async () => {
 })
 
 test('renders consent taken badges', async () => {
+  jest.spyOn(window, 'alert').mockImplementation(jest.fn())
   const studyEnvContext = mockStudyEnvContext()
   const enrollee = mockEnrollee()
   enrollee.consentResponses.push({

--- a/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
@@ -6,7 +6,6 @@ import Api, { EnrolleeSearchResult } from 'api/api'
 import { mockEnrolleeSearchResult, mockStudyEnvContext } from 'test-utils/mocking-utils'
 import { setupRouterTest } from 'test-utils/router-testing-utils'
 import userEvent from '@testing-library/user-event'
-import { act } from 'react-dom/test-utils'
 import { KEYWORD_FACET } from 'api/enrolleeSearch'
 
 const mockSearchApi = (numSearchResults: number) => {
@@ -52,9 +51,7 @@ test('filters participants based on shortcode', async () => {
   await screen.findByText('JOSALK')
 
   //Search for some unknown shortcode
-  await act(() =>
-    userEvent.type(screen.getAllByPlaceholderText('Filter...')[0], 'UNKNOWN SHORTCODE')
-  )
+  await userEvent.type(screen.getAllByPlaceholderText('Filter...')[0], 'UNKNOWN SHORTCODE')
 
   //Assert that JOSALK is no longer visible in the table
   await waitFor(() => {
@@ -102,10 +99,10 @@ test('allows the user to cycle pages', async () => {
   expect(screen.getByText('Showing 10 of 100 rows')).toBeInTheDocument()
   expect(screen.getByText('Page 1 of 10')).toBeInTheDocument()
 
-  await act(() => userEvent.click(screen.getByLabelText('Next page')))
+  await userEvent.click(screen.getByLabelText('Next page'))
   expect(screen.getByText('Page 2 of 10')).toBeInTheDocument()
 
-  await act(() => userEvent.click(screen.getByLabelText('Previous page')))
+  await userEvent.click(screen.getByLabelText('Previous page'))
   expect(screen.getByText('Page 1 of 10')).toBeInTheDocument()
 })
 
@@ -122,7 +119,7 @@ test('allows the user to change the page size', async () => {
   expect(screen.getByText('Page 1 of 10')).toBeInTheDocument()
 
   jest.spyOn(Storage.prototype, 'setItem')
-  await act(() => userEvent.selectOptions(screen.getByLabelText('Number of rows per page'), '25'))
+  await userEvent.selectOptions(screen.getByLabelText('Number of rows per page'), '25')
   expect(screen.getByText('Showing 25 of 100 rows')).toBeInTheDocument()
   expect(screen.getByText('Page 1 of 4')).toBeInTheDocument()
 

--- a/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
@@ -8,20 +8,17 @@ import Api from 'api/api'
 
 describe('CreateSurveyModal', () => {
   test('disables Create button when survey name and stable ID are blank', () => {
-    //Arrange
     const studyEnvContext = mockStudyEnvContext()
     const { RoutedComponent } = setupRouterTest(<CreateSurveyModal
       studyEnvContext={studyEnvContext}
       onDismiss={jest.fn()}/>)
     render(RoutedComponent)
 
-    //Assert
     const createButton = screen.getByText('Create')
     expect(createButton).toBeDisabled()
   })
 
   test('enables Create button when survey name and stable ID are filled out', async () => {
-    //Arrange
     const user = userEvent.setup()
     const studyEnvContext = mockStudyEnvContext()
     const { RoutedComponent } = setupRouterTest(<CreateSurveyModal
@@ -29,19 +26,16 @@ describe('CreateSurveyModal', () => {
       onDismiss={jest.fn()}/>)
     render(RoutedComponent)
 
-    //Act
     const surveyNameInput = screen.getByLabelText('Survey Name')
     const surveyStableIdInput = screen.getByLabelText('Survey Stable ID')
     await user.type(surveyNameInput, 'Test Survey')
     await user.type(surveyStableIdInput, 'test_survey_id')
 
-    //Assert
     const createButton = screen.getByText('Create')
     expect(createButton).toBeEnabled()
   })
 
   test('should autofill the stable ID as the user fills in the survey name', async () => {
-    //Arrange
     const user = userEvent.setup()
     const studyEnvContext = mockStudyEnvContext()
     const { RoutedComponent } = setupRouterTest(<CreateSurveyModal
@@ -49,18 +43,16 @@ describe('CreateSurveyModal', () => {
       onDismiss={jest.fn()}/>)
     render(RoutedComponent)
 
-    //Act
     const surveyNameInput = screen.getByLabelText('Survey Name')
     const surveyStableIdInput = screen.getByLabelText('Survey Stable ID')
     await user.type(surveyNameInput, 'Test Survey')
 
-    //Assert
     //Confirm that auto-fill stable ID worked
     expect(surveyStableIdInput).toHaveValue('testSurvey')
   })
 
   test('create a required survey', async () => {
-    //Arrange
+    jest.spyOn(window, 'alert').mockImplementation(jest.fn())
     const survey = mockSurvey()
     jest.spyOn(Api, 'createConfiguredSurvey').mockImplementation(() => Promise.resolve(mockConfiguredSurvey()))
     jest.spyOn(Api, 'createNewSurvey').mockImplementation(() => Promise.resolve(survey))
@@ -71,7 +63,6 @@ describe('CreateSurveyModal', () => {
       onDismiss={jest.fn()}/>)
     render(RoutedComponent)
 
-    //Act
     const surveyNameInput = screen.getByLabelText('Survey Name')
     const surveyStableIdInput = screen.getByLabelText('Survey Stable ID')
     const requiredCheckbox = screen.getByLabelText('Required')
@@ -80,7 +71,6 @@ describe('CreateSurveyModal', () => {
     await user.click(requiredCheckbox)
     await user.click(screen.getByText('Create'))
 
-    //Assert
     expect(Api.createConfiguredSurvey).toHaveBeenCalledWith(studyEnvContext.portal.shortcode,
       studyEnvContext.study.shortcode,
       studyEnvContext.currentEnv.environmentName,

--- a/ui-participant/src/util/loggingUtils.test.tsx
+++ b/ui-participant/src/util/loggingUtils.test.tsx
@@ -18,6 +18,8 @@ const TestComponent = () => {
 
 test('logs JS exceptions', async () => {
   const logSpy = jest.spyOn(Api, 'log').mockImplementation(jest.fn())
+  // avoid cluttering the console with the error message from the expected error
+  jest.spyOn(console, 'error').mockImplementation(jest.fn())
   render(<TestComponent/>)
   expect(screen.getByText('Will throw error')).toBeInTheDocument()
   await new Promise(r => setTimeout(r, 200))


### PR DESCRIPTION
#### DESCRIPTION

Our JS tests were noisy with console warnings even when they succeeded.  this cleans up the tests to make it easier to find actual failures


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. run js tests for admin and participant uis
2. observe cleaner console.