### PR TITLE
[JN-824] stifling Object.hasOwn errors

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/log/LogEventType.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/log/LogEventType.java
@@ -4,5 +4,6 @@ public enum LogEventType {
   ERROR, // an error occurred
   ACCESS, // someone requesting a resource
   EVENT, // an ApplicationEvent was fired
-  STATS // stats measurement -- e.g. webVitals
+  STATS, // stats measurement -- e.g. webVitals
+  INFO // something interesting that isn't an error
 }

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -137,7 +137,7 @@ export type Config = {
 
 export type LogEvent = {
   id?: string,
-  eventType: 'ERROR' | 'ACCESS' | 'EVENT' | 'STATS'
+  eventType: 'ERROR' | 'ACCESS' | 'EVENT' | 'STATS' | 'INFO'
   eventName: string,
   stackTrace?: string,
   eventDetail?: string,

--- a/ui-participant/src/util/loggingUtils.test.tsx
+++ b/ui-participant/src/util/loggingUtils.test.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import { render, screen } from '@testing-library/react'
-import setupErrorLogger, { logVitals } from './loggingUtils'
+import setupErrorLogger, { logError, logVitals } from './loggingUtils'
 import Api from 'api/api'
 
 const TestComponent = () => {
@@ -44,6 +44,20 @@ test('handles metrics with circular reference', async () => {
     eventDetail: '{"stuff":1,"things":"blah","circular":"[Circular ~]"}',
     eventType: 'STATS',
     eventName: 'webvitals',
+    portalShortcode: 'localhost'
+  })
+})
+
+test('does not log Object.hasOwn as error', async () => {
+  const logSpy = jest.spyOn(Api, 'log').mockImplementation(jest.fn())
+  jest.spyOn(window, 'alert').mockImplementation(jest.fn())
+
+  logError({ message: 'Object.hasOwn is not a function' },  'trace')
+  expect(logSpy).toHaveBeenCalledWith({
+    environmentName: 'live',
+    eventDetail: 'Object.hasOwn is not a function',
+    eventType: 'INFO',
+    eventName: 'js-compatibility',
     portalShortcode: 'localhost'
   })
 })

--- a/ui-participant/src/util/loggingUtils.ts
+++ b/ui-participant/src/util/loggingUtils.ts
@@ -39,10 +39,19 @@ export type ErrorEventDetail = {
 
 /** specific helper function for logging an error */
 export const logError = (detail: ErrorEventDetail, stackTrace: string) => {
-  log({
-    eventType: 'ERROR',
-    eventName: 'jserror',
-    eventDetail: `${stringify(detail)}\n${window.location.href}`,
-    stackTrace
-  })
+  if (detail.message.startsWith('Object.hasOwn is not')) {
+    alert('Your browser does not support this page. ' +
+      'Please use the latest version of Chrome, Safari, Firefox, Edge, or Android')
+    log({
+      eventType: 'INFO', eventName: 'js-compatibility',
+      eventDetail: detail.message
+    })
+  } else {
+    log({
+      eventType: 'ERROR',
+      eventName: 'jserror',
+      eventDetail: `${stringify(detail)}\n${window.location.href}`,
+      stackTrace
+    })
+  }
 }


### PR DESCRIPTION
#### DESCRIPTION

We get lots of log errors about Object.hasOwn not being supported.  This is likely from older or IE browsers (or bots).  We currently don't support those browsers, so this alerts the user for that case, and changes the log message to INFO

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1. I suppose you could use tunneling to try loading the site in IE11, but it's probably best to just run the js tests :)
