### PR TITLE
JN-764 survey editor link browsing

### DIFF
--- a/ui-admin/src/components/Tree.tsx
+++ b/ui-admin/src/components/Tree.tsx
@@ -5,7 +5,7 @@ import React, { Dispatch, SetStateAction, useRef, useState } from 'react'
 
 export type TreeItemT<T> = {
   /** User facing label. */
-  label: string
+  label: React.ReactNode
 
   /** Data associated with this tree item. */
   data: T

--- a/ui-admin/src/forms/FormDesigner.tsx
+++ b/ui-admin/src/forms/FormDesigner.tsx
@@ -1,5 +1,5 @@
 import { flow, get, identity, set, update } from 'lodash/fp'
-import React, {useEffect, useState} from 'react'
+import React from 'react'
 
 import { FormContent, FormContentPage, FormElement } from '@juniper/ui-core'
 
@@ -10,7 +10,7 @@ import { QuestionDesigner } from './designer/QuestionDesigner'
 import { QuestionTemplatesDesigner } from './designer/QuestionTemplatesDesigner'
 import { FormTableOfContents } from './FormTableOfContents'
 import { PageListDesigner } from './designer/PageListDesigner'
-import {useSearchParams} from "react-router-dom";
+import { useSearchParams } from 'react-router-dom'
 
 type FormDesignerProps = {
   readOnly?: boolean
@@ -21,15 +21,13 @@ type FormDesignerProps = {
 /** UI for editing forms. */
 export const FormDesigner = (props: FormDesignerProps) => {
   const { readOnly = false, value, onChange } = props
-    const [searchParams, setSearchParams] = useSearchParams()
-    const selectedElementPath = searchParams.get('selectedElementPath') ?? 'pages'
-    const selectedElement = getSurveyElementFromPath(selectedElementPath, value)
-    const setSelectedElementPath = (path: string) => {
-      searchParams.set('selectedElementPath', path)
-        setSearchParams(searchParams)
-    }
-
-   console.log('selectedElementPath: ', selectedElementPath)
+  const [searchParams, setSearchParams] = useSearchParams()
+  const selectedElementPath = searchParams.get('selectedElementPath') ?? 'pages'
+  const selectedElement = getSurveyElementFromPath(selectedElementPath, value)
+  const setSelectedElementPath = (path: string) => {
+    searchParams.set('selectedElementPath', path)
+    setSearchParams(searchParams)
+  }
   return (
     <div className="overflow-hidden flex-grow-1 d-flex flex-row mh-100" style={{ flexBasis: 0 }}>
       <div className="flex-shrink-0 border-end" style={{ width: 400, overflowY: 'scroll' }}>
@@ -44,7 +42,7 @@ export const FormDesigner = (props: FormDesignerProps) => {
           if (selectedElementPath === 'pages') {
             return (
               <PageListDesigner
-                  setSelectedElementPath={setSelectedElementPath}
+                setSelectedElementPath={setSelectedElementPath}
                 formContent={value}
                 readOnly={readOnly}
                 onChange={onChange}
@@ -63,9 +61,9 @@ export const FormDesigner = (props: FormDesignerProps) => {
           }
           if (selectedElement === undefined) {
             return (
-                <p className="mt-5 text-center">Select an element to edit</p>
+              <p className="mt-5 text-center">Select an element to edit</p>
             )
-        }
+          }
 
           if (!('type' in selectedElement) && !('questionTemplateName' in selectedElement)) {
             return (
@@ -152,10 +150,10 @@ export const FormDesigner = (props: FormDesignerProps) => {
 }
 
 const getSurveyElementFromPath = (elementPath: string, obj: object):  FormContentPage | FormElement | undefined => {
-    try {
-        return get(elementPath, obj) as FormContentPage | FormElement
-    } catch (e) {
-        return undefined
-    }
+  try {
+    return get(elementPath, obj) as FormContentPage | FormElement
+  } catch (e) {
+    return undefined
+  }
 }
 

--- a/ui-admin/src/forms/FormDesigner.tsx
+++ b/ui-admin/src/forms/FormDesigner.tsx
@@ -23,7 +23,7 @@ export const FormDesigner = (props: FormDesignerProps) => {
   const { readOnly = false, value, onChange } = props
     const [searchParams, setSearchParams] = useSearchParams()
     const selectedElementPath = searchParams.get('selectedElementPath') ?? 'pages'
-
+    const selectedElement = getSurveyElementFromPath(selectedElementPath, value)
     const setSelectedElementPath = (path: string) => {
       searchParams.set('selectedElementPath', path)
         setSearchParams(searchParams)
@@ -41,15 +41,10 @@ export const FormDesigner = (props: FormDesignerProps) => {
       </div>
       <div className="flex-grow-1 overflow-scroll py-2 px-3">
         {(() => {
-          if (selectedElementPath === undefined) {
-            return (
-              <p className="mt-5 text-center">Select an element to edit</p>
-            )
-          }
-
           if (selectedElementPath === 'pages') {
             return (
               <PageListDesigner
+                  setSelectedElementPath={setSelectedElementPath}
                 formContent={value}
                 readOnly={readOnly}
                 onChange={onChange}
@@ -66,8 +61,11 @@ export const FormDesigner = (props: FormDesignerProps) => {
               />
             )
           }
-
-          const selectedElement = get(selectedElementPath, value) as FormContentPage | FormElement
+          if (selectedElement === undefined) {
+            return (
+                <p className="mt-5 text-center">Select an element to edit</p>
+            )
+        }
 
           if (!('type' in selectedElement) && !('questionTemplateName' in selectedElement)) {
             return (
@@ -78,6 +76,8 @@ export const FormDesigner = (props: FormDesignerProps) => {
                 onChange={updatedElement => {
                   onChange(set(selectedElementPath, updatedElement, value))
                 }}
+                selectedElementPath={selectedElementPath}
+                setSelectedElementPath={setSelectedElementPath}
               />
             )
           }
@@ -87,6 +87,8 @@ export const FormDesigner = (props: FormDesignerProps) => {
               <PanelDesigner
                 readOnly={readOnly}
                 value={selectedElement}
+                selectedElementPath={selectedElementPath}
+                setSelectedElementPath={setSelectedElementPath}
                 onChange={(updatedElement, removedElement) => {
                   // The path to a panel will always end in an array index since the panel will be
                   // inside an elements array. Extract the path to that elements array and the
@@ -148,3 +150,12 @@ export const FormDesigner = (props: FormDesignerProps) => {
     </div>
   )
 }
+
+const getSurveyElementFromPath = (elementPath: string, obj: object):  FormContentPage | FormElement | undefined => {
+    try {
+        return get(elementPath, obj) as FormContentPage | FormElement
+    } catch (e) {
+        return undefined
+    }
+}
+

--- a/ui-admin/src/forms/FormDesigner.tsx
+++ b/ui-admin/src/forms/FormDesigner.tsx
@@ -1,5 +1,5 @@
 import { flow, get, identity, set, update } from 'lodash/fp'
-import React, { useState } from 'react'
+import React, {useEffect, useState} from 'react'
 
 import { FormContent, FormContentPage, FormElement } from '@juniper/ui-core'
 
@@ -10,6 +10,7 @@ import { QuestionDesigner } from './designer/QuestionDesigner'
 import { QuestionTemplatesDesigner } from './designer/QuestionTemplatesDesigner'
 import { FormTableOfContents } from './FormTableOfContents'
 import { PageListDesigner } from './designer/PageListDesigner'
+import {useSearchParams} from "react-router-dom";
 
 type FormDesignerProps = {
   readOnly?: boolean
@@ -20,9 +21,15 @@ type FormDesignerProps = {
 /** UI for editing forms. */
 export const FormDesigner = (props: FormDesignerProps) => {
   const { readOnly = false, value, onChange } = props
+    const [searchParams, setSearchParams] = useSearchParams()
+    const selectedElementPath = searchParams.get('selectedElementPath') ?? 'pages'
 
-  const [selectedElementPath, setSelectedElementPath] = useState<string>()
+    const setSelectedElementPath = (path: string) => {
+      searchParams.set('selectedElementPath', path)
+        setSearchParams(searchParams)
+    }
 
+   console.log('selectedElementPath: ', selectedElementPath)
   return (
     <div className="overflow-hidden flex-grow-1 d-flex flex-row mh-100" style={{ flexBasis: 0 }}>
       <div className="flex-shrink-0 border-end" style={{ width: 400, overflowY: 'scroll' }}>

--- a/ui-admin/src/forms/FormTableOfContents.test.tsx
+++ b/ui-admin/src/forms/FormTableOfContents.test.tsx
@@ -1,6 +1,7 @@
 import { FormContent } from '@juniper/ui-core'
 
 import { getTableOfContentsTree } from './FormTableOfContents'
+import React from "react";
 
 const formContent: FormContent = {
   title: 'Test Survey',
@@ -82,7 +83,7 @@ describe('getTableOfContentsTree', () => {
                   }
                 },
                 {
-                  label: 'Panel (2 elements)',
+                  label: <span>Panel <span className="fw-light fst-italic">({2} items)</span></span>,
                   data: {
                     isSelectable: true,
                     path: 'pages[0].elements[1]'

--- a/ui-admin/src/forms/FormTableOfContents.test.tsx
+++ b/ui-admin/src/forms/FormTableOfContents.test.tsx
@@ -1,7 +1,7 @@
 import { FormContent } from '@juniper/ui-core'
 
 import { getTableOfContentsTree } from './FormTableOfContents'
-import React from "react";
+import React from 'react'
 
 const formContent: FormContent = {
   title: 'Test Survey',

--- a/ui-admin/src/forms/FormTableOfContents.tsx
+++ b/ui-admin/src/forms/FormTableOfContents.tsx
@@ -17,8 +17,7 @@ const getTableOfContentsTreeHelper = (parentPath: string) => {
   return (formElement: FormElement, elementIndex: number): FormContentTableOfContentsTreeItem => {
     if ('type' in formElement && formElement.type === 'panel') {
       return {
-        label: <span>Panel <span className="fw-light fst-italic">
-          ({formElement.elements.length} items)</span></span>,
+        label: <span>Panel <span className="fw-light fst-italic">({formElement.elements.length} items)</span></span>,
         data: {
           isSelectable: true,
           path: `${parentPath}[${elementIndex}]`

--- a/ui-admin/src/forms/FormTableOfContents.tsx
+++ b/ui-admin/src/forms/FormTableOfContents.tsx
@@ -17,7 +17,8 @@ const getTableOfContentsTreeHelper = (parentPath: string) => {
   return (formElement: FormElement, elementIndex: number): FormContentTableOfContentsTreeItem => {
     if ('type' in formElement && formElement.type === 'panel') {
       return {
-        label: `Panel (${formElement.elements.length} elements)`,
+        label: <span>Panel <span className="fw-light fst-italic">
+          ({formElement.elements.length} items)</span></span>,
         data: {
           isSelectable: true,
           path: `${parentPath}[${elementIndex}]`

--- a/ui-admin/src/forms/designer/PageDesigner.test.tsx
+++ b/ui-admin/src/forms/designer/PageDesigner.test.tsx
@@ -28,7 +28,8 @@ describe('PageDesigner', () => {
       // Arrange
       const user = userEvent.setup()
 
-      render(<PageDesigner readOnly={false} value={page} formContent={{ title: '', pages: [] }} onChange={jest.fn()} />)
+      render(<PageDesigner readOnly={false} value={page} formContent={{ title: '', pages: [] }} onChange={jest.fn()}
+      setSelectedElementPath={jest.fn()} selectedElementPath={'pages[0]'}/>)
 
       const createPanelButton = screen.getByText('Add panel')
 
@@ -49,7 +50,8 @@ describe('PageDesigner', () => {
       const user = userEvent.setup()
 
       const onChange = jest.fn()
-      render(<PageDesigner readOnly={false} value={page} formContent={{ title: '', pages: [] }} onChange={onChange} />)
+      render(<PageDesigner readOnly={false} value={page} formContent={{ title: '', pages: [] }} onChange={onChange}
+                           setSelectedElementPath={jest.fn()} selectedElementPath={'pages[0]'}/>)
 
       await act(() => user.click(screen.getByText('Add panel')))
 

--- a/ui-admin/src/forms/designer/PageDesigner.test.tsx
+++ b/ui-admin/src/forms/designer/PageDesigner.test.tsx
@@ -29,7 +29,7 @@ describe('PageDesigner', () => {
       const user = userEvent.setup()
 
       render(<PageDesigner readOnly={false} value={page} formContent={{ title: '', pages: [] }} onChange={jest.fn()}
-      setSelectedElementPath={jest.fn()} selectedElementPath={'pages[0]'}/>)
+        setSelectedElementPath={jest.fn()} selectedElementPath={'pages[0]'}/>)
 
       const createPanelButton = screen.getByText('Add panel')
 
@@ -51,7 +51,7 @@ describe('PageDesigner', () => {
 
       const onChange = jest.fn()
       render(<PageDesigner readOnly={false} value={page} formContent={{ title: '', pages: [] }} onChange={onChange}
-                           setSelectedElementPath={jest.fn()} selectedElementPath={'pages[0]'}/>)
+        setSelectedElementPath={jest.fn()} selectedElementPath={'pages[0]'}/>)
 
       await act(() => user.click(screen.getByText('Add panel')))
 

--- a/ui-admin/src/forms/designer/PageDesigner.tsx
+++ b/ui-admin/src/forms/designer/PageDesigner.tsx
@@ -28,18 +28,21 @@ export type PageDesignerProps = {
   formContent: FormContent
   value: FormContentPage
   onChange: (newValue: FormContentPage) => void
+    selectedElementPath: string,
+    setSelectedElementPath: (path: string) => void
 }
 
 /** UI for editing a page of a form. */
 export const PageDesigner = (props: PageDesignerProps) => {
-  const { readOnly, formContent, value, onChange } = props
+  const { readOnly, formContent, value, onChange,
+  selectedElementPath, setSelectedElementPath } = props
 
   const [showCreatePanelModal, setShowCreatePanelModal] = useState(false)
   const [showCreateQuestionModal, setShowCreateQuestionModal] = useState(false)
-
+    const pageNum = getPageNumberFromPath(selectedElementPath)
   return (
     <div>
-      <h2>Page</h2>
+      <h2>Page {pageNum !== undefined ? pageNum + 1 : ''}</h2>
 
       <div className="mb-3">
         <Button
@@ -67,6 +70,8 @@ export const PageDesigner = (props: PageDesignerProps) => {
       <PageElementList
         readOnly={readOnly}
         value={value.elements}
+        selectedElementPath={selectedElementPath}
+        setSelectedElementPath={setSelectedElementPath}
         onChange={newValue => {
           onChange({ ...value, elements: newValue })
         }}
@@ -122,4 +127,12 @@ export const PageDesigner = (props: PageDesignerProps) => {
       )}
     </div>
   )
+}
+
+const getPageNumberFromPath = (path: string) => {
+    const matchResult = path.match('pages\\[(\\d+)\\]')
+    if (matchResult) {
+        return parseInt(matchResult[1])
+    }
+    return undefined
 }

--- a/ui-admin/src/forms/designer/PageDesigner.tsx
+++ b/ui-admin/src/forms/designer/PageDesigner.tsx
@@ -34,12 +34,14 @@ export type PageDesignerProps = {
 
 /** UI for editing a page of a form. */
 export const PageDesigner = (props: PageDesignerProps) => {
-  const { readOnly, formContent, value, onChange,
-  selectedElementPath, setSelectedElementPath } = props
+  const {
+    readOnly, formContent, value, onChange,
+    selectedElementPath, setSelectedElementPath
+  } = props
 
   const [showCreatePanelModal, setShowCreatePanelModal] = useState(false)
   const [showCreateQuestionModal, setShowCreateQuestionModal] = useState(false)
-    const pageNum = getPageNumberFromPath(selectedElementPath)
+  const pageNum = getPageNumberFromPath(selectedElementPath)
   return (
     <div>
       <h2>Page {pageNum !== undefined ? pageNum + 1 : ''}</h2>
@@ -130,9 +132,9 @@ export const PageDesigner = (props: PageDesignerProps) => {
 }
 
 const getPageNumberFromPath = (path: string) => {
-    const matchResult = path.match('pages\\[(\\d+)\\]')
-    if (matchResult) {
-        return parseInt(matchResult[1])
-    }
-    return undefined
+  const matchResult = path.match('pages\\[(\\d+)\\]')
+  if (matchResult) {
+    return parseInt(matchResult[1])
+  }
+  return undefined
 }

--- a/ui-admin/src/forms/designer/PageElementList.test.tsx
+++ b/ui-admin/src/forms/designer/PageElementList.test.tsx
@@ -27,7 +27,8 @@ describe('PageElementList', () => {
 
   it('renders elements', () => {
     // Act
-    render(<PageElementList readOnly={false} value={elements} onChange={jest.fn()} />)
+    render(<PageElementList readOnly={false} value={elements} onChange={jest.fn()} selectedElementPath={''}
+    setSelectedElementPath={jest.fn()}/>)
 
     // Assert
     const listItems = screen.getAllByRole('listitem')
@@ -39,7 +40,8 @@ describe('PageElementList', () => {
     const user = userEvent.setup()
 
     const onChange = jest.fn()
-    render(<PageElementList readOnly={false} value={elements} onChange={onChange} />)
+    render(<PageElementList readOnly={false} value={elements} onChange={onChange} selectedElementPath={''}
+                            setSelectedElementPath={jest.fn()}/>)
 
     // Act
     const moveBarUpButton = screen.getAllByLabelText('Move this element before the previous one')[1]
@@ -108,7 +110,8 @@ describe('PageElementList', () => {
       const user = userEvent.setup()
 
       const onChange = jest.fn()
-      render(<PageElementList readOnly={false} value={elements} onChange={onChange} />)
+      render(<PageElementList readOnly={false} value={elements} onChange={onChange} selectedElementPath={''}
+                              setSelectedElementPath={jest.fn()}/>)
 
       // Act
       const deleteButton = screen.getAllByLabelText('Delete this element')[0]
@@ -123,7 +126,8 @@ describe('PageElementList', () => {
       const user = userEvent.setup()
 
       const onChange = jest.fn()
-      render(<PageElementList readOnly={false} value={elements} onChange={onChange} />)
+      render(<PageElementList readOnly={false} value={elements} onChange={onChange} selectedElementPath={''}
+                              setSelectedElementPath={jest.fn()}/>)
 
       // Act
       const deleteButton = screen.getAllByLabelText('Delete this element')[1]
@@ -139,7 +143,8 @@ describe('PageElementList', () => {
         const user = userEvent.setup()
 
         const onChange = jest.fn()
-        render(<PageElementList readOnly={false} value={elements} onChange={onChange} />)
+        render(<PageElementList readOnly={false} value={elements} onChange={onChange} selectedElementPath={''}
+                                setSelectedElementPath={jest.fn()}/>)
 
         // Act
         const deleteButton = screen.getAllByLabelText('Delete this element')[2]
@@ -155,7 +160,8 @@ describe('PageElementList', () => {
         const user = userEvent.setup()
 
         const onChange = jest.fn()
-        render(<PageElementList readOnly={false} value={elements} onChange={onChange} />)
+        render(<PageElementList readOnly={false} value={elements} onChange={onChange} selectedElementPath={''}
+                                setSelectedElementPath={jest.fn()}/>)
 
         const deleteButton = screen.getAllByLabelText('Delete this element')[2]
         await act(() => user.click(deleteButton))
@@ -172,7 +178,8 @@ describe('PageElementList', () => {
         const user = userEvent.setup()
 
         const onChange = jest.fn()
-        render(<PageElementList readOnly={false} value={elements} onChange={onChange} />)
+        render(<PageElementList readOnly={false} value={elements} onChange={onChange} selectedElementPath={''}
+                                setSelectedElementPath={jest.fn()}/>)
 
         const deleteButton = screen.getAllByLabelText('Delete this element')[2]
         await act(() => user.click(deleteButton))

--- a/ui-admin/src/forms/designer/PageElementList.test.tsx
+++ b/ui-admin/src/forms/designer/PageElementList.test.tsx
@@ -28,7 +28,7 @@ describe('PageElementList', () => {
   it('renders elements', () => {
     // Act
     render(<PageElementList readOnly={false} value={elements} onChange={jest.fn()} selectedElementPath={''}
-    setSelectedElementPath={jest.fn()}/>)
+      setSelectedElementPath={jest.fn()}/>)
 
     // Assert
     const listItems = screen.getAllByRole('listitem')
@@ -41,7 +41,7 @@ describe('PageElementList', () => {
 
     const onChange = jest.fn()
     render(<PageElementList readOnly={false} value={elements} onChange={onChange} selectedElementPath={''}
-                            setSelectedElementPath={jest.fn()}/>)
+      setSelectedElementPath={jest.fn()}/>)
 
     // Act
     const moveBarUpButton = screen.getAllByLabelText('Move this element before the previous one')[1]
@@ -111,7 +111,7 @@ describe('PageElementList', () => {
 
       const onChange = jest.fn()
       render(<PageElementList readOnly={false} value={elements} onChange={onChange} selectedElementPath={''}
-                              setSelectedElementPath={jest.fn()}/>)
+        setSelectedElementPath={jest.fn()}/>)
 
       // Act
       const deleteButton = screen.getAllByLabelText('Delete this element')[0]
@@ -127,7 +127,7 @@ describe('PageElementList', () => {
 
       const onChange = jest.fn()
       render(<PageElementList readOnly={false} value={elements} onChange={onChange} selectedElementPath={''}
-                              setSelectedElementPath={jest.fn()}/>)
+        setSelectedElementPath={jest.fn()}/>)
 
       // Act
       const deleteButton = screen.getAllByLabelText('Delete this element')[1]
@@ -144,7 +144,7 @@ describe('PageElementList', () => {
 
         const onChange = jest.fn()
         render(<PageElementList readOnly={false} value={elements} onChange={onChange} selectedElementPath={''}
-                                setSelectedElementPath={jest.fn()}/>)
+          setSelectedElementPath={jest.fn()}/>)
 
         // Act
         const deleteButton = screen.getAllByLabelText('Delete this element')[2]
@@ -161,7 +161,7 @@ describe('PageElementList', () => {
 
         const onChange = jest.fn()
         render(<PageElementList readOnly={false} value={elements} onChange={onChange} selectedElementPath={''}
-                                setSelectedElementPath={jest.fn()}/>)
+          setSelectedElementPath={jest.fn()}/>)
 
         const deleteButton = screen.getAllByLabelText('Delete this element')[2]
         await act(() => user.click(deleteButton))
@@ -179,7 +179,7 @@ describe('PageElementList', () => {
 
         const onChange = jest.fn()
         render(<PageElementList readOnly={false} value={elements} onChange={onChange} selectedElementPath={''}
-                                setSelectedElementPath={jest.fn()}/>)
+          setSelectedElementPath={jest.fn()}/>)
 
         const deleteButton = screen.getAllByLabelText('Delete this element')[2]
         await act(() => user.click(deleteButton))

--- a/ui-admin/src/forms/designer/PageElementList.tsx
+++ b/ui-admin/src/forms/designer/PageElementList.tsx
@@ -12,11 +12,13 @@ type PageElementListProps = {
   readOnly: boolean
   value: FormContentPage['elements']
   onChange: (newValue: FormContentPage['elements']) => void
+    setSelectedElementPath: (path: string) => void
+    selectedElementPath: string
 }
 
 /** UI for re-ordering a list of form elements. */
 export const PageElementList = (props: PageElementListProps) => {
-  const { readOnly, value, onChange } = props
+  const { readOnly, value, onChange, selectedElementPath, setSelectedElementPath } = props
 
   const [confirmingDeletePanel, setConfirmingDeletePanel] = useState<number>()
 
@@ -30,7 +32,7 @@ export const PageElementList = (props: PageElementListProps) => {
               className="list-group-item d-flex align-items-center"
             >
               <div className="flex-grow-1 text-truncate ms-2">
-                {getElementLabel(element)}
+                {getElementLabel(element, `${selectedElementPath}.elements[${i}]`, setSelectedElementPath)}
               </div>
               <div className="flex-shrink-0">
                 <IconButton

--- a/ui-admin/src/forms/designer/PageListDesigner.test.tsx
+++ b/ui-admin/src/forms/designer/PageListDesigner.test.tsx
@@ -27,7 +27,8 @@ describe('PageListDesigner', () => {
     const user = userEvent.setup()
 
     const onChange = jest.fn()
-    render(<PageListDesigner formContent={formContent} readOnly={false} onChange={onChange} />)
+    render(<PageListDesigner formContent={formContent} readOnly={false} onChange={onChange}
+                             setSelectedElementPath={jest.fn()} />)
 
     // Act
     const addPageButton = screen.getByText('Add page')
@@ -58,7 +59,8 @@ describe('PageListDesigner', () => {
     const user = userEvent.setup()
 
     const onChange = jest.fn()
-    render(<PageListDesigner formContent={formContent} readOnly={true} onChange={onChange} />)
+    render(<PageListDesigner formContent={formContent} readOnly={true} onChange={onChange}
+                             setSelectedElementPath={jest.fn()}/>)
 
     // Act
     const addPageButton = screen.getByText('Add page')
@@ -71,7 +73,8 @@ describe('PageListDesigner', () => {
   it('shows a message when there are no pages', async () => {
     // Arrange
     const onChange = jest.fn()
-    render(<PageListDesigner formContent={{ title: 'Empty form', pages: [] }} readOnly={false} onChange={onChange} />)
+    render(<PageListDesigner formContent={{ title: 'Empty form', pages: [] }} readOnly={false} onChange={onChange}
+                             setSelectedElementPath={jest.fn()}/>)
 
     // Assert
     expect(screen.getByText('This form does not contain any pages.')).toBeInTheDocument()

--- a/ui-admin/src/forms/designer/PageListDesigner.test.tsx
+++ b/ui-admin/src/forms/designer/PageListDesigner.test.tsx
@@ -28,7 +28,7 @@ describe('PageListDesigner', () => {
 
     const onChange = jest.fn()
     render(<PageListDesigner formContent={formContent} readOnly={false} onChange={onChange}
-                             setSelectedElementPath={jest.fn()} />)
+      setSelectedElementPath={jest.fn()} />)
 
     // Act
     const addPageButton = screen.getByText('Add page')
@@ -60,7 +60,7 @@ describe('PageListDesigner', () => {
 
     const onChange = jest.fn()
     render(<PageListDesigner formContent={formContent} readOnly={true} onChange={onChange}
-                             setSelectedElementPath={jest.fn()}/>)
+      setSelectedElementPath={jest.fn()}/>)
 
     // Act
     const addPageButton = screen.getByText('Add page')
@@ -74,7 +74,7 @@ describe('PageListDesigner', () => {
     // Arrange
     const onChange = jest.fn()
     render(<PageListDesigner formContent={{ title: 'Empty form', pages: [] }} readOnly={false} onChange={onChange}
-                             setSelectedElementPath={jest.fn()}/>)
+      setSelectedElementPath={jest.fn()}/>)
 
     // Assert
     expect(screen.getByText('This form does not contain any pages.')).toBeInTheDocument()

--- a/ui-admin/src/forms/designer/PageListDesigner.tsx
+++ b/ui-admin/src/forms/designer/PageListDesigner.tsx
@@ -46,7 +46,7 @@ export const PageListDesigner = (props: PageListDesignerProps) => {
           <p>This form does not contain any pages.</p>
         ) : (
           <PagesList
-              setSelectedElementPath={setSelectedElementPath}
+            setSelectedElementPath={setSelectedElementPath}
             formContent={formContent}
             readOnly={readOnly}
             onChange={onChange}

--- a/ui-admin/src/forms/designer/PageListDesigner.tsx
+++ b/ui-admin/src/forms/designer/PageListDesigner.tsx
@@ -12,11 +12,12 @@ type PageListDesignerProps = {
     formContent: FormContent
     readOnly: boolean
     onChange: (newValue: FormContent) => void
+    setSelectedElementPath: (path: string) => void
 }
 
 /** UI for editing pages in a form. */
 export const PageListDesigner = (props: PageListDesignerProps) => {
-  const { formContent, readOnly, onChange } = props
+  const { formContent, readOnly, onChange, setSelectedElementPath } = props
   const { pages = [] } = formContent
 
   const newPage = () => ({ elements: [] })
@@ -45,6 +46,7 @@ export const PageListDesigner = (props: PageListDesignerProps) => {
           <p>This form does not contain any pages.</p>
         ) : (
           <PagesList
+              setSelectedElementPath={setSelectedElementPath}
             formContent={formContent}
             readOnly={readOnly}
             onChange={onChange}

--- a/ui-admin/src/forms/designer/PagesList.test.tsx
+++ b/ui-admin/src/forms/designer/PagesList.test.tsx
@@ -40,13 +40,16 @@ describe('PagesList', () => {
     ]
   }
 
-  it('renders list of pages', () => {
-    // Act
-    render(<PagesList formContent={formContent} readOnly={false} onChange={jest.fn()} />)
+  it('renders list of clickable pages', async () => {
+    const setSelectedElementPath = jest.fn()
+    render(<PagesList formContent={formContent} readOnly={false} onChange={jest.fn()}
+                      setSelectedElementPath={setSelectedElementPath}/>)
 
     // Assert
     const listItems = screen.getAllByRole('listitem')
     expect(listItems.map(el => el.textContent)).toEqual(['Page 1', 'Page 2', 'Page 3'])
+    await userEvent.click(screen.getByText('Page 2'))
+    expect(setSelectedElementPath).toHaveBeenCalledWith('pages[1]')
   })
 
   it('allows reordering pages', async () => {
@@ -54,7 +57,8 @@ describe('PagesList', () => {
     const user = userEvent.setup()
 
     const onChange = jest.fn()
-    render(<PagesList formContent={formContent} readOnly={false} onChange={onChange} />)
+    render(<PagesList formContent={formContent} readOnly={false} onChange={onChange}
+                      setSelectedElementPath={jest.fn()}/>)
 
     // Act
     const listItems = screen.getAllByRole('listitem')
@@ -138,7 +142,8 @@ describe('PagesList', () => {
     const user = userEvent.setup()
 
     const onChange = jest.fn()
-    render(<PagesList formContent={formContent} readOnly={false} onChange={onChange} />)
+    render(<PagesList formContent={formContent} readOnly={false} onChange={onChange}
+                      setSelectedElementPath={jest.fn()}/>)
 
     // Act
     const listItems = screen.getAllByRole('listitem')

--- a/ui-admin/src/forms/designer/PagesList.test.tsx
+++ b/ui-admin/src/forms/designer/PagesList.test.tsx
@@ -43,7 +43,7 @@ describe('PagesList', () => {
   it('renders list of clickable pages', async () => {
     const setSelectedElementPath = jest.fn()
     render(<PagesList formContent={formContent} readOnly={false} onChange={jest.fn()}
-                      setSelectedElementPath={setSelectedElementPath}/>)
+      setSelectedElementPath={setSelectedElementPath}/>)
 
     // Assert
     const listItems = screen.getAllByRole('listitem')
@@ -58,7 +58,7 @@ describe('PagesList', () => {
 
     const onChange = jest.fn()
     render(<PagesList formContent={formContent} readOnly={false} onChange={onChange}
-                      setSelectedElementPath={jest.fn()}/>)
+      setSelectedElementPath={jest.fn()}/>)
 
     // Act
     const listItems = screen.getAllByRole('listitem')
@@ -143,7 +143,7 @@ describe('PagesList', () => {
 
     const onChange = jest.fn()
     render(<PagesList formContent={formContent} readOnly={false} onChange={onChange}
-                      setSelectedElementPath={jest.fn()}/>)
+      setSelectedElementPath={jest.fn()}/>)
 
     // Act
     const listItems = screen.getAllByRole('listitem')

--- a/ui-admin/src/forms/designer/PagesList.tsx
+++ b/ui-admin/src/forms/designer/PagesList.tsx
@@ -3,21 +3,22 @@ import React from 'react'
 
 import { FormContent } from '@juniper/ui-core'
 
-import { IconButton } from 'components/forms/Button'
+import { IconButton, Button } from 'components/forms/Button'
 
 type PagesListProps = {
   formContent: FormContent
   readOnly: boolean
   onChange: (newValue: FormContent) => void
+  setSelectedElementPath: (path: string) => void
 }
 
 /** UI for re-ordering pages in a form. */
 export const PagesList = (props: PagesListProps) => {
-  const { formContent, readOnly, onChange } = props
+  const { formContent, readOnly, onChange, setSelectedElementPath } = props
   const { pages } = formContent
 
   return (
-    <ol className="list-group list-group-numbered">
+    <ol className="list-group list-group">
       {pages.map((page, i) => {
         return (
           <li
@@ -25,7 +26,8 @@ export const PagesList = (props: PagesListProps) => {
             className="list-group-item d-flex align-items-center"
           >
             <div className="flex-grow-1 text-truncate ms-2">
-              Page {i + 1}
+              <Button variant={'secondary'}
+                      onClick={() => setSelectedElementPath(`pages[${i}]`)}>Page {i + 1}</Button>
             </div>
             <div className="flex-shrink-0">
               <IconButton

--- a/ui-admin/src/forms/designer/PagesList.tsx
+++ b/ui-admin/src/forms/designer/PagesList.tsx
@@ -27,7 +27,7 @@ export const PagesList = (props: PagesListProps) => {
           >
             <div className="flex-grow-1 text-truncate ms-2">
               <Button variant={'secondary'}
-                      onClick={() => setSelectedElementPath(`pages[${i}]`)}>Page {i + 1}</Button>
+                onClick={() => setSelectedElementPath(`pages[${i}]`)}>Page {i + 1}</Button>
             </div>
             <div className="flex-shrink-0">
               <IconButton

--- a/ui-admin/src/forms/designer/PanelDesigner.tsx
+++ b/ui-admin/src/forms/designer/PanelDesigner.tsx
@@ -8,11 +8,13 @@ export type PanelDesignerProps = {
   readOnly: boolean
   value: FormPanel
   onChange: (newValue: FormPanel, removedElement?: FormElement) => void
+    setSelectedElementPath: (path: string) => void
+    selectedElementPath: string
 }
 
 /** UI for editing a panel in a form. */
 export const PanelDesigner = (props: PanelDesignerProps) => {
-  const { readOnly, value, onChange } = props
+  const { readOnly, value, onChange, setSelectedElementPath, selectedElementPath } = props
 
   return (
     <div>
@@ -23,6 +25,8 @@ export const PanelDesigner = (props: PanelDesignerProps) => {
         onChange={(newValue, removedElement) => {
           onChange({ ...value, elements: newValue }, removedElement)
         }}
+        setSelectedElementPath={setSelectedElementPath}
+        selectedElementPath={selectedElementPath}
       />
     </div>
   )

--- a/ui-admin/src/forms/designer/PanelElementList.test.tsx
+++ b/ui-admin/src/forms/designer/PanelElementList.test.tsx
@@ -28,8 +28,8 @@ describe('PanelElementList', () => {
   it('renders clickable', async () => {
     const setSelectedElementPath = jest.fn()
     render(<PanelElementList readOnly={false} value={elements}
-                             onChange={jest.fn()} selectedElementPath={'pages[0].elements[0]'}
-    setSelectedElementPath={setSelectedElementPath}/>)
+      onChange={jest.fn()} selectedElementPath={'pages[0].elements[0]'}
+      setSelectedElementPath={setSelectedElementPath}/>)
 
     const listItems = screen.getAllByRole('listitem')
     expect(listItems.map(el => el.textContent)).toEqual(['foo', 'bar', 'baz'])
@@ -43,7 +43,7 @@ describe('PanelElementList', () => {
 
     const onChange = jest.fn()
     render(<PanelElementList readOnly={false} value={elements} onChange={onChange}  selectedElementPath={''}
-                             setSelectedElementPath={jest.fn()}/>)
+      setSelectedElementPath={jest.fn()}/>)
 
     // Act
     const moveBarUpButton = screen.getAllByLabelText('Move this element before the previous one')[1]
@@ -97,7 +97,7 @@ describe('PanelElementList', () => {
 
     const onChange = jest.fn()
     render(<PanelElementList readOnly={false} value={elements} onChange={onChange} selectedElementPath={''}
-                             setSelectedElementPath={jest.fn()} />)
+      setSelectedElementPath={jest.fn()} />)
 
     // Act
     const deleteBarButton = screen.getAllByLabelText('Move this element out of panel')[1]
@@ -131,7 +131,7 @@ describe('PanelElementList', () => {
 
     const onChange = jest.fn()
     render(<PanelElementList readOnly={false} value={elements} onChange={onChange} selectedElementPath={''}
-                             setSelectedElementPath={jest.fn()} />)
+      setSelectedElementPath={jest.fn()} />)
 
     // Act
     const deleteBarButton = screen.getAllByLabelText('Delete this element')[1]

--- a/ui-admin/src/forms/designer/PanelElementList.test.tsx
+++ b/ui-admin/src/forms/designer/PanelElementList.test.tsx
@@ -25,13 +25,16 @@ describe('PanelElementList', () => {
     }
   ]
 
-  it('renders elements', () => {
-    // Act
-    render(<PanelElementList readOnly={false} value={elements} onChange={jest.fn()} />)
+  it('renders clickable', async () => {
+    const setSelectedElementPath = jest.fn()
+    render(<PanelElementList readOnly={false} value={elements}
+                             onChange={jest.fn()} selectedElementPath={'pages[0].elements[0]'}
+    setSelectedElementPath={setSelectedElementPath}/>)
 
-    // Assert
     const listItems = screen.getAllByRole('listitem')
     expect(listItems.map(el => el.textContent)).toEqual(['foo', 'bar', 'baz'])
+    await userEvent.click(screen.getByText('bar'))
+    expect(setSelectedElementPath).toHaveBeenCalledWith('pages[0].elements[0].elements[1]')
   })
 
   it('allows reodering elements', async () => {
@@ -39,7 +42,8 @@ describe('PanelElementList', () => {
     const user = userEvent.setup()
 
     const onChange = jest.fn()
-    render(<PanelElementList readOnly={false} value={elements} onChange={onChange} />)
+    render(<PanelElementList readOnly={false} value={elements} onChange={onChange}  selectedElementPath={''}
+                             setSelectedElementPath={jest.fn()}/>)
 
     // Act
     const moveBarUpButton = screen.getAllByLabelText('Move this element before the previous one')[1]
@@ -92,7 +96,8 @@ describe('PanelElementList', () => {
     const user = userEvent.setup()
 
     const onChange = jest.fn()
-    render(<PanelElementList readOnly={false} value={elements} onChange={onChange} />)
+    render(<PanelElementList readOnly={false} value={elements} onChange={onChange} selectedElementPath={''}
+                             setSelectedElementPath={jest.fn()} />)
 
     // Act
     const deleteBarButton = screen.getAllByLabelText('Move this element out of panel')[1]
@@ -125,7 +130,8 @@ describe('PanelElementList', () => {
     const user = userEvent.setup()
 
     const onChange = jest.fn()
-    render(<PanelElementList readOnly={false} value={elements} onChange={onChange} />)
+    render(<PanelElementList readOnly={false} value={elements} onChange={onChange} selectedElementPath={''}
+                             setSelectedElementPath={jest.fn()} />)
 
     // Act
     const deleteBarButton = screen.getAllByLabelText('Delete this element')[1]

--- a/ui-admin/src/forms/designer/PanelElementList.tsx
+++ b/ui-admin/src/forms/designer/PanelElementList.tsx
@@ -11,11 +11,13 @@ type PanelElementListProps = {
   readOnly: boolean
   value: FormPanel['elements']
   onChange: (newValue: FormPanel['elements'], removedElement?: FormElement) => void
+    setSelectedElementPath: (path: string) => void
+    selectedElementPath: string
 }
 
 /** UI for editing a list of form elements in a panel. */
 export const PanelElementList = (props: PanelElementListProps) => {
-  const { readOnly, value, onChange } = props
+  const { readOnly, value, onChange, setSelectedElementPath, selectedElementPath } = props
 
   return (
     <>
@@ -27,7 +29,7 @@ export const PanelElementList = (props: PanelElementListProps) => {
               className="list-group-item d-flex align-items-center"
             >
               <div className="flex-grow-1 text-truncate ms-2">
-                {getElementLabel(element)}
+                {getElementLabel(element, `${selectedElementPath}.elements[${i}]`, setSelectedElementPath)}
               </div>
               <div className="flex-shrink-0">
                 <IconButton

--- a/ui-admin/src/forms/designer/PanelElementList.tsx
+++ b/ui-admin/src/forms/designer/PanelElementList.tsx
@@ -11,8 +11,8 @@ type PanelElementListProps = {
   readOnly: boolean
   value: FormPanel['elements']
   onChange: (newValue: FormPanel['elements'], removedElement?: FormElement) => void
-    setSelectedElementPath: (path: string) => void
-    selectedElementPath: string
+  setSelectedElementPath: (path: string) => void
+  selectedElementPath: string
 }
 
 /** UI for editing a list of form elements in a panel. */

--- a/ui-admin/src/forms/designer/designer-utils.tsx
+++ b/ui-admin/src/forms/designer/designer-utils.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { FormElement } from '@juniper/ui-core'
-import {Button} from "components/forms/Button";
+import { Button } from 'components/forms/Button'
 
 /** Get the user-facing label for a form element. */
 export const getElementLabel = (element: FormElement, path?: string,
-                                setSelectedElementPath?: (path: string) => void): React.ReactNode => {
+  setSelectedElementPath?: (path: string) => void): React.ReactNode => {
   let labelNode
   if ('type' in element && element.type === 'panel') {
     labelNode = <span>Panel <span className="fw-light fst-italic">

--- a/ui-admin/src/forms/designer/designer-utils.tsx
+++ b/ui-admin/src/forms/designer/designer-utils.tsx
@@ -7,8 +7,7 @@ export const getElementLabel = (element: FormElement, path?: string,
   setSelectedElementPath?: (path: string) => void): React.ReactNode => {
   let labelNode
   if ('type' in element && element.type === 'panel') {
-    labelNode = <span>Panel <span className="fw-light fst-italic">
-      ({element.elements.length} elements)</span> </span>
+    labelNode = <span>Panel <span className="fw-light fst-italic">({element.elements.length} items)</span> </span>
   } else {
     labelNode = <span>{element.name}</span>
   }

--- a/ui-admin/src/forms/designer/designer-utils.tsx
+++ b/ui-admin/src/forms/designer/designer-utils.tsx
@@ -1,9 +1,20 @@
+import React from 'react'
 import { FormElement } from '@juniper/ui-core'
+import {Button} from "components/forms/Button";
 
 /** Get the user-facing label for a form element. */
-export const getElementLabel = (element: FormElement): string => {
+export const getElementLabel = (element: FormElement, path?: string,
+                                setSelectedElementPath?: (path: string) => void): React.ReactNode => {
+  let labelNode
   if ('type' in element && element.type === 'panel') {
-    return `Panel (${element.elements.length} elements)`
+    labelNode = <span>Panel <span className="fw-light fst-italic">
+      ({element.elements.length} elements)</span> </span>
+  } else {
+    labelNode = <span>{element.name}</span>
   }
-  return element.name
+  // if no setter is provided, this is a static label
+  if (!setSelectedElementPath || !path) {
+    return labelNode
+  }
+  return <Button variant="secondary" onClick={() => setSelectedElementPath(path)}>{labelNode}</Button>
 }

--- a/ui-admin/src/study/surveys/SurveyEditorView.test.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.test.tsx
@@ -4,7 +4,7 @@ import SurveyEditorView from './SurveyEditorView'
 import { getFormDraftKey } from 'forms/designer/utils/formDraftUtils'
 import { VersionedForm } from '@juniper/ui-core'
 import { mockStudyEnvContext } from 'test-utils/mocking-utils'
-import {setupRouterTest} from "../../test-utils/router-testing-utils";
+import { setupRouterTest } from '../../test-utils/router-testing-utils'
 
 describe('SurveyEditorView', () => {
   const mockForm: VersionedForm = {
@@ -24,10 +24,10 @@ describe('SurveyEditorView', () => {
 
     jest.spyOn(Storage.prototype, 'getItem')
     const { RoutedComponent } = setupRouterTest(<SurveyEditorView
-        studyEnvContext={mockStudyEnvContext()}
-        currentForm={mockForm}
-        onCancel={jest.fn()}
-        onSave={jest.fn()}
+      studyEnvContext={mockStudyEnvContext()}
+      currentForm={mockForm}
+      onCancel={jest.fn()}
+      onSave={jest.fn()}
     />)
     render(RoutedComponent)
 
@@ -43,10 +43,10 @@ describe('SurveyEditorView', () => {
     jest.spyOn(Storage.prototype, 'getItem')
 
     const { RoutedComponent } = setupRouterTest(<SurveyEditorView
-        studyEnvContext={mockStudyEnvContext()}
-        currentForm={mockForm}
-        onCancel={jest.fn()}
-        onSave={jest.fn()}
+      studyEnvContext={mockStudyEnvContext()}
+      currentForm={mockForm}
+      onCancel={jest.fn()}
+      onSave={jest.fn()}
     />)
     render(RoutedComponent)
 
@@ -58,10 +58,10 @@ describe('SurveyEditorView', () => {
   test('allows the user to download the JSON file', async () => {
     //Arrange
     const { RoutedComponent } = setupRouterTest(<SurveyEditorView
-        studyEnvContext={mockStudyEnvContext()}
-        currentForm={mockForm}
-        onCancel={jest.fn()}
-        onSave={jest.fn()}
+      studyEnvContext={mockStudyEnvContext()}
+      currentForm={mockForm}
+      onCancel={jest.fn()}
+      onSave={jest.fn()}
     />)
     render(RoutedComponent)
 

--- a/ui-admin/src/study/surveys/SurveyEditorView.test.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.test.tsx
@@ -4,6 +4,7 @@ import SurveyEditorView from './SurveyEditorView'
 import { getFormDraftKey } from 'forms/designer/utils/formDraftUtils'
 import { VersionedForm } from '@juniper/ui-core'
 import { mockStudyEnvContext } from 'test-utils/mocking-utils'
+import {setupRouterTest} from "../../test-utils/router-testing-utils";
 
 describe('SurveyEditorView', () => {
   const mockForm: VersionedForm = {
@@ -22,13 +23,13 @@ describe('SurveyEditorView', () => {
     localStorage.setItem(FORM_DRAFT_KEY, JSON.stringify({}))
 
     jest.spyOn(Storage.prototype, 'getItem')
-
-    render(<SurveyEditorView
-      studyEnvContext={mockStudyEnvContext()}
-      currentForm={mockForm}
-      onCancel={jest.fn()}
-      onSave={jest.fn()}
+    const { RoutedComponent } = setupRouterTest(<SurveyEditorView
+        studyEnvContext={mockStudyEnvContext()}
+        currentForm={mockForm}
+        onCancel={jest.fn()}
+        onSave={jest.fn()}
     />)
+    render(RoutedComponent)
 
     //Assert
     const modalHeader = screen.getByText('Survey Draft Loaded')
@@ -41,12 +42,13 @@ describe('SurveyEditorView', () => {
 
     jest.spyOn(Storage.prototype, 'getItem')
 
-    render(<SurveyEditorView
-      studyEnvContext={mockStudyEnvContext()}
-      currentForm={mockForm}
-      onCancel={jest.fn()}
-      onSave={jest.fn()}
+    const { RoutedComponent } = setupRouterTest(<SurveyEditorView
+        studyEnvContext={mockStudyEnvContext()}
+        currentForm={mockForm}
+        onCancel={jest.fn()}
+        onSave={jest.fn()}
     />)
+    render(RoutedComponent)
 
     //Assert
     expect(localStorage.getItem).toHaveBeenCalledWith(FORM_DRAFT_KEY)
@@ -55,12 +57,13 @@ describe('SurveyEditorView', () => {
 
   test('allows the user to download the JSON file', async () => {
     //Arrange
-    render(<SurveyEditorView
-      studyEnvContext={mockStudyEnvContext()}
-      currentForm={mockForm}
-      onCancel={jest.fn()}
-      onSave={jest.fn()}
+    const { RoutedComponent } = setupRouterTest(<SurveyEditorView
+        studyEnvContext={mockStudyEnvContext()}
+        currentForm={mockForm}
+        onCancel={jest.fn()}
+        onSave={jest.fn()}
     />)
+    render(RoutedComponent)
 
     //Act
     const downloadButton = screen.getByRole('button', { name: 'Download JSON' })


### PR DESCRIPTION
#### DESCRIPTION

In working on JN-764, I found it convenient to add browsing buttons to navigate without using the table of contents.  So this PR adds clickable page, panel, and question listing

<img width="1117" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/d03ef9c9-7b71-4a5e-a059-0dc7f8afb58e">

In the above image, clicking the question/panel titles will bring up that panel/question.  the item will also appear as selected on the left.  One thing this PR does NOT do is auto-scroll the table of contents to the selected item, that's a task for another day. 

We now also put the selectedItemPath in the url now, so that reloading the page doesn't lose your place in the survey

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. Go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/forms/surveys/oh_oh_basicInfo
2. click around on the links that now appear in the right panel of the designer
3. reload the page, confirm your place isn't lost
4. navigate to the preview tab, then back, and confirm you don't lose your place

