### PR TITLE
[JN-970] add b2c error page and logging

### DIFF
--- a/ui-participant/src/App.tsx
+++ b/ui-participant/src/App.tsx
@@ -25,6 +25,7 @@ import { ApiProvider, I18nProvider } from '@juniper/ui-core'
 import { BrandConfiguration, brandStyles } from './util/brandUtils'
 import { isBrowserCompatible } from './util/browserCompatibilityUtils'
 import InvitationPage from './landing/registration/InvitationPage'
+import AuthError from './login/AuthError'
 
 const PrivacyPolicyPage = lazy(() => import('terms/PrivacyPolicyPage'))
 const InvestigatorTermsOfUsePage = lazy(() => import('terms/InvestigatorTermsOfUsePage'))
@@ -115,7 +116,10 @@ function App() {
                             <Route path="/" element={<LandingPage localContent={localContent}/>}>
                               {landingRoutes}
                             </Route>
-                            <Route path="/redirect-from-oauth" element={<RedirectFromOAuth/>}/>
+                            <Route path="/redirect-from-oauth">
+                              <Route index element={<RedirectFromOAuth/>}/>
+                              <Route path="error" element={<AuthError/>}/>
+                            </Route>
                             <Route path="/privacy" element={<PrivacyPolicyPage/>}/>
                             <Route path="/terms/investigator" element={<InvestigatorTermsOfUsePage/>}/>
                             <Route path="/terms/participant" element={<ParticipantTermsOfUsePage/>}/>

--- a/ui-participant/src/login/AuthError.tsx
+++ b/ui-participant/src/login/AuthError.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import Navbar from '../Navbar'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faCircleExclamation } from '@fortawesome/free-solid-svg-icons'
+
+/**
+ * Displays when there is an error from b2c.
+ */
+export default function AuthError() {
+  return (
+    <div className="container-fluid bg-white min-vh-100 d-flex flex-column p-0">
+      <Navbar aria-label="Primary"/>
+      <main className="flex-grow-1 p-2 d-flex flex-column justify-content-center">
+        <div className="fs-1 fw-bold d-flex justify-content-center">
+          <div>
+            <FontAwesomeIcon className="me-2" icon={faCircleExclamation}/>
+            <span>Oops!</span>
+          </div>
+        </div>
+        <div className="fs-2 fw-light d-flex justify-content-center text-center">
+            Something went wrong with our authentication service. Please try again later.
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/ui-participant/src/login/AuthError.tsx
+++ b/ui-participant/src/login/AuthError.tsx
@@ -22,8 +22,10 @@ export default function AuthError() {
         </div>
         <div className="fs-2 fw-light d-flex justify-content-center text-center">
           <div>
-            <span>There was an issue with our authentication service. Please try again.</span>
-            <span>If the problem persists, please contact <a href={`mailto:${supportEmail}`}>{supportEmail}</a>.</span>
+            <span>
+              There was an issue with our authentication service. Please try again. If the problem persists, please
+              contact <a href={`mailto:${supportEmail}`}>{supportEmail}</a>.
+            </span>
           </div>
         </div>
       </main>

--- a/ui-participant/src/login/AuthError.tsx
+++ b/ui-participant/src/login/AuthError.tsx
@@ -2,11 +2,14 @@ import React from 'react'
 import Navbar from '../Navbar'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircleExclamation } from '@fortawesome/free-solid-svg-icons'
+import { usePortalEnv } from '../providers/PortalProvider'
 
 /**
  * Displays when there is an error from b2c.
  */
 export default function AuthError() {
+  const portalEnv = usePortalEnv()
+  const supportEmail = portalEnv.portalEnv.portalEnvironmentConfig.emailSourceAddress
   return (
     <div className="container-fluid bg-white min-vh-100 d-flex flex-column p-0">
       <Navbar aria-label="Primary"/>
@@ -14,11 +17,14 @@ export default function AuthError() {
         <div className="fs-1 fw-bold d-flex justify-content-center">
           <div>
             <FontAwesomeIcon className="me-2" icon={faCircleExclamation}/>
-            <span>Oops!</span>
+            <span>Something went wrong</span>
           </div>
         </div>
         <div className="fs-2 fw-light d-flex justify-content-center text-center">
-            Something went wrong with our authentication service. Please try again later.
+          <div>
+            <span>There was an issue with our authentication service. Please try again.</span>
+            <span>If the problem persists, please contact <a href={`mailto:${supportEmail}`}>{supportEmail}</a>.</span>
+          </div>
         </div>
       </main>
     </div>

--- a/ui-participant/src/login/RedirectFromOAuth.tsx
+++ b/ui-participant/src/login/RedirectFromOAuth.tsx
@@ -45,6 +45,7 @@ export const RedirectFromOAuth = () => {
           stackTrace: auth.error.stack || 'stack'
         })
         navigate('/redirect-from-oauth/error')
+        return
       }
 
       if (auth.user) {

--- a/ui-participant/src/login/RedirectFromOAuth.tsx
+++ b/ui-participant/src/login/RedirectFromOAuth.tsx
@@ -8,7 +8,8 @@ import { HubUpdate } from 'hub/hubUpdates'
 import { usePreEnrollResponseId, usePreRegResponseId, useReturnToStudy } from 'browserPersistentState'
 import { userHasJoinedPortalStudy } from 'util/enrolleeUtils'
 import { PageLoadingIndicator } from 'util/LoadingSpinner'
-import { AlertLevel, alertDefaults } from '@juniper/ui-core'
+import { alertDefaults, AlertLevel } from '@juniper/ui-core'
+import { log } from '../util/loggingUtils'
 
 // TODO: Add JSDoc
 // eslint-disable-next-line jsdoc/require-jsdoc
@@ -37,7 +38,13 @@ export const RedirectFromOAuth = () => {
       // we only process the return from OAuth once (when the user is still "anonymous")
 
       if (auth.error) {
-        navigate('/')
+        log({
+          eventType: 'ERROR',
+          eventName: 'oauth-error',
+          eventDetail: auth.error.message || 'error',
+          stackTrace: auth.error.stack || 'stack'
+        })
+        navigate('/redirect-from-oauth/error')
       }
 
       if (auth.user) {


### PR DESCRIPTION
#### DESCRIPTION

Adds an error page when b2c returns an error.

Desktop
<img width="1512" alt="image" src="https://github.com/broadinstitute/juniper/assets/17440010/d87c71b0-556d-4c0d-a2b6-84f07f649af8">

Mobile
<img width="374" alt="image" src="https://github.com/broadinstitute/juniper/assets/17440010/263d5588-4327-4d45-8e6c-036c2c45a308">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

You have to trick the redirect system to believe there was an error. You can do that by adding:

```
      auth.error = { message: 'test message', stack: 'test stack', name: 'test error' }
```

at `RedirectFromOauth.tsx:39`

Then, just try logging in or registering like normal and observe that the backend logs at an error level and you get an error page.

