### PR TITLE
JN-901 Managing relations when withdrawing an enrollee

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeRelationDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeRelationDao.java
@@ -57,8 +57,8 @@ public class EnrolleeRelationDao extends BaseMutableJdbiDao<EnrolleeRelation> {
         }
     }
 
-    public List<EnrolleeRelation> findByEnrolleeId(UUID enrolleeId) {
-        return findAllByProperty("enrollee_id", enrolleeId);
+    public List<EnrolleeRelation> findAllByEnrolleeId(UUID enrolleeId) {
+        return findAllValidByProperty("enrollee_id", enrolleeId);
     }
     /**
      * This method works like the original findAllByTwoProperties method, but it only returns relations that there

--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/WithdrawnEnrolleeDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/WithdrawnEnrolleeDao.java
@@ -19,16 +19,18 @@ public class WithdrawnEnrolleeDao extends BaseJdbiDao<WithdrawnEnrollee> {
   private ConsentResponseDao consentResponseDao;
   private ParticipantTaskDao participantTaskDao;
   private PreEnrollmentResponseDao preEnrollmentResponseDao;
+  private EnrolleeRelationDao enrolleeRelationDao;
 
   public WithdrawnEnrolleeDao(Jdbi jdbi, ProfileDao profileDao, SurveyResponseDao surveyResponseDao,
                               ConsentResponseDao consentResponseDao, ParticipantTaskDao participantTaskDao,
-                              PreEnrollmentResponseDao preEnrollmentResponseDao) {
+                              PreEnrollmentResponseDao preEnrollmentResponseDao, EnrolleeRelationDao enrolleeRelationDao) {
     super(jdbi);
     this.profileDao = profileDao;
     this.surveyResponseDao = surveyResponseDao;
     this.consentResponseDao = consentResponseDao;
     this.participantTaskDao = participantTaskDao;
     this.preEnrollmentResponseDao = preEnrollmentResponseDao;
+    this.enrolleeRelationDao = enrolleeRelationDao;
   }
 
   @Override
@@ -64,6 +66,8 @@ public class WithdrawnEnrolleeDao extends BaseJdbiDao<WithdrawnEnrollee> {
     if (enrollee.getPreEnrollmentResponseId() != null) {
       enrollee.setPreEnrollmentResponse(preEnrollmentResponseDao.find(enrollee.getPreEnrollmentResponseId()).get());
     }
+    enrollee.getRelations().addAll(enrolleeRelationDao.findAllByEnrolleeId(enrollee.getId()));
+    enrollee.getRelations().addAll(enrolleeRelationDao.findByTargetEnrolleeId(enrollee.getId()));
     return enrollee;
   }
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/participant/Enrollee.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/participant/Enrollee.java
@@ -43,4 +43,6 @@ public class Enrollee extends BaseEntity {
     private List<ParticipantNote> participantNotes = new ArrayList<>();
     @Builder.Default
     private List<KitRequestDto> kitRequests = new ArrayList<>();
+    @Builder.Default
+    private List<EnrolleeRelation> relations = new ArrayList<>();
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeRelationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeRelationService.java
@@ -61,6 +61,12 @@ public class EnrolleeRelationService extends DataAuditedService<EnrolleeRelation
                 "deleteAllByEnrolleeIdOrTargetId")).build());
     }
 
+    /**
+     * This method returns a list of enrollees that are exclusively proxied by the given enrollee.
+     * An enrollee is exclusively proxied if it is only proxied by the given enrollee and no other enrollees.
+     * @param enrolleeId the id of the enrollee to find exclusive proxied enrollees for
+     * @return a list of enrollees that are exclusively proxied by the given enrollee
+     * */
     public List<Enrollee> findExclusiveProxiedEnrollees(UUID enrolleeId) {
         List<EnrolleeRelation> enrolleeRelations = dao.findByEnrolleeIdAndRelationshipType(enrolleeId, RelationshipType.PROXY);
         List<Enrollee> exclusiveGovernedEnrollees = new ArrayList<>();

--- a/core/src/test/java/bio/terra/pearl/core/service/participant/WithdrawnEnrolleeServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/participant/WithdrawnEnrolleeServiceTests.java
@@ -5,6 +5,7 @@ import bio.terra.pearl.core.factory.DaoTestUtils;
 import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.WithdrawnEnrollee;
+import bio.terra.pearl.core.model.workflow.HubResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,5 +33,22 @@ public class WithdrawnEnrolleeServiceTests extends BaseSpringBootTest {
     assertThat(enrolleeService.find(enrollee.getId()).isPresent(), equalTo(false));
     assertThat(withdrawnEnrolleeService.find(withdrawnEnrollee.getId()).isPresent(), equalTo(true));
     assertThat(withdrawnEnrolleeService.isWithdrawn(enrollee.getShortcode()), equalTo(true));
+  }
+  @Test
+  @Transactional
+  public void testWithdrawProxyEnrollee(TestInfo info) {
+    HubResponse<Enrollee> hubResponse = enrolleeFactory.buildProxyAndGovernedEnrollee(getTestName(info), "proxy-email@test.com");
+    Enrollee proxyEnrollee = hubResponse.getEnrollee();
+    Enrollee governedEnrollee = hubResponse.getResponse();
+    DaoTestUtils.assertGeneratedProperties(proxyEnrollee);
+    WithdrawnEnrollee withdrawnEnrollee = withdrawnEnrolleeService.withdrawEnrollee(proxyEnrollee);
+    DaoTestUtils.assertGeneratedProperties(withdrawnEnrollee);
+    assertThat(proxyEnrollee.getShortcode().equals(withdrawnEnrollee.getShortcode()), equalTo(true));
+
+    assertThat(enrolleeService.find(proxyEnrollee.getId()).isPresent(), equalTo(false));
+    assertThat(enrolleeService.find(governedEnrollee.getId()).isPresent(), equalTo(false));
+    assertThat(withdrawnEnrolleeService.find(withdrawnEnrollee.getId()).isPresent(), equalTo(true));
+    assertThat(withdrawnEnrolleeService.isWithdrawn(proxyEnrollee.getShortcode()), equalTo(true));
+    assertThat(withdrawnEnrolleeService.isWithdrawn(governedEnrollee.getShortcode()), equalTo(true));
   }
 }


### PR DESCRIPTION
#### DESCRIPTION
This PR adjusts the withdrawing process to make sure the relations are documented and any governed user that does not have another proxy is withdrawn as well


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
at this point, this can only be tested with running the unit tests
