### PR TITLE
JN-736 adding readme detail for populate

### DIFF
--- a/populate/README.md
+++ b/populate/README.md
@@ -1,0 +1,11 @@
+## Populate module
+
+Populate code is concerned with persisting portal configurations to the database from flat files.  This enables us
+to spin up portals in a reqpeatable way for demo and development purposes.  Populate utilities also handle populating synthetic
+test participants.  The goal of development population, is that any user journey should be very easily 
+accessible and reproducible by populating a given portal that has configuration and synthetic participants to
+support seeing any given step in the journey without having to manually create the configuration and participants.
+
+When developing a new feature, especially if that feature involves a new type of configuration, ensure that the populate infrastructure 
+supports populating and testing that configuration.  Both a populate (persisting the configuration to the database) and an extraction
+(taking the configuration from the database and writing it to a zip file) should be supported.

--- a/populate/src/main/java/bio/terra/pearl/populate/service/extract/README.md
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/extract/README.md
@@ -7,3 +7,9 @@ should be as close as possible to the original files that were used to populate 
 
 Most importantly, the files produced by extraction should be easily human readable and editable.  this will facilitate using
 these files as a starting point for test cases.
+
+Roughly speaking, the extraction process is:
+1. go to the populate UX and go to "extract"
+2. type the shortcode of a portal (e.g. 'ourhealth')
+3. observe a zip file is downloaded.
+4. The zip file can then be inspected or modified, or uploaded via the populate UI


### PR DESCRIPTION
#### DESCRIPTION
Following up on the previous  PR https://github.com/broadinstitute/juniper/pull/652, this adds more details to the readmes about the purpose and mechanics of populate.  I meant to include these in that PR, but inadvertently left them out of the merge.


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
Read readmes, confirm they make sense :)
