### PR TITLE
[JN-895] updating demo b2c configs

### DIFF
--- a/api-participant/src/main/resources/b2c-config.yml
+++ b/api-participant/src/main/resources/b2c-config.yml
@@ -10,7 +10,7 @@ b2c:
     policyName: B2C_1A_ddp_participant_signup_signin_hearthive-dev
     changePasswordPolicyName: B2C_1A_ddp_participant_change_password_hearthive-dev
   demo:
-    tenantName: doesNotExist
-    clientId: doesNotExist
-    policyName: doesNotExist-dev
-    changePasswordPolicyName: doesNotExist-dev
+    tenantName: juniperdemodev
+    clientId: 37d95cc4-7c71-465e-9fc2-66be9a54c202
+    policyName: B2C_1A_ddp_participant_signup_signin_demo-dev
+    changePasswordPolicyName: B2C_1A_ddp_participant_change_password_demo-dev

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/dev/aboutUs.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/dev/aboutUs.json
@@ -54,7 +54,7 @@
       "sectionType": "HERO_CENTERED",
       "sectionConfigJson": {
         "blurbAlign": "left",
-        "blurb": "DEV_The OurHealth investigators, led by Co-Principal Investigators Dr. Pradeep Natarajan and Dr. Amit V. Khera, have extensive experience in studying the genetic basis of cardiovascular and cardiometabolic disease. By closely studying the contribution of genetics towards heart and metabolic disease in individuals of South Asian ancestry living outside the United States, they have helped develop a new genotyping array optimized for South Asians. Unfortunately, South Asian datasets remain limited in size, cultural diversity, and diasporic representation.\n\nHelp us close this gap! [Join the OurHealth study](/studies/ourheart/join) and contribute to improving South Asian heart health."
+        "blurb": "DEV_The OurHealth investigators, led by Co-Principal Investigators Dr. Pradeep Natarajan and Dr. Amit V. Khera, have extensive experience in studying the genetic basis of cardiovascular and cardiometabolic disease. By closely studying the contribution of genetics towards heart and metabolic disease in individuals of South Asian ancestry living outside the United States, they have helped develop a new genotyping array optimized for South Asians. Unfortunately, South Asian datasets remain limited in size, cultural diversity, and diasporic representation.\n\nHelp us close this gap! [Join the OurHealth study](/studies/heartdemo/join) and contribute to improving South Asian heart health."
       }
     },
     {

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/dev/faq.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/dev/faq.json
@@ -28,7 +28,7 @@
             },
             {
               "question": "DEV_How can I participate?",
-              "answer": "DEV_If you are over 18 years of age, live in the United States, and identify as South Asian, you can sign up by clicking [“Join”](/studies/ourheart/join)."
+              "answer": "DEV_If you are over 18 years of age, live in the United States, and identify as South Asian, you can sign up by clicking [“Join”](/studies/heartdemo/join)."
             },
             {
               "question": "DEV_What does OurHealth do with the data?",

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/dev/footerSection.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/dev/footerSection.json
@@ -63,7 +63,7 @@
       },{
         "type": "join",
         "text": "DEV_Join OurHealth",
-        "studyShortcode": "ourheart"
+        "studyShortcode": "heartdemo"
       }]
     }]
   }

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/dev/landingPage.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/dev/landingPage.json
@@ -13,7 +13,7 @@
         {
           "text": "DEV_Become a Participant",
           "type": "join",
-          "studyShortcode": "ourheart"
+          "studyShortcode": "heartdemo"
         }
       ],
       "logos": [
@@ -59,7 +59,7 @@
       "buttons": [
         {"text": "DEV_Get Started",
           "type": "join",
-          "studyShortcode": "ourheart"
+          "studyShortcode": "heartdemo"
         }
       ],
       "image": {"cleanFileName": "people_laughing.jpg", "alt": "", "version": 1},
@@ -113,7 +113,7 @@
         },
         {
           "question": "DEV_How can I participate?",
-          "answer": "DEV_If you are over 18 years of age, live in the United States, and identify as South Asian, you can sign up by clicking [“Join”](/studies/ourheart/join)."
+          "answer": "DEV_If you are over 18 years of age, live in the United States, and identify as South Asian, you can sign up by clicking [“Join”](/studies/heartdemo/join)."
         },
         {
           "question": "DEV_What does OurHealth do with the data?",
@@ -167,7 +167,7 @@
       "buttons": [{
         "type": "join",
         "text": "Join OurHealth",
-        "studyShortcode": "ourheart"
+        "studyShortcode": "heartdemo"
       }],
       "background": "linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%)"
     }

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/dev/participation.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/dev/participation.json
@@ -64,7 +64,7 @@
         "buttons": [{
           "type": "join",
           "text": "DEV_Join OurHealth",
-          "studyShortcode": "ourheart"
+          "studyShortcode": "heartdemo"
         }],
         "background": "linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%)"
       }

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/dev/scientificBackground.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/dev/scientificBackground.json
@@ -98,7 +98,7 @@
         "buttons": [{
           "type": "join",
           "text": "Join OurHealth",
-          "studyShortcode": "ourheart"
+          "studyShortcode": "heartdemo"
         }],
         "background": "linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%)"
       }

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/aboutUs.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/aboutUs.json
@@ -54,7 +54,7 @@
       "sectionType": "HERO_CENTERED",
       "sectionConfigJson": {
         "blurbAlign": "left",
-        "blurb": "The OurHealth investigators, led by Co-Principal Investigators Dr. Pradeep Natarajan and Dr. Amit V. Khera, have extensive experience in studying the genetic basis of cardiovascular and cardiometabolic disease. By closely studying the contribution of genetics towards heart and metabolic disease in individuals of South Asian ancestry living outside the United States, they have helped develop a new genotyping array optimized for South Asians. Unfortunately, South Asian datasets remain limited in size, cultural diversity, and diasporic representation.\n\nHelp us close this gap! [Join the OurHealth study](/studies/ourheart/join) and contribute to improving South Asian heart health."
+        "blurb": "The OurHealth investigators, led by Co-Principal Investigators Dr. Pradeep Natarajan and Dr. Amit V. Khera, have extensive experience in studying the genetic basis of cardiovascular and cardiometabolic disease. By closely studying the contribution of genetics towards heart and metabolic disease in individuals of South Asian ancestry living outside the United States, they have helped develop a new genotyping array optimized for South Asians. Unfortunately, South Asian datasets remain limited in size, cultural diversity, and diasporic representation.\n\nHelp us close this gap! [Join the OurHealth study](/studies/heartdemo/join) and contribute to improving South Asian heart health."
       }
     },
     {

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/faq.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/faq.json
@@ -28,7 +28,7 @@
             },
             {
               "question": "How can I participate?",
-              "answer": "If you are over 18 years of age, live in the United States, and identify as South Asian, you can sign up by clicking [“Join”](/studies/ourheart/join)."
+              "answer": "If you are over 18 years of age, live in the United States, and identify as South Asian, you can sign up by clicking [“Join”](/studies/heartdemo/join)."
             },
             {
               "question": "What does OurHealth do with the data?",

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/footerSection.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/footerSection.json
@@ -75,7 +75,7 @@
       },{
         "type": "join",
         "text": "Join OurHealth",
-        "studyShortcode": "ourheart"
+        "studyShortcode": "heartdemo"
       }]
     }]
   }

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/landingPage.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/landingPage.json
@@ -13,7 +13,7 @@
         {
           "text": "Become a Participant",
           "type": "join",
-          "studyShortcode": "ourheart"
+          "studyShortcode": "heartdemo"
         }
       ],
       "logos": [
@@ -59,7 +59,7 @@
       "buttons": [
         {"text": "Get Started",
           "type": "join",
-          "studyShortcode": "ourheart"
+          "studyShortcode": "heartdemo"
         }
       ],
       "image": {"cleanFileName": "people_laughing.jpg", "alt": "", "version": 1},
@@ -112,7 +112,7 @@
         },
         {
           "question": "How can I participate?",
-          "answer": "If you are over 18 years of age, live in the United States, and identify as South Asian, you can sign up by clicking [“Join”](/studies/ourheart/join)."
+          "answer": "If you are over 18 years of age, live in the United States, and identify as South Asian, you can sign up by clicking [“Join”](/studies/heartdemo/join)."
         },
         {
           "question": "What does OurHealth do with the data?",
@@ -170,7 +170,7 @@
       "buttons": [{
         "type": "join",
         "text": "Join OurHealth",
-        "studyShortcode": "ourheart"
+        "studyShortcode": "heartdemo"
       }],
       "background": "linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%)"
     }

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/participation.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/participation.json
@@ -64,7 +64,7 @@
         "buttons": [{
           "type": "join",
           "text": "Join OurHealth",
-          "studyShortcode": "ourheart"
+          "studyShortcode": "heartdemo"
         }],
         "background": "linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%)"
       }

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/scientificBackground.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/scientificBackground.json
@@ -98,7 +98,7 @@
         "buttons": [{
           "type": "join",
           "text": "Join OurHealth",
-          "studyShortcode": "ourheart"
+          "studyShortcode": "heartdemo"
         }],
         "background": "linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%)"
       }

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/es/aboutUs.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/es/aboutUs.json
@@ -54,7 +54,7 @@
       "sectionType": "HERO_CENTERED",
       "sectionConfigJson": {
         "blurbAlign": "left",
-        "blurb": "Los investigadores de OurHealth, liderados por los Co-Investigadores Principales Dr. Pradeep Natarajan y Dr. Amit V. Khera, tienen una amplia experiencia en el estudio de la base genética de la enfermedad cardiovascular y cardiometabólica. Al estudiar de cerca la contribución de la genética a la enfermedad cardíaca y metabólica en personas de ascendencia surasiática que viven fuera de los Estados Unidos, han ayudado a desarrollar un nuevo conjunto de genotipos optimizado para los surasiáticos. Desafortunadamente, los conjuntos de datos surasiáticos siguen siendo limitados en tamaño, diversidad cultural y representación diaspórica.\n\n¡Ayúdenos a cerrar esta brecha! [Únase al estudio OurHealth](/studies/ourheart/join) y contribuya a mejorar la salud cardíaca de los surasiáticos."
+        "blurb": "Los investigadores de OurHealth, liderados por los Co-Investigadores Principales Dr. Pradeep Natarajan y Dr. Amit V. Khera, tienen una amplia experiencia en el estudio de la base genética de la enfermedad cardiovascular y cardiometabólica. Al estudiar de cerca la contribución de la genética a la enfermedad cardíaca y metabólica en personas de ascendencia surasiática que viven fuera de los Estados Unidos, han ayudado a desarrollar un nuevo conjunto de genotipos optimizado para los surasiáticos. Desafortunadamente, los conjuntos de datos surasiáticos siguen siendo limitados en tamaño, diversidad cultural y representación diaspórica.\n\n¡Ayúdenos a cerrar esta brecha! [Únase al estudio OurHealth](/studies/heartdemo/join) y contribuya a mejorar la salud cardíaca de los surasiáticos."
       }
     },
     {

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/es/footerSection.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/es/footerSection.json
@@ -63,7 +63,7 @@
       },{
         "type": "join",
         "text": "Únete a OurHealth",
-        "studyShortcode": "ourheart"
+        "studyShortcode": "heartdemo"
       }]
     }]
   }

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/es/landingPage.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/es/landingPage.json
@@ -13,7 +13,7 @@
         {
           "text": "Conviértase en participante",
           "type": "join",
-          "studyShortcode": "ourheart"
+          "studyShortcode": "heartdemo"
         }
       ],
       "logos": [
@@ -60,7 +60,7 @@
         {
           "text": "Comience",
           "type": "join",
-          "studyShortcode": "ourheart"
+          "studyShortcode": "heartdemo"
         }
       ],
       "image": {"cleanFileName": "people_laughing.jpg", "alt": "", "version": 1},
@@ -115,7 +115,7 @@
         },
         {
           "question": "¿Cómo puedo participar?",
-          "answer": "Si tiene más de 18 años, vive en los Estados Unidos y se identifica como del sur de Asia, puede inscribirse haciendo clic en [“Unirse”](/studies/ourheart/join)."
+          "answer": "Si tiene más de 18 años, vive en los Estados Unidos y se identifica como del sur de Asia, puede inscribirse haciendo clic en [“Unirse”](/studies/heartdemo/join)."
         },
         {
           "question": "¿Qué hace OurHealth con los datos?",
@@ -169,7 +169,7 @@
       "buttons": [{
         "type": "join",
         "text": "Únase a OurHealth",
-        "studyShortcode": "ourheart"
+        "studyShortcode": "heartdemo"
       }],
       "background": "linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%)"
     }

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/es/participation.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/es/participation.json
@@ -64,7 +64,7 @@
         "buttons": [{
           "type": "join",
           "text": "Únete a OurHealth",
-          "studyShortcode": "ourheart"
+          "studyShortcode": "heartdemo"
         }],
         "background": "linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%)"
       }

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/es/scientificBackground.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/es/scientificBackground.json
@@ -98,7 +98,7 @@
         "buttons": [{
           "type": "join",
           "text": "Únete a OurHealth",
-          "studyShortcode": "ourheart"
+          "studyShortcode": "heartdemo"
         }],
         "background": "linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%)"
       }


### PR DESCRIPTION
#### DESCRIPTION

Updates the bc config yaml with the dev tenant for the demo portal.  This also fixes a bunch of site content links that were using OurHealth study shortcodes.  Emails are still not working in the b2c tenant, so you can't sign up, but you can sign in.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  restart ApiParticipantApp 
2. go to https://sandbox.demo.localhost:3001/
3. sign in (using b2c) as consented@test.com

