### PR TITLE
[JN-815] adding login enrollee tests

### DIFF
--- a/api-participant/src/test/java/bio/terra/pearl/api/participant/service/CurrentUserServiceTests.java
+++ b/api-participant/src/test/java/bio/terra/pearl/api/participant/service/CurrentUserServiceTests.java
@@ -6,10 +6,15 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
 import bio.terra.pearl.api.participant.BaseSpringBootTest;
+import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
+import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
 import bio.terra.pearl.core.factory.participant.ParticipantUserFactory;
 import bio.terra.pearl.core.factory.portal.PortalEnvironmentFactory;
 import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
+import bio.terra.pearl.core.model.study.StudyEnvironment;
+import bio.terra.pearl.core.service.participant.PortalParticipantUserService;
 import bio.terra.pearl.core.service.portal.PortalService;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
@@ -23,9 +28,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 public class CurrentUserServiceTests extends BaseSpringBootTest {
   @Autowired CurrentUserService currentUserService;
+  @Autowired PortalParticipantUserService portalParticipantUserService;
   @Autowired ParticipantUserFactory participantUserFactory;
   @Autowired PortalEnvironmentFactory portalEnvironmentFactory;
+  @Autowired StudyEnvironmentFactory studyEnvironmentFactory;
   @Autowired PortalService portalService;
+  @Autowired EnrolleeFactory enrolleeFactory;
 
   @Test
   @Transactional
@@ -51,14 +59,10 @@ public class CurrentUserServiceTests extends BaseSpringBootTest {
     String portalShortcode = portalService.find(portalEnv.getPortalId()).get().getShortcode();
     String token = generateFakeJwtToken(userBundle.user().getUsername());
 
-    try {
-      CurrentUserService.UserLoginDto loadedUser =
-          currentUserService.tokenLogin(token, portalShortcode, portalEnv.getEnvironmentName());
-      assertThat(loadedUser.user().getUsername(), equalTo(userBundle.user().getUsername()));
-      assertThat(loadedUser.user().getPortalParticipantUsers(), hasSize(1));
-    } catch (Exception e) {
-      Assertions.fail("Unexpected exception: " + e.getMessage());
-    }
+    CurrentUserService.UserLoginDto loadedUser =
+        currentUserService.tokenLogin(token, portalShortcode, portalEnv.getEnvironmentName());
+    assertThat(loadedUser.user().getUsername(), equalTo(userBundle.user().getUsername()));
+    assertThat(loadedUser.user().getPortalParticipantUsers(), hasSize(1));
 
     String missingUsername = "missing" + RandomStringUtils.randomAlphabetic(5) + "@test.com";
     String missingUserToken = generateFakeJwtToken(missingUsername);
@@ -72,6 +76,66 @@ public class CurrentUserServiceTests extends BaseSpringBootTest {
           containsString(
               "User not found for environment %s".formatted(portalEnv.getEnvironmentName())));
     }
+  }
+
+  @Test
+  @Transactional
+  public void testUserLoginWithEnrollees(TestInfo info) {
+    StudyEnvironmentFactory.StudyEnvironmentBundle studyEnvBundle =
+        studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.irb);
+    EnrolleeFactory.EnrolleeBundle enrolleeBundle =
+        enrolleeFactory.buildWithPortalUser(
+            getTestName(info), studyEnvBundle.getPortalEnv(), studyEnvBundle.getStudyEnv());
+
+    String token = generateFakeJwtToken(enrolleeBundle.participantUser().getUsername());
+
+    // see if we can login with the user while they have one enrollee
+    CurrentUserService.UserLoginDto loadedUser =
+        currentUserService.tokenLogin(
+            token,
+            studyEnvBundle.getPortal().getShortcode(),
+            studyEnvBundle.getStudyEnv().getEnvironmentName());
+    assertThat(
+        loadedUser.user().getUsername(), equalTo(enrolleeBundle.participantUser().getUsername()));
+    assertThat(loadedUser.user().getPortalParticipantUsers(), hasSize(1));
+    assertThat(loadedUser.enrollees(), hasSize(1));
+
+    // now see if we can do it with two enrollees attached to the user
+    StudyEnvironment studyEnv2 =
+        studyEnvironmentFactory.buildPersisted(studyEnvBundle.getPortalEnv(), getTestName(info));
+    Enrollee enrollee2 =
+        enrolleeFactory.buildPersisted(
+            getTestName(info),
+            studyEnv2.getId(),
+            enrolleeBundle.participantUser().getId(),
+            enrolleeBundle.portalParticipantUser().getProfileId());
+    loadedUser =
+        currentUserService.tokenLogin(
+            token,
+            studyEnvBundle.getPortal().getShortcode(),
+            studyEnvBundle.getStudyEnv().getEnvironmentName());
+    assertThat(
+        loadedUser.user().getUsername(), equalTo(enrolleeBundle.participantUser().getUsername()));
+    assertThat(loadedUser.enrollees(), hasSize(2));
+  }
+
+  @Test
+  @Transactional
+  public void testUserLoginWithProxy(TestInfo info) {
+    String email = "proxy" + RandomStringUtils.randomAlphabetic(5) + "@test.com";
+    EnrolleeFactory.EnrolleeAndProxy enrolleeAndProxy =
+        enrolleeFactory.buildProxyAndGovernedEnrollee(getTestName(info), email);
+    String token = generateFakeJwtToken(email);
+    String portalShortcode =
+        portalService.find(enrolleeAndProxy.portalEnv().getPortalId()).get().getShortcode();
+    // see if we can login with the user while they have one enrollee
+    CurrentUserService.UserLoginDto loadedUser =
+        currentUserService.tokenLogin(
+            token, portalShortcode, enrolleeAndProxy.portalEnv().getEnvironmentName());
+    assertThat(loadedUser.user().getUsername(), equalTo(email));
+    assertThat(loadedUser.user().getPortalParticipantUsers(), hasSize(1));
+    assertThat(loadedUser.enrollees(), hasSize(1));
+    assertThat(loadedUser.relations(), hasSize(1));
   }
 
   @Test

--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeRelationDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeRelationDao.java
@@ -25,15 +25,15 @@ public class EnrolleeRelationDao extends BaseMutableJdbiDao<EnrolleeRelation> {
 
 
     public List<EnrolleeRelation> findByEnrolleeIdAndRelationshipType(UUID enrolleeId, RelationshipType type) {
-        return findAllValidByTwoProperties("enrollee_id", enrolleeId,"relationship_type", type);
+        return findAllByTwoProperties("enrollee_id", enrolleeId,"relationship_type", type);
     }
 
     public List<EnrolleeRelation> findByEnrolleeIdsAndRelationshipType(List<UUID> enrolleeIds, RelationshipType type) {
-        return findAllValidByTwoProperties("relationship_type", type, "enrollee_id", enrolleeIds);
+        return findAllByTwoProperties("relationship_type", type, "enrollee_id", enrolleeIds);
     }
 
     public List<EnrolleeRelation> findByTargetEnrolleeId(UUID enrolleeId) {
-        return findAllValidByProperty("target_enrollee_id", enrolleeId);
+        return findAllByProperty("target_enrollee_id", enrolleeId);
     }
 
     public List<EnrolleeRelation> findEnrolleeRelationsByProxyParticipantUser(UUID participantUserId, List<UUID> targetEnrolleeIds) {
@@ -58,44 +58,6 @@ public class EnrolleeRelationDao extends BaseMutableJdbiDao<EnrolleeRelation> {
     }
 
     public List<EnrolleeRelation> findAllByEnrolleeId(UUID enrolleeId) {
-        return findAllValidByProperty("enrollee_id", enrolleeId);
+        return findAllByProperty("enrollee_id", enrolleeId);
     }
-    /**
-     * This method works like the original findAllByTwoProperties method, but it only returns relations that there
-     * end dates are greater than or equal to the current date.
-     * @param column1Name the name of the first column to filter by
-     * @param column1Value the value of the first column to filter by
-     * @param column2Name the name of the second column to filter by
-     * @param column2Value the value of the second column to filter by
-     * @return a list of EnrolleeRelation objects that match the given properties and have a valid end date.
-     */
-    protected List<EnrolleeRelation> findAllValidByTwoProperties(String column1Name, Object column1Value,
-                                             String column2Name, Object column2Value) {
-        return jdbi.withHandle(handle ->
-                handle.createQuery("select * from " + tableName + " where " + column1Name + " = :column1Value"
-                                + " and " + column2Name + " = :column2Value and (end_date is null or end_date >= NOW());")
-                        .bind("column1Value", column1Value)
-                        .bind("column2Value", column2Value)
-                        .mapTo(clazz)
-                        .list()
-        );
-    }
-
-    /**
-     * This method works like the original findAllByProperty method, but it only returns relations that there
-     * end dates are greater than or equal to the current date.
-     * @param columnName the name of the column to filter by
-     * @param columnValue the value of the column to filter by
-     * @return a list of EnrolleeRelation objects that match the given properties and have a valid end date.
-     */
-    protected List<EnrolleeRelation> findAllValidByProperty(String columnName, Object columnValue) {
-        return jdbi.withHandle(handle ->
-                handle.createQuery("select * from " + tableName + " where " + columnName + " = :columnValue "
-                                + " and (end_date is null or end_date >= NOW());")
-                        .bind("columnValue", columnValue)
-                        .mapTo(clazz)
-                        .list()
-        );
-    }
-
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeRelationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeRelationService.java
@@ -29,15 +29,15 @@ public class EnrolleeRelationService extends DataAuditedService<EnrolleeRelation
     }
 
     public List<EnrolleeRelation> findByEnrolleeIdAndRelationType(UUID enrolleeId, RelationshipType relationshipType) {
-        return dao.findByEnrolleeIdAndRelationshipType(enrolleeId, relationshipType);
+        return filterValid(dao.findByEnrolleeIdAndRelationshipType(enrolleeId, relationshipType));
     }
 
     public List<EnrolleeRelation> findByEnrolleeIdsAndRelationType(List<UUID> enrolleeIds, RelationshipType relationshipType) {
-        return dao.findByEnrolleeIdsAndRelationshipType(enrolleeIds, relationshipType);
+        return filterValid(dao.findByEnrolleeIdsAndRelationshipType(enrolleeIds, relationshipType));
     }
 
     public List<EnrolleeRelation> findByTargetEnrolleeId(UUID enrolleeId) {
-        return dao.findByTargetEnrolleeId(enrolleeId);
+        return filterValid(dao.findByTargetEnrolleeId(enrolleeId));
     }
 
     public boolean isUserProxyForAnyOf(UUID participantUserId, List<UUID> enrolleeIds) {
@@ -76,6 +76,10 @@ public class EnrolleeRelationService extends DataAuditedService<EnrolleeRelation
             }
         }
         return exclusiveGovernedEnrollees;
+    }
+
+    public List<EnrolleeRelation> filterValid(List<EnrolleeRelation> enrolleeRelations) {
+        return enrolleeRelations.stream().filter(this::isRelationshipValid).collect(Collectors.toList());
     }
 
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/participant/EnrolleeRelationServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/participant/EnrolleeRelationServiceTest.java
@@ -202,9 +202,9 @@ class EnrolleeRelationServiceTest extends BaseSpringBootTest {
     @Test
     @Transactional
     public void findExclusiveProxiedEnrolleesTest(TestInfo info){
-        HubResponse<Enrollee> hubResponse = enrolleeFactory.buildProxyAndGovernedEnrollee(getTestName(info), "proxyEmail@test.com");
-        Enrollee proxyEnrollee = hubResponse.getEnrollee();
-        Enrollee governedEnrollee = hubResponse.getResponse();
+        EnrolleeFactory.EnrolleeAndProxy hubResponse = enrolleeFactory.buildProxyAndGovernedEnrollee(getTestName(info), "proxyEmail@test.com");
+        Enrollee proxyEnrollee = hubResponse.proxy();
+        Enrollee governedEnrollee = hubResponse.governedEnrollee();
         List<Enrollee> targetEnrollees = enrolleeRelationService.findExclusiveProxiedEnrollees(proxyEnrollee.getId());
         Assertions.assertEquals(1, targetEnrollees.size());
         Assertions.assertEquals(governedEnrollee, targetEnrollees.get(0));

--- a/core/src/test/java/bio/terra/pearl/core/service/participant/ProfileServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/participant/ProfileServiceTests.java
@@ -188,14 +188,13 @@ public class ProfileServiceTests extends BaseSpringBootTest {
     @Test
     @Transactional
     public void testGovernedUserProfile(TestInfo testInfo){
-        HubResponse hubResponse = enrolleeFactory.buildProxyAndGovernedEnrollee(getTestName(testInfo), getTestName(testInfo));
-        Enrollee enrollee = hubResponse.getEnrollee();
-        Profile governedUserProfile = profileService.find(enrollee.getProfileId()).get();
-        List<EnrolleeRelation> relations = enrolleeRelationService.findByEnrolleeIdAndRelationType(enrollee.getId(), RelationshipType.PROXY);
-        Enrollee proxyEnrollee = enrolleeService.find(relations.get(0).getEnrolleeId()).get();
-        PortalParticipantUser proxyPpUser = portalParticipantUserService.findByParticipantUserId(proxyEnrollee.getParticipantUserId()).get(0);
-        Profile proxyProfile = profileService.find(proxyPpUser.getProfileId()).orElseThrow();
-        Assert.assertTrue(StringUtils.isNoneEmpty(governedUserProfile.getContactEmail()));
-        Assert.assertEquals(proxyProfile.getContactEmail(), governedUserProfile.getContactEmail());
+        EnrolleeFactory.EnrolleeAndProxy enrolleeAndProxy = enrolleeFactory.buildProxyAndGovernedEnrollee(getTestName(testInfo), getTestName(testInfo));
+        Enrollee proxyEnrollee = enrolleeAndProxy.proxy();
+        Profile proxyUserProfile = profileService.find(proxyEnrollee.getProfileId()).get();
+        List<EnrolleeRelation> relations = enrolleeRelationService.findByEnrolleeIdAndRelationType(proxyEnrollee.getId(), RelationshipType.PROXY);
+        Enrollee governedEnrollee = enrolleeService.find(relations.get(0).getEnrolleeId()).get();
+        Profile governedProfile = profileService.find(governedEnrollee.getProfileId()).orElseThrow();
+        Assert.assertTrue(StringUtils.isNoneEmpty(governedProfile.getContactEmail()));
+        Assert.assertEquals(governedProfile.getContactEmail(), proxyUserProfile.getContactEmail());
     }
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/participant/WithdrawnEnrolleeServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/participant/WithdrawnEnrolleeServiceTests.java
@@ -37,9 +37,9 @@ public class WithdrawnEnrolleeServiceTests extends BaseSpringBootTest {
   @Test
   @Transactional
   public void testWithdrawProxyEnrollee(TestInfo info) {
-    HubResponse<Enrollee> hubResponse = enrolleeFactory.buildProxyAndGovernedEnrollee(getTestName(info), "proxy-email@test.com");
-    Enrollee proxyEnrollee = hubResponse.getEnrollee();
-    Enrollee governedEnrollee = hubResponse.getResponse();
+    EnrolleeFactory.EnrolleeAndProxy enrolleeAndProxy = enrolleeFactory.buildProxyAndGovernedEnrollee(getTestName(info), "proxy-email@test.com");
+    Enrollee proxyEnrollee = enrolleeAndProxy.proxy();
+    Enrollee governedEnrollee = enrolleeAndProxy.governedEnrollee();
     DaoTestUtils.assertGeneratedProperties(proxyEnrollee);
     WithdrawnEnrollee withdrawnEnrollee = withdrawnEnrolleeService.withdrawEnrollee(proxyEnrollee);
     DaoTestUtils.assertGeneratedProperties(withdrawnEnrollee);

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/participant/EnrolleeFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/participant/EnrolleeFactory.java
@@ -112,20 +112,21 @@ public class EnrolleeFactory {
         ppUser = portalParticipantUserService.create(ppUser);
         Enrollee enrollee = buildPersisted(testName, studyEnv.getId(), user.getId(), ppUser.getProfileId());
         enrollee.setProfile(ppUser.getProfile());
-        return new EnrolleeBundle(enrollee, ppUser, portalEnv.getPortalId());
+        return new EnrolleeBundle(enrollee, user, ppUser, portalEnv.getPortalId());
     }
 
-    public HubResponse buildProxyAndGovernedEnrollee(String testName, String proxyEmail){
+    public EnrolleeAndProxy buildProxyAndGovernedEnrollee(String testName, String proxyEmail){
         PortalEnvironment portalEnv = portalEnvironmentFactory.buildPersisted(testName);
         StudyEnvironment studyEnv = studyEnvironmentFactory.buildPersisted(portalEnv, testName);
         ParticipantUserFactory.ParticipantUserAndPortalUser userBundle = participantUserFactory.buildPersisted(portalEnv, testName, proxyEmail);
         String studyShortcode = studyService.find(studyEnv.getStudyId()).get().getShortcode();
-        String portalShortcode = portalService.find(portalEnv.getPortalId()).get().getShortcode();
 
-        HubResponse hubResponse = enrollmentService.enrollAsProxy(studyEnv.getEnvironmentName(), studyShortcode, userBundle.user(), userBundle.ppUser(),
+        HubResponse<Enrollee> hubResponse = enrollmentService.enrollAsProxy(studyEnv.getEnvironmentName(), studyShortcode, userBundle.user(), userBundle.ppUser(),
                 null);
-        return hubResponse;
+        return new EnrolleeAndProxy(hubResponse.getResponse(), hubResponse.getEnrollee(), userBundle.ppUser(), portalEnv);
     }
 
-    public record EnrolleeBundle(Enrollee enrollee, PortalParticipantUser portalParticipantUser, UUID portalId) {}
+    public record EnrolleeBundle(Enrollee enrollee, ParticipantUser participantUser, PortalParticipantUser portalParticipantUser, UUID portalId) {}
+
+    public record EnrolleeAndProxy(Enrollee governedEnrollee, Enrollee proxy, PortalParticipantUser proxyPpUser, PortalEnvironment portalEnv) {}
 }

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/participant/ParticipantUserFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/participant/ParticipantUserFactory.java
@@ -51,6 +51,13 @@ public class ParticipantUserFactory {
         return buildPersisted(userBuilder, testName);
     }
 
+    public ParticipantUser buildPersisted(EnvironmentName envName, String testName, String contactEmail) {
+        ParticipantUser.ParticipantUserBuilder userBuilder = builder(testName)
+                .username(contactEmail)
+                .environmentName(envName);
+        return buildPersisted(userBuilder, testName);
+    }
+
     public ParticipantUserAndPortalUser buildPersisted(PortalEnvironment portalEnv, String testName) {
         ParticipantUser user = buildPersisted(portalEnv.getEnvironmentName(), testName);
         PortalParticipantUser ppUser = PortalParticipantUser.builder()
@@ -63,10 +70,10 @@ public class ParticipantUserFactory {
     }
 
     /**
-     * This method creates a participant with the given in their Profile
+     * This method creates a participant with the given contactEmail in their Profile and as their username
      * */
     public ParticipantUserAndPortalUser buildPersisted(PortalEnvironment portalEnv, String testName, String contactEmail) {
-        ParticipantUser user = buildPersisted(portalEnv.getEnvironmentName(), testName);
+        ParticipantUser user = buildPersisted(portalEnv.getEnvironmentName(), testName, contactEmail);
         Profile.ProfileBuilder builder = profileFactory.builder(testName);
         builder.contactEmail(contactEmail);
         Profile proxyProfile = builder.build();


### PR DESCRIPTION
#### DESCRIPTION

Previously, we had no tests validating login for users with enrollees attached.  This adds a few tests for single, multiple, and proxy enrollee situations.  this fixes a bug in how we were finding relations - along the way this switches from filtering invalid relations in the DB to doing it in Java.  The number of relations is almost always 0-1, so doing it in the DB isn't worth the extra query complexity.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1. login to participant UI
