### PR TITLE
JN-875: initial rule parsing stuff

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'org.liquibase.gradle' version '2.1.0'
     id "java-test-fixtures"
     id 'jacoco'
+    id 'antlr'
 }
 
 group = 'bio.terra.pearl.core'
@@ -18,6 +19,9 @@ repositories {
 }
 
 dependencies {
+    antlr "org.antlr:antlr4:4.9.3"
+    compileOnly "org.antlr:antlr4-runtime:4.9.3"
+
     implementation 'org.springframework.boot:spring-boot-starter:3.1.2'
 	implementation group: 'org.postgresql', name: 'postgresql', version: '42.5.0'
     implementation group: 'org.jdbi', name: 'jdbi3-spring5', version: '3.34.0'
@@ -57,6 +61,18 @@ dependencies {
     testFixturesImplementation 'org.apache.commons:commons-text:1.10.0'
     testFixturesImplementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
 }
+
+generateGrammarSource {
+    maxHeapSize = "128m"
+    arguments += ['-package', 'bio.terra.pearl.core.antlr', '-visitor', '-no-listener']
+}
+compileJava.dependsOn generateGrammarSource
+sourceSets {
+    generated {
+        java.srcDir 'generated-src/antlr/main/'
+    }
+}
+compileJava.source sourceSets.generated.java, sourceSets.main.java
 
 test {
     useJUnitPlatform {

--- a/core/src/main/antlr/bio/terra/pearl/core/antlr/CohortRule.g4
+++ b/core/src/main/antlr/bio/terra/pearl/core/antlr/CohortRule.g4
@@ -1,6 +1,7 @@
 grammar CohortRule;
 
-/** A grammar for parsing rules, designed to be a subset of the SurveyJS rule parsing syntax */
+/** A grammar for parsing rules, designed to be a subset of the SurveyJS rule parsing syntax
+   See https://github.com/surveyjs/survey-library/blob/master/src/expressions/grammar.pegjs */
 
 // Parser rules
 expr: PAR_OPEN expr PAR_CLOSE | term OPERATOR term | expr JOINER expr;

--- a/core/src/main/antlr/bio/terra/pearl/core/antlr/CohortRule.g4
+++ b/core/src/main/antlr/bio/terra/pearl/core/antlr/CohortRule.g4
@@ -1,0 +1,20 @@
+grammar CohortRule;
+
+/** A grammar for parsing rules, designed to be a subset of the SurveyJS rule parsing syntax */
+
+// Parser rules
+expr: PAR_OPEN expr PAR_CLOSE | term OPERATOR term | expr JOINER expr;
+term: NUMBER | STRING | VARIABLE | BOOLEAN;
+
+// Lexer rules
+NUMBER: [0-9]+ ('.' [0-9]+)?;
+STRING: '\'' (~[\\'\r\n])* '\'';
+VARIABLE: '{' (~[\\'\r\n])* '}';
+BOOLEAN: 'true' | 'false';
+WS: [ \t\r\n]+ -> skip;
+OPERATOR: '=' | '!=';
+JOINER: '&&' | '||';
+PAR_OPEN: '(';
+PAR_CLOSE: ')';
+
+

--- a/core/src/test/java/bio/terra/pearl/core/antlr/CohortRuleTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/antlr/CohortRuleTests.java
@@ -1,0 +1,47 @@
+package bio.terra.pearl.core.antlr;
+
+import java.util.List;
+
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.Token;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class CohortRuleTests {
+    @Test
+    public void testBasicLexing() {
+        CohortRuleLexer lexer = new CohortRuleLexer(CharStreams.fromString("{foo} = 'yes'"));
+        List<? extends Token> tokens = lexer.getAllTokens();
+        assertThat(tokens, hasSize(3));
+        assertThat(tokens.stream().map(Token::getText).toList(),
+                contains("{foo}", "=", "'yes'"));
+        assertThat(tokens.stream().map(Token::getType).toList(),
+                contains(CohortRuleLexer.VARIABLE, CohortRuleLexer.OPERATOR, CohortRuleLexer.STRING));
+    }
+
+    @Test
+    public void testBasicParsing() {
+        CohortRuleLexer lexer = new CohortRuleLexer(CharStreams.fromString("{foo} = 'yes'"));
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        CohortRuleParser parser = new CohortRuleParser(tokens);
+        CohortRuleParser.ExprContext exp = parser.expr();
+        assertThat(exp.term(0).getText(), equalTo("{foo}"));
+        assertThat(exp.term(1).getText(), equalTo("'yes'"));
+        assertThat(exp.OPERATOR().getText(), equalTo("="));
+    }
+
+    @Test
+    public void testCompoundParsing() {
+        CohortRuleLexer lexer = new CohortRuleLexer(CharStreams.fromString("{foo} = 'yes' && {bar} = 'no'"));
+        CommonTokenStream tokens = new CommonTokenStream(lexer);
+        CohortRuleParser parser = new CohortRuleParser(tokens);
+        CohortRuleParser.ExprContext exp = parser.expr();
+        assertThat(exp.term().size(), equalTo(0));
+        assertThat(exp.JOINER().getText(), equalTo("&&"));
+        assertThat(exp.expr(0).getText(), equalTo("{foo}='yes'"));
+        assertThat(exp.expr(1).getText(), equalTo("{bar}='no'"));
+    }
+}


### PR DESCRIPTION
#### DESCRIPTION

adding antlr4 -- fun times!  In learning how to do this, I heavily leaned on https://tomassetti.me/antlr-mega-tutorial/.   This PR just adds the antlr dependencies and puts in a very basic rule parser.  it's not used anywhere in the app yet.  Next PRs, in likely order will be:
1. using the visitor to evaluate terms given a trivial context
2. figuring out how to load the context for a participant without having to load every answer they've ever given.
3. updating EnrolleeRuleEvaluator to do some basic evaluation 

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. run the unit tests on your machine, make sure there's nothing woky
4. confirm after you run a gradle build that you can see the generated class "CohortRuleParser"