### PR TITLE
[JN-902] Dashboard background is configurable

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/site/LocalizedSiteContent.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/site/LocalizedSiteContent.java
@@ -28,4 +28,5 @@ public class LocalizedSiteContent extends BaseEntity {
     private UUID footerSectionId;
     private HtmlSection footerSection;
     private String primaryBrandColor;
+    private String dashboardBackgroundColor;
 }

--- a/core/src/main/resources/db/changelog/changesets/2024_03_29_add_dashboard_color.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_03_29_add_dashboard_color.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: "add_dashboard_color"
+      author: connorlbark
+      changes:
+        - addColumn:
+            tableName: localized_site_content
+            columns:
+              - column:
+                  name: dashboard_background_color
+                  type: text
+                  defaultValue: 'linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%)'

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -230,6 +230,9 @@ databaseChangeLog:
   - include:
       file: changesets/2024_03_18_localized_email_templates.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2024_03_29_add_dashboard_color.yaml
+      relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/siteContent.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/siteContent.json
@@ -7,6 +7,7 @@
     "navLogoCleanFileName": "juniper-demo-logo.png",
     "navLogoVersion": 1,
     "primaryBrandColor": "rgb(40, 90, 133)",
+    "dashboardBackgroundColor": "linear-gradient(270deg, rgb(133, 135, 227) 0%, rgb(149, 173, 204) 100%)",
     "footerSectionFile": "en/footerSection.json",
     "landingPageFileName": "en/landingPage.json",
     "navbarItemDtos": [{
@@ -23,6 +24,7 @@
     "navLogoCleanFileName": "juniper-demo-logo.png",
     "navLogoVersion": 1,
     "primaryBrandColor": "rgb(40, 90, 133)",
+    "dashboardBackgroundColor": "linear-gradient(270deg, rgb(133, 135, 227) 0%, rgb(149, 173, 204) 100%)",
     "footerSectionFile": "es/footerSection.json",
     "landingPageFileName": "es/landingPage.json",
     "navbarItemDtos": [{
@@ -39,6 +41,7 @@
     "navLogoCleanFileName": "juniper-demo-logo.png",
     "navLogoVersion": 1,
     "primaryBrandColor": "rgb(40, 90, 133)",
+    "dashboardBackgroundColor": "linear-gradient(270deg, rgb(133, 135, 227) 0%, rgb(149, 173, 204) 100%)",
     "footerSectionFile": "dev/footerSection.json",
     "landingPageFileName": "dev/landingPage.json",
     "navbarItemDtos": [{

--- a/populate/src/main/resources/seed/portals/ourhealth/siteContent/siteContent.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/siteContent/siteContent.json
@@ -7,6 +7,7 @@
     "navLogoCleanFileName": "ourhealth-logo.png",
     "navLogoVersion": 1,
     "primaryBrandColor": "rgb(155, 36, 133)",
+    "dashboardBackgroundColor": "linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%)",
     "footerSectionFile": "en/footerSection.json",
     "landingPageFileName": "en/landingPage.json",
     "navbarItemDtos": [{

--- a/ui-admin/src/portal/siteContent/BrandingModal.test.tsx
+++ b/ui-admin/src/portal/siteContent/BrandingModal.test.tsx
@@ -16,14 +16,21 @@ describe('BrandingModal', () => {
       updateLocalContent={updateSpy}
       localContent={{
         ...mockLocalSiteContent(),
-        primaryBrandColor: '#ff0000'
+        primaryBrandColor: '#ff0000',
+        dashboardBackgroundColor: '#00ff00'
       }}/>)
     await waitFor(() => expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument())
     expect(screen.getByTitle('color preview')).toHaveStyle('background-color: #ff0000')
+    expect(screen.getByTitle('dashboard background preview')).toHaveStyle('background-color: #00ff00')
     await userEvent.clear(screen.getByLabelText('Primary Brand Color'))
     await userEvent.type(screen.getByLabelText('Primary Brand Color'), '#00ff00')
+    await userEvent.clear(screen.getByLabelText('Dashboard Background Color'))
+    await userEvent.type(screen.getByLabelText('Dashboard Background Color'), '#0000ff')
     await userEvent.click(screen.getByText('Ok'))
-    expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({ primaryBrandColor: '#00ff00' }))
+    expect(updateSpy).toHaveBeenCalledWith(expect.objectContaining({
+      primaryBrandColor: '#00ff00',
+      dashboardBackgroundColor: '#0000ff'
+    }))
   })
 
   test('nav logo is updatable', async () => {

--- a/ui-admin/src/portal/siteContent/BrandingModal.tsx
+++ b/ui-admin/src/portal/siteContent/BrandingModal.tsx
@@ -36,6 +36,7 @@ export default function BrandingModal({ onDismiss, localContent, updateLocalCont
   }, [portalShortcode])
 
   const [color, setColor] = useState(localContent.primaryBrandColor)
+  const [backgroundColor, setBackgroundColor] = useState(localContent.dashboardBackgroundColor)
 
   return <Modal show={true}
     onHide={() => {
@@ -62,7 +63,22 @@ export default function BrandingModal({ onDismiss, localContent, updateLocalCont
             onChange={event => {
               setColor(event.target.value)
             }}/>
-          <span className="px-4 ms-2" style={{ backgroundColor: color }} title="color preview"/>
+          <span className="px-4 ms-2" style={{ background: color }} title="color preview"/>
+        </div>
+
+        <label htmlFor="colorInput" className="mt-3">Dashboard Background Color</label>
+        <InfoPopup content={<span>
+          Background color for the participant&lsquo;s dashboard. This should be
+          specified as a CSS color string, either hex (<code>#33aabb</code>), RGB (<code>rgb(25,180,100)</code>),
+          or any other valid CSS color string (e.g., <code>linear-gradient</code>)
+        </span>}/>
+        <div className="d-flex">
+          <input type="text" className="form-control" id="colorInput"
+            value={backgroundColor}
+            onChange={event => {
+              setBackgroundColor(event.target.value)
+            }}/>
+          <span className="px-4 ms-2" style={{ background: backgroundColor }} title="color preview"/>
         </div>
 
 
@@ -75,12 +91,14 @@ export default function BrandingModal({ onDismiss, localContent, updateLocalCont
           updateLocalContent({
             ...localContent,
             primaryBrandColor: color,
+            dashboardBackgroundColor: backgroundColor,
             navLogoCleanFileName: selectedNavLogo?.cleanFileName ?? '',
             navLogoVersion: selectedNavLogo?.version ?? 0
           })
           onDismiss()
         }}
-      >Ok</button>
+      >Ok
+      </button>
       <button className="btn btn-secondary" onClick={onDismiss}>Cancel</button>
     </Modal.Footer>
   </Modal>

--- a/ui-admin/src/portal/siteContent/BrandingModal.tsx
+++ b/ui-admin/src/portal/siteContent/BrandingModal.tsx
@@ -66,19 +66,19 @@ export default function BrandingModal({ onDismiss, localContent, updateLocalCont
           <span className="px-4 ms-2" style={{ background: color }} title="color preview"/>
         </div>
 
-        <label htmlFor="colorInput" className="mt-3">Dashboard Background Color</label>
+        <label htmlFor="backgroundColorInput" className="mt-3">Dashboard Background Color</label>
         <InfoPopup content={<span>
           Background color for the participant&lsquo;s dashboard. This should be
           specified as a CSS color string, either hex (<code>#33aabb</code>), RGB (<code>rgb(25,180,100)</code>),
           or any other valid CSS color string (e.g., <code>linear-gradient</code>)
         </span>}/>
         <div className="d-flex">
-          <input type="text" className="form-control" id="colorInput"
+          <input type="text" className="form-control" id="backgroundColorInput"
             value={backgroundColor}
             onChange={event => {
               setBackgroundColor(event.target.value)
             }}/>
-          <span className="px-4 ms-2" style={{ background: backgroundColor }} title="color preview"/>
+          <span className="px-4 ms-2" style={{ background: backgroundColor }} title="dashboard background preview"/>
         </div>
 
 

--- a/ui-core/src/types/landingPageConfig.ts
+++ b/ui-core/src/types/landingPageConfig.ts
@@ -15,6 +15,7 @@ export type LocalSiteContent = {
   navLogoVersion: number
   footerSection?: HtmlSection
   primaryBrandColor?: string
+  dashboardBackgroundColor?: string
 }
 
 export type HtmlPage = {

--- a/ui-participant/src/App.tsx
+++ b/ui-participant/src/App.tsx
@@ -52,6 +52,10 @@ function App() {
     brandConfig.brandColor = localContent.primaryBrandColor
   }
 
+  if (localContent.dashboardBackgroundColor) {
+    brandConfig.backgroundColor = localContent.dashboardBackgroundColor
+  }
+
   useEffect(() => {
     const isCompatible = isBrowserCompatible()
     if (!isCompatible) {

--- a/ui-participant/src/hub/HubPage.tsx
+++ b/ui-participant/src/hub/HubPage.tsx
@@ -7,7 +7,7 @@ import { isTaskActive } from './TaskLink'
 import { DocumentTitle } from 'util/DocumentTitle'
 
 import { HubMessageAlert, HubUpdateMessage, useHubUpdate } from './hubUpdates'
-import { ParticipantDashboardAlert, alertDefaults } from '@juniper/ui-core'
+import { alertDefaults, ParticipantDashboardAlert } from '@juniper/ui-core'
 import KitBanner from './kit/KitBanner'
 import StudyResearchTasks from './StudyResearchTasks'
 import OutreachTasks from './OutreachTasks'
@@ -41,7 +41,7 @@ export default function HubPage() {
       <DocumentTitle title="Dashboard" />
       <div
         className="hub-dashboard-background flex-grow-1"
-        style={{ background: 'linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%' }}
+        style={{ background: 'var(--dashboard-background-color)' }}
       >
         {!hasActiveTasks && noActivitiesAlert && <HubMessageAlert
           message={{

--- a/ui-participant/src/participant/ParticipantProfile.tsx
+++ b/ui-participant/src/participant/ParticipantProfile.tsx
@@ -85,7 +85,7 @@ export function ParticipantProfile(
 
   return <div
     className="hub-dashboard-background flex-grow-1"
-    style={{ background: 'linear-gradient(270deg, #D5ADCC 0%, #E5D7C3 100%' }} // todo: don't hardcode, see jn-902
+    style={{ background: 'var(--dashboard-background-color)' }} // todo: don't hardcode, see jn-902
   >
     <div className="row mx-0 justify-content-center py-5">
       <div className="col-12 col-sm-10 col-lg-6">

--- a/ui-participant/src/util/brandUtils.tsx
+++ b/ui-participant/src/util/brandUtils.tsx
@@ -3,6 +3,7 @@ import { cssVar, parseToRgb, tint } from 'polished'
 
 export type BrandConfiguration = {
   brandColor?: string;
+  backgroundColor?: string;
 }
 
 /**
@@ -10,11 +11,13 @@ export type BrandConfiguration = {
  */
 export const brandStyles = (config: BrandConfiguration): CSSProperties => {
   const brandColor = config.brandColor || cssVar('--bs-blue') as string
+  const backgroundColor = config.backgroundColor || '#fff'
   const brandColorRgb = parseToRgb(brandColor)
 
   return {
     // Custom properties used in index.css.
     '--brand-color': brandColor,
+    '--dashboard-background-color': backgroundColor,
     '--brand-color-rgb': `${brandColorRgb.red}, ${brandColorRgb.green}, ${brandColorRgb.blue}`,
     '--brand-color-contrast': '#fff',
     '--brand-color-shift-10': tint(0.10, brandColor),


### PR DESCRIPTION
#### DESCRIPTION

Paired with Matt

Makes dashboard background configurable in UI. 

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Restart admin API
- Do not populate - ensure that ourhealth dashboard background looks good
- Populate ourhealth & demo - ensure that demo has its own, unique background
- Try changing background and ensure that it still works - NOTE it breaks multi-lang, so you have to stay on English for this. There could be an argument to be made that these brandings should be outside of the local site content, but we figured that was out the scope of this PR to determine if that made sense.