### PR TITLE
[JN-794] Fix dangling foreign key when deleting notifications

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/notification/NotificationDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/notification/NotificationDao.java
@@ -54,11 +54,6 @@ public class NotificationDao extends BaseMutableJdbiDao<Notification> {
     }
 
     public void deleteByEnrolleeId(UUID enrolleeId) {
-        List<Notification> notifications = findByEnrolleeId(enrolleeId);
-        for(Notification notification : notifications) {
-            sendgridEventDao.deleteByNotificationId(notification.getId());
-        }
-
         deleteByProperty("enrollee_id", enrolleeId);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/dao/notification/NotificationDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/notification/NotificationDao.java
@@ -54,6 +54,11 @@ public class NotificationDao extends BaseMutableJdbiDao<Notification> {
     }
 
     public void deleteByEnrolleeId(UUID enrolleeId) {
+        List<Notification> notifications = findByEnrolleeId(enrolleeId);
+        for(Notification notification : notifications) {
+            sendgridEventDao.deleteByNotificationId(notification.getId());
+        }
+
         deleteByProperty("enrollee_id", enrolleeId);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/dao/notification/SendgridEventDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/notification/SendgridEventDao.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 @Component
 public class SendgridEventDao extends BaseMutableJdbiDao<SendgridEvent> {
@@ -30,5 +31,9 @@ public class SendgridEventDao extends BaseMutableJdbiDao<SendgridEvent> {
                         .mapTo(clazz)
                         .findOne()
         );
+    }
+
+    public void deleteByNotificationId(UUID notificationId) {
+        deleteByProperty("notification_id", notificationId);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/NotificationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/NotificationService.java
@@ -1,20 +1,24 @@
 package bio.terra.pearl.core.service.notification;
 
 import bio.terra.pearl.core.dao.notification.NotificationDao;
+import bio.terra.pearl.core.dao.notification.SendgridEventDao;
 import bio.terra.pearl.core.model.notification.Notification;
 import bio.terra.pearl.core.service.CrudService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
 
 @Service
 public class NotificationService extends CrudService<Notification, NotificationDao> {
-    private ObjectMapper objectMapper;
-    public NotificationService(NotificationDao dao, ObjectMapper objectMapper) {
+    private final ObjectMapper objectMapper;
+    private final SendgridEventDao sendgridEventDao;
+    public NotificationService(NotificationDao dao, ObjectMapper objectMapper, SendgridEventDao sendgridEventDao) {
         super(dao);
         this.objectMapper = objectMapper;
+        this.sendgridEventDao = sendgridEventDao;
     }
 
     public List<Notification> findByEnrolleeId(UUID enrolleeId) {
@@ -25,7 +29,12 @@ public class NotificationService extends CrudService<Notification, NotificationD
         return notifications;
     }
 
+    @Transactional
     public void deleteByEnrolleeId(UUID enrolleeId) {
+        List<Notification> notifications = dao.findByEnrolleeId(enrolleeId);
+        for (Notification notification : notifications) {
+            sendgridEventDao.deleteByNotificationId(notification.getId());
+        }
         dao.deleteByEnrolleeId(enrolleeId);
     }
 }


### PR DESCRIPTION
#### DESCRIPTION

Fixes a dangling foreign key reference that caused repopulate to fail

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Repopulate demo
* Ensure at least one sendgrid_event references a notification in demo (you can just set the notification_id for a sendgrid_event manually)
* Repopulate demo, confirm it doesn't through a SQL exception