### PR TITLE
[JN-917] truncating long exceptions

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandler.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandler.java
@@ -7,9 +7,13 @@ import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.exception.ValidationException;
 import bio.terra.pearl.api.admin.model.ErrorReport;
 import bio.terra.pearl.core.service.address.AddressValidationException;
+import bio.terra.pearl.core.service.exception.ExceptionUtils;
 import bio.terra.pearl.core.service.exception.PermissionDeniedException;
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +30,7 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 public class GlobalExceptionHandler {
 
   private final HttpServletRequest request;
+
 
   public GlobalExceptionHandler(HttpServletRequest request) {
     this.request = request;
@@ -95,6 +100,8 @@ public class GlobalExceptionHandler {
         String.format(
             "%s%nRequest: %s %s %s",
             causes, request.getMethod(), request.getRequestURI(), statusCode.value());
+
+    ExceptionUtils.truncateIfNeeded(ex);
 
     String message;
     if (statusCode == HttpStatus.INTERNAL_SERVER_ERROR) {

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandler.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandler.java
@@ -11,9 +11,6 @@ import bio.terra.pearl.core.service.exception.ExceptionUtils;
 import bio.terra.pearl.core.service.exception.PermissionDeniedException;
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Arrays;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,8 +27,7 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 public class GlobalExceptionHandler {
 
   private final HttpServletRequest request;
-
-
+  
   public GlobalExceptionHandler(HttpServletRequest request) {
     this.request = request;
   }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandler.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandler.java
@@ -27,7 +27,7 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 public class GlobalExceptionHandler {
 
   private final HttpServletRequest request;
-  
+
   public GlobalExceptionHandler(HttpServletRequest request) {
     this.request = request;
   }

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandlerTest.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandlerTest.java
@@ -12,7 +12,6 @@ import bio.terra.pearl.api.admin.controller.study.StudyController;
 import bio.terra.pearl.api.admin.model.ErrorReport;
 import bio.terra.pearl.api.admin.models.dto.StudyCreationDto;
 import bio.terra.pearl.api.admin.service.AuthUtilService;
-import bio.terra.pearl.api.admin.service.forms.SurveyExtService;
 import bio.terra.pearl.api.admin.service.study.StudyExtService;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.service.kit.StudyEnvironmentKitTypeService;

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandlerTest.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandlerTest.java
@@ -12,6 +12,7 @@ import bio.terra.pearl.api.admin.controller.study.StudyController;
 import bio.terra.pearl.api.admin.model.ErrorReport;
 import bio.terra.pearl.api.admin.models.dto.StudyCreationDto;
 import bio.terra.pearl.api.admin.service.AuthUtilService;
+import bio.terra.pearl.api.admin.service.forms.SurveyExtService;
 import bio.terra.pearl.api.admin.service.study.StudyExtService;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.service.kit.StudyEnvironmentKitTypeService;
@@ -57,6 +58,7 @@ public class GlobalExceptionHandlerTest {
   @MockBean private PortalService portalService;
   @MockBean private StudyPopulator studyPopulator;
   @MockBean private FilePopulateService filePopulateService;
+  @Autowired private SurveyExtService surveyExtService;
 
   @Test
   void testBuildErrorReport() {

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandlerTest.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/controller/GlobalExceptionHandlerTest.java
@@ -58,7 +58,6 @@ public class GlobalExceptionHandlerTest {
   @MockBean private PortalService portalService;
   @MockBean private StudyPopulator studyPopulator;
   @MockBean private FilePopulateService filePopulateService;
-  @Autowired private SurveyExtService surveyExtService;
 
   @Test
   void testBuildErrorReport() {

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/GlobalExceptionHandler.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.exception.ValidationException;
 import bio.terra.pearl.api.participant.model.ErrorReport;
+import bio.terra.pearl.core.service.exception.ExceptionUtils;
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
@@ -79,7 +80,7 @@ public class GlobalExceptionHandler {
         String.format(
             "%s%nRequest: %s %s %s",
             causes, request.getMethod(), request.getRequestURI(), statusCode.value());
-
+    ExceptionUtils.truncateIfNeeded(ex);
     String message;
     if (statusCode == HttpStatus.INTERNAL_SERVER_ERROR) {
       log.error(logString, ex);

--- a/core/src/main/java/bio/terra/pearl/core/service/exception/ExceptionUtils.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/exception/ExceptionUtils.java
@@ -1,0 +1,45 @@
+package bio.terra.pearl.core.service.exception;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ExceptionUtils {
+    /**
+     * number of lines we grab when stack traces are too long, in addition to any bio.terra.pearl
+     * lines
+     */
+    private static final int TRUNCATED_LOG_MIN_STACK_DEPTH = 5;
+    /** Azure log limit is 16K, and multi-line logging doesn't appear to support json parsing
+     * see
+     * https://azure.microsoft.com/en-us/updates/multiline-logging/#:~:text=Customers%20are%20able%20see%20container,due%20to%20Log%20Analytics%20limits.
+     */
+    private static final int TRUNCATION_THRESHOLD = 14000;
+
+    public static void truncateIfNeeded(Throwable ex) {
+        if (Arrays.stream(ex.getStackTrace())
+                .map(trace -> trace.toString())
+                .collect(Collectors.joining("\n"))
+                .length()
+                > TRUNCATION_THRESHOLD) {
+                        truncateExceptionTrace(ex);
+        }
+    }
+
+    /** truncate an exception stack trace to only the first few lines, plus any juniper-owned code */
+    public static void truncateExceptionTrace(Throwable ex) {
+        ex.setStackTrace(
+                IntStream.range(0, ex.getStackTrace().length)
+                        .filter(
+                                i ->
+                                        i < TRUNCATED_LOG_MIN_STACK_DEPTH
+                                                || ex.getStackTrace()[i].toString().startsWith("bio.terra.pearl"))
+                        .mapToObj(i -> ex.getStackTrace()[i])
+                        .toArray(StackTraceElement[]::new));
+        if (ex.getCause() != null && !ex.getCause().equals(ex)) {
+            truncateExceptionTrace(ex.getCause());
+        }
+    }
+
+
+}

--- a/core/src/test/java/bio/terra/pearl/core/service/exception/ExceptionUtilsTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/exception/ExceptionUtilsTest.java
@@ -1,0 +1,29 @@
+package bio.terra.pearl.core.service.exception;
+
+import bio.terra.pearl.core.BaseSpringBootTest;
+import bio.terra.pearl.core.model.survey.Survey;
+import bio.terra.pearl.core.service.survey.SurveyService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThan;
+
+public class ExceptionUtilsTest extends BaseSpringBootTest {
+    @Autowired
+    private SurveyService surveyService;
+
+    @Test
+    public void testExceptionTruncating() {
+        try {
+            surveyService.create(Survey.builder().build());
+            Assertions.fail("expected exception not thrown");
+        } catch (Exception e) {
+            int prevLength = e.getStackTrace().length;
+            ExceptionUtils.truncateExceptionTrace(e);
+            int newLength = e.getStackTrace().length;
+            assertThat(newLength, lessThan(prevLength));
+        }
+    }
+}


### PR DESCRIPTION
#### DESCRIPTION

Exceptions were being logged as string blobs because they were longer than Azure's 16K limit.  This truncates long exceptions to stay under the limit.  this caused the populate errors during team testing today to not generate log alerts

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. after this is merged, try repopulating demo (prior to merging Matt's fix) on the demo server
2. confirm exception is formed as a proper error and logged to azure/slack