### PR TITLE
JN-843 fixing bean initialization condition

### DIFF
--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/SiteMediaController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/SiteMediaController.java
@@ -28,6 +28,12 @@ public class SiteMediaController implements SiteMediaApi {
     return convertToResourceResponse(siteMediaOpt);
   }
 
+  @Override
+  public ResponseEntity<Resource> getLegacy(
+      String portalShortcode, String envName, String cleanFileName, Integer version) {
+    return get(portalShortcode, envName, cleanFileName, version);
+  }
+
   private ResponseEntity<Resource> convertToResourceResponse(Optional<SiteMedia> imageOpt) {
     if (imageOpt.isPresent()) {
       MediaType contentType;

--- a/api-participant/src/main/resources/api/openapi.yml
+++ b/api-participant/src/main/resources/api/openapi.yml
@@ -379,7 +379,7 @@ paths:
     get:
       summary: Returns the binary image data for the image of the given shortcode (legacy endpoint for siteMedia--will be removed)
       tags: [ siteMedia ]
-      operationId: get
+      operationId: getLegacy
       parameters:
         - { name: portalShortcode, in: path, required: true, schema: { type: string } }
         - { name: envName, in: path, required: true, schema: { type: string } }


### PR DESCRIPTION
#### DESCRIPTION
Apparently adding two endpoints pointing to the same method can cause initialization problems depending on order of setup.  (note https://sandbox.ourhealth.ddp-dev.envs.broadinstitute.org/ is broken right now).  This fixes that by routing the legacy get to a separate method that then delegates to the real method


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  redeploy apiParticipantApp
2. confirm images still load for participants