### PR TITLE
[JN-817] Fix request kits bug

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
@@ -14,6 +14,10 @@ import bio.terra.pearl.core.service.study.StudyService;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -56,9 +60,13 @@ public class KitExtService {
     return response;
   }
 
+  @Getter
+  @SuperBuilder
+  @NoArgsConstructor
+  @Slf4j
   public static class KitRequestListResponse {
-    protected static final List<KitRequestDto> kitRequests = new ArrayList<>();
-    protected static final List<Exception> exceptions = new ArrayList<>();
+    private final List<KitRequestDto> kitRequests = new ArrayList<>();
+    private final List<Exception> exceptions = new ArrayList<>();
 
     public void addKitRequest(KitRequestDto kitRequest) {
       kitRequests.add(kitRequest);


### PR DESCRIPTION
#### DESCRIPTION

The response entity that the endpoint was returning was not a java bean, so it was freaking out when it tried to serialize it. I made it a standard java bean format and now it works.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Restart admin api and ui
- Fill out ourhealth
- Go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/kits/eligible
- Check a couple participants and hit "Send sample collection kit"
- If it either works or has an address validation error, then the endpoint works properly.