### PR TITLE
[JN-868] navbar hover styles

### DIFF
--- a/ui-admin/src/App.css
+++ b/ui-admin/src/App.css
@@ -93,3 +93,14 @@ a {
   flex-direction: column;
   flex-grow: 1;
 }
+
+.sidebar-nav-link:hover {
+  background: rgba(255, 255 ,255, 0.3);
+}
+
+.nav-icon {
+  color: #333F53;
+}
+.nav-icon:hover {
+  color: #858D9A;
+}

--- a/ui-admin/src/navbar/AdminNavbar.tsx
+++ b/ui-admin/src/navbar/AdminNavbar.tsx
@@ -18,42 +18,45 @@ function AdminNavbar() {
   }
   return <>
     <nav className="Navbar navbar navbar-expand-lg navbar-light">
-      <div className="collapse navbar-collapse" id="navbarNavDropdown">
-        <ul className="navbar-nav ms-3">
+      <button className="navbar-toggler" type="button" data-bs-toggle="collapse"
+        data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false"
+        aria-label="Toggle navigation">
+        <span className="navbar-toggler-icon"></span>
+      </button>
+      <div className="collapse navbar-collapse" id="navbarSupportedContent">
+        <ul className="navbar-nav ms-lg-3">
           { breadCrumbs.map((crumb, index) => <li key={index}
-            className="ms-2 d-flex align-items-center">
+            className="ms-2 d-flex align-items-center" >
             {crumb} {(index < breadCrumbs.length -1) &&
               <FontAwesomeIcon icon={faChevronRight} className="fa-xs text-muted"/>}
           </li>)}
         </ul>
         <ul className="navbar-nav ms-auto" style={{
           position: 'sticky',
-          right: 0
+          right: 10
         }}>
           <li className="nav-item dropdown">
-            <a className="nav-link" href="#"
-              role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              <FontAwesomeIcon icon={faQuestionCircle} className="fa-2x text-dark" title="help menu"/>
+            <a className="nav-link" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <FontAwesomeIcon icon={faQuestionCircle} className="fa-2x nav-icon" title="help menu"/>
             </a>
             <div className="dropdown-menu dropdown-menu-end p-3">
               <ul className="list-unstyled">
                 <li>
                   <Link className="dropdown-item" to="https://broad-juniper.zendesk.com" target="_blank">
-                    Help pages
+                      Help pages
                   </Link>
                 </li>
                 <li className="pt-2">
                   <a className="dropdown-item" onClick={() => setShowContactModal(!showContactModal)}>
-                    Contact support
+                      Contact support
                   </a>
                 </li>
               </ul>
             </div>
           </li>
           {!currentUser.user.isAnonymous && <li className="nav-item dropdown">
-            <a className="nav-link" href="#"
-              role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              <FontAwesomeIcon icon={faUserCircle} className="fa-2x text-dark" title="user menu"/>
+            <a className="nav-link" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <FontAwesomeIcon icon={faUserCircle} className="fa-2x nav-icon" title="user menu"/>
             </a>
             <div className="dropdown-menu dropdown-menu-end p-3">
               <h3 className="h6">{currentUser.user.username}</h3>

--- a/ui-admin/src/navbar/AdminSidebar.tsx
+++ b/ui-admin/src/navbar/AdminSidebar.tsx
@@ -16,6 +16,7 @@ const ZONE_COLORS: { [index: string]: string } = {
   'prod': '#333F52' // blue (default)
 }
 
+export const sidebarNavLinkClasses = 'text-white p-1 rounded w-100 d-block sidebar-nav-link'
 
 /** renders the left navbar of admin tool */
 const AdminSidebar = ({ config }: { config: Config }) => {
@@ -47,7 +48,7 @@ const AdminSidebar = ({ config }: { config: Config }) => {
     </button>}
     {open && <>
       <div className="d-flex justify-content-between align-items-center">
-        <Link to="/" className="text-white fs-4 ms-2">Juniper</Link>
+        <Link to="/" className="text-white fs-4 px-2 rounded-1 sidebar-nav-link flex-grow-1">Juniper</Link>
         <button onClick={() => setOpen(!open)} title="toggle sidebar" className="btn btn-link text-white">
           <FontAwesomeIcon icon={faArrowLeft}/>
         </button>
@@ -58,7 +59,7 @@ const AdminSidebar = ({ config }: { config: Config }) => {
       {user.superuser && <CollapsableMenu header={'Superuser functions'} content={
         <ul className="list-unstyled">
           <li className="mb-2">
-            <NavLink to="/users" className="text-white">All users</NavLink>
+            <NavLink to="/users" className="text-white w-100">All users</NavLink>
           </li>
           <li className="mb-2">
             <NavLink to="/populate" className="text-white">Populate</NavLink>

--- a/ui-admin/src/navbar/AdminSidebar.tsx
+++ b/ui-admin/src/navbar/AdminSidebar.tsx
@@ -59,13 +59,13 @@ const AdminSidebar = ({ config }: { config: Config }) => {
       {user.superuser && <CollapsableMenu header={'Superuser functions'} content={
         <ul className="list-unstyled">
           <li className="mb-2">
-            <NavLink to="/users" className="text-white w-100">All users</NavLink>
+            <NavLink to="/users" className={sidebarNavLinkClasses}>All users</NavLink>
           </li>
           <li className="mb-2">
-            <NavLink to="/populate" className="text-white">Populate</NavLink>
+            <NavLink to="/populate" className={sidebarNavLinkClasses}>Populate</NavLink>
           </li>
           <li>
-            <NavLink to="/integrations" className="text-white">Integrations</NavLink>
+            <NavLink to="/integrations" className={sidebarNavLinkClasses}>Integrations</NavLink>
           </li>
         </ul>}/>}
     </>}

--- a/ui-admin/src/navbar/StudySidebar.tsx
+++ b/ui-admin/src/navbar/StudySidebar.tsx
@@ -15,6 +15,8 @@ import {
 } from '../study/StudyEnvironmentRouter'
 import CollapsableMenu from './CollapsableMenu'
 import { studyPublishingPath, studyUsersPath } from '../study/StudyRouter'
+import { sidebarNavLinkClasses } from './AdminSidebar'
+
 
 /** shows menu options related to the current study */
 export const StudySidebar = ({ study, portalList, portalShortcode }:
@@ -25,7 +27,7 @@ export const StudySidebar = ({ study, portalList, portalShortcode }:
     navigate(studyParticipantsPath(portalShortcode, studyShortcode, 'live'))
   }
   const navStyleFunc = ({ isActive }: {isActive: boolean}) => {
-    return isActive ? { background: '#567' } : {}
+    return isActive ? { background: 'rgba(255, 255, 255, 0.3)' } : {}
   }
 
   return <div className="pt-3">
@@ -34,67 +36,67 @@ export const StudySidebar = ({ study, portalList, portalShortcode }:
       <CollapsableMenu header={'Research Coordination'} content={<ul className="list-unstyled">
         <li className="mb-2">
           <NavLink to={studyParticipantsPath(portalShortcode, study.shortcode, 'live')}
-            className="text-white p-1 rounded" style={navStyleFunc}>Participant List</NavLink>
+            className={sidebarNavLinkClasses} style={navStyleFunc}>Participant List</NavLink>
         </li>
         <li className="mb-2">
           <NavLink to={studyKitsPath(portalShortcode, study.shortcode, 'live')}
-            className="text-white p-1 rounded" style={navStyleFunc}>Kits</NavLink>
+            className={sidebarNavLinkClasses} style={navStyleFunc}>Kits</NavLink>
         </li>
         <li className="mb-2">
           <NavLink to={adminTasksPath(portalShortcode, study.shortcode, 'live')}
-            className="text-white p-1 rounded" style={navStyleFunc}>Tasks</NavLink>
+            className={sidebarNavLinkClasses} style={navStyleFunc}>Tasks</NavLink>
         </li>
         <li>
           <NavLink to={studyEnvMailingListPath(portalShortcode, study.shortcode, 'live')}
-            className="text-white p-1 rounded" style={navStyleFunc}>Mailing List</NavLink>
+            className={sidebarNavLinkClasses} style={navStyleFunc}>Mailing List</NavLink>
         </li>
       </ul>}/>
       <CollapsableMenu header={'Analytics & Data'} content={<ul className="list-unstyled">
         <li className="mb-2">
           <NavLink to={studyEnvMetricsPath(portalShortcode, study.shortcode, 'live')}
-            className="text-white p-1 rounded" style={navStyleFunc}>Participant Analytics</NavLink>
+            className={sidebarNavLinkClasses} style={navStyleFunc}>Participant Analytics</NavLink>
         </li>
         <li className="mb-2">
           <NavLink to={studyEnvDataBrowserPath(portalShortcode, study.shortcode, 'live')}
-            className="text-white p-1 rounded" style={navStyleFunc}>Data Export</NavLink>
+            className={sidebarNavLinkClasses} style={navStyleFunc}>Data Export</NavLink>
         </li>
         <li>
           <NavLink to={studyEnvDatasetListViewPath(portalShortcode, study.shortcode, 'live')}
-            className="text-white p-1 rounded" style={navStyleFunc}>Terra Data Repo</NavLink>
+            className={sidebarNavLinkClasses} style={navStyleFunc}>Terra Data Repo</NavLink>
         </li>
       </ul>}/>
       <CollapsableMenu header={'Design & Build'} content={<ul className="list-unstyled">
         <li className="mb-2">
           <NavLink to={studyEnvSiteContentPath(portalShortcode, study.shortcode, 'sandbox')}
-            className="text-white p-1 rounded" style={navStyleFunc}>Website</NavLink>
+            className={sidebarNavLinkClasses} style={navStyleFunc}>Website</NavLink>
         </li>
         <li className="mb-2">
           <NavLink to={studyEnvFormsPath(portalShortcode, study.shortcode, 'sandbox')}
-            className="text-white p-1 rounded" style={navStyleFunc}>Forms &amp; Surveys</NavLink>
+            className={sidebarNavLinkClasses} style={navStyleFunc}>Forms &amp; Surveys</NavLink>
         </li>
         <li className="mb-2">
           <NavLink to={studyEnvNotificationsPath(portalShortcode, study.shortcode, 'sandbox')}
-            className="text-white p-1 rounded" style={navStyleFunc}>Emails &amp; Notifications</NavLink>
+            className={sidebarNavLinkClasses} style={navStyleFunc}>Emails &amp; Notifications</NavLink>
         </li>
         <li>
           <NavLink to={studyEnvAlertsPath(portalShortcode, study.shortcode, 'sandbox')}
-            className="text-white p-1 rounded" style={navStyleFunc}>Participant Dashboard</NavLink>
+            className={sidebarNavLinkClasses} style={navStyleFunc}>Participant Dashboard</NavLink>
         </li>
       </ul>}/>
       <CollapsableMenu header={'Publish'} content={<ul className="list-unstyled">
         <li className="mb-2">
           <NavLink to={studyPublishingPath(portalShortcode, study.shortcode)}
-            className="text-white p-1 rounded" style={navStyleFunc}>Publish Content</NavLink>
+            className={sidebarNavLinkClasses} style={navStyleFunc}>Publish Content</NavLink>
         </li>
         <li>
           <NavLink to={studyEnvSiteSettingsPath(portalShortcode, study.shortcode, 'live')}
-            className="text-white p-1 rounded" style={navStyleFunc}>Site Settings</NavLink>
+            className={sidebarNavLinkClasses} style={navStyleFunc}>Site Settings</NavLink>
         </li>
       </ul>}/>
       <CollapsableMenu header={'Administration'} content={<ul className="list-unstyled">
         <li className="mb-2">
           <NavLink to={studyUsersPath(portalShortcode, study.shortcode)}
-            className="text-white p-1 rounded" style={navStyleFunc}>Manage Team</NavLink>
+            className={sidebarNavLinkClasses} style={navStyleFunc}>Manage Team</NavLink>
         </li>
       </ul>}/>
 


### PR DESCRIPTION
#### DESCRIPTION

This adds hover styling to the side navbar links, and also to the user/help links in the top right.   Sidenav styling is now full-width
<img width="305" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/1800f516-d199-48ac-bee2-ed5ac75d9815">

It also (very roughly) fixes the mobile behavior of the top navbar.  Perviously, the navbar would just disappear, now it does the mobile-expected behavior of collapsing to a button that then triggers a dropdown.  The mobile styling of the admin menus is still awful, but at least it's now somewhat functional.
<img width="399" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/5c52db2a-fa02-4e96-ab0e-c3b159884cdc">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to admin tool, click/hover around the nav menus.  

