### PR TITLE
[JN-829] treating missing body as bad request

### DIFF
--- a/api-admin/build.gradle
+++ b/api-admin/build.gradle
@@ -14,7 +14,7 @@ apply from: 'publishing.gradle'
 
 dependencies {
 
-    implementation 'bio.terra:terra-common-lib:0.1.2-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:0.1.10-SNAPSHOT'
     implementation project(':core')
     implementation project(':populate')
     implementation 'org.apache.commons:commons-dbcp2'

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandler.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -31,7 +32,8 @@ public class GlobalExceptionHandler {
     IllegalArgumentException.class,
     NoHandlerFoundException.class,
     ValidationException.class,
-    BadRequestException.class
+    BadRequestException.class,
+    HttpMessageNotReadableException.class
   })
   public ResponseEntity<ErrorReport> badRequestExceptionHandler(Exception ex) {
     return buildErrorReport(ex, HttpStatus.BAD_REQUEST, request);

--- a/api-participant/build.gradle
+++ b/api-participant/build.gradle
@@ -11,7 +11,7 @@ apply from: 'generators.gradle'
 apply from: 'publishing.gradle'
 
 dependencies {
-    implementation 'bio.terra:terra-common-lib:0.1.2-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:0.1.10-SNAPSHOT'
     implementation project(':core')
     implementation 'org.apache.commons:commons-dbcp2'
     implementation 'org.apache.commons:commons-text:1.10.0'

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/GlobalExceptionHandler.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -34,7 +35,8 @@ public class GlobalExceptionHandler {
     IllegalArgumentException.class,
     NoHandlerFoundException.class,
     ValidationException.class,
-    BadRequestException.class
+    BadRequestException.class,
+    HttpMessageNotReadableException.class
   })
   public ResponseEntity<ErrorReport> badRequestExceptionHandler(Exception ex) {
     return buildErrorReport(ex, HttpStatus.BAD_REQUEST, request);

--- a/buildSrc/src/main/groovy/bio.terra.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.java-common-conventions.gradle
@@ -49,7 +49,7 @@ dependencies {
 
     testImplementation 'org.hamcrest:hamcrest:2.2'
 
-    implementation 'bio.terra:terra-common-lib:0.1.2-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:0.1.10-SNAPSHOT'
     //terra-common-lib pulls in google-oauth-client v1.33.2, which contains vuln CVE-2021-22573
     //This pulls in a patched version of google-oauth-client that supersedes the vulnerable version
     //This is a workaround until TCL adopts a patched version


### PR DESCRIPTION
#### DESCRIPTION

We're getting missing POST body errors in the logs, presumably from bots hitting our participant log endpoint.  I did some code tracing, and I really can't find any way that would happen in our UI.  This updates the error classes in our default error handlers to include missing POST body (and other malformed http) as BAD_REQUEST.

This also updates us to the latest version of bio.terra.terra-java.  I was investigating whether that update would impact whether POST bodies are required, and it doesn't, but it seems like a good update for hygiene anyway, given that it works as a drop-in-replacement

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1. redeploy apiParticipantApp
2. edit ui-participant.  api.tsx  -  delete line 453 so that the log request does not include a body
3. go to `sandbox.ourhealth.localhost:3001`
4. confirm that a bad log request appears in the IntelliJ console, but at log level "INFO"
```
2024-02-01T15:06:57.541-05:00 6dB5lGVo  INFO 70738 --- [nio-8081-exec-7] b.t.p.a.p.c.GlobalExceptionHandler       : Exception: org.springframework.http.converter.HttpMessageNotReadableException: Required request body is missing: public org.springframework.http.ResponseEntity<java.lang.String> bio.terra.pearl.api.participant.controller.LoggingController.log(java.lang.Object)
Request: POST /api/public/log/v1/log 400
```
