### PR TITLE
[JN-749] Implement notification of kit sent events

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/PortalParticipantUserDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/PortalParticipantUserDao.java
@@ -69,6 +69,9 @@ public class PortalParticipantUserDao extends BaseJdbiDao<PortalParticipantUser>
         return findAllByProperty("profile_id", profileId);
     }
 
+    public Optional<PortalParticipantUser> findByParticipantUserIdAndProfileId(UUID userId, UUID profileId) {
+        return findByTwoProperties("participant_user_id", userId, "profile_id", profileId);
+    }
 
 
     /**

--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/PortalParticipantUserDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/PortalParticipantUserDao.java
@@ -65,14 +65,9 @@ public class PortalParticipantUserDao extends BaseJdbiDao<PortalParticipantUser>
         return findAllByProperty("portal_environment_id", portalEnvId);
     }
 
-    public List<PortalParticipantUser> findByProfileId(UUID profileId) {
-        return findAllByProperty("profile_id", profileId);
+    public Optional<PortalParticipantUser> findByProfileId(UUID profileId) {
+        return findByProperty("profile_id", profileId);
     }
-
-    public Optional<PortalParticipantUser> findByParticipantUserIdAndProfileId(UUID userId, UUID profileId) {
-        return findByTwoProperties("participant_user_id", userId, "profile_id", profileId);
-    }
-
 
     /**
      * loads the user along with their profile

--- a/core/src/main/java/bio/terra/pearl/core/model/notification/NotificationEventType.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/notification/NotificationEventType.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.model.notification;
 
 import bio.terra.pearl.core.service.consent.EnrolleeConsentEvent;
+import bio.terra.pearl.core.service.kit.KitSentEvent;
 import bio.terra.pearl.core.service.survey.EnrolleeSurveyEvent;
 import bio.terra.pearl.core.service.workflow.BaseEvent;
 import bio.terra.pearl.core.service.workflow.EnrolleeCreationEvent;
@@ -10,7 +11,8 @@ public enum NotificationEventType {
     PORTAL_REGISTRATION(PortalRegistrationEvent.class),
     SURVEY_RESPONSE(EnrolleeSurveyEvent.class),
     STUDY_ENROLLMENT(EnrolleeCreationEvent.class),
-    STUDY_CONSENT(EnrolleeConsentEvent.class);
+    STUDY_CONSENT(EnrolleeConsentEvent.class),
+    KIT_SENT(KitSentEvent.class);
 
     public final Class<? extends BaseEvent> eventClass;
     NotificationEventType(Class<? extends BaseEvent> eventClass) {

--- a/core/src/main/java/bio/terra/pearl/core/service/consent/ConsentTaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/consent/ConsentTaskDispatcher.java
@@ -45,13 +45,13 @@ public class ConsentTaskDispatcher {
      * for why we use two separate listening methods to accomplish that
      */
     @EventListener
-    @Order(DispatcherOrder.CONSENT)
+    @Order(DispatcherOrder.CONSENT_TASK)
     public void handleEvent(EnrolleeCreationEvent enrolleeEvent) {
         updateConsentTasks(enrolleeEvent);
     }
 
     @EventListener
-    @Order(DispatcherOrder.CONSENT)
+    @Order(DispatcherOrder.CONSENT_TASK)
     public void handleEvent(EnrolleeConsentEvent enrolleeEvent) {
         updateConsentTasks(enrolleeEvent);
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
@@ -278,9 +278,9 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
             kit.setExternalKitFetchedAt(pepperStatusFetchedAt);
             KitRequestStatus newStatus = PepperKitStatus.mapToKitRequestStatus(pepperKit.getCurrentStatus());
             if (newStatus != kit.getStatus()) {
-                eventService.publishKitStatusEvent()
+               eventService.publishKitStatusEvent() //figure out how to load the enrollee and/or portalParticipantUser
             }
-            kit.setStatus(PepperKitStatus.mapToKitRequestStatus(pepperKit.getCurrentStatus()));
+            kit.setStatus(newStatus);
             dao.update(kit);
         } catch (JsonProcessingException e) {
             logger.warn(

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitSentEvent.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitSentEvent.java
@@ -1,0 +1,7 @@
+package bio.terra.pearl.core.service.kit;
+
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+public class KitSentEvent extends KitStatusEvent {
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitStatusEvent.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitStatusEvent.java
@@ -1,0 +1,31 @@
+package bio.terra.pearl.core.service.kit;
+
+import bio.terra.pearl.core.model.kit.KitRequest;
+import bio.terra.pearl.core.model.kit.KitRequestStatus;
+import bio.terra.pearl.core.service.kit.pepper.PepperKitStatus;
+import bio.terra.pearl.core.service.workflow.EnrolleeEvent;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+/** Event for when a change occurs to a kit status */
+@Getter
+@Setter
+@SuperBuilder
+public class KitStatusEvent extends EnrolleeEvent {
+    private KitRequestStatus priorStatus;
+    private KitRequest kitRequest;
+
+    public static KitStatusEvent newInstance(KitRequest kitRequest, KitRequestStatus priorStatus) {
+        if (KitRequestStatus.SENT.equals(kitRequest.getStatus())) {
+            return KitSentEvent.builder()
+                .kitRequest(kitRequest)
+                .priorStatus(priorStatus)
+                    .build();
+        }
+        return KitStatusEvent.builder()
+            .kitRequest(kitRequest)
+            .priorStatus(priorStatus)
+                .build();
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitStatusEvent.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitStatusEvent.java
@@ -2,7 +2,6 @@ package bio.terra.pearl.core.service.kit;
 
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.kit.KitRequestStatus;
-import bio.terra.pearl.core.service.kit.pepper.PepperKitStatus;
 import bio.terra.pearl.core.service.workflow.EnrolleeEvent;
 import lombok.Getter;
 import lombok.Setter;

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/PortalParticipantUserService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/PortalParticipantUserService.java
@@ -70,13 +70,12 @@ public class PortalParticipantUserService extends ImmutableEntityService<PortalP
         return dao.findByPortalEnvironmentId(portalId);
     }
 
-    public List<PortalParticipantUser> findbyProfileId(UUID profileId) {
+    public Optional<PortalParticipantUser> findByProfileId(UUID profileId) {
         return dao.findByProfileId(profileId);
     }
 
     public PortalParticipantUser findForEnrollee(Enrollee enrollee) {
-        Optional<PortalParticipantUser> ppUser =
-                dao.findByParticipantUserIdAndProfileId(enrollee.getParticipantUserId(), enrollee.getProfileId());
+        Optional<PortalParticipantUser> ppUser = dao.findByProfileId(enrollee.getProfileId());
         return ppUser.orElseThrow(() ->
                 new IllegalStateException("No portal participant user found for enrollee %s".formatted(enrollee.getShortcode())));
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/PortalParticipantUserService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/PortalParticipantUserService.java
@@ -3,6 +3,7 @@ package bio.terra.pearl.core.service.participant;
 import bio.terra.pearl.core.dao.participant.PortalParticipantUserDao;
 import bio.terra.pearl.core.dao.survey.PreregistrationResponseDao;
 import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.PortalParticipantUser;
 import bio.terra.pearl.core.model.participant.Profile;
 import bio.terra.pearl.core.service.CascadeProperty;
@@ -71,6 +72,13 @@ public class PortalParticipantUserService extends ImmutableEntityService<PortalP
 
     public List<PortalParticipantUser> findbyProfileId(UUID profileId) {
         return dao.findByProfileId(profileId);
+    }
+
+    public PortalParticipantUser findForEnrollee(Enrollee enrollee) {
+        Optional<PortalParticipantUser> ppUser =
+                dao.findByParticipantUserIdAndProfileId(enrollee.getParticipantUserId(), enrollee.getProfileId());
+        return ppUser.orElseThrow(() ->
+                new IllegalStateException("No portal participant user found for enrollee %s".formatted(enrollee.getShortcode())));
     }
 
     @Override @Transactional

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
@@ -40,7 +40,7 @@ public class SurveyTaskDispatcher {
 
     /** survey tasks could be triggered by just about anything, so listen to all enrollee events */
     @EventListener
-    @Order(DispatcherOrder.SURVEY)
+    @Order(DispatcherOrder.SURVEY_TASK)
     public void createSurveyTasks(EnrolleeEvent enrolleeEvent) {
         List<StudyEnvironmentSurvey> studyEnvSurveys = studyEnvironmentSurveyService
                 .findAllByStudyEnvIdWithSurvey(enrolleeEvent.getEnrollee().getStudyEnvironmentId());

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/DispatcherOrder.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/DispatcherOrder.java
@@ -11,8 +11,9 @@ package bio.terra.pearl.core.service.workflow;
   */
 
 public class DispatcherOrder {
-    public static final int CONSENT = 5;
-    public static final int SURVEY = 10;
+    public static final int CONSENT_TASK = 5;
+    public static final int SURVEY_TASK = 10;
+    public static final int KIT_TASK = 20;
     // notifications should be processed last so they can include all previous processing
     public static final int NOTIFICATION = 100;
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
@@ -9,6 +9,8 @@ import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
 import bio.terra.pearl.core.model.workflow.HubResponse;
 import bio.terra.pearl.core.service.consent.EnrolleeConsentEvent;
+import bio.terra.pearl.core.service.kit.KitStatusEvent;
+import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.rule.EnrolleeRuleData;
 import bio.terra.pearl.core.service.rule.EnrolleeRuleService;
 import bio.terra.pearl.core.service.survey.EnrolleeSurveyEvent;
@@ -25,13 +27,33 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 public class EventService {
-    private ParticipantTaskService participantTaskService;
-    private EnrolleeRuleService enrolleeRuleService;
+    private final ParticipantTaskService participantTaskService;
+    private final EnrolleeRuleService enrolleeRuleService;
+    private final EnrolleeService enrolleeService;
 
     public EventService(ParticipantTaskService participantTaskService,
-                        EnrolleeRuleService enrolleeRuleService) {
+                        EnrolleeRuleService enrolleeRuleService, EnrolleeService enrolleeService) {
         this.participantTaskService = participantTaskService;
         this.enrolleeRuleService = enrolleeRuleService;
+        this.enrolleeService = enrolleeService;
+    }
+
+    /** publishes a KitStatusEvent.
+     *
+     * @param kitRequest the current kit request already updated with the new status
+     * @param priorDsmStatus the prior status
+     */
+    public KitStatusEvent publishKitStatusEvent(KitRequest kitRequest, KitRequestStatus priorStatus,
+                                                PortalParticipantUser ppUser) {
+        KitStatusEvent event = KitStatusEvent.newInstance(kitRequest, priorStatus);
+        event.setEnrollee(enrolleeS);
+        event.setPortalParticipantUser(ppUser);
+        populateEvent(event);
+        log.info("kit status event for enrollee {}, studyEnv {} - status {} => {}",
+                enrollee.getShortcode(), enrollee.getStudyEnvironmentId(),
+                priorStatus, kitRequest.getExternalRequest());
+        applicationEventPublisher.publishEvent(event);
+        return event;
     }
 
     public EnrolleeConsentEvent publishEnrolleeConsentEvent(Enrollee enrollee, ConsentResponse response,

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
@@ -2,6 +2,8 @@ package bio.terra.pearl.core.service.workflow;
 
 import bio.terra.pearl.core.model.BaseEntity;
 import bio.terra.pearl.core.model.consent.ConsentResponse;
+import bio.terra.pearl.core.model.kit.KitRequest;
+import bio.terra.pearl.core.model.kit.KitRequestStatus;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.model.participant.PortalParticipantUser;
@@ -9,6 +11,7 @@ import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
 import bio.terra.pearl.core.model.workflow.HubResponse;
 import bio.terra.pearl.core.service.consent.EnrolleeConsentEvent;
+import bio.terra.pearl.core.service.kit.KitSentEvent;
 import bio.terra.pearl.core.service.kit.KitStatusEvent;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.rule.EnrolleeRuleData;
@@ -20,7 +23,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 /**
- * All event publishing should be done via method calls in this service, to ensure that the events are constructed
+ * All event publishing should be done via method calls in this service,
+ * to ensure that the events are constructed
  * properly with appropriate supporting data.
  */
 
@@ -47,6 +51,24 @@ public class EventService {
                                                 PortalParticipantUser ppUser) {
         KitStatusEvent event = KitStatusEvent.newInstance(kitRequest, priorStatus);
         Enrollee enrollee =
+        event.setEnrollee(enrollee);
+        event.setPortalParticipantUser(ppUser);
+        populateEvent(event);
+        log.info("kit status event for enrollee {}, studyEnv {} - status {} => {}",
+                enrollee.getShortcode(), enrollee.getStudyEnvironmentId(),
+                priorStatus, kitRequest.getExternalRequest());
+        applicationEventPublisher.publishEvent(event);
+        return event;
+    }
+
+    /** publishes a KitStatusEvent.
+     *
+     * @param kitRequest the current kit request already updated with the new status
+     * @param priorDsmStatus the prior status
+     */
+    public KitStatusEvent publishKitStatusEvent(Enrollee enrollee, KitRequest kitRequest, KitRequestStatus priorStatus,
+                                                PortalParticipantUser ppUser) {
+        KitStatusEvent event = KitSentEvent.newInstance(kitRequest, priorStatus);
         event.setEnrollee(enrollee);
         event.setPortalParticipantUser(ppUser);
         populateEvent(event);

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
@@ -33,48 +33,33 @@ import org.springframework.stereotype.Service;
 public class EventService {
     private final ParticipantTaskService participantTaskService;
     private final EnrolleeRuleService enrolleeRuleService;
-    private final EnrolleeService enrolleeService;
 
     public EventService(ParticipantTaskService participantTaskService,
-                        EnrolleeRuleService enrolleeRuleService, EnrolleeService enrolleeService) {
+                        EnrolleeRuleService enrolleeRuleService) {
         this.participantTaskService = participantTaskService;
         this.enrolleeRuleService = enrolleeRuleService;
-        this.enrolleeService = enrolleeService;
     }
 
     /** publishes a KitStatusEvent.
      *
-     * @param kitRequest the current kit request already updated with the new status
-     * @param priorDsmStatus the prior status
+     * @param kitRequest current kit request already updated with the new status
+     * @param priorStatus prior kit status
+     * @return the event that was published, or null if no event was published
      */
     public KitStatusEvent publishKitStatusEvent(KitRequest kitRequest, KitRequestStatus priorStatus,
                                                 PortalParticipantUser ppUser) {
-        KitStatusEvent event = KitStatusEvent.newInstance(kitRequest, priorStatus);
-        Enrollee enrollee =
-        event.setEnrollee(enrollee);
-        event.setPortalParticipantUser(ppUser);
-        populateEvent(event);
-        log.info("kit status event for enrollee {}, studyEnv {} - status {} => {}",
-                enrollee.getShortcode(), enrollee.getStudyEnvironmentId(),
-                priorStatus, kitRequest.getExternalRequest());
-        applicationEventPublisher.publishEvent(event);
-        return event;
-    }
-
-    /** publishes a KitStatusEvent.
-     *
-     * @param kitRequest the current kit request already updated with the new status
-     * @param priorDsmStatus the prior status
-     */
-    public KitStatusEvent publishKitStatusEvent(Enrollee enrollee, KitRequest kitRequest, KitRequestStatus priorStatus,
-                                                PortalParticipantUser ppUser) {
+        // currently only publish events for SENT status
+        if (!KitRequestStatus.SENT.equals(kitRequest.getStatus())) {
+            return null;
+        }
         KitStatusEvent event = KitSentEvent.newInstance(kitRequest, priorStatus);
+        Enrollee enrollee = kitRequest.getEnrollee();
         event.setEnrollee(enrollee);
         event.setPortalParticipantUser(ppUser);
         populateEvent(event);
-        log.info("kit status event for enrollee {}, studyEnv {} - status {} => {}",
+        log.info("Kit status event for enrollee {}, studyEnv {}: status {} => {}",
                 enrollee.getShortcode(), enrollee.getStudyEnvironmentId(),
-                priorStatus, kitRequest.getExternalRequest());
+                priorStatus, kitRequest.getStatus());
         applicationEventPublisher.publishEvent(event);
         return event;
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
@@ -13,7 +13,6 @@ import bio.terra.pearl.core.model.workflow.HubResponse;
 import bio.terra.pearl.core.service.consent.EnrolleeConsentEvent;
 import bio.terra.pearl.core.service.kit.KitSentEvent;
 import bio.terra.pearl.core.service.kit.KitStatusEvent;
-import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.rule.EnrolleeRuleData;
 import bio.terra.pearl.core.service.rule.EnrolleeRuleService;
 import bio.terra.pearl.core.service.survey.EnrolleeSurveyEvent;
@@ -23,9 +22,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 /**
- * All event publishing should be done via method calls in this service,
- * to ensure that the events are constructed
- * properly with appropriate supporting data.
+ * All event publishing should be done via method calls in this service to ensure that the
+ * events are constructed properly with appropriate supporting data.
  */
 
 @Service
@@ -40,22 +38,16 @@ public class EventService {
         this.enrolleeRuleService = enrolleeRuleService;
     }
 
-    /** publishes a KitStatusEvent.
+    /** Publish a KitStatusEvent.
      *
      * @param kitRequest current kit request already updated with the new status
      * @param priorStatus prior kit status
-     * @return the event that was published, or null if no event was published
      */
-    public KitStatusEvent publishKitStatusEvent(KitRequest kitRequest, KitRequestStatus priorStatus,
-                                                PortalParticipantUser ppUser) {
-        // currently only publish events for SENT status
-        if (!KitRequestStatus.SENT.equals(kitRequest.getStatus())) {
-            return null;
-        }
+    public KitStatusEvent publishKitStatusEvent(KitRequest kitRequest, Enrollee enrollee,
+                                                PortalParticipantUser portalParticipantUser, KitRequestStatus priorStatus) {
         KitStatusEvent event = KitSentEvent.newInstance(kitRequest, priorStatus);
-        Enrollee enrollee = kitRequest.getEnrollee();
         event.setEnrollee(enrollee);
-        event.setPortalParticipantUser(ppUser);
+        event.setPortalParticipantUser(portalParticipantUser);
         populateEvent(event);
         log.info("Kit status event for enrollee {}, studyEnv {}: status {} => {}",
                 enrollee.getShortcode(), enrollee.getStudyEnvironmentId(),

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
@@ -46,7 +46,8 @@ public class EventService {
     public KitStatusEvent publishKitStatusEvent(KitRequest kitRequest, KitRequestStatus priorStatus,
                                                 PortalParticipantUser ppUser) {
         KitStatusEvent event = KitStatusEvent.newInstance(kitRequest, priorStatus);
-        event.setEnrollee(enrolleeS);
+        Enrollee enrollee =
+        event.setEnrollee(enrollee);
         event.setPortalParticipantUser(ppUser);
         populateEvent(event);
         log.info("kit status event for enrollee {}, studyEnv {} - status {} => {}",

--- a/core/src/main/resources/db/changelog/changesets/2023_12_06_portal_participant_user.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2023_12_06_portal_participant_user.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: portal_participant_user
+      author: cunningh
+      changes:
+        - addUniqueConstraint:
+            tableName: portal_participant_user
+            constraintName: uc_pp_user_profile_id
+            columnNames: profile_id

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -152,6 +152,9 @@ databaseChangeLog:
   - include:
       file: changesets/2023_11_30_kit_status.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2023_12_06_portal_participant_user.yaml
+      relativeToChangelogFile: true
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements
 # are atomic. When they are grouped in a changeset and one fails the changeset cannot be

--- a/core/src/test/java/bio/terra/pearl/core/dao/participant/EnrolleeSearchDaoTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/participant/EnrolleeSearchDaoTests.java
@@ -77,7 +77,7 @@ public class EnrolleeSearchDaoTests extends BaseSpringBootTest {
     var enrollee = enrolleeFactory.buildPersisted("testKitRequestStatusSearch", studyEnv);
     var kitEnrollee = enrolleeFactory.buildPersisted("testKitRequestStatusSearch", studyEnv);
 
-    kitRequestFactory.buildPersisted("testKitRequestStatusSearch", kitEnrollee.getId());
+    kitRequestFactory.buildPersisted("testKitRequestStatusSearch", kitEnrollee);
 
     var result = enrolleeSearchDao.search(studyEnv.getId(), List.of());
     assertThat(result, hasSize(2));

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
@@ -248,7 +248,7 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
             return null;
         });
 
-        kitRequestService.notifyKitStatus(kitRequest, KitRequestStatus.CREATED);
+        kitRequestService.notifyKitStatusChange(kitRequest, KitRequestStatus.CREATED);
     }
 
     @Transactional

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientIntegrationTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientIntegrationTest.java
@@ -36,7 +36,7 @@ public class LivePepperDSMClientIntegrationTest extends BaseSpringBootTest {
     public void testSendKitRequest() throws Exception {
         var enrollee = enrolleeFactory.buildPersisted("testSendKitRequest");
         var kitType = kitTypeDao.findByName("SALIVA").get();
-        var kitRequest = kitRequestFactory.buildPersisted("testSendKitRequest", enrollee.getId(), kitType.getId());
+        var kitRequest = kitRequestFactory.buildPersisted("testSendKitRequest", enrollee, kitType.getId());
         kitRequest.setKitType(kitType);
         var address = PepperKitAddress.builder()
                 .firstName("Juniper")
@@ -56,7 +56,7 @@ public class LivePepperDSMClientIntegrationTest extends BaseSpringBootTest {
     @IntegrationTest
     public void testSendKitRequestParsesPepperError() throws Exception {
         var enrollee = enrolleeFactory.buildPersisted("testSendKitRequestParsesPepperError");
-        var kitRequest = kitRequestFactory.buildPersisted("testSendKitRequestParsesPepperError", enrollee.getId());
+        var kitRequest = kitRequestFactory.buildPersisted("testSendKitRequestParsesPepperError", enrollee);
         var address = PepperKitAddress.builder()
                 .firstName("Juniper")
                 .lastName("Testerson")

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientTest.java
@@ -55,7 +55,7 @@ public class LivePepperDSMClientTest extends BaseSpringBootTest {
                 .thenReturn("secret");
 
         enrollee = enrolleeFactory.buildPersisted(info.getDisplayName());
-        kitRequest = kitRequestFactory.buildPersisted(info.getDisplayName(), enrollee.getId());
+        kitRequest = kitRequestFactory.buildPersisted(info.getDisplayName(), enrollee);
         address = PepperKitAddress.builder().build();
     }
 

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/StubPepperDSMClientTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/StubPepperDSMClientTest.java
@@ -35,7 +35,7 @@ class StubPepperDSMClientTest extends BaseSpringBootTest {
                         .studyEnvironmentConfig(new StudyEnvironmentConfig())
                         .build());
         var enrollee = enrolleeFactory.buildPersisted("testFetchKitStatus", studyEnvironment);
-        var kit = kitRequestFactory.buildPersisted("testFetchKitStatus", enrollee.getId());
+        var kit = kitRequestFactory.buildPersisted("testFetchKitStatus", enrollee);
 
         // Act
         var kitStatus = stubPepperDSMClient.fetchKitStatus(kit.getId());
@@ -57,7 +57,7 @@ class StubPepperDSMClientTest extends BaseSpringBootTest {
                         .studyEnvironmentConfig(new StudyEnvironmentConfig())
                         .build());
         var enrollee = enrolleeFactory.buildPersisted("testFetchKitStatusByStudy", studyEnvironment);
-        var kit = kitRequestFactory.buildPersisted("testFetchKitStatusByStudy", enrollee.getId());
+        var kit = kitRequestFactory.buildPersisted("testFetchKitStatusByStudy", enrollee);
 
         // Act
         var kitStatuses = stubPepperDSMClient.fetchKitStatusByStudy(study.getShortcode());

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/NotificationDispatcherTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/NotificationDispatcherTests.java
@@ -2,6 +2,8 @@ package bio.terra.pearl.core.service.notification;
 
 import bio.terra.pearl.core.BaseSpringBootTest;
 import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
+import bio.terra.pearl.core.model.kit.KitRequest;
+import bio.terra.pearl.core.model.kit.KitRequestStatus;
 import bio.terra.pearl.core.model.notification.*;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.service.workflow.EventService;
@@ -10,6 +12,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.samePropertyValuesAs;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,32 +22,58 @@ public class NotificationDispatcherTests extends BaseSpringBootTest {
     public void testEventTriggersNotificationCreation() {
         EnrolleeFactory.EnrolleeBundle enrolleeBundle = enrolleeFactory
                 .buildWithPortalUser("notificationTriggers");
+        NotificationConfig config = createNotificationConfig(enrolleeBundle, NotificationEventType.STUDY_ENROLLMENT);
+
+        eventService.publishEnrolleeCreationEvent(enrolleeBundle.enrollee(), enrolleeBundle.portalParticipantUser());
+        verifyNotification(config, enrolleeBundle);
+    }
+
+    @Test
+    @Transactional
+    void testKitSendEvent(TestInfo testInfo) {
+        EnrolleeFactory.EnrolleeBundle enrolleeBundle = enrolleeFactory
+                .buildWithPortalUser(getTestName(testInfo));
+        NotificationConfig config = createNotificationConfig(enrolleeBundle, NotificationEventType.KIT_SENT);
+        KitRequest kitRequest = KitRequest.builder()
+                .status(KitRequestStatus.SENT)
+                .enrolleeId(enrolleeBundle.enrollee().getId())
+                .build();
+
+        eventService.publishKitStatusEvent(kitRequest, enrolleeBundle.enrollee(), enrolleeBundle.portalParticipantUser(), KitRequestStatus.CREATED);
+        verifyNotification(config, enrolleeBundle);
+    }
+
+    private NotificationConfig createNotificationConfig(EnrolleeFactory.EnrolleeBundle enrolleeBundle, NotificationEventType eventType) {
         Enrollee enrollee = enrolleeBundle.enrollee();
         NotificationConfig config = NotificationConfig.builder()
                 .studyEnvironmentId(enrollee.getStudyEnvironmentId())
-                .eventType(NotificationEventType.STUDY_ENROLLMENT)
+                .eventType(eventType)
                 .deliveryType(NotificationDeliveryType.EMAIL)
                 .notificationType(NotificationType.EVENT)
                 .portalEnvironmentId(enrolleeBundle.portalParticipantUser().getPortalEnvironmentId())
                 .build();
         config = notificationConfigService.create(config);
+        return config;
+    }
 
-        eventService.publishEnrolleeCreationEvent(enrollee, enrolleeBundle.portalParticipantUser());
 
+    private void verifyNotification(NotificationConfig config, EnrolleeFactory.EnrolleeBundle enrolleeBundle) {
+        Enrollee enrollee = enrolleeBundle.enrollee();
         List<Notification> notifications = notificationService.findByEnrolleeId(enrollee.getId());
         assertThat(notifications, hasSize(1));
         Notification expectedNotification = Notification.builder()
-            .notificationConfigId(config.getId())
-            .deliveryType(config.getDeliveryType())
-            .studyEnvironmentId(config.getStudyEnvironmentId())
-            .portalEnvironmentId(enrolleeBundle.portalParticipantUser().getPortalEnvironmentId())
-            .deliveryStatus(NotificationDeliveryStatus.SKIPPED) // SKIPPED since the config has no email template
-            .enrolleeId(enrollee.getId())
-            .participantUserId(enrollee.getParticipantUserId())
-            .build();
+                .notificationConfigId(config.getId())
+                .deliveryType(config.getDeliveryType())
+                .studyEnvironmentId(config.getStudyEnvironmentId())
+                .portalEnvironmentId(enrolleeBundle.portalParticipantUser().getPortalEnvironmentId())
+                .deliveryStatus(NotificationDeliveryStatus.SKIPPED) // SKIPPED since the config has no email template
+                .enrolleeId(enrollee.getId())
+                .participantUserId(enrollee.getParticipantUserId())
+                .build();
         assertThat(notifications.get(0), samePropertyValuesAs(expectedNotification,
                 "createdAt", "id", "lastUpdatedAt"));
     }
+
     @Autowired
     private NotificationService notificationService;
     @Autowired

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/kit/KitRequestFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/kit/KitRequestFactory.java
@@ -6,6 +6,7 @@ import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.kit.KitRequestStatus;
 import bio.terra.pearl.core.model.kit.KitType;
+import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.service.kit.pepper.PepperKit;
 import bio.terra.pearl.core.service.kit.pepper.PepperKitAddress;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -36,29 +37,30 @@ public class KitRequestFactory {
                 .status(KitRequestStatus.CREATED);
     }
 
-    public KitRequest buildPersisted(String testName, UUID enrolleeId) throws JsonProcessingException {
+    public KitRequest buildPersisted(String testName, Enrollee enrollee) throws JsonProcessingException {
         KitType kitType = kitTypeFactory.buildPersisted(testName);
-        var kitRequest = buildPersisted(testName, enrolleeId, kitType.getId());
+        var kitRequest = buildPersisted(testName, enrollee, kitType.getId());
         kitRequest.setKitType(kitType);
         return kitRequest;
     }
 
-    public KitRequest buildPersisted(String testName, UUID enrolleeId, UUID kitTypeId) throws JsonProcessingException {
+    public KitRequest buildPersisted(String testName, Enrollee enrollee, UUID kitTypeId) throws JsonProcessingException {
         AdminUser adminUser = adminUserFactory.buildPersisted(testName);
-        return buildPersisted(testName, enrolleeId, kitTypeId, adminUser.getId());
+        return buildPersisted(testName, enrollee, kitTypeId, adminUser.getId());
     }
 
-    public KitRequest buildPersisted(String testName, UUID enrolleeId, UUID kitTypeId, UUID adminUserId)
+    public KitRequest buildPersisted(String testName, Enrollee enrollee, UUID kitTypeId, UUID adminUserId)
             throws JsonProcessingException {
         var kitRequest = builder(testName)
                 .creatingAdminUserId(adminUserId)
-                .enrolleeId(enrolleeId)
+                .enrolleeId(enrollee.getId())
                 .kitTypeId(kitTypeId)
                 .build();
         var savedKitRequest = kitRequestDao.create(kitRequest);
         var dsmStatus = PepperKit.builder()
                 .currentStatus("kit without label")
                 .juniperKitId(savedKitRequest.getId().toString())
+                .participantId(enrollee.getShortcode())
                 .build();
         savedKitRequest.setExternalKit(objectMapper.writeValueAsString(dsmStatus));
         savedKitRequest.setExternalKitFetchedAt(Instant.now());

--- a/ui-admin/src/study/notifications/NotifcationConfigTypeDisplay.tsx
+++ b/ui-admin/src/study/notifications/NotifcationConfigTypeDisplay.tsx
@@ -9,7 +9,8 @@ export const eventTypeDisplayMap: Record<string, string> = {
   PORTAL_REGISTRATION: 'Portal registration',
   SURVEY_RESPONSE: 'Survey response',
   STUDY_ENROLLMENT: 'Study enrollment',
-  STUDY_CONSENT: 'Consent form submission'
+  STUDY_CONSENT: 'Consent form submission',
+  KIT_SENT: 'Kit sent'
 }
 
 /** shows a summary of the notification config */

--- a/ui-admin/src/study/notifications/NotificationConfigView.tsx
+++ b/ui-admin/src/study/notifications/NotificationConfigView.tsx
@@ -15,7 +15,8 @@ const configTypeOptions = [{ label: 'Event', value: 'EVENT' }, { label: 'Task re
   { label: 'Ad hoc', value: 'AD_HOC' }]
 const deliveryTypeOptions = [{ label: 'Email', value: 'EMAIL' }]
 const eventTypeOptions = [{ label: 'Study Enrollment', value: 'STUDY_ENROLLMENT' },
-  { label: 'Study Consent', value: 'STUDY_CONSENT' }, { label: 'Survey Response', value: 'SURVEY_RESPONSE' }]
+  { label: 'Study Consent', value: 'STUDY_CONSENT' }, { label: 'Survey Response', value: 'SURVEY_RESPONSE' },
+  { label: 'Kit Sent', value: 'KIT_SENT' }]
 const taskTypeOptions = [{ label: 'Survey', value: 'SURVEY' }, { label: 'Consent', value: 'CONSENT' }]
 
 


### PR DESCRIPTION
#### DESCRIPTION
This PR implements a notification event when a kit status is changed to 'sent', so admins can configure an email message to be sent to participants when a kit is shipped. Most of the infrastructure for this was already in place -- as it would be for any new events -- so this PR mostly generates the event from KitRequestService.

The testing instructions below suggest using the kit 'Refresh' button. This uses the local simulated kit service to simultaneously advance the status of all requested kits. Since this is cumbersome Devon suggested providing a dropdown on kit list rows to change the status for each kit separately. I will do that in a separate PR, but if that's a blocker for testing this PR I can put that PR up first and incorporate that change into this PR.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
![image](https://github.com/broadinstitute/juniper/assets/129115982/41c82345-c822-4e0c-a95d-5cec927c4841)

1. Populate OurHealth.
2. Goto https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/notificationContent and setup an email notification for kit sent event.
3. Goto https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/kits/requested/created.
4. Repeatedly mash the "Refresh" button until a participant status moves from 'Queued' to 'Sent'.
5. Check the logs. You should see an entry from EventService like "Kit status event for enrollee..." coinciding with the time the participant status changed to 'Sent'.
6. Closely following that message you should see an entry from EnrolleeEmailService like "Email sent...".
7. Check your inbox for a kit sent email notification.
