### PR TITLE
[JN-963] Fix file upload validation

### DIFF
--- a/ui-admin/src/portal/media/SiteMediaUploadModal.test.tsx
+++ b/ui-admin/src/portal/media/SiteMediaUploadModal.test.tsx
@@ -45,6 +45,16 @@ test('upload api is called on submit', async () => {
     .toHaveBeenCalledWith(portalContext.portal.shortcode, file.name, 1, file))
 })
 
+test('uploading an invalid file type displays a validation error message', async () => {
+  const { RoutedComponent } = setupRouterTest(
+    <SiteMediaUploadModal portalContext={mockPortalContext()} onDismiss={jest.fn()} onSubmit={jest.fn()}/>)
+  render(RoutedComponent)
+  const file = new File(['hello'], 'hello.notallowed')
+  const fileInput = screen.getByTestId('fileInput') as HTMLInputElement
+  await userEvent.upload(fileInput, file)
+  expect(screen.getByText('This file extension is not supported.')).toBeInTheDocument()
+})
+
 test('cleanFileName handles names', async () => {
   expect(cleanFileName('hello.png')).toBe('hello.png')
 })

--- a/ui-admin/src/portal/media/SiteMediaUploadModal.tsx
+++ b/ui-admin/src/portal/media/SiteMediaUploadModal.tsx
@@ -9,11 +9,7 @@ import { Button } from 'components/forms/Button'
 import { LoadedPortalContextT } from '../PortalProvider'
 import { useFileUploadButton } from 'util/uploadUtils'
 
-
-export const allowedImageTypes = ['gif', 'ico', 'jpeg', 'jpg', 'png', 'svg', 'webp']
-export const allowedDocumentTypes = ['pdf', 'json']
-export const allowedTextTypes = ['csv', 'txt']
-export const allowedFileTypes = [...allowedImageTypes, ...allowedDocumentTypes, ...allowedTextTypes]
+export const allowedFileTypes = ['gif', 'ico', 'jpeg', 'jpg', 'png', 'svg', 'webp', 'pdf', 'json', 'csv', 'txt']
 
 /** Renders a modal for an admin to submit a sample collection kit request. */
 export default function SiteMediaUploadModal({
@@ -66,7 +62,7 @@ export default function SiteMediaUploadModal({
     <Modal.Body>
       <form onSubmit={e => e.preventDefault()}>
         <div>
-          <p>Supported extensions are {[...allowedImageTypes, ...allowedDocumentTypes].join(', ')}.
+          <p>Supported extensions are {allowedFileTypes.join(', ')}.
             Maximum size is 10MB</p>
           File:
           <div>

--- a/ui-admin/src/portal/media/SiteMediaUploadModal.tsx
+++ b/ui-admin/src/portal/media/SiteMediaUploadModal.tsx
@@ -73,7 +73,7 @@ export default function SiteMediaUploadModal({
             {FileChooser}
             <span className="text-muted fst-italic ms-2">{file?.name}</span>
           </div>
-          {validationMessages.map(msg => <div className='text-danger'>{msg}</div>)}
+          {validationMessages.map((msg, index) => <div key={index} className='text-danger'>{msg}</div>)}
         </div>
         <label className="mt-3 mb-2 form-label">
           Name:

--- a/ui-admin/src/portal/media/SiteMediaUploadModal.tsx
+++ b/ui-admin/src/portal/media/SiteMediaUploadModal.tsx
@@ -14,6 +14,7 @@ export const allowedImageTypes = ['gif', 'ico', 'jpeg', 'jpg', 'png', 'svg', 'we
 export const allowedDocumentTypes = ['pdf', 'json']
 export const allowedTextTypes = ['csv', 'txt']
 export const allowedFileTypes = [...allowedImageTypes, ...allowedDocumentTypes, ...allowedTextTypes]
+const FILE_TYPE_REGEX = new RegExp(`\\.(${allowedFileTypes.join('|')})$`)
 
 /** Renders a modal for an admin to submit a sample collection kit request. */
 export default function SiteMediaUploadModal({
@@ -51,7 +52,7 @@ export default function SiteMediaUploadModal({
   }
 
   const validationMessages = []
-  if (file && !file.name.match(new RegExp(`\\.(${allowedFileTypes.join('|')})$`))) {
+  if (file && !file.name.match(FILE_TYPE_REGEX)) {
     validationMessages.push('This file extension is not supported.')
   }
   if (file && file.size > 10 * 1024 * 1024) {

--- a/ui-admin/src/portal/media/SiteMediaUploadModal.tsx
+++ b/ui-admin/src/portal/media/SiteMediaUploadModal.tsx
@@ -12,14 +12,9 @@ import { useFileUploadButton } from 'util/uploadUtils'
 
 export const allowedImageTypes = ['gif', 'ico', 'jpeg', 'jpg', 'png', 'svg', 'webp']
 export const allowedDocumentTypes = ['pdf', 'json']
-export const allowedTextTypes = ['csv', 'plain']
-const FILE_TYPE_REGEX = new RegExp(
-  [
-    `^(?:image\\/(${allowedImageTypes.join('|')}))`,
-    `(?:application\\/(${allowedDocumentTypes.join('|')}))`,
-    `(?:text\\/(${allowedTextTypes.join('|')}))$`
-  ].join('|')
-)
+export const allowedTextTypes = ['csv', 'txt']
+export const allowedFileTypes = [...allowedImageTypes, ...allowedDocumentTypes, ...allowedTextTypes]
+
 /** Renders a modal for an admin to submit a sample collection kit request. */
 export default function SiteMediaUploadModal({
   portalContext,
@@ -56,7 +51,7 @@ export default function SiteMediaUploadModal({
   }
 
   const validationMessages = []
-  if (file && !file.type.match(FILE_TYPE_REGEX)) {
+  if (file && !file.name.match(new RegExp(`\\.(${allowedFileTypes.join('|')})$`))) {
     validationMessages.push('This file extension is not supported.')
   }
   if (file && file.size > 10 * 1024 * 1024) {

--- a/ui-admin/src/portal/media/SiteMediaUploadModal.tsx
+++ b/ui-admin/src/portal/media/SiteMediaUploadModal.tsx
@@ -9,7 +9,11 @@ import { Button } from 'components/forms/Button'
 import { LoadedPortalContextT } from '../PortalProvider'
 import { useFileUploadButton } from 'util/uploadUtils'
 
-export const allowedFileTypes = ['gif', 'ico', 'jpeg', 'jpg', 'png', 'svg', 'webp', 'pdf', 'json', 'csv', 'txt']
+
+export const allowedImageTypes = ['gif', 'ico', 'jpeg', 'jpg', 'png', 'svg', 'webp']
+export const allowedDocumentTypes = ['pdf', 'json']
+export const allowedTextTypes = ['csv', 'txt']
+export const allowedFileTypes = [...allowedImageTypes, ...allowedDocumentTypes, ...allowedTextTypes]
 
 /** Renders a modal for an admin to submit a sample collection kit request. */
 export default function SiteMediaUploadModal({


### PR DESCRIPTION
#### DESCRIPTION

The existing file type validation was not particular reliable. Icon files can potentially have multiple valid mime types, which was causing issues when Whitney was trying to add a new favicon for the template study. Uploading a `.jpeg` was also broken (but `jpg` was fine). Instead of capturing every possible mime type for each allowed file type, we'll just validate using file extension. This is in line with the backend validation anyway.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Restart admin UI
Try to upload a .jpeg file and a .ico file (confirm it succeeds)
Try to upload a .zip file (confirm that this is still disallowed and that validation still works)