### PR TITLE
[JN-906] adding link capability to logos

### DIFF
--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/dev/landingPage.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/dev/landingPage.json
@@ -21,13 +21,15 @@
           "cleanFileName": "broad_logo.png",
           "version": 1,
           "alt": "DEV_Broad Institute logo",
-          "style": { "height": "40px" }
+          "style": { "height": "40px" },
+          "link": "https://www.broadinstitute.org/"
         },
         {
           "cleanFileName": "mgh_logo.png",
           "version": 1,
           "alt": "DEV_Massachusetts General Hospital logo",
-          "style": { "height": "40px" }
+          "style": { "height": "40px" },
+          "link": "https://massgeneral.org/"
         }
       ]
     }

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/landingPage.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/landingPage.json
@@ -21,13 +21,15 @@
           "cleanFileName": "broad_logo.png",
           "version": 1,
           "alt": "Broad Institute logo",
-          "style": { "height": "40px" }
+          "style": { "height": "40px" },
+          "link": "https://www.broadinstitute.org/"
         },
         {
           "cleanFileName": "mgh_logo.png",
           "version": 1,
           "alt": "Massachusetts General Hospital logo",
-          "style": { "height": "40px" }
+          "style": { "height": "40px" },
+          "link": "https://www.massgeneral.org/"
         }
       ]
     }

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/es/landingPage.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/es/landingPage.json
@@ -21,13 +21,15 @@
           "cleanFileName": "broad_logo.png",
           "version": 1,
           "alt": "Logotipo del Instituto Broad",
-          "style": { "height": "40px" }
+          "style": { "height": "40px" },
+          "link": "https://www.broadinstitute.org/"
         },
         {
           "cleanFileName": "mgh_logo.png",
           "version": 1,
           "alt": "Logotipo del Hospital General de Massachusetts",
-          "style": { "height": "40px" }
+          "style": { "height": "40px" },
+          "link": "https://massgeneral.org/"
         }
       ]
     }

--- a/ui-core/src/participant/landing/ConfiguredMedia.test.tsx
+++ b/ui-core/src/participant/landing/ConfiguredMedia.test.tsx
@@ -25,5 +25,16 @@ describe('ConfiguredMedia', () => {
     render(<ConfiguredMedia media={{ cleanFileName: 'foo.png', version: 1, alt: 'testImage' }}/>)
     expect(screen.getByAltText('testImage')).toBeInTheDocument()
     expect(screen.queryByTestId('media-iframe')).not.toBeInTheDocument()
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+
+  it('renders image with a link', () => {
+    render(<ConfiguredMedia media={{
+      cleanFileName: 'foo.png', version: 1,
+      alt: 'testImage', link: 'https://fizzle.com'
+    }}/>)
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', 'https://fizzle.com')
+    expect(link).toContainElement(screen.getByAltText('testImage'))
   })
 })

--- a/ui-core/src/participant/landing/ConfiguredMedia.tsx
+++ b/ui-core/src/participant/landing/ConfiguredMedia.tsx
@@ -18,6 +18,7 @@ export type ImageConfig = {
   alt?: string
   className?: string
   style?: CSSProperties
+  link?: string
 }
 
 export type MediaConfig = ImageConfig | VideoConfig
@@ -33,6 +34,7 @@ export const validateMediaConfig = (imageConfig: unknown): MediaConfig => {
   const alt = requireOptionalString(config, 'alt', message)
   const className = requireOptionalString(config, 'className', message)
   const videoLink = requireOptionalString(config, 'videoLink', message)
+  const link = requireOptionalString(config, 'link', message)
   // Only validate that style is an object. React will handle invalid keys.
   const style = config.style ? requirePlainObject(config.style, `${message}: Invalid style`) : undefined
 
@@ -42,7 +44,7 @@ export const validateMediaConfig = (imageConfig: unknown): MediaConfig => {
     alt,
     className,
     style,
-    videoLink
+    link
   } as MediaConfig
 }
 
@@ -66,13 +68,17 @@ export default function ConfiguredMedia(props: ConfiguredImageProps) {
       {!videoAllowed && <span className="text-danger">Disallowed video source</span> }
     </div>
   }
-  return <img
+  const image = <img
     src={getImageUrl((media as ImageConfig).cleanFileName, (media as ImageConfig).version)}
     alt={media.alt}
     className={classNames('configured-image', className, media.className)}
     loading="lazy"
     style={{ ...style, ...media.style }}
   />
+  if ((media as ImageConfig).link) {
+    return <a href={(media as ImageConfig).link} target="_blank" rel="noreferrer">{image}</a>
+  }
+  return image
 }
 
 const ALLOWED_VIDEO_HOSTS = ['youtube.com', 'youtu.be', 'vimeo.com']

--- a/ui-core/src/participant/landing/ConfiguredMedia.tsx
+++ b/ui-core/src/participant/landing/ConfiguredMedia.tsx
@@ -44,7 +44,8 @@ export const validateMediaConfig = (imageConfig: unknown): MediaConfig => {
     alt,
     className,
     style,
-    link
+    link,
+    videoLink
   } as MediaConfig
 }
 


### PR DESCRIPTION
#### DESCRIPTION

Adds the ability to add "link" to any configured image so that the image will be rendered in a link.  this was requested for logo display

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. repopulate demo
2. go to sandbox.demo.localhost:3001. 
3. confirm you can click the logos for Broad and MGH and go places