### PR TITLE
[JN-820] Fix flaky test

### DIFF
--- a/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientTest.java
@@ -71,8 +71,8 @@ public class LivePepperDSMClientTest extends BaseSpringBootTest {
     @Transactional
     @Test
     public void testBadErrorResponseFromPepper(TestInfo info) throws Exception {
-        Enrollee enrollee = enrolleeFactory.buildPersisted(info.getDisplayName());
-        KitRequest kitRequest = kitRequestFactory.buildPersisted(info.getDisplayName(), enrollee);
+        Enrollee enrollee = enrolleeFactory.buildPersisted(getTestName(info));
+        KitRequest kitRequest = kitRequestFactory.buildPersisted(getTestName(info), enrollee);
         PepperKitAddress address = PepperKitAddress.builder().build();
 
         // Arrange
@@ -90,8 +90,8 @@ public class LivePepperDSMClientTest extends BaseSpringBootTest {
     @Transactional
     @Test
     public void testErrorResponseFromPepperWithUnexpectedAttributes(TestInfo info) throws Exception {
-        Enrollee enrollee = enrolleeFactory.buildPersisted(info.getDisplayName());
-        KitRequest kitRequest = kitRequestFactory.buildPersisted(info.getDisplayName(), enrollee);
+        Enrollee enrollee = enrolleeFactory.buildPersisted(getTestName(info));
+        KitRequest kitRequest = kitRequestFactory.buildPersisted(getTestName(info), enrollee);
         PepperKitAddress address = PepperKitAddress.builder().build();
 
         var unexpectedJsonBody = """
@@ -118,8 +118,8 @@ public class LivePepperDSMClientTest extends BaseSpringBootTest {
     @Transactional
     @Test
     public void test4xxResponseFromPepper(TestInfo info) throws Exception {
-        Enrollee enrollee = enrolleeFactory.buildPersisted(info.getDisplayName());
-        KitRequest kitRequest = kitRequestFactory.buildPersisted(info.getDisplayName(), enrollee);
+        Enrollee enrollee = enrolleeFactory.buildPersisted(getTestName(info));
+        KitRequest kitRequest = kitRequestFactory.buildPersisted(getTestName(info), enrollee);
         PepperKitAddress address = PepperKitAddress.builder().build();
 
         var kitId = "111-222-333";
@@ -143,8 +143,8 @@ public class LivePepperDSMClientTest extends BaseSpringBootTest {
     @Transactional
     @Test
     public void test5xxResponseFromPepper(TestInfo info) throws Exception {
-        Enrollee enrollee = enrolleeFactory.buildPersisted(info.getDisplayName());
-        KitRequest kitRequest = kitRequestFactory.buildPersisted(info.getDisplayName(), enrollee);
+        Enrollee enrollee = enrolleeFactory.buildPersisted(getTestName(info));
+        KitRequest kitRequest = kitRequestFactory.buildPersisted(getTestName(info), enrollee);
         PepperKitAddress address = PepperKitAddress.builder().build();
 
         // Arrange
@@ -162,8 +162,8 @@ public class LivePepperDSMClientTest extends BaseSpringBootTest {
     @Transactional
     @Test
     public void testSendKitRequest(TestInfo info) throws Exception {
-        Enrollee enrollee = enrolleeFactory.buildPersisted(info.getDisplayName());
-        KitRequest kitRequest = kitRequestFactory.buildPersisted(info.getDisplayName(), enrollee);
+        Enrollee enrollee = enrolleeFactory.buildPersisted(getTestName(info));
+        KitRequest kitRequest = kitRequestFactory.buildPersisted(getTestName(info), enrollee);
         PepperKitAddress address = PepperKitAddress.builder().build();
 
         PepperKit kitStatus = PepperKit.builder()

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientTest.java
@@ -185,7 +185,7 @@ public class LivePepperDSMClientTest extends BaseSpringBootTest {
 
     @Transactional
     @Test
-    public void testFetchKitStatus(TestInfo info) throws Exception {
+    public void testFetchKitStatus() throws Exception {
         // Arrange
         PepperKit kitStatus = PepperKit.builder()
                 .juniperKitId("testFetchKitStatusByStudy1")


### PR DESCRIPTION
#### DESCRIPTION

Fixes test which failed erroneously on an earlier PR I pushed up. I believe it is due to the fact that there were database objects being created outside of the @Transcational annotation, which lead to race conditions.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

All tests pass