### PR TITLE
[JN-957] fixing doNotEmail populate

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/RegistrationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/RegistrationService.java
@@ -157,6 +157,7 @@ public class RegistrationService {
         Profile proxyProfile = profileService.find(proxyPpUser.getProfileId()).orElseThrow();
         Profile governedProfile =  Profile.builder()
                 .contactEmail(proxyProfile.getContactEmail())
+                .doNotEmail(proxyProfile.isDoNotEmail())
                 .givenName(null)
                 .familyName(null)
                 .build();


### PR DESCRIPTION
#### DESCRIPTION

The logic for marking an enrollee as "doNotEmail" during populate got scrambled -- this fixes it so that you don't get welcome emails every time you run populate.  

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy apiAdminApp
2. run ./scripts/populate_portal.sh demo
3. observe that you don't get welcome emails for participants, and you see things in the logs like:
` skipping email, enrollee HDVERS is doNotEmail:`
4. Observe in the database that profile.do_not_email is reset to false for enrollees post-populate
