### PR TITLE
[JN-875] adding auto-assign capability to surveys

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/ParticipantTaskExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/ParticipantTaskExtService.java
@@ -65,7 +65,8 @@ public class ParticipantTaskExtService {
             .orElseThrow(StudyEnvironmentMissing::new);
 
     if (assignDto.taskType().equals(TaskType.SURVEY)) {
-      return surveyTaskDispatcher.assign(assignDto, studyEnv.getId(), operator);
+      return surveyTaskDispatcher.assign(
+          assignDto, studyEnv.getId(), new ResponsibleEntity(operator));
     }
     throw new UnsupportedOperationException(
         "task type %s not supported".formatted(assignDto.taskType()));

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/SurveyExtServiceAuthTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/SurveyExtServiceAuthTests.java
@@ -17,6 +17,7 @@ import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
 import bio.terra.pearl.core.service.survey.SurveyService;
+import bio.terra.pearl.core.service.workflow.EventService;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
@@ -39,6 +40,7 @@ public class SurveyExtServiceAuthTests {
   @MockBean private StudyEnvironmentSurveyService mockStudyEnvironmentSurveyService;
   @MockBean private StudyEnvironmentService mockStudyEnvironmentService;
   @MockBean private PortalEnvironmentService mockPortalEnvironmentService;
+  @MockBean private EventService mockEventService;
 
   @Test
   public void createConfiguredRequiresPortalAuth() {

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/Survey.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/Survey.java
@@ -53,6 +53,8 @@ public class Survey extends BaseEntity implements Versioned, PortalAttached {
     @Builder.Default
     private boolean assignToAllNewEnrollees = true; // whether to assign the survey to all new enrollees by default
     @Builder.Default
+    private boolean assignToExistingEnrollees = false; // whether to assign the survey automatically to existing enrollees
+    @Builder.Default
     private boolean autoUpdateTaskAssignments = false; // whether to auto-update all tasks to the latest version on publish
 }
 

--- a/core/src/main/resources/db/changelog/changesets/2024_02_22_survey_assign_existing.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_02_22_survey_assign_existing.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: "assign_to_existing_enrollees"
+      author: dbush
+      changes:
+        - addColumn:
+            tableName: survey
+            columns:
+              - column: { name: assign_to_existing_enrollees, type: boolean, defaultValueBoolean: false,
+                          constraints: { nullable: false }
+              }

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -203,6 +203,9 @@ databaseChangeLog:
   - include:
       file: changesets/2024_02_14_enrollee_proxy.yaml
       relativeToChangelogFile: true
+  - include:
+     file: changesets/2024_02_22_survey_assign_existing.yaml
+     relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
@@ -16,6 +16,7 @@ import bio.terra.pearl.core.factory.participant.ParticipantTaskFactory;
 import bio.terra.pearl.core.factory.survey.SurveyFactory;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.model.audit.ResponsibleEntity;
 import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
@@ -105,7 +106,7 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
         Survey survey = surveyFactory.buildPersisted(getTestName(testInfo));
         surveyFactory.attachToEnv(survey, sandboxBundle.getStudyEnv().getId(), true);
         ParticipantTaskAssignDto assignDto = new ParticipantTaskAssignDto(TaskType.SURVEY, survey.getStableId(), survey.getVersion(), null, true, true );
-        surveyTaskDispatcher.assign(assignDto, sandboxBundle.getStudyEnv().getId(), operator);
+        surveyTaskDispatcher.assign(assignDto, sandboxBundle.getStudyEnv().getId(), new ResponsibleEntity(operator));
         List<ParticipantTask> participantTasks = participantTaskService.findTasksByStudyAndTarget(sandboxBundle.getStudyEnv().getId(), List.of(survey.getStableId()));
         assertThat(participantTasks, hasSize(2));
     }
@@ -124,19 +125,19 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
 
         // shouldn't create a duplicate task if directed to assign to all unassigned
         ParticipantTaskAssignDto assignDto = new ParticipantTaskAssignDto(TaskType.SURVEY, survey.getStableId(), survey.getVersion(), null, true, false );
-        surveyTaskDispatcher.assign(assignDto, sandboxBundle.getStudyEnv().getId(), operator);
+        surveyTaskDispatcher.assign(assignDto, sandboxBundle.getStudyEnv().getId(), new ResponsibleEntity(operator));
         List<ParticipantTask> participantTasks = participantTaskService.findTasksByStudyAndTarget(sandboxBundle.getStudyEnv().getId(), List.of(survey.getStableId()));
         assertThat(participantTasks, hasSize(1));
 
         // shouldn't create a duplicate task even if the enrolleeId is provided manually, since eligibility override is false
         assignDto = new ParticipantTaskAssignDto(TaskType.SURVEY, survey.getStableId(), survey.getVersion(), List.of(sandbox1.enrollee().getId()), false, false );
-        surveyTaskDispatcher.assign(assignDto, sandboxBundle.getStudyEnv().getId(), operator);
+        surveyTaskDispatcher.assign(assignDto, sandboxBundle.getStudyEnv().getId(), new ResponsibleEntity(operator));
         participantTasks = participantTaskService.findTasksByStudyAndTarget(sandboxBundle.getStudyEnv().getId(), List.of(survey.getStableId()));
         assertThat(participantTasks, hasSize(1));
 
         // if overriding eligibility is specified, then a duplicate task should be created
         assignDto = new ParticipantTaskAssignDto(TaskType.SURVEY, survey.getStableId(), survey.getVersion(), List.of(sandbox1.enrollee().getId()), false, true );
-        surveyTaskDispatcher.assign(assignDto, sandboxBundle.getStudyEnv().getId(), operator);
+        surveyTaskDispatcher.assign(assignDto, sandboxBundle.getStudyEnv().getId(), new ResponsibleEntity(operator));
         participantTasks = participantTaskService.findTasksByStudyAndTarget(sandboxBundle.getStudyEnv().getId(), List.of(survey.getStableId()));
         assertThat(participantTasks, hasSize(2));
     }

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
@@ -29,7 +29,7 @@
     },
     {
       "surveyStableId": "hd_hd_socialHealth",
-      "surveyVersion": 2,
+      "surveyVersion": 3,
       "answerPopDtos": [
         { "questionStableId": "hd_hd_socialHealth_neighborhoodGetsAlong", "stringValue": "agree"},
         { "questionStableId": "hd_hd_socialHealth_neighborhoodSharesValues", "stringValue": "stronglyAgree"},

--- a/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
@@ -98,6 +98,7 @@ describe('CreateSurveyModal', () => {
       {
         ...defaultSurvey,
         autoUpdateTaskAssignments: true,
+        assignToExistingEnrollees: true,
         blurb: 'Testing out the marketing blurb...',
         content: expect.stringContaining('{"pages":[{"elements":[{"type":"html","name":"outreach_content_'),
         createdAt: 0,
@@ -138,6 +139,7 @@ describe('CreateSurveyModal', () => {
         ...defaultSurvey,
         autoUpdateTaskAssignments: true,
         blurb: 'Testing out the screener blurb...',
+        assignToExistingEnrollees: true,
         content: '{"pages":[]}',
         createdAt: 0,
         id: '',

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -40,6 +40,7 @@ const CreateSurveyModal = ({ studyEnvContext, onDismiss, type }:
         {
           ...defaultSurvey,
           autoUpdateTaskAssignments: type === 'OUTREACH',
+          assignToExistingEnrollees: type === 'OUTREACH',
           createdAt: 0, id: '', lastUpdatedAt: 0, version: 1, surveyType: type, blurb: surveyBlurb,
           content: defaultTemplateJson, name: formName, stableId: formStableId
         })

--- a/ui-admin/src/study/surveys/FormOptions.tsx
+++ b/ui-admin/src/study/surveys/FormOptions.tsx
@@ -39,7 +39,7 @@ export default function FormOptions({
   }
   const isSurvey = !!(workingForm as Survey).surveyType
 
-  return <Modal show={true} onHide={onDismiss}>
+  return <Modal show={true} onHide={onDismiss} size="lg">
     <Modal.Header closeButton>
       <Modal.Title>{workingForm.name}</Modal.Title>
     </Modal.Header>
@@ -67,13 +67,20 @@ export default function FormOptions({
               /> Auto-assign to new participants
             </label>
             <label className="form-label d-block">
+              <input type="checkbox" checked={(workingForm as Survey).assignToExistingEnrollees}
+                onChange={e => updateWorkingForm({
+                  ...workingForm, assignToExistingEnrollees: e.target.checked
+                })}
+              /> Auto-assign to existing participants
+            </label>
+            <label className="form-label d-block">
               <input type="checkbox" checked={(workingForm as Survey).autoUpdateTaskAssignments}
                 onChange={e => updateWorkingForm({
                   ...workingForm, autoUpdateTaskAssignments: e.target.checked
                 })}
               /> Auto-update participant tasks to the latest version of this survey after publishing
             </label>
-            <div className="fw-light fst-italic">
+            <div className="fw-light fst-italic mt-4">
               Note: you must  &quot;Save&quot; the survey
               for changes to these options to take effect.
             </div>

--- a/ui-admin/src/study/surveys/SurveyView.tsx
+++ b/ui-admin/src/study/surveys/SurveyView.tsx
@@ -19,7 +19,9 @@ export type SurveyParamsT = StudyParams & {
 export type SaveableFormProps = {
   content: string
   required?: boolean
-  assignToAllNewEnrollees?: boolean,
+  assignToAllNewEnrollees?: boolean
+  assignToExistingEnrollees?: boolean
+  rule?: string
   autoUpdateTaskAssignments?: boolean
 }
 

--- a/ui-core/src/types/forms.ts
+++ b/ui-core/src/types/forms.ts
@@ -16,7 +16,9 @@ export type Survey = VersionedForm & {
   surveyType: SurveyType
   blurb?: string
   required: boolean
+  rule?: string
   assignToAllNewEnrollees: boolean
+  assignToExistingEnrollees: boolean
   autoUpdateTaskAssignments: boolean
   recur: boolean
   recurrenceIntervalDays: number
@@ -29,6 +31,7 @@ export type Survey = VersionedForm & {
 export const defaultSurvey = {
   required: false,
   assignToAllNewEnrollees: true,
+  assignToExistingEnrollees: false,
   autoUpdateTaskAssignments: false,
   recur: false,
   recurrenceIntervalDays: 0,


### PR DESCRIPTION
#### DESCRIPTION

Adds the ability to mark a survey as automatically assigned to *existing* participants.  This is most useful for outreach surveys, where on publishing them, the staff wants them to go to everyone automatically.  Accordingly, this is false by default for research surveys, and true for outreach surveys.  

<img width="714" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/50c2b414-00cd-485d-9897-8e5e0478552b">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1.  redeploy ApiAdminApp 
2. repopulate ourhealth
3. go to ourhealth forms and surveys, and create a new survey https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/forms
4. after you've created it, set it to auto-assign to existing participants
5. save
6. go to the task list for Jonas Salk https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants/OHSALK/tasks. 
7. confirm you see a task for your new survey
