### PR TITLE
[JN-892] Support top 10 countries

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/address/SmartyInternationalAddressValidationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/address/SmartyInternationalAddressValidationService.java
@@ -36,7 +36,17 @@ public class SmartyInternationalAddressValidationService implements AddressValid
             "CA",
             "GB",
             "MX",
-            "AU"
+            "AU",
+            "TR",
+            "ES",
+            "PL",
+            "DE",
+            "FR", // todo
+            "IT", // todo
+            "CZ",
+            "BR",
+            "SE",
+            "CH" // todo
     );
 
     @Override
@@ -117,6 +127,8 @@ public class SmartyInternationalAddressValidationService implements AddressValid
 
         if (input.getCountry().equals("GB")) {
             return suggestedAddressSubpremiseOnItsOwnLine(input, candidate);
+        } else if (input.getCountry().equals("TR")) {
+            return suggestedAddressDependentLocalityOnItsOwnLine(input, candidate);
         }
 
         return standardSuggestedAddress(input, candidate);
@@ -184,6 +196,29 @@ public class SmartyInternationalAddressValidationService implements AddressValid
         // the second address line from smarty contains city/state/postal info, so
         // we don't want that in a freeform line
         if (!StringUtils.isEmpty(components.getSubBuilding())) {
+            return MailingAddress
+                    .builder()
+                    .city(components.getLocality())
+                    .state(components.getAdministrativeArea())
+                    .street2(candidate.getAddress2())
+                    .street1(candidate.getAddress1())
+                    .country(input.getCountry())
+                    .postalCode(components.getPostalCode())
+                    .createdAt(null)
+                    .lastUpdatedAt(null)
+                    .build();
+        }
+
+        return standardSuggestedAddress(input, candidate);
+    }
+
+    private MailingAddress suggestedAddressDependentLocalityOnItsOwnLine(MailingAddress input, Candidate candidate) {
+        Components components = candidate.getComponents();
+        // if there is a subpremise in some countries (e.g., GB), then the first street line is
+        // the subpremise, so we need both street1 and street2. In most countries,
+        // the second address line from smarty contains city/state/postal info, so
+        // we don't want that in a freeform line
+        if (!StringUtils.isEmpty(components.getDependentLocality())) {
             return MailingAddress
                     .builder()
                     .city(components.getLocality())

--- a/core/src/main/java/bio/terra/pearl/core/service/address/SmartyInternationalAddressValidationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/address/SmartyInternationalAddressValidationService.java
@@ -18,6 +18,9 @@ import java.util.Objects;
  * Validation client for international addresses. Due to the complexity of global
  * address formats, does not support all countries, but only a verified subset of
  * countries.
+ * <br>
+ * Many of these countries likely have edge cases that break our validation. We
+ * should make sure that users always have the ability to override if necessary.
  */
 @Component
 @Slf4j
@@ -41,12 +44,12 @@ public class SmartyInternationalAddressValidationService implements AddressValid
             "ES",
             "PL",
             "DE",
-            "FR", // todo
-            "IT", // todo
+            "FR",
+            "IT",
             "CZ",
             "BR",
             "SE",
-            "CH" // todo
+            "CH"
     );
 
     @Override
@@ -125,7 +128,8 @@ public class SmartyInternationalAddressValidationService implements AddressValid
 
     private MailingAddress suggestedAddress(MailingAddress input, Candidate candidate) {
 
-        if (input.getCountry().equals("GB")) {
+        // many countries put the apartment on its own line
+        if (List.of("GB", "FR", "IT", "CH").contains(input.getCountry())) {
             return suggestedAddressSubpremiseOnItsOwnLine(input, candidate);
         } else if (input.getCountry().equals("TR")) {
             return suggestedAddressDependentLocalityOnItsOwnLine(input, candidate);

--- a/core/src/main/java/bio/terra/pearl/core/service/address/SmartyInternationalAddressValidationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/address/SmartyInternationalAddressValidationService.java
@@ -52,6 +52,8 @@ public class SmartyInternationalAddressValidationService implements AddressValid
             "CH"
     );
 
+
+    private static final List<String> APARTMENT_ON_OWN_LINE = List.of("GB", "FR", "IT", "CH");
     @Override
     public AddressValidationResultDto validate(MailingAddress address) throws AddressValidationException {
 
@@ -129,7 +131,7 @@ public class SmartyInternationalAddressValidationService implements AddressValid
     private MailingAddress suggestedAddress(MailingAddress input, Candidate candidate) {
 
         // many countries put the apartment on its own line
-        if (List.of("GB", "FR", "IT", "CH").contains(input.getCountry())) {
+        if (APARTMENT_ON_OWN_LINE.contains(input.getCountry())) {
             return suggestedAddressSubpremiseOnItsOwnLine(input, candidate);
         } else if (input.getCountry().equals("TR")) {
             return suggestedAddressDependentLocalityOnItsOwnLine(input, candidate);

--- a/core/src/test/java/bio/terra/pearl/core/service/address/SmartyInternationalAddressValidationServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/address/SmartyInternationalAddressValidationServiceTest.java
@@ -303,48 +303,4 @@ class SmartyInternationalAddressValidationServiceTest extends BaseSpringBootTest
 
         Mockito.doAnswer(answer).when(mockSmartyClient).send(any(Lookup.class));
     }
-
-    private static final String MORE_RESPONSES = """
-                  {
-                    "address1": "Şehreküstü Mah.",
-                    "address2": "Cimek Sokak 3/1",
-                    "address3": "37300 Tosya/Kastamonu",
-                    "components": {
-                      "super_administrative_area": "Karadeniz",
-                      "administrative_area": "Kastamonu",
-                      "sub_administrative_area": "Tosya",
-                      "country_iso_3": "TUR",
-                      "locality": "Tosya",
-                      "dependent_locality": "Şehreküstü Mah.",
-                      "postal_code": "37300",
-                      "postal_code_short": "37300",
-                      "premise": "3/1",
-                      "premise_number": "3/1",
-                      "thoroughfare": "Cimek Sokak"
-                    },
-                    "metadata": {
-                      "address_format": "dependent_locality|thoroughfare premise|postal_code locality/administrative_area"
-                    },
-                    "analysis": {
-                      "verification_status": "Verified",
-                      "address_precision": "DeliveryPoint",
-                      "max_address_precision": "DeliveryPoint",
-                      "changes": {
-                        "components": {
-                          "super_administrative_area": "Added",
-                          "administrative_area": "Verified-NoChange",
-                          "sub_administrative_area": "Added",
-                          "country_iso_3": "Added",
-                          "locality": "Verified-NoChange",
-                          "dependent_locality": "Verified-NoChange",
-                          "postal_code": "Verified-NoChange",
-                          "postal_code_short": "Verified-NoChange",
-                          "premise": "Verified-NoChange",
-                          "premise_number": "Verified-NoChange",
-                          "thoroughfare": "Verified-NoChange"
-                        }
-                      }
-                    }
-                  }
-            """;
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/address/SmartyInternationalAddressValidationServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/address/SmartyInternationalAddressValidationServiceTest.java
@@ -303,4 +303,48 @@ class SmartyInternationalAddressValidationServiceTest extends BaseSpringBootTest
 
         Mockito.doAnswer(answer).when(mockSmartyClient).send(any(Lookup.class));
     }
+
+    private static final String MORE_RESPONSES = """
+                  {
+                    "address1": "Şehreküstü Mah.",
+                    "address2": "Cimek Sokak 3/1",
+                    "address3": "37300 Tosya/Kastamonu",
+                    "components": {
+                      "super_administrative_area": "Karadeniz",
+                      "administrative_area": "Kastamonu",
+                      "sub_administrative_area": "Tosya",
+                      "country_iso_3": "TUR",
+                      "locality": "Tosya",
+                      "dependent_locality": "Şehreküstü Mah.",
+                      "postal_code": "37300",
+                      "postal_code_short": "37300",
+                      "premise": "3/1",
+                      "premise_number": "3/1",
+                      "thoroughfare": "Cimek Sokak"
+                    },
+                    "metadata": {
+                      "address_format": "dependent_locality|thoroughfare premise|postal_code locality/administrative_area"
+                    },
+                    "analysis": {
+                      "verification_status": "Verified",
+                      "address_precision": "DeliveryPoint",
+                      "max_address_precision": "DeliveryPoint",
+                      "changes": {
+                        "components": {
+                          "super_administrative_area": "Added",
+                          "administrative_area": "Verified-NoChange",
+                          "sub_administrative_area": "Added",
+                          "country_iso_3": "Added",
+                          "locality": "Verified-NoChange",
+                          "dependent_locality": "Verified-NoChange",
+                          "postal_code": "Verified-NoChange",
+                          "postal_code_short": "Verified-NoChange",
+                          "premise": "Verified-NoChange",
+                          "premise_number": "Verified-NoChange",
+                          "thoroughfare": "Verified-NoChange"
+                        }
+                      }
+                    }
+                  }
+            """;
 }

--- a/ui-admin/src/address/EditMailingAddress.tsx
+++ b/ui-admin/src/address/EditMailingAddress.tsx
@@ -19,6 +19,7 @@ import classNames from 'classnames'
 // Supported country alpha-2 codes; see
 // SmartyInternationalAddressValidationService in core
 const SUPPORTED_COUNTRIES = [
+  'US',
   'CA',
   'GB',
   'MX',

--- a/ui-admin/src/address/EditMailingAddress.tsx
+++ b/ui-admin/src/address/EditMailingAddress.tsx
@@ -20,10 +20,19 @@ import classNames from 'classnames'
 // SmartyInternationalAddressValidationService in core
 const SUPPORTED_COUNTRIES = [
   'CA',
-  'MX',
   'GB',
+  'MX',
   'AU',
-  'US'
+  'TR',
+  'ES',
+  'PL',
+  'DE',
+  'FR',
+  'IT',
+  'CZ',
+  'BR',
+  'SE',
+  'CH'
 ]
 
 /**


### PR DESCRIPTION
#### DESCRIPTION

Adds more address validation support. It was very hard to find real address examples online and I have only a limited number of API calls before I run out :'(. I tried my best to try one 'complex' address per country but it's really hard to find real addresses that are more than just a house number (e.g., apartments, etc.). I do think there are gonna be edge cases users are gonna find, so we'll have to make sure to allow them to override any errors or suggestions they get. 

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- edit admin ui `application.yml:14` to be `addrValidationServiceClass: ${ADDR_VALIDATION_CLIENT_CLASS:SmartyAddressValidationService}`
- enter your api keys into your intellij runtime environment vars as `SMARTY_AUTH_ID` and `SMARTY_AUTH_TOKEN`
- Restart admin api / ui
- Go to any enrollee's profile
- Ensure all of the countries we should support with this make the validate button go blue
- Try a variety of random addresses you can find on google maps (I think at the end of the day the best testing for this is gonna be real users, unfortunately)