### PR TITLE
[JN-978] enabling single-survey publish UX (member's choice)

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/portal/PortalPublishingExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/portal/PortalPublishingExtService.java
@@ -44,10 +44,6 @@ public class PortalPublishingExtService {
     if (!user.isSuperuser()) {
       throw new PermissionDeniedException("You do not have permission to update environments");
     }
-    try {
-      return portalPublishingService.applyChanges(portalShortcode, destEnv, change, user);
-    } catch (Exception e) {
-      throw new IllegalArgumentException(e);
-    }
+    return portalPublishingService.applyChanges(portalShortcode, destEnv, change, user);
   }
 }

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -236,28 +236,28 @@ export type MailingListContact = {
 
 
 export type PortalEnvironmentChange = {
-  siteContentChange: VersionedEntityChange,
-  configChanges: ConfigChange[],
-  preRegSurveyChanges: VersionedEntityChange,
+  siteContentChange: VersionedEntityChange
+  configChanges: ConfigChange[]
+  preRegSurveyChanges: VersionedEntityChange
   triggerChanges: ListChange<Trigger, VersionedConfigChange>
-  participantDashboardAlertChanges: ParticipantDashboardAlertChange[],
+  participantDashboardAlertChanges: ParticipantDashboardAlertChange[]
   studyEnvChanges: StudyEnvironmentChange[]
 }
 
 export type StudyEnvironmentChange = {
-  studyShortcode: string,
-  configChanges: ConfigChange[],
-  preEnrollSurveyChanges: VersionedEntityChange,
-  consentChanges: ListChange<StudyEnvironmentConsent, VersionedConfigChange>,
-  surveyChanges: ListChange<StudyEnvironmentSurvey, VersionedConfigChange>,
+  studyShortcode: string
+  configChanges: ConfigChange[]
+  preEnrollSurveyChanges: VersionedEntityChange
+  consentChanges: ListChange<StudyEnvironmentConsent, VersionedConfigChange>
+  surveyChanges: ListChange<StudyEnvironmentSurvey, VersionedConfigChange>
   triggerChanges: ListChange<Trigger, VersionedConfigChange>
 }
 
 export type VersionedEntityChange = {
-  changed: true,
-  oldStableId: string,
-  newStableId: string,
-  oldVersion: number,
+  changed: true
+  oldStableId: string
+  newStableId: string
+  oldVersion: number
   newVersion: number
 } | {
   changed: false
@@ -265,25 +265,26 @@ export type VersionedEntityChange = {
 
 type ConfigChangeValue = object | string | boolean
 export type ConfigChange = {
-  propertyName: string,
-  oldValue: ConfigChangeValue,
+  propertyName: string
+  oldValue: ConfigChangeValue
   newValue: ConfigChangeValue
 }
 
 export type ListChange<T, CT> = {
-  addedItems: T[],
-  removedItems: T[],
+  addedItems: T[]
+  removedItems: T[]
   changedItems: CT[]
 }
 
 export type VersionedConfigChange = {
-  sourceId: string,
-  configChanges: ConfigChange[],
+  sourceId: string
+  destId: string
+  configChanges: ConfigChange[]
   documentChange: VersionedEntityChange
 }
 
 export type ParticipantDashboardAlertChange = {
-  trigger: AlertTrigger,
+  trigger: AlertTrigger
   changes: ConfigChange[]
 }
 

--- a/ui-admin/src/portal/publish/diffComponents.test.tsx
+++ b/ui-admin/src/portal/publish/diffComponents.test.tsx
@@ -34,6 +34,7 @@ describe('configChangeList', () => {
       addedItems: [],
       changedItems: [{
         sourceId: 'someGuid',
+        destId: 'aotherGuid',
         configChanges: [],
         documentChange: { oldVersion: 1, newVersion: 2, oldStableId: 'foo', newStableId: 'bar', changed: true }
       }],

--- a/ui-admin/src/study/surveys/SurveyEnvrionmentTable.test.tsx
+++ b/ui-admin/src/study/surveys/SurveyEnvrionmentTable.test.tsx
@@ -8,6 +8,8 @@ import { screen } from '@testing-library/react'
 import { StudyEnvironmentSurveyNamed } from '@juniper/ui-core'
 import SurveyEnvironmentTable from './SurveyEnvironmentTable'
 import { renderWithRouter } from '../../test-utils/router-testing-utils'
+import { getTableCell } from '../../test-utils/table-testing-utils'
+import userEvent from '@testing-library/user-event'
 
 describe('SurveyEnvironmentTest', () => {
   test('shows survey name and versions', async () => {
@@ -16,14 +18,14 @@ describe('SurveyEnvironmentTest', () => {
       envName: 'sandbox',
       survey: {
         ...mockSurvey(),
-        version: 1
+        version: 2
       }
     }, {
       ...mockConfiguredSurvey(),
       envName: 'irb',
       survey: {
         ...mockSurvey(),
-        version: 2
+        version: 1
       }
     }]
 
@@ -38,7 +40,47 @@ describe('SurveyEnvironmentTest', () => {
       updateConfiguredSurvey={jest.fn()}
     />)
 
-    // button should appear since there are participants assigned to version 1
     expect(screen.getByText(configuredSurveys[0].survey.name)).toBeInTheDocument()
+  })
+
+  test('shows publishing controls', async () => {
+    const configuredSurveys: StudyEnvironmentSurveyNamed[] = [{
+      ...mockConfiguredSurvey(),
+      envName: 'sandbox',
+      survey: {
+        ...mockSurvey(),
+        version: 2
+      }
+    }, {
+      ...mockConfiguredSurvey(),
+      envName: 'irb',
+      survey: {
+        ...mockSurvey(),
+        version: 1
+      }
+    }]
+
+    renderWithRouter(<SurveyEnvironmentTable stableIds={[configuredSurveys[0].survey.stableId]}
+      studyEnvParams={mockStudyEnvParams()}
+      configuredSurveys={configuredSurveys}
+      setSelectedSurveyConfig={jest.fn()}
+      showDeleteSurveyModal={false}
+      setShowDeleteSurveyModal={jest.fn()}
+      showArchiveSurveyModal={false}
+      setShowArchiveSurveyModal={jest.fn()}
+      updateConfiguredSurvey={jest.fn()}
+    />)
+
+    expect(screen.getByText(configuredSurveys[0].survey.name)).toBeInTheDocument()
+    const sandboxCell = getTableCell(screen.getByRole('table'), configuredSurveys[0].survey.name, 'sandbox')
+    await userEvent.click(sandboxCell.querySelector('button[aria-label="Configure survey menu"]')!)
+    expect(screen.getByText('Publish to irb')).toBeVisible()
+
+    const irbCell = getTableCell(screen.getByRole('table'), configuredSurveys[0].survey.name, 'sandbox')
+    await userEvent.click(irbCell.querySelector('button[aria-label="Configure survey menu"]')!)
+    expect(screen.getByText('Publish to live')).toBeVisible()
+    await userEvent.click(screen.getByText('Publish to live'))
+    expect(screen.getByText('This survey is not current in the live environment, and publishing will add it.'))
+      .toBeInTheDocument()
   })
 })

--- a/ui-admin/src/study/surveys/SurveyPublishModal.tsx
+++ b/ui-admin/src/study/surveys/SurveyPublishModal.tsx
@@ -1,0 +1,86 @@
+import React, { useContext, useState } from 'react'
+import { StudyEnvParams } from 'study/StudyEnvironmentRouter'
+import Modal from 'react-bootstrap/Modal'
+import LoadingSpinner from 'util/LoadingSpinner'
+
+import { EnvironmentName, StudyEnvironmentSurvey } from '@juniper/ui-core'
+import Api, { PortalEnvironmentChange } from 'api/api'
+import { emptyChangeSet, emptyStudyEnvChange } from 'portal/publish/PortalEnvDiffView'
+import { doApiLoad } from '../../api/api-utils'
+import { Store } from 'react-notifications-component'
+
+import { successNotification } from '../../util/notifications'
+import { PortalContext, PortalContextT } from '../../portal/PortalProvider'
+
+/** renders a modal that allows publishing a single survey to a new environment */
+const SurveyPublishModal = ({
+  studyEnvParams, surveyName, destinationEnv, sourceConfig, destConfig, onDismiss
+}: {
+  studyEnvParams: StudyEnvParams, surveyName: string, sourceConfig: StudyEnvironmentSurvey,
+  destConfig?: StudyEnvironmentSurvey, destinationEnv: EnvironmentName, onDismiss: () => void}) => {
+  const [isLoading, setIsLoading] = useState(false)
+  const { reloadPortal } = useContext(PortalContext) as PortalContextT
+  const changeSet: PortalEnvironmentChange = {
+    ...emptyChangeSet,
+    studyEnvChanges: [
+      {
+        ...emptyStudyEnvChange,
+        studyShortcode: studyEnvParams.studyShortcode,
+        surveyChanges: {
+          removedItems: [],
+          // whether we're adding or changing something depends on whether the survey is already in the dest. env.
+          addedItems: destConfig ? [] : [sourceConfig],
+          changedItems: destConfig ? [
+            {
+              sourceId: sourceConfig.id,
+              destId: destConfig.id,
+              configChanges: [],
+              documentChange: {
+                changed: true,
+                oldVersion: destConfig.survey.version,
+                oldStableId: destConfig.survey.stableId,
+                newVersion: sourceConfig.survey.version,
+                newStableId: sourceConfig.survey.stableId
+              }
+            }
+          ] : []
+        }
+      }
+    ]
+  }
+
+  const publish = async () => {
+    doApiLoad(async () => {
+      await Api.applyEnvChanges(studyEnvParams.portalShortcode, destinationEnv, changeSet)
+      Store.addNotification(successNotification(`${destinationEnv} environment updated`))
+      await reloadPortal(studyEnvParams.portalShortcode)
+      onDismiss()
+    }, { setIsLoading })
+  }
+
+  return <Modal show={true} onHide={onDismiss}>
+    <Modal.Header closeButton>
+      <Modal.Title>Publish {surveyName}</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>
+      <div className="mb-3">
+        Confirm publishing version {sourceConfig.survey.version} to
+        the <span className="fw-bold">{destinationEnv}</span> environment.
+      </div>
+      {destConfig && <div>This will replace version {destConfig.survey.version} in that environment.</div>}
+      {!destConfig && <div>This survey is not current in the {destinationEnv} environment,
+        and publishing will add it.</div>}
+    </Modal.Body>
+    <Modal.Footer>
+      <LoadingSpinner isLoading={isLoading}>
+        <button
+          className="btn btn-primary"
+          onClick={publish}
+        >Ok</button>
+        <button className="btn btn-secondary" onClick={onDismiss}>Cancel</button>
+      </LoadingSpinner>
+    </Modal.Footer>
+  </Modal>
+}
+
+export default SurveyPublishModal


### PR DESCRIPTION
#### DESCRIPTION

This adds a UX shortcut for publishing surveys one at a time.  
![image](https://github.com/broadinstitute/juniper/assets/2800795/02743814-1e6a-4b04-a674-554cf8d38bcc)

![image](https://github.com/broadinstitute/juniper/assets/2800795/099f4127-e07c-4a2c-9d9c-ef4bc4f8f8db)

This doesn't change any backend functionality -- I think it's better to have a single publish API that takes a relatively complex object than to try to build out lots of custom APIs for various publishing flows.  This does upgrade the error handling of publishing methods to match our latest patterns.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1.  redeploy apiAdminApp 
2. repopulate demo
3. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/forms
4. click on the ... menu for "Social Determinants of Health" in the sandbox environment
5. click "Publish to IRB"
6. click "Ok" in the modal
7. confirm the irb version is now version 3
