### PR TITLE
JN-790 Enabling manual assignment of surveys

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/ParticipantTaskController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/ParticipantTaskController.java
@@ -7,6 +7,7 @@ import bio.terra.pearl.api.admin.service.enrollee.ParticipantTaskUpdateDto;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
+import bio.terra.pearl.core.service.workflow.ParticipantTaskAssignDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
@@ -41,6 +42,19 @@ public class ParticipantTaskController implements ParticipantTaskApi {
     List<ParticipantTask> participantTasks =
         participantTaskExtService.updateTasks(
             portalShortcode, studyShortcode, environmentName, updateDto, operator);
+    return ResponseEntity.ok(participantTasks);
+  }
+
+  @Override
+  public ResponseEntity<Object> assignToEnrollees(
+      String portalShortcode, String studyShortcode, String envName, Object body) {
+    AdminUser operator = authUtilService.requireAdminUser(request);
+    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
+    ParticipantTaskAssignDto assignDto =
+        objectMapper.convertValue(body, ParticipantTaskAssignDto.class);
+    List<ParticipantTask> participantTasks =
+        participantTaskExtService.assignToEnrollees(
+            portalShortcode, studyShortcode, environmentName, assignDto, operator);
     return ResponseEntity.ok(participantTasks);
   }
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/ParticipantTaskExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/ParticipantTaskExtService.java
@@ -6,10 +6,13 @@ import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.workflow.DataAuditInfo;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
+import bio.terra.pearl.core.model.workflow.TaskType;
 import bio.terra.pearl.core.service.exception.internal.InternalServerException;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import bio.terra.pearl.core.service.study.exception.StudyEnvironmentMissing;
+import bio.terra.pearl.core.service.survey.SurveyTaskDispatcher;
+import bio.terra.pearl.core.service.workflow.ParticipantTaskAssignDto;
 import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,16 +24,19 @@ public class ParticipantTaskExtService {
   private StudyEnvironmentService studyEnvironmentService;
   private AuthUtilService authUtilService;
   private EnrolleeService enrolleeService;
+  private SurveyTaskDispatcher surveyTaskDispatcher;
 
   public ParticipantTaskExtService(
       ParticipantTaskService participantTaskService,
       StudyEnvironmentService studyEnvironmentService,
       AuthUtilService authUtilService,
-      EnrolleeService enrolleeService) {
+      EnrolleeService enrolleeService,
+      SurveyTaskDispatcher surveyTaskDispatcher1) {
     this.participantTaskService = participantTaskService;
     this.studyEnvironmentService = studyEnvironmentService;
     this.authUtilService = authUtilService;
     this.enrolleeService = enrolleeService;
+    this.surveyTaskDispatcher = surveyTaskDispatcher1;
   }
 
   public List<ParticipantTask> findAll(
@@ -45,6 +51,25 @@ public class ParticipantTaskExtService {
             .findByStudy(studyShortcode, environmentName)
             .orElseThrow(StudyEnvironmentMissing::new);
     return participantTaskService.findTasksByStudyAndTarget(studyEnv.getId(), List.of(stableId));
+  }
+
+  public List<ParticipantTask> assignToEnrollees(
+      String portalShortcode,
+      String studyShortcode,
+      EnvironmentName environmentName,
+      ParticipantTaskAssignDto assignDto,
+      AdminUser operator) {
+    authUtilService.authUserToStudy(operator, portalShortcode, studyShortcode);
+    StudyEnvironment studyEnv =
+        studyEnvironmentService
+            .findByStudy(studyShortcode, environmentName)
+            .orElseThrow(StudyEnvironmentMissing::new);
+
+    if (assignDto.taskType().equals(TaskType.SURVEY)) {
+      return surveyTaskDispatcher.assign(assignDto, studyEnv.getId(), operator);
+    }
+    throw new UnsupportedOperationException(
+        "task type %s not supported".formatted(assignDto.taskType()));
   }
 
   /**

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/ParticipantTaskUpdateDto.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/ParticipantTaskUpdateDto.java
@@ -16,7 +16,5 @@ public record ParticipantTaskUpdateDto(
       String targetStableId,
       int updateToVersion,
       Integer updateFromVersion,
-      boolean createForUnassigned, // create new tasks for enrollees not assigned to any version
-      // (assuming they are eligible)
       TaskStatus newStatus) {}
 }

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -656,7 +656,25 @@ paths:
         content: { application/json: { schema: { type: object } } }
       responses:
         '200':
-          description: updated PArticipantTask objects
+          description: updated ParticipantTask objects
+          content: { application/json: { schema: { type: object } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/participantTasks/assignToEnrollees:
+    post:
+      summary: Assigns the specified tasks according to the passed-in ParticipantTaskAssignDto
+      tags: [ participantTask ]
+      operationId: assignToEnrollees
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: studyShortcode, in: path, required: true, schema: { type: string } }
+        - { name: envName, in: path, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content: { application/json: { schema: { type: object } } }
+      responses:
+        '200':
+          description: updated ParticipantTask objects
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/enrollee/ParticipantTaskExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/enrollee/ParticipantTaskExtServiceTests.java
@@ -63,7 +63,7 @@ public class ParticipantTaskExtServiceTests extends BaseSpringBootTest {
 
     // issue a command to update surveyA tasks to version 2
     ParticipantTaskUpdateDto.TaskUpdateSpec updateSpec =
-        new ParticipantTaskUpdateDto.TaskUpdateSpec("surveyA", 2, 1, false, null);
+        new ParticipantTaskUpdateDto.TaskUpdateSpec("surveyA", 2, 1, null);
     ParticipantTaskUpdateDto updateDto =
         new ParticipantTaskUpdateDto(List.of(updateSpec), null, true);
     participantTaskExtService.updateTasks(

--- a/api-participant/src/main/resources/b2c-config.yml
+++ b/api-participant/src/main/resources/b2c-config.yml
@@ -9,3 +9,8 @@ b2c:
     clientId: 8c778931-b7f6-4503-b30e-e975ab8ea615
     policyName: B2C_1A_ddp_participant_signup_signin_hearthive-dev
     changePasswordPolicyName: B2C_1A_ddp_participant_change_password_hearthive-dev
+  demo:
+    tenantName: doesNotExist
+    clientId: doesNotExist
+    policyName: doesNotExist-dev
+    changePasswordPolicyName: doesNotExist-dev

--- a/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
@@ -355,6 +355,35 @@ public abstract class BaseJdbiDao<T extends BaseEntity> {
         );
     }
 
+    /**
+     * Returns a list of the items using the ordering of the columnValues to sort them.
+     * Be careful about using this for potentially large queries -- it has not been performance tuned at all
+     * and it generates a potentially very long query string.
+     */
+    protected List<T> findAllByPropertyCollectionPreserveOrder(String columnName, List<?> columnValues) {
+        if (columnValues.isEmpty()) {
+            // short circuit this case because bindList errors if list is empty
+            return new ArrayList<>();
+        }
+        String valuesString = IntStream.range(0, columnValues.size())
+                .mapToObj(i -> "(:column1Value%s, %s)".formatted(i, i)).collect(Collectors.joining(","));
+        return jdbi.withHandle(handle -> {
+            Query query = handle.createQuery("""
+                            select * from %s               
+                            join (values %s) as sortJoin (column1, ordering)                        
+                            on (%s = sortJoin.column1)
+                            where %s IN (<columnValues>)
+                            order by sortJoin.ordering;
+                            """.formatted(tableName, valuesString, columnName, columnName))
+                    .bindList("columnValues", columnValues);
+            for (int i = 0; i < columnValues.size(); i++) {
+                query = query.bind("column1Value" + i, columnValues.get(i))
+                        .bind("column2Value" + i, columnValues.get(i));
+            }
+            return query.mapTo(clazz).list();
+        });
+    }
+
     protected List<T> findAllByPropertySorted(String columnName, Object columnValue, String sortProperty, String sortDir) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("select * from " + tableName + " where " + columnName + " = :columnValue"

--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeDao.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.Query;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -112,5 +113,34 @@ public class EnrolleeDao extends BaseMutableJdbiDao<Enrollee> {
     /** updates the global consent status of the enrollee */
     public void updateConsented(UUID enrolleeId, boolean consented) {
         updateProperty(enrolleeId, "consented", consented);
+    }
+
+    public List<Enrollee> findUnassignedToTask(UUID studyEnvironmentId,
+                                         String targetStableId,
+                                         Integer targetAssignedVersion) {
+
+        return jdbi.withHandle(handle -> {
+            String versionWhereClause = "";
+            if (targetAssignedVersion != null) {
+                versionWhereClause = " and target_assigned_version = :targetAssignedVersion";
+            }
+            Query query = handle.createQuery("""
+                                    select * from enrollee
+                                     where id 
+                                     not in
+                                     (select distinct enrollee_id from participant_task 
+                                        where study_environment_id = :studyEnvironmentId
+                                        and participant_task.target_stable_id = :targetStableId
+                                        %s
+                                     )
+                                     and study_environment_id = :studyEnvironmentId;
+                            """.formatted(versionWhereClause))
+                    .bind("targetStableId", targetStableId)
+                    .bind("studyEnvironmentId", studyEnvironmentId);
+            if (targetAssignedVersion != null) {
+                query = query.bind("targetAssignedVersion", targetAssignedVersion);
+            }
+            return query.mapTo(clazz).list();
+        });
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/PortalParticipantUserDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/PortalParticipantUserDao.java
@@ -69,6 +69,10 @@ public class PortalParticipantUserDao extends BaseJdbiDao<PortalParticipantUser>
         return findByProperty("profile_id", profileId);
     }
 
+    public List<PortalParticipantUser> findByProfileIds(List<UUID> profileIds) {
+        return findAllByPropertyCollectionPreserveOrder("profile_id", profileIds);
+    }
+
     /**
      * loads the user along with their profile
      * */

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/Survey.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/Survey.java
@@ -50,5 +50,7 @@ public class Survey extends BaseEntity implements Versioned, PortalAttached {
     private boolean allowParticipantReedit = true; // whether participants can change answers after submission
     @Builder.Default
     private boolean prepopulate = false; // whether to bring forward answers from prior completions (if recur is true)
+    @Builder.Default
+    private boolean assignToAllNewEnrollees = true;
 }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeService.java
@@ -250,6 +250,12 @@ public class EnrolleeService extends CrudService<Enrollee, EnrolleeDao> {
         logger.info("Updated enrollee consent status: enrollee: {}, consented {}", enrolleeId, consented);
     }
 
+    public List<Enrollee> findUnassignedToTask(UUID studyEnvironmentId,
+                                     String targetStableId,
+                                     Integer targetAssignedVersion) {
+        return dao.findUnassignedToTask(studyEnvironmentId, targetStableId, targetAssignedVersion);
+    }
+
     /** It's possible there are snazzier ways to get postgres to generate this for us,
      * but for now, just keep trying strings until we get a unique one
      * returns null if we couldn't generate one.

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/PortalParticipantUserService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/PortalParticipantUserService.java
@@ -88,6 +88,10 @@ public class PortalParticipantUserService extends ImmutableEntityService<PortalP
                 new IllegalStateException("No portal participant user found for enrollee %s".formatted(enrollee.getShortcode())));
     }
 
+    public List<PortalParticipantUser> findByProfileIds(List<UUID> profileIds) {
+        return dao.findByProfileIds(profileIds);
+    }
+
     @Override @Transactional
     public void delete(UUID portalParticipantUserId, Set<CascadeProperty> cascades) {
         PortalParticipantUser ppUser = dao.find(portalParticipantUserId).get();

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/ParticipantTaskAssignDto.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/ParticipantTaskAssignDto.java
@@ -1,0 +1,22 @@
+package bio.terra.pearl.core.service.workflow;
+
+import bio.terra.pearl.core.model.workflow.TaskType;
+
+import java.util.List;
+import java.util.UUID;
+
+public record ParticipantTaskAssignDto (
+        TaskType taskType,
+        String targetStableId,
+        int targetAssignedVersion,
+        List<UUID> enrolleeIds,
+        // if true, the enrolleeIds list will be ignored and tasks will be assigned to all enrollees
+        // not already having the task in the duplicate window
+        boolean assignAllUnassigned,
+        // if true, the tasks will be assigned regardless of any rules on the tasks -- this allows
+        // study staff to override duplication or other criteria on the tasks themselves.
+        // obviously, this should be used with caution
+        boolean overrideEligibility
+) {}
+
+

--- a/core/src/main/resources/db/changelog/changesets/2024_02_04_add_survey_assign.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_02_04_add_survey_assign.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: "add_survey_assign"
+      author: dbush
+      changes:
+        - addColumn:
+            tableName: survey
+            columns:
+              - column: { name: assign_to_all_new_enrollees, type: boolean, defaultValueBoolean: true,
+                constraints: { nullable: false }
+              }

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -185,6 +185,9 @@ databaseChangeLog:
   - include:
       file: changesets/2024_01_25_system_audit.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2024_02_04_add_survey_assign.yaml
+      relativeToChangelogFile: true
 
 
 

--- a/core/src/test/java/bio/terra/pearl/core/dao/BaseJdbiDaoTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/BaseJdbiDaoTests.java
@@ -25,10 +25,7 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.*;
 
 public class BaseJdbiDaoTests extends BaseSpringBootTest {
     /** we use the portalDao to test base capability since it doesn't have any required foreign keys */
@@ -141,5 +138,25 @@ public class BaseJdbiDaoTests extends BaseSpringBootTest {
 
         // Assert
         assertThat(foundPortals, contains(portal1, portal2));
+    }
+
+    @Test
+    @Transactional
+    public void testFindByPropertyCollectionPreserveOrder(TestInfo testInfo) {
+        Portal portalA = portalDao.create(portalFactory.builder(getTestName(testInfo)).shortcode("A_Portal").build());
+        Portal portalB = portalDao.create(portalFactory.builder(getTestName(testInfo)).shortcode("B_Portal").build());
+        Portal portalC = portalDao.create(portalFactory.builder(getTestName(testInfo)).shortcode("C_Portal").build());
+
+        List<String> shortcodeList = List.of("A_Portal","B_Portal","C_Portal");
+        List<Portal> portals = portalDao.findAllByPropertyCollectionPreserveOrder("shortcode", shortcodeList);
+        assertThat(portals.stream().map(Portal::getShortcode).toList(), equalTo(shortcodeList));
+
+        shortcodeList = List.of("C_Portal","B_Portal", "A_Portal");
+        portals = portalDao.findAllByPropertyCollectionPreserveOrder("shortcode", shortcodeList);
+        assertThat(portals.stream().map(Portal::getShortcode).toList(), equalTo(shortcodeList));
+
+        shortcodeList = List.of("B_Portal", "A_Portal");
+        portals = portalDao.findAllByPropertyCollectionPreserveOrder("shortcode", shortcodeList);
+        assertThat(portals.stream().map(Portal::getShortcode).toList(), equalTo(shortcodeList));
     }
 }

--- a/core/src/test/java/bio/terra/pearl/core/dao/metrics/MetricsDaoTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/metrics/MetricsDaoTest.java
@@ -102,12 +102,12 @@ public class MetricsDaoTest extends BaseSpringBootTest {
       PortalParticipantUser ppUser2 = portalParticipantUserFactory.buildPersisted(getTestName(info), enrollee2, portalEnv);
     Enrollee enrollee3 = enrolleeFactory.buildPersisted(getTestName(info), studyEnv);
       PortalParticipantUser ppUser3 = portalParticipantUserFactory.buildPersisted(getTestName(info), enrollee3, portalEnv);
-      ParticipantTask task = surveyTaskDispatcher.buildTask(studyEnvSurvey, studyEnvSurvey.getSurvey(), enrollee1, ppUser1);
+      ParticipantTask task = surveyTaskDispatcher.buildTask( enrollee1, ppUser1, studyEnvSurvey, studyEnvSurvey.getSurvey());
     task.setStatus(TaskStatus.COMPLETE);
       DataAuditInfo auditInfo = getAuditInfo(info);
     participantTaskService.create(task, auditInfo);
-    participantTaskService.create(surveyTaskDispatcher.buildTask(studyEnvSurvey, studyEnvSurvey.getSurvey(), enrollee2, ppUser2), auditInfo);
-    ParticipantTask taskToUpdate = participantTaskService.create(surveyTaskDispatcher.buildTask(studyEnvSurvey, studyEnvSurvey.getSurvey(), enrollee3, ppUser3), auditInfo);
+    participantTaskService.create(surveyTaskDispatcher.buildTask(enrollee2, ppUser2, studyEnvSurvey, studyEnvSurvey.getSurvey()), auditInfo);
+    ParticipantTask taskToUpdate = participantTaskService.create(surveyTaskDispatcher.buildTask(enrollee3, ppUser3, studyEnvSurvey, studyEnvSurvey.getSurvey()), auditInfo);
 
       List<BasicMetricDatum> rangeMetrics = metricsDao.studyRequiredSurveyCompletions(studyEnv.getId(), new TimeRange(null, null));
     assertThat(rangeMetrics, hasSize(1));

--- a/core/src/test/java/bio/terra/pearl/core/dao/participant/EnrolleeDaoTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/participant/EnrolleeDaoTests.java
@@ -1,0 +1,97 @@
+package bio.terra.pearl.core.dao.participant;
+
+import bio.terra.pearl.core.BaseSpringBootTest;
+import bio.terra.pearl.core.dao.workflow.ParticipantTaskDao;
+import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
+import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
+import bio.terra.pearl.core.factory.participant.ParticipantTaskFactory;
+import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.study.StudyEnvironment;
+import bio.terra.pearl.core.model.workflow.ParticipantTask;
+import bio.terra.pearl.core.model.workflow.TaskStatus;
+import bio.terra.pearl.core.model.workflow.TaskType;
+import org.checkerframework.checker.units.qual.A;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+
+public class EnrolleeDaoTests extends BaseSpringBootTest {
+    @Autowired
+    private StudyEnvironmentFactory studyEnvironmentFactory;
+    @Autowired
+    private EnrolleeFactory enrolleeFactory;
+    @Autowired
+    private ParticipantTaskFactory participantTaskFactory;
+    @Autowired
+    private EnrolleeDao enrolleeDao;
+
+    @Test
+    @Transactional
+    public void testFindUnassignedToTask(TestInfo testInfo) {
+        String TASK_STABLE_ID = "testFindUnassignedToTask";
+        // set up a sandbox and irb environment, with 2 enrollees in each
+        StudyEnvironmentFactory.StudyEnvironmentBundle sandboxBundle = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.sandbox);
+        EnrolleeFactory.EnrolleeBundle sandbox1 = enrolleeFactory.buildWithPortalUser(getTestName(testInfo), sandboxBundle.getPortalEnv(), sandboxBundle.getStudyEnv());
+        EnrolleeFactory.EnrolleeBundle sandbox2 = enrolleeFactory.buildWithPortalUser(getTestName(testInfo), sandboxBundle.getPortalEnv(), sandboxBundle.getStudyEnv());
+
+        StudyEnvironmentFactory.StudyEnvironmentBundle irbBundle = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.irb);
+        EnrolleeFactory.EnrolleeBundle irb1 = enrolleeFactory.buildWithPortalUser(getTestName(testInfo), irbBundle.getPortalEnv(), irbBundle.getStudyEnv());
+        EnrolleeFactory.EnrolleeBundle irb2 = enrolleeFactory.buildWithPortalUser(getTestName(testInfo), irbBundle.getPortalEnv(), irbBundle.getStudyEnv());
+
+        // returns both enrollees if no one is assigned any tasks
+        List<Enrollee> unassignedEnrollees = enrolleeDao.findUnassignedToTask(sandboxBundle.getStudyEnv().getId(), TASK_STABLE_ID, null);
+        assertThat(unassignedEnrollees, containsInAnyOrder(sandbox1.enrollee(), sandbox2.enrollee()));
+
+        // still returns no enrollees if someone from another environment is assigned
+        participantTaskFactory.buildPersisted(irb1, TASK_STABLE_ID, TaskStatus.NEW, TaskType.SURVEY);
+        unassignedEnrollees = enrolleeDao.findUnassignedToTask(sandboxBundle.getStudyEnv().getId(), TASK_STABLE_ID, null);
+        assertThat(unassignedEnrollees, containsInAnyOrder(sandbox1.enrollee(), sandbox2.enrollee()));
+
+        // returns the unassigned on if the other one is assigned
+        participantTaskFactory.buildPersisted(sandbox2, TASK_STABLE_ID, TaskStatus.NEW, TaskType.SURVEY);
+        unassignedEnrollees = enrolleeDao.findUnassignedToTask(sandboxBundle.getStudyEnv().getId(), TASK_STABLE_ID, null);
+        assertThat(unassignedEnrollees, containsInAnyOrder(sandbox1.enrollee()));
+
+        // returns empty if both are assigned
+        participantTaskFactory.buildPersisted(sandbox1, TASK_STABLE_ID, TaskStatus.NEW, TaskType.SURVEY);
+        unassignedEnrollees = enrolleeDao.findUnassignedToTask(sandboxBundle.getStudyEnv().getId(), TASK_STABLE_ID, null);
+        assertThat(unassignedEnrollees, hasSize(0));
+
+        // returns both for an unrelated task
+        unassignedEnrollees = enrolleeDao.findUnassignedToTask(sandboxBundle.getStudyEnv().getId(), "otherTask", null);
+        assertThat(unassignedEnrollees, containsInAnyOrder(sandbox1.enrollee(), sandbox2.enrollee()));
+    }
+
+    @Test
+    @Transactional
+    public void testFindUnassignedToTaskByVersion(TestInfo testInfo) {
+        String TASK_STABLE_ID = "testFindUnassignedToTaskByVersion";
+        // set up a sandbox and irb environment, with 2 enrollees in each
+        StudyEnvironmentFactory.StudyEnvironmentBundle sandboxBundle = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.sandbox);
+        EnrolleeFactory.EnrolleeBundle sandbox1 = enrolleeFactory.buildWithPortalUser(getTestName(testInfo), sandboxBundle.getPortalEnv(), sandboxBundle.getStudyEnv());
+        EnrolleeFactory.EnrolleeBundle sandbox2 = enrolleeFactory.buildWithPortalUser(getTestName(testInfo), sandboxBundle.getPortalEnv(), sandboxBundle.getStudyEnv());
+
+        // give the first enrollee v1 of the task, and the second enrollee v2
+        participantTaskFactory.buildPersisted(sandbox1, ParticipantTaskFactory.DEFAULT_BUILDER
+                .targetStableId(TASK_STABLE_ID)
+                .targetAssignedVersion(1));
+        participantTaskFactory.buildPersisted(sandbox2, ParticipantTaskFactory.DEFAULT_BUILDER
+                .targetStableId(TASK_STABLE_ID)
+                .targetAssignedVersion(2));
+
+        // returns neither if null version specified
+        List<Enrollee> unassignedEnrollees = enrolleeDao.findUnassignedToTask(sandboxBundle.getStudyEnv().getId(), TASK_STABLE_ID, null);
+        assertThat(unassignedEnrollees, hasSize(0));
+        // returns that enrollee1 has not been assigned version 2 of the task
+        unassignedEnrollees = enrolleeDao.findUnassignedToTask(sandboxBundle.getStudyEnv().getId(), TASK_STABLE_ID, 2);
+        assertThat(unassignedEnrollees, containsInAnyOrder(sandbox1.enrollee()));
+    }
+}

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
@@ -166,7 +166,7 @@ public class SurveyResponseServiceTests extends BaseSpringBootTest {
         Survey survey = surveyFactory.buildPersisted(testName);
         StudyEnvironmentSurvey configuredSurvey = surveyFactory.attachToEnv(survey, enrolleeBundle.enrollee().getStudyEnvironmentId(), true);
 
-        ParticipantTask task = surveyTaskDispatcher.buildTask(configuredSurvey, survey, enrolleeBundle.enrollee(), enrolleeBundle.portalParticipantUser());
+        ParticipantTask task = surveyTaskDispatcher.buildTask(enrolleeBundle.enrollee(), enrolleeBundle.portalParticipantUser(), configuredSurvey, survey);
         task = participantTaskService.create(task, getAuditInfo(testInfo));
         assertThat(task.getStatus(), equalTo(TaskStatus.NEW));
 
@@ -216,7 +216,7 @@ public class SurveyResponseServiceTests extends BaseSpringBootTest {
         Survey survey = surveyFactory.buildPersisted(testName);
         StudyEnvironmentSurvey configuredSurvey = surveyFactory.attachToEnv(survey, enrolleeBundle.enrollee().getStudyEnvironmentId(), true);
 
-        ParticipantTask task = surveyTaskDispatcher.buildTask(configuredSurvey, survey, enrolleeBundle.enrollee(), enrolleeBundle.portalParticipantUser());
+        ParticipantTask task = surveyTaskDispatcher.buildTask(enrolleeBundle.enrollee(), enrolleeBundle.portalParticipantUser(), configuredSurvey, survey);
         task = participantTaskService.create(task, getAuditInfo(testInfo));
         assertThat(task.getStatus(), equalTo(TaskStatus.NEW));
 

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
@@ -1,5 +1,7 @@
 package bio.terra.pearl.core.service.survey;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -7,13 +9,40 @@ import java.util.List;
 import java.util.Set;
 
 import bio.terra.pearl.core.BaseSpringBootTest;
+import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
+import bio.terra.pearl.core.factory.admin.AdminUserFactory;
+import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
+import bio.terra.pearl.core.factory.participant.ParticipantTaskFactory;
+import bio.terra.pearl.core.factory.survey.SurveyFactory;
+import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
+import bio.terra.pearl.core.model.workflow.TaskStatus;
 import bio.terra.pearl.core.model.workflow.TaskType;
+import bio.terra.pearl.core.service.workflow.ParticipantTaskAssignDto;
+import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 class SurveyTaskDispatcherTest extends BaseSpringBootTest {
+    @Autowired
+    private SurveyFactory surveyFactory;
+    @Autowired
+    private EnrolleeFactory enrolleeFactory;
+    @Autowired
+    private StudyEnvironmentFactory studyEnvironmentFactory;
+    @Autowired
+    private ParticipantTaskFactory participantTaskFactory;
+    @Autowired
+    private ParticipantTaskService participantTaskService;
+    @Autowired
+    private SurveyTaskDispatcher surveyTaskDispatcher;
+    @Autowired
+    private AdminUserFactory adminUserFactory;
 
     @Test
     void testIsDuplicateTask() {
@@ -65,4 +94,51 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
                 existingTasks);
         assertTrue(isDuplicate);
     }
+
+    @Test
+    @Transactional
+    public void testAssign(TestInfo testInfo) {
+        StudyEnvironmentFactory.StudyEnvironmentBundle sandboxBundle = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.sandbox);
+        AdminUser operator = adminUserFactory.buildPersisted(getTestName(testInfo), true);
+        EnrolleeFactory.EnrolleeBundle sandbox1 = enrolleeFactory.buildWithPortalUser(getTestName(testInfo), sandboxBundle.getPortalEnv(), sandboxBundle.getStudyEnv());
+        EnrolleeFactory.EnrolleeBundle sandbox2 = enrolleeFactory.buildWithPortalUser(getTestName(testInfo), sandboxBundle.getPortalEnv(), sandboxBundle.getStudyEnv());
+        Survey survey = surveyFactory.buildPersisted(getTestName(testInfo));
+        surveyFactory.attachToEnv(survey, sandboxBundle.getStudyEnv().getId(), true);
+        ParticipantTaskAssignDto assignDto = new ParticipantTaskAssignDto(TaskType.SURVEY, survey.getStableId(), survey.getVersion(), null, true, true );
+        surveyTaskDispatcher.assign(assignDto, sandboxBundle.getStudyEnv().getId(), operator);
+        List<ParticipantTask> participantTasks = participantTaskService.findTasksByStudyAndTarget(sandboxBundle.getStudyEnv().getId(), List.of(survey.getStableId()));
+        assertThat(participantTasks, hasSize(2));
+    }
+
+    @Test
+    @Transactional
+    public void testAssignDoesntDuplicate(TestInfo testInfo) {
+        StudyEnvironmentFactory.StudyEnvironmentBundle sandboxBundle = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.sandbox);
+        AdminUser operator = adminUserFactory.buildPersisted(getTestName(testInfo), true);
+        EnrolleeFactory.EnrolleeBundle sandbox1 = enrolleeFactory.buildWithPortalUser(getTestName(testInfo), sandboxBundle.getPortalEnv(), sandboxBundle.getStudyEnv());
+        Survey survey = surveyFactory.buildPersisted(getTestName(testInfo));
+        surveyFactory.attachToEnv(survey, sandboxBundle.getStudyEnv().getId(), true);
+        // the enrollee already has a task
+        participantTaskFactory.buildPersisted(sandbox1, ParticipantTaskFactory.DEFAULT_BUILDER
+                .targetStableId(survey.getStableId()).targetAssignedVersion(survey.getVersion()));
+
+        // shouldn't create a duplicate task if directed to assign to all unassigned
+        ParticipantTaskAssignDto assignDto = new ParticipantTaskAssignDto(TaskType.SURVEY, survey.getStableId(), survey.getVersion(), null, true, false );
+        surveyTaskDispatcher.assign(assignDto, sandboxBundle.getStudyEnv().getId(), operator);
+        List<ParticipantTask> participantTasks = participantTaskService.findTasksByStudyAndTarget(sandboxBundle.getStudyEnv().getId(), List.of(survey.getStableId()));
+        assertThat(participantTasks, hasSize(1));
+
+        // shouldn't create a duplicate task even if the enrolleeId is provided manually, since eligibility override is false
+        assignDto = new ParticipantTaskAssignDto(TaskType.SURVEY, survey.getStableId(), survey.getVersion(), List.of(sandbox1.enrollee().getId()), false, false );
+        surveyTaskDispatcher.assign(assignDto, sandboxBundle.getStudyEnv().getId(), operator);
+        participantTasks = participantTaskService.findTasksByStudyAndTarget(sandboxBundle.getStudyEnv().getId(), List.of(survey.getStableId()));
+        assertThat(participantTasks, hasSize(1));
+
+        // if overriding eligibility is specified, then a duplicate task should be created
+        assignDto = new ParticipantTaskAssignDto(TaskType.SURVEY, survey.getStableId(), survey.getVersion(), List.of(sandbox1.enrollee().getId()), false, true );
+        surveyTaskDispatcher.assign(assignDto, sandboxBundle.getStudyEnv().getId(), operator);
+        participantTasks = participantTaskService.findTasksByStudyAndTarget(sandboxBundle.getStudyEnv().getId(), List.of(survey.getStableId()));
+        assertThat(participantTasks, hasSize(2));
+    }
+
 }

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
@@ -12,7 +12,8 @@
     "surveys/basic.json",
     "surveys/socialHealth.json",
     "surveys/socialHealthV2.json",
-    "surveys/socialHealthV3.json"
+    "surveys/socialHealthV3.json",
+    "surveys/sandboxSurvey.json"
   ],
   "consentFormFiles": [
     "surveys/ourHealthConsent.json"
@@ -47,7 +48,8 @@
         {"populateFileName": "surveys/phq9gad7.json"},
         {"populateFileName": "surveys/socialHealth.json", "active": false},
         {"populateFileName": "surveys/socialHealthV2.json", "active": false},
-        {"populateFileName": "surveys/socialHealthV3.json"}
+        {"populateFileName": "surveys/socialHealthV3.json"},
+        {"populateFileName": "surveys/sandboxSurvey.json"}
       ],
       "configuredConsentDtos": [
         {

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/sandboxSurvey.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/sandboxSurvey.json
@@ -1,0 +1,49 @@
+{
+  "stableId": "hd_hd_sandbox",
+  "version": 1,
+  "name": "Sandbox survey",
+  "assignToAllNewEnrollees": false,
+  "jsonContent": {
+    "showQuestionNumbers": "off",
+    "showProgressBar": "bottom",
+    "pages": [
+      {
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "name": "hd_hd_sandbox_intro",
+                "type": "html",
+                "html": "<p>This is a draft survey that is only in the sandbox environment initially.  It's not assigned by default so that it can simulate a freshly created survey</p>"
+              }
+            ]
+          },
+          {
+            "name": "hd_hd_sandbox_colorChoid",
+            "type": "radiogroup",
+            "title": "What color is your parachute?",
+            "choices": [
+              {
+                "text": "Red",
+                "value": "red"
+              },
+              {
+                "text": "Green",
+                "value": "green"
+              },
+              {
+                "text": "Blue",
+                "value": "blue"
+              },
+              {
+                "text": "Clear",
+                "value": "clear"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/populate/src/test/java/bio/terra/pearl/populate/extract/PortalExtractTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/extract/PortalExtractTest.java
@@ -47,7 +47,7 @@ public class PortalExtractTest extends BasePopulatePortalsTest {
         Portal restoredPortal = portalPopulator.populateFromZipFile(zis, true);
 
         // confirm all templates got repopulated
-        assertThat(surveyService.findByPortalId(restoredPortal.getId()), hasSize(11));
+        assertThat(surveyService.findByPortalId(restoredPortal.getId()), hasSize(12));
         assertThat(studyService.findByPortalId(restoredPortal.getId()), hasSize(1));
         assertThat(consentFormService.findByPortalId(restoredPortal.getId()), hasSize(1));
         assertThat(emailTemplateService.findByPortalId(restoredPortal.getId()), hasSize(5));

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -3,7 +3,7 @@ import {
   ConsentForm,
   ConsentResponse, EnvironmentName,
   ParticipantDashboardAlert,
-  ParticipantTask,
+  ParticipantTask, ParticipantTaskType,
   Portal,
   PortalEnvironment,
   PortalEnvironmentConfig,
@@ -378,6 +378,16 @@ export type ParticipantTaskUpdateDto = {
   updateAll: boolean // if true, the portalParticipantUserIds list will be ignored and all participants will be updated
 }
 
+export type ParticipantTaskAssignDto = {
+  taskType: ParticipantTaskType
+  targetStableId: string
+  targetAssignedVersion: number
+  enrolleeIds?: string[]
+  // if true, the enrolleeIds list will be ignored and tasks will be assigned to all enrollees
+  // not already having the task in the duplicate window
+  assignAllUnassigned: boolean
+}
+
 export type TaskUpdateSpec ={
     targetStableId: string
     updateToVersion: number
@@ -717,13 +727,24 @@ export default {
     return await this.processJsonResponse(response)
   },
 
-  async updateParticipantTaskVersions(portalShortcode: string, studyShortcode: string,
-    envName: string, update: ParticipantTaskUpdateDto): Promise<ParticipantTask[]> {
-    const url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/participantTasks/updateAll`
+  async updateParticipantTaskVersions(studyEnvParams: StudyEnvParams,
+    update: ParticipantTaskUpdateDto): Promise<ParticipantTask[]> {
+    const url = `${baseStudyEnvUrlFromParams(studyEnvParams)}/participantTasks/updateAll`
     const response = await fetch(url, {
       method: 'POST',
       headers: this.getInitHeaders(),
       body: JSON.stringify(update)
+    })
+    return await this.processJsonResponse(response)
+  },
+
+  async assignParticipantTasksToEnrollees(studyEnvParams: StudyEnvParams,
+    assignDto: ParticipantTaskAssignDto): Promise<ParticipantTask[]> {
+    const url = `${baseStudyEnvUrlFromParams(studyEnvParams)}/participantTasks/assignToEnrollees`
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: this.getInitHeaders(),
+      body: JSON.stringify(assignDto)
     })
     return await this.processJsonResponse(response)
   },

--- a/ui-admin/src/portal/MailingListView.tsx
+++ b/ui-admin/src/portal/MailingListView.tsx
@@ -65,8 +65,7 @@ export default function MailingListView({ portalContext, portalEnv }:
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
-    onRowSelectionChange: setRowSelection,
-    debugTable: true
+    onRowSelectionChange: setRowSelection
   })
 
   /** download selected contacts as a csv */

--- a/ui-admin/src/study/participants/DataChangeRecords.tsx
+++ b/ui-admin/src/study/participants/DataChangeRecords.tsx
@@ -87,8 +87,7 @@ export default function DataChangeRecords({ enrollee, studyEnvContext }:
     enableRowSelection: true,
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    debugTable: true
+    getSortedRowModel: getSortedRowModel()
   })
 
 

--- a/ui-admin/src/study/participants/datarepo/DatasetDashboard.tsx
+++ b/ui-admin/src/study/participants/datarepo/DatasetDashboard.tsx
@@ -65,8 +65,7 @@ const DatasetDashboard = ({ studyEnvContext }: {studyEnvContext: StudyEnvContext
     },
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    debugTable: true
+    getSortedRowModel: getSortedRowModel()
   })
 
   const contentHeaderStyle = {

--- a/ui-admin/src/study/participants/enrolleeView/ParticipantTaskView.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/ParticipantTaskView.tsx
@@ -51,8 +51,7 @@ const ParticipantTaskView = ({ enrollee }: {enrollee: Enrollee}) => {
     onSortingChange: setSorting,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
-    onRowSelectionChange: setRowSelection,
-    debugTable: true
+    onRowSelectionChange: setRowSelection
   })
 
   return <div className="container p-3">

--- a/ui-admin/src/study/surveys/FormOptions.tsx
+++ b/ui-admin/src/study/surveys/FormOptions.tsx
@@ -58,6 +58,13 @@ export default function FormOptions({
               })}
             /> Required
           </label>
+          <label className="form-label d-block">
+            <input type="checkbox" checked={(workingForm as Survey).assignToAllNewEnrollees}
+              onChange={e => updateWorkingForm({
+                ...workingForm, assignToAllNewEnrollees: e.target.checked
+              })}
+            /> Auto-assign to new participants
+          </label>
           <div className="fw-light fst-italic">
             Note that you need to  &quot;Save&quot; the survey
             for any changes to options to take effect.

--- a/ui-admin/src/study/surveys/SurveyEnvironmentDetailModal.tsx
+++ b/ui-admin/src/study/surveys/SurveyEnvironmentDetailModal.tsx
@@ -78,8 +78,7 @@ export default function SurveyEnvironmentDetailModal(props: SurveyEnvironmentDet
     columns,
     enableRowSelection: true,
     getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    debugTable: true
+    getSortedRowModel: getSortedRowModel()
   })
 
   const assignSurveyTasks = () => {

--- a/ui-admin/src/study/surveys/SurveyEnvironmentDetailModal.tsx
+++ b/ui-admin/src/study/surveys/SurveyEnvironmentDetailModal.tsx
@@ -125,7 +125,7 @@ export default function SurveyEnvironmentDetailModal(props: SurveyEnvironmentDet
           { basicTableLayout(table, { tableClass: 'table table-striped align-middle' })}
           <div className="d-flex">
             <Button variant="secondary" outline={true} onClick={assignSurveyTasks}>
-            Assign to all
+            Assign to {studyEnvParams.envName} participants
             </Button>
             <InfoPopup content={`Assign ${surveyName} to all participants in the ${studyEnvParams.envName} 
               environment who are eligible.`}/>

--- a/ui-admin/src/study/surveys/SurveyEnvironmentDetailModal.tsx
+++ b/ui-admin/src/study/surveys/SurveyEnvironmentDetailModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import Modal from 'react-bootstrap/Modal'
 import LoadingSpinner from 'util/LoadingSpinner'
 import { ParticipantTask, StudyEnvironmentSurvey } from '@juniper/ui-core'
@@ -6,10 +6,12 @@ import { instantToDateString } from 'util/timeUtils'
 import { doApiLoad, useLoadingEffect } from 'api/api-utils'
 import { StudyEnvParams } from '../StudyEnvironmentRouter'
 import Api, { ParticipantTaskUpdateDto } from 'api/api'
-import { Button } from '../../components/forms/Button'
-import InfoPopup from '../../components/forms/InfoPopup'
-import { successNotification } from '../../util/notifications'
+import { Button } from 'components/forms/Button'
+import { successNotification } from 'util/notifications'
 import { Store } from 'react-notifications-component'
+import { ColumnDef, getCoreRowModel, getSortedRowModel, useReactTable } from '@tanstack/react-table'
+import InfoPopup from 'components/forms/InfoPopup'
+import { basicTableLayout } from 'util/tableUtils'
 
 export type SurveyEnvironmentDetailModalProps = {
   studyEnvParams: StudyEnvParams
@@ -24,6 +26,7 @@ export default function SurveyEnvironmentDetailModal(props: SurveyEnvironmentDet
   const { onDismiss, stableId, studyEnvParams  } = props
   const [configuredSurveys, setConfiguredSurveys] = useState<StudyEnvironmentSurvey[]>([])
   const [participantTasks, setParticipantTasks] = useState<ParticipantTask[]>([])
+
   const { isLoading, reload } = useLoadingEffect(async () => {
     const configsResponse = await Api.findConfiguredSurveys(studyEnvParams.portalShortcode,
       studyEnvParams.studyShortcode,
@@ -37,6 +40,61 @@ export default function SurveyEnvironmentDetailModal(props: SurveyEnvironmentDet
 
   const mostRecentVersion = configuredSurveys[configuredSurveys.length - 1]?.survey?.version
 
+  const columns = useMemo((): ColumnDef<StudyEnvironmentSurvey>[] => {
+    return [{
+      id: 'versionName',
+      header: '',
+      cell: ({ row }) => row.original.survey.version
+    }, {
+      id: 'launchDate',
+      header: 'Launch date',
+      cell: ({ row }) => instantToDateString(row.original.createdAt)
+    }, {
+      id: 'numParticipants',
+      header: '# participants currently assigned',
+      cell: ({ row }) => participantTasks
+        .filter(task => task.targetAssignedVersion === row.original.survey.version).length
+    }, {
+      id: 'actions',
+      header: '',
+      cell: ({ row }) => <>
+        { (hasParticipantsOnOldVersions && row.original.survey.version === mostRecentVersion) &&
+          <span className="ms-4">
+            <Button variant="secondary" outline={true} onClick={updateAllTasks}>
+              Update all to version {mostRecentVersion}
+            </Button>
+            <InfoPopup content={`Update all participants in the ${studyEnvParams.envName} 
+            environment to have the latest version of this form.  
+            This means when they revisit, they will see the latest version, with any prior
+            answers already filled-in`}/>
+          </span>
+        }
+      </>
+    }]
+  }, [stableId, participantTasks.length])
+
+  const table = useReactTable({
+    data: configuredSurveys,
+    columns,
+    enableRowSelection: true,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    debugTable: true
+  })
+
+  const assignSurveyTasks = () => {
+    doApiLoad(async () => {
+      const newTasks = await Api.assignParticipantTasksToEnrollees(studyEnvParams, {
+        assignAllUnassigned: true,
+        targetStableId: stableId,
+        targetAssignedVersion: mostRecentVersion,
+        taskType: 'SURVEY'
+      })
+      Store.addNotification(successNotification(`Assigned survey to ${newTasks.length} enrollees`))
+      reload()
+    })
+  }
+
   const updateAllTasks = () => {
     doApiLoad(async () => {
       const updateObj: ParticipantTaskUpdateDto = {
@@ -45,60 +103,34 @@ export default function SurveyEnvironmentDetailModal(props: SurveyEnvironmentDet
           { targetStableId: stableId, updateToVersion: mostRecentVersion }
         ]
       }
-      await Api.updateParticipantTaskVersions(studyEnvParams.portalShortcode,
-        studyEnvParams.studyShortcode,
-        studyEnvParams.envName, updateObj)
+      await Api.updateParticipantTaskVersions(studyEnvParams, updateObj)
       Store.addNotification(successNotification('Task versions updated'))
       reload()
     })
   }
 
+  const surveyName = (configuredSurveys[0] && configuredSurveys[0].survey.name) ?? ''
   const hasParticipantsOnOldVersions = participantTasks.some(task => task.targetAssignedVersion !== mostRecentVersion)
 
-  return <Modal show={true} onHide={onDismiss}>
+  return <Modal show={true} onHide={onDismiss} className="modal-lg">
     <LoadingSpinner isLoading={isLoading}>
       <Modal.Header closeButton>
         <Modal.Title>
           <div>{studyEnvParams.envName}</div>
-          <span className="fst-italic fw-light">{configuredSurveys[0] && configuredSurveys[0].survey.name}</span>
+          <span className="fst-italic fw-light">{surveyName}</span>
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        <table className="table table-striped">
-          <thead>
-            <tr>
-              <td></td>
-              <td>launch date</td>
-              <td># participants<br/> currently assigned</td>
-            </tr>
-          </thead>
-          <tbody>
-            {configuredSurveys.map((config, index) => {
-              const numParticipants = participantTasks
-                .filter(task => task.targetAssignedVersion === config.survey.version).length
-              const isLastRow = config.survey.version === mostRecentVersion
-              return <tr key={index}>
-                <td className="align-middle">v{config.survey.version}</td>
-                <td className="align-middle">{ instantToDateString(config.createdAt)}</td>
-                <td className="align-middle">
-                  <span>{ numParticipants }</span>
-                  { (hasParticipantsOnOldVersions && isLastRow) &&
-                    <span className="ms-4">
-                      <Button variant="light" className="border m-1"
-                        onClick={updateAllTasks}>
-                    Update all to version {mostRecentVersion}
-                      </Button>
-                      <InfoPopup content={`Update all participants in the ${studyEnvParams.envName} 
-                      environment to have the latest version of this form.  
-                      This means when they revisit, they will see the latest version, with any prior
-                      answers already filled-in`}/>
-                    </span>
-                  }
-                </td>
-              </tr>
-            })}
-          </tbody>
-        </table>
+        <LoadingSpinner isLoading={isLoading}>
+          { basicTableLayout(table, { tableClass: 'table table-striped align-middle' })}
+          <div className="d-flex">
+            <Button variant="secondary" outline={true} onClick={assignSurveyTasks}>
+            Assign to all
+            </Button>
+            <InfoPopup content={`Assign ${surveyName} to all participants in the ${studyEnvParams.envName} 
+              environment who are eligible.`}/>
+          </div>
+        </LoadingSpinner>
       </Modal.Body>
       <Modal.Footer>
         <LoadingSpinner isLoading={isLoading}>

--- a/ui-admin/src/study/surveys/SurveyEnvironmentTable.tsx
+++ b/ui-admin/src/study/surveys/SurveyEnvironmentTable.tsx
@@ -65,8 +65,7 @@ export default function SurveyEnvironmentTable(props: SurveyTableProps) {
     columns,
     enableRowSelection: true,
     getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    debugTable: true
+    getSortedRowModel: getSortedRowModel()
   })
 
   return <div>

--- a/ui-admin/src/study/surveys/SurveyView.tsx
+++ b/ui-admin/src/study/surveys/SurveyView.tsx
@@ -17,8 +17,9 @@ export type SurveyParamsT = StudyParams & {
 }
 
 export type SaveableFormProps = {
-  content: string,
+  content: string
   required?: boolean
+  assignToAllNewEnrollees?: boolean
 }
 
 /** Handles logic for updating study environment surveys */

--- a/ui-admin/src/util/tableUtils.tsx
+++ b/ui-admin/src/util/tableUtils.tsx
@@ -374,7 +374,8 @@ export function DownloadControl<T>({ table, fileName, excludedColumns = ['select
  * such as headers, rows, etc. All configuration properties are optional.
  */
 export type BasicTableConfig = {
-  filterable?: boolean
+  filterable?: boolean,
+  tableClass?: string
 }
 
 /** Default configuration if no `BasicTableConfig` is provided or any of its attributes are not specified. */
@@ -385,7 +386,7 @@ const defaultBasicTableConfig = {
 /** helper function for simple table layouts */
 export function basicTableLayout<T>(table: Table<T>, config: BasicTableConfig = {}) {
   const { filterable } = { ...defaultBasicTableConfig, ...config }
-  return <table className="table table-striped">
+  return <table className={config.tableClass ? config.tableClass : 'table table-striped'}>
     <thead>
       <tr>
         {table.getFlatHeaders().map(header => tableHeader(header, { sortable: true, filterable }))}

--- a/ui-core/src/types/forms.ts
+++ b/ui-core/src/types/forms.ts
@@ -16,6 +16,7 @@ export type Survey = VersionedForm & {
   surveyType: SurveyType
   blurb?: string
   required: boolean
+  assignToAllNewEnrollees: boolean
   recur: boolean
   recurrenceIntervalDays: number
   allowAdminEdit: boolean
@@ -26,6 +27,7 @@ export type Survey = VersionedForm & {
 
 export const defaultSurvey = {
   required: false,
+  assignToAllNewEnrollees: true,
   recur: false,
   recurrenceIntervalDays: 0,
   allowAdminEdit: true,


### PR DESCRIPTION
#### DESCRIPTION
This enables study staff to manually assign a survey to participants in an environment.  For now the UX is just a single "assign to everyone" button, but the API supports more sophisticated operations. The idea is that this will serve as the infrastructure for enabling advanced survey triggers in later work.  
![image](https://github.com/broadinstitute/juniper/assets/2800795/b43f931f-4033-4d4a-9312-efb35a0c9071)

To enable testing, and also because it will be generally useful, a new property has been added to Survey: `assignToAllNewEnrollees`.  This defaults to true.  If false, the survey will not be assigned by default to new participants.  

LATER WORK:
  UX improvements to the survey table around the 'unpublished badge'
  Adding "autoUpdateToLatestVersion" as configurable survey property

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1. redeploy ApiAdminApp
2. repopulate demo
3. go to `https://localhost:3000/demo/studies/heartdemo/env/sandbox/forms`
4. Click on the 'sandbox' version of the Sandbox survey
5. note that no participants are currently assigned to it (the modal should look like the above screenshot)
6. click "Assign..."
7. Confirm the participants were all assigned the sandbox survey
8. enroll. a new participant in demo sandbox.  
9. Confirm they are *not* assigned the sandbox survey


