### PR TITLE
[JN-954] Allow admin user to be added to more than one portal

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/admin/AdminUserService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/admin/AdminUserService.java
@@ -34,7 +34,11 @@ public class AdminUserService extends CrudService<AdminUser, AdminUserDao> {
     @Transactional
     @Override
     public AdminUser create(AdminUser adminUser) {
-        AdminUser savedUser = dao.create(adminUser);
+        //An AdminUser could belong to more than one portal, so we need to check if the user already exists
+        //before creating. If the user exists, we'll just add the new portal to the existing user.
+        AdminUser savedUser = dao.findByUsername(adminUser.getUsername())
+                                 .orElseGet(() -> dao.create(adminUser));
+
         logger.info("Created AdminUser - id: {}, username: {}", savedUser.getId(), savedUser.getUsername());
         for (PortalAdminUser portalAdminUser : adminUser.getPortalAdminUsers()) {
             portalAdminUser.setAdminUserId(savedUser.getId());


### PR DESCRIPTION
#### DESCRIPTION

This fixes a bug where an AdminUser couldn't be added to a new portal after initial creation.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Restart admin API
Add a new admin user to OurHealth
Add the same admin user to HeartHive
Verify that the admin user has gets to both portals