### PR TITLE
[JN-793] Color code sidebar based on environment

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ConfigExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ConfigExtService.java
@@ -34,17 +34,22 @@ public class ConfigExtService {
 
   private Map<String, String> buildConfigMap() {
     return Map.of(
-        "b2cTenantName", StringUtils.defaultIfEmpty(b2CConfiguration.tenantName(), ""),
-        "b2cClientId", StringUtils.defaultIfEmpty(b2CConfiguration.clientId(), ""),
-        "b2cPolicyName", StringUtils.defaultIfEmpty(b2CConfiguration.policyName(), ""),
+        "b2cTenantName",
+        StringUtils.defaultIfEmpty(b2CConfiguration.tenantName(), ""),
+        "b2cClientId",
+        StringUtils.defaultIfEmpty(b2CConfiguration.clientId(), ""),
+        "b2cPolicyName",
+        StringUtils.defaultIfEmpty(b2CConfiguration.policyName(), ""),
         "participantUiHostname",
-            StringUtils.defaultIfEmpty(applicationRoutingPaths.getParticipantUiHostname(), ""),
+        StringUtils.defaultIfEmpty(applicationRoutingPaths.getParticipantUiHostname(), ""),
         "participantApiHostname",
-            StringUtils.defaultIfEmpty(applicationRoutingPaths.getParticipantApiHostname(), ""),
+        StringUtils.defaultIfEmpty(applicationRoutingPaths.getParticipantApiHostname(), ""),
         "adminUiHostname",
-            StringUtils.defaultIfEmpty(applicationRoutingPaths.getAdminUiHostname(), ""),
+        StringUtils.defaultIfEmpty(applicationRoutingPaths.getAdminUiHostname(), ""),
         "adminApiHostname",
-            StringUtils.defaultIfEmpty(applicationRoutingPaths.getAdminApiHostname(), ""));
+        StringUtils.defaultIfEmpty(applicationRoutingPaths.getAdminApiHostname(), ""),
+        "deploymentZone",
+        StringUtils.defaultIfEmpty(applicationRoutingPaths.getDeploymentZone(), ""));
   }
 
   /**

--- a/ui-admin/src/App.tsx
+++ b/ui-admin/src/App.tsx
@@ -8,6 +8,8 @@ import './print.css'
 import { BrowserRouter, Outlet, Route, Routes, useLocation } from 'react-router-dom'
 import { ReactNotifications } from 'react-notifications-component'
 
+import { Config } from 'api/api'
+
 import { RedirectFromOAuth } from 'login/RedirectFromOAuth'
 import { ProtectedRoute } from 'login/ProtectedRoute'
 import AdminNavbar from 'navbar/AdminNavbar'
@@ -54,7 +56,7 @@ function App() {
                   <Routes>
                     <Route path="/">
                       <Route element={<ProtectedRoute>
-                        <NavContextProvider><PageFrame/></NavContextProvider>
+                        <NavContextProvider><PageFrame config={config}/></NavContextProvider>
                       </ProtectedRoute>}>
                         <Route path="populate/*" element={<PopulateRouteSelect/>}/>
                         <Route path="users" element={<UserList/>}/>
@@ -79,10 +81,10 @@ function App() {
 }
 
 /** Renders the navbar and footer for the page */
-function PageFrame() {
+function PageFrame({ config }: { config: Config }) {
   return (
     <div className="d-flex">
-      <AdminSidebar/>
+      <AdminSidebar config={config}/>
       <div className="flex-grow-1 d-flex flex-column" style={{ backgroundColor: '#fff' }}>
         <AdminNavbar/>
         <Outlet/>

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -236,7 +236,8 @@ export type Config = {
   participantUiHostname: string,
   participantApiHostname: string,
   adminUiHostname: string,
-  adminApiHostname: string
+  adminApiHostname: string,
+  deploymentZone: string
 }
 
 export type MailingListContact = {

--- a/ui-admin/src/navbar/AdminSidebar.test.tsx
+++ b/ui-admin/src/navbar/AdminSidebar.test.tsx
@@ -5,11 +5,23 @@ import { mockAdminUser, MockUserProvider } from 'test-utils/user-mocking-utils'
 import { render, screen, waitFor } from '@testing-library/react'
 import AdminSidebar from './AdminSidebar'
 import userEvent from '@testing-library/user-event'
+import { Config } from '../api/api'
 
+
+const testConfig: Config = {
+  b2cTenantName: '',
+  adminApiHostname: '',
+  adminUiHostname: '',
+  b2cClientId: '',
+  b2cPolicyName: '',
+  participantApiHostname: '',
+  participantUiHostname: '',
+  deploymentZone: 'live'
+}
 test('renders the superuser menu for superusers', async () => {
   const { RoutedComponent } = setupRouterTest(
     <MockUserProvider user={mockAdminUser(true)}>
-      <AdminSidebar/>
+      <AdminSidebar config={testConfig}/>
     </MockUserProvider>)
   render(RoutedComponent)
   expect(screen.getByText('Superuser functions')).toBeInTheDocument()
@@ -18,7 +30,7 @@ test('renders the superuser menu for superusers', async () => {
 test('menu components collapse on click', async () => {
   const { RoutedComponent } = setupRouterTest(
     <MockUserProvider user={mockAdminUser(true)}>
-      <AdminSidebar/>
+      <AdminSidebar config={testConfig}/>
     </MockUserProvider>)
   render(RoutedComponent)
   expect(screen.getByText('All users')).toBeVisible()
@@ -31,7 +43,7 @@ test('menu components collapse on click', async () => {
 test('does not render the superuser menu for  regular users', async () => {
   const { RoutedComponent } = setupRouterTest(
     <MockUserProvider user={mockAdminUser(false)}>
-      <AdminSidebar/>
+      <AdminSidebar config={testConfig}/>
     </MockUserProvider>)
   render(RoutedComponent)
   expect(screen.queryByText('Superuser functions')).toBeNull()

--- a/ui-admin/src/navbar/AdminSidebar.tsx
+++ b/ui-admin/src/navbar/AdminSidebar.tsx
@@ -8,9 +8,10 @@ import { studyShortcodeFromPath } from '../study/StudyRouter'
 import { useNavContext } from './NavContextProvider'
 import { StudySidebar } from './StudySidebar'
 import CollapsableMenu from './CollapsableMenu'
+import { Config } from '../api/api'
 
 /** renders the left navbar of admin tool */
-const AdminSidebar = () => {
+const AdminSidebar = ({ config }: { config: Config }) => {
   const [open, setOpen] = useState(true)
   const { user } = useUser()
   const params = useParams()
@@ -29,7 +30,15 @@ const AdminSidebar = () => {
   }
   const currentStudy = studyList.find(study => study.shortcode === studyShortcode)
 
-  return <div style={{ backgroundColor: '#333F52', minHeight: '100vh', minWidth: open ? '250px' : '50px' }}
+  const color =
+    config.deploymentZone === 'local'
+      ? '#33523c'
+      : (config.deploymentZone === 'demo'
+        ? '#575757'
+        : '#333F52')
+
+
+  return <div style={{ backgroundColor: color, minHeight: '100vh', minWidth: open ? '250px' : '50px' }}
     className="p-2 pt-3">
 
     {!open &&  <button onClick={() => setOpen(!open)} title="toggle sidebar" className="btn btn-link text-white">

--- a/ui-admin/src/navbar/AdminSidebar.tsx
+++ b/ui-admin/src/navbar/AdminSidebar.tsx
@@ -10,6 +10,13 @@ import { StudySidebar } from './StudySidebar'
 import CollapsableMenu from './CollapsableMenu'
 import { Config } from '../api/api'
 
+const ZONE_COLORS: { [index: string]: string } = {
+  'demo': '#575757', // dark green
+  'local': '#33523c', // grey
+  'prod': '#333F52' // blue (default)
+}
+
+
 /** renders the left navbar of admin tool */
 const AdminSidebar = ({ config }: { config: Config }) => {
   const [open, setOpen] = useState(true)
@@ -30,13 +37,7 @@ const AdminSidebar = ({ config }: { config: Config }) => {
   }
   const currentStudy = studyList.find(study => study.shortcode === studyShortcode)
 
-  const color =
-    config.deploymentZone === 'local'
-      ? '#33523c'
-      : (config.deploymentZone === 'demo'
-        ? '#575757'
-        : '#333F52')
-
+  const color = ZONE_COLORS[config.deploymentZone] || ZONE_COLORS['prod']
 
   return <div style={{ backgroundColor: color, minHeight: '100vh', minWidth: open ? '250px' : '50px' }}
     className="p-2 pt-3">

--- a/ui-admin/src/navbar/AdminSidebar.tsx
+++ b/ui-admin/src/navbar/AdminSidebar.tsx
@@ -11,8 +11,8 @@ import CollapsableMenu from './CollapsableMenu'
 import { Config } from '../api/api'
 
 const ZONE_COLORS: { [index: string]: string } = {
-  'demo': '#575757', // dark green
-  'local': '#33523c', // grey
+  'demo': 'rgb(70 143 124)', // dark green
+  'local': 'rgb(23 26 30)', // grey
   'prod': '#333F52' // blue (default)
 }
 

--- a/ui-admin/src/providers/ConfigProvider.tsx
+++ b/ui-admin/src/providers/ConfigProvider.tsx
@@ -9,7 +9,8 @@ const uninitializedConfig = {
   participantUiHostname: 'uninitialized',
   participantApiHostname: 'uninitialized',
   adminUiHostname: 'uninitialized',
-  adminApiHostname: 'uninitialized'
+  adminApiHostname: 'uninitialized',
+  deploymentZone: 'uninitialized'
 }
 
 const ConfigContext = React.createContext<Config>(uninitializedConfig)


### PR DESCRIPTION
#### DESCRIPTION

Color codes the sidebar based on environment. Local is green, demo is grey, prod is the same as always.

Local
<img width="1512" alt="image" src="https://github.com/broadinstitute/juniper/assets/17440010/dba7414e-d091-43b7-9dea-0b60979c53f4">

Demo
<img width="1512" alt="image" src="https://github.com/broadinstitute/juniper/assets/17440010/e5893f80-1506-4f65-9339-af7a8c96f86b">

Colors provided by Erin


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Restart adminapi
- Ensure sidebar is green
- Edit `api-admin/src/main/resources/application.yml` line 4 to say `deploymentZone: demo`
- Restart adminapi
- Ensure sidebar is grey
- (I wasn't sure if changing to prod would enable some crazy features, but you can manually change the deployment zone in `ui-admin/src/navbar/AdminSidebar.tsx`)