### PR TITLE
[JN-946] add dashboardUrl back

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
@@ -40,6 +40,7 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
         valueMap.put("portalEnv", contextInfo.portalEnv());
         valueMap.put("envConfig", contextInfo.portalEnvConfig());
         valueMap.put("dashboardLink", getDashboardLink(contextInfo.portalEnv(), contextInfo.portalEnvConfig(), contextInfo.portal(), contextInfo.study()));
+        valueMap.put("dashboardUrl", getDashboardUrl(contextInfo.portalEnv(), contextInfo.portalEnvConfig(), contextInfo.portal()));
         valueMap.put("siteLink", getSiteLink(contextInfo.portalEnv(), contextInfo.portalEnvConfig(), contextInfo.portal()));
         valueMap.put("participantSupportEmailLink", getParticipantSupportEmailLink(contextInfo.portalEnv(), contextInfo.portalEnvConfig()));
         valueMap.put("siteMediaBaseUrl", getImageBaseUrl(contextInfo.portalEnv(), contextInfo.portalEnvConfig(), contextInfo.portal().getShortcode()));


### PR DESCRIPTION
#### DESCRIPTION

This got dropped in a recent PR, this adds it back

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Generate a "thank you for submitting your consent form" email for a participant and verify that the dashboard url is correct