### PR TITLE
[JN-8xx] add empty search

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/search/EnrolleeSearchExpressionParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/EnrolleeSearchExpressionParser.java
@@ -4,6 +4,7 @@ import bio.terra.pearl.core.antlr.CohortRuleLexer;
 import bio.terra.pearl.core.antlr.CohortRuleParser;
 import bio.terra.pearl.core.service.search.expressions.BooleanSearchExpression;
 import bio.terra.pearl.core.service.search.expressions.ComparisonOperator;
+import bio.terra.pearl.core.service.search.expressions.DefaultSearchExpression;
 import bio.terra.pearl.core.service.search.expressions.EnrolleeTermComparisonFacet;
 import bio.terra.pearl.core.service.search.terms.AgeTerm;
 import bio.terra.pearl.core.service.search.terms.AnswerTerm;
@@ -14,6 +15,7 @@ import bio.terra.pearl.core.service.search.terms.UserInputTerm;
 import bio.terra.pearl.core.service.survey.AnswerService;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.apache.commons.lang3.StringUtils;
 import org.jooq.Operator;
 import org.springframework.stereotype.Component;
 
@@ -27,6 +29,9 @@ public class EnrolleeSearchExpressionParser {
 
 
     public EnrolleeSearchExpression parseRule(String rule) {
+        if (StringUtils.isBlank(rule)) {
+            return new DefaultSearchExpression();
+        }
         CohortRuleLexer lexer = new CohortRuleLexer(CharStreams.fromString(rule));
         CommonTokenStream tokens = new CommonTokenStream(lexer);
         CohortRuleParser parser = new CohortRuleParser(tokens);

--- a/core/src/main/java/bio/terra/pearl/core/service/search/expressions/DefaultSearchExpression.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/expressions/DefaultSearchExpression.java
@@ -1,0 +1,23 @@
+package bio.terra.pearl.core.service.search.expressions;
+
+import bio.terra.pearl.core.service.search.EnrolleeSearchContext;
+import bio.terra.pearl.core.service.search.EnrolleeSearchExpression;
+import bio.terra.pearl.core.service.search.sql.EnrolleeSearchQueryBuilder;
+
+import java.util.UUID;
+
+/** represents an empty search/filter rule, which means return everything */
+public class DefaultSearchExpression implements EnrolleeSearchExpression {
+    public DefaultSearchExpression() {}
+
+    @Override
+    public boolean evaluate (EnrolleeSearchContext enrolleeCtx){
+        return true;
+    }
+
+    @Override
+    public EnrolleeSearchQueryBuilder generateQueryBuilder (UUID studyEnvId) {
+        return new EnrolleeSearchQueryBuilder(studyEnvId);
+    }
+
+}

--- a/core/src/test/java/bio/terra/pearl/core/dao/participant/EnrolleeSearchDaoTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/participant/EnrolleeSearchDaoTests.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.core.dao.participant;
 
 
 import bio.terra.pearl.core.BaseSpringBootTest;
+import bio.terra.pearl.core.dao.search.EnrolleeSearchExpressionDao;
 import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
 import bio.terra.pearl.core.factory.kit.KitRequestFactory;
 import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
@@ -23,6 +24,8 @@ import bio.terra.pearl.core.model.workflow.TaskType;
 import bio.terra.pearl.core.service.participant.ParticipantUserService;
 import bio.terra.pearl.core.service.participant.search.facets.*;
 import bio.terra.pearl.core.service.participant.search.facets.sql.*;
+import bio.terra.pearl.core.service.search.EnrolleeSearchExpression;
+import bio.terra.pearl.core.service.search.EnrolleeSearchExpressionParser;
 import bio.terra.pearl.core.service.survey.AnswerService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -50,6 +53,10 @@ public class EnrolleeSearchDaoTests extends BaseSpringBootTest {
   private KitRequestFactory kitRequestFactory;
   @Autowired
   private ParticipantUserService participantUserService;
+  @Autowired
+  private EnrolleeSearchExpressionDao enrolleeSearchExpressionDao;
+  @Autowired
+  private EnrolleeSearchExpressionParser enrolleeSearchExpressionParser;
 
   @Test
   @Transactional
@@ -62,12 +69,17 @@ public class EnrolleeSearchDaoTests extends BaseSpringBootTest {
     participantUser.setLastLogin(Instant.now());
     participantUserService.update(participantUser);
 
-      List<EnrolleeSearchResult> result = enrolleeSearchDao.search(studyEnv.getId(), List.of());
+    List<EnrolleeSearchResult> result = enrolleeSearchDao.search(studyEnv.getId(), List.of());
     assertThat(result, hasSize(1));
     assertThat(result.get(0).getEnrollee().getShortcode(), equalTo(enrollee.getShortcode()));
 
     assertThat(result.get(0).getParticipantUser().getUsername(), equalTo(participantUser.getUsername()));
     assertThat(result.get(0).getParticipantUser().getLastLogin(), greaterThan(Instant.now().minusMillis(3000)));
+
+    EnrolleeSearchExpression exp = enrolleeSearchExpressionParser.parseRule("");
+    List<Enrollee> enrollees = enrolleeSearchExpressionDao.executeSearch(exp, studyEnv.getId());
+    assertThat(enrollees, hasSize(1));
+    assertThat(enrollees.get(0).getShortcode(), equalTo(enrollee.getShortcode()));
   }
 
   @Test


### PR DESCRIPTION
#### DESCRIPTION

Adds a "default"/empty search so we can do a search with no filters

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. run unit tests