### PR TITLE
[JN-620] Form name i18n

### DIFF
--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/ConsentFormExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/ConsentFormExtServiceTests.java
@@ -40,7 +40,10 @@ public class ConsentFormExtServiceTests extends BaseSpringBootTest {
 
     Portal portal = portalFactory.buildPersisted(getTestName(testInfo));
     ConsentForm.ConsentFormBuilder builder =
-        consentFormFactory.builderWithDependencies(getTestName(testInfo)).portalId(portal.getId());
+        (ConsentForm.ConsentFormBuilder)
+            consentFormFactory
+                .builderWithDependencies(getTestName(testInfo))
+                .portalId(portal.getId());
     ConsentForm form = consentFormFactory.buildPersisted(builder);
 
     List<ConsentForm> forms =

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/task/ParticipantTaskController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/task/ParticipantTaskController.java
@@ -5,42 +5,33 @@ import bio.terra.pearl.api.participant.service.ParticipantTaskExtService;
 import bio.terra.pearl.api.participant.service.RequestUtilService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
-import bio.terra.pearl.core.model.workflow.TaskType;
-import bio.terra.pearl.core.service.participant.EnrolleeService;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 @Controller
 public class ParticipantTaskController implements ParticipantTaskApi {
-  private EnrolleeService enrolleeService;
-  private ParticipantTaskExtService participantTaskExtService;
-  private RequestUtilService requestUtilService;
-  private HttpServletRequest request;
+  private final ParticipantTaskExtService participantTaskExtService;
+  private final RequestUtilService requestUtilService;
+  private final HttpServletRequest request;
 
   @Autowired
   public ParticipantTaskController(
-      EnrolleeService enrolleeService,
       ParticipantTaskExtService participantTaskExtService,
       RequestUtilService requestUtilService,
       HttpServletRequest request) {
-    this.enrolleeService = enrolleeService;
     this.participantTaskExtService = participantTaskExtService;
     this.requestUtilService = requestUtilService;
     this.request = request;
   }
 
   @Override
-  public ResponseEntity<Object> listTasksWithSurveys(
-      String portalShortcode, String envName, String taskType) {
+  public ResponseEntity<Object> listTasksWithSurveys(String portalShortcode, String envName) {
     ParticipantUser user = requestUtilService.requireUser(request);
     EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
-    TaskType taskTypeEnum = taskType != null ? TaskType.valueOf(taskType.toUpperCase()) : null;
-    List<ParticipantTaskExtService.TaskAndSurvey> outreachSurveys =
-        participantTaskExtService.listSurveyTasks(
-            user, portalShortcode, environmentName, taskTypeEnum);
-    return ResponseEntity.ok(outreachSurveys);
+
+    return ResponseEntity.ok(
+        participantTaskExtService.listAllTasksAndForms(user, portalShortcode, environmentName));
   }
 }

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/service/ParticipantTaskExtService.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/service/ParticipantTaskExtService.java
@@ -1,67 +1,94 @@
 package bio.terra.pearl.api.participant.service;
 
 import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.form.VersionedForm;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
-import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
 import bio.terra.pearl.core.model.workflow.TaskType;
+import bio.terra.pearl.core.service.consent.ConsentFormService;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.portal.PortalWithPortalUser;
 import bio.terra.pearl.core.service.survey.SurveyService;
 import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class ParticipantTaskExtService {
-  private ParticipantTaskService participantTaskService;
-  private SurveyService surveyService;
-  private EnrolleeService enrolleeService;
-  private AuthUtilService authUtilService;
+  private final ParticipantTaskService participantTaskService;
+  private final SurveyService surveyService;
+  private final ConsentFormService consentFormService;
+  private final EnrolleeService enrolleeService;
+  private final AuthUtilService authUtilService;
 
   @Autowired
   public ParticipantTaskExtService(
       ParticipantTaskService participantTaskService,
       SurveyService surveyService,
+      ConsentFormService consentFormService,
       EnrolleeService enrolleeService,
       AuthUtilService authUtilService) {
     this.participantTaskService = participantTaskService;
     this.surveyService = surveyService;
+    this.consentFormService = consentFormService;
     this.enrolleeService = enrolleeService;
     this.authUtilService = authUtilService;
   }
 
-  // Loads all outreach activities for the logged-in PortalParticipantUser
-  public List<TaskAndSurvey> listSurveyTasks(
-      ParticipantUser user, String portalShortcode, EnvironmentName envName, TaskType taskType) {
+  public TasksAndForms listAllTasksAndForms(
+      ParticipantUser user, String portalShortcode, EnvironmentName envName) {
     PortalWithPortalUser portalUser =
         authUtilService.authParticipantToPortal(user.getId(), portalShortcode, envName);
     List<Enrollee> participantEnrollees =
         enrolleeService.findByPortalParticipantUser(portalUser.ppUser());
 
-    List<ParticipantTask> outreachTasks =
+    Map<TaskType, List<ParticipantTask>> tasksByType =
         participantTaskService
             .findByEnrolleeIds(participantEnrollees.stream().map(Enrollee::getId).toList())
             .values()
             .stream()
             .flatMap(Collection::stream)
-            .filter(task -> taskType == null || task.getTaskType().equals(taskType))
-            .toList();
+            .collect(Collectors.groupingBy(ParticipantTask::getTaskType));
 
-    List<Survey> outreachSurveys =
-        surveyService.findByStableIds(
-            outreachTasks.stream().map(ParticipantTask::getTargetStableId).toList(),
-            outreachTasks.stream().map(ParticipantTask::getTargetAssignedVersion).toList());
-    List<TaskAndSurvey> tasksAndSurveys =
-        IntStream.range(0, outreachTasks.size())
-            .mapToObj(i -> new TaskAndSurvey(outreachSurveys.get(i), outreachTasks.get(i)))
-            .toList();
-    return tasksAndSurveys;
+    List<TaskAndForm> researchTaskAndSurveys =
+        getTasksAndFormsByType(TaskType.SURVEY, surveyService::findByStableIds, tasksByType);
+
+    List<TaskAndForm> outreachTaskAndSurveys =
+        getTasksAndFormsByType(TaskType.OUTREACH, surveyService::findByStableIds, tasksByType);
+
+    List<TaskAndForm> consentTaskAndSurveys =
+        getTasksAndFormsByType(TaskType.CONSENT, consentFormService::findByStableIds, tasksByType);
+
+    return new TasksAndForms(researchTaskAndSurveys, outreachTaskAndSurveys, consentTaskAndSurveys);
   }
 
-  public record TaskAndSurvey(Survey survey, ParticipantTask task) {}
+  private <F extends VersionedForm> List<TaskAndForm> getTasksAndFormsByType(
+      TaskType taskType,
+      BiFunction<List<String>, List<Integer>, List<F>> findByStableIds,
+      Map<TaskType, List<ParticipantTask>> tasksByType) {
+
+    List<ParticipantTask> tasks = tasksByType.getOrDefault(taskType, List.of());
+    List<F> forms =
+        findByStableIds.apply(
+            tasks.stream().map(ParticipantTask::getTargetStableId).toList(),
+            tasks.stream().map(ParticipantTask::getTargetAssignedVersion).toList());
+
+    return IntStream.range(0, tasks.size())
+        .mapToObj(i -> new TaskAndForm(forms.get(i), tasks.get(i)))
+        .toList();
+  }
+
+  public record TaskAndForm(VersionedForm form, ParticipantTask task) {}
+
+  public record TasksAndForms(
+      List<TaskAndForm> surveyTasks,
+      List<TaskAndForm> outreachTasks,
+      List<TaskAndForm> consentTasks) {}
 }

--- a/api-participant/src/main/resources/api/openapi.yml
+++ b/api-participant/src/main/resources/api/openapi.yml
@@ -295,13 +295,12 @@ paths:
           $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/env/{envName}/tasks:
     get:
-      summary: List the tasks available to the signed-in user of the given type, includes the survey for each task
+      summary: List the tasks available to the signed-in user, includes the survey for each task
       tags: [ participantTask ]
       operationId: listTasksWithSurveys
       parameters:
         - { name: portalShortcode, in: path, required: true, schema: { type: string } }
         - { name: envName, in: path, required: true, schema: { type: string } }
-        - { name: taskType, in: query, required: false, schema: { type: string } }
       responses:
         '200':
           description: list of outreach activities

--- a/core/src/main/java/bio/terra/pearl/core/dao/workflow/ParticipantTaskDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/workflow/ParticipantTaskDao.java
@@ -38,6 +38,11 @@ public class ParticipantTaskDao extends BaseMutableJdbiDao<ParticipantTask> {
                 .stream().collect(Collectors.groupingBy(ParticipantTask::getEnrolleeId, Collectors.toList()));
     }
 
+    public Map<UUID, List<ParticipantTask>> findByEnrolleeIdsAndType(Collection<UUID> enrolleeIds, TaskType taskType) {
+        return findAllByTwoProperties("task_type", taskType.name(), "enrollee_id", enrolleeIds)
+                .stream().collect(Collectors.groupingBy(ParticipantTask::getEnrolleeId, Collectors.toList()));
+    }
+
     /** Attempts to find a task for the given activity and study.  If there are multiple, it will return the first */
     public Optional<ParticipantTask> findTaskForActivity(UUID ppUserId, UUID studyEnvironmentId, String activityStableId) {
         return jdbi.withHandle(handle ->

--- a/core/src/main/java/bio/terra/pearl/core/model/consent/ConsentForm.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/consent/ConsentForm.java
@@ -4,6 +4,8 @@ import bio.terra.pearl.core.model.BaseEntity;
 import bio.terra.pearl.core.model.PortalAttached;
 import bio.terra.pearl.core.model.Versioned;
 import java.util.UUID;
+
+import bio.terra.pearl.core.model.form.VersionedForm;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,13 +17,4 @@ import lombok.experimental.SuperBuilder;
 @Setter
 @NoArgsConstructor
 @SuperBuilder
-public class ConsentForm extends BaseEntity implements Versioned, PortalAttached {
-    private String stableId;
-    @Builder.Default
-    private int version = 1;
-    private Integer publishedVersion;
-    private String content;
-    private String name;
-    // used to keep forms attached to their portal even if they are not on an environment currently
-    private UUID portalId;
-}
+public class ConsentForm extends VersionedForm { }

--- a/core/src/main/java/bio/terra/pearl/core/model/form/VersionedForm.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/form/VersionedForm.java
@@ -1,0 +1,28 @@
+package bio.terra.pearl.core.model.form;
+
+import bio.terra.pearl.core.model.BaseEntity;
+import bio.terra.pearl.core.model.PortalAttached;
+import bio.terra.pearl.core.model.Versioned;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+public abstract class VersionedForm extends BaseEntity implements Versioned, PortalAttached {
+    private String stableId;
+    @Builder.Default
+    private int version = 1;
+    private Integer publishedVersion;
+    private String content;
+    private String name;
+
+    // used to keep forms attached to their portal even if they are not on an environment currently
+    private UUID portalId;
+}

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/Survey.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/Survey.java
@@ -6,6 +6,8 @@ import bio.terra.pearl.core.model.Versioned;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+
+import bio.terra.pearl.core.model.form.VersionedForm;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,19 +15,10 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Getter @Setter @NoArgsConstructor @SuperBuilder
-public class Survey extends BaseEntity implements Versioned, PortalAttached {
-    private String stableId;
-    @Builder.Default
-    private int version = 1;
-    private Integer publishedVersion;
-    private String content;
-    private String name;
+public class Survey extends VersionedForm {
     @Builder.Default
     private SurveyType surveyType = SurveyType.RESEARCH;
     private String blurb; // brief description of the survey for, e.g., showing in a dashboard
-
-    // used to keep surveys attached to their portal even if they are not on an environment currently
-    private UUID portalId;
     @Builder.Default
     private List<AnswerMapping> answerMappings = new ArrayList<>();
     // markdown to be displayed below every page of the survey

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/ParticipantTaskService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/ParticipantTaskService.java
@@ -11,6 +11,7 @@ import bio.terra.pearl.core.model.workflow.ParticipantTask;
 import java.time.Instant;
 import java.util.*;
 
+import bio.terra.pearl.core.model.workflow.TaskType;
 import bio.terra.pearl.core.service.DataAuditedService;
 import bio.terra.pearl.core.service.exception.internal.InternalServerException;
 import bio.terra.pearl.core.service.study.exception.StudyEnvironmentMissing;
@@ -32,6 +33,10 @@ public class ParticipantTaskService extends DataAuditedService<ParticipantTask, 
 
     public Map<UUID, List<ParticipantTask>> findByEnrolleeIds(List<UUID> enrolleeIds) {
         return dao.findByEnrolleeIds(enrolleeIds);
+    }
+
+    public Map<UUID, List<ParticipantTask>> findByEnrolleeIdsAndType(List<UUID> enrolleeIds, TaskType taskType) {
+        return dao.findByEnrolleeIdsAndType(enrolleeIds, taskType);
     }
 
     public List<ParticipantTask> findTasksByStudyAndTarget(UUID studyEnvId, List<String> targetStableIds) {

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/survey/SurveyFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/survey/SurveyFactory.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.core.factory.survey;
 
+import bio.terra.pearl.core.model.form.VersionedForm;
 import bio.terra.pearl.core.model.survey.AnswerMapping;
 import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
 import bio.terra.pearl.core.model.survey.Survey;
@@ -39,6 +40,10 @@ public class SurveyFactory {
 
     public Survey buildPersisted(Survey.SurveyBuilder builder) {
         return surveyService.create(builder.build());
+    }
+
+    public Survey buildPersisted(VersionedForm.VersionedFormBuilder builder) {
+        return surveyService.create(((Survey.SurveyBuilder) builder).build());
     }
 
     public Survey buildPersisted(String testName, List<AnswerMapping> mappings) {

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/cardioHistory.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/cardioHistory.json
@@ -4,7 +4,11 @@
   "name": "Cardiometabolic Medical History",
   "footer": "Resources used for this survey:\n * All of Us\n * California Teacher’s Study (CTS)\n * Mike Honigberg, American Heart Association\n * OurHealth",
   "jsonContent": {
-    "title": "OurHealth Medical History",
+    "title": {
+      "default": "Cardiometabolic Medical History",
+      "es": "Historial Médico Cardiometabólico",
+      "dev": "DEV_Cardiometabolic Medical History"
+    },
     "showProgressBar": "bottom",
     "showQuestionNumbers": "off",
     "questionTemplates": [

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/familyHistory.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/familyHistory.json
@@ -4,6 +4,11 @@
   "name": "Family History",
   "footer": "Unless otherwise mentioned, all questions are sourced from the All of Us research study.",
   "jsonContent": {
+    "title": {
+      "default": "Family History",
+      "es": "Historial Familiar",
+      "dev": "DEV_Family History"
+    },
     "showQuestionNumbers": "off",
     "showProgressBar": "bottom",
     "questionTemplates": [

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/lifestyle.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/lifestyle.json
@@ -4,6 +4,11 @@
   "name": "Lifestyle",
   "footer": "Resources used for this survey:\n * Tobacco Use Supplement to the Current Population Survey (TUS&#8209;CPS)\n * American Thoracic Society Division of Lung Disease questionnaire (ATS&nbsp;&#8209;&nbsp;DLD&nbsp;&#8209;&nbsp;78)\n * Million Veterans Program\n * Prostate, Lung, Colorectal, and Ovarian (PLCO) Cancer Screening Trial\n * Population Assessment of Tobacco and Health (PATH)\n * National Epidemiologic Survey on Alcohol and Related Conditions (NESARC)\n * Alcohol Use Disorders Identification Test (AUDIT&#8209;C)\n * NM ASSIST (NIDA-Modified Alcohol, Smoking, and Substance Involvement Screening Test)",
   "jsonContent": {
+    "title": {
+      "default": "Lifestyle",
+      "es": "Estilo de Vida",
+      "dev": "DEV_Lifestyle"
+    },
     "showQuestionNumbers": "off",
     "showProgressBar": "bottom",
     "questionTemplates": [

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/medList.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/medList.json
@@ -3,7 +3,11 @@
   "version": 1,
   "name": "Medications",
   "jsonContent": {
-    "title": "Medications",
+    "title": {
+      "default": "Medications",
+      "es": "Medicamentos",
+      "dev": "DEV_Medications"
+    },
     "showQuestionNumbers": "off",
     "showProgressBar": "bottom",
     "pages": [

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/medicalHistory.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/medicalHistory.json
@@ -4,7 +4,11 @@
   "name": "Other Medical History",
   "footer": "Resources used for this survey:\n * All of Us\n * California Teacher’s Study (CTS)\n * Mike Honigberg, American Heart Association\n * OurHealth",
   "jsonContent": {
-  "title": "Other Medical History",
+  "title": {
+    "default": "Other Medical History",
+    "es": "Otro Historial Médico",
+    "dev": "DEV_Other Medical History"
+  },
   "showQuestionNumbers": "off",
   "showProgressBar": "bottom",
   "questionTemplates": [

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/ourHealthConsent.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/ourHealthConsent.json
@@ -4,6 +4,11 @@
   "version": 1,
   "jsonContent":
 {
+  "title": {
+    "default": "OurHealth Consent",
+    "es": "Consentimiento OurHealth",
+    "dev": "DEV_OurHealth Consent"
+  },
   "logoPosition": "right",
   "showQuestionNumbers": "off",
   "showProgressBar": "bottom",

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/phq9gad7.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/phq9gad7.json
@@ -4,6 +4,11 @@
   "name": "Mental Health",
   "footer": "UHS Rev 4/2020, Developed by Drs. Robert L. Spitzer, Janet B.W. Williams, Kurt Kroenke and colleagues, with an educational grant from Pfizer Inc., No permission required to reproduce, translate, display or distribute, 1999. ",
   "jsonContent": {
+    "title": {
+      "default": "Mental Health",
+      "es": "Salud Mental",
+      "dev": "DEV_Mental Health"
+    },
     "showQuestionNumbers": "off",
     "showProgressBar": "bottom",
     "pages": [

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
@@ -11,7 +11,11 @@
     }
   ],
   "jsonContent": {
-    "title": "OurHealth pre-enroll",
+    "title": {
+      "default": "OurHealth pre-enroll",
+      "es": "Preinscripción de OurHealth",
+      "dev": "DEV_OurHealth pre-enroll"
+    },
     "logoPosition": "right",
     "showProgressBar": "bottom",
     "showQuestionNumbers": "off",
@@ -20,70 +24,126 @@
     "pages": [
       {
         "name": "page1",
-        "title": "Study Eligibility",
-        "description": "Thank you for your interest in participating in OurHealth. To get started, please answer these questions to make sure you’re eligible to participate. ",
+        "title": {
+          "default": "Study Eligibility",
+          "es": "Elegibilidad para el estudio",
+          "dev": "DEV_Study Eligibility"
+        },
+        "description": {
+          "default": "Thank you for your interest in participating in OurHealth. To get started, please answer these questions to make sure you’re eligible to participate.",
+          "es": "Gracias por su interés en participar en OurHealth. Para comenzar, responda estas preguntas para asegurarse de que es elegible para participar.",
+          "dev": "DEV_Thank you for your interest in participating in OurHealth. To get started, please answer these questions to make sure you’re eligible to participate."
+        },
         "elements": [
           {
             "type": "radiogroup",
             "name": "hd_hd_preenroll_southAsianAncestry",
-            "title": "I identify as having South Asian ancestry from one or more of these countries: Bangladesh, Bhutan, India, the Maldives, Nepal, Pakistan, or Sri Lanka.",
+            "title": {
+              "default": "I identify as having South Asian ancestry from one or more of these countries: Bangladesh, Bhutan, India, the Maldives, Nepal, Pakistan, or Sri Lanka.",
+              "es": "Me identifico con ascendencia del sur de Asia de uno o más de estos países: Bangladesh, Bután, India, Maldivas, Nepal, Pakistán o Sri Lanka.",
+              "dev": "DEV_I identify as having South Asian ancestry from one or more of these countries: Bangladesh, Bhutan, India, the Maldives, Nepal, Pakistan, or Sri Lanka."
+            },
             "isRequired": true,
             "choices": [
               {
                 "value": "yes",
-                "text": "Yes"
+                "text": {
+                  "default": "Yes",
+                  "es": "Sí",
+                  "dev": "DEV_Yes"
+                }
               },
               {
                 "value": "no",
-                "text": "No"
+                "text": {
+                  "default": "No",
+                  "es": "No",
+                  "dev": "DEV_No"
+                }
               }
             ]
           },
           {
             "type": "radiogroup",
             "name": "hd_hd_preenroll_understandsEnglish",
-            "title": "I am comfortable reading or speaking English.",
+            "title": {
+              "default": "I am comfortable reading or speaking English.",
+              "es": "Me siento cómodo leyendo o hablando inglés.",
+              "dev": "DEV_I am comfortable reading or speaking English."
+            },
             "isRequired": true,
             "choices": [
               {
                 "value": "yes",
-                "text": "Yes"
+                "text": {
+                  "default": "Yes",
+                  "es": "Sí",
+                  "dev": "DEV_Yes"
+                }
               },
               {
                 "value": "no",
-                "text": "No"
+                "text": {
+                  "default": "No",
+                  "es": "No",
+                  "dev": "DEV_No"
+                }
               }
             ]
           },
           {
             "type": "radiogroup",
             "name": "hd_hd_preenroll_isAdult",
-            "title": "I am 18 years old or older.",
+            "title": {
+              "default": "I am 18 years old or older.",
+              "es": "Tengo 18 años o más.",
+              "dev": "DEV_I am 18 years old or older."
+            },
             "isRequired": true,
             "choices": [
               {
                 "value": "yes",
-                "text": "Yes"
+                "text": {
+                  "default": "Yes",
+                  "es": "Sí",
+                  "dev": "DEV_Yes"
+                }
               },
               {
                 "value": "no",
-                "text": "No"
+                "text": {
+                  "default": "No",
+                  "es": "No",
+                  "dev": "DEV_No"
+                }
               }
             ]
           },
           {
             "type": "radiogroup",
             "name": "hd_hd_preenroll_livesInUS",
-            "title": "I live in the United States.",
+            "title": {
+              "default": "I live in the United States.",
+              "es": "Vivo en Estados Unidos.",
+              "dev": "DEV_I live in the United States."
+            },
             "isRequired": true,
             "choices": [
               {
                 "value": "yes",
-                "text": "Yes"
+                "text": {
+                  "default": "Yes",
+                  "es": "Sí",
+                  "dev": "DEV_Yes"
+                }
               },
               {
                 "value": "no",
-                "text": "No"
+                "text": {
+                  "default": "No",
+                  "es": "No",
+                  "dev": "DEV_No"
+                }
               }
             ]
           }
@@ -94,17 +154,33 @@
           {
             "type": "radiogroup",
             "name": "proxy_enrollment",
-            "title": "Who are you enrolling in the study?",
-            "description": "Please choose the correct response. If you are enrolling both yourself and your child/dependent, please first complete the enrollment for yourself and later you can add your dependent",
+            "title": {
+              "default": "Who are you enrolling in the study?",
+              "es": "¿A quién inscribirá en el estudio?",
+              "dev": "DEV_Who are you enrolling in the study?"
+            },
+            "description": {
+              "default": "Please choose the correct response. If you are enrolling both yourself and your child/dependent, please first complete the enrollment for yourself and later you can add your dependent",
+              "es": "Por favor elija la respuesta correcta. Si se está inscribiendo usted y su hijo/dependiente, primero complete la inscripción usted mismo y luego podrá agregar a su dependiente.",
+              "dev": "DEV_Please choose the correct response. If you are enrolling both yourself and your child/dependent, please first complete the enrollment for yourself and later you can add your dependent"
+            },
             "isRequired": true,
             "choices": [
               {
-                "text": "I am enrolling myself.",
-                "value": "false"
+                "value": "false",
+                "text": {
+                  "default": "I am enrolling myself.",
+                  "es": "Me estoy inscribiendo.",
+                  "dev": "DEV_I am enrolling myself."
+                }
               },
               {
-                "text": "I am enrolling on behalf of my child / my legal dependent.",
-                "value": "true"
+                "value": "true",
+                "text": {
+                  "default": "I am enrolling on behalf of my child / my legal dependent.",
+                  "es": "Me inscribo en nombre de mi hijo/mi dependiente legal.",
+                  "dev": "DEV_I am enrolling on behalf of my child / my legal dependent."
+                }
               }
             ]
           }

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/sandboxSurvey.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/sandboxSurvey.json
@@ -4,6 +4,11 @@
   "name": "Sandbox survey",
   "assignToAllNewEnrollees": false,
   "jsonContent": {
+    "title": {
+      "default": "Sandbox survey",
+      "es": "Encuesta de zona de pruebas",
+      "dev": "DEV_Sandbox survey"
+    },
     "showQuestionNumbers": "off",
     "showProgressBar": "bottom",
     "pages": [

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/socialHealth.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/socialHealth.json
@@ -4,6 +4,11 @@
   "name": "Social Determinants of Health",
   "publishedVersion": 1,
   "jsonContent": {
+    "title": {
+      "default": "Social Determinants of Health",
+      "es": "Determinantes Sociales de la Salud",
+      "dev": "DEV_Social Determinants of Health"
+    },
     "showProgressBar": "bottom",
     "showQuestionNumbers": "off",
     "pages": [

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/socialHealthV2.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/socialHealthV2.json
@@ -3,6 +3,11 @@
   "version": 2,
   "name": "Social Determinants of Health",
   "jsonContent": {
+    "title": {
+      "default": "Social Determinants of Health",
+      "es": "Determinantes Sociales de la Salud",
+      "dev": "DEV_Social Determinants of Health"
+    },
     "showProgressBar": "bottom",
     "showQuestionNumbers": "off",
     "pages": [

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/socialHealthV3.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/socialHealthV3.json
@@ -3,6 +3,11 @@
   "version": 3,
   "name": "Social Determinants of Health",
   "jsonContent": {
+    "title": {
+      "default": "Social Determinants of Health",
+      "es": "Determinantes Sociales de la Salud",
+      "dev": "DEV_Social Determinants of Health"
+    },
     "showProgressBar": "bottom",
     "showQuestionNumbers": "off",
     "pages": [

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -134,7 +134,13 @@ export type HubResponse = {
 
 export type TaskWithSurvey = {
   task: ParticipantTask,
-  survey: Survey
+  form: Survey
+}
+
+export type TasksWithSurveys = {
+  consentTasks: TaskWithSurvey[],
+  surveyTasks: TaskWithSurvey[],
+  outreachTasks: TaskWithSurvey[]
 }
 
 export type PortalParticipantUser = {
@@ -223,9 +229,8 @@ export default {
     return await this.processJsonResponse(response)
   },
 
-  async listOutreachActivities(
-  ): Promise<TaskWithSurvey[]> {
-    const url = `${baseEnvUrl(false)}/tasks?taskType=outreach`
+  async listTasksWithSurveys(): Promise<TasksWithSurveys> {
+    const url = `${baseEnvUrl(false)}/tasks`
     const response = await fetch(url, this.getGetInit())
     return await this.processJsonResponse(response)
   },

--- a/ui-participant/src/hub/HubPage.test.tsx
+++ b/ui-participant/src/hub/HubPage.test.tsx
@@ -1,8 +1,10 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import HubPage from './HubPage'
 import { setupRouterTest } from 'test-utils/router-testing-utils'
 import { MockI18nProvider, mockTextsDefault } from '@juniper/ui-core'
+import { mockParticipantTask, mockSurvey } from '../test-utils/test-participant-factory'
+import Api from '../api/api'
 
 jest.mock('../providers/PortalProvider', () => {
   return {
@@ -68,13 +70,26 @@ describe('HubPage', () => {
     expect(screen.getByText('Test Study')).toBeInTheDocument()
   })
 
-  it('is rendered with a Start button for the next new task', () => {
+  it('is rendered with a Start button for the next new task', async () => {
+    const mockTasks = {
+      surveyTasks: [],
+      consentTasks: [
+        {
+          task: mockParticipantTask('CONSENT', 'NEW'),
+          form: mockSurvey('test_consent')
+        }
+      ],
+      outreachTasks: []
+    }
+    jest.spyOn(Api, 'listTasksWithSurveys').mockResolvedValue(mockTasks)
+
     const { RoutedComponent } = setupRouterTest(
       <MockI18nProvider mockTexts={mockTextsDefault}>
-        <HubPage />
+        <HubPage/>
       </MockI18nProvider>)
     render(RoutedComponent)
 
-    expect(screen.getByText('Start Consent')).toBeInTheDocument()
+    const startConsent = await waitFor(() => screen.getByText('Start Consent'))
+    expect(startConsent).toBeInTheDocument()
   })
 })

--- a/ui-participant/src/hub/OutreachTasks.test.tsx
+++ b/ui-participant/src/hub/OutreachTasks.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { mockEnrollee, mockParticipantTask, mockSurvey } from 'test-utils/test-participant-factory'
 import OutreachTasks from './OutreachTasks'
 import { mockStudy, mockStudyEnv } from 'test-utils/test-portal-factory'
-import Api, { TaskWithSurvey } from 'api/api'
+import { TaskWithSurvey } from 'api/api'
 import { MockI18nProvider } from '@juniper/ui-core'
 
 describe('OutreachTasks', () => {
@@ -21,7 +21,7 @@ describe('OutreachTasks', () => {
           targetStableId: 'outreach1',
           studyEnvironmentId: 'studyEnv1'
         },
-        survey: {
+        form: {
           ...mockSurvey('outreach1'),
           surveyType: 'OUTREACH',
           blurb: 'Survey 1 blurb'
@@ -33,17 +33,16 @@ describe('OutreachTasks', () => {
           targetStableId: 'outreach2',
           studyEnvironmentId: 'studyEnv1'
         },
-        survey: {
+        form: {
           ...mockSurvey('outreach2'),
           surveyType: 'OUTREACH',
           blurb: 'Survey 2 blurb'
         }
       }
     ]
-    jest.spyOn(Api, 'listOutreachActivities').mockResolvedValue(tasksWithSurvey)
     const { RoutedComponent } = setupRouterTest(
       <MockI18nProvider>
-        <OutreachTasks enrollees={[enrollee]} studies={[study]}/>
+        <OutreachTasks enrollees={[enrollee]} studies={[study]} outreachTasks={tasksWithSurvey}/>
       </MockI18nProvider>
     )
     render(RoutedComponent)

--- a/ui-participant/src/hub/StudyResearchTasks.test.tsx
+++ b/ui-participant/src/hub/StudyResearchTasks.test.tsx
@@ -1,38 +1,68 @@
 import React from 'react'
 import { setupRouterTest } from 'test-utils/router-testing-utils'
 import { render, screen } from '@testing-library/react'
-import { mockEnrollee, mockParticipantTask } from 'test-utils/test-participant-factory'
+import { mockEnrollee, mockParticipantTask, mockSurvey } from 'test-utils/test-participant-factory'
 import StudyResearchTasks from './StudyResearchTasks'
 import { MockI18nProvider, mockTextsDefault } from '@juniper/ui-core'
+import { TasksWithSurveys } from '../api/api'
 
 describe('HubPage', () => {
   it('renders tasks with consent and required surveys first', () => {
     const enrollee = mockEnrollee()
-    const participantTasks = [
-      {
-        ...mockParticipantTask('SURVEY', 'NEW'),
-        targetName: 'Optional Survey',
-        blocksHub: false,
-        taskOrder: 5
-      },
-      {
-        ...mockParticipantTask('CONSENT', 'NEW'),
-        targetName: 'Our consent form'
-      },
-      {
-        ...mockParticipantTask('SURVEY', 'NEW'),
-        targetName: 'Required Survey',
-        taskOrder: 1
-      },
-      {
-        ...mockParticipantTask('OUTREACH', 'COMPLETE'),
-        targetName: 'Outreach Survey'
-      }
-    ]
+
+    const tasksWithForms: TasksWithSurveys = {
+      surveyTasks: [
+        {
+          task: {
+            ...mockParticipantTask('SURVEY', 'NEW'),
+            blocksHub: false,
+            taskOrder: 5
+          },
+          form: {
+            ...mockSurvey('test_survey1'),
+            name: 'Optional Survey'
+          }
+        },
+        {
+          task: {
+            ...mockParticipantTask('SURVEY', 'NEW'),
+            taskOrder: 1
+          },
+          form: {
+            ...mockSurvey('test_survey2'),
+            name: 'Required Survey'
+          }
+        }
+      ],
+      consentTasks: [
+        {
+          task: mockParticipantTask('CONSENT', 'NEW'),
+          form: {
+            ...mockSurvey('test_consent'),
+            name: 'Our consent form'
+          }
+        }
+      ],
+      outreachTasks: [
+        {
+          task: mockParticipantTask('OUTREACH', 'COMPLETE'),
+          form: {
+            ...mockSurvey('test_outreach'),
+            name: 'Outreach Survey'
+          }
+        }
+      ]
+    }
 
     const { RoutedComponent } = setupRouterTest(
       <MockI18nProvider mockTexts={mockTextsDefault}>
-        <StudyResearchTasks enrollee={enrollee} participantTasks={participantTasks} studyShortcode={'study1'}/>
+        <StudyResearchTasks
+          enrollee={enrollee}
+          participantTasks={[]}
+          studyShortcode={'study1'}
+          consentTasks={tasksWithForms.consentTasks}
+          surveyTasks={tasksWithForms.surveyTasks}
+        />
       </MockI18nProvider>
     )
     render(RoutedComponent)

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -6,7 +6,7 @@ import Api, { Enrollee, Portal, StudyEnvironmentSurvey, Survey, SurveyResponse, 
 
 import { Survey as SurveyComponent } from 'survey-react-ui'
 import {
-  getDataWithCalculatedValues,
+  getDataWithCalculatedValues, getLocalizedSurveyTitle,
   getResumeData,
   getUpdatedAnswers,
   PageNumberControl,
@@ -149,11 +149,13 @@ export function RawSurveyView({
 
   return (
     <>
-      <DocumentTitle title={form.name} />
+      <DocumentTitle title={getLocalizedSurveyTitle(form, selectedLanguage)} />
       {/* f3f3f3 background is to match surveyJs "modern" theme */}
       <div style={{ background: '#f3f3f3' }} className="flex-grow-1">
         { showHeaders && <SurveyReviewModeButton surveyModel={surveyModel}/> }
-        { showHeaders && <h1 className="text-center mt-5 mb-0 pb-0 fw-bold">{form.name}</h1> }
+        { showHeaders && <h1 className="text-center mt-5 mb-0 pb-0 fw-bold">
+          {getLocalizedSurveyTitle(form, selectedLanguage)}
+        </h1> }
         <SurveyComponent model={surveyModel}/>
         <SurveyFooter survey={form} surveyModel={surveyModel}/>
       </div>

--- a/ui-participant/src/util/surveyJsUtils.tsx
+++ b/ui-participant/src/util/surveyJsUtils.tsx
@@ -196,6 +196,23 @@ export function getSurveyJsAnswerList(surveyJSModel: SurveyModel, selectedLangua
     .map(([key, value]) => makeAnswer(value as SurveyJsValueType, key, surveyJSModel.data, selectedLanguage))
 }
 
+/**
+ * Returns the appropriate localized title for the survey
+ */
+export function getLocalizedSurveyTitle(survey: Survey, selectedLanguage?: string): string {
+  const parsedForm = JSON.parse(survey.content)
+
+  if (!parsedForm.title || typeof parsedForm.title !== 'object') {
+    return survey.name
+  }
+
+  if (!selectedLanguage || !parsedForm.title[selectedLanguage]) {
+    return parsedForm.title.default || survey.name
+  }
+
+  return parsedForm.title[selectedLanguage]
+}
+
 /** return an Answer for the given value.  This should be updated to take some sort of questionType/dataType param */
 export function makeAnswer(value: SurveyJsValueType, questionStableId: string,
   surveyJsData: Record<string, SurveyJsValueType>, viewedLanguage?: string): Answer {


### PR DESCRIPTION
#### DESCRIPTION

Opening this for early feedback. There are still a few wrinkles to iron out.

This internationalizes forms by using the built in SurveyJS "title" field. This required a refactor of how we populate the task list in a participant dashboard because we need to also retrieve the form with the task so we can parse the title in the appropriate language. We were already doing this type of retrieval for Outreach tasks, so this rolls Consents and Surveys into the same endpoint.

This is currently a bit rough in a few areas:

* We still ask for and persist the "name" field on surveys when they're created. In the future, setting the "name" field when creating a new survey should automatically inject the title into the survey JSON upon creation.
* Until consents and surveys are unified, some of the backend code is a little bit rough
* Likely needs some harmonization with currently-open proxy PRs

![Screenshot 2024-03-27 at 5 47 08 PM](https://github.com/broadinstitute/juniper/assets/7257391/9fb6c93e-bb25-48c7-a247-842650b99192)

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Repopulate demo
* Login as jsalk
* Confirm that you see Spanish and DEV form titles
