### PR TITLE
[JN-946] enrollee invitation proof-of-concept

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/CoreCliApp.java
+++ b/core/src/main/java/bio/terra/pearl/core/CoreCliApp.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 /**
  * Placeholder application to make spring and liquibase configuration and testing easier.
@@ -11,6 +12,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  */
 @SpringBootApplication
 @Slf4j
+@ConfigurationPropertiesScan("bio.terra.pearl.core.config.b2c")
 public class CoreCliApp
         implements CommandLineRunner {
 

--- a/core/src/main/java/bio/terra/pearl/core/CoreCliApp.java
+++ b/core/src/main/java/bio/terra/pearl/core/CoreCliApp.java
@@ -4,7 +4,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 /**
  * Placeholder application to make spring and liquibase configuration and testing easier.
@@ -12,7 +11,6 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
  */
 @SpringBootApplication
 @Slf4j
-@ConfigurationPropertiesScan("bio.terra.pearl.core.config.b2c")
 public class CoreCliApp
         implements CommandLineRunner {
 

--- a/core/src/main/java/bio/terra/pearl/core/service/DataAuditedService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/DataAuditedService.java
@@ -86,6 +86,8 @@ public abstract class DataAuditedService<M extends BaseEntity, D extends BaseMut
     public List<M> findAll() { return dao.findAll(); }
     public List<M> findAll(List<UUID> uuids) { return dao.findAll(uuids); }
 
+    public List<M> findAllPreserveOrder(List<UUID> uuids) { return dao.findAllPreserveOrder(uuids); }
+
     @Transactional
     public void delete(UUID id, DataAuditInfo auditInfo, Set<CascadeProperty> cascade) {
         if (auditInfo != null) {

--- a/core/src/main/java/bio/terra/pearl/core/service/ImmutableEntityService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/ImmutableEntityService.java
@@ -41,6 +41,8 @@ public abstract class ImmutableEntityService<M extends BaseEntity, D extends Bas
     public List<M> findAll() { return dao.findAll(); }
     public List<M> findAll(List<UUID> uuids) { return dao.findAll(uuids); }
 
+    public List<M> findAllPreserveOrder(List<UUID> ids) { return dao.findAllPreserveOrder(ids); }
+
     @Transactional
     public void delete(UUID id, Set<CascadeProperty> cascade) {
         dao.delete(id);

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
@@ -5,9 +5,14 @@ import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.portal.PortalEnvironmentConfig;
 import bio.terra.pearl.core.model.study.Study;
+import bio.terra.pearl.core.service.exception.internal.IOInternalException;
 import bio.terra.pearl.core.service.notification.NotificationContextInfo;
 import bio.terra.pearl.core.service.rule.EnrolleeRuleData;
 import bio.terra.pearl.core.shared.ApplicationRoutingPaths;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -109,9 +114,14 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
 
     /** gets a link the participant can use to create their b2c account, given that they already exist in Juniper */
     public String getInvitationLink(PortalEnvironment portalEnv, PortalEnvironmentConfig config, String portalShortcode, ParticipantUser participantUser) {
-        return "%s%s?accountName=%s".formatted(
-                routingPaths.getParticipantBaseUrl(portalEnv, config, portalShortcode),
-                routingPaths.getParticipantInvitationPath() ,
-                participantUser != null ? participantUser.getUsername() : "");
+        try {
+            return "%s%s?accountName=%s".formatted(
+                    routingPaths.getParticipantBaseUrl(portalEnv, config, portalShortcode),
+                    routingPaths.getParticipantInvitationPath() ,
+                    participantUser != null ?
+                            URLEncoder.encode(participantUser.getUsername(), StandardCharsets.UTF_8.toString())  : "");
+        } catch (UnsupportedEncodingException e) {
+            throw new IOInternalException("unable to encode username");
+        }
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
@@ -1,7 +1,9 @@
 package bio.terra.pearl.core.service.notification.substitutors;
 
+import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
+import bio.terra.pearl.core.model.portal.PortalEnvironmentConfig;
 import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.service.notification.NotificationContextInfo;
 import bio.terra.pearl.core.service.rule.EnrolleeRuleData;
@@ -29,20 +31,18 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
         this.enrolleeRuleData = ruleData;
         this.contextInfo = contextInfo;
         this.routingPaths = routingPaths;
-        valueMap.putAll(Map.of("profile", enrolleeRuleData.getProfile(),
-                "portalEnv", contextInfo.portalEnv(),
-                "envConfig", contextInfo.portalEnv().getPortalEnvironmentConfig(),
-                "dashboardLink", getDashboardLink(contextInfo.portalEnv(),
-                        contextInfo.portal(), contextInfo.study()),
-                "dashboardUrl", getDashboardUrl(contextInfo.portalEnv(), contextInfo.portal()),
-                "siteLink", getSiteLink(contextInfo.portalEnv(), contextInfo.portal()),
-                "participantSupportEmailLink", getParticipantSupportEmailLink(contextInfo.portalEnv()),
-                "siteMediaBaseUrl", getImageBaseUrl(contextInfo.portalEnv(), contextInfo.portal().getShortcode()),
-                // legacy template substitution support
-                "siteImageBaseUrl", getImageBaseUrl(contextInfo.portalEnv(), contextInfo.portal().getShortcode()),
-                // providing a study isn't required, since emails might come from the portal, rather than a study
-                // but immutable map doesn't allow nulls
-                "study", contextInfo.study() != null ? contextInfo.study() : ""));
+        valueMap.put("profile", enrolleeRuleData.getProfile());
+        valueMap.put("portalEnv", contextInfo.portalEnv());
+        valueMap.put("envConfig", contextInfo.portalEnvConfig());
+        valueMap.put("dashboardLink", getDashboardLink(contextInfo.portalEnv(), contextInfo.portalEnvConfig(), contextInfo.portal(), contextInfo.study()));
+        valueMap.put("siteLink", getSiteLink(contextInfo.portalEnv(), contextInfo.portalEnvConfig(), contextInfo.portal()));
+        valueMap.put("participantSupportEmailLink", getParticipantSupportEmailLink(contextInfo.portalEnv(), contextInfo.portalEnvConfig()));
+        valueMap.put("siteMediaBaseUrl", getImageBaseUrl(contextInfo.portalEnv(), contextInfo.portalEnvConfig(), contextInfo.portal().getShortcode()));
+        valueMap.put("siteImageBaseUrl", getImageBaseUrl(contextInfo.portalEnv(), contextInfo.portalEnvConfig(), contextInfo.portal().getShortcode()));
+        valueMap.put("profile", enrolleeRuleData.getProfile());
+        valueMap.put("study", contextInfo.study());
+        valueMap.put("participantUser", ruleData.getParticipantUser());
+        valueMap.put("invitationLink", getInvitationLink(contextInfo.portalEnv(), contextInfo.portalEnvConfig(), contextInfo.portal().getShortcode(), ruleData.getParticipantUser()));
         if (messages != null) {
             valueMap.putAll(messages);
         }
@@ -75,31 +75,31 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
         return "";
     }
 
-    public String getSiteLink(PortalEnvironment portalEnv, Portal portal) {
-        String href = routingPaths.getParticipantBaseUrl(portalEnv, portal.getShortcode());
+    public String getSiteLink(PortalEnvironment portalEnv, PortalEnvironmentConfig config, Portal portal) {
+        String href = routingPaths.getParticipantBaseUrl(portalEnv, config, portal.getShortcode());
         return String.format("<a rel=\"noopener\" href=\"%s\" target=\"_blank\">%s</a>", href, href);
     }
 
 
-    public String getDashboardLink(PortalEnvironment portalEnv, Portal portal, Study study) {
-        String href = getDashboardUrl(portalEnv, portal);
+    public String getDashboardLink(PortalEnvironment portalEnv, PortalEnvironmentConfig config, Portal portal, Study study) {
+        String href = getDashboardUrl(portalEnv, config, portal);
         String linkNameText = study != null ? study.getName() : portal.getName();
         return String.format("<a href=\"%s\">Return to %s</a>", href, linkNameText);
     }
 
-    public String getDashboardUrl(PortalEnvironment portalEnv, Portal portal) {
-        return routingPaths.getParticipantBaseUrl(portalEnv, portal.getShortcode()) +
+    public String getDashboardUrl(PortalEnvironment portalEnv, PortalEnvironmentConfig config, Portal portal) {
+        return routingPaths.getParticipantBaseUrl(portalEnv, config, portal.getShortcode()) +
                 routingPaths.getParticipantDashboardPath();
     }
 
-    public String getImageBaseUrl(PortalEnvironment portalEnvironment, String portalShortcode) {
-        return routingPaths.getParticipantBaseUrl(portalEnvironment, portalShortcode)
-                + "/api/public/portals/v1/" + portalShortcode + "/env/" + portalEnvironment.getEnvironmentName()
+    public String getImageBaseUrl(PortalEnvironment portalEnv, PortalEnvironmentConfig config, String portalShortcode) {
+        return routingPaths.getParticipantBaseUrl(portalEnv, config, portalShortcode)
+                + "/api/public/portals/v1/" + portalShortcode + "/env/" + portalEnv.getEnvironmentName()
                 + "/siteMedia";
     }
 
-    public String getParticipantSupportEmailLink(PortalEnvironment portalEnvironment) {
-        String emailAddress =portalEnvironment.getPortalEnvironmentConfig().getEmailSourceAddress();
+    public String getParticipantSupportEmailLink(PortalEnvironment portalEnvironment, PortalEnvironmentConfig config) {
+        String emailAddress = config.getEmailSourceAddress();
         if (StringUtils.isBlank(emailAddress)) {
             // if there's nothing configured for the study, default to the site-wide Juniper support email
             emailAddress = routingPaths.getSupportEmailAddress();
@@ -107,5 +107,11 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
         return String.format("<a href=\"mailto:%s\" rel=\"noopener\" target=\"_blank\">%s</a>", emailAddress, emailAddress);
     }
 
-
+    /** gets a link the participant can use to create their b2c account, given that they already exist in Juniper */
+    public String getInvitationLink(PortalEnvironment portalEnv, PortalEnvironmentConfig config, String portalShortcode, ParticipantUser participantUser) {
+        return "%s%s?accountName=%s".formatted(
+                routingPaths.getParticipantBaseUrl(portalEnv, config, portalShortcode),
+                routingPaths.getParticipantInvitationPath() ,
+                participantUser != null ? participantUser.getUsername() : "");
+    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeService.java
@@ -146,7 +146,7 @@ public class EnrolleeService extends CrudService<Enrollee, EnrolleeDao> {
         enrollee.getParticipantNotes().addAll(participantNoteService.findByEnrollee(enrollee.getId()));
         enrollee.getParticipantTasks().addAll(participantTaskService.findByEnrolleeId(enrollee.getId()));
         enrollee.getKitRequests().addAll(kitRequestService.findByEnrollee(enrollee));
-        enrollee.setProfile(profileService.loadWithMailingAddress(enrollee.getProfileId()).orElseThrow());
+        enrollee.setProfile(profileService.loadWithMailingAddress(enrollee.getProfileId()).orElseThrow(() -> new IllegalStateException("enrollee does not have a profile")));
         return enrollee;
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/rule/EnrolleeRuleData.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/rule/EnrolleeRuleData.java
@@ -1,12 +1,15 @@
 package bio.terra.pearl.core.service.rule;
 
 import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.model.participant.Profile;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/** minimal set of data that we pre-load when processing enrollees for business logic and/or emails */
 @Getter @AllArgsConstructor
 public class EnrolleeRuleData {
     private final Enrollee enrollee;
     private final Profile profile;
+    private final ParticipantUser participantUser;
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/rule/EnrolleeRuleService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/rule/EnrolleeRuleService.java
@@ -1,43 +1,49 @@
 package bio.terra.pearl.core.service.rule;
 
 import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.model.participant.Profile;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
+import bio.terra.pearl.core.service.participant.ParticipantUserService;
 import bio.terra.pearl.core.service.participant.ProfileService;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.IntStream;
+
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 @Service
 public class EnrolleeRuleService {
-    private ProfileService profileService;
-    private EnrolleeService enrolleeService;
+    private final ProfileService profileService;
+    private final EnrolleeService enrolleeService;
+    private final ParticipantUserService participantUserService;
 
 
-    public EnrolleeRuleService(ProfileService profileService, @Lazy EnrolleeService enrolleeService) {
+    public EnrolleeRuleService(ProfileService profileService, @Lazy EnrolleeService enrolleeService, ParticipantUserService participantUserService) {
         this.profileService = profileService;
         this.enrolleeService = enrolleeService;
+        this.participantUserService = participantUserService;
     }
 
     public EnrolleeRuleData fetchData(Enrollee enrollee) {
         return new EnrolleeRuleData(enrollee,
-                profileService.loadWithMailingAddress(enrollee.getProfileId()).orElse(null));
+                profileService.loadWithMailingAddress(enrollee.getProfileId()).orElse(null),
+                participantUserService.find(enrollee.getParticipantUserId()).orElseThrow(() -> new IllegalStateException("no participant user for enrollee")));
     }
 
     /**
      * useful for bulk-fetching enrollees for processing
      * this isn't terribly optimized -- we could do the join in the DB.  But this is assuming that the number of enrollees
-     *  is ~5-30, not 1000+, and so the main goal is just making sure we only do 2 total DB roundtrips
+     *  is ~5-30, not 1000+, and so the main goal is just making sure we only do 3 total DB roundtrips
      */
     public List<EnrolleeRuleData> fetchData(List<UUID> enrolleeIds) {
         List<Enrollee> enrollees = enrolleeService.findAll(enrolleeIds);
-        List<Profile> profiles = profileService.findAll(enrollees.stream().map(Enrollee::getProfileId).toList());
-        List<EnrolleeRuleData> ruleData = enrollees.stream().map(enrollee -> {
-            Profile profile = profiles.stream().filter(p ->
-                    p.getId().equals(enrollee.getProfileId())).findFirst().orElse(null);
-            return new EnrolleeRuleData(enrollee, profile);
-        }).toList();
+        List<Profile> profiles = profileService.findAllPreserveOrder(enrollees.stream().map(Enrollee::getProfileId).toList());
+        List<ParticipantUser> users = participantUserService.findAllPreserveOrder(enrollees.stream().map(Enrollee::getParticipantUserId).toList());
+        List<EnrolleeRuleData> ruleData = IntStream.range(0, enrollees.size()).mapToObj(i ->
+            new EnrolleeRuleData(enrollees.get(i), profiles.get(i), users.get(i))
+        ).toList();
         return ruleData;
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/shared/ApplicationRoutingPaths.java
+++ b/core/src/main/java/bio/terra/pearl/core/shared/ApplicationRoutingPaths.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.shared;
 
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
+import bio.terra.pearl.core.model.portal.PortalEnvironmentConfig;
 import lombok.Getter;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
@@ -18,6 +19,8 @@ public class ApplicationRoutingPaths {
     private final String adminUiHostname;
     @Getter
     private final String participantDashboardPath = "/hub";
+    @Getter
+    private final String participantInvitationPath = "/join/invitation";
     @Getter
     private final String supportEmailAddress;  // the site-wide support email address (e.g. support@juniper...) NOT study-specific
     @Getter
@@ -40,8 +43,8 @@ public class ApplicationRoutingPaths {
         return "https://" + adminUiHostname + "/" + portalShortcode;
     }
 
-    public String getParticipantBaseUrl(PortalEnvironment portalEnv, String portalShortcode) {
-        String participantHostname = portalEnv.getPortalEnvironmentConfig().getParticipantHostname();
+    public String getParticipantBaseUrl(PortalEnvironment portalEnv, PortalEnvironmentConfig config, String portalShortcode) {
+        String participantHostname = config.getParticipantHostname();
         if (participantHostname == null) {
             participantHostname = portalShortcode + "." + getParticipantUiHostname();
         }

--- a/core/src/test/java/bio/terra/pearl/core/rule/EnrolleeRuleEvaluatorTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/rule/EnrolleeRuleEvaluatorTests.java
@@ -11,7 +11,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class EnrolleeRuleEvaluatorTests {
 
-    private EnrolleeRuleData EMPTY_RULE_DATA = new EnrolleeRuleData(null, null);
+    private EnrolleeRuleData EMPTY_RULE_DATA = new EnrolleeRuleData(null, null, null);
 
     @Test
     public void testStringEvaluation() throws Exception {
@@ -49,37 +49,37 @@ public class EnrolleeRuleEvaluatorTests {
     public void testStringVariableInsertion() throws Exception {
         String rule = "{profile.sexAtBirth} = 'M'";
         assertThat(EnrolleeRuleEvaluator.evaluateRuleChecked(rule,
-                new EnrolleeRuleData(null, Profile.builder().sexAtBirth("M").build())),
+                new EnrolleeRuleData(null, Profile.builder().sexAtBirth("M").build(), null)),
                 equalTo(true));
         assertThat(EnrolleeRuleEvaluator.evaluateRuleChecked(rule,
-                        new EnrolleeRuleData(null, Profile.builder().sexAtBirth("F").build())),
+                        new EnrolleeRuleData(null, Profile.builder().sexAtBirth("F").build(), null)),
                 equalTo(false));
         assertThat(EnrolleeRuleEvaluator.evaluateRuleChecked(rule,
-                        new EnrolleeRuleData(null, Profile.builder().sexAtBirth(null).build())),
+                        new EnrolleeRuleData(null, Profile.builder().sexAtBirth(null).build(), null)),
                 equalTo(false));
         assertThat(EnrolleeRuleEvaluator.evaluateRuleChecked(rule,
-                        new EnrolleeRuleData(null, null)),
+                        new EnrolleeRuleData(null, null, null)),
                 equalTo(false));
     }
 
     @Test
     public void testBooleanVariableInsertion() throws Exception {
         String rule = "{enrollee.consented} = true";
-        assertThat(EnrolleeRuleEvaluator.evaluateRuleChecked(rule, new EnrolleeRuleData(Enrollee.builder().consented(true).build(), null)), equalTo(true));
-        assertThat(EnrolleeRuleEvaluator.evaluateRuleChecked(rule, new EnrolleeRuleData(Enrollee.builder().consented(false).build(), null)), equalTo(false));
+        assertThat(EnrolleeRuleEvaluator.evaluateRuleChecked(rule, new EnrolleeRuleData(Enrollee.builder().consented(true).build(), null, null)), equalTo(true));
+        assertThat(EnrolleeRuleEvaluator.evaluateRuleChecked(rule, new EnrolleeRuleData(Enrollee.builder().consented(false).build(), null, null)), equalTo(false));
     }
 
     @Test
     public void testUnrecognizedVariableInsertion() throws Exception {
         String rule = "{enrollee.doesNotExistZZZ} = true";
-        assertThat(EnrolleeRuleEvaluator.evaluateRuleChecked(rule, new EnrolleeRuleData(new Enrollee(), null)), equalTo(false));
+        assertThat(EnrolleeRuleEvaluator.evaluateRuleChecked(rule, new EnrolleeRuleData(new Enrollee(), null, null)), equalTo(false));
     }
 
     @Test
     public void testVariableNullCheck() throws Exception {
         String rule = "{enrollee.shortcode} = null";
-        assertThat(EnrolleeRuleEvaluator.evaluateRuleChecked(rule, new EnrolleeRuleData(new Enrollee(), null)), equalTo(true));
-        assertThat(EnrolleeRuleEvaluator.evaluateRuleChecked(rule, new EnrolleeRuleData(Enrollee.builder().shortcode("FOO").build(), null)), equalTo(false));
+        assertThat(EnrolleeRuleEvaluator.evaluateRuleChecked(rule, new EnrolleeRuleData(new Enrollee(), null, null)), equalTo(true));
+        assertThat(EnrolleeRuleEvaluator.evaluateRuleChecked(rule, new EnrolleeRuleData(Enrollee.builder().shortcode("FOO").build(), null, null)), equalTo(false));
     }
 
     /**

--- a/core/src/test/java/bio/terra/pearl/core/service/consent/ConsentTaskDispatcherTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/consent/ConsentTaskDispatcherTests.java
@@ -47,7 +47,7 @@ public class ConsentTaskDispatcherTests extends BaseSpringBootTest {
                 .enrollee(enrollee)
                 .portalParticipantUser(ppUser)
                 .build();
-        EnrolleeRuleData enrolleeRuleData = new EnrolleeRuleData(enrollee, null);
+        EnrolleeRuleData enrolleeRuleData = new EnrolleeRuleData(enrollee, null, null);
         ConsentForm consent = consentFormFactory.builder(getTestName(info)).build();
         StudyEnvironmentConsent studyEnvConsent = StudyEnvironmentConsent.builder()
                 .consentForm(consent)
@@ -92,7 +92,7 @@ public class ConsentTaskDispatcherTests extends BaseSpringBootTest {
                 .enrollee(enrollee)
                 .portalParticipantUser(ppUser)
                 .build();
-        EnrolleeRuleData enrolleeRuleData = new EnrolleeRuleData(enrollee, null);
+        EnrolleeRuleData enrolleeRuleData = new EnrolleeRuleData(enrollee, null, null);
         ConsentForm consent1 = consentFormFactory.builder(getTestName(info)).build();
         StudyEnvironmentConsent studyEnvConsent1 = StudyEnvironmentConsent.builder()
                 .consentForm(consent1)

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailServiceTests.java
@@ -61,7 +61,7 @@ public class EnrolleeEmailServiceTests extends BaseSpringBootTest {
                 .contactEmail("test@test.com")
                 .build();
         Enrollee enrollee = Enrollee.builder().build();
-        EnrolleeRuleData ruleData = new EnrolleeRuleData(enrollee, profile);
+        EnrolleeRuleData ruleData = new EnrolleeRuleData(enrollee, profile, null);
         PortalEnvironmentConfig portalEnvConfig = PortalEnvironmentConfig.builder()
                 .emailSourceAddress("info@portal.org").build();
         PortalEnvironment portalEnv = PortalEnvironment.builder()
@@ -97,7 +97,7 @@ public class EnrolleeEmailServiceTests extends BaseSpringBootTest {
 
     private void testSendProfile(EnrolleeEmailService enrolleeEmailService, EnrolleeFactory.EnrolleeBundle enrolleeBundle, Trigger config) {
         Notification notification = notificationFactory.buildPersisted(enrolleeBundle, config);
-        EnrolleeRuleData ruleData = new EnrolleeRuleData(enrolleeBundle.enrollee(), Profile.builder().build());
+        EnrolleeRuleData ruleData = new EnrolleeRuleData(enrolleeBundle.enrollee(), Profile.builder().build(), null);
         NotificationContextInfo contextInfo = new NotificationContextInfo(null, null, null, null, null);
         enrolleeEmailService.processNotification(notification, config, ruleData, contextInfo);
         Notification updatedNotification = notificationService.find(notification.getId()).get();
@@ -107,7 +107,7 @@ public class EnrolleeEmailServiceTests extends BaseSpringBootTest {
 
     private void testDoNotSendProfile(EnrolleeEmailService enrolleeEmailService, EnrolleeFactory.EnrolleeBundle enrolleeBundle, Trigger config) {
         Notification notification = notificationFactory.buildPersisted(enrolleeBundle, config);
-        EnrolleeRuleData ruleData = new EnrolleeRuleData(enrolleeBundle.enrollee(), Profile.builder().doNotEmail(true).build());
+        EnrolleeRuleData ruleData = new EnrolleeRuleData(enrolleeBundle.enrollee(), Profile.builder().doNotEmail(true).build(), null);
         NotificationContextInfo contextInfo = new NotificationContextInfo(null, null, null, null, null);
         enrolleeEmailService.processNotification(notification, config, ruleData, contextInfo);
         Notification updatedNotification = notificationService.find(notification.getId()).get();

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailSubstitutorTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailSubstitutorTests.java
@@ -4,6 +4,7 @@ import bio.terra.pearl.core.BaseSpringBootTest;
 import bio.terra.pearl.core.factory.portal.PortalEnvironmentFactory;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.model.participant.Profile;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
@@ -32,7 +33,7 @@ public class EnrolleeEmailSubstitutorTests extends BaseSpringBootTest {
     public void profileVariablesAreReplaced() {
         Profile profile = Profile.builder().givenName("tester").build();
         Enrollee enrollee = Enrollee.builder().build();
-        EnrolleeRuleData ruleData = new EnrolleeRuleData(enrollee, profile);
+        EnrolleeRuleData ruleData = new EnrolleeRuleData(enrollee, profile, null);
 
         PortalEnvironmentConfig portalEnvironmentConfig = PortalEnvironmentConfig.builder().build();
         PortalEnvironment portalEnv = portalEnvironmentFactory.builder("profileVariablesAreReplaced")
@@ -45,9 +46,7 @@ public class EnrolleeEmailSubstitutorTests extends BaseSpringBootTest {
 
     @Test
     public void envConfigVariablesAreReplaced() {
-        Profile profile = Profile.builder().build();
-        Enrollee enrollee = Enrollee.builder().build();
-        EnrolleeRuleData ruleData = new EnrolleeRuleData(enrollee, profile);
+        EnrolleeRuleData ruleData = new EnrolleeRuleData(new Enrollee(), new Profile(), null);
         PortalEnvironmentConfig portalEnvironmentConfig = PortalEnvironmentConfig.builder()
                 .participantHostname("testHostName")
                 .build();
@@ -62,9 +61,7 @@ public class EnrolleeEmailSubstitutorTests extends BaseSpringBootTest {
 
     @Test
     public void studyNameVariablesAreReplaced(TestInfo info) {
-        Profile profile = Profile.builder().build();
-        Enrollee enrollee = Enrollee.builder().build();
-        EnrolleeRuleData ruleData = new EnrolleeRuleData(enrollee, profile);
+        EnrolleeRuleData ruleData = new EnrolleeRuleData(new Enrollee(), new Profile(), null);
         PortalEnvironmentConfig portalEnvironmentConfig = PortalEnvironmentConfig.builder()
                 .participantHostname("testHostName")
                 .build();
@@ -80,9 +77,7 @@ public class EnrolleeEmailSubstitutorTests extends BaseSpringBootTest {
 
     @Test
     public void testDashLinkVariablesReplaced(TestInfo info) {
-        Profile profile = Profile.builder().build();
-        Enrollee enrollee = Enrollee.builder().build();
-        EnrolleeRuleData ruleData = new EnrolleeRuleData(enrollee, profile);
+        EnrolleeRuleData ruleData = new EnrolleeRuleData(new Enrollee(), new Profile(), null);
         PortalEnvironmentConfig portalEnvironmentConfig = PortalEnvironmentConfig.builder()
                 .participantHostname("newstudy.org")
                 .build();
@@ -105,9 +100,7 @@ public class EnrolleeEmailSubstitutorTests extends BaseSpringBootTest {
 
     @Test
     public void testMailLinkVariablesReplaced(TestInfo info) {
-        Profile profile = Profile.builder().build();
-        Enrollee enrollee = Enrollee.builder().build();
-        EnrolleeRuleData ruleData = new EnrolleeRuleData(enrollee, profile);
+        EnrolleeRuleData ruleData = new EnrolleeRuleData(new Enrollee(), new Profile(), null);
         PortalEnvironmentConfig portalEnvironmentConfig = PortalEnvironmentConfig.builder()
                 .emailSourceAddress("info@test.edu")
                 .build();
@@ -123,9 +116,7 @@ public class EnrolleeEmailSubstitutorTests extends BaseSpringBootTest {
 
     @Test
     public void testImageVariablesReplaced(TestInfo info) {
-        Profile profile = Profile.builder().build();
-        Enrollee enrollee = Enrollee.builder().build();
-        EnrolleeRuleData ruleData = new EnrolleeRuleData(enrollee, profile);
+        EnrolleeRuleData ruleData = new EnrolleeRuleData(new Enrollee(), new Profile(), null);
         PortalEnvironmentConfig portalEnvironmentConfig = PortalEnvironmentConfig.builder()
                 .participantHostname("newstudy.org")
                 .build();
@@ -137,5 +128,33 @@ public class EnrolleeEmailSubstitutorTests extends BaseSpringBootTest {
         StringSubstitutor replacer = EnrolleeEmailSubstitutor.newSubstitutor(ruleData, contextInfo, routingPaths);
         assertThat(replacer.replace("here's an image: <img src=\"${siteMediaBaseUrl}/1/ourhealth-logo.png\"/>"),
                 equalTo("here's an image: <img src=\"https://irb.newstudy.org/api/public/portals/v1/foo/env/irb/siteMedia/1/ourhealth-logo.png\"/>"));
+    }
+
+    @Test
+    public void testParticipantUserVariablesReplaced(TestInfo info) {
+        ParticipantUser user = ParticipantUser.builder().username("test123@test.com").build();
+        EnrolleeRuleData ruleData = new EnrolleeRuleData(new Enrollee(), new Profile(), user);
+        PortalEnvironment portalEnv = PortalEnvironment.builder().environmentName(EnvironmentName.irb).build();
+        NotificationContextInfo contextInfo = new NotificationContextInfo(new Portal(), portalEnv, new PortalEnvironmentConfig(), null, null);
+        StringSubstitutor replacer = EnrolleeEmailSubstitutor.newSubstitutor(ruleData, contextInfo, routingPaths);
+        assertThat(replacer.replace("your username is ${participantUser.username}"),
+                equalTo("your username is test123@test.com"));
+    }
+
+    @Test
+    public void testInvitationLinkReplaced(TestInfo info) {
+        EnrolleeRuleData ruleData = new EnrolleeRuleData(new Enrollee(), new Profile(), ParticipantUser.builder().username("test123@test.com").build());
+        PortalEnvironmentConfig portalEnvironmentConfig = PortalEnvironmentConfig.builder()
+                .participantHostname("newstudy.org")
+                .build();
+        PortalEnvironment portalEnv = portalEnvironmentFactory.builder(getTestName(info))
+                .portalEnvironmentConfig(portalEnvironmentConfig).environmentName(EnvironmentName.irb).build();
+        Portal portal = Portal.builder().name("PortalA").build();
+
+        NotificationContextInfo contextInfo = new NotificationContextInfo(portal, portalEnv, portalEnvironmentConfig, null, null);
+        StringSubstitutor replacer = EnrolleeEmailSubstitutor.newSubstitutor(ruleData, contextInfo, routingPaths);
+        assertThat(replacer.replace("here's an invite: ${invitationLink}"),
+                equalTo("here's an invite: https://irb.newstudy.org/invitation?accountName=test123@test.com"));
+
     }
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailSubstitutorTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailSubstitutorTests.java
@@ -154,7 +154,7 @@ public class EnrolleeEmailSubstitutorTests extends BaseSpringBootTest {
         NotificationContextInfo contextInfo = new NotificationContextInfo(portal, portalEnv, portalEnvironmentConfig, null, null);
         StringSubstitutor replacer = EnrolleeEmailSubstitutor.newSubstitutor(ruleData, contextInfo, routingPaths);
         assertThat(replacer.replace("here's an invite: ${invitationLink}"),
-                equalTo("here's an invite: https://irb.newstudy.org/invitation?accountName=test123@test.com"));
+                equalTo("here's an invite: https://irb.newstudy.org/join/invitation?accountName=test123%40test.com"));
 
     }
 }

--- a/core/src/test/java/bio/terra/pearl/core/shared/ApplicationRoutingPathsTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/shared/ApplicationRoutingPathsTests.java
@@ -25,7 +25,7 @@ public class ApplicationRoutingPathsTests extends BaseSpringBootTest {
                 .build();
         PortalEnvironment portalEnv = portalEnvironmentFactory.builder(getTestName(info))
                 .portalEnvironmentConfig(portalEnvironmentConfig).environmentName(EnvironmentName.live).build();
-        String result = routingPaths.getParticipantBaseUrl(portalEnv, "whatevs");
+        String result = routingPaths.getParticipantBaseUrl(portalEnv, portalEnvironmentConfig, "whatevs");
         assertThat(result, equalTo("https://newstudy.org"));
     }
 
@@ -36,7 +36,7 @@ public class ApplicationRoutingPathsTests extends BaseSpringBootTest {
                 .build();
         PortalEnvironment portalEnv = portalEnvironmentFactory.builder(getTestName(info))
                 .portalEnvironmentConfig(portalEnvironmentConfig).environmentName(EnvironmentName.irb).build();
-        String result = routingPaths.getParticipantBaseUrl(portalEnv, "whatevs");
+        String result = routingPaths.getParticipantBaseUrl(portalEnv, portalEnvironmentConfig,"whatevs");
         assertThat(result, equalTo("https://irb.newstudy.org"));
     }
 
@@ -47,7 +47,7 @@ public class ApplicationRoutingPathsTests extends BaseSpringBootTest {
                 .build();
         PortalEnvironment portalEnv = portalEnvironmentFactory.builder(getTestName(info))
                 .portalEnvironmentConfig(portalEnvironmentConfig).environmentName(EnvironmentName.sandbox).build();
-        String result = routingPaths.getParticipantBaseUrl(portalEnv, "snazzportal");
+        String result = routingPaths.getParticipantBaseUrl(portalEnv, portalEnvironmentConfig,"snazzportal");
         assertThat(result, equalTo("https://sandbox.snazzportal.localhost:3001"));
     }
 }

--- a/populate/src/main/java/bio/terra/pearl/populate/dao/ParticipantUserPopulateDao.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/dao/ParticipantUserPopulateDao.java
@@ -16,11 +16,12 @@ public class ParticipantUserPopulateDao extends ParticipantUserDao {
         super(jdbi);
     }
 
-    public List<ParticipantUser> findUserByPrefix(String usernamePrefix, EnvironmentName environmentName) {
+    /** finds users with a keyed username from populating.  e.g. dbush+invite-f232@broadinstitute.org */
+    public List<ParticipantUser> findUserByPrefix(String usernameKey, EnvironmentName environmentName) {
         return jdbi.withHandle(handle ->
-                handle.createQuery("select * from " + tableName + " where username LIKE :usernamePrefix"
+                handle.createQuery("select * from " + tableName + " where username LIKE :usernameKey"
                                 + " and environment_name = :environmentName")
-                        .bind("usernamePrefix", usernamePrefix + "%")
+                        .bind("usernameKey", "%+" + usernameKey + "-%")
                         .bind("environmentName", environmentName)
                         .mapTo(clazz)
                         .list()

--- a/populate/src/main/java/bio/terra/pearl/populate/dao/ParticipantUserPopulateDao.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/dao/ParticipantUserPopulateDao.java
@@ -1,2 +1,30 @@
-package bio.terra.pearl.populate.dao;public class ParticipantUserPopulateDao {
+package bio.terra.pearl.populate.dao;
+
+import bio.terra.pearl.core.dao.participant.ParticipantUserDao;
+import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.participant.ParticipantUser;
+import org.jdbi.v3.core.Jdbi;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class ParticipantUserPopulateDao extends ParticipantUserDao {
+    public ParticipantUserPopulateDao(Jdbi jdbi) {
+        super(jdbi);
+    }
+
+    public List<ParticipantUser> findUserByPrefix(String usernamePrefix, EnvironmentName environmentName) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("select * from " + tableName + " where username LIKE :usernamePrefix"
+                                + " and environment_name = :environmentName")
+                        .bind("usernamePrefix", usernamePrefix + "%")
+                        .bind("environmentName", environmentName)
+                        .mapTo(clazz)
+                        .list()
+        );
+
+    }
 }

--- a/populate/src/main/java/bio/terra/pearl/populate/dao/ParticipantUserPopulateDao.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/dao/ParticipantUserPopulateDao.java
@@ -1,0 +1,2 @@
+package bio.terra.pearl.populate.dao;public class ParticipantUserPopulateDao {
+}

--- a/populate/src/main/java/bio/terra/pearl/populate/dto/participant/EnrolleePopDto.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/dto/participant/EnrolleePopDto.java
@@ -19,7 +19,7 @@ import lombok.Setter;
 @Getter @Setter @NoArgsConstructor
 public class EnrolleePopDto extends Enrollee implements TimeShiftable {
     private String linkedUsername;
-    private String linkedUsernamePrefix; // for enrollees linked to users with prefix-specified accounts
+    private String linkedUsernameKey; // for enrollees linked to users with key-specified accounts
     /**
      * if true, the data for this enrollee will be processed through service calls as if they were submitted
      * via the API, so all side effects, including tasks and events, will be created.

--- a/populate/src/main/java/bio/terra/pearl/populate/dto/participant/EnrolleePopDto.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/dto/participant/EnrolleePopDto.java
@@ -19,6 +19,7 @@ import lombok.Setter;
 @Getter @Setter @NoArgsConstructor
 public class EnrolleePopDto extends Enrollee implements TimeShiftable {
     private String linkedUsername;
+    private String linkedUsernamePrefix; // for enrollees linked to users with prefix-specified accounts
     /**
      * if true, the data for this enrollee will be processed through service calls as if they were submitted
      * via the API, so all side effects, including tasks and events, will be created.

--- a/populate/src/main/java/bio/terra/pearl/populate/dto/participant/ParticipantUserPopDto.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/dto/participant/ParticipantUserPopDto.java
@@ -11,4 +11,6 @@ import lombok.Setter;
 @NoArgsConstructor
 public class ParticipantUserPopDto extends ParticipantUser {
     private Integer lastLoginHoursAgo;
+    /** for cases where we want to generate a unique user on every populate to avoid b2c conflicts */
+    private String usernamePrefix;
 }

--- a/populate/src/main/java/bio/terra/pearl/populate/dto/participant/ParticipantUserPopDto.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/dto/participant/ParticipantUserPopDto.java
@@ -1,7 +1,6 @@
 package bio.terra.pearl.populate.dto.participant;
 
 import bio.terra.pearl.core.model.participant.ParticipantUser;
-import bio.terra.pearl.populate.dto.TimeShiftable;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,5 +11,5 @@ import lombok.Setter;
 public class ParticipantUserPopDto extends ParticipantUser {
     private Integer lastLoginHoursAgo;
     /** for cases where we want to generate a unique user on every populate to avoid b2c conflicts */
-    private String usernamePrefix;
+    private String usernameKey;
 }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
@@ -414,13 +414,13 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
     }
 
     private ParticipantUser findLinkedUser(EnrolleePopDto popDto, EnvironmentName environmentName) {
-        if (popDto.getLinkedUsernamePrefix() != null) {
-            List<ParticipantUser> users = participantUserPopulateDao.findUserByPrefix(popDto.getLinkedUsernamePrefix(), environmentName);
+        if (popDto.getLinkedUsernameKey() != null) {
+            List<ParticipantUser> users = participantUserPopulateDao.findUserByPrefix(popDto.getLinkedUsernameKey(), environmentName);
             if (users.size() > 1) {
-                throw new IllegalStateException("Multiple usernames found for enrollee with prefix: " + popDto.getLinkedUsernamePrefix());
+                throw new IllegalStateException("Multiple usernames found for enrollee with prefix: " + popDto.getLinkedUsernameKey());
             }
             if (users.size() == 0) {
-                throw new IllegalStateException("No usernames found for enrollee with prefix: " + popDto.getLinkedUsernamePrefix());
+                throw new IllegalStateException("No usernames found for enrollee with prefix: " + popDto.getLinkedUsernameKey());
             }
             return users.get(0);
         }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/PortalParticipantUserPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/PortalParticipantUserPopulator.java
@@ -20,6 +20,7 @@ import java.util.stream.IntStream;
 
 import bio.terra.pearl.populate.service.contexts.StudyPopulateContext;
 import bio.terra.pearl.populate.util.PopulateUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -40,6 +41,9 @@ public class PortalParticipantUserPopulator extends BasePopulator<PortalParticip
     protected void preProcessDto(PortalParticipantUserPopDto popDto, PortalPopulateContext context) {
         ParticipantUserPopDto userDto = popDto.getParticipantUser();
         userDto.setEnvironmentName(context.getEnvironmentName());
+        if (userDto.getUsernamePrefix() != null) {
+            userDto.setUsername("%s-%s@test.com".formatted(userDto.getUsernamePrefix(), RandomStringUtils.randomAlphabetic(8)));
+        }
         Optional<ParticipantUser> existingUserOpt = participantUserService
                 .findOne(userDto.getUsername(), context.getEnvironmentName());
         ParticipantUser user = existingUserOpt.orElseGet(() -> participantUserService.create(userDto));

--- a/populate/src/main/java/bio/terra/pearl/populate/service/PortalPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/PortalPopulator.java
@@ -168,6 +168,7 @@ public class PortalPopulator extends BasePopulator<Portal, PortalPopDto, FilePop
     public Portal overwriteExisting(Portal existingObj, PortalPopDto popDto, FilePopulateContext context) throws IOException {
         Set<CascadeProperty> set = new HashSet<>();
         set.add(PortalService.AllowedCascades.STUDY);
+        set.add(PortalService.AllowedCascades.PARTICIPANT_USER);
         portalService.delete(existingObj.getId(), set);
         return createNew(popDto, context, true);
     }

--- a/populate/src/main/resources/seed/portals/demo/participants/invited.json
+++ b/populate/src/main/resources/seed/portals/demo/participants/invited.json
@@ -1,6 +1,6 @@
 {
   "participantUser": {
-    "usernamePrefix": "invited",
+    "usernameKey": "invited",
     "lastLoginHoursAgo": 5
   },
   "profile": {

--- a/populate/src/main/resources/seed/portals/demo/participants/invited.json
+++ b/populate/src/main/resources/seed/portals/demo/participants/invited.json
@@ -1,0 +1,19 @@
+{
+  "participantUser": {
+    "usernamePrefix": "invited",
+    "lastLoginHoursAgo": 5
+  },
+  "profile": {
+    "givenName": "Invited",
+    "familyName": "PriorUser",
+    "contactEmail": "invited@test.com",
+    "sexAtBirth": "male",
+    "mailingAddress": {
+      "street1": "465 Spruce Street",
+      "city": "New York",
+      "state": "NY",
+      "country": "US",
+      "postalCode": "10009"
+    }
+  }
+}

--- a/populate/src/main/resources/seed/portals/demo/portal.json
+++ b/populate/src/main/resources/seed/portals/demo/portal.json
@@ -38,7 +38,8 @@
         "participants/withdrawn.json",
         "participants/oldVersion.json",
         "participants/proxy.json",
-        "participants/proxyFamily2.json"
+        "participants/proxyFamily2.json",
+        "participants/invited.json"
 
       ],
       "mailingListContacts": [

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/invite.html
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/invite.html
@@ -1,0 +1,280 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <!--[if gte mso 9]>
+    <xml>
+        <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+    </xml>
+    <![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="x-apple-disable-message-reformatting">
+    <!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
+    <title></title>
+
+    <style type="text/css">
+        @media only screen and (min-width: 620px) {
+            .u-row {
+                width: 600px !important;
+            }
+            .u-row .u-col {
+                vertical-align: top;
+            }
+
+            .u-row .u-col-100 {
+                width: 600px !important;
+            }
+
+        }
+
+        @media (max-width: 620px) {
+            .u-row-container {
+                max-width: 100% !important;
+                padding-left: 0px !important;
+                padding-right: 0px !important;
+            }
+            .u-row .u-col {
+                min-width: 320px !important;
+                max-width: 100% !important;
+                display: block !important;
+            }
+            .u-row {
+                width: 100% !important;
+            }
+            .u-col {
+                width: 100% !important;
+            }
+            .u-col > div {
+                margin: 0 auto;
+            }
+        }
+        body {
+            margin: 0;
+            padding: 0;
+        }
+
+        table,
+        tr,
+        td {
+            vertical-align: top;
+            border-collapse: collapse;
+        }
+
+        p {
+            margin: 0;
+        }
+
+        .ie-container table,
+        .mso-container table {
+            table-layout: fixed;
+        }
+
+        * {
+            line-height: inherit;
+        }
+
+        a[x-apple-data-detectors='true'] {
+            color: inherit !important;
+            text-decoration: none !important;
+        }
+
+        table, td { color: #000000; } #u_body a { color: #9b2485; text-decoration: underline; } @media (max-width: 480px) { #u_content_image_1 .v-src-width { width: auto !important; } #u_content_image_1 .v-src-max-width { max-width: 87% !important; } #u_content_text_2 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_3 .v-container-padding-padding { padding: 10px 20px !important; } #u_content_divider_6 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_deprecated_1 .v-container-padding-padding { padding: 20px !important; } #u_content_text_4 .v-container-padding-padding { padding: 20px 20px 10px !important; } }
+    </style>
+
+
+
+    <!--[if !mso]><!--><link href="https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap" rel="stylesheet" type="text/css"><!--<![endif]-->
+
+</head>
+
+<body class="clean-body u_body" style="margin: 0;padding: 0;-webkit-text-size-adjust: 100%;background-color: #eeeeee;color: #000000">
+<!--[if IE]><div class="ie-container"><![endif]-->
+<!--[if mso]><div class="mso-container"><![endif]-->
+<table id="u_body" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;min-width: 320px;Margin: 0 auto;background-color: #eeeeee;width:100%" cellpadding="0" cellspacing="0">
+    <tbody>
+
+    <tr style="vertical-align: top">
+        <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top">
+            <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td align="center" style="background-color: #eeeeee;"><![endif]-->
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_image_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:40px 0px 20px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                                                <tr>
+                                                    <td style="padding-right: 0px;padding-left: 0px;" align="center">
+
+                                                        <img align="center" border="0"
+                                                             src="${siteMediaBaseUrl}/1/ourhealth-logo.png"
+                                                             alt="OurHealth logo"
+                                                             style="outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;clear: both;display: inline-block !important;border: none;height: auto;float: none;width: 34%;max-width: 204px;"
+                                                             width="204" class="v-src-width v-src-max-width"/>
+
+                                                    </td>
+                                                </tr>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;"><!--<![endif]-->
+
+                                <table id="u_content_text_2" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">You are invited to join ${study.name}.</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">To begin, use the link below to create your account.  You must use the username ${participantUser.username} so that the account can be linked to your data.</p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_text_3" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;"><a href="${invitationLink}">Join ${study.name}</a></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_divider_6" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:20px 50px 10px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table height="0px" align="left" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;border-top: 1px solid #ced4d9;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%">
+                                                <tbody>
+                                                <tr style="vertical-align: top">
+                                                    <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top;font-size: 0px;line-height: 0px;mso-line-height-rule: exactly;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%">
+                                                        <span>&#160;</span>
+                                                    </td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_text_deprecated_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at ${participantSupportEmailLink} if you have any questions.</span></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_text_4" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">We are so grateful for your participation - thank you again!</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Best regards,</p>
+                                                <p style="line-height: 140%;"><em>The Demo Study Staff</em></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+            <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
+        </td>
+    </tr>
+    </tbody>
+</table>
+<!--[if mso]></div><![endif]-->
+<!--[if IE]></div><![endif]-->
+</body>
+
+</html>

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/invite.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/emails/invite.json
@@ -1,0 +1,8 @@
+{
+  "name": "Invitation email",
+  "bodyPopulateFile": "invite.html",
+  "subject": "Register for ${study.name}",
+  "stableId": "hd_hd_invite",
+  "version": 1,
+  "publishedVersion": 1
+}

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/invited.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/invited.json
@@ -1,5 +1,5 @@
 {
-  "linkedUsernamePrefix": "invited",
+  "linkedUsernameKey": "invited",
   "shortcode": "HDINVI",
   "simulateSubmissions": true,
   "surveyResponseDtos": [

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/invited.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/invited.json
@@ -1,0 +1,51 @@
+{
+  "linkedUsernamePrefix": "invited",
+  "shortcode": "HDINVI",
+  "simulateSubmissions": true,
+  "surveyResponseDtos": [
+    {
+      "surveyStableId": "hd_hd_basicInfo",
+      "surveyVersion": 1,
+      "answerPopDtos": [
+        {"questionStableId": "hd_hd_basic_firstName", "stringValue": "Invited"},
+        {"questionStableId": "hd_hd_basic_lastName", "stringValue": "PriorUser"},
+        {"questionStableId": "hd_hd_basic_streetAddress", "stringValue": "465 Spruce Street"},
+        {"questionStableId": "hd_hd_basic_mghPatient", "stringValue": "yes"},
+        {"questionStableId": "hd_hd_basic_sexualOrientation", "stringValue": "preferNoAnswer"}
+      ],
+      "currentPageNo": 1,
+      "complete": true
+    }
+  ],
+  "kitRequestDtos": [
+    {
+      "creatingAdminUsername": "staff@heartdemo.org",
+      "kitTypeName": "SALIVA",
+      "status": "SENT",
+      "skipAddressValidation": true,
+      "externalKitJson": {
+        "kitId": "11111111-2222-3333-4444-555555555555",
+        "currentStatus": "kit without label",
+        "labelDate": "2023-05-24",
+        "scanDate": "2023-05-24",
+        "receiveDate": "2023-05-24",
+        "scannedByEmail": "",
+        "receivedByEmail": "",
+        "labeledByEmail": "",
+        "deactivationDate": "",
+        "deactivatedBy": "",
+        "deactivationReason": "",
+        "trackingNumbers": [],
+        "returnTrackingNumber": "",
+        "errors": [
+          {
+            "errorDate": "2023-05-24",
+            "errorMessage": ""
+          }
+        ],
+        "discardDate": "2023-05-24",
+        "discardReason": ""
+      }
+    }
+  ]
+}

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
@@ -23,6 +23,7 @@
     "emails/studyEnroll.json",
     "emails/consentReminder.json",
     "emails/surveyReminder.json",
+    "emails/invite.json",
     "emails/adHoc.json"
   ],
   "studyEnvironmentDtos": [
@@ -77,6 +78,9 @@
       },{
         "triggerType": "AD_HOC",
         "populateFileName": "emails/adHoc.json"
+      },{
+        "triggerType": "AD_HOC",
+        "populateFileName": "emails/invite.json"
       }],
       "enrolleeFiles": [
         "enrollees/jsalk.json",
@@ -87,7 +91,8 @@
         "enrollees/oldVersion.json",
         "enrollees/child1.json",
         "enrollees/child1Family2.json",
-        "enrollees/child2Family2.json"
+        "enrollees/child2Family2.json",
+        "enrollees/invited.json"
       ],
       "preEnrollmentResponseDtos": [{
           "qualified": false,

--- a/populate/src/test/java/bio/terra/pearl/populate/BasePopulatePortalsTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/BasePopulatePortalsTest.java
@@ -6,12 +6,7 @@ import bio.terra.pearl.core.service.export.DictionaryExportService;
 import bio.terra.pearl.core.service.export.EnrolleeExportService;
 import bio.terra.pearl.core.service.notification.TriggerService;
 import bio.terra.pearl.core.service.notification.email.EmailTemplateService;
-import bio.terra.pearl.core.service.participant.EnrolleeRelationService;
-import bio.terra.pearl.core.service.participant.EnrolleeService;
-import bio.terra.pearl.core.service.participant.ParticipantNoteService;
-import bio.terra.pearl.core.service.participant.PortalParticipantUserService;
-import bio.terra.pearl.core.service.participant.ProfileService;
-import bio.terra.pearl.core.service.participant.WithdrawnEnrolleeService;
+import bio.terra.pearl.core.service.participant.*;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
 import bio.terra.pearl.core.service.portal.PortalService;
 import bio.terra.pearl.core.service.site.SiteContentService;
@@ -75,6 +70,8 @@ public abstract class BasePopulatePortalsTest extends BaseSpringBootTest {
     protected EnrolleeRelationService enrolleeRelationService;
     @Autowired
     protected PortalParticipantUserService portalParticipantUserService;
+    @Autowired
+    protected ParticipantUserService participantUserService;
     @Autowired
     protected ProfileService profileService;
 }

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
@@ -49,7 +49,7 @@ public class PopulateDemoTest extends BasePopulatePortalsTest {
         Assertions.assertEquals(11, enrollees.size());
 
         checkOldVersionEnrollee(enrollees);
-        checkPrefixedEnrollee(enrollees);
+        checkKeyedEnrollee(enrollees);
         checkProxyWithOneGovernedEnrollee(enrollees);
         checkProxyWithTwoGovernedEnrollee(enrollees);
         checkExportContent(sandboxEnvironmentId);
@@ -73,12 +73,12 @@ public class PopulateDemoTest extends BasePopulatePortalsTest {
         );
     }
 
-    private void checkPrefixedEnrollee(List<Enrollee> sandboxEnrollees) {
+    private void checkKeyedEnrollee(List<Enrollee> sandboxEnrollees) {
         Enrollee enrollee = sandboxEnrollees.stream().filter(sandboxEnrollee -> "HDINVI".equals(sandboxEnrollee.getShortcode()))
                 .findFirst().get();
         ParticipantUser user = participantUserService.find(enrollee.getParticipantUserId()).get();
-        assertThat(user.getUsername(), startsWith("invited-"));
-        assertThat(user.getUsername(), endsWith("test.com"));
+        assertThat(user.getUsername().contains("+invited-"), equalTo(true));
+        assertThat(user.getUsername(), endsWith("broadinstitute.org"));
     }
 
     /** confirm the proxy enrollee with one governed user was enrolled appropriately */

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
@@ -183,7 +183,7 @@ public class PopulateDemoTest extends BasePopulatePortalsTest {
             assertThat(siteContent.getStableId(), Matchers.startsWith(newShortcode));
         });
         List<EmailTemplate> emailTemplates = emailTemplateService.findByPortalId(portal.getId());
-        assertThat(emailTemplates, hasSize(5));
+        assertThat(emailTemplates, hasSize(6));
         emailTemplates.forEach(emailTemplate -> {
             assertThat(emailTemplate.getStableId(), Matchers.startsWith(newShortcode));
         });

--- a/populate/src/test/java/bio/terra/pearl/populate/extract/PortalExtractTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/extract/PortalExtractTest.java
@@ -56,7 +56,7 @@ public class PortalExtractTest extends BasePopulatePortalsTest {
         // confirm the sandbox got configured
         Study study = studyService.findByPortalId(restoredPortal.getId()).get(0);
         StudyEnvironment sandboxEnv = studyEnvironmentService.findByStudy(study.getShortcode(), EnvironmentName.sandbox).orElseThrow();
-        assertThat(triggerService.findByStudyEnvironmentId(sandboxEnv.getId()), hasSize(5));
+        assertThat(triggerService.findByStudyEnvironmentId(sandboxEnv.getId()), hasSize(6));
     }
 
 }

--- a/populate/src/test/java/bio/terra/pearl/populate/extract/PortalExtractTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/extract/PortalExtractTest.java
@@ -49,7 +49,7 @@ public class PortalExtractTest extends BasePopulatePortalsTest {
         assertThat(surveyService.findByPortalId(restoredPortal.getId()), hasSize(12));
         assertThat(studyService.findByPortalId(restoredPortal.getId()), hasSize(1));
         assertThat(consentFormService.findByPortalId(restoredPortal.getId()), hasSize(1));
-        assertThat(emailTemplateService.findByPortalId(restoredPortal.getId()), hasSize(5));
+        assertThat(emailTemplateService.findByPortalId(restoredPortal.getId()), hasSize(6));
         // confirm both the old and current versions of the site content got populated
         assertThat(siteContentService.findByPortalId(restoredPortal.getId()), hasSize(2));
 

--- a/ui-participant/src/App.tsx
+++ b/ui-participant/src/App.tsx
@@ -24,6 +24,7 @@ import { IdleStatusMonitor } from 'login/IdleStatusMonitor'
 import { ApiProvider, I18nProvider } from '@juniper/ui-core'
 import { BrandConfiguration, brandStyles } from './util/brandUtils'
 import { isBrowserCompatible } from './util/browserCompatibilityUtils'
+import InvitationPage from './landing/registration/InvitationPage'
 
 const PrivacyPolicyPage = lazy(() => import('terms/PrivacyPolicyPage'))
 const InvestigatorTermsOfUsePage = lazy(() => import('terms/InvestigatorTermsOfUsePage'))
@@ -74,8 +75,11 @@ function App() {
       <Route index key="main" element={<HtmlPageView page={localContent.landingPage}/>}/>
     )
   }
-  // add routes for portal registration not tied to a specific study (e.g. 'join HeartHive')
-  landingRoutes.push(<Route key="portalReg" path="/join/*"
+  // add routes for portal registration and invitations not tied to a specific study (e.g. 'join HeartHive')
+  landingRoutes.push(<Route key="portalReg" path="/join/invitation"
+    element={<InvitationPage/>}>
+  </Route>)
+  landingRoutes.push(<Route key="portalRegInvite" path="/join/*"
     element={<PortalRegistrationRouter portal={portal} returnTo="/hub"/>}>
   </Route>)
 

--- a/ui-participant/src/landing/registration/InvitationPage.tsx
+++ b/ui-participant/src/landing/registration/InvitationPage.tsx
@@ -25,7 +25,7 @@ export default function InvitationPage() {
     auth.signinRedirect({
       redirectMethod: 'replace',
       extraQueryParams: {
-        option: 'signup2',
+        option: 'signup',
         // eslint-disable-next-line camelcase
         login_hint: accountName
       }

--- a/ui-participant/src/landing/registration/InvitationPage.tsx
+++ b/ui-participant/src/landing/registration/InvitationPage.tsx
@@ -1,0 +1,38 @@
+import React, { useEffect } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useAuth } from 'react-oidc-context'
+import { PageLoadingIndicator } from 'util/LoadingSpinner'
+
+/** Page for participants who already have enrollee data in Juniper (from a migration or admin action), and need
+ * to join to link their account */
+export default function InvitationPage() {
+  const auth = useAuth()
+  const [searchParams] = useSearchParams()
+  const accountName = searchParams.get('accountName') || ''
+  const navigate = useNavigate()
+
+  const register = () => {
+    if (process.env.REACT_APP_UNAUTHED_LOGIN) {
+      /**
+       * this is a no-op redirect to hub -- since we're in Unauthed mode,
+       * there is no b2c account that needs to be created
+       */
+      navigate('/hub')
+      return
+    }
+    auth.signinRedirect({
+      redirectMethod: 'replace',
+      extraQueryParams: {
+        option: 'signup2',
+        // eslint-disable-next-line camelcase
+        login_hint: accountName
+      }
+    })
+  }
+
+  useEffect(() => {
+    register()
+  }, [])
+
+  return <PageLoadingIndicator />
+}

--- a/ui-participant/src/landing/registration/InvitationPage.tsx
+++ b/ui-participant/src/landing/registration/InvitationPage.tsx
@@ -2,6 +2,8 @@ import React, { useEffect } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useAuth } from 'react-oidc-context'
 import { PageLoadingIndicator } from 'util/LoadingSpinner'
+import { useUser } from 'providers/UserProvider'
+import Api from 'api/api'
 
 /** Page for participants who already have enrollee data in Juniper (from a migration or admin action), and need
  * to join to link their account */
@@ -10,13 +12,13 @@ export default function InvitationPage() {
   const [searchParams] = useSearchParams()
   const accountName = searchParams.get('accountName') || ''
   const navigate = useNavigate()
+  const { loginUser } = useUser()
 
-  const register = () => {
+  const register = async () => {
     if (process.env.REACT_APP_UNAUTHED_LOGIN) {
-      /**
-       * this is a no-op redirect to hub -- since we're in Unauthed mode,
-       * there is no b2c account that needs to be created
-       */
+      // we don't need to create a b2c account, just log the user in
+      const result = await Api.unauthedLogin(accountName)
+      loginUser(result, result.user.token)
       navigate('/hub')
       return
     }

--- a/ui-participant/src/landing/registration/PortalRegistrationRouter.tsx
+++ b/ui-participant/src/landing/registration/PortalRegistrationRouter.tsx
@@ -8,7 +8,6 @@ import Registration from './Registration'
 import { usePreRegResponseId } from 'browserPersistentState'
 import RegistrationUnauthed from './RegistrationUnauthed'
 
-
 export type RegistrationContextT = {
   preRegSurvey?: Survey,
   preRegResponseId: string | null,


### PR DESCRIPTION
#### DESCRIPTION

This enables invitation emails to be sent to participants who have data in Juniper (such as from a migration), but do not have b2c accounts, allowing them to create their linked b2c account

<img width="609" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/828a6990-c488-489e-a993-fad98a8fe928">

To enable easy testing of this feature, I needed a way to repeatedly create an enrollee who did not have a b2c account.  So I introduced the concept of "keyed" populate users.  This lets us be sure that every time we populate demo, the `HDINVI` enrollee will be created with a new username and so will be able to be invited without conflicting with an existing b2c account.  The email generated looks like [your username]+[key]-[randomchars]@broadinstitute.org.

FUTURE WORK:
 1. b2c configuration to prefill the email address field (and maybe make it read-only)
 2. not hardcoding all "AD_HOC" emails to prompt for subject/body text
 3. some sort of indication in the data model (other than lastLogin) that a participantUser is (a) from a migration and (b) does not yet have a b2c account

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy ApiAdminApp
2. repopulate demo
3. make sure the ui-participant is running with b2c auth *on*
4. go to sandbox participant list `https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants`
5. check-select the HDINVI enrollee, and press "Send email"
6. In the "email template" dropdown, select "Invitation email"
7. ignore the text fields, and press "send to 1 participant"
8. Confirm you get an email that looks like the screenshot above
9. click the link, confirm you are taken (after a redirect) to the "Verify your email" screen
10. (you won't be able to actually verify the email since demo b2c isn't yet configured)