### PR TITLE
[JN-997] populate_portal.sh can accept multiple portal shortcodes

### DIFF
--- a/scripts/populate_portal.sh
+++ b/scripts/populate_portal.sh
@@ -6,6 +6,8 @@ set -u
 ACCESS_TOKEN="eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJlbWFpbCI6ImRidXNoQGJyb2FkaW5zdGl0dXRlLm9yZyIsInRva2VuIjoiNzJjZDQyZTgtMWE0ZS00Nzg5LWFmODQtZDIwMDgxY2JlNWJjIn0."
 # uncomment the below line to use a real Azure B2C token  (needed for populating anywhere other than localhost)
 # ACCESS_TOKEN=$(az account get-access-token | jq -r .accessToken)
-curl -X POST -H "Authorization: Bearer $ACCESS_TOKEN" "$SERVER_NAME/api/internal/v1/populate/portal?filePathName=portals/$1/portal.json&overwrite=true"
-
-echo ""
+for portal in "$@"
+do
+  curl -X POST -H "Authorization: Bearer $ACCESS_TOKEN" "$SERVER_NAME/api/internal/v1/populate/portal?filePathName=portals/$portal/portal.json&overwrite=true"
+  echo ""
+done


### PR DESCRIPTION
#### DESCRIPTION

Just a quick dev QOL tweak that allows you to specify multiple portal shortcodes when running the populate script

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Confirm that the single case still works `./scripts/populate_portal.sh ourhealth` still works
Confirm that the multi-portal case works `./scripts/populate_portal.sh ourhealth hearthive demo`