### PR TITLE
JN-642 autofix unused imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module'
   },
-  plugins: ['react', 'jsx-a11y', 'import', 'jest', 'jsdoc'],
+  plugins: ['react', 'jsx-a11y', 'import', 'jest', 'jsdoc', 'unused-imports'],
   rules: {
     'array-bracket-newline': ['warn', 'consistent'],
     'array-bracket-spacing': 'warn',
@@ -63,6 +63,7 @@ module.exports = {
     'no-multiple-empty-lines': 'warn',
     'no-trailing-spaces': 'warn',
     'no-unneeded-ternary': 'warn',
+    'unused-imports/no-unused-imports': 'error',
     'no-whitespace-before-property': 'warn',
     'nonblock-statement-body-position': 'warn',
     'object-curly-newline': ['warn', { multiline: true, consistent: true }],

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "eslint-import-resolver-typescript": "^3.5.5",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-jsdoc": "^46.2.6",
+        "eslint-plugin-unused-imports": "^2.0.0",
         "prettier": "^1.19.1",
         "prettier-eslint": "^11.0.0",
         "react-scripts": "5.0.1",
@@ -9305,6 +9306,36 @@
         "eslint": "^7.5.0 || ^8.0.0"
       }
     },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz",
+      "integrity": "sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==",
+      "dev": true,
+      "dependencies": {
+        "eslint-rule-composer": "^0.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "eslint": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
@@ -17851,15 +17882,6 @@
         }
       }
     },
-    "node_modules/react-colorful": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
-      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -22693,7 +22715,6 @@
         "query-string": "^7.1.3",
         "react": "^18.2.0",
         "react-bootstrap": "^2.8.0",
-        "react-colorful": "^5.6.1",
         "react-contenteditable": "^3.3.6",
         "react-dom": "^18.2.0",
         "react-email-editor": "^1.7.9",
@@ -25478,7 +25499,6 @@
         "query-string": "^7.1.3",
         "react": "^18.2.0",
         "react-bootstrap": "^2.8.0",
-        "react-colorful": "^5.6.1",
         "react-contenteditable": "^3.3.6",
         "react-dom": "^18.2.0",
         "react-email-editor": "^1.7.9",
@@ -30746,6 +30766,21 @@
       "requires": {
         "@typescript-eslint/utils": "^5.58.0"
       }
+    },
+    "eslint-plugin-unused-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz",
+      "integrity": "sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==",
+      "dev": true,
+      "requires": {
+        "eslint-rule-composer": "^0.3.0"
+      }
+    },
+    "eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "7.2.0",
@@ -36950,12 +36985,6 @@
         "uncontrollable": "^7.2.1",
         "warning": "^4.0.3"
       }
-    },
-    "react-colorful": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
-      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-      "requires": {}
     },
     "react-dev-utils": {
       "version": "12.0.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "eslint-import-resolver-typescript": "^3.5.5",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jsdoc": "^46.2.6",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "prettier": "^1.19.1",
     "prettier-eslint": "^11.0.0",
     "react-scripts": "5.0.1",

--- a/ui-core/src/surveyjs/questionValidation.test.ts
+++ b/ui-core/src/surveyjs/questionValidation.test.ts
@@ -1,5 +1,6 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { Component } from 'react' // dummy import to make this a React module
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-imports
+import React from 'react'
+// dummy import to make this a React module
 
 describe('questionRegexValidation', () => {
   it('handles whole number ranges up to 500', () => {

--- a/ui-core/src/surveyjs/questionValidation.test.ts
+++ b/ui-core/src/surveyjs/questionValidation.test.ts
@@ -1,6 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-imports
-import React from 'react'
-// dummy import to make this a React module
+import React from 'react' // dummy import to make this a React module
 
 describe('questionRegexValidation', () => {
   it('handles whole number ranges up to 500', () => {

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -7,8 +7,7 @@ import Api, {
   StudyEnvironmentSurvey,
   Survey,
   SurveyResponse,
-  SurveyWithResponse,
-  ConsentForm
+  SurveyWithResponse
 } from 'api/api'
 
 import { Survey as SurveyComponent } from 'survey-react-ui'

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -7,7 +7,8 @@ import Api, {
   StudyEnvironmentSurvey,
   Survey,
   SurveyResponse,
-  SurveyWithResponse
+  SurveyWithResponse,
+  ConsentForm
 } from 'api/api'
 
 import { Survey as SurveyComponent } from 'survey-react-ui'


### PR DESCRIPTION
#### DESCRIPTION

Adds an eslint plugin so that unused imports will be auto-removed on running lint --fix.  This also means if you set your IDE to autorun lint --fix on save, it will clean out unused imports on save too.  

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  Open a javascript file
2. add an unneeded import
3. from the command line, run  `npm run lint -- --fix`
4. confirm the unneeded import is cleared.