### PR TITLE
JN-774 adding more "Add question" buttons

### DIFF
--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -10,6 +10,7 @@ import { FormPreview } from './FormPreview'
 import { validateFormContent } from './formContentValidation'
 import ErrorBoundary from 'util/ErrorBoundary'
 import { isEmpty } from 'lodash'
+import useStateCallback from '../util/useStateCallback'
 
 type FormContentEditorProps = {
   initialContent: string
@@ -26,7 +27,7 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
   const [activeTab, setActiveTab] = useState<string | null>('designer')
   const [tabsEnabled, setTabsEnabled] = useState(true)
 
-  const [editedContent, setEditedContent] = useState(() => JSON.parse(initialContent) as FormContent)
+  const [editedContent, setEditedContent] = useStateCallback(() => JSON.parse(initialContent) as FormContent)
 
   return (
     <div className="FormContentEditor d-flex flex-column flex-grow-1">
@@ -45,9 +46,9 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
           <ErrorBoundary>
             <FormDesigner
               readOnly={readOnly}
-              value={editedContent}
-              onChange={newContent => {
-                setEditedContent(newContent)
+              content={editedContent}
+              onChange={(newContent, callback?: () => void) => {
+                setEditedContent(newContent, callback)
                 try {
                   const errors = validateFormContent(newContent)
                   onChange(errors, newContent)

--- a/ui-admin/src/forms/FormDesigner.test.tsx
+++ b/ui-admin/src/forms/FormDesigner.test.tsx
@@ -30,7 +30,7 @@ const formContent: FormContent = {
 
 describe('FormDesigner', () => {
   it('renders form', () => {
-    renderWithRouter(<FormDesigner value={formContent} onChange={jest.fn()}/>)
+    renderWithRouter(<FormDesigner content={formContent} onChange={jest.fn()}/>)
 
     expect(screen.getByLabelText('test_firstName')).toBeInTheDocument()
     expect(screen.getByLabelText('test_lastName')).toBeInTheDocument()
@@ -39,7 +39,7 @@ describe('FormDesigner', () => {
   })
 
   it('shows elements based on the path', () => {
-    renderWithRouter(<FormDesigner value={formContent} onChange={jest.fn()}/>,
+    renderWithRouter(<FormDesigner content={formContent} onChange={jest.fn()}/>,
       ['/forms/surveys/oh_oh_basicInfo?selectedElementPath=pages[0].elements[1]'])
     // we should be showing the editor for the second question
     expect(screen.getByText('Last name')).toBeInTheDocument()
@@ -49,7 +49,7 @@ describe('FormDesigner', () => {
 
   it('adds questions after a current question', async () => {
     const updateValue = jest.fn()
-    const { RoutedComponent, router } = setupRouterTest(<FormDesigner value={formContent} onChange={updateValue}/>,
+    const { RoutedComponent, router } = setupRouterTest(<FormDesigner content={formContent} onChange={updateValue}/>,
       ['/forms/surveys/oh_oh_basicInfo?selectedElementPath=pages[0].elements[1]'])
     render(RoutedComponent)
     // we should be showing the editor for the second question
@@ -81,7 +81,7 @@ describe('FormDesigner', () => {
 
   it('adds questions to the end of a page', async () => {
     const updateValue = jest.fn()
-    const { RoutedComponent, router } = setupRouterTest(<FormDesigner value={formContent} onChange={updateValue}/>,
+    const { RoutedComponent, router } = setupRouterTest(<FormDesigner content={formContent} onChange={updateValue}/>,
       ['/forms/surveys/oh_oh_basicInfo?selectedElementPath=pages[0]'])
     render(RoutedComponent)
     // we should be showing the page 1 summary

--- a/ui-admin/src/forms/FormDesigner.test.tsx
+++ b/ui-admin/src/forms/FormDesigner.test.tsx
@@ -48,8 +48,11 @@ describe('FormDesigner', () => {
   })
 
   it('adds questions after a current question', async () => {
+    // dummy update function that just invokes the callback
     const updateValue = jest.fn()
-    const { RoutedComponent, router } = setupRouterTest(<FormDesigner content={formContent} onChange={updateValue}/>,
+      .mockImplementation((content: FormContent, callback?: () => void) => { callback?.() })
+    const { RoutedComponent, router } = setupRouterTest(
+      <FormDesigner content={formContent} onChange={updateValue}/>,
       ['/forms/surveys/oh_oh_basicInfo?selectedElementPath=pages[0].elements[1]'])
     render(RoutedComponent)
     // we should be showing the editor for the second question
@@ -61,7 +64,7 @@ describe('FormDesigner', () => {
     await userEvent.type(getByLabelText(newQuestionForm, 'Question text*'), 'fave color?')
     await userEvent.click(screen.getByText('Create question'))
     await waitFor(() => expect(router.state.location.search)
-      .toContain('selectedElementPath=pages%5B0%5D.elements%5B2%5D'))
+      .toContain('?selectedElementPath=pages%5B0%5D.elements%5B2%5D'))
     expect(updateValue).toHaveBeenCalledWith({
       ...formContent,
       pages: [
@@ -76,11 +79,13 @@ describe('FormDesigner', () => {
           ]
         }
       ]
-    })
+    }, expect.anything())
   })
 
   it('adds questions to the end of a page', async () => {
+    // dummy update function that just invokes the callback
     const updateValue = jest.fn()
+      .mockImplementation((content: FormContent, callback?: () => void) => { callback?.() })
     const { RoutedComponent, router } = setupRouterTest(<FormDesigner content={formContent} onChange={updateValue}/>,
       ['/forms/surveys/oh_oh_basicInfo?selectedElementPath=pages[0]'])
     render(RoutedComponent)
@@ -95,7 +100,7 @@ describe('FormDesigner', () => {
     await userEvent.type(getByLabelText(newQuestionForm, 'Question text*'), 'fave color?')
     await userEvent.click(screen.getByText('Create question'))
     await waitFor(() => expect(router.state.location.search)
-      .toContain('selectedElementPath=pages%5B0%5D.elements%5B2%5D'))
+      .toContain('?selectedElementPath=pages%5B0%5D.elements%5B2%5D'))
     expect(updateValue).toHaveBeenCalledWith({
       ...formContent,
       pages: [
@@ -110,6 +115,6 @@ describe('FormDesigner', () => {
           ]
         }
       ]
-    })
+    }, expect.anything())
   })
 })

--- a/ui-admin/src/forms/FormDesigner.test.tsx
+++ b/ui-admin/src/forms/FormDesigner.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react'
+import { FormContent } from '@juniper/ui-core'
+import { getByLabelText, render, screen, waitFor } from '@testing-library/react'
+import { FormDesigner } from './FormDesigner'
+import { renderWithRouter, setupRouterTest } from 'test-utils/router-testing-utils'
+import userEvent from '@testing-library/user-event'
+import { baseQuestions } from './designer/questions/questionTypes'
+
+const formContent: FormContent = {
+  title: 'Test survey',
+  pages: [
+    {
+      elements: [
+        {
+          name: 'test_firstName',
+          type: 'text',
+          title: 'First name',
+          isRequired: true
+        },
+        {
+          name: 'test_lastName',
+          type: 'text',
+          title: 'Last name',
+          isRequired: true
+        }
+      ]
+    }
+  ]
+}
+
+describe('FormDesigner', () => {
+  it('renders form', () => {
+    renderWithRouter(<FormDesigner value={formContent} onChange={jest.fn()}/>)
+
+    expect(screen.getByLabelText('test_firstName')).toBeInTheDocument()
+    expect(screen.getByLabelText('test_lastName')).toBeInTheDocument()
+    // 'pages' should appear in table of contents, and be currently selected
+    expect(screen.getAllByText('Pages')).toHaveLength(2)
+  })
+
+  it('shows elements based on the path', () => {
+    renderWithRouter(<FormDesigner value={formContent} onChange={jest.fn()}/>,
+      ['/forms/surveys/oh_oh_basicInfo?selectedElementPath=pages[0].elements[1]'])
+    // we should be showing the editor for the second question
+    expect(screen.getByText('Last name')).toBeInTheDocument()
+    expect(screen.getByText('Question text')).toBeInTheDocument()
+    expect(screen.queryByText('First name')).not.toBeInTheDocument()
+  })
+
+  it('adds questions after a current question', async () => {
+    const updateValue = jest.fn()
+    const { RoutedComponent, router } = setupRouterTest(<FormDesigner value={formContent} onChange={updateValue}/>,
+      ['/forms/surveys/oh_oh_basicInfo?selectedElementPath=pages[0].elements[1]'])
+    render(RoutedComponent)
+    // we should be showing the editor for the second question
+    await userEvent.click(screen.getByText('Add next question'))
+    expect(screen.getByText('New Question')).toBeInTheDocument()
+    const newQuestionForm = screen.getByTestId('newQuestionForm')
+    await userEvent.type(getByLabelText(newQuestionForm, 'Question stable ID'), 'stableId1')
+    await userEvent.selectOptions(getByLabelText(newQuestionForm, 'Question type'), 'text')
+    await userEvent.type(getByLabelText(newQuestionForm, 'Question text*'), 'fave color?')
+    await userEvent.click(screen.getByText('Create question'))
+    await waitFor(() => expect(router.state.location.search)
+      .toContain('selectedElementPath=pages%5B0%5D.elements%5B2%5D'))
+    expect(updateValue).toHaveBeenCalledWith({
+      ...formContent,
+      pages: [
+        {
+          elements: [
+            ...formContent.pages[0].elements,
+            {
+              ...baseQuestions.text,
+              name: 'stableId1',
+              title: 'fave color?'
+            }
+          ]
+        }
+      ]
+    })
+  })
+
+  it('adds questions to the end of a page', async () => {
+    const updateValue = jest.fn()
+    const { RoutedComponent, router } = setupRouterTest(<FormDesigner value={formContent} onChange={updateValue}/>,
+      ['/forms/surveys/oh_oh_basicInfo?selectedElementPath=pages[0]'])
+    render(RoutedComponent)
+    // we should be showing the page 1 summary
+    expect(screen.getAllByText('Page 1')).toHaveLength(2)
+
+    await userEvent.click(screen.getByText('Add question'))
+    expect(screen.getByText('New Question')).toBeInTheDocument()
+    const newQuestionForm = screen.getByTestId('newQuestionForm')
+    await userEvent.type(getByLabelText(newQuestionForm, 'Question stable ID'), 'stableId1')
+    await userEvent.selectOptions(getByLabelText(newQuestionForm, 'Question type'), 'dropdown')
+    await userEvent.type(getByLabelText(newQuestionForm, 'Question text*'), 'fave color?')
+    await userEvent.click(screen.getByText('Create question'))
+    await waitFor(() => expect(router.state.location.search)
+      .toContain('selectedElementPath=pages%5B0%5D.elements%5B2%5D'))
+    expect(updateValue).toHaveBeenCalledWith({
+      ...formContent,
+      pages: [
+        {
+          elements: [
+            ...formContent.pages[0].elements,
+            {
+              ...baseQuestions.dropdown,
+              name: 'stableId1',
+              title: 'fave color?'
+            }
+          ]
+        }
+      ]
+    })
+  })
+})

--- a/ui-admin/src/forms/FormDesigner.tsx
+++ b/ui-admin/src/forms/FormDesigner.tsx
@@ -125,7 +125,6 @@ export const FormDesigner = (props: FormDesignerProps) => {
             return (
               <PageDesigner
                 readOnly={readOnly}
-                formContent={value}
                 value={selectedElement as FormContentPage}
                 onChange={updatedElement => {
                   onChange(set(selectedElementPath, updatedElement, value))

--- a/ui-admin/src/forms/designer/HtmlDesigner.test.tsx
+++ b/ui-admin/src/forms/designer/HtmlDesigner.test.tsx
@@ -14,7 +14,7 @@ describe('HtmlDesigner', () => {
 
   it('renders HTML', () => {
     // Act
-    render(<HtmlDesigner element={element} readOnly={false} onChange={jest.fn()} />)
+    render(<HtmlDesigner element={element} readOnly={false} onChange={jest.fn()} addNextQuestion={jest.fn()} />)
 
     // Assert
     const htmlTextarea = screen.getByLabelText('HTML')
@@ -24,7 +24,7 @@ describe('HtmlDesigner', () => {
   it('allows editing HTML', () => {
     // Arrange
     const onChange = jest.fn()
-    render(<HtmlDesigner element={element} readOnly={false} onChange={onChange} />)
+    render(<HtmlDesigner element={element} readOnly={false} onChange={onChange} addNextQuestion={jest.fn()}/>)
 
     // Act
     const htmlTextarea = screen.getByLabelText('HTML')

--- a/ui-admin/src/forms/designer/HtmlDesigner.tsx
+++ b/ui-admin/src/forms/designer/HtmlDesigner.tsx
@@ -24,7 +24,7 @@ export const HtmlDesigner = (props: HtmlDesignerProps) => {
         <h2>{element.name} (html)</h2>
         {addNextQuestion && <div>
           <Button variant="secondary" className="ms-auto" onClick={addNextQuestion}>
-            <FontAwesomeIcon icon={faPlus}/> Add question
+            <FontAwesomeIcon icon={faPlus}/> Add next question
           </Button>
         </div>}
       </div>

--- a/ui-admin/src/forms/designer/HtmlDesigner.tsx
+++ b/ui-admin/src/forms/designer/HtmlDesigner.tsx
@@ -3,20 +3,31 @@ import React from 'react'
 import { HtmlElement } from '@juniper/ui-core'
 
 import { Textarea } from 'components/forms/Textarea'
+import { Button } from '../../components/forms/Button'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faPlus } from '@fortawesome/free-solid-svg-icons'
 
 export type HtmlDesignerProps = {
   element: HtmlElement
   readOnly: boolean
   onChange: (newValue: HtmlElement) => void
+  addNextQuestion: () => void
 }
 
 /** UI for editing an HTML element in a form. */
 export const HtmlDesigner = (props: HtmlDesignerProps) => {
-  const { element, readOnly, onChange } = props
+  const { element, readOnly, onChange, addNextQuestion } = props
 
   return (
     <div className="d-flex flex-column h-100">
-      <h2>{element.name}</h2>
+      <div className="d-flex align-items-center justify-content-between">
+        <h2>{element.name} (html)</h2>
+        {addNextQuestion && <div>
+          <Button variant="secondary" className="ms-auto" onClick={addNextQuestion}>
+            <FontAwesomeIcon icon={faPlus}/> Add question
+          </Button>
+        </div>}
+      </div>
       <label className="form-label fs-4 mb-0" htmlFor="html-element-html">HTML</label>
       <Textarea
         className="w-100 flex-grow-1 font-monospace"

--- a/ui-admin/src/forms/designer/NewQuestionForm.tsx
+++ b/ui-admin/src/forms/designer/NewQuestionForm.tsx
@@ -30,139 +30,137 @@ export const NewQuestionForm = (props: NewQuestionFormProps) => {
   const { name: questionName } = question
 
   return (
-    <>
-      <div className="text-align-right">
+    <div className="text-align-right" data-testid="newQuestionForm">
+      <div className="mb-3">
         <div className="mb-3">
-          <div className="mb-3">
-            <TextInput
-              description='The unique stable identifier for the survey question'
-              label='Question stable ID'
-              value={questionName}
-              onChange={value => {
-                setQuestion({ ...question, name: value })
-              }}
-            />
-          </div>
-
-          { !isEmpty(questionTemplates) && <div className="mb-3">
-            <label className="form-label" htmlFor="questionTemplate">Question template (optional)</label>
-            <Select
-              options={questionTemplates.map(questionTemplate => {
-                return { label: questionTemplate.name, value: questionTemplate.name }
-              })}
-              isClearable={true}
-              value={selectedQuestionTemplateName}
-              onChange={newValue => {
-                setFreetextMode(false)
-                if (newValue) {
-                  setQuestion({ name: questionName, questionTemplateName: newValue.value } as Question)
-                  setSelectedQuestionTemplateName(newValue)
-                  //Change the selected question type to match the template
-                  const referencedQuestionTemplate = questionTemplates.find(questionTemplate =>
-                    questionTemplate.name === newValue.value) as Exclude<Question, TemplatedQuestion>
-                  setSelectedQuestionType(referencedQuestionTemplate.type)
-                } else {
-                  //Remove the questionTemplateName from the question object
-                  setQuestion(omit({
-                    ...baseQuestions[selectedQuestionType || 'text'],
-                    ...question,
-                    name: questionName,
-                    type: selectedQuestionType
-                  }, ['questionTemplateName']) as Question)
-                  setSelectedQuestionTemplateName(undefined)
-                }
-              }}
-            />
-            <p
-              className="form-text"
-              id="questionTemplateDesc"
-            >
-              Select a question template to pre-populate the question fields
-            </p>
-          </div> }
-
-          <label className="form-label" htmlFor="questionType">Question type</label>
-          <select id="questionType"
-            disabled={!!selectedQuestionTemplateName}
-            className="form-select"
-            value={selectedQuestionType}
-            onChange={e => {
-              const newQuestionType = e.target.value as QuestionType
-              setSelectedQuestionType(newQuestionType)
-              setQuestion({ ...baseQuestions[newQuestionType], ...question, type: newQuestionType } as Question)
-            }}>
-            <option hidden>Select a question type</option>
-            <option value="text">Text</option>
-            <option value="checkbox">Checkbox</option>
-            <option value="dropdown">Dropdown</option>
-            <option value="medications">Medications</option>
-            <option value="radiogroup">Radio group</option>
-            <option value="signaturepad">Signature</option>
-            <option value="html">Html</option>
-          </select>
-        </div>
-
-        <Checkbox
-          checked={freetextMode}
-          disabled={readOnly || !!selectedQuestionTemplateName}
-          description={'Automatically fill out the question fields based on entered text'}
-          label={'Enable freetext mode'}
-          onChange={checked => {
-            setFreetextMode(checked)
-          }}
-        />
-
-        { freetextMode && <div className="mb-3">
-          <Textarea
-            description="As you enter text, we'll try to automatically detect the various question fields"
-            disabled={readOnly}
-            label="Freetext"
-            rows={3}
-            value={freetext}
+          <TextInput
+            description='The unique stable identifier for the survey question'
+            label='Question stable ID'
+            value={questionName}
             onChange={value => {
-              setFreetext(value)
-              const newQuestionObj = questionFromRawText(value)
-              const newType = newQuestionObj.type as QuestionType
-              setSelectedQuestionType(newType)
-              //questionFromRawText can only reasonably predict the type of question, it's choices, and it's text.
-              //We'll pick those three fields out and allow the user to decide the rest of the fields explicitly.
-              setQuestion({
-                ...question,
-                type: newType,
-                title: newQuestionObj.title || '',
-                choices: newQuestionObj.choices
-              } as Question)
+              setQuestion({ ...question, name: value })
             }}
           />
+        </div>
+
+        { !isEmpty(questionTemplates) && <div className="mb-3">
+          <label className="form-label" htmlFor="questionTemplate">Question template (optional)</label>
+          <Select
+            options={questionTemplates.map(questionTemplate => {
+              return { label: questionTemplate.name, value: questionTemplate.name }
+            })}
+            isClearable={true}
+            value={selectedQuestionTemplateName}
+            onChange={newValue => {
+              setFreetextMode(false)
+              if (newValue) {
+                setQuestion({ name: questionName, questionTemplateName: newValue.value } as Question)
+                setSelectedQuestionTemplateName(newValue)
+                //Change the selected question type to match the template
+                const referencedQuestionTemplate = questionTemplates.find(questionTemplate =>
+                  questionTemplate.name === newValue.value) as Exclude<Question, TemplatedQuestion>
+                setSelectedQuestionType(referencedQuestionTemplate.type)
+              } else {
+                //Remove the questionTemplateName from the question object
+                setQuestion(omit({
+                  ...baseQuestions[selectedQuestionType || 'text'],
+                  ...question,
+                  name: questionName,
+                  type: selectedQuestionType
+                }, ['questionTemplateName']) as Question)
+                setSelectedQuestionTemplateName(undefined)
+              }
+            }}
+          />
+          <p
+            className="form-text"
+            id="questionTemplateDesc"
+          >
+              Select a question template to pre-populate the question fields
+          </p>
         </div> }
 
-        { (selectedQuestionType || selectedQuestionTemplateName) && <QuestionDesigner
-          question={question}
-          isNewQuestion={true}
-          showName={false}
-          readOnly={readOnly}
-          onChange={updatedElement => {
-            setQuestion(updatedElement)
-          }}
-        /> }
+        <label className="form-label" htmlFor="questionType">Question type</label>
+        <select id="questionType"
+          disabled={!!selectedQuestionTemplateName}
+          className="form-select"
+          value={selectedQuestionType}
+          onChange={e => {
+            const newQuestionType = e.target.value as QuestionType
+            setSelectedQuestionType(newQuestionType)
+            setQuestion({ ...baseQuestions[newQuestionType], ...question, type: newQuestionType } as Question)
+          }}>
+          <option hidden>Select a question type</option>
+          <option value="text">Text</option>
+          <option value="checkbox">Checkbox</option>
+          <option value="dropdown">Dropdown</option>
+          <option value="medications">Medications</option>
+          <option value="radiogroup">Radio group</option>
+          <option value="signaturepad">Signature</option>
+          <option value="html">Html</option>
+        </select>
+      </div>
 
-        <Button
-          variant="primary"
-          disabled={readOnly || (!selectedQuestionType && !selectedQuestionTemplateName) || !questionName}
-          onClick={() => {
-            //While preserving the state during editing, we may have accumulated some extra fields
-            //that don't exist on the final question type. So we need to remove them before saving.
-            const sanitizedQuestion = selectedQuestionTemplateName ?
+      <Checkbox
+        checked={freetextMode}
+        disabled={readOnly || !!selectedQuestionTemplateName}
+        description={'Automatically fill out the question fields based on entered text'}
+        label={'Enable freetext mode'}
+        onChange={checked => {
+          setFreetextMode(checked)
+        }}
+      />
+
+      { freetextMode && <div className="mb-3">
+        <Textarea
+          description="As you enter text, we'll try to automatically detect the various question fields"
+          disabled={readOnly}
+          label="Freetext"
+          rows={3}
+          value={freetext}
+          onChange={value => {
+            setFreetext(value)
+            const newQuestionObj = questionFromRawText(value)
+            const newType = newQuestionObj.type as QuestionType
+            setSelectedQuestionType(newType)
+            //questionFromRawText can only reasonably predict the type of question, it's choices, and it's text.
+            //We'll pick those three fields out and allow the user to decide the rest of the fields explicitly.
+            setQuestion({
+              ...question,
+              type: newType,
+              title: newQuestionObj.title || '',
+              choices: newQuestionObj.choices
+            } as Question)
+          }}
+        />
+      </div> }
+
+      { (selectedQuestionType || selectedQuestionTemplateName) && <QuestionDesigner
+        question={question}
+        isNewQuestion={true}
+        showName={false}
+        readOnly={readOnly}
+        onChange={updatedElement => {
+          setQuestion(updatedElement)
+        }}
+      /> }
+
+      <Button
+        variant="primary"
+        disabled={readOnly || (!selectedQuestionType && !selectedQuestionTemplateName) || !questionName}
+        onClick={() => {
+          //While preserving the state during editing, we may have accumulated some extra fields
+          //that don't exist on the final question type. So we need to remove them before saving.
+          const sanitizedQuestion = selectedQuestionTemplateName ?
                 pick(question, [
                   'name', 'title', 'isRequired', 'visibleIf', 'description', 'questionTemplateName'
                 ]) as Question :
                 pick(question, Object.keys(baseQuestions[selectedQuestionType || 'text'])) as Question
-            onCreate(sanitizedQuestion)
-          }}
-        >
+          onCreate(sanitizedQuestion)
+        }}
+      >
           Create question
-        </Button>
-      </div>
-    </>
+      </Button>
+    </div>
   )
 }

--- a/ui-admin/src/forms/designer/PageDesigner.test.tsx
+++ b/ui-admin/src/forms/designer/PageDesigner.test.tsx
@@ -28,7 +28,7 @@ describe('PageDesigner', () => {
       // Arrange
       const user = userEvent.setup()
 
-      render(<PageDesigner readOnly={false} value={page} formContent={{ title: '', pages: [] }} onChange={jest.fn()}
+      render(<PageDesigner readOnly={false} value={page} onChange={jest.fn()}
         setSelectedElementPath={jest.fn()} selectedElementPath={'pages[0]'} addNextQuestion={jest.fn()}/>)
 
       const createPanelButton = screen.getByText('Add panel')
@@ -50,7 +50,7 @@ describe('PageDesigner', () => {
       const user = userEvent.setup()
 
       const onChange = jest.fn()
-      render(<PageDesigner readOnly={false} value={page} formContent={{ title: '', pages: [] }} onChange={onChange}
+      render(<PageDesigner readOnly={false} value={page} onChange={onChange}
         setSelectedElementPath={jest.fn()} selectedElementPath={'pages[0]'} addNextQuestion={jest.fn()}/>)
 
       await act(() => user.click(screen.getByText('Add panel')))

--- a/ui-admin/src/forms/designer/PageDesigner.test.tsx
+++ b/ui-admin/src/forms/designer/PageDesigner.test.tsx
@@ -29,7 +29,7 @@ describe('PageDesigner', () => {
       const user = userEvent.setup()
 
       render(<PageDesigner readOnly={false} value={page} formContent={{ title: '', pages: [] }} onChange={jest.fn()}
-        setSelectedElementPath={jest.fn()} selectedElementPath={'pages[0]'}/>)
+        setSelectedElementPath={jest.fn()} selectedElementPath={'pages[0]'} setShowCreateQuestionModal={jest.fn()}/>)
 
       const createPanelButton = screen.getByText('Add panel')
 
@@ -51,7 +51,7 @@ describe('PageDesigner', () => {
 
       const onChange = jest.fn()
       render(<PageDesigner readOnly={false} value={page} formContent={{ title: '', pages: [] }} onChange={onChange}
-        setSelectedElementPath={jest.fn()} selectedElementPath={'pages[0]'}/>)
+        setSelectedElementPath={jest.fn()} selectedElementPath={'pages[0]'} setShowCreateQuestionModal={jest.fn()}/>)
 
       await act(() => user.click(screen.getByText('Add panel')))
 

--- a/ui-admin/src/forms/designer/PageDesigner.test.tsx
+++ b/ui-admin/src/forms/designer/PageDesigner.test.tsx
@@ -29,7 +29,7 @@ describe('PageDesigner', () => {
       const user = userEvent.setup()
 
       render(<PageDesigner readOnly={false} value={page} formContent={{ title: '', pages: [] }} onChange={jest.fn()}
-        setSelectedElementPath={jest.fn()} selectedElementPath={'pages[0]'} setShowCreateQuestionModal={jest.fn()}/>)
+        setSelectedElementPath={jest.fn()} selectedElementPath={'pages[0]'} addNextQuestion={jest.fn()}/>)
 
       const createPanelButton = screen.getByText('Add panel')
 
@@ -51,7 +51,7 @@ describe('PageDesigner', () => {
 
       const onChange = jest.fn()
       render(<PageDesigner readOnly={false} value={page} formContent={{ title: '', pages: [] }} onChange={onChange}
-        setSelectedElementPath={jest.fn()} selectedElementPath={'pages[0]'} setShowCreateQuestionModal={jest.fn()}/>)
+        setSelectedElementPath={jest.fn()} selectedElementPath={'pages[0]'} addNextQuestion={jest.fn()}/>)
 
       await act(() => user.click(screen.getByText('Add panel')))
 

--- a/ui-admin/src/forms/designer/PageDesigner.tsx
+++ b/ui-admin/src/forms/designer/PageDesigner.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Modal } from 'react-bootstrap'
 
-import { FormContent, FormContentPage, FormElement, HtmlElement, Question } from '@juniper/ui-core'
+import { FormContentPage, FormElement, HtmlElement, Question } from '@juniper/ui-core'
 
 import { Button } from 'components/forms/Button'
 
@@ -24,18 +24,17 @@ export const canBeIncludedInPanel = (element: FormElement): element is HtmlEleme
 
 export type PageDesignerProps = {
   readOnly: boolean
-  formContent: FormContent
   value: FormContentPage
   onChange: (newValue: FormContentPage) => void
-    selectedElementPath: string,
-    setSelectedElementPath: (path: string) => void
+  selectedElementPath: string,
+  setSelectedElementPath: (path: string) => void
   addNextQuestion: () => void
 }
 
 /** UI for editing a page of a form. */
 export const PageDesigner = (props: PageDesignerProps) => {
   const {
-    readOnly, formContent, value, onChange,
+    readOnly, value, onChange,
     selectedElementPath, setSelectedElementPath, addNextQuestion
   } = props
 

--- a/ui-admin/src/forms/designer/PageDesigner.tsx
+++ b/ui-admin/src/forms/designer/PageDesigner.tsx
@@ -7,7 +7,6 @@ import { Button } from 'components/forms/Button'
 
 import { PageElementList } from './PageElementList'
 import { NewPanelForm } from './NewPanelForm'
-import { NewQuestionForm } from './NewQuestionForm'
 import { faPlus } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
@@ -30,14 +29,14 @@ export type PageDesignerProps = {
   onChange: (newValue: FormContentPage) => void
     selectedElementPath: string,
     setSelectedElementPath: (path: string) => void
-  setShowCreateQuestionModal: (show: boolean) => void
+  addNextQuestion: () => void
 }
 
 /** UI for editing a page of a form. */
 export const PageDesigner = (props: PageDesignerProps) => {
   const {
     readOnly, formContent, value, onChange,
-    selectedElementPath, setSelectedElementPath, setShowCreateQuestionModal
+    selectedElementPath, setSelectedElementPath, addNextQuestion
   } = props
 
   const [showCreatePanelModal, setShowCreatePanelModal] = useState(false)
@@ -51,9 +50,7 @@ export const PageDesigner = (props: PageDesignerProps) => {
           disabled={readOnly}
           tooltip="Create a new question."
           variant="secondary"
-          onClick={() => {
-            setShowCreateQuestionModal(true)
-          }}
+          onClick={addNextQuestion}
         >
           <FontAwesomeIcon icon={faPlus}/> Add question
         </Button>

--- a/ui-admin/src/forms/designer/PageDesigner.tsx
+++ b/ui-admin/src/forms/designer/PageDesigner.tsx
@@ -30,17 +30,17 @@ export type PageDesignerProps = {
   onChange: (newValue: FormContentPage) => void
     selectedElementPath: string,
     setSelectedElementPath: (path: string) => void
+  setShowCreateQuestionModal: (show: boolean) => void
 }
 
 /** UI for editing a page of a form. */
 export const PageDesigner = (props: PageDesignerProps) => {
   const {
     readOnly, formContent, value, onChange,
-    selectedElementPath, setSelectedElementPath
+    selectedElementPath, setSelectedElementPath, setShowCreateQuestionModal
   } = props
 
   const [showCreatePanelModal, setShowCreatePanelModal] = useState(false)
-  const [showCreateQuestionModal, setShowCreateQuestionModal] = useState(false)
   const pageNum = getPageNumberFromPath(selectedElementPath)
   return (
     <div>
@@ -78,28 +78,6 @@ export const PageDesigner = (props: PageDesignerProps) => {
           onChange({ ...value, elements: newValue })
         }}
       />
-
-      {showCreateQuestionModal && (
-        <Modal show className="modal-lg" onHide={() => setShowCreateQuestionModal(false)}>
-          <Modal.Header closeButton>New Question</Modal.Header>
-          <Modal.Body>
-            <NewQuestionForm
-              readOnly={readOnly}
-              questionTemplates={formContent.questionTemplates || []}
-              onCreate={newQuestion => {
-                setShowCreateQuestionModal(false)
-                onChange({
-                  ...value,
-                  elements: [
-                    ...value.elements,
-                    newQuestion
-                  ]
-                })
-              }}
-            />
-          </Modal.Body>
-        </Modal>
-      )}
 
       {showCreatePanelModal && (
         <Modal show onHide={() => setShowCreatePanelModal(false)}>

--- a/ui-admin/src/forms/designer/PanelDesigner.tsx
+++ b/ui-admin/src/forms/designer/PanelDesigner.tsx
@@ -9,17 +9,17 @@ import { faPlus } from '@fortawesome/free-solid-svg-icons'
 
 export type PanelDesignerProps = {
   readOnly: boolean
-  value: FormPanel
+  panel: FormPanel
   onChange: (newValue: FormPanel, removedElement?: FormElement) => void
-    setSelectedElementPath: (path: string) => void
-    selectedElementPath: string
-    addNextQuestion?: () => void
+  setSelectedElementPath: (path: string) => void
+  selectedElementPath: string
+  addNextQuestion?: () => void
 }
 
 /** UI for editing a panel in a form. */
 export const PanelDesigner = (props: PanelDesignerProps) => {
   const {
-    readOnly, value, onChange,
+    readOnly, panel, onChange,
     setSelectedElementPath, selectedElementPath, addNextQuestion
   } = props
 
@@ -35,9 +35,9 @@ export const PanelDesigner = (props: PanelDesignerProps) => {
       </div>
       <PanelElementList
         readOnly={readOnly}
-        value={value.elements}
+        value={panel.elements}
         onChange={(newValue, removedElement) => {
-          onChange({ ...value, elements: newValue }, removedElement)
+          onChange({ ...panel, elements: newValue }, removedElement)
         }}
         setSelectedElementPath={setSelectedElementPath}
         selectedElementPath={selectedElementPath}

--- a/ui-admin/src/forms/designer/PanelDesigner.tsx
+++ b/ui-admin/src/forms/designer/PanelDesigner.tsx
@@ -3,9 +3,9 @@ import React from 'react'
 import { FormElement, FormPanel } from '@juniper/ui-core'
 
 import { PanelElementList } from './PanelElementList'
-import {Button} from "../../components/forms/Button";
-import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faPlus} from "@fortawesome/free-solid-svg-icons";
+import { Button } from '../../components/forms/Button'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faPlus } from '@fortawesome/free-solid-svg-icons'
 
 export type PanelDesignerProps = {
   readOnly: boolean
@@ -13,25 +13,26 @@ export type PanelDesignerProps = {
   onChange: (newValue: FormPanel, removedElement?: FormElement) => void
     setSelectedElementPath: (path: string) => void
     selectedElementPath: string
-    addNextQuestion?: (show: boolean) => void
+    addNextQuestion?: () => void
 }
 
 /** UI for editing a panel in a form. */
 export const PanelDesigner = (props: PanelDesignerProps) => {
-  const { readOnly, value, onChange,
-      setSelectedElementPath, selectedElementPath, addNextQuestion } = props
+  const {
+    readOnly, value, onChange,
+    setSelectedElementPath, selectedElementPath, addNextQuestion
+  } = props
 
   return (
     <div>
-        <div className="d-flex align-items-center justify-content-between">
-            <h2>Panel</h2>
-            {addNextQuestion && <div>
-                <Button variant="secondary" className="ms-auto"
-                        onClick={() => addNextQuestion(true)}>
-                    <FontAwesomeIcon icon={faPlus}/> Add question
-                </Button>
-            </div>}
-        </div>
+      <div className="d-flex align-items-center justify-content-between">
+        <h2>Panel</h2>
+        {addNextQuestion && <div>
+          <Button variant="secondary" className="ms-auto" onClick={addNextQuestion}>
+            <FontAwesomeIcon icon={faPlus}/> Add question
+          </Button>
+        </div>}
+      </div>
       <PanelElementList
         readOnly={readOnly}
         value={value.elements}

--- a/ui-admin/src/forms/designer/PanelDesigner.tsx
+++ b/ui-admin/src/forms/designer/PanelDesigner.tsx
@@ -3,6 +3,9 @@ import React from 'react'
 import { FormElement, FormPanel } from '@juniper/ui-core'
 
 import { PanelElementList } from './PanelElementList'
+import {Button} from "../../components/forms/Button";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faPlus} from "@fortawesome/free-solid-svg-icons";
 
 export type PanelDesignerProps = {
   readOnly: boolean
@@ -10,15 +13,25 @@ export type PanelDesignerProps = {
   onChange: (newValue: FormPanel, removedElement?: FormElement) => void
     setSelectedElementPath: (path: string) => void
     selectedElementPath: string
+    addNextQuestion?: (show: boolean) => void
 }
 
 /** UI for editing a panel in a form. */
 export const PanelDesigner = (props: PanelDesignerProps) => {
-  const { readOnly, value, onChange, setSelectedElementPath, selectedElementPath } = props
+  const { readOnly, value, onChange,
+      setSelectedElementPath, selectedElementPath, addNextQuestion } = props
 
   return (
     <div>
-      <h2>Panel</h2>
+        <div className="d-flex align-items-center justify-content-between">
+            <h2>Panel</h2>
+            {addNextQuestion && <div>
+                <Button variant="secondary" className="ms-auto"
+                        onClick={() => addNextQuestion(true)}>
+                    <FontAwesomeIcon icon={faPlus}/> Add question
+                </Button>
+            </div>}
+        </div>
       <PanelElementList
         readOnly={readOnly}
         value={value.elements}

--- a/ui-admin/src/forms/designer/QuestionDesigner.tsx
+++ b/ui-admin/src/forms/designer/QuestionDesigner.tsx
@@ -10,9 +10,9 @@ import { questionTypeDescriptions, questionTypeLabels } from './questions/questi
 import { TextFields } from './questions/TextFields'
 import { VisibilityFields } from './questions/VisibilityFields'
 import { Textarea } from 'components/forms/Textarea'
-import {Button} from "components/forms/Button"
-import {faPlus} from "@fortawesome/free-solid-svg-icons"
-import {FontAwesomeIcon} from "@fortawesome/react-fontawesome"
+import { Button } from 'components/forms/Button'
+import { faPlus } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 export type QuestionDesignerProps = {
   question: Question
@@ -31,15 +31,14 @@ export const QuestionDesigner = (props: QuestionDesignerProps) => {
 
   return (
     <div>
-        <div className="d-flex align-items-center justify-content-between">
-      {showName && <h2>{question.name}</h2>}
-            {addNextQuestion && <div>
-                <Button variant="secondary" className="ms-auto"
-                        onClick={() => addNextQuestion()}>
-                    <FontAwesomeIcon icon={faPlus}/> Add next question
-                </Button>
-            </div>}
-        </div>
+      <div className="d-flex align-items-center justify-content-between">
+        {showName && <h2>{question.name}</h2>}
+        {addNextQuestion && <div>
+          <Button variant="secondary" className="ms-auto" onClick={addNextQuestion}>
+            <FontAwesomeIcon icon={faPlus}/> Add next question
+          </Button>
+        </div>}
+      </div>
       {!isTemplated && (
         <>
           <p className="fs-4 mb-0">{questionTypeLabels[question.type]} question</p>

--- a/ui-admin/src/forms/designer/QuestionDesigner.tsx
+++ b/ui-admin/src/forms/designer/QuestionDesigner.tsx
@@ -9,7 +9,10 @@ import { OtherOptionFields } from './questions/OtherOptionFields'
 import { questionTypeDescriptions, questionTypeLabels } from './questions/questionTypes'
 import { TextFields } from './questions/TextFields'
 import { VisibilityFields } from './questions/VisibilityFields'
-import { Textarea } from '../../components/forms/Textarea'
+import { Textarea } from 'components/forms/Textarea'
+import {Button} from "components/forms/Button"
+import {faPlus} from "@fortawesome/free-solid-svg-icons"
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome"
 
 export type QuestionDesignerProps = {
   question: Question
@@ -17,18 +20,26 @@ export type QuestionDesignerProps = {
   readOnly: boolean
   showName: boolean
   onChange: (newValue: Question) => void
+    addNextQuestion?: () => void
 }
 
 /** UI for editing a question in a form. */
 export const QuestionDesigner = (props: QuestionDesignerProps) => {
-  const { question, isNewQuestion, readOnly, showName, onChange } = props
+  const { question, isNewQuestion, readOnly, showName, onChange, addNextQuestion } = props
 
   const isTemplated = 'questionTemplateName' in question
 
   return (
     <div>
+        <div className="d-flex align-items-center justify-content-between">
       {showName && <h2>{question.name}</h2>}
-
+            {addNextQuestion && <div>
+                <Button variant="secondary" className="ms-auto"
+                        onClick={() => addNextQuestion()}>
+                    <FontAwesomeIcon icon={faPlus}/> Add next question
+                </Button>
+            </div>}
+        </div>
       {!isTemplated && (
         <>
           <p className="fs-4 mb-0">{questionTypeLabels[question.type]} question</p>

--- a/ui-admin/src/forms/designer/designer-utils.tsx
+++ b/ui-admin/src/forms/designer/designer-utils.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import { FormElement } from '@juniper/ui-core'
+import { FormContentPage, FormElement } from '@juniper/ui-core'
 import { Button } from 'components/forms/Button'
+import { get } from 'lodash/fp'
 
 /** Get the user-facing label for a form element. */
 export const getElementLabel = (element: FormElement, path?: string,
@@ -16,4 +17,38 @@ export const getElementLabel = (element: FormElement, path?: string,
     return labelNode
   }
   return <Button variant="secondary" onClick={() => setSelectedElementPath(path)}>{labelNode}</Button>
+}
+
+
+/** returns the element at the given path in the given object, or undefined if the path is invalid */
+export const getSurveyElementFromPath = (elementPath: string, obj: object):
+    FormContentPage | FormElement | undefined => {
+  try {
+    return get(elementPath, obj) as FormContentPage | FormElement
+  } catch (e) {
+    return undefined
+  }
+}
+
+/**
+ * gets the index of the element in its parent.  if the elementPath given does not end in an elements[]
+ * array, undefined is returned
+ */
+export const getCurrentElementIndex = (elementPath: string): number | undefined => {
+  if (!elementPath.includes('.elements[') || !elementPath.endsWith(']')) {
+    return undefined
+  }
+  return parseInt(elementPath.substring(elementPath.lastIndexOf('.elements[') + 10,
+    elementPath.lastIndexOf(']')))
+}
+
+/** gets the nearest "container" element for the path (e.g. for adding an item to),
+ *  which might be the element itself */
+export const getContainerElementPath = (elementPath: string, obj: object): string => {
+  const currentElement = getSurveyElementFromPath(elementPath, obj)
+  let containerPath = elementPath
+  if (currentElement && (('type' in currentElement) && !['page', 'panel'].includes(currentElement.type))) {
+    containerPath = elementPath.substring(0, elementPath.lastIndexOf('.elements['))
+  }
+  return containerPath
 }

--- a/ui-admin/src/test-utils/router-testing-utils.tsx
+++ b/ui-admin/src/test-utils/router-testing-utils.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import { Router as RemixRouter } from '@remix-run/router/dist/router'
+import { render } from '@testing-library/react'
 
 /**
  * return both the component wrapped in a router, and the router object itself,
@@ -26,4 +27,11 @@ export function setupRouterTest(ComponentToRender: ReactElement, initialEntries=
   const RoutedComponent = <RouterProvider router={router} />
 
   return { RoutedComponent, router }
+}
+
+/** render a component wrapped in a router, use 'setupRouterTest' if you need to access the router
+ * directly */
+export function renderWithRouter(ComponentToRender: ReactElement, initialEntries=['/']) {
+  const { RoutedComponent } = setupRouterTest(ComponentToRender, initialEntries)
+  return render(RoutedComponent)
 }

--- a/ui-admin/src/util/useStateCallback.ts
+++ b/ui-admin/src/util/useStateCallback.ts
@@ -1,0 +1,36 @@
+import { SetStateAction, useCallback, useEffect, useRef, useState } from 'react'
+
+type Callback<T> = (value?: T) => void;
+type DispatchWithCallback<T> = (value: T, callback?: Callback<T>) => void;
+
+/**
+ * Normally, we use useEffect to do something after state changes.  But sometimes we want particular
+ * code to run after particular paths for a state change, and passing a callback function to setState
+ * for the thing to do afterwards is cleaner than having custom detection logic in a useEffect.
+ *
+ * adapted from https://stackoverflow.com/questions/56247433/how-to-use-setstate-callback-on-react-hooks
+ * @param initialState
+ */
+function useStateCallback<T>(initialState: T | (() => T)): [T, DispatchWithCallback<SetStateAction<T>>] {
+  const [state, _setState] = useState(initialState)
+
+  const callbackRef = useRef<Callback<T>>()
+  const isFirstCallbackCall = useRef<boolean>(true)
+
+  const setState = useCallback((setStateAction: SetStateAction<T>, callback?: Callback<T>): void => {
+    callbackRef.current = callback
+    _setState(setStateAction)
+  }, [])
+
+  useEffect(() => {
+    if (isFirstCallbackCall.current) {
+      isFirstCallbackCall.current = false
+      return
+    }
+    callbackRef.current?.(state)
+  }, [state])
+
+  return [state, setState]
+}
+
+export default useStateCallback


### PR DESCRIPTION
#### DESCRIPTION

In creating the "add html question" ticket, I found it was frustrating to keep clicking back and forth to be able to add a new question.  This adds an "add question" button to the question panel display, and also an "add next question" to individual questions, to make it easier to create/test surveys sequentially.  (Note, this counts as a member's choice ticket, but I'm doing it now since next week I'll probably mostly be helping Connor and/or working in Matt's changes)

![image](https://github.com/broadinstitute/juniper/assets/2800795/abeeec8c-7daf-4c47-8d8c-bb07ae1e67c2)


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/forms/surveys/oh_oh_basicInfo?selectedElementPath=pages%5B0%5D.elements%5B3%5D
2. Confirm you're on the ourhealth basics survey, editing the `oh_oh_basic_mghPatient` question
3. press "Add next question"
4. complete the new question dialog
5. confirm your new question is created immediately following the oh_oh_basic_mghPatient question, and that it is brought into focus