### PR TITLE
[JN-985] Add survey autocomplete button to irb and sandbox environments

### DIFF
--- a/ui-participant/src/hub/consent/ConsentView.tsx
+++ b/ui-participant/src/hub/consent/ConsentView.tsx
@@ -98,11 +98,9 @@ function RawConsentView({ form, enrollee, resumableData, pager, studyShortcode, 
 }
 
 /** handles paging the form */
-function PagedConsentView({ form, responses, enrollee, studyShortcode }:
-                              {
-                                form: StudyEnvironmentConsent, responses: ConsentResponse[], enrollee: Enrollee,
-                              studyShortcode: string
-                            }) {
+function PagedConsentView({ form, responses, enrollee, studyShortcode }: {
+  form: StudyEnvironmentConsent, responses: ConsentResponse[], enrollee: Enrollee, studyShortcode: string
+}) {
   const response = responses[0]
   let answers: Answer[] = []
   if (response?.fullData) {

--- a/ui-participant/src/hub/consent/ConsentView.tsx
+++ b/ui-participant/src/hub/consent/ConsentView.tsx
@@ -24,6 +24,8 @@ import { usePortalEnv } from 'providers/PortalProvider'
 import { useUser } from 'providers/UserProvider'
 import { DocumentTitle } from 'util/DocumentTitle'
 import { PageLoadingIndicator } from 'util/LoadingSpinner'
+import SurveyReviewModeButton from '../survey/ReviewModeButton'
+import SurveyAutoCompleteButton from '../survey/SurveyAutoCompleteButton'
 
 /**
  * display a single consent form to a participant.  The pageNumber argument can be specified to start at the given
@@ -82,19 +84,23 @@ function RawConsentView({ form, enrollee, resumableData, pager, studyShortcode, 
     })
   }
 
-
   return (
     <>
-      <DocumentTitle title={form.name} />
-      {surveyModel ? <SurveyComponent model={surveyModel} /> : null}
+      <DocumentTitle title={form.name}/>
+      <div style={{ background: '#f3f3f3' }} className="flex-grow-1">
+        <SurveyReviewModeButton surveyModel={surveyModel}/>
+        <SurveyAutoCompleteButton surveyModel={surveyModel}/>
+        {surveyModel ? <SurveyComponent model={surveyModel} /> : null}
+      </div>
     </>
+
   )
 }
 
 /** handles paging the form */
 function PagedConsentView({ form, responses, enrollee, studyShortcode }:
-                            {
-                              form: StudyEnvironmentConsent, responses: ConsentResponse[], enrollee: Enrollee,
+                              {
+                                form: StudyEnvironmentConsent, responses: ConsentResponse[], enrollee: Enrollee,
                               studyShortcode: string
                             }) {
   const response = responses[0]

--- a/ui-participant/src/hub/survey/SurveyAutoCompleteButton.test.tsx
+++ b/ui-participant/src/hub/survey/SurveyAutoCompleteButton.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import SurveyAutoCompleteButton from './SurveyAutoCompleteButton'
+import { getEnvSpec } from 'api/api'
+import { asMockedFn } from '@juniper/ui-core'
+
+jest.mock('api/api')
+
+describe('SurveyAutoCompleteButton', () => {
+  it('should render in sandbox environment', () => {
+    asMockedFn(getEnvSpec).mockReturnValue({
+      envName: 'sandbox',
+      shortcodeOrHostname: 'demo',
+      shortcode: 'demo'
+    })
+    render(<SurveyAutoCompleteButton surveyModel={null} />)
+    expect(screen.getByLabelText('automatically complete the survey')).toBeInTheDocument()
+  })
+
+  it('should not render in live environment', () => {
+    asMockedFn(getEnvSpec).mockReturnValue({
+      envName: 'live',
+      shortcodeOrHostname: 'demo',
+      shortcode: 'demo'
+    })
+    render(<SurveyAutoCompleteButton surveyModel={null} />)
+    expect(screen.queryByLabelText('automatically complete the survey')).not.toBeInTheDocument()
+  })
+})

--- a/ui-participant/src/hub/survey/SurveyAutoCompleteButton.tsx
+++ b/ui-participant/src/hub/survey/SurveyAutoCompleteButton.tsx
@@ -19,6 +19,9 @@ export default function SurveyAutoCompleteButton({ surveyModel }: { surveyModel:
           if (question.getType() === 'text') {
             surveyModel.setValue(question.name, Math.random().toString(36).substring(5))
           }
+          if (question.getType() === 'signaturepad') {
+            surveyModel.setValue(question.name, 'data:image/png;base64,')
+          }
         })
       })
       surveyModel.currentPageNo = surveyModel.pageCount - 1

--- a/ui-participant/src/hub/survey/SurveyAutoCompleteButton.tsx
+++ b/ui-participant/src/hub/survey/SurveyAutoCompleteButton.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { SurveyModel } from 'survey-core'
+import { getEnvSpec } from 'api/api'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faWandSparkles } from '@fortawesome/free-solid-svg-icons'
+
+/** button to automatically fill in a survey. this doesn't handle every single question type, but works with the more
+ * commonly tested forms like preEnroll. Only available in sandbox and irb environments. */
+export default function SurveyAutoCompleteButton({ surveyModel }: { surveyModel: SurveyModel | null }) {
+  const { envName } = getEnvSpec()
+
+  const autoCompleteSurvey = () => {
+    if (surveyModel) {
+      surveyModel.pages.forEach(page => {
+        page.questions.forEach(question => {
+          if (question.getType() === 'radiogroup' || 'checkbox' && question.choices && question.choices.length > 0) {
+            surveyModel.setValue(question.name, question.choices[0].value)
+          }
+          if (question.getType() === 'text') {
+            surveyModel.setValue(question.name, Math.random().toString(36).substring(5))
+          }
+        })
+      })
+      surveyModel.currentPageNo = surveyModel.pageCount - 1
+    }
+  }
+  if (envName === 'live') {
+    return null
+  }
+  return <button className="float-end btn" aria-label="automatically complete the survey"
+    title="automatically complete the current survey. (Available only in sandbox & irb environments)"
+    onClick={autoCompleteSurvey}>
+    Auto-complete: <FontAwesomeIcon icon={faWandSparkles}/>
+  </button>
+}

--- a/ui-participant/src/hub/survey/SurveyAutoCompleteButton.tsx
+++ b/ui-participant/src/hub/survey/SurveyAutoCompleteButton.tsx
@@ -31,8 +31,8 @@ export default function SurveyAutoCompleteButton({ surveyModel }: { surveyModel:
     return null
   }
   return <button className="float-end btn" aria-label="automatically complete the survey"
-    title="automatically complete the current survey. (Available only in sandbox & irb environments)"
+    title="Automatically complete the current survey. (Available only in sandbox & irb environments)"
     onClick={autoCompleteSurvey}>
-    Auto-complete: <FontAwesomeIcon icon={faWandSparkles}/>
+    Autocomplete: <FontAwesomeIcon icon={faWandSparkles}/>
   </button>
 }

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -29,6 +29,7 @@ import { withErrorBoundary } from 'util/ErrorBoundary'
 import SurveyReviewModeButton from './ReviewModeButton'
 import { SurveyModel } from 'survey-core'
 import { DocumentTitle } from 'util/DocumentTitle'
+import SurveyAutoCompleteButton from './SurveyAutoCompleteButton'
 
 const TASK_ID_PARAM = 'taskId'
 const AUTO_SAVE_INTERVAL = 3 * 1000  // auto-save every 3 seconds if there are changes
@@ -154,6 +155,7 @@ export function RawSurveyView({
       {/* f3f3f3 background is to match surveyJs "modern" theme */}
       <div style={{ background: '#f3f3f3' }} className="flex-grow-1">
         { showHeaders && <SurveyReviewModeButton surveyModel={surveyModel}/> }
+        { showHeaders && <SurveyAutoCompleteButton surveyModel={surveyModel}/> }
         { showHeaders && <h1 className="text-center mt-5 mb-0 pb-0 fw-bold">
           {i18n(`${form.stableId}:${form.version}`, form.name)}
         </h1> }

--- a/ui-participant/src/studies/enroll/PreEnroll.tsx
+++ b/ui-participant/src/studies/enroll/PreEnroll.tsx
@@ -4,6 +4,8 @@ import { getResumeData, getSurveyJsAnswerList, useSurveyJSModel } from 'util/sur
 import { useNavigate } from 'react-router-dom'
 import { StudyEnrollContext } from './StudyEnrollRouter'
 import { useI18n } from '@juniper/ui-core'
+import SurveyReviewModeButton from '../../hub/survey/ReviewModeButton'
+import SurveyAutoCompleteButton from '../../hub/survey/SurveyAutoCompleteButton'
 
 /**
  * pre-enrollment surveys are expected to have a calculated value that indicates
@@ -69,5 +71,11 @@ export default function PreEnrollView({ enrollContext, survey }:
     updatePreEnrollResponseId(null)
   }, [])
 
-  return <div className="d-flex flex-grow-1">{SurveyComponent}</div>
+  return (
+    <div style={{ background: '#f3f3f3' }} className="flex-grow-1">
+      <SurveyReviewModeButton surveyModel={surveyModel}/>
+      <SurveyAutoCompleteButton surveyModel={surveyModel}/>
+      {SurveyComponent}
+    </div>
+  )
 }

--- a/ui-participant/src/studies/enroll/PreEnroll.tsx
+++ b/ui-participant/src/studies/enroll/PreEnroll.tsx
@@ -4,8 +4,8 @@ import { getResumeData, getSurveyJsAnswerList, useSurveyJSModel } from 'util/sur
 import { useNavigate } from 'react-router-dom'
 import { StudyEnrollContext } from './StudyEnrollRouter'
 import { useI18n } from '@juniper/ui-core'
-import SurveyReviewModeButton from '../../hub/survey/ReviewModeButton'
-import SurveyAutoCompleteButton from '../../hub/survey/SurveyAutoCompleteButton'
+import SurveyReviewModeButton from 'hub/survey/ReviewModeButton'
+import SurveyAutoCompleteButton from 'hub/survey/SurveyAutoCompleteButton'
 
 /**
  * pre-enrollment surveys are expected to have a calculated value that indicates


### PR DESCRIPTION
#### DESCRIPTION

I waste wayyyy too much time manually filling out preenroll and consent forms while developing. This adds a new button to the top-right of the form view to automatically fill out every question in the form with one click. Only available in sandbox and irb environments.

It probably doesn't handle every question type properly, and might insert things into the survey response that are a bit nonsensical based on the question type/question requirements, but it works well enough for the existing Heart Demo surveys which was my main motivation, and it's really just a developer productivity thing anyway.

<img width="365" alt="Screenshot 2024-04-09 at 10 19 47 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/c6feb0aa-2d84-4b57-aa25-7673582704c0">

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Repopulate Heart Demo
* Register as a new user on sandbox or irb
* Click the auto-complete button on the pre-enroll form
* Verify that the form is filled out and that you're navigated to the last page of the form
* Try doing the same on a live environment, and verify that you don't see the auto-complete button (or the review mode button, since I brought that into the consent and pre-enroll views)
