### PR TITLE
[JN-875] enabling search by answer values

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeSearchDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeSearchDao.java
@@ -95,7 +95,8 @@ public class EnrolleeSearchDao {
           facetsGroupByTable.get(facet.getTableName()).add(facet);
         });
 
-    List<String> selects = facets.stream().map(facet -> facet.getSelectQuery())
+    List<String> selects = IntStream.range(0, facets.size()).mapToObj(i ->
+            facets.get(i).getSelectQuery(i))
         .filter(query -> query != null)
         .collect(Collectors.toList());
     selects.add(0, baseSelectString);

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/Answer.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/Answer.java
@@ -44,7 +44,7 @@ public class Answer extends BaseEntity {
         if (answerType.equals(AnswerType.STRING)) {
             stringValue = (String) value;
         } else if (answerType.equals(AnswerType.NUMBER)) {
-            numberValue = (Double) value;
+            numberValue = ((Number) value).doubleValue();
         } else if (answerType.equals(AnswerType.BOOLEAN)) {
             booleanValue = (Boolean) value;
         } else {

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/AnswerType.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/AnswerType.java
@@ -10,7 +10,7 @@ public enum AnswerType {
     public static AnswerType forValue(Object value) {
         if (String.class.isInstance(value)) {
             return STRING;
-        } else if (Double.class.isInstance(value)) {
+        } else if (Number.class.isInstance(value)) {
             return NUMBER;
         } else if (Boolean.class.isInstance(value)) {
             return BOOLEAN;

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/search/facets/AnswerFacetValue.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/search/facets/AnswerFacetValue.java
@@ -1,0 +1,67 @@
+package bio.terra.pearl.core.service.participant.search.facets;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+/**
+ * Much of this class mimics some of the type processing found in Answer.java.  However, we don't support querying
+ * objectValue stuff yet.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class AnswerFacetValue implements FacetValue {
+  private String stringValue;
+  private Boolean booleanValue;
+  private Double numberValue;
+  private String questionStableId;
+  private String surveyStableId;
+
+  public AnswerFacetValue(String surveyStableId, String questionStableId, String value) {
+        this.stringValue = value;
+        this.questionStableId = questionStableId;
+      this.surveyStableId = surveyStableId;
+  }
+
+    public AnswerFacetValue(String surveyStableId, String questionStableId, Boolean value) {
+        this.booleanValue = value;
+        this.questionStableId = questionStableId;
+        this.surveyStableId = surveyStableId;
+    }
+
+    public AnswerFacetValue(String surveyStableId, String questionStableId, Double value) {
+        this.numberValue = value;
+        this.questionStableId = questionStableId;
+        this.surveyStableId = surveyStableId;
+    }
+
+    public String valueAsString() {
+        if (booleanValue != null) {
+            return booleanValue.toString();
+        } else if (numberValue != null) {
+            return numberValue.toString();
+        }
+        return stringValue;
+    }
+
+    public Object getValue() {
+        if (booleanValue != null) {
+            return booleanValue;
+        } else if (numberValue != null) {
+            return numberValue;
+        }
+        return stringValue;
+    }
+
+    @Override
+    public String getKeyName() {
+        return "%s_%s_%s".formatted(surveyStableId, questionStableId, valueAsString());
+    }
+
+    @Override
+    public void setKeyName(String keyName) {
+
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/search/facets/FacetValueFactory.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/search/facets/FacetValueFactory.java
@@ -19,6 +19,9 @@ public class FacetValueFactory {
       ),
       "keyword", Map.of(
               "keyword", new FacetDefinition(StringFacetValue.class, new KeywordFacetSqlGenerator())
+      ),
+      "survey", Map.of(
+              "answer", new FacetDefinition(AnswerFacetValue.class, new AnswerFacetSqlGenerator())
       )
   );
 

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/search/facets/sql/AnswerFacetSqlGenerator.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/search/facets/sql/AnswerFacetSqlGenerator.java
@@ -31,23 +31,21 @@ public class AnswerFacetSqlGenerator implements FacetSqlGenerator<AnswerFacetVal
 
     @Override
     public String getSelectQuery(AnswerFacetValue facetValue, int facetIndex) {
-        String columnName = getColumnName(facetValue);
-        // this will only return a single matched task, we'll need to extend this if we want to return more complex stuff
-        return " answer.%s AS answer_%s"
-                .formatted(columnName, facetIndex);
+        return " answer.%s AS answer_%s".formatted(getColumnName(facetValue), facetIndex);
     }
 
     @Override
     public String getWhereClause(AnswerFacetValue facetValue, int facetIndex) {
-        String queryValue = facetValue.valueAsString();
-        if (facetValue.getStringValue() != null) {
-            queryValue = "'%s'".formatted(queryValue);
-        }
         return """
                  answer.%s = :%s
                  and answer.survey_stable_id = :%s
                  and answer.question_stable_id = :%s    
-                """.formatted(getColumnName(facetValue), getValueParam(facetIndex), getSurveyStableIdParam(facetIndex), getQuestionStableIdParam(facetIndex));
+                """.formatted(
+                        getColumnName(facetValue),
+                        getValueParam(facetIndex),
+                        getSurveyStableIdParam(facetIndex),
+                        getQuestionStableIdParam(facetIndex)
+                );
     }
 
     @Override

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/search/facets/sql/AnswerFacetSqlGenerator.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/search/facets/sql/AnswerFacetSqlGenerator.java
@@ -1,0 +1,76 @@
+package bio.terra.pearl.core.service.participant.search.facets.sql;
+
+import bio.terra.pearl.core.service.participant.search.facets.AnswerFacetValue;
+import org.jdbi.v3.core.statement.Query;
+
+import java.util.List;
+
+public class AnswerFacetSqlGenerator implements FacetSqlGenerator<AnswerFacetValue> {
+    private static final String TABLE_NAME = "answer";
+
+    public AnswerFacetSqlGenerator() {}
+
+    @Override
+    public String getTableName() {
+        return TABLE_NAME;
+    }
+
+    @Override
+    public String getJoinQuery() {
+        return " left join answer on answer.enrollee_id = enrollee.id";
+    }
+
+    public String getColumnName(AnswerFacetValue facetValue) {
+        if (facetValue.getBooleanValue() != null) {
+            return "boolean_value";
+        } else if (facetValue.getNumberValue() != null) {
+            return "number_value";
+        }
+        return "string_value";
+    }
+
+    @Override
+    public String getSelectQuery(AnswerFacetValue facetValue, int facetIndex) {
+        String columnName = getColumnName(facetValue);
+        // this will only return a single matched task, we'll need to extend this if we want to return more complex stuff
+        return " answer.%s AS answer_%s"
+                .formatted(columnName, facetIndex);
+    }
+
+    @Override
+    public String getWhereClause(AnswerFacetValue facetValue, int facetIndex) {
+        String queryValue = facetValue.valueAsString();
+        if (facetValue.getStringValue() != null) {
+            queryValue = "'%s'".formatted(queryValue);
+        }
+        return """
+                 answer.%s = :%s
+                 and answer.survey_stable_id = :%s
+                 and answer.question_stable_id = :%s    
+                """.formatted(getColumnName(facetValue), getValueParam(facetIndex), getSurveyStableIdParam(facetIndex), getQuestionStableIdParam(facetIndex));
+    }
+
+    @Override
+    public String getCombinedWhereClause(List<AnswerFacetValue> facetValues) {
+        return "";
+    }
+
+    @Override
+    public void bindSqlParameters(AnswerFacetValue facetValue, int facetIndex, Query query) {
+        query.bind(getValueParam(facetIndex), facetValue.getValue());
+        query.bind(getSurveyStableIdParam(facetIndex), facetValue.getSurveyStableId());
+        query.bind(getQuestionStableIdParam(facetIndex), facetValue.getQuestionStableId());
+    }
+
+    private String getQuestionStableIdParam(int facetIndex) {
+        return "question_stable_id_%s".formatted(facetIndex);
+    }
+
+    private String getSurveyStableIdParam(int facetIndex) {
+        return "survey_stable_id_%s".formatted(facetIndex);
+    }
+
+    private String getValueParam(int facetIndex) {
+        return "answer_val_%s".formatted(facetIndex);
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/search/facets/sql/FacetSqlGenerator.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/search/facets/sql/FacetSqlGenerator.java
@@ -7,7 +7,7 @@ import org.jdbi.v3.core.statement.Query;
 public interface FacetSqlGenerator<T extends FacetValue> {
   // the table name the facet uses for join/selects.  Used for deduping queries.  Use "" if the facet does not need any additional tables
   String getTableName();
-  String getSelectQuery(T facetValue);
+  String getSelectQuery(T facetValue, int facetIndex);
   String getJoinQuery();
   String getWhereClause(T facetValue, int facetIndex);
   String getCombinedWhereClause(List<T> facetValues);

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/search/facets/sql/KeywordFacetSqlGenerator.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/search/facets/sql/KeywordFacetSqlGenerator.java
@@ -25,7 +25,7 @@ public class KeywordFacetSqlGenerator implements FacetSqlGenerator<StringFacetVa
     }
 
     @Override
-    public String getSelectQuery(StringFacetValue facetValue) {
+    public String getSelectQuery(StringFacetValue facetValue, int facetIndex) {
         return null; // already included in base query
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/search/facets/sql/ParticipantTaskFacetSqlGenerator.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/search/facets/sql/ParticipantTaskFacetSqlGenerator.java
@@ -29,7 +29,7 @@ public class ParticipantTaskFacetSqlGenerator implements FacetSqlGenerator<Combi
   }
 
   @Override
-  public String getSelectQuery(CombinedStableIdFacetValue facetValue) {
+  public String getSelectQuery(CombinedStableIdFacetValue facetValue, int facetIndex) {
     String columnName = getColumnName(facetValue);
     // this will only return a single matched task, we'll need to extend this if we want to return more complex stuff
     return " %s.%s AS %s__%s, %s.target_stable_id AS %s__target_stable_id"

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/search/facets/sql/ProfileAgeFacetSqlGenerator.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/search/facets/sql/ProfileAgeFacetSqlGenerator.java
@@ -18,7 +18,7 @@ public class ProfileAgeFacetSqlGenerator implements FacetSqlGenerator<IntRangeFa
   }
 
   @Override
-  public String getSelectQuery(IntRangeFacetValue facetValue) {
+  public String getSelectQuery(IntRangeFacetValue facetValue, int facetIndex) {
     return null; // already included in base query
   }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/search/facets/sql/ProfileFacetSqlGenerator.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/search/facets/sql/ProfileFacetSqlGenerator.java
@@ -25,7 +25,7 @@ public class ProfileFacetSqlGenerator implements FacetSqlGenerator<StringFacetVa
     }
 
     @Override
-    public String getSelectQuery(StringFacetValue facetValue) {
+    public String getSelectQuery(StringFacetValue facetValue, int facetIndex) {
       return null; // already included in base query
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/search/facets/sql/SqlSearchableFacet.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/search/facets/sql/SqlSearchableFacet.java
@@ -14,8 +14,8 @@ public class SqlSearchableFacet<T extends FacetValue> {
   public String getTableName() {
     return sqlGenerator.getTableName();
   };
-  public String getSelectQuery() {
-    return sqlGenerator.getSelectQuery(value);
+  public String getSelectQuery(int facetIndex) {
+    return sqlGenerator.getSelectQuery(value, facetIndex);
   };
   public String getJoinQuery() {
     return sqlGenerator.getJoinQuery();

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/survey/AnswerFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/survey/AnswerFactory.java
@@ -1,10 +1,22 @@
 package bio.terra.pearl.core.factory.survey;
 
+import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.survey.Answer;
+import bio.terra.pearl.core.model.survey.Survey;
+import bio.terra.pearl.core.model.survey.SurveyResponse;
+import bio.terra.pearl.core.service.survey.AnswerService;
+import bio.terra.pearl.core.service.survey.SurveyService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Map;
 
+@Component
 public class AnswerFactory {
+    @Autowired
+    private AnswerService answerService;
+
     public static List<Answer> fromMap(Map<String, Object> valueMap) {
        return valueMap.entrySet().stream().map(entry -> {
             Answer answer = Answer.builder()
@@ -13,5 +25,25 @@ public class AnswerFactory {
             answer.setValueAndType(entry.getValue());
             return answer;
         }).toList();
+    }
+
+    public List<Answer> createFromMap(Map<String, Object> valueMap,
+                                       Enrollee enrollee,
+                                       Survey survey,
+                                       SurveyResponse surveyResponse) {
+        List<Answer> answers = valueMap.entrySet().stream().map(entry -> {
+            Answer answer = Answer.builder()
+                    .questionStableId(entry.getKey())
+                    .creatingParticipantUserId(enrollee.getParticipantUserId())
+                    .enrolleeId(enrollee.getId())
+                    .surveyResponseId(surveyResponse.getId())
+                    .surveyStableId(survey.getStableId())
+                    .surveyVersion(survey.getVersion())
+                    .build();
+            answer.setValueAndType(entry.getValue());
+            answer = answerService.create(answer);
+            return answer;
+        }).toList();
+        return answers;
     }
 }

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/survey/SurveyResponseFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/survey/SurveyResponseFactory.java
@@ -2,11 +2,15 @@ package bio.terra.pearl.core.factory.survey;
 
 import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
 import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.survey.Answer;
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
 import bio.terra.pearl.core.service.survey.SurveyResponseService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
 
 @Component
 public class SurveyResponseFactory {
@@ -16,6 +20,8 @@ public class SurveyResponseFactory {
     private SurveyFactory surveyFactory;
     @Autowired
     private SurveyResponseService surveyResponseService;
+    @Autowired
+    private AnswerFactory answerFactory;
 
     public SurveyResponse.SurveyResponseBuilder builder(String testName) {
         return SurveyResponse.builder().complete(false);
@@ -32,5 +38,16 @@ public class SurveyResponseFactory {
 
     public SurveyResponse buildPersisted(String testName) {
         return surveyResponseService.create(builderWithDependencies(testName).build());
+    }
+
+    public SurveyResponse buildWithAnswers(Enrollee enrollee, Survey survey, Map<String, Object> answerMap) {
+        SurveyResponse response = surveyResponseService.create(SurveyResponse.builder()
+                .enrolleeId(enrollee.getId())
+                .creatingParticipantUserId(enrollee.getParticipantUserId())
+                .surveyId(survey.getId())
+                .build());
+        List<Answer> answers = answerFactory.createFromMap(answerMap, enrollee, survey, response);
+        response.setAnswers(answers);
+        return response;
     }
 }


### PR DESCRIPTION
#### DESCRIPTION
This enables a search facet that matches based on answer values.  Yet another piece of infrastructure we'll need for cohort building.  This PR has no application-visible changes -- this search facet is not exposed in the UI.  

Following PRs will include:
1. Enabling the rule evaluator to produce search facets.  In essence, if a rule isn't capable of being evaluated based on just the simple enrollee/profile information we already had loaded, it will get converted to SearchFacets, and then run as a "search" with an extra facet of the enrollee id.  And then if the search returns a row, the result will be true. 
2. Making search facets more robust -- right now they just support ANDed facets and equality operators.  We'll need ORs and inequality operators too.  (this is the big advantage of this overall approach -- by consolidating search and Rule evaluation, we can make both better at the same time)


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1. no functional changes, so just run some searches in the participant list and confirm nothing got broken.
