### PR TITLE
[JN-714] Publish dashboard alerts

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/portal/PortalEnvironment.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/portal/PortalEnvironment.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.core.model.portal;
 
 import bio.terra.pearl.core.model.BaseEntity;
 import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.dashboard.ParticipantDashboardAlert;
 import bio.terra.pearl.core.model.notification.NotificationConfig;
 import bio.terra.pearl.core.model.site.SiteContent;
 import bio.terra.pearl.core.model.survey.Survey;
@@ -29,4 +30,6 @@ public class PortalEnvironment extends BaseEntity {
     private Survey preRegSurvey;
     @Builder.Default
     private List<NotificationConfig> notificationConfigs = new ArrayList<>();
+    @Builder.Default
+    private List<ParticipantDashboardAlert> participantDashboardAlerts = new ArrayList<>();
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/publishing/ConfigChange.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/publishing/ConfigChange.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.model.publishing;
 
 import java.beans.BeanInfo;
+import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -9,7 +10,7 @@ import java.util.Objects;
 import org.apache.commons.beanutils.PropertyUtils;
 
 public record ConfigChange(String propertyName, Object oldValue, Object newValue) {
-    public ConfigChange(Object source, Object dest, String propertyName) throws Exception {
+    public ConfigChange(Object source, Object dest, String propertyName) throws ReflectiveOperationException {
         this(propertyName,
                 dest != null ? PropertyUtils.getProperty(dest, propertyName) : null,
                 source != null ? PropertyUtils.getProperty(source, propertyName) : null);
@@ -19,7 +20,7 @@ public record ConfigChange(String propertyName, Object oldValue, Object newValue
      * gets a list of change records for each property that has changed between source and dest.  If one of source
      * or dest is null, all properties will be returned.  If both are null, an empty list will be returned
      */
-    public static <T> List<ConfigChange> allChanges(T source, T dest, List<String> ignoreProperties) throws Exception {
+    public static <T> List<ConfigChange> allChanges(T source, T dest, List<String> ignoreProperties) throws ReflectiveOperationException, IntrospectionException {
         if (source == null && dest == null) {
             return List.of();
         }

--- a/core/src/main/java/bio/terra/pearl/core/model/publishing/ParticipantDashboardAlertChange.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/publishing/ParticipantDashboardAlertChange.java
@@ -1,0 +1,8 @@
+package bio.terra.pearl.core.model.publishing;
+
+import bio.terra.pearl.core.model.dashboard.AlertTrigger;
+
+import java.util.List;
+
+public record ParticipantDashboardAlertChange(AlertTrigger trigger, List<ConfigChange> changes) {
+}

--- a/core/src/main/java/bio/terra/pearl/core/model/publishing/PortalEnvironmentChange.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/publishing/PortalEnvironmentChange.java
@@ -15,5 +15,6 @@ public record PortalEnvironmentChange(VersionedEntityChange<SiteContent> siteCon
                                       List<ConfigChange> configChanges,
                                       VersionedEntityChange<Survey> preRegSurveyChanges,
                                       ListChange<NotificationConfig, VersionedConfigChange<EmailTemplate>> notificationConfigChanges,
+                                      List<ParticipantDashboardAlertChange> participantDashboardAlertChanges,
                                       List<StudyEnvironmentChange> studyEnvChanges)
 {}

--- a/core/src/main/java/bio/terra/pearl/core/service/publishing/PortalDiffService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/publishing/PortalDiffService.java
@@ -25,6 +25,8 @@ import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import bio.terra.pearl.core.service.study.StudyService;
 import bio.terra.pearl.core.service.survey.SurveyService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.beans.IntrospectionException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -104,7 +106,7 @@ public class PortalDiffService {
 
     protected List<ParticipantDashboardAlertChange> diffAlertLists(
             List<ParticipantDashboardAlert> sourceAlerts,
-            List<ParticipantDashboardAlert> destAlerts) throws Exception {
+            List<ParticipantDashboardAlert> destAlerts) throws ReflectiveOperationException, IntrospectionException {
         List<ParticipantDashboardAlert> unmatchedDestAlerts = new ArrayList<>(destAlerts);
         List<ParticipantDashboardAlertChange> alertChangeLists = new ArrayList<>();
         for (ParticipantDashboardAlert sourceAlert : sourceAlerts) {

--- a/core/src/main/java/bio/terra/pearl/core/service/publishing/PortalDiffService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/publishing/PortalDiffService.java
@@ -6,6 +6,7 @@ import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.Versioned;
 import bio.terra.pearl.core.model.consent.ConsentForm;
 import bio.terra.pearl.core.model.consent.StudyEnvironmentConsent;
+import bio.terra.pearl.core.model.dashboard.ParticipantDashboardAlert;
 import bio.terra.pearl.core.model.notification.EmailTemplate;
 import bio.terra.pearl.core.model.notification.NotificationConfig;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
@@ -16,6 +17,7 @@ import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.service.notification.NotificationConfigService;
+import bio.terra.pearl.core.service.portal.PortalDashboardConfigService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentConfigService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
 import bio.terra.pearl.core.service.site.SiteContentService;
@@ -32,12 +34,13 @@ import org.springframework.stereotype.Service;
 public class PortalDiffService {
     public static final List<String> CONFIG_IGNORE_PROPS = List.of("id", "createdAt", "lastUpdatedAt", "class",
             "studyEnvironmentId", "portalEnvironmentId", "emailTemplateId", "emailTemplate",
-            "consentFormId", "consentForm", "surveyId", "survey", "versionedEntity");
+            "consentFormId", "consentForm", "surveyId", "survey", "versionedEntity", "trigger");
     private PortalEnvironmentService portalEnvService;
     private PortalEnvironmentConfigService portalEnvironmentConfigService;
     private SiteContentService siteContentService;
     private SurveyService surveyService;
     private NotificationConfigService notificationConfigService;
+    private PortalDashboardConfigService portalDashboardConfigService;
     private ObjectMapper objectMapper;
     private PortalEnvironmentChangeRecordDao portalEnvironmentChangeRecordDao;
     private StudyEnvironmentService studyEnvironmentService;
@@ -47,6 +50,7 @@ public class PortalDiffService {
                              PortalEnvironmentConfigService portalEnvironmentConfigService,
                              SiteContentService siteContentService, SurveyService surveyService,
                              NotificationConfigService notificationConfigService,
+                             PortalDashboardConfigService portalDashboardConfigService,
                              ObjectMapper objectMapper,
                              PortalEnvironmentChangeRecordDao portalEnvironmentChangeRecordDao,
                              StudyEnvironmentService studyEnvironmentService, StudyService studyService) {
@@ -55,6 +59,7 @@ public class PortalDiffService {
         this.siteContentService = siteContentService;
         this.surveyService = surveyService;
         this.notificationConfigService = notificationConfigService;
+        this.portalDashboardConfigService = portalDashboardConfigService;
         this.objectMapper = objectMapper;
         this.portalEnvironmentChangeRecordDao = portalEnvironmentChangeRecordDao;
         this.studyEnvironmentService = studyEnvironmentService;
@@ -83,13 +88,42 @@ public class PortalDiffService {
             studyEnvChanges.add(studyEnvChange);
         }
 
+        List<ParticipantDashboardAlert> destAlerts = new ArrayList<>(destEnv.getParticipantDashboardAlerts());
+        List<ParticipantDashboardAlert> sourceAlerts = new ArrayList<>(sourceEnv.getParticipantDashboardAlerts());
+        List<ParticipantDashboardAlertChange> participantDashboardAlertChanges = diffAlertLists(sourceAlerts, destAlerts);
+
         return new PortalEnvironmentChange(
                 siteContentRecord,
                 envConfigChanges,
                 preRegRecord,
                 notificationConfigChanges,
+                participantDashboardAlertChanges,
                 studyEnvChanges
         );
+    }
+
+    protected List<ParticipantDashboardAlertChange> diffAlertLists(
+            List<ParticipantDashboardAlert> sourceAlerts,
+            List<ParticipantDashboardAlert> destAlerts) throws Exception {
+        List<ParticipantDashboardAlert> unmatchedDestAlerts = new ArrayList<>(destAlerts);
+        List<ParticipantDashboardAlertChange> changedAlerts = new ArrayList<>();
+        for (ParticipantDashboardAlert sourceAlert : sourceAlerts) {
+            ParticipantDashboardAlert matchedAlert = unmatchedDestAlerts.stream().filter(
+                            destAlert -> sourceAlert.getTrigger().equals(destAlert.getTrigger()))
+                    .findAny().orElse(null);
+            if (matchedAlert == null) {
+                List<ConfigChange> newAlert = ConfigChange.allChanges(sourceAlert, null, CONFIG_IGNORE_PROPS);
+                changedAlerts.add(new ParticipantDashboardAlertChange(sourceAlert.getTrigger(), newAlert));
+            } else {
+                unmatchedDestAlerts.remove(matchedAlert);
+                List<ConfigChange> changedAlert = ConfigChange.allChanges(sourceAlert, matchedAlert, CONFIG_IGNORE_PROPS);
+                if(!changedAlert.isEmpty()) {
+                    changedAlerts.add(new ParticipantDashboardAlertChange(sourceAlert.getTrigger(), changedAlert));
+                }
+            }
+        }
+
+        return changedAlerts;
     }
 
     protected PortalEnvironment loadPortalEnvForProcessing(String shortcode, EnvironmentName envName) {
@@ -107,6 +141,9 @@ public class PortalDiffService {
         var notificationConfigs = notificationConfigService.findByPortalEnvironmentId(portalEnv.getId());
         notificationConfigService.attachTemplates(notificationConfigs);
         portalEnv.setNotificationConfigs(notificationConfigs);
+
+        List<ParticipantDashboardAlert> alerts = portalDashboardConfigService.findByPortalEnvId(portalEnv.getId());
+        portalEnv.setParticipantDashboardAlerts(alerts);
 
         return portalEnv;
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/publishing/PortalPublishingService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/publishing/PortalPublishingService.java
@@ -150,7 +150,7 @@ public class PortalPublishingService {
         }
     }
 
-    protected void applyChangesToParticipantDashboardAlerts(PortalEnvironment destEnv, List<ParticipantDashboardAlertChange> changes) throws Exception {
+    protected void applyChangesToParticipantDashboardAlerts(PortalEnvironment destEnv, List<ParticipantDashboardAlertChange> changes) {
         for(ParticipantDashboardAlertChange change : changes) {
             Optional<ParticipantDashboardAlert> destAlert = portalDashboardConfigService.findByPortalEnvIdAndTrigger(destEnv.getId(), change.trigger());
             if(destAlert.isEmpty()) {

--- a/core/src/main/java/bio/terra/pearl/core/service/publishing/PortalPublishingService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/publishing/PortalPublishingService.java
@@ -178,12 +178,7 @@ public class PortalPublishingService {
     protected void applyAlertChanges(ParticipantDashboardAlert alert, List<ConfigChange> changes) {
         try {
             for (ConfigChange alertChange : changes) {
-                //The 'type' property is an enum, so we need to handle it differently than the other properties
-                if(alertChange.propertyName().equals("type")) {
-                    PropertyUtils.setProperty(alert, alertChange.propertyName(), AlertType.valueOf(alertChange.newValue().toString()));
-                } else {
-                    PropertyUtils.setProperty(alert, alertChange.propertyName(), alertChange.newValue());
-                }
+                PublishingUtils.setPropertyEnumSafe(alert, alertChange.propertyName(), alertChange.newValue());
             }
         } catch (Exception e) {
             throw new RuntimeException("Error applying changes to alert: " + alert.getId(), e);

--- a/core/src/main/java/bio/terra/pearl/core/service/publishing/PublishingUtils.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/publishing/PublishingUtils.java
@@ -23,7 +23,7 @@ public class PublishingUtils {
                                     EnvironmentName destEnvName) throws Exception {
         C destConfig = configService.find(versionedConfigChange.destId()).get();
         for (ConfigChange change : versionedConfigChange.configChanges()) {
-            PropertyUtils.setProperty(destConfig, change.propertyName(), change.newValue());
+            setPropertyEnumSafe(destConfig, change.propertyName(), change.newValue());
         }
         if (versionedConfigChange.documentChange().isChanged()) {
             VersionedEntityChange<T> docChange = versionedConfigChange.documentChange();
@@ -55,6 +55,14 @@ public class PublishingUtils {
         if (destEnvName.isLive() && newConfig.versionedEntityId() != null)  {
             T entity = service.find(newConfig.versionedEntityId()).get();
             service.assignPublishedVersion(entity.getId());
+        }
+    }
+
+    public static void setPropertyEnumSafe(Object object, String propertyName, Object newValue) throws Exception {
+        if(object.getClass().getDeclaredField(propertyName).getType().isEnum()) {
+            PropertyUtils.setProperty(object, propertyName, Enum.valueOf((Class<Enum>) PropertyUtils.getPropertyType(object, propertyName), newValue.toString()));
+        } else {
+            PropertyUtils.setProperty(object, propertyName, newValue);
         }
     }
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/publishing/PortalPublishingServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/publishing/PortalPublishingServiceTests.java
@@ -7,8 +7,11 @@ import bio.terra.pearl.core.factory.portal.PortalFactory;
 import bio.terra.pearl.core.factory.survey.SurveyFactory;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.model.dashboard.AlertTrigger;
+import bio.terra.pearl.core.model.dashboard.ParticipantDashboardAlert;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
+import bio.terra.pearl.core.model.publishing.ConfigChange;
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentConfigService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
@@ -17,6 +20,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
 
 public class PortalPublishingServiceTests extends BaseSpringBootTest {
     @Test
@@ -55,6 +60,22 @@ public class PortalPublishingServiceTests extends BaseSpringBootTest {
         assertThat(updatedLiveEnv.getPreRegSurveyId(), equalTo(survey.getId()));
         survey = surveyService.find(survey.getId()).get();
         assertThat(survey.getPublishedVersion(), equalTo(1));
+    }
+
+    @Test
+    public void testApplyAlertChanges() throws Exception {
+        ParticipantDashboardAlert alert = ParticipantDashboardAlert.builder()
+                .title("No activities left!")
+                .detail("This message shouldn't change")
+                .trigger(AlertTrigger.NO_ACTIVITIES_REMAIN)
+                .build();
+
+        List<ConfigChange> changesToApply = List.of(new ConfigChange("title", "No activities left!", (Object)"All activities complete"));
+
+        portalPublishingService.applyAlertChanges(alert, changesToApply);
+
+        assertThat(alert.getTitle(), equalTo("All activities complete"));
+        assertThat(alert.getDetail(), equalTo("This message shouldn't change"));
     }
 
     @Autowired

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -1,5 +1,6 @@
 import _pick from 'lodash/pick'
 import {
+  AlertTrigger,
   ConsentForm,
   Survey,
   ConsentResponse,
@@ -263,6 +264,7 @@ export type PortalEnvironmentChange = {
   configChanges: ConfigChange[],
   preRegSurveyChanges: VersionedEntityChange,
   notificationConfigChanges: ListChange<NotificationConfig, VersionedConfigChange>
+  participantDashboardAlertChanges: ParticipantDashboardAlertChange[],
   studyEnvChanges: StudyEnvironmentChange[]
 }
 
@@ -302,6 +304,11 @@ export type VersionedConfigChange = {
   sourceId: string,
   configChanges: ConfigChange[],
   documentChange: VersionedEntityChange
+}
+
+export type ParticipantDashboardAlertChange = {
+  trigger: AlertTrigger,
+  changes: ConfigChange[]
 }
 
 export type ExportOptions = {

--- a/ui-admin/src/portal/publish/PortalEnvDiff.test.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiff.test.tsx
@@ -24,15 +24,15 @@ describe('PortalEnvDiff', () => {
   })
 
   it('handles a changeset with one item', async () => {
-    const {portal} = mockPortalContext()
+    const { portal } = mockPortalContext()
     const changeSet: PortalEnvironmentChange = {
       ...emptyChangeSet,
       configChanges: [
-        {propertyName: 'password', oldValue: 'secret', newValue: 'moreSecret'}
+        { propertyName: 'password', oldValue: 'secret', newValue: 'moreSecret' }
       ]
     }
     const spyApplyChanges = jest.fn(() => 1)
-    const {RoutedComponent} = setupRouterTest(<PortalEnvDiffView
+    const { RoutedComponent } = setupRouterTest(<PortalEnvDiffView
       portal={portal}
       destEnvName={portal.portalEnvironments[0].environmentName}
       applyChanges={spyApplyChanges}
@@ -55,7 +55,7 @@ describe('PortalEnvDiff', () => {
   })
 
   it('handles changes with siteContent', async () => {
-    const {portal} = mockPortalContext()
+    const { portal } = mockPortalContext()
     const changeSet: PortalEnvironmentChange = {
       ...emptyChangeSet,
       siteContentChange: {
@@ -67,7 +67,7 @@ describe('PortalEnvDiff', () => {
       }
     }
     const spyApplyChanges = jest.fn(() => 1)
-    const {RoutedComponent} = setupRouterTest(<PortalEnvDiffView
+    const { RoutedComponent } = setupRouterTest(<PortalEnvDiffView
       portal={portal}
       destEnvName={portal.portalEnvironments[0].environmentName}
       applyChanges={spyApplyChanges}

--- a/ui-admin/src/portal/publish/PortalEnvDiff.test.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiff.test.tsx
@@ -5,7 +5,7 @@ import PortalEnvDiffView, { emptyChangeSet } from './PortalEnvDiffView'
 import { setupRouterTest } from 'test-utils/router-testing-utils'
 
 import { PortalEnvironmentChange } from 'api/api'
-import userEvent from '@testing-library/user-event';
+import userEvent from '@testing-library/user-event'
 
 
 describe('PortalEnvDiff', () => {

--- a/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
@@ -16,6 +16,7 @@ export const emptyChangeSet: PortalEnvironmentChange = {
   configChanges: [],
   preRegSurveyChanges: { changed: false },
   notificationConfigChanges: { addedItems: [], removedItems: [], changedItems: [] },
+  participantDashboardAlertChanges: [],
   studyEnvChanges: []
 }
 
@@ -134,9 +135,42 @@ export default function PortalEnvDiffView(
       </div>
       <div className="my-2">
         <h2 className="h6">
-          Dashboard config</h2>
-        <div className="ms-4 ">
-          <span className="text-muted fst-italic">not yet implemented</span>
+          Participant dashboard alerts</h2>
+        <div className="ms-4">
+          { changeSet.participantDashboardAlertChanges.length > 0 ?
+            changeSet.participantDashboardAlertChanges.map(alertChange => (
+              <div key={alertChange.trigger} className="px-3 my-2 py-2" style={{ backgroundColor: '#ededed' }}>
+                <h2 className="h5 pb-2">{alertChange.trigger}</h2>
+                <ConfigChanges configChanges={alertChange.changes}
+                  selectedChanges={selectedChanges.participantDashboardAlertChanges.find(change =>
+                    change.trigger === alertChange.trigger)?.changes || []
+                  }
+                  updateSelectedChanges={(updatedConfigChanges: ConfigChange[]) => {
+                    const updatedAlertChanges = [
+                      ...changeSet.participantDashboardAlertChanges.map(change => {
+                        return {
+                          trigger: change.trigger,
+                          changes: []
+                        }
+                      }),
+                      ...selectedChanges.participantDashboardAlertChanges
+                    ]
+                    const matchedIndex = updatedAlertChanges.findIndex(change =>
+                      change.trigger === alertChange.trigger)
+                    updatedAlertChanges[matchedIndex] = {
+                      trigger: alertChange.trigger,
+                      changes: updatedConfigChanges
+                    }
+                    setSelectedChanges({
+                      ...selectedChanges,
+                      participantDashboardAlertChanges: updatedAlertChanges
+                    })
+                  }}
+                />
+              </div>
+            )) :
+            <span className="fst-italic text-muted">no changes</span>
+          }
         </div>
       </div>
       <div className="my-2">

--- a/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
@@ -45,6 +45,12 @@ const getDefaultPortalEnvChanges = (changes: PortalEnvironmentChange) => {
   }
   return {
     ...emptyChangeSet,
+    participantDashboardAlertChanges: changes.participantDashboardAlertChanges.map(alertChange => (
+      {
+        trigger: alertChange.trigger,
+        changes: []
+      }
+    )),
     studyEnvChanges: changes.studyEnvChanges.map(studyEnvChange => (
       {
         ...getDefaultStudyEnvChanges(studyEnvChange),
@@ -146,18 +152,10 @@ export default function PortalEnvDiffView(
                     change.trigger === alertChange.trigger)?.changes || []
                   }
                   updateSelectedChanges={(updatedConfigChanges: ConfigChange[]) => {
-                    const updatedAlertChanges = [
-                      ...changeSet.participantDashboardAlertChanges.map(change => {
-                        return {
-                          trigger: change.trigger,
-                          changes: []
-                        }
-                      }),
-                      ...selectedChanges.participantDashboardAlertChanges
-                    ]
-                    const matchedIndex = updatedAlertChanges.findIndex(change =>
+                    const updatedAlertChanges = selectedChanges.participantDashboardAlertChanges
+                    const alertIndex = updatedAlertChanges.findIndex(change =>
                       change.trigger === alertChange.trigger)
-                    updatedAlertChanges[matchedIndex] = {
+                    updatedAlertChanges[alertIndex] = {
                       trigger: alertChange.trigger,
                       changes: updatedConfigChanges
                     }


### PR DESCRIPTION
#### DESCRIPTION

This adds the alert publishing functionality that was missing from #642. Note that this is a PR into #642, not into `development`.

https://github.com/broadinstitute/juniper/assets/7257391/b2d17b37-7527-4653-aa06-07250d35c507


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Launch admin API and UI
* Update the default `NO_ACTIVITIES_REMAIN` alert in sandbox
* View the publish diff view for sandbox vs IRB: https://localhost:3000/ourhealth/studies/ourheart/diff/sandbox/irb
* Confirm that you see your changes represented in the diff
* Select some of the changes and publish
* Confirm that they show up in the IRB environment