### PR TITLE
[JN-879] fixing case where no pre-enroll found

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
@@ -158,7 +158,7 @@ public class EnrollmentService {
      * If the user's response is true, it will return true, otherwise it returns false;
      */
    protected boolean isProxyEnrollment(UUID preEnrollResponseId) {
-        PreEnrollmentResponse preEnrollResponse = preEnrollmentResponseDao.find(preEnrollResponseId).get();
+        PreEnrollmentResponse preEnrollResponse = preEnrollmentResponseDao.find(preEnrollResponseId).orElse(null);
         if (preEnrollResponse == null || !preEnrollResponse.isQualified()) {
             return false;
         }
@@ -253,7 +253,7 @@ public class EnrollmentService {
      */
     public HubResponse enroll(EnvironmentName environmentName, String studyShortcode, ParticipantUser user,
                               PortalParticipantUser portalParticipantUser, UUID preEnrollResponseId) {
-        if (isProxyEnrollment(preEnrollResponseId)) {
+        if (preEnrollResponseId != null && isProxyEnrollment(preEnrollResponseId)) {
             return enrollAsProxy(environmentName, studyShortcode, user, portalParticipantUser, preEnrollResponseId);
         }
         return enroll(environmentName, studyShortcode, user, portalParticipantUser, preEnrollResponseId, true);

--- a/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentWorkflowTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentWorkflowTests.java
@@ -13,6 +13,7 @@ import static org.hamcrest.Matchers.samePropertyValuesAs;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import bio.terra.pearl.core.BaseSpringBootTest;
 import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
@@ -289,6 +290,12 @@ public class EnrollmentWorkflowTests extends BaseSpringBootTest {
 
     }
 
+    @Test
+    @Transactional
+    public void testDetectingProxyNoPreEnroll(TestInfo info) {
+        Assertions.assertFalse(enrollmentService.isProxyEnrollment(null));
+        Assertions.assertFalse(enrollmentService.isProxyEnrollment(UUID.randomUUID()));
+    }
 
 
     @Autowired


### PR DESCRIPTION
#### DESCRIPTION
This cased a registration with no enrollee in the demo server.  Occasionally we lose the link to the preEnroll survey depending on refresh patterns.  when that happens, we want to just create the enrollee anyway.  This was erroring during enrollment.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1.  enroll in ourhealth, confirm you can enroll
