### PR TITLE
[JN-840] handling circular metrics references

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/log/LogEventType.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/log/LogEventType.java
@@ -4,5 +4,6 @@ public enum LogEventType {
   ERROR, // an error occurred
   ACCESS, // someone requesting a resource
   EVENT, // an ApplicationEvent was fired
-  STATS // stats measurement -- e.g. webVitals
+  STATS, // stats measurement -- e.g. webVitals
+  INFO // something interesting that isn't an error
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,15 @@
         "ui-participant",
         "e2e-tests"
       ],
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1"
+      },
       "devDependencies": {
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
         "@types/jest": "^27.5.2",
+        "@types/json-stringify-safe": "^5.0.3",
         "@types/node": "^16.11.58",
         "chokidar-cli": "^3.0.0",
         "eslint": "^8.23.0",
@@ -4400,6 +4404,12 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "node_modules/@types/json-stringify-safe": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/json-stringify-safe/-/json-stringify-safe-5.0.3.tgz",
+      "integrity": "sha512-oNOjRxLfPeYbBSQ60maucaFNqbslVOPU4WWs5t/sHvAh6tyo/CThXSG+E24tEzkgh/fzvxyDrYdOJufgeNy1sQ==",
       "dev": true
     },
     "node_modules/@types/json5": {
@@ -10206,9 +10216,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
+      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
     "node_modules/flatten-vertex-data": {
@@ -13464,6 +13474,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -26915,6 +26930,12 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
+    "@types/json-stringify-safe": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/json-stringify-safe/-/json-stringify-safe-5.0.3.tgz",
+      "integrity": "sha512-oNOjRxLfPeYbBSQ60maucaFNqbslVOPU4WWs5t/sHvAh6tyo/CThXSG+E24tEzkgh/fzvxyDrYdOJufgeNy1sQ==",
+      "dev": true
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -31459,9 +31480,9 @@
       }
     },
     "flatted": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
+      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
     "flatten-vertex-data": {
@@ -33953,6 +33974,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "json5": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^27.5.2",
+    "@types/json-stringify-safe": "^5.0.3",
     "@types/node": "^16.11.58",
     "chokidar-cli": "^3.0.0",
     "eslint": "^8.23.0",
@@ -29,5 +30,8 @@
   },
   "scripts": {
     "lint": "eslint --max-warnings=0 e2e-tests ui-admin/src ui-core/src ui-participant/src"
+  },
+  "dependencies": {
+    "json-stringify-safe": "^5.0.1"
   }
 }

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -137,7 +137,7 @@ export type Config = {
 
 export type LogEvent = {
   id?: string,
-  eventType: 'ERROR' | 'ACCESS' | 'EVENT' | 'STATS'
+  eventType: 'ERROR' | 'ACCESS' | 'EVENT' | 'STATS' | 'INFO'
   eventName: string,
   stackTrace?: string,
   eventDetail?: string,

--- a/ui-participant/src/util/loggingUtils.test.tsx
+++ b/ui-participant/src/util/loggingUtils.test.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import { render, screen } from '@testing-library/react'
-import setupErrorLogger, { logVitals } from './loggingUtils'
+import setupErrorLogger, { logError, logVitals } from './loggingUtils'
 import Api from 'api/api'
 
 const TestComponent = () => {
@@ -44,6 +44,20 @@ test('handles metrics with circular reference', async () => {
     eventDetail: '{"stuff":1,"things":"blah","circular":"[Circular ~]"}',
     eventType: 'STATS',
     eventName: 'webvitals',
+    portalShortcode: 'localhost'
+  })
+})
+
+test('does not log Object.hasOwn as error', async () => {
+  const logSpy = jest.spyOn(Api, 'log').mockImplementation(jest.fn())
+  jest.spyOn(window, 'alert').mockImplementation(jest.fn())
+
+  logError({ message: 'Object.hasOwn is not a function' },  'trace')
+  expect(logSpy).toHaveBeenCalledWith({
+    environmentName: 'live',
+    eventDetail: 'Object.hasOwn is not a function',
+    eventType: 'INFO',
+    eventName: 'js-compatibility',
     portalShortcode: 'localhost'
   })
 })

--- a/ui-participant/src/util/loggingUtils.test.tsx
+++ b/ui-participant/src/util/loggingUtils.test.tsx
@@ -35,7 +35,7 @@ test('logs JS exceptions', async () => {
 // See JN-840
 test('handles metrics with circular reference', async () => {
   const logSpy = jest.spyOn(Api, 'log').mockImplementation(jest.fn())
-  const metricsObj: Record<string, any> = { stuff: 1, things: 'blah' }
+  const metricsObj: Record<string, unknown> = { stuff: 1, things: 'blah' }
   metricsObj.circular = metricsObj
 
   logVitals(metricsObj)

--- a/ui-participant/src/util/loggingUtils.test.tsx
+++ b/ui-participant/src/util/loggingUtils.test.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import { render, screen } from '@testing-library/react'
-import setupErrorLogger from './loggingUtils'
+import setupErrorLogger, { logVitals } from './loggingUtils'
 import Api from 'api/api'
 
 const TestComponent = () => {
@@ -25,7 +25,25 @@ test('logs JS exceptions', async () => {
   await new Promise(r => setTimeout(r, 200))
   expect(logSpy).toHaveBeenCalledTimes(1)
   expect(logSpy).toHaveBeenCalledWith({
+    environmentName: 'live',
+    portalShortcode: 'localhost',
     eventDetail: '{"message":"foo"}\nhttp://localhost/',
     eventName: 'jserror', eventType: 'ERROR', stackTrace: undefined
+  })
+})
+
+// See JN-840
+test('handles metrics with circular reference', async () => {
+  const logSpy = jest.spyOn(Api, 'log').mockImplementation(jest.fn())
+  const metricsObj: Record<string, any> = { stuff: 1, things: 'blah' }
+  metricsObj.circular = metricsObj
+
+  logVitals(metricsObj)
+  expect(logSpy).toHaveBeenCalledWith({
+    environmentName: 'live',
+    eventDetail: '{"stuff":1,"things":"blah","circular":"[Circular ~]"}',
+    eventType: 'STATS',
+    eventName: 'webvitals',
+    portalShortcode: 'localhost'
   })
 })

--- a/ui-participant/src/util/loggingUtils.ts
+++ b/ui-participant/src/util/loggingUtils.ts
@@ -1,4 +1,7 @@
 import Api, { getEnvSpec, LogEvent } from 'api/api'
+// we use flatted here since we don't control the objects we're serializing, and so we need to be more
+// robust to circular references than JSON.stringify
+import stringify from 'json-stringify-safe'
 
 /** listens to all window errors and logs them  */
 const setupErrorLogger = () => {
@@ -14,7 +17,7 @@ export const logVitals = (metric: object) => {
   log({
     eventType: 'STATS',
     eventName: 'webvitals',
-    eventDetail: JSON.stringify(metric)
+    eventDetail: stringify(metric)
   })
 }
 
@@ -36,10 +39,10 @@ export type ErrorEventDetail = {
 
 /** specific helper function for logging an error */
 export const logError = (detail: ErrorEventDetail, stackTrace: string) => {
-  Api.log({
+  log({
     eventType: 'ERROR',
     eventName: 'jserror',
-    eventDetail: `${JSON.stringify(detail)}\n${window.location.href}`,
+    eventDetail: `${stringify(detail)}\n${window.location.href}`,
     stackTrace
   })
 }

--- a/ui-participant/src/util/loggingUtils.ts
+++ b/ui-participant/src/util/loggingUtils.ts
@@ -39,10 +39,19 @@ export type ErrorEventDetail = {
 
 /** specific helper function for logging an error */
 export const logError = (detail: ErrorEventDetail, stackTrace: string) => {
-  log({
-    eventType: 'ERROR',
-    eventName: 'jserror',
-    eventDetail: `${stringify(detail)}\n${window.location.href}`,
-    stackTrace
-  })
+  if (detail.message.startsWith('Object.hasOwn is not')) {
+    alert('Your browser does not support this page. ' +
+      'Please use the latest version of Chrome, Safari, Firefox, Edge, or Android')
+    log({
+      eventType: 'INFO', eventName: 'js-compatibility',
+      eventDetail: detail.message
+    })
+  } else {
+    log({
+      eventType: 'ERROR',
+      eventName: 'jserror',
+      eventDetail: `${stringify(detail)}\n${window.location.href}`,
+      stackTrace
+    })
+  }
 }


### PR DESCRIPTION
#### DESCRIPTION
In production, we had a circular reference error trying to log some metrics.  We don't control what those metrics are (they're reported by React core utils), so this changes our serializer to one that filters out circular refs.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
I couldn't reproduce the actual error, but you can run the js tests, and also confirm that metrics logging still works by going to `sandbox.ourhealth.localhost:3001` and confirming in the network tab that logs of metrics are still being sent
