### PR TITLE
[JN-714] fixing test transaction wrapping

### DIFF
--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeExportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeExportServiceTests.java
@@ -45,7 +45,8 @@ public class EnrolleeExportServiceTests extends BaseSpringBootTest {
     private SurveyFactory surveyFactory;
 
     @Test
-    public void testExportNumberLimit(TestInfo testInfo) throws Exception {
+    @Transactional
+    public void testExportNumberLimit(TestInfo testInfo) {
         String testName = getTestName(testInfo);
         StudyEnvironment studyEnv = studyEnvironmentFactory.buildPersisted(testName);
         Enrollee enrollee1 = enrolleeFactory.buildPersisted(testName, studyEnv, new Profile());

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateHeartHiveTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateHeartHiveTest.java
@@ -66,6 +66,8 @@ public class PopulateHeartHiveTest extends BasePopulatePortalsTest {
             withdrawnEnrolleeService.withdrawEnrollee(prodEnrollee.enrollee());
             // confirm we can now repopulate with overwrite
             portalPopulator.populate(new FilePopulateContext("portals/hearthive/portal.json"), true);
+            // now roll back the whole transaction so that the test doesn't actually persist the changes
+            status.setRollbackOnly();
             return null;
         });
     }


### PR DESCRIPTION
#### DESCRIPTION

There was a test that wasn't transactionally wrapped with rollback, which I think might have been causing the increase in test failures due to race conditions

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. reset your local database `local-dev/run_postgres.sh start` 
2. run java tests `./gradlew test`
3. log into test database.  `psql -U test_dbuser -d pearl_test -h localhost`.  (password is `dbpwd`)
4. confirm `select * from study;` returns no results