### PR TITLE
[JN-818] fixing save of published triggers

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/notifications/TriggerExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/notifications/TriggerExtService.java
@@ -194,8 +194,10 @@ public class TriggerExtService {
     newConfig.setStudyEnvironmentId(studyEnvironment.getId());
     newConfig.setPortalEnvironmentId(portalEnvironment.getId());
     if (newConfig.getEmailTemplate() != null && newConfig.getEmailTemplateId() == null) {
-      // this is a new email template, set the portal appropriately
+      // this is a new email template, set the portal appropriately, and clear published versions
       newConfig.getEmailTemplate().setPortalId(portalEnvironment.getPortalId());
+      newConfig.getEmailTemplate().cleanForCopying();
+      newConfig.getEmailTemplate().setPublishedVersion(null);
     }
     Trigger savedConfig = triggerService.create(newConfig);
     return savedConfig;

--- a/populate/src/main/resources/seed/portals/demo/portal.json
+++ b/populate/src/main/resources/seed/portals/demo/portal.json
@@ -44,7 +44,11 @@
         "acceptingRegistration": true,
         "passwordProtected": false,
         "password": "broad_institute",
-        "initialized": false
+        "initialized": true,
+        "emailSourceAddress": "support@juniper.terra.bio"
+      },
+      "siteContentPopDto": {
+        "populateFileName": "siteContent/siteContent-2/siteContent.json"
       }
     },{
       "environmentName": "live",
@@ -52,7 +56,11 @@
         "acceptingRegistration": true,
         "passwordProtected": false,
         "password": "broad_institute",
-        "initialized": false
+        "initialized": true,
+        "emailSourceAddress": "support@juniper.terra.bio"
+      },
+      "siteContentPopDto": {
+        "populateFileName": "siteContent/siteContent-1/siteContent.json"
       }
     }
   ],

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/adHoc.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/adHoc.json
@@ -3,5 +3,6 @@
   "bodyPopulateFile": "adHoc.html",
   "subject": "${adHocSubject}",
   "stableId": "hd_hd_adhoc",
-  "version": 1
+  "version": 1,
+  "publishedVersion": 1
 }

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/consentReminder.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/consentReminder.json
@@ -3,5 +3,6 @@
   "bodyPopulateFile": "consentReminder.html",
   "subject": "Reminder: Please complete the ${study.name} Consent form",
   "stableId": "hd_hd_reminderConsent",
-  "version": 1
+  "version": 1,
+  "publishedVersion": 1
 }

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/studyConsent.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/studyConsent.json
@@ -3,5 +3,6 @@
   "bodyPopulateFile": "studyConsent.html",
   "subject": "Thank you!",
   "stableId": "hd_hd_studyConsent",
-  "version": 1
+  "version": 1,
+  "publishedVersion": 1
 }

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/studyEnroll.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/studyEnroll.json
@@ -3,5 +3,6 @@
   "bodyPopulateFile": "studyEnroll.html",
   "subject": "Welcome!",
   "stableId": "hd_hd_studyEnroll",
-  "version": 1
+  "version": 1,
+  "publishedVersion": 1
 }

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/surveyReminder.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/surveyReminder.json
@@ -3,5 +3,6 @@
   "bodyPopulateFile": "surveyReminder.html",
   "subject": "Please come back to finish your study activities",
   "stableId": "hd_hd_reminderSurvey",
-  "version": 1
+  "version": 1,
+  "publishedVersion": 1
 }

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
@@ -106,21 +106,105 @@
     },
     {
       "environmentName": "irb",
+      "kitTypeNames": [ "SALIVA" ],
       "studyEnvironmentConfig": {
         "acceptingEnrollment": true,
         "passwordProtected": false,
         "password": "broad_institute",
-        "initialized": false
-      }
+        "initialized": true
+      },
+      "preEnrollSurveyDto": {
+        "populateFileName": "surveys/preEnroll.json"
+      },
+      "configuredSurveyDtos": [
+        {"populateFileName": "surveys/basic.json", "required": true},
+        {"populateFileName": "surveys/cardioHistory.json", "required": true},
+        {"populateFileName": "surveys/medicalHistory.json"},
+        {"populateFileName": "surveys/familyHistory.json"},
+        {"populateFileName": "surveys/medList.json"},
+        {"populateFileName": "surveys/lifestyle.json"},
+        {"populateFileName": "surveys/phq9gad7.json"},
+        {"populateFileName": "surveys/socialHealth.json", "active": false},
+        {"populateFileName": "surveys/socialHealthV2.json"}
+      ],
+      "configuredConsentDtos": [
+        {
+          "populateFileName": "surveys/ourHealthConsent.json"
+        }
+      ],
+      "triggerDtos": [{
+        "triggerType": "EVENT",
+        "eventType": "STUDY_ENROLLMENT",
+        "populateFileName": "emails/studyEnroll.json"
+      },{
+        "triggerType": "EVENT",
+        "eventType": "STUDY_CONSENT",
+        "populateFileName": "emails/studyConsent.json"
+      },{
+        "triggerType": "TASK_REMINDER",
+        "taskType": "CONSENT",
+        "populateFileName": "emails/consentReminder.json"
+      },{
+        "triggerType": "TASK_REMINDER",
+        "taskType": "SURVEY",
+        "reminderIntervalMinutes": 10080,
+        "maxNumReminders": 2,
+        "populateFileName": "emails/surveyReminder.json"
+      },{
+        "triggerType": "AD_HOC",
+        "populateFileName": "emails/adHoc.json"
+      }]
     },
     {
       "environmentName": "live",
+      "kitTypeNames": [ "SALIVA" ],
       "studyEnvironmentConfig": {
         "acceptingEnrollment": true,
         "passwordProtected": false,
         "password": "broad_institute",
-        "initialized": false
-      }
+        "initialized": true
+      },
+      "preEnrollSurveyDto": {
+        "populateFileName": "surveys/preEnroll.json"
+      },
+      "configuredSurveyDtos": [
+        {"populateFileName": "surveys/basic.json", "required": true},
+        {"populateFileName": "surveys/cardioHistory.json", "required": true},
+        {"populateFileName": "surveys/medicalHistory.json"},
+        {"populateFileName": "surveys/familyHistory.json"},
+        {"populateFileName": "surveys/medList.json"},
+        {"populateFileName": "surveys/lifestyle.json"},
+        {"populateFileName": "surveys/phq9gad7.json"},
+        {"populateFileName": "surveys/socialHealth.json", "active": false},
+        {"populateFileName": "surveys/socialHealthV2.json"}
+      ],
+      "configuredConsentDtos": [
+        {
+          "populateFileName": "surveys/ourHealthConsent.json"
+        }
+      ],
+      "triggerDtos": [{
+        "triggerType": "EVENT",
+        "eventType": "STUDY_ENROLLMENT",
+        "populateFileName": "emails/studyEnroll.json"
+      },{
+        "triggerType": "EVENT",
+        "eventType": "STUDY_CONSENT",
+        "populateFileName": "emails/studyConsent.json"
+      },{
+        "triggerType": "TASK_REMINDER",
+        "taskType": "CONSENT",
+        "populateFileName": "emails/consentReminder.json"
+      },{
+        "triggerType": "TASK_REMINDER",
+        "taskType": "SURVEY",
+        "reminderIntervalMinutes": 10080,
+        "maxNumReminders": 2,
+        "populateFileName": "emails/surveyReminder.json"
+      },{
+        "triggerType": "AD_HOC",
+        "populateFileName": "emails/adHoc.json"
+      }]
     }
   ]
 }

--- a/ui-admin/src/study/StudyEnvironmentRouter.tsx
+++ b/ui-admin/src/study/StudyEnvironmentRouter.tsx
@@ -20,7 +20,7 @@ import Select from 'react-select'
 import MailingListView from '../portal/MailingListView'
 import StudySettings from './StudySettings'
 import { ENVIRONMENT_ICON_MAP } from './publishing/StudyPublishingView'
-import NotificationContent from './notifications/NotificationContent'
+import TriggerList from './notifications/TriggerList'
 import SiteContentLoader from '../portal/siteContent/SiteContentLoader'
 import AdminTaskList from './adminTasks/AdminTaskList'
 import SiteImageList from '../portal/images/SiteImageList'
@@ -87,7 +87,7 @@ function StudyEnvironmentRouter({ study }: {study: Study}) {
       />
     </NavBreadcrumb>
     <Routes>
-      <Route path="notificationContent/*" element={<NotificationContent studyEnvContext={studyEnvContext}
+      <Route path="notificationContent/*" element={<TriggerList studyEnvContext={studyEnvContext}
         portalContext={portalContext}/>}/>
       <Route path="alerts" element={<DashboardSettings studyEnvContext={studyEnvContext}
         portalContext={portalContext}/>}/>

--- a/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
+++ b/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
@@ -4,10 +4,15 @@ import { EmailTemplate } from '@juniper/ui-core'
 import { Tab, Tabs } from 'react-bootstrap'
 import { getImageBaseUrl } from 'api/api'
 
+export type EmailTemplateEditorProps = {
+  emailTemplate: EmailTemplate,
+  portalShortcode: string,
+  updateEmailTemplate: (emailTemplate: EmailTemplate) => void
+}
+
 /** Enables editing an email with design/preview modes */
-export default function EmailTemplateEditor({ emailTemplate, updateEmailTemplate, portalShortcode }: {
-    emailTemplate: EmailTemplate, portalShortcode: string, updateEmailTemplate: (emailTemplate: EmailTemplate) => void
-}) {
+export default function EmailTemplateEditor({ emailTemplate, updateEmailTemplate, portalShortcode }:
+  EmailTemplateEditorProps) {
   const emailEditorRef = useRef<EditorRef>(null)
   // wrapper so that the unlayer event handler always accesses the latest state when updating
   const emailTemplateRef = useRef(emailTemplate)

--- a/ui-admin/src/study/notifications/TestEmailSender.test.tsx
+++ b/ui-admin/src/study/notifications/TestEmailSender.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 
-import { mockNotificationConfig } from 'test-utils/mocking-utils'
+import { mockTrigger } from 'test-utils/mocking-utils'
 import { setupRouterTest } from 'test-utils/router-testing-utils'
 import { mockAdminUser, MockUserProvider } from 'test-utils/user-mocking-utils'
 import TestEmailSender from './TestEmailSender'
@@ -12,7 +12,7 @@ test('replaces the email with the username', async () => {
           <MockUserProvider user={{ ...mockAdminUser(false), username: 'admin@user.com' }}>
             <TestEmailSender studyEnvParams={{ portalShortcode: 'portal', envName: 'irb', studyShortcode: 'study' }}
               onDismiss={jest.fn()}
-              trigger={mockNotificationConfig()}/>
+              trigger={mockTrigger()}/>
           </MockUserProvider>
         )
   render(RoutedComponent)

--- a/ui-admin/src/study/notifications/TriggerList.test.tsx
+++ b/ui-admin/src/study/notifications/TriggerList.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 
-import { mockNotificationConfig, mockPortalContext, mockStudyEnvContext } from 'test-utils/mocking-utils'
+import { mockTrigger, mockPortalContext, mockStudyEnvContext } from 'test-utils/mocking-utils'
 import { setupRouterTest } from 'test-utils/router-testing-utils'
-import NotificationContent from './NotificationContent'
+import TriggerList from './TriggerList'
 import userEvent from '@testing-library/user-event'
 import Api from 'api/api'
 import { ReactNotifications } from 'react-notifications-component'
@@ -11,7 +11,7 @@ import { ReactNotifications } from 'react-notifications-component'
 test('renders routable config list', async () => {
   const studyEnvContext = mockStudyEnvContext()
   const enrollEmailConfig = {
-    ...mockNotificationConfig(),
+    ...mockTrigger(),
     id: 'event1',
     triggerType: 'EVENT',
     eventType: 'STUDY_ENROLLMENT'
@@ -19,13 +19,13 @@ test('renders routable config list', async () => {
   const triggers = [
     enrollEmailConfig,
     {
-      ...mockNotificationConfig(),
+      ...mockTrigger(),
       id: 'reminder1',
       triggerType: 'TASK_REMINDER',
       taskType: 'CONSENT'
     },
     {
-      ...mockNotificationConfig(),
+      ...mockTrigger(),
       id: 'reminder2',
       triggerType: 'TASK_REMINDER',
       taskType: 'SURVEY'
@@ -39,7 +39,7 @@ test('renders routable config list', async () => {
   const { RoutedComponent, router } =
       setupRouterTest(<>
         <ReactNotifications/>
-        <NotificationContent studyEnvContext={studyEnvContext} portalContext={mockPortalContext()}/>
+        <TriggerList studyEnvContext={studyEnvContext} portalContext={mockPortalContext()}/>
       </>)
   render(RoutedComponent)
   expect(screen.getByText('Participant email configuration')).toBeInTheDocument()
@@ -54,21 +54,21 @@ test('renders routable config list', async () => {
 test('allows deletion of notification config', async () => {
   const studyEnvContext = mockStudyEnvContext()
   const consentConfig = {
-    ...mockNotificationConfig(),
+    ...mockTrigger(),
     id: 'reminder1',
     triggerType: 'TASK_REMINDER',
     taskType: 'CONSENT'
   }
   const notificationConfigs = [
     {
-      ...mockNotificationConfig(),
+      ...mockTrigger(),
       id: 'event1',
       triggerType: 'EVENT',
       eventType: 'STUDY_ENROLLMENT'
     },
     consentConfig,
     {
-      ...mockNotificationConfig(),
+      ...mockTrigger(),
       id: 'reminder2',
       triggerType: 'TASK_REMINDER',
       taskType: 'SURVEY'
@@ -83,7 +83,7 @@ test('allows deletion of notification config', async () => {
   const { RoutedComponent } =
     setupRouterTest(<>
       <ReactNotifications/>
-      <NotificationContent studyEnvContext={studyEnvContext} portalContext={mockPortalContext()}/>
+      <TriggerList studyEnvContext={studyEnvContext} portalContext={mockPortalContext()}/>
     </>)
   render(RoutedComponent)
 

--- a/ui-admin/src/study/notifications/TriggerList.tsx
+++ b/ui-admin/src/study/notifications/TriggerList.tsx
@@ -22,7 +22,7 @@ const CONFIG_GROUPS = [
 ]
 
 /** shows configuration of notifications for a study */
-export default function NotificationContent({ studyEnvContext, portalContext }:
+export default function TriggerList({ studyEnvContext, portalContext }:
   {studyEnvContext: StudyEnvContextT, portalContext: LoadedPortalContextT}) {
   const currentEnv = studyEnvContext.currentEnv
   const navigate = useNavigate()

--- a/ui-admin/src/study/notifications/TriggerView.test.tsx
+++ b/ui-admin/src/study/notifications/TriggerView.test.tsx
@@ -18,7 +18,6 @@ test('enables updating of email templates', async () => {
   const saveSpy = jest.spyOn(Api, 'updateTrigger')
     .mockImplementation(() => Promise.resolve(trigger))
 
-  // jest.doMock('./EmailTemplateEditor', () => MockEmailTemplateEditor)
   renderWithRouter(<div>
     <ReactNotifications />
     <TriggerView studyEnvContext={studyEnvContext} portalContext={mockPortalContext()}

--- a/ui-admin/src/study/notifications/TriggerView.test.tsx
+++ b/ui-admin/src/study/notifications/TriggerView.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { mockTrigger, mockPortalContext, mockStudyEnvContext } from 'test-utils/mocking-utils'
+import Api from 'api/api'
+import { renderWithRouter } from 'test-utils/router-testing-utils'
+import TriggerView from './TriggerView'
+import { waitFor, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ReactNotifications } from 'react-notifications-component'
+
+
+test('enables updating of email templates', async () => {
+  const studyEnvContext = mockStudyEnvContext()
+  const trigger = {
+    ...mockTrigger()
+  }
+  const findSpy = jest.spyOn(Api, 'findTrigger')
+    .mockImplementation(() => Promise.resolve(trigger))
+  const saveSpy = jest.spyOn(Api, 'updateTrigger')
+    .mockImplementation(() => Promise.resolve(trigger))
+
+  // jest.doMock('./EmailTemplateEditor', () => MockEmailTemplateEditor)
+  renderWithRouter(<div>
+    <ReactNotifications />
+    <TriggerView studyEnvContext={studyEnvContext} portalContext={mockPortalContext()}
+      onDelete={jest.fn()}/>
+  </div>, [`/${trigger.id}`], ':configId')
+
+  await waitFor(() => expect(findSpy).toHaveBeenCalledTimes(1))
+  expect(findSpy).toHaveBeenCalledWith(studyEnvContext.portal.shortcode, studyEnvContext.study.shortcode,
+    studyEnvContext.currentEnv.environmentName, trigger.id)
+
+  await userEvent.type(screen.getByLabelText('Subject'), 'blah')
+  await userEvent.click(screen.getByText('Save'))
+  expect(saveSpy).toHaveBeenCalledTimes(1)
+  expect(saveSpy).toHaveBeenCalledWith(studyEnvContext.portal.shortcode, studyEnvContext.currentEnv.environmentName,
+    studyEnvContext.study.shortcode, trigger.id, {
+      ...trigger,
+      emailTemplate: {
+        ...trigger.emailTemplate,
+        id: undefined,  // confirm id and publishedVersion are cleared
+        publishedVersion: undefined,
+        version: 2, // confirm version is incremented
+        subject: 'Mock subjectblah'
+      }
+    })
+})

--- a/ui-admin/src/study/notifications/TriggerView.tsx
+++ b/ui-admin/src/study/notifications/TriggerView.tsx
@@ -118,6 +118,7 @@ export default function TriggerView({ studyEnvContext, portalContext, onDelete }
             emailTemplate: {
               ...updatedTemplate,
               id: undefined,
+              publishedVersion: undefined,
               version: config ? config.emailTemplate.version + 1 : 1
             }
           }

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -373,7 +373,7 @@ export const mockParticipantNote = (): ParticipantNote => {
 }
 
 /** mock NotificationConfig */
-export const mockNotificationConfig = (): Trigger => {
+export const mockTrigger = (): Trigger => {
   return {
     id: 'noteId1',
     triggerType: 'EVENT',

--- a/ui-admin/src/test-utils/router-testing-utils.tsx
+++ b/ui-admin/src/test-utils/router-testing-utils.tsx
@@ -13,25 +13,35 @@ type RoutableTestStruct = {
 }
 
 /** adapted from
- https://stackoverflow.com/questions/70313688/how-i-could-test-location-with-memoryrouter-on-react-router-dom-v6 */
-export function setupRouterTest(ComponentToRender: ReactElement, initialEntries=['/']): RoutableTestStruct {
-  const router = createMemoryRouter(
-    [{
+  * https://stackoverflow.com/questions/70313688/how-i-could-test-location-with-memoryrouter-on-react-router-dom-v6
+  * paths in the initialEntries array should always start with a '/'
+ * componentPath is the route to mount the component at.  Use this argument if you need to pass a routing param
+ * to the component
+ */
+export function setupRouterTest(ComponentToRender: ReactElement, initialEntries=['/'], componentPath = '*'): RoutableTestStruct {
+  const routes = [{
+    path: componentPath,
+    element: ComponentToRender
+  }]
+  if (componentPath !== '*') {
+    routes.push({
       path: '*',
-      element: ComponentToRender
-    }],
-    {
-      initialEntries
-    }
-  )
+      element: <div>catch-all route</div>
+    })
+  }
+  const router = createMemoryRouter(routes, { initialEntries })
   const RoutedComponent = <RouterProvider router={router} />
 
   return { RoutedComponent, router }
 }
 
 /** render a component wrapped in a router, use 'setupRouterTest' if you need to access the router
- * directly */
-export function renderWithRouter(ComponentToRender: ReactElement, initialEntries=['/']) {
-  const { RoutedComponent } = setupRouterTest(ComponentToRender, initialEntries)
+ * directly.
+ * paths in the initialEntries array should always start with a '/'.
+ * componentPath is the route to mount the component at.  Use this argument if you need to pass a routing param
+ * to the component
+ * */
+export function renderWithRouter(ComponentToRender: ReactElement, initialEntries=['/'], componentPath= '*') {
+  const { RoutedComponent } = setupRouterTest(ComponentToRender, initialEntries, componentPath)
   return render(RoutedComponent)
 }

--- a/ui-admin/src/test-utils/router-testing-utils.tsx
+++ b/ui-admin/src/test-utils/router-testing-utils.tsx
@@ -18,7 +18,8 @@ type RoutableTestStruct = {
  * componentPath is the route to mount the component at.  Use this argument if you need to pass a routing param
  * to the component
  */
-export function setupRouterTest(ComponentToRender: ReactElement, initialEntries=['/'], componentPath = '*'): RoutableTestStruct {
+export function setupRouterTest(ComponentToRender: ReactElement,
+  initialEntries=['/'], componentPath = '*'): RoutableTestStruct {
   const routes = [{
     path: componentPath,
     element: ComponentToRender


### PR DESCRIPTION
#### DESCRIPTION
Saving updates to triggers was failing for any trigger that had already been published to the live environment.  This is because we weren't clearing the 'publishedVersion' field from the entity we were trying to save, so the save failed with a unique constraint violation as we were trying to make a new template with the same stableId and publishedVersion as a previous template.

This also does some notificationConfig -> trigger naming cleanup. and updates the demo portal to have an initialized live environment with published stuff

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1. restart ApiAdminServer
2. repopulate demo `./scripts/populate_portal.sh demo`
3. go to `https://localhost:3000/demo/studies/heartdemo/env/sandbox/notificationContent`
4. pick any of the triggers, and update the email
5. save it, and confirm it saves
