### PR TITLE
[JN-828] Store viewed language in survey answers [draft]

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalDao.java
@@ -20,7 +20,6 @@ public class PortalDao extends BaseMutableJdbiDao<Portal> {
     private PortalStudyDao portalStudyDao;
     private StudyDao studyDao;
     private PortalAdminUserDao portalAdminUserDao;
-    private PortalLanguageDao portalLanguageDao;
 
     @Override
     protected Class<Portal> getClazz() {
@@ -28,14 +27,12 @@ public class PortalDao extends BaseMutableJdbiDao<Portal> {
     }
 
     public PortalDao(Jdbi jdbi, PortalEnvironmentDao portalEnvironmentDao,
-                     PortalStudyDao portalStudyDao, StudyDao studyDao, PortalAdminUserDao portalAdminUserDao,
-                     PortalLanguageDao portalLanguageDao) {
+                     PortalStudyDao portalStudyDao, StudyDao studyDao, PortalAdminUserDao portalAdminUserDao) {
         super(jdbi);
         this.portalEnvironmentDao = portalEnvironmentDao;
         this.portalStudyDao = portalStudyDao;
         this.studyDao = studyDao;
         this.portalAdminUserDao = portalAdminUserDao;
-        this.portalLanguageDao = portalLanguageDao;
     }
 
     public Optional<Portal> findOneByShortcode(String shortcode) {

--- a/core/src/main/java/bio/terra/pearl/core/dao/survey/AnswerDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/survey/AnswerDao.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.dao.survey;
 
 import bio.terra.pearl.core.dao.BaseMutableJdbiDao;
+import bio.terra.pearl.core.dao.portal.PortalLanguageDao;
 import bio.terra.pearl.core.model.survey.Answer;
 import java.util.ArrayList;
 import java.util.List;
@@ -11,8 +12,10 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class AnswerDao extends BaseMutableJdbiDao<Answer> {
-    public AnswerDao(Jdbi jdbi) {
+    private PortalLanguageDao portalLanguageDao;
+    public AnswerDao(Jdbi jdbi, PortalLanguageDao portalLanguageDao) {
         super(jdbi);
+        this.portalLanguageDao = portalLanguageDao;
     }
 
     @Override
@@ -21,7 +24,7 @@ public class AnswerDao extends BaseMutableJdbiDao<Answer> {
     }
 
     public List<Answer> findByResponse(UUID surveyResponseId) {
-        return findAllByProperty("survey_response_id", surveyResponseId);
+        return findAllByPropertyWithChild("survey_response_id", surveyResponseId, "viewed_language_id", "viewedLanguage", portalLanguageDao);
     }
 
     public void deleteByResponseId(UUID responseId) {
@@ -54,6 +57,6 @@ public class AnswerDao extends BaseMutableJdbiDao<Answer> {
     }
 
     public List<Answer> findByEnrolleeId(UUID enrolleeId) {
-        return findAllByProperty("enrollee_id", enrolleeId);
+        return findAllByPropertyWithChild("enrollee_id", enrolleeId, "viewed_language_id", "viewedLanguage", portalLanguageDao);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/Answer.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/Answer.java
@@ -3,6 +3,7 @@ package bio.terra.pearl.core.model.survey;
 import bio.terra.pearl.core.model.BaseEntity;
 import java.util.Objects;
 import java.util.UUID;
+import bio.terra.pearl.core.model.portal.PortalEnvironmentLanguage;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -26,6 +27,8 @@ public class Answer extends BaseEntity {
     private String surveyStableId;
     private String otherDescription;
     private int surveyVersion;
+    private PortalEnvironmentLanguage viewedLanguage;
+    private UUID viewedLanguageId;
     private AnswerType answerType;
     private String stringValue;
     // objects are stored as JSON strings

--- a/core/src/main/java/bio/terra/pearl/core/service/portal/PortalLanguageService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/portal/PortalLanguageService.java
@@ -15,8 +15,8 @@ public class PortalLanguageService extends ImmutableEntityService<PortalEnvironm
         super(portalLanguageDao);
     }
 
-    public List<PortalEnvironmentLanguage> findByPortalId(UUID portalId) {
-        return dao.findByPortalEnvId(portalId);
+    public List<PortalEnvironmentLanguage> findByPortalEnvId(UUID portalEnvId) {
+        return dao.findByPortalEnvId(portalEnvId);
     }
 
 }

--- a/core/src/main/resources/db/changelog/changesets/2024_02_09_answer_viewed_language.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_02_09_answer_viewed_language.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: add_answer_viewed_lang
+      author: mbemis
+      changes:
+        - addColumn:
+            tableName: answer
+            columns:
+              - column: { name: viewed_language_id, type: uuid, constraints: {
+                nullable: true, foreignKeyName: fk_answer_portal_env_language, references: portal_environment_language(id) }
+              }

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -194,11 +194,14 @@ databaseChangeLog:
   - include:
       file: changesets/2024_02_06_portal_languages.yaml
       relativeToChangelogFile: true
-
-
   - include:
       file: changesets/proxy_data_model.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2024_02_09_answer_viewed_language.yaml
+      relativeToChangelogFile: true
+
+
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements
 # are atomic. When they are grouped in a changeset and one fails the changeset cannot be

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
@@ -52,10 +52,18 @@
       "surveyStableId": "hd_hd_basicInfo",
       "surveyVersion": 1,
       "answerPopDtos": [
-        {"questionStableId": "hd_hd_basic_firstName", "stringValue": "Jonas"},
-        {"questionStableId": "hd_hd_basic_lastName", "stringValue": "Salk"},
-        {"questionStableId": "hd_hd_basic_streetAddress", "stringValue": "123 Walnut Street"},
-        {"questionStableId": "hd_hd_basic_mghPatient", "stringValue": "yes"}
+        {"questionStableId": "hd_hd_basic_firstName", "stringValue": "Jonas", "viewedLanguage": {
+          "languageCode": "en", "languageName": "English"
+        }},
+        {"questionStableId": "hd_hd_basic_lastName", "stringValue": "Salk", "viewedLanguage": {
+          "languageCode": "en", "languageName": "English"
+        }},
+        {"questionStableId": "hd_hd_basic_streetAddress", "stringValue": "123 Walnut Street", "viewedLanguage": {
+          "languageCode": "es", "languageName": "Español"
+        }},
+        {"questionStableId": "hd_hd_basic_mghPatient", "stringValue": "yes", "viewedLanguage": {
+          "languageCode": "es", "languageName": "Español"
+        }}
       ],
       "currentPageNo": 1,
       "complete": true,

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 
-import SurveyFullDataView, { getDisplayValue } from './SurveyFullDataView'
+import SurveyFullDataView, { getDisplayValue, ItemDisplay } from './SurveyFullDataView'
 import { Question } from 'survey-core'
 import { Answer } from '@juniper/ui-core/build/types/forms'
 import { setupRouterTest } from 'test-utils/router-testing-utils'
@@ -79,4 +79,43 @@ test('shows the download/print modal', async () => {
   await userEvent.click(screen.getByText('print/download'))
   expect(screen.getByText('Done')).toBeVisible()
   await waitFor(() => expect(printSpy).toHaveBeenCalledTimes(1))
+})
+
+describe('ItemDisplay', () => {
+  it('renders the language used to answer a question', async () => {
+    const question = { name: 'testQ', text: 'test question', isVisible: true }
+    const answer: Answer = {
+      stringValue: 'test123',
+      questionStableId: 'testQ',
+      surveyVersion: 1,
+      viewedLanguage: { languageName: 'Spanish', languageCode: 'es' }
+    } as Answer
+    const answerMap: Record<string, Answer> = {}
+    answerMap[answer.questionStableId] = answer
+    render(<ItemDisplay
+      question={question as unknown as Question}
+      answerMap={answerMap}
+      surveyVersion={1}
+      showFullQuestions={true}/>)
+
+    expect(screen.getByText('(testQ) (Answered in Spanish)')).toBeInTheDocument()
+  })
+
+  it('renders correctly if a viewedLanguage is not specified', async () => {
+    const question = { name: 'testQ', text: 'test question', isVisible: true }
+    const answer: Answer = {
+      stringValue: 'test123',
+      questionStableId: 'testQ',
+      surveyVersion: 1
+    } as Answer
+    const answerMap: Record<string, Answer> = {}
+    answerMap[answer.questionStableId] = answer
+    render(<ItemDisplay
+      question={question as unknown as Question}
+      answerMap={answerMap}
+      surveyVersion={1}
+      showFullQuestions={true}/>)
+
+    expect(screen.getByText('(testQ)')).toBeInTheDocument()
+  })
 })

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -8,7 +8,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faDownload } from '@fortawesome/free-solid-svg-icons'
 import PrintFormModal from './PrintFormModal'
 import { Link, Route, Routes } from 'react-router-dom'
-import { renderTruncatedText } from '../../../util/pageUtils'
+import { renderTruncatedText } from 'util/pageUtils'
 type SurveyFullDataViewProps = {
   answers: Answer[],
   survey: Survey | ConsentForm,
@@ -79,8 +79,14 @@ type ItemDisplayProps = {
   showFullQuestions: boolean
 }
 
-const ItemDisplay = ({ question, answerMap, surveyVersion, showFullQuestions }: ItemDisplayProps) => {
+/**
+ *
+ */
+export const ItemDisplay = ({
+  question, answerMap, surveyVersion, showFullQuestions
+}: ItemDisplayProps) => {
   const answer = answerMap[question.name]
+  const answerLanguage = answer?.viewedLanguage?.languageName
   const displayValue = getDisplayValue(answer, question)
   let stableIdText = question.name
   if (answer && answer.surveyVersion !== surveyVersion) {
@@ -92,7 +98,9 @@ const ItemDisplay = ({ question, answerMap, surveyVersion, showFullQuestions }: 
   return <>
     <dt className="fw-normal">
       {renderQuestionText(answer, question, showFullQuestions)}
-      <span className="ms-2 fst-italic text-muted">({stableIdText})</span>
+      <span className="ms-2 fst-italic text-muted">
+        ({stableIdText})
+        {answerLanguage ? ` (Answered in ${answerLanguage})` : ''}</span>
     </dt>
     <dl><pre className="fw-bold">{displayValue}</pre></dl>
   </>

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -80,7 +80,8 @@ type ItemDisplayProps = {
 }
 
 /**
- *
+ * Renders a single survey question and its answer,
+ * with stableId and the viewed language (if applicable)
  */
 export const ItemDisplay = ({
   question, answerMap, surveyVersion, showFullQuestions

--- a/ui-core/src/types/forms.ts
+++ b/ui-core/src/types/forms.ts
@@ -1,3 +1,5 @@
+import { PortalEnvironmentLanguage } from './portal'
+
 export type VersionedForm = {
   id: string
   stableId: string
@@ -49,6 +51,7 @@ export type Answer = {
   otherDescription?: string
   surveyStableId?: string
   surveyVersion?: number
+  viewedLanguage?: PortalEnvironmentLanguage
 }
 
 export type FormResponse = {

--- a/ui-participant/src/hub/survey/SurveyView.test.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.test.tsx
@@ -31,7 +31,8 @@ beforeEach(() => {
   (usePortalEnv as jest.Mock).mockReturnValue({
     portal: { name: 'demo' },
     portalEnv: {
-      environmentName: 'sandbox'
+      environmentName: 'sandbox',
+      supportedLanguages: []
     }
   })
 })

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -50,8 +50,8 @@ export function RawSurveyView({
   resumableData: SurveyJsResumeData | null, pager: PageNumberControl, studyShortcode: string, showHeaders?: boolean
 }) {
   const navigate = useNavigate()
-  const { selectedLanguage } = useUser()
-  const { updateEnrollee } = useUser()
+  const { selectedLanguage, updateEnrollee } = useUser()
+  const { portalEnv } = usePortalEnv()
   const prevSave = useRef(resumableData?.data ?? {})
   const lastAutoSaveErrored = useRef(false)
 
@@ -64,7 +64,9 @@ export function RawSurveyView({
     const responseDto = {
       resumeData: getResumeData(surveyModel, enrollee.participantUserId, true),
       enrolleeId: enrollee.id,
-      answers: getUpdatedAnswers(prevSave.current as Record<string, object>, currentModelValues),
+      answers: getUpdatedAnswers(prevSave.current as Record<string, object>,
+        currentModelValues, portalEnv.supportedLanguages.find(l =>
+          l.languageCode === selectedLanguage)),
       creatingParticipantId: enrollee.participantUserId,
       surveyId: form.id,
       complete: true
@@ -96,7 +98,9 @@ export function RawSurveyView({
   /** if the survey has been updated, save the updated answers. */
   const saveDiff = () => {
     const currentModelValues = getDataWithCalculatedValues(surveyModel)
-    const updatedAnswers = getUpdatedAnswers(prevSave.current as Record<string, object>, currentModelValues)
+    const updatedAnswers = getUpdatedAnswers(
+        prevSave.current as Record<string, object>, currentModelValues, portalEnv.supportedLanguages.find(l =>
+          l.languageCode === selectedLanguage))
     if (updatedAnswers.length < 1) {
       // don't bother saving if there are no changes
       return


### PR DESCRIPTION
#### DESCRIPTION

This actually turned out to be a bit trickier than I had realized.

My v0 approach for getting this to work was to just store the languageCode on the Answer instead of storing the entire PortalEnvironmentLanguage, but I wanted to keep a FK to the PortalEnvironmentLanguage instead of just storing a random string (this also makes rendering the language a bit easier in the UI and makes validating the language a bit easier too).

Regardless, either approach runs into an issue with Consent and PreReg response: we store the entire response as a JSON blob instead of an individual list of Answers. We could inject the language information into that (and I was doing so in an earlier commit), but then there's no validation that the language is real and we can't keep any FK reference to the actual language. So this PR only handles Survey responses right now, because there may need to be more refactoring that I hadn't originally anticipated.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

