### PR TITLE
[JN-754] Add DSM env vars to participant app

### DIFF
--- a/api-participant/src/main/resources/application.yml
+++ b/api-participant/src/main/resources/application.yml
@@ -10,6 +10,11 @@ env:
     user: ${DATABASE_USER:dbuser}
   sam:
     basePath: ${SAM_ADDRESS:https://sam.dsde-dev.broadinstitute.org}
+  dsm:
+    useLiveDsm: ${USE_LIVE_DSM:false}
+    basePath: ${DSM_ADDRESS:https://dsm-dev.datadonationplatform.org/dsm}
+    issuerClaim: ${DSM_JWT_ISSUER:admin-d2p.ddp-dev.envs.broadinstitute.org}
+    secret: ${DSM_JWT_SIGNING_SECRET:}
   swagger:
     # if true, the swagger UI page will be made available at swagger-ui.html -- should be false for production
     enabled: ${SWAGGER_ENABLED:false}

--- a/local-dev/render_environment_vars.sh
+++ b/local-dev/render_environment_vars.sh
@@ -26,6 +26,7 @@ ADMIN_API_ENV_VARS=(
 PARTICIPANT_API_ENV_VARS=(
   "REDIRECT_ALL_EMAILS_TO:static:$DEV_EMAIL"
   "B2C_CONFIG_FILE:static:b2c-config.yml"
+  "DSM_JWT_SIGNING_SECRET:vault:vault read -field jwt_signing_secret secret/dsp/ddp/d2p/dev/dsm"
   "SENDGRID_API_KEY:vault:vault read -field=api_key secret/dsp/ddp/d2p/dev/sendgrid"
   "SWAGGER_ENABLED:static:true"
 )


### PR DESCRIPTION
#### DESCRIPTION

This moves the DSM env vars into the participant app so we don't run into problems in the future when we eventually need them. The participant and admin apps will have access to the same variables once this terra-helmfile PR is merged: https://github.com/broadinstitute/terra-helmfile/pull/4927

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. Run `bash ./local-dev/render_environment_vars.sh ApiParticipantApp foo@bar.org` and ensure that the DSM signing secret is now included