### PR TITLE
[JN-770] Create new outreach modal

### DIFF
--- a/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
@@ -51,6 +51,99 @@ describe('CreateSurveyModal', () => {
     expect(surveyStableIdInput).toHaveValue('testSurvey')
   })
 
+  test('outreach surveys should present a blurb input', async () => {
+    const user = userEvent.setup()
+    const studyEnvContext = mockStudyEnvContext()
+    const { RoutedComponent } = setupRouterTest(<CreateSurveyModal
+      studyEnvContext={studyEnvContext} type={'OUTREACH'}
+      onDismiss={jest.fn()}/>)
+    render(RoutedComponent)
+
+    const surveyNameInput = screen.getByLabelText('Name')
+    const surveyStableIdInput = screen.getByLabelText('Stable ID')
+    const outreachBlurbInput = screen.getByLabelText('Blurb')
+    await user.type(surveyNameInput, 'Test Survey')
+    await user.type(surveyStableIdInput, 'test_survey_id')
+    await user.type(outreachBlurbInput, 'Test Blurb')
+
+    const createButton = screen.getByText('Create')
+    expect(createButton).toBeEnabled()
+  })
+
+  test('outreach surveys should allow creating marketing types', async () => {
+    jest.spyOn(window, 'alert').mockImplementation(jest.fn())
+    const user = userEvent.setup()
+    const studyEnvContext = mockStudyEnvContext()
+    const survey = mockSurvey()
+    jest.spyOn(Api, 'createNewSurvey').mockImplementation(() => Promise.resolve(survey))
+    jest.spyOn(Api, 'createConfiguredSurvey').mockImplementation(() => Promise.resolve(mockConfiguredSurvey()))
+    const { RoutedComponent } = setupRouterTest(<CreateSurveyModal
+      studyEnvContext={studyEnvContext} type={'OUTREACH'}
+      onDismiss={jest.fn()}/>)
+    render(RoutedComponent)
+
+    const surveyNameInput = screen.getByLabelText('Name')
+    const outreachBlurbInput = screen.getByLabelText('Blurb')
+    const marketingCheckbox = screen.getByText('Marketing')
+    await user.type(surveyNameInput, 'Test Marketing')
+    await user.type(outreachBlurbInput, 'Testing out the marketing blurb...')
+    await user.click(marketingCheckbox)
+
+    const createButton = screen.getByText('Create')
+    expect(createButton).toBeEnabled()
+
+    await user.click(createButton)
+    expect(Api.createNewSurvey).toHaveBeenCalledWith(studyEnvContext.portal.shortcode,
+      {
+        blurb: 'Testing out the marketing blurb...',
+        content: '{"pages":[{"elements":[{"type":"html","name":"outreach_content"}]}]}',
+        createdAt: 0,
+        id: '',
+        lastUpdatedAt: 0,
+        name: 'Test Marketing',
+        stableId: 'testMarketing',
+        surveyType: 'OUTREACH',
+        version: 1
+      })
+  })
+
+  test('outreach surveys should allow creating screener types', async () => {
+    jest.spyOn(window, 'alert').mockImplementation(jest.fn())
+    const user = userEvent.setup()
+    const studyEnvContext = mockStudyEnvContext()
+    const survey = mockSurvey()
+    jest.spyOn(Api, 'createNewSurvey').mockImplementation(() => Promise.resolve(survey))
+    jest.spyOn(Api, 'createConfiguredSurvey').mockImplementation(() => Promise.resolve(mockConfiguredSurvey()))
+    const { RoutedComponent } = setupRouterTest(<CreateSurveyModal
+      studyEnvContext={studyEnvContext} type={'OUTREACH'}
+      onDismiss={jest.fn()}/>)
+    render(RoutedComponent)
+
+    const surveyNameInput = screen.getByLabelText('Name')
+    const outreachBlurbInput = screen.getByLabelText('Blurb')
+    const screenerSelect = screen.getByText('Screener')
+    await user.type(surveyNameInput, 'Test Screener')
+    await user.type(outreachBlurbInput, 'Testing out the screener blurb...')
+    await user.click(screenerSelect)
+
+    const createButton = screen.getByText('Create')
+    expect(createButton).toBeEnabled()
+
+    await user.click(createButton)
+    expect(Api.createNewSurvey).toHaveBeenCalledWith(studyEnvContext.portal.shortcode,
+      {
+        blurb: 'Testing out the screener blurb...',
+        content: '{"pages":[]}',
+        createdAt: 0,
+        id: '',
+        lastUpdatedAt: 0,
+        name: 'Test Screener',
+        stableId: 'testScreener',
+        surveyType: 'OUTREACH',
+        version: 1
+      })
+  })
+
   test('create a required survey', async () => {
     jest.spyOn(window, 'alert').mockImplementation(jest.fn())
     const survey = mockSurvey()

--- a/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
@@ -96,7 +96,7 @@ describe('CreateSurveyModal', () => {
     expect(Api.createNewSurvey).toHaveBeenCalledWith(studyEnvContext.portal.shortcode,
       {
         blurb: 'Testing out the marketing blurb...',
-        content: '{"pages":[{"elements":[{"type":"html","name":"outreach_content"}]}]}',
+        content: expect.stringContaining('{"pages":[{"elements":[{"type":"html","name":"outreach_content_'),
         createdAt: 0,
         id: '',
         lastUpdatedAt: 0,

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -29,9 +29,10 @@ const CreateSurveyModal = ({ studyEnvContext, onDismiss, type }:
   // outreach defaults to a template with an HTML question. Users can edit that
   // HTML from the survey editor. Alternatively, we could allow them to design the
   // content within this modal and insert the content into the survey on their behalf.
+  const randomSuffix = Math.random().toString(36).substring(2, 15)
   const defaultTemplateJson = type === 'RESEARCH' || isOutreachScreener ?
     '{"pages":[]}' :
-    '{"pages":[{"elements":[{"type":"html","name":"outreach_content"}]}]}'
+    `{"pages":[{"elements":[{"type":"html","name":"outreach_content_${randomSuffix}"}]}]}`
 
   const createSurvey = async () => {
     doApiLoad(async () => {
@@ -102,7 +103,7 @@ const CreateSurveyModal = ({ studyEnvContext, onDismiss, type }:
               icon={faUsersViewfinder}
               title="Screener"
               description="Screener opportunities allow you to send a questionnaire to your participants
-              so you can follow up and engage with qualified participants."
+              so you can follow up with qualified participants."
               onSelect={() => setIsOutreachScreener(true)}
               isSelected={isOutreachScreener}
             />

--- a/ui-core/src/types/forms.ts
+++ b/ui-core/src/types/forms.ts
@@ -14,6 +14,7 @@ export type SurveyType = 'RESEARCH' | 'OUTREACH'
 
 export type Survey = VersionedForm & {
   surveyType: SurveyType
+  blurb?: string
 }
 
 export type ConsentForm = VersionedForm


### PR DESCRIPTION
#### DESCRIPTION

This adds to the outreach modal in #670 by letting the user select a marketing or screener outreach type. The marketing type will prepopulate the survey with an empty HTML question, and the screener outreach type will use the same default form content as research surveys. This also exposes the blurb concept in #670 for admins to set. This does not yet allow selecting cohorts or uploading images.

https://github.com/broadinstitute/juniper/assets/7257391/ba81cf22-6362-4082-a595-0c94ceb7519c



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Launch Admin API
* Create a new outreach: https://localhost:3000/hearthive/studies/hh_registry/env/sandbox/forms
* Test that both the marketing and screener types work correctly
* Test that blurbs can be set (although they currently aren't displayed anywhere)
