### PR TITLE
[JN-711] making deploymentZone available to api-participant

### DIFF
--- a/api-participant/src/main/resources/application.yml
+++ b/api-participant/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 # All env variables that are used in one place
 # This is for deployment-specific values, which may be managed by other teams
 env:
+  deploymentZone: ${DEPLOYMENT_ZONE:local}
   db:
     host: ${DATABASE_HOSTNAME:127.0.0.1}:5432
     init: ${INIT_DB:false}


### PR DESCRIPTION
#### DESCRIPTION

The deployment zone wasn't previously known to the participant api, and so emails that came from there (emails that come from direct triggers, rather than scheduled reminders)  were showing up as "(local)"

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. I suppose you could change your local DEPLOYMENT_ZONE env. variable, restart apiParticipant, and sign up a new participant and confirm the changed env appears.  But given that this is a simple fix that depends on terraform configs, probably easiest to just merge it and retest demo.