### PR TITLE
[JN-874] changing default video sizing

### DIFF
--- a/ui-core/src/participant/landing/ConfiguredMedia.tsx
+++ b/ui-core/src/participant/landing/ConfiguredMedia.tsx
@@ -62,10 +62,10 @@ export default function ConfiguredMedia(props: ConfiguredImageProps) {
   if ((media as VideoConfig).videoLink) {
     const videoLinkMedia = media as VideoConfig
     const videoAllowed = isVideoLinkAllowed(videoLinkMedia.videoLink)
-    return <div style={{ ...style, ...media.style }}
+    return <div style={{ width: '100%', height: '100%', ...style, ...media.style }}
       className={classNames('configured-image', className, media.className)}>
       {videoAllowed && <iframe src={videoLinkMedia.videoLink} frameBorder="0" allowFullScreen={true}
-        data-testid="media-iframe"></iframe> }
+        data-testid="media-iframe" style={{ width: '100%', height: '100%' }}></iframe> }
       {!videoAllowed && <span className="text-danger">Disallowed video source</span> }
     </div>
   }


### PR DESCRIPTION
#### DESCRIPTION

This changes the default video sizing to full-width.  it can still be overridden by specifying `style: {width...}` on the config.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. populate hearthive
2. go to sandbox.hearthive.localhost:3000.  Confirm the video occupies the full half
<img width="977" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/4110441d-57f5-4f6c-84a8-193976568963">

