### PR TITLE
[JN-805] Avoid duplicating outreach tasks

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/workflow/EventClass.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/workflow/EventClass.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.core.model.workflow;
 
 import bio.terra.pearl.core.service.consent.EnrolleeConsentEvent;
 import bio.terra.pearl.core.service.kit.KitStatusEvent;
+import bio.terra.pearl.core.service.survey.EnrolleeSurveyEvent;
 import bio.terra.pearl.core.service.workflow.BaseEvent;
 import bio.terra.pearl.core.service.workflow.EnrolleeCreationEvent;
 import bio.terra.pearl.core.service.workflow.PortalRegistrationEvent;
@@ -9,7 +10,7 @@ import bio.terra.pearl.core.service.workflow.PortalRegistrationEvent;
 public enum EventClass {
     ENROLLEE_CREATION_EVENT(EnrolleeCreationEvent.class),
     PORTAL_REGISTRATION_EVENT(PortalRegistrationEvent.class),
-    ENROLLEE_SURVEY_EVENT(EnrolleeCreationEvent.class),
+    ENROLLEE_SURVEY_EVENT(EnrolleeSurveyEvent.class),
     ENROLLEE_CONSENT_EVENT(EnrolleeConsentEvent.class),
     KIT_STATUS_EVENT(KitStatusEvent.class);
 

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
@@ -100,15 +100,15 @@ public class SurveyTaskDispatcher {
     }
 
     /**
-     * To avoid accidentally assigning the same survey to a participant multiple times, confirm that
-     * if the stableId matches an existing task, the existing task must be complete and the configured
-     * survey must allow recurrence.
+     * To avoid accidentally assigning the same survey or outreach activity to a participant multiple times,
+     * confirm that if the stableId matches an existing task, the existing task must be complete and the
+     * configured survey must allow recurrence.
      */
     public static boolean isDuplicateTask(StudyEnvironmentSurvey studySurvey, ParticipantTask task,
                                    Set<ParticipantTask> allTasks) {
-        boolean isSurveyOrOutreach = task.getTaskType() == TaskType.SURVEY || task.getTaskType() == TaskType.OUTREACH;
         return !allTasks.stream()
-                .filter(existingTask -> isSurveyOrOutreach &&
+                .filter(existingTask ->
+                        (existingTask.getTaskType() == TaskType.SURVEY || existingTask.getTaskType() == TaskType.OUTREACH) &&
                         existingTask.getTargetStableId().equals(task.getTargetStableId()) &&
                         !isRecurrenceWindowOpen(studySurvey, existingTask))
                 .toList().isEmpty();

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
@@ -106,8 +106,9 @@ public class SurveyTaskDispatcher {
      */
     public static boolean isDuplicateTask(StudyEnvironmentSurvey studySurvey, ParticipantTask task,
                                    Set<ParticipantTask> allTasks) {
+        boolean isSurveyOrOutreach = task.getTaskType() == TaskType.SURVEY || task.getTaskType() == TaskType.OUTREACH;
         return !allTasks.stream()
-                .filter(existingTask -> (existingTask.getTaskType() == TaskType.SURVEY) &&
+                .filter(existingTask -> isSurveyOrOutreach &&
                         existingTask.getTargetStableId().equals(task.getTargetStableId()) &&
                         !isRecurrenceWindowOpen(studySurvey, existingTask))
                 .toList().isEmpty();

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
@@ -42,4 +42,23 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
                 existingTasks);
         assertFalse(isDuplicate);
     }
+
+    @Test
+    void testOutreachIsDuplicate() {
+        StudyEnvironmentSurvey studyEnvironmentSurvey = StudyEnvironmentSurvey.builder()
+                .recur(false)
+                .build();
+        ParticipantTask outreachTask1 = ParticipantTask.builder()
+                .targetStableId("oh_outsideAdvert")
+                .taskType(TaskType.OUTREACH)
+                .build();
+        Set<ParticipantTask> existingTasks = Set.of(outreachTask1);
+        ParticipantTask outreachTask2 = ParticipantTask.builder()
+                .targetStableId("oh_outsideAdvert")
+                .taskType(TaskType.OUTREACH)
+                .build();
+        boolean isDuplicate = SurveyTaskDispatcher.isDuplicateTask(studyEnvironmentSurvey, outreachTask2,
+                existingTasks);
+        assertTrue(isDuplicate);
+    }
 }


### PR DESCRIPTION
#### DESCRIPTION

I'm fairly new to events/tasks, but my understanding is:

1. A participant views an outreach activity
2. This triggers an "EnrolleeSurveyEvent" to be published from EventService.java
3. The createSurveyTasks event listener in SurveyTaskDispatcher.java picks up this event and attempts to create a new task
4. The check in `isDuplicateTask` was only de-duplicating `SURVEY` task types, not `OUTREACH` task types

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. Reboot participant API and participant UI
2. Log in to HeartHive
3. Scroll to the bottom of the dashboard and click on the `Foobar study` outreach activity
4. Refresh the page
5. You should not see a duplicate of this outreach activity