### PR TITLE
[JN-896] enabling export of matrix question values

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatter.java
@@ -242,7 +242,7 @@ public class SurveyFormatter extends ModuleFormatter<SurveyResponse, ItemFormatt
 
     protected static String formatObjectValue(Answer answer, List<QuestionChoice> choices, boolean stableIdForOptions, ObjectMapper objectMapper) {
         try {
-            // for now, the only object values we support are arrays of strings
+            // for now, the only object values we support explicitly parsing are arrays of strings
             String[] answerArray = objectMapper.readValue(answer.getObjectValue(), String[].class);
             if (stableIdForOptions) {
                 return StringUtils.join(answerArray, ", ");
@@ -250,9 +250,8 @@ public class SurveyFormatter extends ModuleFormatter<SurveyResponse, ItemFormatt
             return Arrays.stream(answerArray).map(ansValue -> formatStringValue(ansValue, choices, stableIdForOptions, answer))
                     .collect(Collectors.joining(", "));
         } catch (Exception e) {
-            log.warn("Error parsing answer object value enrollee: {}, question: {}, answer: {}",
-                    answer.getEnrolleeId(), answer.getQuestionStableId(), answer.getId());
-            return "<PARSE ERROR>";
+            // if we don't know what to do with it, just return the raw value
+            return answer.getObjectValue();
         }
     }
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/SurveyFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/SurveyFormatterTests.java
@@ -1,4 +1,4 @@
-package bio.terra.pearl.core.service.export.formatters;
+package bio.terra.pearl.core.service.export.formatters.module;
 
 import bio.terra.pearl.core.BaseSpringBootTest;
 import bio.terra.pearl.core.model.survey.Answer;
@@ -166,6 +166,23 @@ public class SurveyFormatterTests extends BaseSpringBootTest {
         assertThat(SurveyFormatter.stripStudyAndSurveyPrefixes("someQuestion"), equalTo("someQuestion"));
     }
 
+<<<<<<< Updated upstream:core/src/test/java/bio/terra/pearl/core/service/export/formatters/SurveyFormatterTests.java
+=======
+    @Test
+    public void testParseUnrecognizedObjectValue() {
+        Survey testSurvey =  Survey.builder().id(UUID.randomUUID()).stableId("oh_surveyA").version(1).build();
+        SurveyQuestionDefinition questionDef = SurveyQuestionDefinition.builder()
+                .questionStableId("oh_surveyA_q1")
+                .questionType("matrix")
+                .exportOrder(1)
+                .build();
+        SurveyFormatter moduleFormatter = new SurveyFormatter(new ExportOptions(), "oh_surveyA", List.of(testSurvey), List.of(questionDef), objectMapper);
+        String value = moduleFormatter.formatObjectValue(Answer.builder().objectValue("d[f}asdfja").build(), null, false, new ObjectMapper());
+        assertThat(value, equalTo("d[f}asdfja"));
+
+    }
+
+>>>>>>> Stashed changes:core/src/test/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatterTests.java
     /** helper for testing generation of answer maps values for a single question-answer pair */
     private Map<String, String> generateAnswerMap(SurveyQuestionDefinition question, Answer answer, ExportOptions exportOptions) throws JsonProcessingException {
         Map<String, String> valueMap = new HashMap<>();

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatterTests.java
@@ -8,9 +8,6 @@ import bio.terra.pearl.core.model.survey.SurveyResponse;
 import bio.terra.pearl.core.service.export.EnrolleeExportData;
 import bio.terra.pearl.core.service.export.ExportOptions;
 import bio.terra.pearl.core.service.export.formatters.item.AnswerItemFormatter;
-import bio.terra.pearl.core.service.export.formatters.module.ModuleFormatter;
-import bio.terra.pearl.core.service.export.formatters.module.SurveyFormatter;
-import bio.terra.pearl.core.service.export.formatters.item.ItemFormatter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -166,8 +163,6 @@ public class SurveyFormatterTests extends BaseSpringBootTest {
         assertThat(SurveyFormatter.stripStudyAndSurveyPrefixes("someQuestion"), equalTo("someQuestion"));
     }
 
-<<<<<<< Updated upstream:core/src/test/java/bio/terra/pearl/core/service/export/formatters/SurveyFormatterTests.java
-=======
     @Test
     public void testParseUnrecognizedObjectValue() {
         Survey testSurvey =  Survey.builder().id(UUID.randomUUID()).stableId("oh_surveyA").version(1).build();
@@ -182,7 +177,6 @@ public class SurveyFormatterTests extends BaseSpringBootTest {
 
     }
 
->>>>>>> Stashed changes:core/src/test/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatterTests.java
     /** helper for testing generation of answer maps values for a single question-answer pair */
     private Map<String, String> generateAnswerMap(SurveyQuestionDefinition question, Answer answer, ExportOptions exportOptions) throws JsonProcessingException {
         Map<String, String> valueMap = new HashMap<>();

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
@@ -32,7 +32,8 @@
       "surveyVersion": 2,
       "answerPopDtos": [
         { "questionStableId": "hd_hd_socialHealth_neighborhoodGetsAlong", "stringValue": "agree"},
-        { "questionStableId": "hd_hd_socialHealth_neighborhoodSharesValues", "stringValue": "stronglyAgree"}
+        { "questionStableId": "hd_hd_socialHealth_neighborhoodSharesValues", "stringValue": "stronglyAgree"},
+        {"questionStableId": "neighborhoodMatrix", "objectValue": "{\"affordable\":5,\"does what it claims\":4,\"better than others\":5,\"easy to use\":3}\n", "viewedLanguage": "en"}
       ],
       "currentPageNo": 1,
       "complete": true,

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
@@ -33,7 +33,7 @@
       "answerPopDtos": [
         { "questionStableId": "hd_hd_socialHealth_neighborhoodGetsAlong", "stringValue": "agree"},
         { "questionStableId": "hd_hd_socialHealth_neighborhoodSharesValues", "stringValue": "stronglyAgree"},
-        {"questionStableId": "neighborhoodMatrix", "objectValue": "{\"affordable\":5,\"does what it claims\":4,\"better than others\":5,\"easy to use\":3}\n", "viewedLanguage": "en"}
+        {"questionStableId": "neighborhoodMatrix", "objectValue": "{\"affordable\":5,\"friendlyPeople\":4,\"betterThanOthers\":5,\"easyTravelTo\":3}\n", "viewedLanguage": "en"}
       ],
       "currentPageNo": 1,
       "complete": true,

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/sandboxSurvey.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/sandboxSurvey.json
@@ -20,7 +20,7 @@
             ]
           },
           {
-            "name": "hd_hd_sandbox_colorChoid",
+            "name": "hd_hd_sandbox_colorChoice",
             "type": "radiogroup",
             "title": "What color is your parachute?",
             "choices": [

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/socialHealthV3.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/socialHealthV3.json
@@ -171,6 +171,53 @@
               {"text": "Strongly agree", "value": "stronglyAgree"},
               {"text": "Don’t know/Not sure", "value": "dontKnowNotSure"}
             ]
+          },
+          {
+            "type": "matrix",
+            "name": "neighborhoodMatrix",
+            "title": "Please indicate if you agree or disagree with the following statements about your neighborhood.",
+            "alternateRows": true,
+            "columns": [
+              {
+                "value": 5,
+                "text": "Strongly agree"
+              },
+              {
+                "value": 4,
+                "text": "Agree"
+              },
+              {
+                "value": 3,
+                "text": "Neutral"
+              },
+              {
+                "value": 2,
+                "text": "Disagree"
+              },
+              {
+                "value": 1,
+                "text": "Strongly disagree"
+              }
+            ],
+            "rows": [
+              {
+                "value": "affordable",
+                "text": "Neighborhood is affordable"
+              },
+              {
+                "value": "has friendly people",
+                "text": "Neighborhood has friendly people"
+              },
+              {
+                "value": "better than others",
+                "text": "Neighborhood is better than others nearby"
+              },
+              {
+                "value": "easy to travel to",
+                "text": "Neighborhood is easy to travel to"
+              }
+            ],
+            "isAllRowRequired": true
           }
         ]
       },

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/socialHealthV3.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/socialHealthV3.json
@@ -205,15 +205,15 @@
                 "text": "Neighborhood is affordable"
               },
               {
-                "value": "has friendly people",
+                "value": "friendlyPeople",
                 "text": "Neighborhood has friendly people"
               },
               {
-                "value": "better than others",
+                "value": "betterThanOthers",
                 "text": "Neighborhood is better than others nearby"
               },
               {
-                "value": "easy to travel to",
+                "value": "easyTravelTo",
                 "text": "Neighborhood is easy to travel to"
               }
             ],


### PR DESCRIPTION
#### DESCRIPTION
HeartHive would like to start using matrix questions.  This is generally supported in the participant and admin UI, except the export failed due to a hardcoded limitation on what kinds of objectValues we wanted to return.  This removes that limitation


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1.  redeploy ApiAdminApp
2. repopulate demo
3. Go to the demo sandbox data export `https://localhost:3000/demo/studies/heartdemo/env/sandbox/export/dataBrowser`
4. scroll down to the `hd_hd_socialHealth.neighborhoodMatrix` question.  Confirm that a json string appears for Jonas Salk
