### PR TITLE
[JN-888] fixing empty shortcode override behavior

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/internal/PopulateController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/internal/PopulateController.java
@@ -74,6 +74,9 @@ public class PopulateController implements PopulateApi {
   public ResponseEntity<Object> uploadPortal(
       Boolean overwrite, String shortcodeOverride, MultipartFile portalZip) {
     AdminUser user = authUtilService.requireAdminUser(request);
+    if (StringUtils.isBlank(shortcodeOverride)) {
+      shortcodeOverride = null;
+    }
     Portal populatedObj =
         populateExtService.populatePortal(
             portalZip, user, Boolean.TRUE.equals(overwrite), shortcodeOverride);

--- a/core/src/test/java/bio/terra/pearl/core/service/admin/AdminUserServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/admin/AdminUserServiceTests.java
@@ -26,10 +26,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 public class AdminUserServiceTests extends BaseSpringBootTest {
     @Autowired
@@ -161,7 +158,10 @@ public class AdminUserServiceTests extends BaseSpringBootTest {
         adminUserService.create(adminUser);
 
         List<AdminUser> adminUsersList = adminUserService.findAllWithRoles();
-        List<UUID> portalIds = adminUsersList.get(0).getPortalAdminUsers().stream().map(PortalAdminUser::getPortalId).toList();
-        assertThat(portalIds, hasItems(portal1.getId(), portal2.getId()));
+        List<UUID> portalIds = adminUsersList.stream()
+                .filter(user -> user.getUsername().equals(adminUser.getUsername()))
+                .findFirst().get()
+                .getPortalAdminUsers().stream().map(PortalAdminUser::getPortalId).toList();
+        assertThat(portalIds, containsInAnyOrder(portal1.getId(), portal2.getId()));
     }
 }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/contexts/FilePopulateContext.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/contexts/FilePopulateContext.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Stores the path and current filename to populate from.
@@ -96,7 +97,7 @@ public class FilePopulateContext {
     }
 
     public String applyShortcodeOverride(String stableId) {
-        if (shortcodeOverride != null) {
+        if (!StringUtils.isBlank(shortcodeOverride)) {
             String newStableId = stableId;
             // if the stableId is already prefixed, strip it
             if (stableId.lastIndexOf("_") != -1) {


### PR DESCRIPTION
#### DESCRIPTION

This fixes some populate behavior when populating from zip files without a shortcode override.  

This also updates the portalAdminUser test to be more robust to test ordering

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. Extract the demo portal from `https://admin-d2p.ddp-dev.envs.broadinstitute.org/populate/extractPortal`
2. upload that portal locally, from `https://localhost:3000/populate/portal` and do not specify a shortcode override
3. confirm populate succeeds