### PR TITLE
[JN-868] cleaning up kit tab style

### DIFF
--- a/ui-admin/src/study/kits/KitList.tsx
+++ b/ui-admin/src/study/kits/KitList.tsx
@@ -128,8 +128,8 @@ export default function KitList({ studyEnvContext }: { studyEnvContext: StudyEnv
   })
 
   const tabLinkStyle = ({ isActive }: {isActive: boolean}) => ({
-    borderBottom: isActive ? '2px solid #666': '',
-    background: isActive ? '#ddd' : ''
+    borderBottom: isActive ? '2px solid #708DBC': '',
+    background: isActive ? '#E1E8F7' : ''
   })
 
   const refreshStatuses = async () => {
@@ -145,7 +145,7 @@ export default function KitList({ studyEnvContext }: { studyEnvContext: StudyEnv
 
   return <LoadingSpinner isLoading={isLoading}>
     <div className="container-fluid p-0 mt-2">
-      <div className="d-flex w-100 align-items-center mb-2" style={{ backgroundColor: '#ccc' }}>
+      <div className="d-flex w-100 align-items-center mb-2" style={{ backgroundColor: '#F5F8FF' }}>
         { statusTabs.map(tab => {
           const kits = kitsByTabKey[tab.key] || []
           return <NavLink key={tab.key} to={tab.key} style={tabLinkStyle}>

--- a/ui-admin/src/study/kits/KitsRouter.tsx
+++ b/ui-admin/src/study/kits/KitsRouter.tsx
@@ -17,7 +17,7 @@ export default function KitsRouter({ studyEnvContext }: {studyEnvContext: StudyE
 
   const tabLinkStyle = ({ isActive }: {isActive: boolean}) => ({
     borderBottom: isActive ? '3px solid #333': '',
-    background: isActive ? '#ddd' : ''
+    background: isActive ? '#E1E8F7' : '#F5F8FF'
   })
 
   return <>
@@ -26,7 +26,7 @@ export default function KitsRouter({ studyEnvContext }: {studyEnvContext: StudyE
     </NavBreadcrumb>
     <div className="container-fluid px-4 py-2">
       { renderPageHeader('Kits') }
-      <div className="d-flex w-100 mb-2" style={{ backgroundColor: '#ccc' }}>
+      <div className="d-flex mb-2">
         <NavLink to="eligible" style={tabLinkStyle}>
           <div className="py-3 px-5">
             Eligible for kit


### PR DESCRIPTION
#### DESCRIPTION
Form Erin, this is just improving the styling of the kit page with better colors
<img width="1183" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/99776028-8aa7-4d3b-ae65-28b917525775">



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/kits/requested/created observe the new colors in the heading bars