### PR TITLE
JN-893: fixing e2e tests to work with https

### DIFF
--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -25,11 +25,14 @@ const globalSetup = async () => {
     process.env.ADMIN_URL = 'http://localhost:8080'
     process.env.PARTICIPANT_URL = 'http://sandbox.demo.localhost:8081'
   } else {
-    process.env.ADMIN_URL = 'http://localhost:3000'
-    process.env.PARTICIPANT_URL = 'http://sandbox.demo.localhost:3001'
+    process.env.ADMIN_URL = 'https://localhost:3000'
+    process.env.PARTICIPANT_URL = 'https://sandbox.demo.localhost:3001'
   }
-
-  await runPopulatePortalScript()
+  if (process.env.CI) {
+    await runPopulatePortalScript()
+  } else {
+    console.log('INFO - Skipping `populate_portal.sh demo` -- Non-CI env. assumes demo is already populated')
+  }
 }
 
 export default globalSetup

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -36,7 +36,13 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] }
+      use: {
+        ...devices['Desktop Chrome'],
+        contextOptions: {
+          ignoreHTTPSErrors: true
+        },
+        ignoreHTTPSErrors: true
+      }
     }
 
     // {
@@ -89,16 +95,18 @@ export default defineConfig({
     ...(
       process.env.CI ? [] : [
         {
-          command: 'cd .. && npm -w ui-admin start',
-          url: 'http://localhost:3000',
+          command: 'cd .. && REACT_APP_UNAUTHED_LOGIN=true HTTPs=true npm -w ui-admin start',
+          url: 'https://localhost:3000',
           timeout: 120 * 1000,
-          reuseExistingServer: !process.env.CI
+          reuseExistingServer: !process.env.CI,
+          ignoreHTTPSErrors: true
         },
         {
-          command: 'cd .. && npm -w ui-participant start',
-          url: 'http://localhost:3001',
+          command: 'cd .. && REACT_APP_UNAUTHED_LOGIN=true HTTPS=true npm -w ui-participant start',
+          url: 'https://localhost:3001',
           timeout: 120 * 1000,
-          reuseExistingServer: !process.env.CI
+          reuseExistingServer: !process.env.CI,
+          ignoreHTTPSErrors: true
         }
       ]
     )


### PR DESCRIPTION
#### DESCRIPTION

This updates our e2e test to work with local dev servers running HTTPS, which is now the standard way we do things.  It also changes the tests to assume that 'demo' is already populated in non-CI environments rather than rerunning it every time.  This will make development of these tests much faster.  

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. ensure the 'demo' study is populated in your local environment
2. `cd e2e-tests`
3. run `npx install`
4. run `npx playwright test`
5. you should get a confirmation that our 1 test passed
