### PR TITLE
JN-906: Improving look of logo grid

### DIFF
--- a/ui-core/src/participant/landing/sections/HeroWithImageTemplate.tsx
+++ b/ui-core/src/participant/landing/sections/HeroWithImageTemplate.tsx
@@ -152,11 +152,14 @@ function HeroWithImageTemplate(props: HeroWithImageTemplateProps) {
             >
               {_.map(logos, (logo, i) => {
                 return (
-                  <ConfiguredMedia
-                    key={i}
-                    media={logo}
-                    className={classNames({ 'mt-4': i !== 0 }, 'mt-sm-0', 'me-sm-4')}
-                  />
+                  <div style={{ width: '250px', paddingRight: '10px' }}>
+                    <ConfiguredMedia
+                      key={i}
+                      media={logo}
+                      style={{ maxWidth: '100%' }}
+                      className={classNames({ 'mt-4': i !== 0 }, 'mt-sm-0', 'me-sm-4')}
+                    />
+                  </div>
                 )
               })}
             </div>


### PR DESCRIPTION
#### DESCRIPTION

This puts logos in a fixed grid to make them look less ragged.  

![image](https://github.com/broadinstitute/juniper/assets/2800795/405a3992-4e45-40a2-88cd-7f1ed005257f)

We may eventually want to make this toggleable, since there might be some very long or very short logos that look worse with this format, but I checked both HeartHive and OurHealth, and it looks better with both, so no sense in adding config we don't need yet

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to OurHealth participant view, confirm logos look good at a variety of browser sizes