### PR TITLE
[JN-888] Adding renaming ability to upload/populate

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/internal/PopulateController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/internal/PopulateController.java
@@ -15,6 +15,7 @@ import bio.terra.pearl.populate.service.BaseSeedPopulator;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
@@ -57,18 +58,25 @@ public class PopulateController implements PopulateApi {
   }
 
   @Override
-  public ResponseEntity<Object> populatePortal(String filePathName, Boolean overwrite) {
+  public ResponseEntity<Object> populatePortal(
+      String filePathName, Boolean overwrite, String shortcodeOverride) {
     AdminUser user = authUtilService.requireAdminUser(request);
+    if (StringUtils.isBlank(shortcodeOverride)) {
+      shortcodeOverride = null;
+    }
     Portal populatedObj =
-        populateExtService.populatePortal(filePathName, user, Boolean.TRUE.equals(overwrite));
+        populateExtService.populatePortal(
+            filePathName, user, Boolean.TRUE.equals(overwrite), shortcodeOverride);
     return ResponseEntity.ok(populatedObj);
   }
 
   @Override
-  public ResponseEntity<Object> uploadPortal(Boolean overwrite, MultipartFile portalZip, String shortcodeOverride) {
+  public ResponseEntity<Object> uploadPortal(
+      Boolean overwrite, String shortcodeOverride, MultipartFile portalZip) {
     AdminUser user = authUtilService.requireAdminUser(request);
     Portal populatedObj =
-        populateExtService.populatePortal(portalZip, user, Boolean.TRUE.equals(overwrite), shortcodeOverride);
+        populateExtService.populatePortal(
+            portalZip, user, Boolean.TRUE.equals(overwrite), shortcodeOverride);
     return ResponseEntity.ok(populatedObj);
   }
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/internal/PopulateController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/internal/PopulateController.java
@@ -65,10 +65,10 @@ public class PopulateController implements PopulateApi {
   }
 
   @Override
-  public ResponseEntity<Object> uploadPortal(Boolean overwrite, MultipartFile portalZip) {
+  public ResponseEntity<Object> uploadPortal(Boolean overwrite, MultipartFile portalZip, String shortcodeOverride) {
     AdminUser user = authUtilService.requireAdminUser(request);
     Portal populatedObj =
-        populateExtService.populatePortal(portalZip, user, Boolean.TRUE.equals(overwrite));
+        populateExtService.populatePortal(portalZip, user, Boolean.TRUE.equals(overwrite), shortcodeOverride);
     return ResponseEntity.ok(populatedObj);
   }
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/PopulateExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/PopulateExtService.java
@@ -69,7 +69,8 @@ public class PopulateExtService {
     }
   }
 
-  public Portal populatePortal(MultipartFile zipFile, AdminUser user, boolean overwrite, String shortcodeOverride) {
+  public Portal populatePortal(
+      MultipartFile zipFile, AdminUser user, boolean overwrite, String shortcodeOverride) {
     authorizeUser(user);
     try {
       ZipInputStream zis = new ZipInputStream(zipFile.getInputStream());
@@ -79,9 +80,11 @@ public class PopulateExtService {
     }
   }
 
-  public Portal populatePortal(String filePathName, AdminUser user, boolean overwrite) {
+  public Portal populatePortal(
+      String filePathName, AdminUser user, boolean overwrite, String shortcodeOverride) {
     authorizeUser(user);
-    return portalPopulator.populate(new FilePopulateContext(filePathName), overwrite);
+    return portalPopulator.populate(
+        new FilePopulateContext(filePathName, false, shortcodeOverride), overwrite);
   }
 
   public Survey populateSurvey(

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/PopulateExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/PopulateExtService.java
@@ -69,11 +69,11 @@ public class PopulateExtService {
     }
   }
 
-  public Portal populatePortal(MultipartFile zipFile, AdminUser user, boolean overwrite) {
+  public Portal populatePortal(MultipartFile zipFile, AdminUser user, boolean overwrite, String shortcodeOverride) {
     authorizeUser(user);
     try {
       ZipInputStream zis = new ZipInputStream(zipFile.getInputStream());
-      return portalPopulator.populateFromZipFile(zis, overwrite);
+      return portalPopulator.populateFromZipFile(zis, overwrite, shortcodeOverride);
     } catch (IOException e) {
       throw new IllegalArgumentException("error reading/writing zip file", e);
     }
@@ -88,7 +88,8 @@ public class PopulateExtService {
       String portalShortcode, String filePathName, AdminUser user, boolean overwrite) {
     authorizeUser(user);
     PortalPopulateContext config =
-        new PortalPopulateContext(filePathName, portalShortcode, null, new HashMap<>(), false);
+        new PortalPopulateContext(
+            filePathName, portalShortcode, null, new HashMap<>(), false, null);
     return surveyPopulator.populate(config, overwrite);
   }
 
@@ -96,7 +97,8 @@ public class PopulateExtService {
       String portalShortcode, String filePathName, AdminUser user, boolean overwrite) {
     authorizeUser(user);
     PortalPopulateContext config =
-        new PortalPopulateContext(filePathName, portalShortcode, null, new HashMap<>(), false);
+        new PortalPopulateContext(
+            filePathName, portalShortcode, null, new HashMap<>(), false, null);
     try {
       // first, repopulate images to cove any new/changed images.
       String portalFilePath = "portals/%s/portal.json".formatted(portalShortcode);
@@ -118,7 +120,7 @@ public class PopulateExtService {
     authorizeUser(user);
     StudyPopulateContext config =
         new StudyPopulateContext(
-            filePathName, portalShortcode, studyShortcode, envName, new HashMap<>(), false);
+            filePathName, portalShortcode, studyShortcode, envName, new HashMap<>(), false, null);
     return enrolleePopulator.populate(config, overwrite);
   }
 

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -1327,6 +1327,7 @@ paths:
       parameters:
         - { name: filePathName, in: query, required: true, schema: { type: string } }
         - { name: overwrite, in: query, required: false, schema: { type: boolean } }
+        - { name: shortcodeOverride, in: query, required: false, schema: { type: string } }
       responses:
         '201':
           description: portal object
@@ -1343,7 +1344,7 @@ paths:
       operationId: uploadPortal
       parameters:
         - { name: overwrite, in: query, required: false, schema: { type: boolean } }
-        - { name: shortcodeOverride, in: query, required: false, schema: { type: boolean } }
+        - { name: shortcodeOverride, in: query, required: false, schema: { type: string } }
       requestBody:
         content:
           multipart/form-data:

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -1343,6 +1343,7 @@ paths:
       operationId: uploadPortal
       parameters:
         - { name: overwrite, in: query, required: false, schema: { type: boolean } }
+        - { name: shortcodeOverride, in: query, required: false, schema: { type: boolean } }
       requestBody:
         content:
           multipart/form-data:

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/PopulateExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/PopulateExtServiceTests.java
@@ -21,7 +21,8 @@ public class PopulateExtServiceTests {
   public void portalRequiresAuth() {
     AdminUser user = new AdminUser();
     Assertions.assertThrows(
-        PermissionDeniedException.class, () -> emptyService.populatePortal("dfafd", user, false));
+        PermissionDeniedException.class,
+        () -> emptyService.populatePortal("dfafd", user, false, null));
   }
 
   @Test

--- a/populate/src/main/java/bio/terra/pearl/populate/service/AdminConfigPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/AdminConfigPopulator.java
@@ -19,7 +19,7 @@ public class AdminConfigPopulator {
   public AdminConfigStats populate(boolean overwrite) throws IOException {
     for (String emailFile : EMAILS_TO_POPULATE) {
       // these templates are not specific to a portal, so the shortcode and environment is null
-      PortalPopulateContext context = new PortalPopulateContext(emailFile, null, null, new HashMap<>(), false);
+      PortalPopulateContext context = new PortalPopulateContext(emailFile, null, null, new HashMap<>(), false, null);
       // always overwrite, we don't care about versioning for admin emails yet
       emailTemplatePopulator.populate(context, overwrite);
     }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/ConsentFormPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/ConsentFormPopulator.java
@@ -33,6 +33,7 @@ public class ConsentFormPopulator extends BasePopulator<ConsentForm, ConsentForm
     protected void preProcessDto(ConsentFormPopDto popDto, PortalPopulateContext context) {
         UUID portalId = portalService.findOneByShortcode(context.getPortalShortcode()).get().getId();
         popDto.setPortalId(portalId);
+        popDto.setStableId(context.applyShortcodeOverride(popDto.getStableId()));
         String newContent = popDto.getJsonContent().toString();
         popDto.setContent(newContent);
     }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/EmailTemplatePopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/EmailTemplatePopulator.java
@@ -59,6 +59,7 @@ public class EmailTemplatePopulator extends BasePopulator<EmailTemplate, EmailTe
     protected void preProcessDto(EmailTemplatePopDto popDto, PortalPopulateContext context) throws IOException  {
         String bodyContent = filePopulateService.readFile(popDto.getBodyPopulateFile(), context);
         popDto.setBody(bodyContent);
+        popDto.setStableId(context.applyShortcodeOverride(popDto.getStableId()));
         UUID portalId = portalService.findOneByShortcode(context.getPortalShortcode()).orElse(
                 /** if the context doesn't have a portal, it's because we're populating admin config
                  * so we want the portalId to be null

--- a/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
@@ -150,9 +150,9 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
     }
 
     private void populateResponse(Enrollee enrollee, SurveyResponsePopDto responsePopDto,
-                                  PortalParticipantUser ppUser, boolean simulateSubmissions)
+                                  PortalParticipantUser ppUser, boolean simulateSubmissions, StudyPopulateContext context)
             throws JsonProcessingException {
-        Survey survey = surveyService.findByStableIdWithMappings(responsePopDto.getSurveyStableId(),
+        Survey survey = surveyService.findByStableIdWithMappings(context.applyShortcodeOverride(responsePopDto.getSurveyStableId()),
                 responsePopDto.getSurveyVersion()).get();
 
         SurveyResponse response = SurveyResponse.builder()
@@ -215,12 +215,12 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
     }
 
     /** persists any preEnrollmentResponse, and then attaches it to the enrollee */
-    private PreEnrollmentResponse populatePreEnrollResponse(EnrolleePopDto enrolleeDto, StudyEnvironment studyEnv) throws JsonProcessingException {
+    private PreEnrollmentResponse populatePreEnrollResponse(EnrolleePopDto enrolleeDto, StudyEnvironment studyEnv, StudyPopulateContext context) throws JsonProcessingException {
         PreEnrollmentResponsePopDto responsePopDto = enrolleeDto.getPreEnrollmentResponseDto();
         if (responsePopDto == null) {
             return null;
         }
-        Survey survey = surveyService.findByStableId(responsePopDto.getSurveyStableId(),
+        Survey survey = surveyService.findByStableId(context.applyShortcodeOverride(responsePopDto.getSurveyStableId()),
                 responsePopDto.getSurveyVersion()).get();
         String fullData = objectMapper.writeValueAsString(responsePopDto.getAnswers());
         PreEnrollmentResponse response = PreEnrollmentResponse.builder()
@@ -235,8 +235,8 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
     }
 
     private void populateConsent(Enrollee enrollee, PortalParticipantUser ppUser, ConsentResponsePopDto responsePopDto,
-                                 List<ParticipantTask> tasks, boolean simulateSubmissions) throws JsonProcessingException {
-        ConsentForm consentForm = consentFormService.findByStableId(responsePopDto.getConsentStableId(),
+                                 List<ParticipantTask> tasks, boolean simulateSubmissions, StudyPopulateContext context) throws JsonProcessingException {
+        ConsentForm consentForm = consentFormService.findByStableId(context.applyShortcodeOverride(responsePopDto.getConsentStableId()),
                 responsePopDto.getConsentVersion()).get();
 
         ConsentResponse savedResponse;
@@ -361,7 +361,7 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
                 .findByStudy(context.getStudyShortcode(), context.getEnvironmentName()).get();
         popDto.setStudyEnvironmentId(attachedEnv.getId());
 
-        PreEnrollmentResponse preEnrollmentResponse = populatePreEnrollResponse(popDto, attachedEnv);
+        PreEnrollmentResponse preEnrollmentResponse = populatePreEnrollResponse(popDto, attachedEnv, context);
         popDto.setPreEnrollmentResponseId(preEnrollmentResponse != null ? preEnrollmentResponse.getId() : null);
         EnrolleePopulationEntities enrolleePopulationEntities = null;
         if (!popDto.getProxyPopDtos().isEmpty()) {
@@ -386,7 +386,7 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
         );
         popDto.setProfileId(ppUser.getProfileId());
         populateEnrolleeData(enrolleePopulationEntities.getEnrollee(), popDto, ppUser, profile,
-                enrolleePopulationEntities.getTasks(), attachedEnv);
+                enrolleePopulationEntities.getTasks(), attachedEnv, context);
 
         return enrolleePopulationEntities.getEnrollee();
     }
@@ -417,14 +417,15 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
         return new EnrolleePopulationEntities(popDto, enrollee, ppUser, tasks, null);
     }
 
-    private void populateEnrolleeData(Enrollee enrollee, EnrolleePopDto popDto, PortalParticipantUser ppUser, Profile profile, List<ParticipantTask> tasks, StudyEnvironment attachedEnv)
+    private void populateEnrolleeData(Enrollee enrollee, EnrolleePopDto popDto, PortalParticipantUser ppUser,
+                                      Profile profile, List<ParticipantTask> tasks, StudyEnvironment attachedEnv, StudyPopulateContext context)
             throws JsonProcessingException {
         boolean isDoNotEmail = profile.isDoNotEmail();
         for (SurveyResponsePopDto responsePopDto : popDto.getSurveyResponseDtos()) {
-            populateResponse(enrollee, responsePopDto, ppUser, popDto.isSimulateSubmissions());
+            populateResponse(enrollee, responsePopDto, ppUser, popDto.isSimulateSubmissions(), context);
         }
         for (ConsentResponsePopDto consentPopDto : popDto.getConsentResponseDtos()) {
-            populateConsent(enrollee, ppUser, consentPopDto, tasks, popDto.isSimulateSubmissions());
+            populateConsent(enrollee, ppUser, consentPopDto, tasks, popDto.isSimulateSubmissions(), context);
         }
         for (ParticipantTaskPopDto taskDto : popDto.getParticipantTaskDtos()) {
             populateTask(enrollee, ppUser, taskDto);
@@ -487,7 +488,7 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
     }
 
     public void bulkPopulateEnrollees(String portalShortcode, EnvironmentName envName, String studyShortcode, List<String> usernamesToLink) {
-        StudyPopulateContext context = new StudyPopulateContext("portals/" + portalShortcode + "/studies/" + studyShortcode + "/enrollees/seed.json", portalShortcode, studyShortcode, envName, new HashMap<>(), false);
+        StudyPopulateContext context = new StudyPopulateContext("portals/" + portalShortcode + "/studies/" + studyShortcode + "/enrollees/seed.json", portalShortcode, studyShortcode, envName, new HashMap<>(), false, null);
 
         usernamesToLink.forEach(username -> {
             try {

--- a/populate/src/main/java/bio/terra/pearl/populate/service/PortalParticipantUserPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/PortalParticipantUserPopulator.java
@@ -83,7 +83,7 @@ public class PortalParticipantUserPopulator extends BasePopulator<PortalParticip
     }
 
     public List<String> bulkPopulateParticipants(String portalShortcode, EnvironmentName envName, String studyShortcode, Integer numEnrollees) {
-        StudyPopulateContext context = new StudyPopulateContext("portals/" + portalShortcode + "/participants/seed.json", portalShortcode, studyShortcode, envName, new HashMap<>(), false);
+        StudyPopulateContext context = new StudyPopulateContext("portals/" + portalShortcode + "/participants/seed.json", portalShortcode, studyShortcode, envName, new HashMap<>(), false, null);
 
         List<String> populatedUsernames = IntStream.range(0, numEnrollees).mapToObj(i -> {
             try {

--- a/populate/src/main/java/bio/terra/pearl/populate/service/PortalPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/PortalPopulator.java
@@ -11,8 +11,6 @@ import bio.terra.pearl.core.model.study.PortalStudy;
 import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.service.CascadeProperty;
-import bio.terra.pearl.core.service.participant.EnrolleeService;
-import bio.terra.pearl.core.service.portal.*;
 import bio.terra.pearl.core.service.portal.MailingListContactService;
 import bio.terra.pearl.core.service.portal.PortalDashboardConfigService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
@@ -154,6 +152,11 @@ public class PortalPopulator extends BasePopulator<Portal, PortalPopDto, FilePop
     }
 
     @Override
+    public void preProcessDto(PortalPopDto popDto, FilePopulateContext context) {
+        popDto.setShortcode(context.getShortcodeOverride());
+    }
+
+    @Override
     public Optional<Portal> findFromDto(PortalPopDto popDto, FilePopulateContext context) {
         return portalService.findOneByShortcode(popDto.getShortcode());
     }
@@ -225,7 +228,7 @@ public class PortalPopulator extends BasePopulator<Portal, PortalPopDto, FilePop
         }
     }
 
-    public Portal populateFromZipFile(ZipInputStream zipInputStream, boolean overwrite) throws IOException {
+    public Portal populateFromZipFile(ZipInputStream zipInputStream, boolean overwrite, String shortcodeOverride) throws IOException {
         String folderName =
                 "portal_%s_%s"
                         .formatted(
@@ -236,6 +239,6 @@ public class PortalPopulator extends BasePopulator<Portal, PortalPopDto, FilePop
         tempDir.mkdirs();
         ZipUtils.unzipFile(tempDir, zipInputStream);
         return populate(
-                new FilePopulateContext(folderName + "/portal.json", true), overwrite);
+                new FilePopulateContext(folderName + "/portal.json", true, shortcodeOverride), overwrite);
     }
 }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/PortalPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/PortalPopulator.java
@@ -153,7 +153,10 @@ public class PortalPopulator extends BasePopulator<Portal, PortalPopDto, FilePop
 
     @Override
     public void preProcessDto(PortalPopDto popDto, FilePopulateContext context) {
-        popDto.setShortcode(context.getShortcodeOverride());
+        if (context.getShortcodeOverride() != null) {
+            popDto.setShortcode(context.getShortcodeOverride());
+            popDto.setName(context.getShortcodeOverride());
+        }
     }
 
     @Override

--- a/populate/src/main/java/bio/terra/pearl/populate/service/SiteContentPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/SiteContentPopulator.java
@@ -83,6 +83,7 @@ public class SiteContentPopulator extends BasePopulator<SiteContent, SiteContent
     protected void preProcessDto(SiteContentPopDto popDto, PortalPopulateContext context) throws IOException {
         Portal attachedPortal = portalService.findOneByShortcode(context.getPortalShortcode()).get();
         popDto.setPortalId(attachedPortal.getId());
+        popDto.setStableId(context.applyShortcodeOverride(popDto.getStableId()));
         for (LocalizedSiteContentPopDto lsc : popDto.getLocalizedSiteContentDtos()) {
             initializeLandingPage(lsc, context);
             for (NavbarItemPopDto navItem : lsc.getNavbarItemDtos()) {

--- a/populate/src/main/java/bio/terra/pearl/populate/service/StudyPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/StudyPopulator.java
@@ -138,6 +138,7 @@ public class StudyPopulator extends BasePopulator<Study, StudyPopDto, PortalPopu
     @Override
     public void preProcessDto(StudyPopDto popDto, PortalPopulateContext context) {
         popDto.setShortcode(context.applyShortcodeOverride(popDto.getShortcode()));
+        popDto.setName(context.applyShortcodeOverride(popDto.getName()));
     }
 
     @Override

--- a/populate/src/main/java/bio/terra/pearl/populate/service/StudyPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/StudyPopulator.java
@@ -105,7 +105,7 @@ public class StudyPopulator extends BasePopulator<Study, StudyPopDto, PortalPopu
 
         // save any of the pre-enrollment responses that aren't associated with an enrollee
         for (PreEnrollmentResponsePopDto responsePopDto : studyPopEnv.getPreEnrollmentResponseDtos()) {
-            Survey survey = surveyService.findByStableId(responsePopDto.getSurveyStableId(),
+            Survey survey = surveyService.findByStableId(context.applyShortcodeOverride(responsePopDto.getSurveyStableId()),
                     responsePopDto.getSurveyVersion()).get();
             String fullData = objectMapper.writeValueAsString(responsePopDto.getAnswers());
             PreEnrollmentResponse response = PreEnrollmentResponse.builder()
@@ -133,6 +133,11 @@ public class StudyPopulator extends BasePopulator<Study, StudyPopDto, PortalPopu
     @Override
     protected Class<StudyPopDto> getDtoClazz() {
         return StudyPopDto.class;
+    }
+
+    @Override
+    public void preProcessDto(StudyPopDto popDto, PortalPopulateContext context) {
+        popDto.setShortcode(context.applyShortcodeOverride(popDto.getShortcode()));
     }
 
     @Override

--- a/populate/src/main/java/bio/terra/pearl/populate/service/SurveyPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/SurveyPopulator.java
@@ -43,6 +43,7 @@ public class SurveyPopulator extends BasePopulator<Survey, SurveyPopDto, PortalP
     protected void preProcessDto(SurveyPopDto popDto, PortalPopulateContext context) {
         UUID portalId = portalService.findOneByShortcode(context.getPortalShortcode()).get().getId();
         popDto.setPortalId(portalId);
+        popDto.setStableId(context.applyShortcodeOverride(popDto.getStableId()));
         String newContent = popDto.getJsonContent().toString();
         popDto.setContent(newContent);
     }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/contexts/FilePopulateContext.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/contexts/FilePopulateContext.java
@@ -27,6 +27,7 @@ public class FilePopulateContext {
     protected Map<String, UUID> populatedFileEntities = new HashMap<>();
     /** whether this context maps to the populate seed directory, or the temp directory */
     protected boolean isFromTempDir = false;
+    protected String shortcodeOverride = null;
 
     public FilePopulateContext(String filePathName) {
         setPaths(filePathName);
@@ -36,6 +37,12 @@ public class FilePopulateContext {
         this(filePathName);
         this.isFromTempDir = isFromTempDir;
     }
+
+    public FilePopulateContext(String filePathName, boolean isFromTempDir, String shortcodeOverride) {
+        this(filePathName, isFromTempDir);
+        this.shortcodeOverride = shortcodeOverride;
+    }
+
 
     protected void setPaths(String filePathName) {
         Path filePath = Paths.get(filePathName);
@@ -47,6 +54,7 @@ public class FilePopulateContext {
         FilePopulateContext popContext = new FilePopulateContext(applyRelativePath(relativeFilePath));
         popContext.populatedFileEntities = this.populatedFileEntities;
         popContext.isFromTempDir = this.isFromTempDir;
+        popContext.shortcodeOverride = this.shortcodeOverride;
         return popContext;
     }
 
@@ -85,6 +93,18 @@ public class FilePopulateContext {
             }
         }
         return Optional.empty();
+    }
+
+    public String applyShortcodeOverride(String stableId) {
+        if (shortcodeOverride != null) {
+            String newStableId = stableId;
+            // if the stableId is already prefixed, strip it
+            if (stableId.lastIndexOf("_") != -1) {
+                newStableId = stableId.substring(stableId.lastIndexOf("_") + 1);
+            }
+            return shortcodeOverride + "_" + newStableId;
+        }
+        return stableId;
     }
 
 }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/contexts/PortalPopulateContext.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/contexts/PortalPopulateContext.java
@@ -10,24 +10,26 @@ public class PortalPopulateContext extends FilePopulateContext {
     private String portalShortcode;
     private EnvironmentName environmentName;
     public PortalPopulateContext(String filePathName, String portalShortcode, EnvironmentName environmentName,
-                                 Map<String, UUID> populatedFileEntities, boolean isFromTempDir) {
-        super(filePathName);
+                                 Map<String, UUID> populatedFileEntities, boolean isFromTempDir, String prefixOverride) {
+        super(filePathName, isFromTempDir, prefixOverride);
         this.populatedFileEntities = populatedFileEntities;
         this.environmentName = environmentName;
         this.portalShortcode = portalShortcode;
-        this.isFromTempDir = isFromTempDir;
     }
 
-    public PortalPopulateContext(FilePopulateContext context, String portalShortcode, EnvironmentName environmentName) {
-        this(context.getCurrentFile(), portalShortcode, environmentName, context.populatedFileEntities, context.isFromTempDir);
+    public PortalPopulateContext(FilePopulateContext context, String portalShortcode,
+                                 EnvironmentName environmentName) {
+        this(context.getCurrentFile(), portalShortcode, environmentName,
+                context.populatedFileEntities, context.isFromTempDir, context.shortcodeOverride);
     }
 
     public PortalPopulateContext newFrom(String relativeFilePath) {
         return new PortalPopulateContext(applyRelativePath(relativeFilePath), portalShortcode, environmentName,
-                populatedFileEntities, isFromTempDir);
+                populatedFileEntities, isFromTempDir, shortcodeOverride);
     }
 
     public PortalPopulateContext newFrom(EnvironmentName environmentName) {
-        return new PortalPopulateContext(getCurrentFile(), portalShortcode, environmentName, populatedFileEntities, isFromTempDir);
+        return new PortalPopulateContext(getCurrentFile(), portalShortcode, environmentName,
+                populatedFileEntities, isFromTempDir, shortcodeOverride);
     }
 }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/contexts/StudyPopulateContext.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/contexts/StudyPopulateContext.java
@@ -9,23 +9,23 @@ import lombok.Getter;
 public class StudyPopulateContext extends PortalPopulateContext {
     private String studyShortcode;
     public StudyPopulateContext(String filePathName, String portalShortcode, String studyShortcode, EnvironmentName environmentName,
-                                Map<String, UUID> populatedFileEntities, boolean isFromTempDir) {
-        super(filePathName, portalShortcode, environmentName, populatedFileEntities, isFromTempDir);
+                                Map<String, UUID> populatedFileEntities, boolean isFromTempDir, String prefixOverride) {
+        super(filePathName, portalShortcode, environmentName, populatedFileEntities, isFromTempDir, prefixOverride);
         this.studyShortcode = studyShortcode;
     }
 
     public StudyPopulateContext(PortalPopulateContext context, String studyShortcode) {
         this(context.getCurrentFile(), context.getPortalShortcode(), studyShortcode, context.getEnvironmentName(),
-                context.populatedFileEntities, context.isFromTempDir);
+                context.populatedFileEntities, context.isFromTempDir, context.shortcodeOverride);
     }
 
     public StudyPopulateContext newFrom(String relativeFilePath) {
         return new StudyPopulateContext(applyRelativePath(relativeFilePath), getPortalShortcode(), studyShortcode,
-                getEnvironmentName(), populatedFileEntities, isFromTempDir);
+                getEnvironmentName(), populatedFileEntities, isFromTempDir, shortcodeOverride);
     }
 
     public StudyPopulateContext newFrom(EnvironmentName environmentName) {
         return new StudyPopulateContext(getCurrentFile(), getPortalShortcode(), getStudyShortcode(), environmentName,
-                populatedFileEntities, isFromTempDir);
+                populatedFileEntities, isFromTempDir, shortcodeOverride);
     }
 }

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
@@ -151,4 +151,13 @@ public class PopulateDemoTest extends BasePopulatePortalsTest {
         // confirm answer from question that was removed in current version is still exported
         assertThat(oldVersionMap.get("hd_hd_socialHealth.hd_hd_socialHealth_neighborhoodIsWalkable"), equalTo("Disagree"));
     }
+
+    @Test
+    @Transactional
+    public void testPopulateWithShortcodeOverride() throws Exception {
+        Portal portal = portalPopulator.populate(new FilePopulateContext("portals/demo/portal.json", false, "demo2"), true);
+        assertThat(portal.getShortcode(), equalTo("demo2"));
+        Study mainStudy = portal.getPortalStudies().stream().findFirst().get().getStudy();
+        assertThat(mainStudy.getShortcode(), equalTo("demo2_heartdemo"));
+    }
 }

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
@@ -160,6 +160,7 @@ public class PopulateDemoTest extends BasePopulatePortalsTest {
     @Test
     @Transactional
     public void testPopulateWithShortcodeOverride() {
+        setUpEnvironments();
         String newShortcode = RandomStringUtils.randomAlphabetic(6);
         Portal portal = portalPopulator.populate(new FilePopulateContext("portals/demo/portal.json", false, newShortcode), true);
         assertThat(portal.getShortcode(), equalTo(newShortcode));

--- a/populate/src/test/java/bio/terra/pearl/populate/SurveyPopulatorTests.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/SurveyPopulatorTests.java
@@ -50,7 +50,7 @@ public class SurveyPopulatorTests extends BaseSpringBootTest {
         Portal portal = portalFactory.buildPersisted(getTestName(info));
         String surveyFile = "portals/ourhealth/studies/ourheart/surveys/basic.json";
         PortalPopulateContext context =
-                new PortalPopulateContext(surveyFile, portal.getShortcode(), null, new HashMap<>(), false);
+                new PortalPopulateContext(surveyFile, portal.getShortcode(), null, new HashMap<>(), false, null);
         Survey freshSurvey = surveyPopulator.populate(context, false);
         checkSurvey(freshSurvey, "oh_oh_basicInfo", 1);
 
@@ -73,7 +73,7 @@ public class SurveyPopulatorTests extends BaseSpringBootTest {
                 .jsonContent(objectMapper.readTree("{\"foo\": 12}"))
                 .name("Survey 1").build();
         PortalPopulateContext context =
-                new PortalPopulateContext("fake/file", portal.getShortcode(), null, new HashMap<>(), false);
+                new PortalPopulateContext("fake/file", portal.getShortcode(), null, new HashMap<>(), false, null);
         Survey newSurvey = surveyPopulator.populateFromDto(popDto1, context, true);
         checkSurvey(newSurvey, stableId, 1);
 
@@ -83,7 +83,7 @@ public class SurveyPopulatorTests extends BaseSpringBootTest {
                 .jsonContent(objectMapper.readTree("{\"foo\":17}"))
                 .name("Survey 1").build();
         PortalPopulateContext context2 =
-                new PortalPopulateContext("fake/file", portal.getShortcode(), null, new HashMap<>(), false);
+                new PortalPopulateContext("fake/file", portal.getShortcode(), null, new HashMap<>(), false, null);
         Survey overrideSurvey = surveyPopulator.populateFromDto(popDto2, context, true);
         // should override the previous survey, and so still be version 1
         checkSurvey(overrideSurvey, stableId, 1);
@@ -102,7 +102,7 @@ public class SurveyPopulatorTests extends BaseSpringBootTest {
                 .jsonContent(objectMapper.readTree("{\"foo\": 12}"))
                 .name("Survey 1").build();
         PortalPopulateContext context =
-                new PortalPopulateContext("fake/file", portal.getShortcode(), null, new HashMap<>(), false);
+                new PortalPopulateContext("fake/file", portal.getShortcode(), null, new HashMap<>(), false, null);
         Survey newSurvey = surveyPopulator.populateFromDto(popDto1, context, true);
         checkSurvey(newSurvey, stableId, 1);
 
@@ -112,7 +112,7 @@ public class SurveyPopulatorTests extends BaseSpringBootTest {
                 .jsonContent(objectMapper.readTree("{\"foo\":17}"))
                 .name("Survey 1").build();
         PortalPopulateContext context2 =
-                new PortalPopulateContext("fake/file", portal.getShortcode(), null, new HashMap<>(), false);
+                new PortalPopulateContext("fake/file", portal.getShortcode(), null, new HashMap<>(), false, null);
         Survey overrideSurvey = surveyPopulator.populateFromDto(popDto2, context, false);
 
         // should NOT override the previous survey, and so still be saved as version 2

--- a/populate/src/test/java/bio/terra/pearl/populate/extract/PortalExtractTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/extract/PortalExtractTest.java
@@ -44,7 +44,7 @@ public class PortalExtractTest extends BasePopulatePortalsTest {
         portalService.delete(portal.getId(), Set.of(PortalService.AllowedCascades.STUDY));
 
         ZipInputStream zis = new ZipInputStream(new FileInputStream(tmpFileName));
-        Portal restoredPortal = portalPopulator.populateFromZipFile(zis, true);
+        Portal restoredPortal = portalPopulator.populateFromZipFile(zis, true, null);
 
         // confirm all templates got repopulated
         assertThat(surveyService.findByPortalId(restoredPortal.getId()), hasSize(12));
@@ -59,6 +59,5 @@ public class PortalExtractTest extends BasePopulatePortalsTest {
         StudyEnvironment sandboxEnv = studyEnvironmentService.findByStudy(study.getShortcode(), EnvironmentName.sandbox).orElseThrow();
         assertThat(triggerService.findByStudyEnvironmentId(sandboxEnv.getId()), hasSize(5));
     }
-
 
 }

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -1248,8 +1248,9 @@ Promise<Trigger> {
     return await this.processJsonResponse(response)
   },
 
-  async populatePortal(fileName: string, overwrite: boolean) {
-    const url = `${basePopulateUrl()}/portal?filePathName=${fileName}&overwrite=${overwrite}`
+  async populatePortal(fileName: string, overwrite: boolean, shortcodeOverride: string | undefined) {
+    const params = queryString.stringify({ filePathName: fileName, overwrite, shortcodeOverride  })
+    const url = `${basePopulateUrl()}/portal?${params}`
     const response = await fetch(url, {
       method: 'POST',
       headers: this.getInitHeaders()
@@ -1257,9 +1258,10 @@ Promise<Trigger> {
     return await this.processJsonResponse(response)
   },
 
-  async uploadPortal(file: File, overwrite: boolean):
+  async uploadPortal(file: File, overwrite: boolean, shortcodeOverride: string | undefined):
     Promise<SiteMediaMetadata> {
-    const url = `${basePopulateUrl()}/portal/upload?overwrite=${overwrite}`
+    const params = queryString.stringify({ overwrite, shortcodeOverride })
+    const url = `${basePopulateUrl()}/portal/upload?${params}`
     const headers = this.getInitHeaders()
     delete headers['Content-Type'] // browsers will auto-add the correct type for the multipart file
     const formData = new FormData()

--- a/ui-admin/src/populate/PopulatePortalControl.tsx
+++ b/ui-admin/src/populate/PopulatePortalControl.tsx
@@ -10,15 +10,16 @@ import { useFileUploadButton } from '../util/uploadUtils'
 export default function PopulatePortalControl() {
   const [isLoading, setIsLoading] = useState(false)
   const [isOverwrite, setIsOverwrite] = useState(false)
+  const [shortcodeOverride, setShortcodeOverride] = useState('')
   const [fileName, setFileName] = useState('')
   const { file, FileChooser } = useFileUploadButton(() => 1)
   /** execute the command */
   const populate = async () => {
     doApiLoad(async () => {
       if (fileName.length) {
-        await Api.populatePortal(fileName, isOverwrite)
+        await Api.populatePortal(fileName, isOverwrite, shortcodeOverride)
       } else if (file) {
-        await Api.uploadPortal(file, isOverwrite)
+        await Api.uploadPortal(file, isOverwrite, shortcodeOverride)
       } else {
         Store.addNotification(failureNotification('No file or name provided'))
         return
@@ -43,6 +44,11 @@ export default function PopulatePortalControl() {
         - or -
       <FileNameControl fileName={fileName} setFileName={setFileName}/>
 
+      <label className="form-label mt-3">
+        Shortcode override (optional)
+        <input type="text" value={shortcodeOverride} className="form-control"
+          onChange={e => setShortcodeOverride(e.target.value)}/>
+      </label>
 
       <OverwriteControl isOverwrite={isOverwrite} setIsOverwrite={setIsOverwrite}
         text={<span>
@@ -50,7 +56,7 @@ export default function PopulatePortalControl() {
                 except for synthetic participants which are refreshed.<br/>
                 If yes, existing participants, surveys, and site content will be destroyed, and everything reset to
                 from the files.  This method will fail if there are participants in the live environment who
-                have not been withdrawn.
+                have not been withdrawn.  This option has no effect if &quot;Shortcode override&quot; is set.
         </span>}/>
       <PopulateButton onClick={populate} isLoading={isLoading}/>
     </div>


### PR DESCRIPTION
#### DESCRIPTION

This adds the ability to rename/recode portals when you are uploading or populating them (and was inspired by Connor's PR and a conversation about the template portal).  This allows you to extract a portal, and then re-upload it as a different portal, effectively "cloning it".  This takes care of assigning new stableIds to any documents attached to the portal so that the new portal is independent from the old.  

<img width="640" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/95c38982-0dd7-4167-96cc-49a927380d59">

Future PRs will handle defaulting the b2c configuration, and allowing changing the display names of the portals/studies

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to the portal populate page `https://localhost:3000/populate/portal`
2. put in the path for the ourhealth study (`portals/ourhealth/portal.json`)
3. add a shortcode override
4. populate it.
5. Observe the new portal got created with a different name/shortcode. (note the participant side won't be accessible due to b2c config missing -- that's for a later PR)
<img width="540" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/89338869-f5ba-4a14-957b-06c489cfa12e">



