### PR TITLE
[JN-843] adding legacy image endpoint

### DIFF
--- a/api-participant/src/main/resources/api/openapi.yml
+++ b/api-participant/src/main/resources/api/openapi.yml
@@ -375,6 +375,26 @@ paths:
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/public/portals/v1/{portalShortcode}/env/{envName}/siteImages/{version}/{cleanFileName}:
+    get:
+      summary: Returns the binary image data for the image of the given shortcode (legacy endpoint for siteMedia--will be removed)
+      tags: [ siteMedia ]
+      operationId: get
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: envName, in: path, required: true, schema: { type: string } }
+        - { name: cleanFileName, in: path, required: true, schema: { type: string } }
+        - { name: version, in: path, required: true, schema: { type: integer } }
+      responses:
+        '200':
+          description: image data
+          content:
+            image/*: # see https://superuser.com/questions/979135/is-there-a-generic-mime-type-for-all-image-files
+              schema:
+                type: string
+                format: binary
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/public/portals/v1/{portalShortcode}/env/{envName}/siteMedia/{version}/{cleanFileName}:
     get:
       summary: Returns the binary image data for the image of the given shortcode

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
@@ -38,6 +38,8 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
                 "siteLink", getSiteLink(contextInfo.portalEnv(), contextInfo.portal()),
                 "participantSupportEmailLink", getParticipantSupportEmailLink(contextInfo.portalEnv()),
                 "siteMediaBaseUrl", getImageBaseUrl(contextInfo.portalEnv(), contextInfo.portal().getShortcode()),
+                // legacy template substitution support
+                "siteImageBaseUrl", getImageBaseUrl(contextInfo.portalEnv(), contextInfo.portal().getShortcode()),
                 // providing a study isn't required, since emails might come from the portal, rather than a study
                 // but immutable map doesn't allow nulls
                 "study", contextInfo.study() != null ? contextInfo.study() : ""));

--- a/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
+++ b/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
@@ -21,9 +21,12 @@ export default function EmailTemplateEditor({ emailTemplate, updateEmailTemplate
 
   const replacePlaceholders = (html: string) => {
     return html.replaceAll('${siteMediaBaseUrl}', location.origin + getMediaBaseUrl(portalShortcode))
+      // support legacy tempaltes that reference this as siteImageBaseUrl
+      .replaceAll('${siteImageBaseUrl}', location.origin + getMediaBaseUrl(portalShortcode))
   }
   const insertPlaceholders = (html: string) => {
     return html.replaceAll(location.origin + getMediaBaseUrl(portalShortcode), '${siteMediaBaseUrl}')
+      .replaceAll('${siteImageBaseUrl}', location.origin + getMediaBaseUrl(portalShortcode))
   }
 
   const onEditorLoaded: EmailEditorProps['onReady'] = unlayer => {


### PR DESCRIPTION
#### DESCRIPTION

Adds a legacy image endpoint to give us a smoother migration path for customer data.  This doesn't add a legacy endpoint to the admin tool -- seeing the broken images there will help us find any paths to migrate.  Also updates email templates to support legacy replacement

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  Redeploy apiParticipantApp
2.  check out a past version of the codebase prior to Connor's image updates (e.g. 6c64d25f45c800b1074eb6a6eaba78546b9f40ba)
3. go to sandbox.ourhealth.localhost:3001
4. confirm images are loaded, despite the api requests going to .../siteImages/...