### PR TITLE
JN-764 adding html to question type select

### DIFF
--- a/ui-admin/src/forms/FormContentJsonEditor.test.tsx
+++ b/ui-admin/src/forms/FormContentJsonEditor.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { cloneDeep } from 'lodash'
 import React from 'react'
 
-import { FormContent, Question } from '@juniper/ui-core'
+import { FormContent, TitledQuestion } from '@juniper/ui-core'
 
 import { FormContentJsonEditor } from './FormContentJsonEditor'
 
@@ -62,7 +62,7 @@ describe('FormContentJsonEditor', () => {
 
     // Assert
     const expectedEditedContent = cloneDeep(formContent)
-    ;(expectedEditedContent.pages[0].elements[0] as Question).title = 'Given name'
+    ;(expectedEditedContent.pages[0].elements[0] as TitledQuestion).title = 'Given name'
 
     expect(onChange).toHaveBeenCalledWith([], expectedEditedContent)
   })

--- a/ui-admin/src/forms/designer/NewQuestionForm.test.tsx
+++ b/ui-admin/src/forms/designer/NewQuestionForm.test.tsx
@@ -16,17 +16,21 @@ describe('NewQuestionForm', () => {
   })
 
   test('updates to the appropriate QuestionDesigner when a new question type is selected', async () => {
-    //Arrange
     const user = userEvent.setup()
     render(<NewQuestionForm onCreate={() => jest.fn()} questionTemplates={[]} readOnly={false}/>)
 
-    //Act
     const questionTypeSelect = screen.getByLabelText('Question type')
     await act(() => user.selectOptions(questionTypeSelect, 'checkbox'))
 
-    //Assert
     expect(questionTypeSelect).toHaveValue('checkbox')
     expect(screen.getByText(questionTypeDescriptions.checkbox)).toBeInTheDocument()
+
+    // now check we can change the type to html
+    await act(() => user.selectOptions(questionTypeSelect, 'html'))
+
+    expect(questionTypeSelect).toHaveValue('html')
+    expect(screen.getByText(questionTypeDescriptions.html)).toBeInTheDocument()
+    expect(screen.queryByLabelText('Question text')).not.toBeInTheDocument()
   })
 
   test('renders freetext input', async () => {

--- a/ui-admin/src/forms/designer/NewQuestionForm.tsx
+++ b/ui-admin/src/forms/designer/NewQuestionForm.tsx
@@ -98,6 +98,7 @@ export const NewQuestionForm = (props: NewQuestionFormProps) => {
             <option value="medications">Medications</option>
             <option value="radiogroup">Radio group</option>
             <option value="signaturepad">Signature</option>
+            <option value="html">Html</option>
           </select>
         </div>
 

--- a/ui-admin/src/forms/designer/QuestionDesigner.tsx
+++ b/ui-admin/src/forms/designer/QuestionDesigner.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Question } from '@juniper/ui-core'
+import { HtmlQuestion, Question } from '@juniper/ui-core'
 
 import { BaseFields } from './questions/BaseFields'
 import { CheckboxFields } from './questions/CheckboxFields'
@@ -9,6 +9,7 @@ import { OtherOptionFields } from './questions/OtherOptionFields'
 import { questionTypeDescriptions, questionTypeLabels } from './questions/questionTypes'
 import { TextFields } from './questions/TextFields'
 import { VisibilityFields } from './questions/VisibilityFields'
+import { Textarea } from '../../components/forms/Textarea'
 
 export type QuestionDesignerProps = {
   question: Question
@@ -88,6 +89,19 @@ export const QuestionDesigner = (props: QuestionDesignerProps) => {
               />
             )
           }
+          {
+            question.type === 'html' && <Textarea
+              disabled={readOnly}
+              label="HTML"
+              rows={5}
+              value={(question as HtmlQuestion)?.html || ''}
+              onChange={value => {
+                onChange({
+                  ...question,
+                  html: value
+                })
+              }}
+            />}
         </>
       )}
 

--- a/ui-admin/src/forms/designer/questions/BaseFields.tsx
+++ b/ui-admin/src/forms/designer/questions/BaseFields.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { Question } from '@juniper/ui-core'
+import { HtmlQuestion, InteractiveQuestion, Question } from '@juniper/ui-core'
 
 import { Checkbox } from 'components/forms/Checkbox'
 import { Textarea } from 'components/forms/Textarea'
@@ -14,7 +14,10 @@ type BaseFieldsProps = {
 /** Controls for editing base question fields. */
 export const BaseFields = (props: BaseFieldsProps) => {
   const { disabled, question, onChange } = props
-
+  if ((question as HtmlQuestion).type === 'html') {
+    return null
+  }
+  const regularQuestion = question as InteractiveQuestion
   return (
     <>
       <div className="mb-3">
@@ -23,10 +26,10 @@ export const BaseFields = (props: BaseFieldsProps) => {
           label="Question text"
           required={!Object.hasOwnProperty.call(question, 'questionTemplateName')}
           rows={2}
-          value={question.title || ''}
+          value={regularQuestion.title || ''}
           onChange={value => {
             onChange({
-              ...question,
+              ...regularQuestion,
               title: value
             })
           }}
@@ -39,10 +42,10 @@ export const BaseFields = (props: BaseFieldsProps) => {
           disabled={disabled}
           label="Description"
           rows={2}
-          value={question.description || ''}
+          value={regularQuestion.description || ''}
           onChange={value => {
             onChange({
-              ...question,
+              ...regularQuestion,
               description: value
             })
           }}
@@ -51,14 +54,14 @@ export const BaseFields = (props: BaseFieldsProps) => {
 
       <div className="mb-3">
         <Checkbox
-          checked={!!question.isRequired}
+          checked={!!regularQuestion.isRequired}
           // eslint-disable-next-line max-len
           description="If checked, participants will be required to enter a response before they can continue to the next page of the form."
           disabled={disabled}
           label="Require response"
           onChange={checked => {
             onChange({
-              ...question,
+              ...regularQuestion,
               isRequired: checked
             })
           }}

--- a/ui-admin/src/forms/designer/questions/questionTypes.tsx
+++ b/ui-admin/src/forms/designer/questions/questionTypes.tsx
@@ -6,7 +6,8 @@ export const questionTypeLabels: Record<QuestionType, string> = {
   dropdown: 'Dropdown',
   radiogroup: 'Radio group',
   signaturepad: 'Signature',
-  medications: 'Medications'
+  medications: 'Medications',
+  html: 'Html'
 }
 
 export const questionTypeDescriptions: Record<QuestionType, string> = {
@@ -15,7 +16,8 @@ export const questionTypeDescriptions: Record<QuestionType, string> = {
   dropdown: 'Prompts the participant to choose a response from a menu of choices.',
   radiogroup: 'Shows choices as radio buttons and prompts the participant to select a response.',
   signaturepad: 'Prompts the participant to sign a form.',
-  medications: 'Prompts the participant to choose medications from a list.'
+  medications: 'Prompts the participant to choose medications from a list.',
+  html: 'freeform HTML'
 }
 
 //Returns an object with all possible fields for each question type
@@ -88,6 +90,13 @@ export const baseQuestions: Record<QuestionType, Question> = {
     min: undefined,
     max: undefined,
     size: undefined,
+    visibleIf: undefined
+  },
+  html: {
+    type: 'html',
+    name: '',
+    html: '',
+    isRequired: false,
     visibleIf: undefined
   }
 }

--- a/ui-core/src/types/forms.ts
+++ b/ui-core/src/types/forms.ts
@@ -95,9 +95,12 @@ export type HtmlElement = {
 
 type BaseQuestion = BaseElement & {
   name: string
-  title: string
   description?: string
   isRequired?: boolean
+}
+
+export type TitledQuestion = BaseQuestion & {
+    title: string
 }
 
 export type QuestionChoice = {
@@ -112,7 +115,7 @@ type WithOtherOption<T> = T & {
   otherErrorText?: string
 }
 
-export type CheckboxQuestion = WithOtherOption<BaseQuestion & {
+export type CheckboxQuestion = WithOtherOption<TitledQuestion & {
   type: 'checkbox'
   choices: QuestionChoice[]
   showNoneItem?: boolean
@@ -120,23 +123,23 @@ export type CheckboxQuestion = WithOtherOption<BaseQuestion & {
   noneValue?: string
 }>
 
-export type DropdownQuestion = WithOtherOption<BaseQuestion & {
+export type DropdownQuestion = WithOtherOption<TitledQuestion & {
   type: 'dropdown'
   choices: QuestionChoice[]
 }>
 
-export type RadiogroupQuestion = WithOtherOption<BaseQuestion & {
+export type RadiogroupQuestion = WithOtherOption<TitledQuestion & {
   type: 'radiogroup'
   choices: QuestionChoice[]
 }>
 
-export type TemplatedQuestion = Omit<BaseQuestion, 'title'> & {
+export type TemplatedQuestion = BaseQuestion & {
   name: string
   title?: string
   questionTemplateName: string
 }
 
-export type TextQuestion = BaseQuestion & {
+export type TextQuestion = TitledQuestion & {
   type: 'text'
   inputType?: 'text' | 'number'
   size?: number
@@ -144,12 +147,18 @@ export type TextQuestion = BaseQuestion & {
   max?: number
 }
 
-export type SignatureQuestion = BaseQuestion & {
+export type SignatureQuestion = TitledQuestion & {
   type: 'signaturepad'
 }
 
-export type MedicationsQuestion = BaseQuestion & {
+export type MedicationsQuestion = TitledQuestion & {
   type: 'medications'
+}
+
+
+export type HtmlQuestion = BaseQuestion & {
+  type: 'html',
+  html: string
 }
 
 export type Question =
@@ -160,6 +169,9 @@ export type Question =
   | SignatureQuestion
   | TemplatedQuestion
   | TextQuestion
+  | HtmlQuestion
+
+export type InteractiveQuestion = Exclude<Question, HtmlQuestion>
 
 /** Possible values for the 'type' field of a Question. */
 export type QuestionType = Exclude<Question, TemplatedQuestion>['type']


### PR DESCRIPTION
#### DESCRIPTION

this enables adding "html" type questions via the standard question flow.  

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/forms/surveys/oh_oh_basicInfo?readOnly=false
2. click "Page 1" on the left menu
3. click "add question"
4. add a stableId, then select "html" as the type, and fill in some text
5. confirm the question is added successfully, and shows up in preview/json editor.