### PR TITLE
[JN-929] undefined-safing choiceslist

### DIFF
--- a/ui-admin/src/forms/designer/questions/ChoicesList.test.tsx
+++ b/ui-admin/src/forms/designer/questions/ChoicesList.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, getByLabelText, render, screen } from '@testing-library
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 
-import { CheckboxQuestion } from '@juniper/ui-core'
+import { CheckboxQuestion, QuestionChoice } from '@juniper/ui-core'
 
 import { ChoicesList } from './ChoicesList'
 
@@ -154,5 +154,14 @@ describe('ChoicesList', () => {
         { value: 'baz', text: 'Baz' }
       ]
     })
+  })
+
+  it('renders nothing for questions with no choices', async () => {
+    render(<ChoicesList question={{
+      ...question,
+      choices: undefined as unknown as QuestionChoice[]
+    }} isNewQuestion={false} readOnly={false} onChange={jest.fn} />)
+
+    expect(screen.queryByText('Choices')).not.toBeInTheDocument()
   })
 })

--- a/ui-admin/src/forms/designer/questions/ChoicesList.tsx
+++ b/ui-admin/src/forms/designer/questions/ChoicesList.tsx
@@ -22,7 +22,9 @@ export const ChoicesList = (props: ChoicesListProps) => {
   const { question, isNewQuestion, readOnly, onChange } = props
 
   const labelId = useId()
-
+  if (!question.choices) {
+    return null
+  }
   return (
     <div className="mb-3 mt-4">
       <p className="mb-2 fw-semibold" id={labelId}>Choices</p>


### PR DESCRIPTION
#### DESCRIPTION
 This continues our gradual better support of "choicesByUrl" -- now viewing a standard question type (checkbox, dropdown, etc...) in the editor with no choices won't crash the display.  We'll want to improve this in the future by giving designer support to the "choicesByUrl" property, but for now, this works


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. in the json editor for a survey, delete the choices for a checkbox question, and add a "choicesByUrl" property.  (e.g. a link to `"https://admin-d2p.ddp-dev.envs.broadinstitute.org/api/public/portals/v1/demo/env/live/siteMedia/1/colors.json"`
2. go back to the question designer, and confirm you can click on that question without an error