### PR TITLE
[JN-777] Sort mailing list by joined date by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17851,15 +17851,6 @@
         }
       }
     },
-    "node_modules/react-colorful": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
-      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -22693,7 +22684,6 @@
         "query-string": "^7.1.3",
         "react": "^18.2.0",
         "react-bootstrap": "^2.8.0",
-        "react-colorful": "^5.6.1",
         "react-contenteditable": "^3.3.6",
         "react-dom": "^18.2.0",
         "react-email-editor": "^1.7.9",
@@ -25478,7 +25468,6 @@
         "query-string": "^7.1.3",
         "react": "^18.2.0",
         "react-bootstrap": "^2.8.0",
-        "react-colorful": "^5.6.1",
         "react-contenteditable": "^3.3.6",
         "react-dom": "^18.2.0",
         "react-email-editor": "^1.7.9",
@@ -36950,12 +36939,6 @@
         "uncontrollable": "^7.2.1",
         "warning": "^4.0.3"
       }
-    },
-    "react-colorful": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
-      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-      "requires": {}
     },
     "react-dev-utils": {
       "version": "12.0.1",

--- a/ui-admin/src/portal/MailingListView.test.tsx
+++ b/ui-admin/src/portal/MailingListView.test.tsx
@@ -16,7 +16,7 @@ const contacts: MailingListContact[] = [{
   id: 'id2',
   name: 'person2',
   email: 'fake2@test.com',
-  createdAt: 0
+  createdAt: 1
 }]
 
 test('renders a mailing list', async () => {
@@ -72,4 +72,21 @@ test('delete button shows confirmation', async () => {
   await userEvent.click(selectAll)
   await userEvent.click(screen.getByText('Remove'))
   expect(screen.getByText('This operation CANNOT BE UNDONE.')).toBeInTheDocument()
+})
+
+test('sorts by join date by default', async () => {
+  jest.spyOn(Api, 'fetchMailingList').mockImplementation(() => Promise.resolve(contacts))
+  const portalContext = mockPortalContext()
+  const portalEnv = portalContext.portal.portalEnvironments[0]
+  const { RoutedComponent } =
+      setupRouterTest(<MailingListView portalContext={portalContext} portalEnv={portalEnv}/>)
+  render(RoutedComponent)
+  await waitFor(() => {
+    expect(screen.getByText('person1')).toBeInTheDocument()
+  })
+
+  const joined = screen.getByText('Joined')
+
+  // "Joined" text is two parents away from the <th> element
+  expect(joined.parentElement?.parentElement?.getAttribute("aria-sort")).toBe("descending");
 })

--- a/ui-admin/src/portal/MailingListView.test.tsx
+++ b/ui-admin/src/portal/MailingListView.test.tsx
@@ -88,5 +88,5 @@ test('sorts by join date by default', async () => {
   const joined = screen.getByText('Joined')
 
   // "Joined" text is two parents away from the <th> element
-  expect(joined.parentElement?.parentElement?.getAttribute("aria-sort")).toBe("descending");
+  expect(joined.parentElement?.parentElement?.getAttribute('aria-sort')).toBe('descending')
 })

--- a/ui-admin/src/portal/MailingListView.test.tsx
+++ b/ui-admin/src/portal/MailingListView.test.tsx
@@ -87,6 +87,7 @@ test('sorts by join date by default', async () => {
 
   const joined = screen.getByText('Joined')
 
+
   // "Joined" text is two parents away from the <th> element
-  expect(joined.parentElement?.parentElement?.getAttribute('aria-sort')).toBe('descending')
+  expect(joined.closest('[aria-sort]')?.getAttribute('aria-sort')).toBe('descending')
 })

--- a/ui-admin/src/portal/MailingListView.tsx
+++ b/ui-admin/src/portal/MailingListView.tsx
@@ -26,7 +26,7 @@ import { renderPageHeader } from 'util/pageUtils'
 export default function MailingListView({ portalContext, portalEnv }:
 {portalContext: LoadedPortalContextT, portalEnv: PortalEnvironment}) {
   const [contacts, setContacts] = useState<MailingListContact[]>([])
-  const [sorting, setSorting] = React.useState<SortingState>([])
+  const [sorting, setSorting] = React.useState<SortingState>([{ 'id': 'createdAt', 'desc': true }])
   const [rowSelection, setRowSelection] = React.useState<Record<string, boolean>>({})
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const columns: ColumnDef<MailingListContact>[] = [{


### PR DESCRIPTION
#### DESCRIPTION

Before this ticket, you could sort on the mailing list page, but there was no default sort. Now, the default sort is by the joined date, with most recently joined users appearing at the top.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Add multiple users to the mailing list. Ensure that they are sorted by their join date, descending.
