### PR TITLE
[JN-789] Cohort builder modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,6 @@
         "ui-participant",
         "e2e-tests"
       ],
-      "dependencies": {
-        "react-querybuilder": "^6.5.4"
-      },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^14.0.0",
@@ -22753,6 +22750,7 @@
         "react-notifications-component": "^4.0.1",
         "react-oidc-context": "^2.2.0",
         "react-plotly.js": "^2.6.0",
+        "react-querybuilder": "^6.5.4",
         "react-router-dom": "^6.4.0",
         "react-select": "^5.4.0",
         "survey-react-ui": "^1.9.75",
@@ -25537,6 +25535,7 @@
         "react-notifications-component": "^4.0.1",
         "react-oidc-context": "^2.2.0",
         "react-plotly.js": "^2.6.0",
+        "react-querybuilder": "^6.5.4",
         "react-router-dom": "^6.4.0",
         "react-select": "^5.4.0",
         "survey-react-ui": "^1.9.75",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         "ui-participant",
         "e2e-tests"
       ],
+      "dependencies": {
+        "react-querybuilder": "^6.5.4"
+      },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^14.0.0",
@@ -6603,6 +6606,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -18015,6 +18026,27 @@
         "react": ">0.13.0"
       }
     },
+    "node_modules/react-querybuilder": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/react-querybuilder/-/react-querybuilder-6.5.4.tgz",
+      "integrity": "sha512-m7LShwKQsFJTbGj8UxdYhbyhrVZmJ0VZV7JDElGui6jv7KsUPaIfXP8FtBBTiaP7SWbhXI1p7sGY7Z6eaU8MTg==",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "immer": "^10.0.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/react-querybuilder/node_modules/immer": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
+      "integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -28650,6 +28682,11 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "clsx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -37094,6 +37131,22 @@
       "integrity": "sha512-g93xcyhAVCSt9kV1svqG1clAEdL6k3U+jjuSzfTV7owaSU9Go6Ph8bl25J+jKfKvIGAEYpe4qj++WHJuc9IaeA==",
       "requires": {
         "prop-types": "^15.8.1"
+      }
+    },
+    "react-querybuilder": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/react-querybuilder/-/react-querybuilder-6.5.4.tgz",
+      "integrity": "sha512-m7LShwKQsFJTbGj8UxdYhbyhrVZmJ0VZV7JDElGui6jv7KsUPaIfXP8FtBBTiaP7SWbhXI1p7sGY7Z6eaU8MTg==",
+      "requires": {
+        "clsx": "^2.0.0",
+        "immer": "^10.0.3"
+      },
+      "dependencies": {
+        "immer": {
+          "version": "10.0.3",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
+          "integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A=="
+        }
       }
     },
     "react-refresh": {

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
   },
   "scripts": {
     "lint": "eslint --max-warnings=0 e2e-tests ui-admin/src ui-core/src ui-participant/src"
+  },
+  "dependencies": {
+    "react-querybuilder": "^6.5.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,8 +29,5 @@
   },
   "scripts": {
     "lint": "eslint --max-warnings=0 e2e-tests ui-admin/src ui-core/src ui-participant/src"
-  },
-  "dependencies": {
-    "react-querybuilder": "^6.5.4"
   }
 }

--- a/ui-admin/package.json
+++ b/ui-admin/package.json
@@ -24,6 +24,7 @@
     "react-notifications-component": "^4.0.1",
     "react-oidc-context": "^2.2.0",
     "react-plotly.js": "^2.6.0",
+    "react-querybuilder": "^6.5.4",
     "react-router-dom": "^6.4.0",
     "react-select": "^5.4.0",
     "survey-react-ui": "^1.9.75",

--- a/ui-admin/src/HomePage.tsx
+++ b/ui-admin/src/HomePage.tsx
@@ -8,12 +8,14 @@ import { faPlus } from '@fortawesome/free-solid-svg-icons'
 import { Button } from './components/forms/Button'
 import CreateNewStudyModal from './study/CreateNewStudyModal'
 import { useUser } from './user/UserProvider'
+import CreateNewCohortModal from './study/CreateNewCohortModal'
 
 /** Shows a user the list of portals available to them */
 function HomePage() {
   const { portalList } = useNavContext()
   const { user } = useUser()
   const [showNewStudyModal, setShowNewStudyModal] = useState(false)
+  const [showNewCohortModal, setShowNewCohortModal] = useState(false)
 
   return <div className="container">
     <h1 className="h2">Juniper Home</h1>
@@ -38,8 +40,12 @@ function HomePage() {
       { user.superuser && <Button variant='secondary' onClick={() => setShowNewStudyModal(true)}>
         <FontAwesomeIcon icon={faPlus}/> Add a study
       </Button> }
+      { user.superuser && <Button variant='secondary' onClick={() => setShowNewCohortModal(true)}>
+        <FontAwesomeIcon icon={faPlus}/> Create a cohort
+      </Button> }
     </div>
     { showNewStudyModal && <CreateNewStudyModal onDismiss={() => setShowNewStudyModal(false)}/> }
+    { showNewCohortModal && <CreateNewCohortModal onDismiss={() => setShowNewCohortModal(false)}/> }
   </div>
 }
 

--- a/ui-admin/src/study/CreateNewCohortModal.test.tsx
+++ b/ui-admin/src/study/CreateNewCohortModal.test.tsx
@@ -4,12 +4,14 @@ import { render, screen } from '@testing-library/react'
 import CreateNewCohortModal from './CreateNewCohortModal'
 import { makeMockPortal, makeMockPortalStudy } from '../test-utils/mocking-utils'
 import { useNavContext } from '../navbar/NavContextProvider'
+import { Store } from 'react-notifications-component'
 
 jest.mock('../navbar/NavContextProvider')
 
 describe('CreateNewCohortModal', () => {
   test('enables Create button when cohort name, study, and portal are filled out', async () => {
     const user = userEvent.setup()
+    jest.spyOn(Store, 'addNotification').mockImplementation(() => '')
 
     const portalList = [
       makeMockPortal('Test portal', [
@@ -35,11 +37,11 @@ describe('CreateNewCohortModal', () => {
 
     const portalSelect = screen.getByLabelText('Portal')
     await user.click(portalSelect)
-    await user.click(screen.getByText('Test portal'))
+    await user.click(screen.queryAllByText('Test portal')[0])
 
     const studySelect = screen.getByLabelText('Study')
     await user.click(studySelect)
-    await user.click(screen.getByText('Test study'))
+    await user.click(screen.queryAllByText('Test study')[0])
 
     expect(screen.getByText('Create')).toHaveAttribute('aria-disabled', 'false')
   })

--- a/ui-admin/src/study/CreateNewCohortModal.test.tsx
+++ b/ui-admin/src/study/CreateNewCohortModal.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/react'
+import CreateNewCohortModal from './CreateNewCohortModal'
+import { makeMockPortal, makeMockPortalStudy } from '../test-utils/mocking-utils'
+import { useNavContext } from '../navbar/NavContextProvider'
+
+jest.mock('../navbar/NavContextProvider')
+
+describe('CreateNewCohortModal', () => {
+  test('enables Create button when cohort name, study, and portal are filled out', async () => {
+    const user = userEvent.setup()
+
+    const portalList = [
+      makeMockPortal('Test portal', [
+        makeMockPortalStudy('Test study', 'testStudy')
+      ])
+    ]
+
+    const mockContextValue = {
+      breadCrumbs: [],
+      setBreadCrumbs: jest.fn(),
+      portalList,
+      setPortalList: jest.fn()
+    }
+
+    ;(useNavContext as jest.Mock).mockReturnValue(mockContextValue)
+
+    render(<CreateNewCohortModal onDismiss={jest.fn()}/>)
+
+    expect(screen.getByText('Create')).toHaveAttribute('aria-disabled', 'true')
+
+    const nameInput = screen.getByLabelText('Cohort Name')
+    await user.type(nameInput, 'Test cohort')
+
+    const portalSelect = screen.getByLabelText('Portal')
+    await user.click(portalSelect)
+    await user.click(screen.getByText('Test portal'))
+
+    const studySelect = screen.getByLabelText('Study')
+    await user.click(studySelect)
+    await user.click(screen.getByText('Test study'))
+
+    expect(screen.getByText('Create')).toHaveAttribute('aria-disabled', 'false')
+  })
+})

--- a/ui-admin/src/study/CreateNewCohortModal.tsx
+++ b/ui-admin/src/study/CreateNewCohortModal.tsx
@@ -18,8 +18,10 @@ export default function CreateNewCohortModal({ onDismiss }: {onDismiss: () => vo
   const initialQuery = { combinator: 'and', rules: [] }
   const [query, setQuery] = useState(initialQuery)
   const [cohortName, setCohortName] = useState('')
-  const [selectedPortal, setSelectedPortal] = useState<Portal>()
-  const [selectedStudy, setSelectedStudy] = useState<PortalStudy>()
+  const initialPortal = portalList.length == 1 ? portalList[0] : undefined
+  const [selectedPortal, setSelectedPortal] = useState<Portal | undefined>(initialPortal)
+  const initialStudy = selectedPortal?.portalStudies.length == 1 ? selectedPortal?.portalStudies[0] : undefined
+  const [selectedStudy, setSelectedStudy] = useState<PortalStudy | undefined>(initialStudy)
   const [participantFields, setParticipantFields] = useState<ExportData>()
 
   useLoadingEffect(async () => {

--- a/ui-admin/src/study/CreateNewCohortModal.tsx
+++ b/ui-admin/src/study/CreateNewCohortModal.tsx
@@ -9,8 +9,6 @@ import Api, { ExportData } from '../api/api'
 import { useLoadingEffect } from 'api/api-utils'
 import { Field, QueryBuilder } from 'react-querybuilder'
 import 'react-querybuilder/dist/query-builder.scss'
-import { Store } from 'react-notifications-component'
-import { failureNotification } from '../util/notifications'
 
 /**
  * Returns a cohort builder modal
@@ -31,12 +29,8 @@ export default function CreateNewCohortModal({ onDismiss }: {onDismiss: () => vo
       selectedStudy.study.shortcode,
       'live', { fileFormat: 'JSON', limit: 0 })
     const result = await response.json()
-    if (!response.ok) {
-      Store.addNotification(failureNotification('Failed to load cohort criteria options', result.message))
-    } else {
-      setParticipantFields(result)
-    }
-  }, [selectedStudy])
+    setParticipantFields(result)
+  }, [selectedStudy], 'Failed to load cohort criteria options')
 
   const fields: Field[] = participantFields?.columnKeys.map(field => ({
     name: field,

--- a/ui-admin/src/study/CreateNewCohortModal.tsx
+++ b/ui-admin/src/study/CreateNewCohortModal.tsx
@@ -1,0 +1,121 @@
+import { useNavContext } from '../navbar/NavContextProvider'
+import React, { useEffect, useState } from 'react'
+import { Portal, PortalStudy } from '@juniper/ui-core'
+import Modal from 'react-bootstrap/Modal'
+import { Button } from '../components/forms/Button'
+import Select from 'react-select'
+import useReactSingleSelect from '../util/react-select-utils'
+import Api, { ExportData } from '../api/api'
+import { useLoadingEffect } from 'api/api-utils'
+import { Field, QueryBuilder } from 'react-querybuilder'
+import 'react-querybuilder/dist/query-builder.scss'
+import { Store } from 'react-notifications-component'
+import { failureNotification } from '../util/notifications'
+
+/**
+ * Returns a cohort builder modal
+ */
+export default function CreateNewCohortModal({ onDismiss }: {onDismiss: () => void}) {
+  const { portalList } = useNavContext()
+  const initialQuery = { combinator: 'and', rules: [] }
+  const [query, setQuery] = useState(initialQuery)
+  const [cohortName, setCohortName] = useState('')
+  const [selectedPortal, setSelectedPortal] = useState<Portal>()
+  const [selectedStudy, setSelectedStudy] = useState<PortalStudy>()
+  const [participantFields, setParticipantFields] = useState<ExportData>()
+
+  useLoadingEffect(async () => {
+    if (!selectedStudy || !selectedPortal) { return }
+    const response = await Api.exportEnrollees(
+      selectedPortal.shortcode,
+      selectedStudy.study.shortcode,
+      'live', { fileFormat: 'JSON', limit: 0 })
+    const result = await response.json()
+    if (!response.ok) {
+      Store.addNotification(failureNotification('Failed to load cohort criteria options', result.message))
+    } else {
+      setParticipantFields(result)
+    }
+  }, [selectedStudy])
+
+  const fields: Field[] = participantFields?.columnKeys.map(field => ({
+    name: field,
+    label: field
+  })) || []
+
+  useEffect(() => {
+    setQuery(initialQuery)
+  }, [selectedStudy, selectedPortal])
+
+  const {
+    onChange: portalOnChange, options: portalOptions,
+    selectedOption: selectedPortalOption, selectInputId: selectPortalInputId
+  } =
+    useReactSingleSelect(
+      portalList,
+      (portal: Portal) => ({ label: portal.name, value: portal }),
+      setSelectedPortal,
+      selectedPortal)
+
+  const {
+    onChange: studyOnChange, options: studyOptions,
+    selectedOption: selectedStudyOption, selectInputId: selectStudyInputId
+  } =
+    useReactSingleSelect(
+      selectedPortal?.portalStudies || [],
+      (study: PortalStudy) => ({ label: study.study.name, value: study }),
+      setSelectedStudy,
+      selectedStudy)
+
+  return <Modal show={true} className="modal-xl" onHide={onDismiss}>
+    <Modal.Header closeButton>
+      <Modal.Title>Create a cohort</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>
+      <label htmlFor="cohortName" className="h5">Cohort Name</label>
+      <p className="text-muted mb-2">Give your cohort a unique name. You can reuse this cohort when targeting
+        this same subset of participants for new opportunities.</p>
+      <div className="container">
+        <div className="row my-3">
+          <input type="text" className="form-control" id="cohortName"
+            onChange={e => setCohortName(e.target.value)} value={cohortName}/>
+        </div>
+      </div>
+      <h5>Cohort Source</h5>
+      <p className="text-muted mb-2">Choose the source of your cohort participants.</p>
+      <div className="my-3">
+        <label htmlFor={selectPortalInputId}>Portal</label>
+        <Select inputId={selectPortalInputId} options={portalOptions}
+          value={selectedPortalOption} onChange={portalOnChange}/>
+        <label htmlFor={selectStudyInputId} className="mt-3">Study</label>
+        <Select isDisabled={!selectedPortal} inputId={selectStudyInputId} options={studyOptions}
+          value={selectedStudyOption} onChange={studyOnChange}/>
+      </div>
+      <hr/>
+      <h5>Cohort Criteria</h5>
+      <span className="text-muted mb-2">Choose the criteria for your cohort based on previous
+        survey responses from the participants in your studies. You may define as many rules
+        as you would like to narrow down your cohort.
+      </span>
+      <div className="mt-3">
+        { selectedStudy ?
+          <QueryBuilder
+            fields={fields}
+            query={query}
+            onQueryChange={q => setQuery(q)}
+            addRuleToNewGroups
+            controlClassnames={{ queryBuilder: 'queryBuilder-branches' }}
+          /> :
+          <span className="text-muted fst-italic">You must select a study before selecting cohort criteria</span> }
+      </div>
+
+    </Modal.Body>
+    <Modal.Footer>
+      <Button variant="primary"
+        disabled={!cohortName || !selectedStudy}
+        onClick={() => alert('not yet implemented')}
+      >Create</Button>
+      <button className="btn btn-secondary" onClick={onDismiss}>Cancel</button>
+    </Modal.Footer>
+  </Modal>
+}


### PR DESCRIPTION
#### DESCRIPTION

Wanted to just get this out into review because I've been sitting on it for a bit. This will need integration work with the backend once the rules engine and everything is in place, so for now it's just visible to superusers.

During demo, it was mentioned that it would be nice to make the field selector searchable, allowing the user to easily find a field if there are hundreds to sift through. I attempted to override the `fieldSelector` component of react-querybuilder , but React-Select didn't play too nicely with the internal rules builder. I'm sure we can get it to work, but it was starting to be a bit of a time sink and I didn't want to invest too much time before knowing if this was definitely the path we wanted to go down. For now, I think it's okay if HeartHive has to sift through a few fields- they have fewer surveys and fields than OurHealth.

<img width="1152" alt="Screenshot 2024-01-08 at 9 50 42 AM" src="https://github.com/broadinstitute/juniper/assets/7257391/20e5114d-09d7-4327-8927-592307e72256">

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1) Go to the portal list: https://localhost:3000/ and click "Create a cohort"
2) Select a portal and study and try adding some criteria (note this uses live to gather the fields, so if the live environment for your selected study isn't initialized then it will be lacking options)
3) You can't save it yet, so you'll see a "Not yet implemented" message when you click Create