### PR TITLE
[JN-943] Proxy profile mappings

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/survey/AnswerMappingTargetType.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/AnswerMappingTargetType.java
@@ -3,5 +3,6 @@ package bio.terra.pearl.core.model.survey;
 /** types of entities we allow mapping survey answers to */
 public enum AnswerMappingTargetType {
     PROFILE,
+    PROXY_PROFILE,
     PROXY
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -118,7 +118,7 @@ public class EnrolleeImportService {
         /** now create the enrollee */
         EnrolleeFormatter enrolleeFormatter = new EnrolleeFormatter(exportOptions);
         Enrollee enrollee = enrolleeFormatter.fromStringMap(studyEnv.getId(), enrolleeMap);
-        HubResponse<Enrollee> response = enrollmentService.enroll(studyEnv.getEnvironmentName(), studyShortcode, regResult.participantUser(), regResult.portalParticipantUser(), null, enrollee.isSubject());
+        HubResponse<Enrollee> response = enrollmentService.enroll(regResult.portalParticipantUser(), studyEnv.getEnvironmentName(), studyShortcode, regResult.participantUser(), regResult.portalParticipantUser(), null, enrollee.isSubject());
 
         /** now update the profile */
         Profile profile = importProfile(enrolleeMap, regResult.profile(), exportOptions, studyEnv, auditInfo);

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
@@ -100,7 +100,7 @@ public class AnswerProcessingService {
         if (proxyProfileMappings.isEmpty() || !hasTargetedChanges(proxyProfileMappings, answers, AnswerMappingTargetType.PROXY_PROFILE)) {
             return;
         }
-        // grab the operator (or the proxy's) profile to update it
+        // grab the operator (which is the proxy) profile to update it
         Profile profile = profileService.loadWithMailingAddress(operator.getProfileId()).get();
         mapValuesToType(
                 answers,

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
@@ -107,6 +107,7 @@ public class AnswerProcessingService {
                 proxyProfileMappings,
                 profile,
                 AnswerMappingTargetType.PROXY_PROFILE);
+        profileService.updateWithMailingAddress(profile, auditInfo);
     }
 
     /**

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
@@ -107,8 +107,6 @@ public class AnswerProcessingService {
                 proxyProfileMappings,
                 profile,
                 AnswerMappingTargetType.PROXY_PROFILE);
-
-        profileService.updateWithMailingAddress(profile, auditInfo);
     }
 
     /**

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -148,8 +148,12 @@ public class SurveyResponseService extends ImmutableEntityService<SurveyResponse
                 .build();
 
         // process any answers that need to be propagated elsewhere to the data model
-        answerProcessingService.processAllAnswerMappings(responseDto.getAnswers(),
-                survey.getAnswerMappings(), ppUser, auditInfo);
+        answerProcessingService.processAllAnswerMappings(
+                enrollee,
+                responseDto.getAnswers(),
+                survey.getAnswerMappings(),
+                ppUser,
+                auditInfo);
 
         // now update the task status and response id
         updateTaskToResponse(task, response, updatedAnswers, auditInfo);

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
@@ -11,32 +11,35 @@ import bio.terra.pearl.core.model.participant.PortalParticipantUser;
 import bio.terra.pearl.core.model.participant.RelationshipType;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.study.StudyEnvironmentConfig;
+import bio.terra.pearl.core.model.survey.Answer;
 import bio.terra.pearl.core.model.survey.AnswerMapping;
 import bio.terra.pearl.core.model.survey.AnswerMappingTargetType;
 import bio.terra.pearl.core.model.survey.ParsedPreEnrollResponse;
 import bio.terra.pearl.core.model.survey.PreEnrollmentResponse;
 import bio.terra.pearl.core.model.survey.Survey;
+import bio.terra.pearl.core.model.survey.SurveyResponse;
 import bio.terra.pearl.core.model.workflow.HubResponse;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.participant.EnrolleeRelationService;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.participant.ParticipantUserService;
 import bio.terra.pearl.core.service.participant.PortalParticipantUserService;
-import bio.terra.pearl.core.service.participant.RandomUtilService;
-import bio.terra.pearl.core.service.portal.PortalService;
-import bio.terra.pearl.core.service.rule.EnrolleeContextService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentConfigService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import bio.terra.pearl.core.service.study.exception.StudyEnvConfigMissing;
+import bio.terra.pearl.core.service.survey.AnswerProcessingService;
 import bio.terra.pearl.core.service.survey.SurveyParseUtils;
+import bio.terra.pearl.core.service.survey.SurveyResponseService;
 import bio.terra.pearl.core.service.survey.SurveyService;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -44,34 +47,34 @@ import java.util.UUID;
 @Slf4j
 public class EnrollmentService {
     private static final String QUALIFIED_STABLE_ID = "qualified";
-    private SurveyService surveyService;
-    private PreEnrollmentResponseDao preEnrollmentResponseDao;
-    private StudyEnvironmentService studyEnvironmentService;
-    private StudyEnvironmentConfigService studyEnvironmentConfigService;
-    private PortalParticipantUserService portalParticipantUserService;
-    private ParticipantUserService participantUserService;
-    private EnrolleeService enrolleeService;
-    private PortalService portalService;
-    private EnrolleeRelationService enrolleeRelationService;
-    private RegistrationService registrationService;
-    private EventService eventService;
-    private ObjectMapper objectMapper;
-    private RandomUtilService randomUtilService;
-    private AnswerMappingDao answerMappingDao;
+    private final SurveyService surveyService;
+    private final PreEnrollmentResponseDao preEnrollmentResponseDao;
+    private final StudyEnvironmentService studyEnvironmentService;
+    private final StudyEnvironmentConfigService studyEnvironmentConfigService;
+    private final PortalParticipantUserService portalParticipantUserService;
+    private final ParticipantUserService participantUserService;
+    private final EnrolleeService enrolleeService;
+    private final EnrolleeRelationService enrolleeRelationService;
+    private final RegistrationService registrationService;
+    private final EventService eventService;
+    private final ObjectMapper objectMapper;
+    private final AnswerMappingDao answerMappingDao;
+    private final SurveyResponseService surveyResponseService;
+    private final AnswerProcessingService answerProcessingService;
 
-    public EnrollmentService(SurveyService surveyService, PreEnrollmentResponseDao preEnrollmentResponseDao,
+    public EnrollmentService(SurveyService surveyService,
+                             PreEnrollmentResponseDao preEnrollmentResponseDao,
                              StudyEnvironmentService studyEnvironmentService,
                              PortalParticipantUserService portalParticipantUserService,
-                             EnrolleeContextService enrolleeContextService,
                              StudyEnvironmentConfigService studyEnvironmentConfigService,
                              EnrolleeService enrolleeService,
                              EventService eventService, ObjectMapper objectMapper,
                              RegistrationService registrationService,
-                             PortalService portalService,
                              EnrolleeRelationService enrolleeRelationService,
-                             RandomUtilService randomUtilService,
                              ParticipantUserService participantUserService,
-                             AnswerMappingDao answerMappingDao) {
+                             AnswerMappingDao answerMappingDao,
+                             SurveyResponseService surveyResponseService,
+                             AnswerProcessingService answerProcessingService) {
         this.surveyService = surveyService;
         this.preEnrollmentResponseDao = preEnrollmentResponseDao;
         this.studyEnvironmentService = studyEnvironmentService;
@@ -81,11 +84,11 @@ public class EnrollmentService {
         this.enrolleeService = enrolleeService;
         this.objectMapper = objectMapper;
         this.registrationService = registrationService;
-        this.portalService = portalService;
         this.enrolleeRelationService = enrolleeRelationService;
-        this.randomUtilService = randomUtilService;
         this.participantUserService = participantUserService;
         this.answerMappingDao = answerMappingDao;
+        this.surveyResponseService = surveyResponseService;
+        this.answerProcessingService = answerProcessingService;
     }
 
     /**
@@ -119,7 +122,7 @@ public class EnrollmentService {
     }
 
     @Transactional
-    public HubResponse<Enrollee> enroll(EnvironmentName envName, String studyShortcode, ParticipantUser user, PortalParticipantUser ppUser,
+    public HubResponse<Enrollee> enroll(PortalParticipantUser operator, EnvironmentName envName, String studyShortcode, ParticipantUser user, PortalParticipantUser ppUser,
                                         UUID preEnrollResponseId, boolean isSubject) {
         log.info("creating enrollee for user {}, study {}", user.getId(), studyShortcode);
         StudyEnvironment studyEnv = studyEnvironmentService.findByStudy(studyShortcode, envName)
@@ -145,6 +148,9 @@ public class EnrollmentService {
             preEnrollResponse.setCreatingParticipantUserId(user.getId());
             preEnrollResponse.setPortalParticipantUserId(ppUser.getId());
             preEnrollmentResponseDao.update(preEnrollResponse);
+
+            // backfill the enrollee with the pre-enrollment response data
+            this.backfillPreEnrollResponse(operator, enrollee, preEnrollResponse);
         }
 
         EnrolleeEvent event = eventService.publishEnrolleeCreationEvent(enrollee, ppUser);
@@ -152,6 +158,45 @@ public class EnrollmentService {
                 user.getId(), studyShortcode, enrollee.getShortcode(), enrollee.getParticipantTasks().size());
         HubResponse hubResponse = eventService.buildHubResponse(event, enrollee);
         return hubResponse;
+    }
+
+    private void backfillPreEnrollResponse(PortalParticipantUser operator, Enrollee enrollee, PreEnrollmentResponse preEnrollResponse) {
+        List<Answer> answers = null;
+        try {
+            answers = objectMapper.readValue(preEnrollResponse.getFullData(), new TypeReference<List<Answer>>() {
+            });
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        PortalParticipantUser ppUser = portalParticipantUserService.findForEnrollee(enrollee);
+
+        SurveyResponse surveyResponse =
+                SurveyResponse
+                        .builder()
+                        .surveyId(preEnrollResponse.getSurveyId())
+                        .answers(answers)
+                        .enrolleeId(enrollee.getId())
+                        .complete(true)
+                        .creatingParticipantUserId(enrollee.getParticipantUserId())
+                        .build();
+
+        surveyResponseService.create(surveyResponse);
+
+        DataAuditInfo auditInfo = DataAuditInfo.builder()
+                .responsibleUserId(enrollee.getParticipantUserId())
+                .enrolleeId(enrollee.getId())
+                .surveyId(preEnrollResponse.getSurveyId())
+                .portalParticipantUserId(ppUser.getId())
+                .build();
+        
+        // process any answers that need to be propagated elsewhere to the data model
+        answerProcessingService.processAllAnswerMappings(
+                enrollee,
+                answers,
+                answerMappingDao.findBySurveyId(preEnrollResponse.getSurveyId()),
+                operator,
+                auditInfo);
     }
 
     /**
@@ -192,10 +237,11 @@ public class EnrollmentService {
     public HubResponse<Enrollee> enrollAsProxy(EnvironmentName envName, String studyShortcode, ParticipantUser proxyUser,
                                                PortalParticipantUser ppUser, UUID preEnrollResponseId, String governedUsername) {
         Enrollee proxyEnrollee = enrolleeService.findByParticipantUserIdAndStudyEnv(proxyUser.getId(), studyShortcode, envName)
-                .orElseGet(() -> this.enroll(envName, studyShortcode, proxyUser, ppUser, null, false).getEnrollee());
+                .orElseGet(() -> this.enroll(ppUser, envName, studyShortcode, proxyUser, ppUser, null, false).getEnrollee());
         HubResponse<Enrollee> governedResponse =
                 this.enrollGovernedUser(envName, studyShortcode, proxyEnrollee, proxyUser, ppUser, preEnrollResponseId, governedUsername);
         governedResponse.setEnrollee(proxyEnrollee);
+
         return governedResponse;
     }
 
@@ -209,7 +255,7 @@ public class EnrollmentService {
                 registrationService.registerGovernedUser(proxyUser, proxyPpUser, governedUserName, governedUserParticipantUserOpt);
 
         HubResponse<Enrollee> hubResponse =
-                this.enroll(envName, studyShortcode, registrationResult.participantUser(), registrationResult.portalParticipantUser(),
+                this.enroll(proxyPpUser, envName, studyShortcode, registrationResult.participantUser(), registrationResult.portalParticipantUser(),
                         preEnrollResponseId, true);
 
         EnrolleeRelation relation = EnrolleeRelation.builder()
@@ -259,6 +305,6 @@ public class EnrollmentService {
         if (preEnrollResponseId != null && isProxyEnrollment(preEnrollResponseId)) {
             return enrollAsProxy(environmentName, studyShortcode, user, portalParticipantUser, preEnrollResponseId);
         }
-        return enroll(environmentName, studyShortcode, user, portalParticipantUser, preEnrollResponseId, true);
+        return enroll(portalParticipantUser, environmentName, studyShortcode, user, portalParticipantUser, preEnrollResponseId, true);
     }
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentServiceTests.java
@@ -62,7 +62,7 @@ public class EnrollmentServiceTests extends BaseSpringBootTest {
         ParticipantUserFactory.ParticipantUserAndPortalUser userBundle = participantUserFactory.buildPersisted(portalEnv,
                 getTestName(testInfo));
         String portalShortcode = portalService.find(portalEnv.getPortalId()).get().getShortcode();
-        HubResponse hubResponse = enrollmentService.enroll(studyEnv.getEnvironmentName(), studyShortcode,
+        HubResponse hubResponse = enrollmentService.enroll(userBundle.ppUser(), studyEnv.getEnvironmentName(), studyShortcode,
                 userBundle.user(), userBundle.ppUser(), savedResponse.getId(), false);
         assertThat(hubResponse.getEnrollee(), notNullValue());
     }
@@ -86,7 +86,7 @@ public class EnrollmentServiceTests extends BaseSpringBootTest {
 
         String portalShortcode = portalService.find(portalEnv.getPortalId()).get().getShortcode();
 
-        HubResponse hubResponse = enrollmentService.enroll(studyEnv.getEnvironmentName(), studyShortcode,
+        HubResponse hubResponse = enrollmentService.enroll(userBundle.ppUser(), studyEnv.getEnvironmentName(), studyShortcode,
                 userBundle.user(), userBundle.ppUser(), null, false);
         assertThat(hubResponse.getEnrollee(), notNullValue());
     }
@@ -106,7 +106,7 @@ public class EnrollmentServiceTests extends BaseSpringBootTest {
         String studyShortcode = studyService.find(studyEnv.getStudyId()).get().getShortcode();
         String portalShortcode = portalService.find(portalEnv.getPortalId()).get().getShortcode();
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            enrollmentService.enroll(studyEnv.getEnvironmentName(), studyShortcode,  userBundle.user(), userBundle.ppUser(),
+            enrollmentService.enroll(userBundle.ppUser(), studyEnv.getEnvironmentName(), studyShortcode, userBundle.user(), userBundle.ppUser(),
                    null, false);
         });
     }

--- a/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentWorkflowTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentWorkflowTests.java
@@ -73,7 +73,7 @@ public class EnrollmentWorkflowTests extends BaseSpringBootTest {
 
         String portalShortcode = portalService.find(portalEnv.getPortalId()).get().getShortcode();
 
-        HubResponse hubResponse = enrollmentService.enroll(studyEnv.getEnvironmentName(), studyShortcode,
+        HubResponse hubResponse = enrollmentService.enroll(userBundle.ppUser(), studyEnv.getEnvironmentName(), studyShortcode,
                 userBundle.user(), userBundle.ppUser(), null, true);
         Enrollee enrollee = hubResponse.getEnrollee();
         assertThat(enrollee.getShortcode(), notNullValue());
@@ -113,7 +113,7 @@ public class EnrollmentWorkflowTests extends BaseSpringBootTest {
         String portalShortcode = portalService.find(portalEnv.getPortalId()).get().getShortcode();
 
         String studyShortcode = studyService.find(studyEnv.getStudyId()).get().getShortcode();
-        HubResponse hubResponse = enrollmentService.enroll(studyEnv.getEnvironmentName(), studyShortcode,
+        HubResponse hubResponse = enrollmentService.enroll(userBundle.ppUser(), studyEnv.getEnvironmentName(), studyShortcode,
                 userBundle.user(), userBundle.ppUser(), null, true);
         Enrollee enrollee = hubResponse.getEnrollee();
         assertThat(hubResponse.getProfile(), notNullValue());

--- a/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentWorkflowTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentWorkflowTests.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.service.workflow;
 
 import bio.terra.pearl.core.BaseSpringBootTest;
+import bio.terra.pearl.core.dao.survey.AnswerMappingDao;
 import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
 import bio.terra.pearl.core.factory.consent.ConsentFormFactory;
 import bio.terra.pearl.core.factory.participant.ParticipantUserFactory;
@@ -13,10 +14,14 @@ import bio.terra.pearl.core.model.consent.ConsentResponseDto;
 import bio.terra.pearl.core.model.consent.StudyEnvironmentConsent;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.EnrolleeRelation;
+import bio.terra.pearl.core.model.participant.Profile;
 import bio.terra.pearl.core.model.participant.RelationshipType;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
+import bio.terra.pearl.core.model.survey.AnswerMapping;
+import bio.terra.pearl.core.model.survey.AnswerMappingMapType;
+import bio.terra.pearl.core.model.survey.AnswerMappingTargetType;
 import bio.terra.pearl.core.model.survey.PreEnrollmentResponse;
 import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
 import bio.terra.pearl.core.model.survey.Survey;
@@ -28,8 +33,10 @@ import bio.terra.pearl.core.model.workflow.TaskType;
 import bio.terra.pearl.core.service.consent.ConsentResponseService;
 import bio.terra.pearl.core.service.participant.EnrolleeRelationService;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
+import bio.terra.pearl.core.service.participant.ProfileService;
 import bio.terra.pearl.core.service.portal.PortalService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentConsentService;
+import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
 import bio.terra.pearl.core.service.study.StudyService;
 import bio.terra.pearl.core.service.survey.SurveyResponseService;
@@ -56,6 +63,45 @@ import static org.hamcrest.Matchers.samePropertyValuesAs;
 
 /** class for high-level tests of workflow operations -- enroll, consent, etc... */
 public class EnrollmentWorkflowTests extends BaseSpringBootTest {
+    @Autowired
+    private StudyEnvironmentFactory studyEnvironmentFactory;
+    @Autowired
+    private ParticipantUserFactory participantUserFactory;
+    @Autowired
+    private StudyService studyService;
+    @Autowired
+    private PortalService portalService;
+    @Autowired
+    private EnrolleeService enrolleeService;
+    @Autowired
+    private EnrollmentService enrollmentService;
+    @Autowired
+    private EnrolleeRelationService enrolleeRelationService;
+    @Autowired
+    private PortalEnvironmentFactory portalEnvironmentFactory;
+    @Autowired
+    private ConsentFormFactory consentFormFactory;
+    @Autowired
+    private SurveyFactory surveyFactory;
+    @Autowired
+    private StudyEnvironmentConsentService studyEnvironmentConsentService;
+    @Autowired
+    private StudyEnvironmentSurveyService studyEnvironmentSurveyService;
+    @Autowired
+    private ParticipantTaskService participantTaskService;
+    @Autowired
+    private ConsentResponseService consentResponseService;
+    @Autowired
+    private SurveyResponseService surveyResponseService;
+    @Autowired
+    private PreEnrollmentSurveyFactory preEnrollmentSurveyFactory;
+    @Autowired
+    private AnswerMappingDao answerMappingDao;
+    @Autowired
+    private ProfileService profileService;
+    @Autowired
+    private StudyEnvironmentService studyEnvironmentService;
+    
     @Test
     @Transactional
     public void testEnroll(TestInfo info) {
@@ -286,7 +332,91 @@ public class EnrollmentWorkflowTests extends BaseSpringBootTest {
         // confirm that two enrollees were created, and only one is a subject
         assertThat(hubResponse.getEnrollee().isSubject(), equalTo(false));
         assertThat(hubResponse.getResponse().isSubject(), equalTo(true));
+    }
 
+    @Test
+    @Transactional
+    public void testMappingProxyAndGovernedUserProfileFromPreEnroll(TestInfo info) {
+        PortalEnvironment portalEnv = portalEnvironmentFactory.buildPersisted(getTestName(info));
+        StudyEnvironment studyEnv = studyEnvironmentFactory.buildPersisted(portalEnv, getTestName(info));
+        Survey preEnrollmentSurvey = surveyFactory.buildPersisted(getTestName(info));
+        StudyEnvironmentSurvey.builder()
+                .surveyId(preEnrollmentSurvey.getId())
+                .studyEnvironmentId(studyEnv.getId())
+                .build();
+        studyEnv.setPreEnrollSurveyId(preEnrollmentSurvey.getId());
+        studyEnvironmentService.update(studyEnv);
+        String proxyQuestionStableId = "proxyQuestion";
+        preEnrollmentSurveyFactory.buildPersistedProxyAnswerMapping(getTestName(info), preEnrollmentSurvey.getId(), proxyQuestionStableId);
+        answerMappingDao.create(
+                AnswerMapping
+                        .builder()
+                        .mapType(AnswerMappingMapType.STRING_TO_STRING)
+                        .targetField("givenName")
+                        .targetType(AnswerMappingTargetType.PROXY_PROFILE)
+                        .questionStableId("proxyGivenName")
+                        .surveyId(preEnrollmentSurvey.getId())
+                        .build()
+        );
+        answerMappingDao.create(
+                AnswerMapping
+                        .builder()
+                        .mapType(AnswerMappingMapType.STRING_TO_STRING)
+                        .targetField("familyName")
+                        .targetType(AnswerMappingTargetType.PROXY_PROFILE)
+                        .questionStableId("proxyFamilyName")
+                        .surveyId(preEnrollmentSurvey.getId())
+                        .build()
+        );
+        answerMappingDao.create(
+                AnswerMapping
+                        .builder()
+                        .mapType(AnswerMappingMapType.STRING_TO_STRING)
+                        .targetField("givenName")
+                        .targetType(AnswerMappingTargetType.PROFILE)
+                        .questionStableId("governedUserGivenName")
+                        .surveyId(preEnrollmentSurvey.getId())
+                        .build()
+        );
+        answerMappingDao.create(
+                AnswerMapping
+                        .builder()
+                        .mapType(AnswerMappingMapType.STRING_TO_STRING)
+                        .targetField("familyName")
+                        .targetType(AnswerMappingTargetType.PROFILE)
+                        .questionStableId("governedUserFamilyName")
+                        .surveyId(preEnrollmentSurvey.getId())
+                        .build()
+        );
+        String preEnrollmentSurveyResponseForProxy = """
+                [
+                {"questionStableId":"proxyQuestion","surveyVersion":0,"viewedLanguage":"en","stringValue":"true"},
+                {"createdAt":1710527339.202811000,"lastUpdatedAt":1710527339.202811000,"questionStableId":"qualified","surveyVersion":0,"booleanValue":true},
+                {"questionStableId":"proxyGivenName","surveyVersion":0,"viewedLanguage":"en","stringValue":"John"},
+                {"questionStableId":"proxyFamilyName","surveyVersion":0,"viewedLanguage":"en","stringValue":"Doe"},
+                {"questionStableId":"governedUserGivenName","surveyVersion":0,"viewedLanguage":"en","stringValue":"Emily"},
+                {"questionStableId":"governedUserFamilyName","surveyVersion":0,"viewedLanguage":"en","stringValue":"Smith"}
+                ]""";
+        ParticipantUserFactory.ParticipantUserAndPortalUser userProxyBundle = participantUserFactory.buildPersisted(portalEnv, getTestName(info));
+        PreEnrollmentResponse preEnrollmentResponseProxy = preEnrollmentSurveyFactory.buildPersisted(getTestName(info), preEnrollmentSurvey.getId(), true, preEnrollmentSurveyResponseForProxy, userProxyBundle.ppUser().getId(), userProxyBundle.user().getId(), studyEnv.getId());
+
+        Study study = studyService.find(studyEnv.getStudyId()).get();
+        HubResponse<Enrollee> hubResponse = enrollmentService.enroll(
+                studyEnv.getEnvironmentName(),
+                study.getShortcode(),
+                userProxyBundle.user(),
+                userProxyBundle.ppUser(),
+                preEnrollmentResponseProxy.getId());
+        // confirm that two enrollees were created, and only one is a subject
+        assertThat(hubResponse.getEnrollee().isSubject(), equalTo(false));
+        assertThat(hubResponse.getResponse().isSubject(), equalTo(true));
+        Profile governedProfile = profileService.find(hubResponse.getResponse().getProfileId()).get();
+        Profile proxyProfile = profileService.find(hubResponse.getEnrollee().getProfileId()).get();
+
+        assertThat(governedProfile.getGivenName(), equalTo("Emily"));
+        assertThat(governedProfile.getFamilyName(), equalTo("Smith"));
+        assertThat(proxyProfile.getGivenName(), equalTo("John"));
+        assertThat(proxyProfile.getFamilyName(), equalTo("Doe"));
 
     }
 
@@ -298,39 +428,5 @@ public class EnrollmentWorkflowTests extends BaseSpringBootTest {
     }
 
 
-    @Autowired
-    private StudyEnvironmentFactory studyEnvironmentFactory;
-    @Autowired
-    private ParticipantUserFactory participantUserFactory;
-    @Autowired
-    private StudyService studyService;
-    @Autowired
-    private PortalService portalService;
-    @Autowired
-    private EnrolleeService enrolleeService;
 
-    @Autowired
-    private EnrollmentService enrollmentService;
-
-    @Autowired
-    private EnrolleeRelationService enrolleeRelationService;
-
-    @Autowired
-    private PortalEnvironmentFactory portalEnvironmentFactory;
-    @Autowired
-    private ConsentFormFactory consentFormFactory;
-    @Autowired
-    private SurveyFactory surveyFactory;
-    @Autowired
-    private StudyEnvironmentConsentService studyEnvironmentConsentService;
-    @Autowired
-    private StudyEnvironmentSurveyService studyEnvironmentSurveyService;
-    @Autowired
-    private ParticipantTaskService participantTaskService;
-    @Autowired
-    private ConsentResponseService consentResponseService;
-    @Autowired
-    private SurveyResponseService surveyResponseService;
-    @Autowired
-    private PreEnrollmentSurveyFactory preEnrollmentSurveyFactory;
 }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
@@ -402,7 +402,7 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
         Enrollee enrollee;
         List<ParticipantTask> tasks;
         if (popDto.isSimulateSubmissions()) {
-            HubResponse<Enrollee>  hubResponse = enrollmentService.enroll(environmentName, context.getStudyShortcode(),
+            HubResponse<Enrollee> hubResponse = enrollmentService.enroll(ppUser, environmentName, context.getStudyShortcode(),
                     attachedUser, ppUser, popDto.getPreEnrollmentResponseId(), true);
             enrollee = hubResponse.getEnrollee();
             tasks = hubResponse.getTasks();

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
@@ -8,6 +8,18 @@
       "targetType": "PROXY",
       "targetField": "isProxy",
       "mapType": "STRING_TO_BOOLEAN"
+    },
+    {
+      "questionStableId": "proxy_given_name",
+      "targetType": "PROXY_PROFILE",
+      "targetField": "givenName",
+      "mapType": "STRING_TO_STRING"
+    },
+    {
+      "questionStableId": "proxy_family_name",
+      "targetType": "PROXY_PROFILE",
+      "targetField": "familyName",
+      "mapType": "STRING_TO_STRING"
     }
   ],
   "jsonContent": {
@@ -107,6 +119,27 @@
                 "value": "true"
               }
             ]
+          },
+          {
+            "type": "text",
+            "name": "proxy_given_name",
+            "title": "Proxy Given Name",
+            "description": "Proxy given name",
+            "visibleIf": "{proxy_enrollment} = true"
+          },
+          {
+            "type": "text",
+            "name": "proxy_family_name",
+            "title": "Proxy Family Name",
+            "description": "Proxy family name",
+            "visibleIf": "{proxy_enrollment} = true"
+          },
+          {
+            "type": "text",
+            "name": "proxy_email",
+            "title": "Proxy Email",
+            "description": "Proxy email",
+            "visibleIf": "{proxy_enrollment} = true"
           }
         ]
       }

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
@@ -20,6 +20,18 @@
       "targetType": "PROXY_PROFILE",
       "targetField": "familyName",
       "mapType": "STRING_TO_STRING"
+    },
+    {
+      "questionStableId": "governed_given_name",
+      "targetType": "PROFILE",
+      "targetField": "givenName",
+      "mapType": "STRING_TO_STRING"
+    },
+    {
+      "questionStableId": "governed_family_name",
+      "targetType": "PROFILE",
+      "targetField": "familyName",
+      "mapType": "STRING_TO_STRING"
     }
   ],
   "jsonContent": {
@@ -122,24 +134,29 @@
           },
           {
             "type": "text",
+            "isRequired": true,
             "name": "proxy_given_name",
             "title": "Proxy Given Name",
-            "description": "Proxy given name",
             "visibleIf": "{proxy_enrollment} = true"
           },
           {
             "type": "text",
+            "isRequired": true,
             "name": "proxy_family_name",
             "title": "Proxy Family Name",
-            "description": "Proxy family name",
             "visibleIf": "{proxy_enrollment} = true"
           },
           {
             "type": "text",
-            "name": "proxy_email",
-            "title": "Proxy Email",
-            "description": "Proxy email",
-            "visibleIf": "{proxy_enrollment} = true"
+            "isRequired": true,
+            "name": "governed_given_name",
+            "title": "Governed User Given Name"
+          },
+          {
+            "type": "text",
+            "isRequired": true,
+            "name": "governed_family_name",
+            "title": "Governed User Family Name"
           }
         ]
       }

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
@@ -136,27 +136,27 @@
             "type": "text",
             "isRequired": true,
             "name": "proxy_given_name",
-            "title": "Proxy Given Name",
+            "title": "Proxy User Given Name",
             "visibleIf": "{proxy_enrollment} = true"
           },
           {
             "type": "text",
             "isRequired": true,
             "name": "proxy_family_name",
-            "title": "Proxy Family Name",
+            "title": "Proxy User Family Name",
             "visibleIf": "{proxy_enrollment} = true"
           },
           {
             "type": "text",
             "isRequired": true,
             "name": "governed_given_name",
-            "title": "Governed User Given Name"
+            "title": "Given Name"
           },
           {
             "type": "text",
             "isRequired": true,
             "name": "governed_family_name",
-            "title": "Governed User Family Name"
+            "title": "Family Name"
           }
         ]
       }

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateOurhealthTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateOurhealthTest.java
@@ -73,7 +73,7 @@ public class PopulateOurhealthTest extends BasePopulatePortalsTest {
         Survey cardioHistorySurvey = surveyService.findByStableId("oh_oh_cardioHx", 1, portalId).get();
 
         List<SurveyResponse> jonasResponses = surveyResponseService.findByEnrolleeId(jonas.getId());
-        Assertions.assertEquals(3, jonasResponses.size());
+        Assertions.assertEquals(4, jonasResponses.size());
         SurveyResponse cardioHistoryResp = jonasResponses.stream()
                 .filter(response -> cardioHistorySurvey.getId().equals(response.getSurveyId()))
                 .findFirst().get();


### PR DESCRIPTION
#### DESCRIPTION

Allows you to add proxy profile questions as answer mappings.

Also, refactors how pre enrollment surveys work. During enrollment, those answers are backfilled so that we can use all the same answer mapping / etc infrastructure that all other surveys use. This enables the ability to use answer mappings in pre enrollment surveys. It also allows us to simplify how these are displayed in the UI, as there doesn't need to be any parsing of the "fullData" field - they're just totally normal survey responses now. 

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Repopulate demo
- Register new user as proxy, fill out governed user and proxy names in pre enroll survey
- Observe that these names are reflected properly in the database / admin tool
