### PR TITLE
[JN-980] save preferred language during registration

### DIFF
--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/registration/RegistrationController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/registration/RegistrationController.java
@@ -55,7 +55,11 @@ public class RegistrationController implements RegistrationApi {
 
   @Override
   public ResponseEntity<Object> internalRegister(
-      String portalShortcode, String envName, String preferredLanguage, UUID preRegResponseId, RegistrationInfo body) {
+      String portalShortcode,
+      String envName,
+      String preferredLanguage,
+      UUID preRegResponseId,
+      RegistrationInfo body) {
     EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
 
     RegistrationService.RegistrationResult registrationResult =

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/registration/RegistrationController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/registration/RegistrationController.java
@@ -55,12 +55,12 @@ public class RegistrationController implements RegistrationApi {
 
   @Override
   public ResponseEntity<Object> internalRegister(
-      String portalShortcode, String envName, UUID preRegResponseId, RegistrationInfo body) {
+      String portalShortcode, String envName, String preferredLanguage, UUID preRegResponseId, RegistrationInfo body) {
     EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
 
     RegistrationService.RegistrationResult registrationResult =
         registrationService.register(
-            portalShortcode, environmentName, body.getEmail(), preRegResponseId, null);
+            portalShortcode, environmentName, body.getEmail(), preRegResponseId, preferredLanguage);
     // log in the user if not already
     if (registrationResult.participantUser().getToken() == null) {
       CurrentUserService.UserLoginDto loggedInUser =

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/registration/RegistrationController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/registration/RegistrationController.java
@@ -39,11 +39,15 @@ public class RegistrationController implements RegistrationApi {
 
   @Override
   public ResponseEntity<Object> register(
-      String portalShortcode, String envName, UUID preRegResponseId, RegistrationInfo body) {
+      String portalShortcode,
+      String envName,
+      String preferredLanguage,
+      UUID preRegResponseId,
+      RegistrationInfo body) {
     EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
     String token = requestUtilService.requireToken(request);
     registrationService.register(
-        portalShortcode, environmentName, body.getEmail(), preRegResponseId);
+        portalShortcode, environmentName, body.getEmail(), preRegResponseId, preferredLanguage);
     CurrentUserService.UserLoginDto userLoginDto =
         currentUserService.tokenLogin(token, portalShortcode, environmentName);
     return ResponseEntity.ok(userLoginDto);
@@ -56,7 +60,7 @@ public class RegistrationController implements RegistrationApi {
 
     RegistrationService.RegistrationResult registrationResult =
         registrationService.register(
-            portalShortcode, environmentName, body.getEmail(), preRegResponseId);
+            portalShortcode, environmentName, body.getEmail(), preRegResponseId, null);
     // log in the user if not already
     if (registrationResult.participantUser().getToken() == null) {
       CurrentUserService.UserLoginDto loggedInUser =

--- a/api-participant/src/main/resources/api/openapi.yml
+++ b/api-participant/src/main/resources/api/openapi.yml
@@ -377,6 +377,7 @@ paths:
       parameters:
         - { name: portalShortcode, in: path, required: true, schema: { type: string } }
         - { name: envName, in: path, required: true, schema: { type: string } }
+        - { name: preferredLanguage, in: query, required: false, schema: { type: string } }
         - { name: preRegResponseId, in: query, required: false, schema: { type: string, format: uuid } }
       requestBody:
         content:

--- a/api-participant/src/main/resources/api/openapi.yml
+++ b/api-participant/src/main/resources/api/openapi.yml
@@ -357,6 +357,7 @@ paths:
       parameters:
         - { name: portalShortcode, in: path, required: true, schema: { type: string } }
         - { name: envName, in: path, required: true, schema: { type: string } }
+        - { name: preferredLanguage, in: query, required: false, schema: { type: string } }
         - { name: preRegResponseId, in: query, required: false, schema: { type: string, format: uuid } }
       requestBody:
         content:

--- a/core/src/main/java/bio/terra/pearl/core/service/consent/ConsentTaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/consent/ConsentTaskDispatcher.java
@@ -108,7 +108,6 @@ public class ConsentTaskDispatcher {
                                                    List<StudyEnvironmentConsent> studyEnvConsents) {
         List<ParticipantTask> tasks = new ArrayList<>();
         for (StudyEnvironmentConsent studyConsent : studyEnvConsents) {
-            System.out.println(enrollee.isSubject());
             // TODO JN-977: this logic will need to change because we might need to support consents for proxies
             if (enrollee.isSubject() && enrolleeSearchExpressionParser
                     .parseRule(studyConsent.getEligibilityRule())

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -99,7 +99,7 @@ public class EnrolleeImportService {
         if (participantUser.getUsername() == null) {
             throw new IllegalArgumentException("username must be provided for enrollee import");
         }
-        RegistrationService.RegistrationResult regResult = registrationService.register(portalShortcode, studyEnv.getEnvironmentName(), participantUser.getUsername(), null);
+        RegistrationService.RegistrationResult regResult = registrationService.register(portalShortcode, studyEnv.getEnvironmentName(), participantUser.getUsername(), null, null);
         /** temporarily update the profile to no emails since they'll receive a special welcome email */
         regResult.profile().setDoNotEmail(true);
         profileService.update(regResult.profile(), auditInfo);

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/RegistrationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/RegistrationService.java
@@ -96,13 +96,13 @@ public class RegistrationService {
 
     @Transactional
     public RegistrationResult register(String portalShortcode, EnvironmentName environmentName,
-                                       String email, UUID preRegResponseId) {
+                                       String email, UUID preRegResponseId, String preferredLanguage) {
         RequiredRegistrationInfo info = RequiredRegistrationInfo.builder().email(email).build();
-        return register(portalShortcode, environmentName, preRegResponseId, info);
+        return register(portalShortcode, environmentName, preRegResponseId, preferredLanguage, info);
     }
 
     private RegistrationResult register(String portalShortcode, EnvironmentName environmentName, UUID preRegResponseId,
-                                        RequiredRegistrationInfo info) {
+                                        String preferredLanguage, RequiredRegistrationInfo info) {
         PortalEnvironment portalEnv = portalEnvService.findOne(portalShortcode, environmentName).get();
         PreregistrationResponse preRegResponse = null;
         if (portalEnv.getPreRegSurveyId() != null) {
@@ -126,6 +126,9 @@ public class RegistrationService {
                 .givenName(info.getFirstName())
                 .familyName(info.getLastName())
                 .build();
+        if(preferredLanguage != null){
+            profile.setPreferredLanguage(preferredLanguage);
+        }
         ppUser.setProfile(profile);
 
         ppUser = portalParticipantUserService.create(ppUser);

--- a/core/src/test/java/bio/terra/pearl/core/service/workflow/RegistrationServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/workflow/RegistrationServiceTests.java
@@ -40,7 +40,7 @@ public class RegistrationServiceTests extends BaseSpringBootTest {
         String portalShortcode = portalService.find(portalEnv.getPortalId()).get().getShortcode();
         String username = "test" + RandomStringUtils.randomAlphabetic(5) + "@test.com";
         RegistrationService.RegistrationResult result = registrationService.register(portalShortcode,
-                portalEnv.getEnvironmentName(), username, null);
+                portalEnv.getEnvironmentName(), username, null, null);
         Assertions.assertEquals(username, result.participantUser().getUsername());
         Assertions.assertTrue(participantUserService.findOne(username, portalEnv.getEnvironmentName()).isPresent());
     }

--- a/core/src/test/java/bio/terra/pearl/core/service/workflow/RegistrationServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/workflow/RegistrationServiceTests.java
@@ -5,12 +5,9 @@ import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
 import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
 import bio.terra.pearl.core.factory.portal.PortalEnvironmentFactory;
 import bio.terra.pearl.core.model.EnvironmentName;
-import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
-import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.participant.ParticipantUserService;
-import bio.terra.pearl.core.service.participant.ProfileService;
 import bio.terra.pearl.core.service.portal.PortalService;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Assertions;
@@ -18,8 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 public class RegistrationServiceTests extends BaseSpringBootTest {
     @Autowired
@@ -32,8 +27,6 @@ public class RegistrationServiceTests extends BaseSpringBootTest {
     private ParticipantUserService participantUserService;
     @Autowired
     private PortalService portalService;
-    @Autowired
-    private ProfileService profileService;
     @Autowired
     private EnrolleeFactory enrolleeFactory;
 

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -13,7 +13,7 @@ import {
   SurveyResponse
 } from '@juniper/ui-core'
 import { defaultApiErrorHandle } from 'util/error-utils'
-import queryString from 'querystring'
+import queryString from 'query-string'
 
 export type {
   Answer,
@@ -305,9 +305,11 @@ export default {
   },
 
   /** submits registration data for a particular portal, from an anonymous user */
-  async internalRegister({ preRegResponseId, fullData }: { preRegResponseId: string, fullData: object }):
+  async internalRegister({ preRegResponseId, fullData, preferredLanguage }: {
+    preRegResponseId: string, fullData: object, preferredLanguage: string
+  }):
     Promise<RegistrationResponse> {
-    const params = queryString.stringify({ preRegResponseId })
+    const params = queryString.stringify({ preRegResponseId, preferredLanguage })
     const url = `${baseEnvUrl(true)}/internalRegister?${params}`
     const response = await fetch(url, {
       method: 'POST',

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -289,13 +289,23 @@ export default {
     }
   },
 
-  async register({ preRegResponseId, email, accessToken }: {
-    preRegResponseId: string | null, email: string, accessToken: string }): Promise<LoginResult> {
+  async register({ preRegResponseId, email, accessToken, preferredLanguage }: {
+    preRegResponseId: string | null, email: string, accessToken: string, preferredLanguage?: string
+  }): Promise<LoginResult> {
     bearerToken = accessToken
     let url = `${baseEnvUrl(false)}/register`
+    const queryParams = []
     if (preRegResponseId) {
-      url += `?preRegResponseId=${preRegResponseId}`
+      queryParams.push(`preRegResponseId=${preRegResponseId}`)
     }
+    if (preferredLanguage) {
+      queryParams.push(`preferredLanguage=${preferredLanguage}`)
+    }
+    // Joining all parameters with '&' and appending to the url
+    if (queryParams.length > 0) {
+      url += `?${queryParams.join('&')}`
+    }
+
     const response = await fetch(url, {
       method: 'POST',
       headers: this.getInitHeaders(),

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -13,6 +13,7 @@ import {
   SurveyResponse
 } from '@juniper/ui-core'
 import { defaultApiErrorHandle } from 'util/error-utils'
+import queryString from 'querystring'
 
 export type {
   Answer,
@@ -293,19 +294,8 @@ export default {
     preRegResponseId: string | null, email: string, accessToken: string, preferredLanguage: string | null
   }): Promise<LoginResult> {
     bearerToken = accessToken
-    let url = `${baseEnvUrl(false)}/register`
-    const queryParams = []
-    if (preRegResponseId) {
-      queryParams.push(`preRegResponseId=${preRegResponseId}`)
-    }
-    if (preferredLanguage) {
-      queryParams.push(`preferredLanguage=${preferredLanguage}`)
-    }
-    // Joining all parameters with '&' and appending to the url
-    if (queryParams.length > 0) {
-      url += `?${queryParams.join('&')}`
-    }
-
+    const params = queryString.stringify({ preRegResponseId, preferredLanguage })
+    const url = `${baseEnvUrl(false)}/register?${params}`
     const response = await fetch(url, {
       method: 'POST',
       headers: this.getInitHeaders(),
@@ -317,10 +307,8 @@ export default {
   /** submits registration data for a particular portal, from an anonymous user */
   async internalRegister({ preRegResponseId, fullData }: { preRegResponseId: string, fullData: object }):
     Promise<RegistrationResponse> {
-    let url = `${baseEnvUrl(true)}/internalRegister`
-    if (preRegResponseId) {
-      url += `?preRegResponseId=${preRegResponseId}`
-    }
+    const params = queryString.stringify({ preRegResponseId })
+    const url = `${baseEnvUrl(true)}/internalRegister?${params}`
     const response = await fetch(url, {
       method: 'POST',
       headers: this.getInitHeaders(),
@@ -337,16 +325,8 @@ export default {
   async createEnrollee({ studyShortcode, preEnrollResponseId }:
                          { studyShortcode: string, preEnrollResponseId: string | null }):
     Promise<HubResponse> {
-    let url = `${baseStudyEnvUrl(false, studyShortcode)}/enrollee`
-    const queryParams = []
-
-    if (preEnrollResponseId) {
-      queryParams.push(`preEnrollResponseId=${preEnrollResponseId}`)
-    }
-    // Joining all parameters with '&' and appending to the url
-    if (queryParams.length > 0) {
-      url += `?${queryParams.join('&')}`
-    }
+    const params = queryString.stringify({ preEnrollResponseId })
+    const url = `${baseStudyEnvUrl(false, studyShortcode)}/enrollee?${params}`
     const response = await fetch(url, {
       method: 'POST',
       headers: this.getInitHeaders()

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -290,7 +290,7 @@ export default {
   },
 
   async register({ preRegResponseId, email, accessToken, preferredLanguage }: {
-    preRegResponseId: string | null, email: string, accessToken: string, preferredLanguage?: string
+    preRegResponseId: string | null, email: string, accessToken: string, preferredLanguage: string | null
   }): Promise<LoginResult> {
     bearerToken = accessToken
     let url = `${baseEnvUrl(false)}/register`

--- a/ui-participant/src/browserPersistentState.tsx
+++ b/ui-participant/src/browserPersistentState.tsx
@@ -14,6 +14,9 @@ export const usePreEnrollResponseId = () => useSessionStorage('preEnrollResponse
 /** store the study being enrolled in so that we remember it when coming back from B2C sign-up. */
 export const useReturnToStudy = () => useSessionStorage('returnToStudy')
 
+/** store the participants preferred language so that we remember it when coming back from B2C sign-up. */
+export const useReturnToLanguage = () => useSessionStorage('returnToLanguage')
+
 /** store whether the user has successfully provided a password for a password protected study */
 export const useHasProvidedStudyPassword = (studyShortcode: string): [boolean, () => void] => {
   const [value, setValue] = useSessionStorage(`provided-study-password/${studyShortcode}`)

--- a/ui-participant/src/landing/registration/Registration.tsx
+++ b/ui-participant/src/landing/registration/Registration.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 import { useParams } from 'react-router-dom'
 import { useAuth } from 'react-oidc-context'
-import { useReturnToStudy } from 'browserPersistentState'
+import { useReturnToLanguage, useReturnToStudy } from 'browserPersistentState'
 import { PageLoadingIndicator } from 'util/LoadingSpinner'
 import { useI18n } from '@juniper/ui-core'
 
@@ -11,11 +11,13 @@ export default function Registration() {
   const { selectedLanguage } = useI18n()
   const studyShortcode = useParams().studyShortcode || null
   const [, setReturnToStudy] = useReturnToStudy()
+  const [, setReturnToLanguage] = useReturnToLanguage()
 
   const register = () => {
     // Remember study for when we come back from B2C,
     // at which point RedirectFromOAuth will complete the registration
     setReturnToStudy(studyShortcode)
+    setReturnToLanguage(selectedLanguage)
     auth.signinRedirect({
       redirectMethod: 'replace',
       extraQueryParams: {

--- a/ui-participant/src/landing/registration/RegistrationUnauthed.tsx
+++ b/ui-participant/src/landing/registration/RegistrationUnauthed.tsx
@@ -5,7 +5,7 @@ import Api, { Survey } from 'api/api'
 import { RegistrationContextT } from './PortalRegistrationRouter'
 import { useUser } from '../../providers/UserProvider'
 import { useNavigate } from 'react-router-dom'
-import { defaultSurvey } from '@juniper/ui-core'
+import { defaultSurvey, useI18n } from '@juniper/ui-core'
 
 /** This registration survey is a hardcoded survey--will be deprecated soon */
 const registrationSurvey = {
@@ -59,6 +59,7 @@ export default function RegistrationUnauthed({ registrationContext, returnTo }: 
   const pager = { pageNumber: 0, updatePageNumber: () => 0 }
   const { surveyModel, refreshSurvey } = useSurveyJSModel(registrationSurveyModel, null, onComplete, pager)
   const { loginUser } = useUser()
+  const { selectedLanguage } = useI18n()
   const navigate = useNavigate()
 
   /** submit the response */
@@ -73,6 +74,7 @@ export default function RegistrationUnauthed({ registrationContext, returnTo }: 
     const resumeData = surveyModel?.data
     Api.internalRegister({
       preRegResponseId: preRegResponseId as string,
+      preferredLanguage: selectedLanguage,
       fullData: registrationInfo
     }).then(response => {
       loginUser({

--- a/ui-participant/src/login/RedirectFromOAuth.tsx
+++ b/ui-participant/src/login/RedirectFromOAuth.tsx
@@ -19,7 +19,7 @@ import { AlertLevel, alertDefaults } from '@juniper/ui-core'
 // eslint-disable-next-line jsdoc/require-jsdoc
 export const RedirectFromOAuth = () => {
   const auth = useAuth()
-  const { loginUser, updateEnrollee, user, ppUser, profile } = useUser()
+  const { loginUser, updateEnrollee, user } = useUser()
   const navigate = useNavigate()
   const [preRegResponseId, setPreRegResponseId] = usePreRegResponseId()
   const [preEnrollResponseId, setPreEnrollResponseId] = usePreEnrollResponseId()
@@ -33,16 +33,6 @@ export const RedirectFromOAuth = () => {
 
   // Select the portal's single study if there is only one; otherwise return null
   const getSingleStudy = () => portal.portalStudies.length === 1 ? portal.portalStudies[0] : null
-
-  async function updatePreferredLanguage(selectedLanguage: string) {
-    console.log('updatePreferredLanguage', selectedLanguage, profile, ppUser)
-    if (profile && ppUser) {
-      await Api.updateProfile({
-        profile: { ...profile, preferredLanguage: selectedLanguage },
-        ppUserId: ppUser.id
-      })
-    }
-  }
 
   useEffect(() => {
     const handleRedirectFromOauth = async () => {
@@ -72,7 +62,7 @@ export const RedirectFromOAuth = () => {
           // Register or login
           try {
             const loginResult = auth.user.profile.newUser
-              ? await Api.register({ preRegResponseId, email, accessToken, preferredLanguage: returnToLanguage ||'en' })
+              ? await Api.register({ preRegResponseId, email, accessToken, preferredLanguage: returnToLanguage })
               : await Api.tokenLogin(accessToken)
 
             loginUser(loginResult, accessToken)


### PR DESCRIPTION
#### DESCRIPTION

This sets the preferredLanguage profile field upon registration. Previously, we did not honor a user's preferred language immediately after registration (they would have to re-select it to actually set the profile field). This resulted in some of the content being loaded in the default language (english) and they'd also receive the welcome email in english.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* In the *demo* study, select a language other than English
* Register a new user (try this twice: once with b2c enabled and once with it disabled - it should work for both)
* Verify that when you're redirected to the dashboard, the content is in the language that you originally selected prior to the b2c registration screens
* Also confirm that you receive the welcome email in the correct language