### PR TITLE
[JN-872] Move the rest of application texts into languageTexts

### DIFF
--- a/populate/src/main/resources/seed/i18n/dev/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/dev/languageTexts.json
@@ -10,5 +10,11 @@
   {"keyName": "taskDeclined", "text": "DEV_Declined", "language": "dev"},
   {"keyName": "taskLocked", "text": "DEV_Locked", "language": "dev"},
   {"keyName": "tasksNoneForStudy", "text": "DEV_No tasks for this study", "language": "dev"},
-  {"keyName": "surveysSomeLocked", "text": "DEV_Some surveys are locked until other required tasks are completed.", "language": "dev"}
+  {"keyName": "surveysSomeLocked", "text": "DEV_Some surveys are locked until other required tasks are completed.", "language": "dev"},
+  {"keyName": "taskTypeSurvey", "text": "DEV_Survey", "language": "dev"},
+  {"keyName": "taskTypeSurveys", "text": "DEV_Surveys", "language": "dev"},
+  {"keyName": "taskTypeConsent", "text": "DEV_Consent", "language": "dev"},
+  {"keyName": "taskTypeForms", "text": "DEV_Forms", "language": "dev"},
+  {"keyName": "taskStart", "text": "DEV_Start", "language": "dev"},
+  {"keyName": "taskContinue", "text": "DEV_Continue", "language": "dev"}
 ]

--- a/populate/src/main/resources/seed/i18n/dev/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/dev/languageTexts.json
@@ -16,5 +16,6 @@
   {"keyName": "taskTypeConsent", "text": "DEV_Consent", "language": "dev"},
   {"keyName": "taskTypeForms", "text": "DEV_Forms", "language": "dev"},
   {"keyName": "taskStart", "text": "DEV_Start", "language": "dev"},
-  {"keyName": "taskContinue", "text": "DEV_Continue", "language": "dev"}
+  {"keyName": "taskContinue", "text": "DEV_Continue", "language": "dev"},
+  {"keyName": "outreachLearnMore", "text": "DEV_Learn More", "language": "dev"}
 ]

--- a/populate/src/main/resources/seed/i18n/en/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/en/languageTexts.json
@@ -10,5 +10,11 @@
   {"keyName": "taskDeclined", "text": "Declined", "language": "en"},
   {"keyName": "taskLocked", "text": "Locked", "language": "en"},
   {"keyName": "tasksNoneForStudy", "text": "No tasks for this study", "language": "en"},
-  {"keyName": "surveysSomeLocked", "text": "Some surveys are locked until other required tasks are completed.", "language": "en"}
+  {"keyName": "surveysSomeLocked", "text": "Some surveys are locked until other required tasks are completed.", "language": "en"},
+  {"keyName": "taskTypeSurvey", "text": "Survey", "language": "en"},
+  {"keyName": "taskTypeSurveys", "text": "Surveys", "language": "en"},
+  {"keyName": "taskTypeConsent", "text": "Consent", "language": "en"},
+  {"keyName": "taskTypeForms", "text": "Forms", "language": "en"},
+  {"keyName": "taskStart", "text": "Start", "language": "en"},
+  {"keyName": "taskContinue", "text": "Continue", "language": "en"}
 ]

--- a/populate/src/main/resources/seed/i18n/en/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/en/languageTexts.json
@@ -16,5 +16,6 @@
   {"keyName": "taskTypeConsent", "text": "Consent", "language": "en"},
   {"keyName": "taskTypeForms", "text": "Forms", "language": "en"},
   {"keyName": "taskStart", "text": "Start", "language": "en"},
-  {"keyName": "taskContinue", "text": "Continue", "language": "en"}
+  {"keyName": "taskContinue", "text": "Continue", "language": "en"},
+  {"keyName": "outreachLearnMore", "text": "Learn More", "language": "en"}
 ]

--- a/populate/src/main/resources/seed/i18n/es/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/es/languageTexts.json
@@ -16,5 +16,6 @@
   {"keyName": "taskTypeConsent", "text": "Consentimiento", "language": "es"},
   {"keyName": "taskTypeForms", "text": "Formas", "language": "es"},
   {"keyName": "taskStart", "text": "Comenzar", "language": "es"},
-  {"keyName": "taskContinue", "text": "Continuar", "language": "es"}
+  {"keyName": "taskContinue", "text": "Continuar", "language": "es"},
+  {"keyName": "outreachLearnMore", "text": "Aprende Más", "language": "es"}
 ]

--- a/populate/src/main/resources/seed/i18n/es/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/es/languageTexts.json
@@ -10,5 +10,11 @@
   {"keyName": "taskDeclined", "text": "Rechazado", "language": "es"},
   {"keyName": "taskLocked", "text": "Bloqueado", "language": "es"},
   {"keyName": "tasksNoneForStudy", "text": "No hay tareas para este estudio", "language": "es"},
-  {"keyName": "surveysSomeLocked", "text": "Algunas encuestas están bloqueadas hasta que se completen otras tareas requeridas.", "language": "es"}
+  {"keyName": "surveysSomeLocked", "text": "Algunas encuestas están bloqueadas hasta que se completen otras tareas requeridas.", "language": "es"},
+  {"keyName": "taskTypeSurvey", "text": "Encuesta", "language": "es"},
+  {"keyName": "taskTypeSurveys", "text": "Encuestas", "language": "es"},
+  {"keyName": "taskTypeConsent", "text": "Consentimiento", "language": "es"},
+  {"keyName": "taskTypeForms", "text": "Formas", "language": "es"},
+  {"keyName": "taskStart", "text": "Comenzar", "language": "es"},
+  {"keyName": "taskContinue", "text": "Continuar", "language": "es"}
 ]

--- a/ui-admin/src/forms/FormPreview.tsx
+++ b/ui-admin/src/forms/FormPreview.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Survey as SurveyJSComponent } from 'survey-react-ui'
+import 'survey-core/survey.i18n'
 
 import { FormContent, PortalEnvironmentLanguage, surveyJSModelFromFormContent, useForceUpdate } from '@juniper/ui-core'
 

--- a/ui-core/src/participant/landing/sections/FrequentlyAskedQuestionsTemplate.tsx
+++ b/ui-core/src/participant/landing/sections/FrequentlyAskedQuestionsTemplate.tsx
@@ -35,6 +35,8 @@ type FrequentlyAskedQuestionsConfig = {
   questions: FaqQuestion[], // the questions
   showToggleAllButton?: boolean, // whether or not the show the expand/collapse button
   title?: string, // large heading text
+  collapseAllText?: string,
+  expandAllText?: string
 }
 
 const validateFaqQuestion = (questionConfig: unknown): FaqQuestion => {
@@ -51,6 +53,8 @@ const validateFrequentlyAskedQuestionsConfig = (config: SectionConfig): Frequent
   const title = requireOptionalString(config, 'title', message)
   const blurb = requireOptionalString(config, 'blurb', message)
   const showToggleAllButton = requireOptionalBoolean(config, 'showToggleAllButton', message)
+  const collapseAllText = requireOptionalString(config, 'collapseAllText', message)
+  const expandAllText = requireOptionalString(config, 'expandAllText', message)
 
   const questions = config.questions
   if (!Array.isArray(questions)) {
@@ -61,7 +65,9 @@ const validateFrequentlyAskedQuestionsConfig = (config: SectionConfig): Frequent
     blurb,
     questions: questions.map(validateFaqQuestion),
     showToggleAllButton,
-    title
+    title,
+    collapseAllText,
+    expandAllText
   }
 }
 
@@ -120,7 +126,9 @@ function FrequentlyAskedQuestionsTemplate(props: FrequentlyAskedQuestionsProps) 
     blurb,
     questions,
     showToggleAllButton = true,
-    title = 'Frequently Asked Questions'
+    title = 'Frequently Asked Questions',
+    collapseAllText = 'Collapse All',
+    expandAllText = 'Expand All'
   } = config
 
   const { getImageUrl } = useApiContext()
@@ -165,7 +173,7 @@ function FrequentlyAskedQuestionsTemplate(props: FrequentlyAskedQuestionsProps) 
             <span className="d-inline-block me-2 text-center" style={{ width: 20 }}>
               <FontAwesomeIcon icon={allQuestionsAreExpanded ? faXmark : faPlus} />
             </span>
-            {allQuestionsAreExpanded ? 'Collapse' : 'Expand'} all
+            {allQuestionsAreExpanded ? collapseAllText : expandAllText}
           </button>
         </div>
       )}

--- a/ui-participant/src/hub/HubPage.test.tsx
+++ b/ui-participant/src/hub/HubPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import React from 'react'
 import HubPage from './HubPage'
 import { setupRouterTest } from '../test-utils/router-testing-utils'
+import { MockI18nProvider, mockTextsDefault } from '../test-utils/i18n-testing-utils'
 
 
 jest.mock('../providers/PortalProvider', () => {
@@ -57,24 +58,22 @@ jest.mock('../providers/UserProvider', () => {
   }
 })
 
-jest.mock('providers/I18nProvider', () => {
-  return {
-    useI18n: () => ({
-      i18n: (key: string) => key
-    })
-  }
-})
-
 describe('HubPage', () => {
   it('is rendered with the study name', () => {
-    const { RoutedComponent } = setupRouterTest(<HubPage />)
+    const { RoutedComponent } = setupRouterTest(
+      <MockI18nProvider mockTexts={{}}>
+        <HubPage/>
+      </MockI18nProvider>)
     render(RoutedComponent)
 
     expect(screen.getByText('Test Study')).toBeInTheDocument()
   })
 
   it('is rendered with a Start button for the next new task', () => {
-    const { RoutedComponent } = setupRouterTest(<HubPage />)
+    const { RoutedComponent } = setupRouterTest(
+      <MockI18nProvider mockTexts={mockTextsDefault}>
+        <HubPage />
+      </MockI18nProvider>)
     render(RoutedComponent)
 
     expect(screen.getByText('Start Consent')).toBeInTheDocument()

--- a/ui-participant/src/hub/HubPage.test.tsx
+++ b/ui-participant/src/hub/HubPage.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import React from 'react'
 import HubPage from './HubPage'
-import { setupRouterTest } from '../test-utils/router-testing-utils'
-import { MockI18nProvider, mockTextsDefault } from '../test-utils/i18n-testing-utils'
+import { setupRouterTest } from 'test-utils/router-testing-utils'
+import { MockI18nProvider, mockTextsDefault } from 'test-utils/i18n-testing-utils'
 
 
 jest.mock('../providers/PortalProvider', () => {

--- a/ui-participant/src/hub/OutreachTasks.test.tsx
+++ b/ui-participant/src/hub/OutreachTasks.test.tsx
@@ -5,7 +5,7 @@ import { mockEnrollee, mockParticipantTask, mockSurvey } from 'test-utils/test-p
 import OutreachTasks from './OutreachTasks'
 import { mockStudy, mockStudyEnv } from 'test-utils/test-portal-factory'
 import Api, { TaskWithSurvey } from 'api/api'
-import { MockI18nProvider } from '../test-utils/i18n-testing-utils'
+import { MockI18nProvider } from 'test-utils/i18n-testing-utils'
 
 describe('OutreachTasks', () => {
   it('show tasks with blurbs', async () => {

--- a/ui-participant/src/hub/OutreachTasks.test.tsx
+++ b/ui-participant/src/hub/OutreachTasks.test.tsx
@@ -5,6 +5,7 @@ import { mockEnrollee, mockParticipantTask, mockSurvey } from 'test-utils/test-p
 import OutreachTasks from './OutreachTasks'
 import { mockStudy, mockStudyEnv } from 'test-utils/test-portal-factory'
 import Api, { TaskWithSurvey } from 'api/api'
+import { MockI18nProvider } from '../test-utils/i18n-testing-utils'
 
 describe('OutreachTasks', () => {
   it('show tasks with blurbs', async () => {
@@ -40,8 +41,11 @@ describe('OutreachTasks', () => {
       }
     ]
     jest.spyOn(Api, 'listOutreachActivities').mockResolvedValue(tasksWithSurvey)
-    const { RoutedComponent } = setupRouterTest(<OutreachTasks
-      enrollees={[enrollee]} studies={[study]}/>)
+    const { RoutedComponent } = setupRouterTest(
+      <MockI18nProvider mockTexts={{}}>
+        <OutreachTasks enrollees={[enrollee]} studies={[study]}/>
+      </MockI18nProvider>
+    )
     render(RoutedComponent)
     await waitFor(() => expect(screen.getByText('Survey 1 blurb')).toBeInTheDocument())
     await waitFor(() => expect(screen.getByText('Survey 2 blurb')).toBeInTheDocument())

--- a/ui-participant/src/hub/OutreachTasks.tsx
+++ b/ui-participant/src/hub/OutreachTasks.tsx
@@ -4,7 +4,7 @@ import { getTaskPath } from './TaskLink'
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 import SurveyModal from './SurveyModal'
 import { useTaskIdParam } from './survey/SurveyView'
-import { useI18n } from '../providers/I18nProvider'
+import { useI18n } from 'providers/I18nProvider'
 
 type OutreachParams = {
     enrolleeShortcode?: string,

--- a/ui-participant/src/hub/OutreachTasks.tsx
+++ b/ui-participant/src/hub/OutreachTasks.tsx
@@ -4,6 +4,7 @@ import { getTaskPath } from './TaskLink'
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 import SurveyModal from './SurveyModal'
 import { useTaskIdParam } from './survey/SurveyView'
+import { useI18n } from '../providers/I18nProvider'
 
 type OutreachParams = {
     enrolleeShortcode?: string,
@@ -27,6 +28,7 @@ const useOutreachParams = () => {
  * all of the tasks from the portal the user has signed into are shown, and that may include
  * multiple studies and therefore enrollees */
 export default function OutreachTasks({ enrollees, studies }: {enrollees: Enrollee[], studies: Study[]}) {
+  const { i18n } = useI18n()
   const navigate = useNavigate()
   const outreachParams = useOutreachParams()
   const [outreachTasks, setOutreachActivities] = useState<TaskWithSurvey[]>([])
@@ -88,7 +90,7 @@ export default function OutreachTasks({ enrollees, studies }: {enrollees: Enroll
             </p>
             <div className="py-3 text-center" style={{ background: 'var(--brand-color-shift-90)' }}>
               <Link to={taskUrl} className="btn rounded-pill ps-4 pe-4 fw-bold btn-primary">
-              Learn More
+                {i18n('outreachLearnMore')}
               </Link>
             </div>
           </div>

--- a/ui-participant/src/hub/StudyResearchTasks.test.tsx
+++ b/ui-participant/src/hub/StudyResearchTasks.test.tsx
@@ -3,7 +3,7 @@ import { setupRouterTest } from 'test-utils/router-testing-utils'
 import { render, screen } from '@testing-library/react'
 import { mockEnrollee, mockParticipantTask } from 'test-utils/test-participant-factory'
 import StudyResearchTasks from './StudyResearchTasks'
-import { MockI18nProvider, mockTextsDefault } from '../test-utils/i18n-testing-utils'
+import { MockI18nProvider, mockTextsDefault } from 'test-utils/i18n-testing-utils'
 
 describe('HubPage', () => {
   it('renders tasks with consent and required surveys first', () => {

--- a/ui-participant/src/hub/StudyResearchTasks.test.tsx
+++ b/ui-participant/src/hub/StudyResearchTasks.test.tsx
@@ -3,10 +3,7 @@ import { setupRouterTest } from 'test-utils/router-testing-utils'
 import { render, screen } from '@testing-library/react'
 import { mockEnrollee, mockParticipantTask } from 'test-utils/test-participant-factory'
 import StudyResearchTasks from './StudyResearchTasks'
-
-jest.mock('providers/I18nProvider', () => ({
-  useI18n: () => ({ i18n: (key: string) => key })
-}))
+import { MockI18nProvider, mockTextsDefault } from '../test-utils/i18n-testing-utils'
 
 describe('HubPage', () => {
   it('renders tasks with consent and required surveys first', () => {
@@ -32,10 +29,14 @@ describe('HubPage', () => {
         targetName: 'Outreach Survey'
       }
     ]
-    const { RoutedComponent } = setupRouterTest(<StudyResearchTasks
-      enrollee={enrollee} participantTasks={participantTasks} studyShortcode={'study1'}
-    />)
+
+    const { RoutedComponent } = setupRouterTest(
+      <MockI18nProvider mockTexts={mockTextsDefault}>
+        <StudyResearchTasks enrollee={enrollee} participantTasks={participantTasks} studyShortcode={'study1'}/>
+      </MockI18nProvider>
+    )
     render(RoutedComponent)
+
     expect(screen.getByText('Start Consent')).toBeInTheDocument()
     // compareDocumentPosition returns the relationship of the argument with respect to the element (which is the
     // opposite of how I always read it). So below we are asserting the consent form is preceding the survey

--- a/ui-participant/src/hub/StudyResearchTasks.tsx
+++ b/ui-participant/src/hub/StudyResearchTasks.tsx
@@ -5,9 +5,9 @@ import { Enrollee, ParticipantTask } from 'api/api'
 import { useI18n } from 'providers/I18nProvider'
 
 
-const taskTypeDisplayMap: Record<string, string> = {
-  CONSENT: 'Consent',
-  SURVEY: 'Survey'
+const taskTypeMap: Record<string, string> = {
+  CONSENT: 'taskTypeConsent',
+  SURVEY: 'taskTypeSurvey'
 }
 
 const enrolleeHasStartedTaskType = (enrollee: Enrollee, taskType: string): boolean => {
@@ -61,9 +61,9 @@ export default function StudyResearchTasks(props: StudyResearchTasksProps) {
             className="btn rounded-pill ps-4 pe-4 fw-bold btn-primary"
           >
             {enrolleeHasStartedTaskType(enrollee, nextTask.taskType)
-              ? 'Continue'
-              : 'Start'}
-            {' '}{taskTypeDisplayMap[nextTask.taskType]}
+              ? i18n('taskContinue')
+              : i18n('taskStart')}
+            {' '}{i18n(taskTypeMap[nextTask.taskType])}
             {numTasksOfNextTaskType > 1 && 's'}
           </Link>
         </div>
@@ -74,7 +74,7 @@ export default function StudyResearchTasks(props: StudyResearchTasksProps) {
           enrollee={enrollee}
           studyShortcode={studyShortcode}
           tasks={sortedActiveConsentTasks}
-          title="Consent"
+          title={i18n('taskTypeConsent')}
         />
       )}
 
@@ -83,7 +83,7 @@ export default function StudyResearchTasks(props: StudyResearchTasksProps) {
           enrollee={enrollee}
           tasks={sortedSurveyTasks}
           studyShortcode={studyShortcode}
-          title="Surveys"
+          title={i18n('taskTypeSurveys')}
         />
       )}
 
@@ -92,7 +92,7 @@ export default function StudyResearchTasks(props: StudyResearchTasksProps) {
           enrollee={enrollee}
           studyShortcode={studyShortcode}
           tasks={completedConsentTasks}
-          title="Forms"
+          title={i18n('taskTypeForms')}
         />
       )}
     </>

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import 'survey-core/survey.i18n'
 
 import Api, {
   Enrollee,

--- a/ui-participant/src/landing/LandingPage.test.tsx
+++ b/ui-participant/src/landing/LandingPage.test.tsx
@@ -8,7 +8,7 @@ import {
   mockPortal,
   mockPortalEnvironment
 } from 'test-utils/test-portal-factory'
-import { MockI18nProvider } from '../test-utils/i18n-testing-utils'
+import { MockI18nProvider } from 'test-utils/i18n-testing-utils'
 
 jest.mock('providers/PortalProvider', () => {
   return {

--- a/ui-participant/src/landing/LandingPage.test.tsx
+++ b/ui-participant/src/landing/LandingPage.test.tsx
@@ -8,6 +8,7 @@ import {
   mockPortal,
   mockPortalEnvironment
 } from 'test-utils/test-portal-factory'
+import { MockI18nProvider } from '../test-utils/i18n-testing-utils'
 
 jest.mock('providers/PortalProvider', () => {
   return {
@@ -15,10 +16,6 @@ jest.mock('providers/PortalProvider', () => {
     usePortalEnv: jest.fn()
   }
 })
-
-jest.mock('providers/I18nProvider', () => ({
-  useI18n: () => ({ i18n: (key: string) => key })
-}))
 
 describe('LandingPage', () => {
   beforeEach(() => {
@@ -33,7 +30,10 @@ describe('LandingPage', () => {
   it('handles trivial landing page', () => {
     const { RoutedComponent } =
             setupRouterTest(
-              <LandingPage localContent={mockLocalSiteContent()}/>)
+              <MockI18nProvider mockTexts={{}}>
+                <LandingPage localContent={mockLocalSiteContent()}/>
+              </MockI18nProvider>
+            )
     render(RoutedComponent)
     // mailing list modal is hidden by default
     expectNever(() =>
@@ -44,7 +44,9 @@ describe('LandingPage', () => {
   it('shows mailing list modal if url param is present', () => {
     const { RoutedComponent } =
             setupRouterTest(
-              <LandingPage localContent={mockLocalSiteContent()}/>, ['?showJoinMailingList=true'])
+              <MockI18nProvider mockTexts={{}}>
+                <LandingPage localContent={mockLocalSiteContent()}/>
+              </MockI18nProvider>, ['?showJoinMailingList=true'])
     render(RoutedComponent)
     // mailing list modal is hidden by default
     waitFor(() => expect(screen.getByLabelText('Join mailing list'))

--- a/ui-participant/src/providers/I18nProvider.tsx
+++ b/ui-participant/src/providers/I18nProvider.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useEffect, useState } from 'react'
 import Api from 'api/api'
 import { useUser } from './UserProvider'
 
-const I18nContext = createContext<I18nContextT | null>(null)
+export const I18nContext = createContext<I18nContextT | null>(null)
 
 export type I18nContextT = {
   languageTexts: Record<string, string>

--- a/ui-participant/src/test-utils/i18n-testing-utils.tsx
+++ b/ui-participant/src/test-utils/i18n-testing-utils.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { I18nContext, I18nContextT } from '../providers/I18nProvider'
+
+export const mockTextsDefault: Record<string, string> = { taskTypeConsent: 'Consent', taskStart: 'Start' }
+
+/**
+ * Returns a MockI18nProvider. Used to test components that need an I18nContext
+ */
+export const MockI18nProvider = ({ children, mockTexts }: {
+    children: React.ReactNode, mockTexts: Record<string, string>
+}) => {
+  const fakeI18nContext: I18nContextT = {
+    languageTexts: mockTexts,
+    i18n: (key: string) => mockTexts[key]
+  }
+  return <I18nContext.Provider value={fakeI18nContext}>
+    {children}
+  </I18nContext.Provider>
+}

--- a/ui-participant/src/test-utils/i18n-testing-utils.tsx
+++ b/ui-participant/src/test-utils/i18n-testing-utils.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { I18nContext, I18nContextT } from '../providers/I18nProvider'
+import { I18nContext, I18nContextT } from 'providers/I18nProvider'
 
 export const mockTextsDefault: Record<string, string> = { taskTypeConsent: 'Consent', taskStart: 'Start' }
 


### PR DESCRIPTION
#### DESCRIPTION

Most texts were done as part of https://github.com/broadinstitute/juniper/pull/747

This also makes use of SurveyJS's built-in i18n so we can have various SurveyJS UI elements translated without having to internationalize them ourselves.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Restart admin API to repopulate the database with the new texts
In the participant UI, confirm that you see the updated texts
Change the language and also verify that you can see the translations for various SurveyJS UI elements (note that Next button or the page number indicators at the bottom of the survey view)