### PR TITLE
[JN-413] Add kit received event handling

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/README.md
+++ b/core/src/main/java/bio/terra/pearl/core/dao/README.md
@@ -1,3 +1,14 @@
+The DAO layer interacts with the database. DAO concrete classes derive from BaseJdbiDao, via BaseMutableJdbiDao or
+BaseVersionedJdbiDao, and each is associated with an entity class that acts as a data transfer object (DTO).
+Those entity classes are may include nested entity classes, which are also DTOs. Typically, the nested entity classes
+are not instantiated by the associated DAO class, so callers should assume those nested entity classes are empty unless 
+the DAO method explicitly documents otherwise. 
+
+Nested entity classes are instantiated at various points in the code, often for the purpose of populating a response
+object. A common pattern for a service class method that takes an entity class argument with nested entities is to 
+take the nested entities as separate arguments, rather than relying on the entity class to have the nested entities 
+attached.
+
 When creating a DAO test:
 1. the DAO test should test its own DAO, but not call any other DAOs.
 To the extent it needs to create/read other objects, it should do so via factories and services.

--- a/core/src/main/java/bio/terra/pearl/core/model/notification/NotificationEventType.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/notification/NotificationEventType.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.model.notification;
 
 import bio.terra.pearl.core.service.consent.EnrolleeConsentEvent;
+import bio.terra.pearl.core.service.kit.KitReceivedEvent;
 import bio.terra.pearl.core.service.kit.KitSentEvent;
 import bio.terra.pearl.core.service.survey.EnrolleeSurveyEvent;
 import bio.terra.pearl.core.service.workflow.BaseEvent;
@@ -12,7 +13,8 @@ public enum NotificationEventType {
     SURVEY_RESPONSE(EnrolleeSurveyEvent.class),
     STUDY_ENROLLMENT(EnrolleeCreationEvent.class),
     STUDY_CONSENT(EnrolleeConsentEvent.class),
-    KIT_SENT(KitSentEvent.class);
+    KIT_SENT(KitSentEvent.class),
+    KIT_RECEIVED(KitReceivedEvent.class);
 
     public final Class<? extends BaseEvent> eventClass;
     NotificationEventType(Class<? extends BaseEvent> eventClass) {

--- a/core/src/main/java/bio/terra/pearl/core/service/README.md
+++ b/core/src/main/java/bio/terra/pearl/core/service/README.md
@@ -22,3 +22,10 @@ they are covered by ingress logging, DB logging, and exception handling.
    that allows setting of non-dependent entities that should be deleted if orphaned.  this cascades method 
    should be passed along to other service-delete methods called.  An enu 'AllowedCascades' can be
    provided in the service to specify which non-dependent deletes are implemented.
+
+If circular dependencies are encountered when wiring service dependencies with Spring, first consider the service design. If that is
+sound, then use the @Lazy annotation. Ideally the @Lazy annotation should be applied to services that are higher up in 
+the dependency tree, not necessarily on the usage in the new service.
+
+When wiring services dependencies with Spring via constructor arguments, do not call the services in the constructor.
+This ensures order of instantiation is not an issue.

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitReceivedEvent.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitReceivedEvent.java
@@ -1,0 +1,7 @@
+package bio.terra.pearl.core.service.kit;
+
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+public class KitReceivedEvent extends KitStatusEvent{
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
@@ -299,8 +299,8 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
         if (priorStatus == kitRequest.getStatus()) {
             return;
         }
-        // for now, only notify when the kit is sent
-        if (!KitRequestStatus.SENT.equals(kitRequest.getStatus())) {
+        // only notify when the kit is sent or received
+        if (!KitRequestStatus.SENT.equals(kitRequest.getStatus()) && !KitRequestStatus.RECEIVED.equals(kitRequest.getStatus())) {
             return;
         }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
@@ -300,7 +300,7 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
             return;
         }
         // only notify when the kit is sent or received
-        if (!KitRequestStatus.SENT.equals(kitRequest.getStatus()) && !KitRequestStatus.RECEIVED.equals(kitRequest.getStatus())) {
+        if (!List.of(KitRequestStatus.SENT, KitRequestStatus.RECEIVED).contains(kitRequest.getStatus())) {
             return;
         }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitStatusEvent.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitStatusEvent.java
@@ -16,20 +16,15 @@ public class KitStatusEvent extends EnrolleeEvent {
     private KitRequest kitRequest;
 
     public static KitStatusEvent newInstance(KitRequest kitRequest, KitRequestStatus priorStatus) {
+        KitStatusEventBuilder<?, ?> builder = KitStatusEvent.builder();
         if (KitRequestStatus.SENT.equals(kitRequest.getStatus())) {
-            return KitSentEvent.builder()
-                .kitRequest(kitRequest)
-                .priorStatus(priorStatus)
-                    .build();
+            builder = KitSentEvent.builder();
         } else if (KitRequestStatus.RECEIVED.equals(kitRequest.getStatus())) {
-            return KitReceivedEvent.builder()
-                .kitRequest(kitRequest)
-                .priorStatus(priorStatus)
-                    .build();
+            builder = KitReceivedEvent.builder();
         }
-        return KitStatusEvent.builder()
+        return builder
             .kitRequest(kitRequest)
             .priorStatus(priorStatus)
-                .build();
+            .build();
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitStatusEvent.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitStatusEvent.java
@@ -21,6 +21,11 @@ public class KitStatusEvent extends EnrolleeEvent {
                 .kitRequest(kitRequest)
                 .priorStatus(priorStatus)
                     .build();
+        } else if (KitRequestStatus.RECEIVED.equals(kitRequest.getStatus())) {
+            return KitReceivedEvent.builder()
+                .kitRequest(kitRequest)
+                .priorStatus(priorStatus)
+                    .build();
         }
         return KitStatusEvent.builder()
             .kitRequest(kitRequest)

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
@@ -11,7 +11,6 @@ import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
 import bio.terra.pearl.core.model.workflow.HubResponse;
 import bio.terra.pearl.core.service.consent.EnrolleeConsentEvent;
-import bio.terra.pearl.core.service.kit.KitSentEvent;
 import bio.terra.pearl.core.service.kit.KitStatusEvent;
 import bio.terra.pearl.core.service.rule.EnrolleeRuleData;
 import bio.terra.pearl.core.service.rule.EnrolleeRuleService;
@@ -45,7 +44,7 @@ public class EventService {
      */
     public KitStatusEvent publishKitStatusEvent(KitRequest kitRequest, Enrollee enrollee,
                                                 PortalParticipantUser portalParticipantUser, KitRequestStatus priorStatus) {
-        KitStatusEvent event = KitSentEvent.newInstance(kitRequest, priorStatus);
+        KitStatusEvent event = KitStatusEvent.newInstance(kitRequest, priorStatus);
         event.setEnrollee(enrollee);
         event.setPortalParticipantUser(portalParticipantUser);
         populateEvent(event);

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/NotificationDispatcherTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/NotificationDispatcherTests.java
@@ -30,7 +30,7 @@ public class NotificationDispatcherTests extends BaseSpringBootTest {
 
     @Test
     @Transactional
-    void testKitSendEvent(TestInfo testInfo) {
+    void testKitSentEvent(TestInfo testInfo) {
         EnrolleeFactory.EnrolleeBundle enrolleeBundle = enrolleeFactory
                 .buildWithPortalUser(getTestName(testInfo));
         NotificationConfig config = createNotificationConfig(enrolleeBundle, NotificationEventType.KIT_SENT);
@@ -39,7 +39,24 @@ public class NotificationDispatcherTests extends BaseSpringBootTest {
                 .enrolleeId(enrolleeBundle.enrollee().getId())
                 .build();
 
-        eventService.publishKitStatusEvent(kitRequest, enrolleeBundle.enrollee(), enrolleeBundle.portalParticipantUser(), KitRequestStatus.CREATED);
+        eventService.publishKitStatusEvent(kitRequest, enrolleeBundle.enrollee(), enrolleeBundle.portalParticipantUser(),
+                KitRequestStatus.CREATED);
+        verifyNotification(config, enrolleeBundle);
+    }
+
+    @Test
+    @Transactional
+    void testKitReceivedEvent(TestInfo testInfo) {
+        EnrolleeFactory.EnrolleeBundle enrolleeBundle = enrolleeFactory
+                .buildWithPortalUser(getTestName(testInfo));
+        NotificationConfig config = createNotificationConfig(enrolleeBundle, NotificationEventType.KIT_RECEIVED);
+        KitRequest kitRequest = KitRequest.builder()
+                .status(KitRequestStatus.RECEIVED)
+                .enrolleeId(enrolleeBundle.enrollee().getId())
+                .build();
+
+        eventService.publishKitStatusEvent(kitRequest, enrolleeBundle.enrollee(), enrolleeBundle.portalParticipantUser(),
+                KitRequestStatus.SENT);
         verifyNotification(config, enrolleeBundle);
     }
 

--- a/ui-admin/src/study/notifications/NotifcationConfigTypeDisplay.tsx
+++ b/ui-admin/src/study/notifications/NotifcationConfigTypeDisplay.tsx
@@ -10,7 +10,8 @@ export const eventTypeDisplayMap: Record<string, string> = {
   SURVEY_RESPONSE: 'Survey response',
   STUDY_ENROLLMENT: 'Study enrollment',
   STUDY_CONSENT: 'Consent form submission',
-  KIT_SENT: 'Kit sent'
+  KIT_SENT: 'Kit sent',
+  KIT_RECEIVED: 'Kit returned'
 }
 
 /** shows a summary of the notification config */

--- a/ui-admin/src/study/notifications/NotificationConfigView.tsx
+++ b/ui-admin/src/study/notifications/NotificationConfigView.tsx
@@ -16,7 +16,7 @@ const configTypeOptions = [{ label: 'Event', value: 'EVENT' }, { label: 'Task re
 const deliveryTypeOptions = [{ label: 'Email', value: 'EMAIL' }]
 const eventTypeOptions = [{ label: 'Study Enrollment', value: 'STUDY_ENROLLMENT' },
   { label: 'Study Consent', value: 'STUDY_CONSENT' }, { label: 'Survey Response', value: 'SURVEY_RESPONSE' },
-  { label: 'Kit Sent', value: 'KIT_SENT' }]
+  { label: 'Kit Sent', value: 'KIT_SENT' }, { label: 'Kit Returned', value: 'KIT_RECEIVED' }]
 const taskTypeOptions = [{ label: 'Survey', value: 'SURVEY' }, { label: 'Consent', value: 'CONSENT' }]
 
 


### PR DESCRIPTION
#### DESCRIPTION
This PR implements a notification event when a kit status is changed to 'RECEIVED', so admins can configure an email message to be sent to participants when their kit is received by GP. This is need to implement JN-749.

Also included are updates to two README files, documenting things I learned while talking with Devon. Feel free to suggest edits if the information is incorrect, or the wording can be improved.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
![image](https://github.com/broadinstitute/juniper/assets/129115982/058c05de-eb06-4353-9f3d-5835adba6dba)

1. Populate OurHealth.
2. Goto https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/notificationContent and setup an email notification for kit received event.
3. Goto https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/kits/requested/created.
4. Repeatedly mash the "Refresh" button until a participant status moves from 'Sent' to 'Returned'.
5. Check the logs. You should see an entry from EventService like "Kit status event for enrollee..." coinciding with the time the participant status changed to 'Sent'.
6. Closely following that message you should see an entry from EnrolleeEmailService like "Email sent...".
7. Check your inbox for a kit received email notification.