### PR TITLE
[JN-944] adding account information to export

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportData.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportData.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.service.export;
 
 import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.model.participant.Profile;
 import bio.terra.pearl.core.model.survey.Answer;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
@@ -16,6 +17,7 @@ import lombok.Setter;
 @Getter @Setter @Builder @AllArgsConstructor
 public class EnrolleeExportData {
     private Enrollee enrollee;
+    private ParticipantUser participantUser;
     private Profile profile;
     private List<Answer> answers;
     private List<ParticipantTask> tasks;

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
@@ -7,9 +7,11 @@ import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.model.survey.SurveyQuestionDefinition;
+import bio.terra.pearl.core.service.admin.AdminUserService;
 import bio.terra.pearl.core.service.export.formatters.module.*;
 import bio.terra.pearl.core.service.kit.KitRequestService;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
+import bio.terra.pearl.core.service.participant.ParticipantUserService;
 import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
 import bio.terra.pearl.core.service.participant.ProfileService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
@@ -35,6 +37,7 @@ public class EnrolleeExportService {
     private final ParticipantTaskService participantTaskService;
     private final EnrolleeService enrolleeService;
     private final KitRequestService kitRequestService;
+    private final ParticipantUserService participantUserService;
     private final KitTypeDao kitTypeDao;
     private final ObjectMapper objectMapper;
 
@@ -43,7 +46,9 @@ public class EnrolleeExportService {
                                  SurveyQuestionDefinitionDao surveyQuestionDefinitionDao,
                                  StudyEnvironmentSurveyService studyEnvironmentSurveyService, SurveyResponseService surveyResponseService,
                                  ParticipantTaskService participantTaskService,
-                                 EnrolleeService enrolleeService, KitRequestService kitRequestService, KitTypeDao kitTypeDao, ObjectMapper objectMapper) {
+                                 EnrolleeService enrolleeService, KitRequestService kitRequestService,
+                                 ParticipantUserService participantUserService,
+                                 KitTypeDao kitTypeDao, ObjectMapper objectMapper) {
         this.profileService = profileService;
         this.answerDao = answerDao;
         this.surveyQuestionDefinitionDao = surveyQuestionDefinitionDao;
@@ -52,6 +57,7 @@ public class EnrolleeExportService {
         this.participantTaskService = participantTaskService;
         this.enrolleeService = enrolleeService;
         this.kitRequestService = kitRequestService;
+        this.participantUserService = participantUserService;
         this.kitTypeDao = kitTypeDao;
         this.objectMapper = objectMapper;
     }
@@ -103,6 +109,7 @@ public class EnrolleeExportService {
     public List<ModuleFormatter> generateModuleInfos(ExportOptions exportOptions, UUID studyEnvironmentId)  {
         List<ModuleFormatter> moduleFormatters = new ArrayList<>();
         moduleFormatters.add(new EnrolleeFormatter(exportOptions));
+        moduleFormatters.add(new ParticipantUserFormatter(exportOptions));
         moduleFormatters.add(new ProfileFormatter(exportOptions));
         moduleFormatters.add(new KitRequestFormatter());
         moduleFormatters.addAll(generateSurveyModules(exportOptions, studyEnvironmentId));
@@ -145,6 +152,7 @@ public class EnrolleeExportService {
     protected EnrolleeExportData loadEnrolleeData(Enrollee enrollee) {
         return new EnrolleeExportData(
                 enrollee,
+                participantUserService.find(enrollee.getParticipantUserId()).orElseThrow(),
                 profileService.loadWithMailingAddress(enrollee.getProfileId()).get(),
                 answerDao.findByEnrolleeId(enrollee.getId()),
                 participantTaskService.findByEnrolleeId(enrollee.getId()),

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ParticipantUserFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ParticipantUserFormatter.java
@@ -1,0 +1,27 @@
+package bio.terra.pearl.core.service.export.formatters.module;
+
+import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.participant.ParticipantUser;
+import bio.terra.pearl.core.service.export.EnrolleeExportData;
+import bio.terra.pearl.core.service.export.ExportOptions;
+import bio.terra.pearl.core.service.export.formatters.item.PropertyItemFormatter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ParticipantUserFormatter extends BeanModuleFormatter<ParticipantUser> {
+    public static final String PARTICIPANT_USER_MODULE_NAME = "account";
+    public static final List<String> INCLUDED_PROPERTIES = List.of("username", "createdAt");
+
+    public ParticipantUserFormatter(ExportOptions exportOptions) {
+        itemFormatters = INCLUDED_PROPERTIES.stream().map(propName -> new PropertyItemFormatter<ParticipantUser>(propName, ParticipantUser.class))
+                .collect(Collectors.toList());
+        moduleName = PARTICIPANT_USER_MODULE_NAME;
+        displayName = "Account";
+    }
+
+    @Override
+    public ParticipantUser getBean(EnrolleeExportData enrolleeExportData) {
+        return enrolleeExportData.getParticipantUser();
+    }
+}

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/EnrolleeFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/EnrolleeFormatterTests.java
@@ -20,7 +20,7 @@ public class EnrolleeFormatterTests {
                 .createdAt(Instant.parse("2023-08-21T05:17:25.00Z"))
                 .build();
         EnrolleeFormatter moduleFormatter = new EnrolleeFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(enrollee, null, null, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(enrollee, null, null, null, null, null, null);
         Map<String, String> valueMap = moduleFormatter.toStringMap(exportData);
 
         assertThat(valueMap.get("enrollee.shortcode"), equalTo("TESTER"));

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/KitRequestFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/KitRequestFormatterTests.java
@@ -38,7 +38,7 @@ public class KitRequestFormatterTests {
                 .createdAt(Instant.now().minus(1, java.time.temporal.ChronoUnit.DAYS))
                 .build()
         );
-        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null, null, kitRequests);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null, null, null, kitRequests);
         Map<String, String> valueMap = moduleFormatter.toStringMap(exportData);
 
         // the older kit should be first

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ParticipantUserFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ParticipantUserFormatterTests.java
@@ -1,0 +1,32 @@
+package bio.terra.pearl.core.service.export.formatters;
+
+import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.participant.ParticipantUser;
+import bio.terra.pearl.core.service.export.EnrolleeExportData;
+import bio.terra.pearl.core.service.export.ExportOptions;
+import bio.terra.pearl.core.service.export.formatters.module.EnrolleeFormatter;
+import bio.terra.pearl.core.service.export.formatters.module.ParticipantUserFormatter;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ParticipantUserFormatterTests {
+    @Test
+    public void testToStringMap() throws Exception {
+        ParticipantUser participantUser = ParticipantUser.builder()
+                .username("tester-" + RandomStringUtils.randomAlphabetic(5))
+                .createdAt(Instant.parse("2023-08-21T05:17:25.00Z"))
+                .build();
+        ParticipantUserFormatter moduleFormatter = new ParticipantUserFormatter(new ExportOptions());
+        EnrolleeExportData exportData = new EnrolleeExportData(null, participantUser, null, null, null, null, null);
+        Map<String, String> valueMap = moduleFormatter.toStringMap(exportData);
+
+        assertThat(valueMap.get("account.username"), equalTo(participantUser.getUsername()));
+        assertThat(valueMap.get("account.createdAt"), equalTo("2023-08-21 05:17AM"));
+    }
+}

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ProfileFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ProfileFormatterTests.java
@@ -26,7 +26,7 @@ public class ProfileFormatterTests {
                         .build())
                 .build();
         ProfileFormatter moduleFormatter = new ProfileFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(null, profile, null, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, profile, null, null, null, null);
         Map<String, String> enrolleeMap = moduleFormatter.toStringMap(exportData);
 
         assertThat(enrolleeMap.get("profile.familyName"), equalTo("Tester"));
@@ -42,7 +42,7 @@ public class ProfileFormatterTests {
                 .familyName("Tester")
                 .build();
         ProfileFormatter moduleFormatter = new ProfileFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(null, profile, null, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, profile, null, null, null, null);
         Map<String, String> enrolleeMap = moduleFormatter.toStringMap(exportData);
 
         assertThat(enrolleeMap.get("profile.familyName"), equalTo("Tester"));

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatterTests.java
@@ -42,7 +42,7 @@ public class SurveyFormatterTests extends BaseSpringBootTest {
                 .surveyResponseId(testResponse.getId())
                 .stringValue("easyValue")
                 .build();
-        EnrolleeExportData enrolleeExportData = new EnrolleeExportData(null, null,
+        EnrolleeExportData enrolleeExportData = new EnrolleeExportData(null, null, null,
                 List.of(answer), null, List.of(testResponse), null);
         Map<String, String> valueMap = moduleFormatter.toStringMap(enrolleeExportData);
 

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
@@ -151,6 +151,7 @@ public class PopulateDemoTest extends BasePopulatePortalsTest {
         assertThat(exportData, hasSize(8));
         Map<String, String> oldVersionMap = exportData.stream().filter(map -> "HDVERS".equals(map.get("enrollee.shortcode")))
                 .findFirst().get();
+        assertThat(oldVersionMap.get("account.username"), equalTo("oldversion@test.com"));
         // confirm text (including typo) from prior version is carried through
         assertThat(oldVersionMap.get("hd_hd_socialHealth.hd_hd_socialHealth_neighborhoodSharesValues"), equalTo("Disagre"));
         // confirm answer from question that was removed in current version is still exported


### PR DESCRIPTION
#### DESCRIPTION

In preparation for building the ingestor, we'll want to have account information in the export.  This will make it easier to test symmetric import-export.  
<img width="1093" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/14e6f105-7b60-4f65-bf60-819865fabd5a">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  redeploy apiAdminApp
2. go to `https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/export/dataBrowser`
3. confirm you see `account.username` and `account.createdAt` fields