### PR TITLE
[JN-806] Prevent completed survey responses from being marked as incomplete

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -149,7 +149,10 @@ public class SurveyResponseService extends ImmutableEntityService<SurveyResponse
         SurveyResponse response;
         if (taskResponseId != null) {
             response = dao.find(taskResponseId).get();
-            response.setComplete(responseDto.isComplete());
+            // don't allow the response to be marked incomplete if it's already complete
+            if(!response.isComplete()) {
+                response.setComplete(responseDto.isComplete());
+            }
             // to enable simultaneous editing with page-saving, update this to be a merge, rather than a set
             response.setResumeData(responseDto.getResumeData());
             dao.update(response);

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
@@ -199,4 +199,58 @@ public class SurveyResponseServiceTests extends BaseSpringBootTest {
         assertThat(answerService.findByResponse(savedResponse.getId()), hasSize(2));
     }
 
+    @Test
+    @Transactional
+    public void testCompletedSurveyResponseCannotBeUpdatedToIncomplete(TestInfo testInfo) {
+        // create a survey and an enrollee with one survey task
+        String testName = getTestName(testInfo);
+        EnrolleeFactory.EnrolleeBundle enrolleeBundle = enrolleeFactory.buildWithPortalUser(testName);
+        Survey survey = surveyFactory.buildPersisted(testName);
+        StudyEnvironmentSurvey configuredSurvey = surveyFactory.attachToEnv(survey, enrolleeBundle.enrollee().getStudyEnvironmentId(), true);
+
+        ParticipantTask task = surveyTaskDispatcher.buildTask(configuredSurvey, survey, enrolleeBundle.enrollee(), enrolleeBundle.portalParticipantUser());
+        task = participantTaskService.create(task);
+        assertThat(task.getStatus(), equalTo(TaskStatus.NEW));
+
+        // create a response complete flag set to true
+        SurveyResponse response = SurveyResponse.builder()
+                .enrolleeId(enrolleeBundle.enrollee().getId())
+                .creatingParticipantUserId(enrolleeBundle.enrollee().getParticipantUserId())
+                .surveyId(survey.getId())
+                .complete(true) // set the response to complete
+                .answers(List.of())
+                .build();
+
+        surveyResponseService.updateResponse(response, enrolleeBundle.enrollee().getParticipantUserId(),
+                enrolleeBundle.portalParticipantUser(), enrolleeBundle.enrollee(), task.getId());
+
+        // check that the task response was created and task status updated to complete
+        task = participantTaskService.find(task.getId()).orElseThrow();
+        assertThat(task.getStatus(), equalTo(TaskStatus.COMPLETE));
+
+        // check that the SurveyResponse is marked as complete
+        SurveyResponse savedResponse = surveyResponseService.findByEnrolleeId(enrolleeBundle.enrollee().getId()).get(0);
+        assertThat(savedResponse.isComplete(), equalTo(true));
+
+        // create a response with complete flag set to false
+        response = SurveyResponse.builder()
+                .enrolleeId(enrolleeBundle.enrollee().getId())
+                .creatingParticipantUserId(enrolleeBundle.enrollee().getParticipantUserId())
+                .surveyId(survey.getId())
+                .complete(false) // set the response to incomplete
+                .answers(List.of())
+                .build();
+
+        surveyResponseService.updateResponse(response, enrolleeBundle.enrollee().getParticipantUserId(),
+                enrolleeBundle.portalParticipantUser(), enrolleeBundle.enrollee(), task.getId());
+
+        // check that the task status remains complete
+        task = participantTaskService.find(task.getId()).orElseThrow();
+        assertThat(task.getStatus(), equalTo(TaskStatus.COMPLETE));
+
+        // check that the SurveyResponse is still marked as complete
+        savedResponse = surveyResponseService.findByEnrolleeId(enrolleeBundle.enrollee().getId()).get(0);
+        assertThat(savedResponse.isComplete(), equalTo(true));
+    }
+
 }


### PR DESCRIPTION
#### DESCRIPTION

The bug in question is related to survey tasks being marked as **complete**, with the associated survey responses being marked as **incomplete**:

![inconsistent_states](https://github.com/broadinstitute/juniper/assets/7257391/5afebf10-a175-499c-adb7-c2ce01fbeef2)

Note that this is a **speculative** fix:

My theory is that users with slow internet connections could run into a race condition where there are two concurrent `updateSurveyResponse` API calls in flight at the time of survey completion: the first call would be triggered by an autosave from answering the final question, and the second call would be triggered from clicking the "Complete" button immediately afterwards.

In that case, the first call would have `surveyResponse.complete` set to `false`, and the second call would have `surveyResponse.complete` set to `true`. Since the survey response will end up with the state of the last call that finishes, if the first call completes last, we'll end up with inconsistent statuses. Fortunately, this race condition would not result in the loss of any survey answers because of how answers are compiled across consecutive saves.

Tasks already had logic to prevent reversing a `COMPLETE` status, which is why the task status was never flipped back from the second call. This PR adds the same logic for SurveyResponses.

The reason that this fix is speculative is that I wasn't able to reproduce this locally, even when throttling my connection speed with dev tools. But there are some good clues in the database to support this:

If you run `SELECT pt.status as task_status, sr.complete as survey_marked_complete, pt.target_name as survey_name, sr.resume_data FROM participant_task pt JOIN survey_response sr ON pt.survey_response_id = sr.id WHERE pt.status='COMPLETE' AND sr.complete = false order by sr.last_updated_at desc;`, you'll see that the `currentPageNo` in the `resume_data` for almost every instance is set to the final page of the survey. When the survey is completed, this should have been set back to the first page. But in the case of the race condition, this resume_data would be overwritten as well.


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. Reboot ApiAdminApp, ApiParticipantApp, and both UIs
2. Repopulate OurHealth
3. Log in as a user that has a completed survey, i.e. `jsalk@test.com`
4. Go to a completed survey, open your dev tools, and click the Complete button for the survey
5. Find the network call to updateSurveyResponse, and right click -> Copy as curl
6. Edit the payload in the curl call to have `complete` set to `false`
7. Execute the curl call
8. Verify that the survey response is still marked as complete: https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants/OHSALK/profile