### PR TITLE
[JN-845] fixing flaky task test

### DIFF
--- a/core/src/test/java/bio/terra/pearl/core/dao/participant/ParticipantTaskDaoTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/participant/ParticipantTaskDaoTests.java
@@ -96,7 +96,7 @@ public class ParticipantTaskDaoTests extends BaseSpringBootTest {
         ParticipantTaskDao.EnrolleeWithTasks enrollee1tasks = enrolleeTasks.stream().filter(et ->
                 et.getEnrolleeId().equals(enrolleeBundle.enrollee().getId())).findFirst().get();
         assertThat(enrollee1tasks.getTaskTargetNames(), hasSize(2));
-        assertThat(enrollee1tasks.getTaskTargetNames(), contains(task1_1.getTargetName(), task1_2.getTargetName()));
+        assertThat(enrollee1tasks.getTaskTargetNames(), containsInAnyOrder(task1_1.getTargetName(), task1_2.getTargetName()));
 
         // Now check that it filters out tasks if there is a recent notification
         Trigger trigger = triggerFactory.buildPersisted(Trigger.builder()


### PR DESCRIPTION
#### DESCRIPTION

The test was inadvertently using an order-specific assertion but the underlying dao method does not guarantee any order in which the enrollees are returned

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. confirm tests pass for this PR  

