### PR TITLE
[JN-993] Script to generate release notes

### DIFF
--- a/scripts/generate_release_notes.sh
+++ b/scripts/generate_release_notes.sh
@@ -28,6 +28,6 @@ while IFS= read -r message; do
     ticket=$(echo "$message" | grep -o -E 'JN-\d+')
     pr=$(echo "$message" | grep -o -E '#\d+' | tr -d '#')
     message=$(echo "$message" | tr -d '[]')
-    echo "[${message}](https://broadworkbench.atlassian.net/browse/$ticket) [(View GitHub PR)](https://github.com/broadinstitute/juniper/pull/$pr)"
+    echo "[${message}](https://broadworkbench.atlassian.net/browse/$ticket) [(GitHub PR)](https://github.com/broadinstitute/juniper/pull/$pr)"
   fi
 done <<< "$messages"

--- a/scripts/generate_release_notes.sh
+++ b/scripts/generate_release_notes.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Fetch the latest Juniper tags, this doesn't happen automatically
+git fetch --tags
+
 # Check what versions demo and production are currently running
 demoResponse=$(curl -s 'https://admin-d2p.ddp-dev.envs.broadinstitute.org/version')
 demoGitTag=$(echo $demoResponse | jq -r '.gitTag')

--- a/scripts/generate_release_notes.sh
+++ b/scripts/generate_release_notes.sh
@@ -22,10 +22,12 @@ commits=$(git log $demoGitTag..$prodGitTag \
 messages=$(echo $commits | jq -r '.[].message')
 
 # Generate the release notes markdown. This can be pasted directly into a Jira ticket
+# or a Google Doc (if you have markdown enabled)
 while IFS= read -r message; do
   if echo "$message" | grep -q -E 'JN-\d+'; then
     ticket=$(echo "$message" | grep -o -E 'JN-\d+')
+    pr=$(echo "$message" | grep -o -E '#\d+' | tr -d '#')
     message=$(echo "$message" | tr -d '[]')
-    echo "[${message}](https://broadworkbench.atlassian.net/browse/$ticket)"
+    echo "[${message}](https://broadworkbench.atlassian.net/browse/$ticket) [(View GitHub PR)](https://github.com/broadinstitute/juniper/pull/$pr)"
   fi
 done <<< "$messages"

--- a/scripts/generate_release_notes.sh
+++ b/scripts/generate_release_notes.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# Check what versions demo and production are currently running
+demoResponse=$(curl -s 'https://admin-d2p.ddp-dev.envs.broadinstitute.org/version')
+demoGitTag=$(echo $demoResponse | jq -r '.gitTag')
+
+prodResponse=$(curl -s 'https://juniper.terra.bio/version')
+prodGitTag=$(echo $prodResponse | jq -r '.gitTag')
+
+echo "Demo is currently running git tag \033[32m$demoGitTag\033[0m"
+echo "Production is currently running git tag \033[32m$prodGitTag\033[0m"
+echo "Generating release notes...\n"
+
+# Pull the differing commits between the demo and production tags
+# git log JSON formatter adapted from https://gist.github.com/textarcana/1306223
+commits=$(git log $demoGitTag..$prodGitTag \
+    --pretty=format:'{%n "message": "%s"%n},' \
+    $@ | \
+    perl -pe 'BEGIN{print "["}; END{print "]\n"}' | \
+    perl -pe 's/},]/}]/')
+
+messages=$(echo $commits | jq -r '.[].message')
+
+# Generate the release notes markdown. This can be pasted directly into a Jira ticket
+while IFS= read -r message; do
+  if echo "$message" | grep -q -E 'JN-\d+'; then
+    ticket=$(echo "$message" | grep -o -E 'JN-\d+')
+    message=$(echo "$message" | tr -d '[]')
+    echo "[${message}](https://broadworkbench.atlassian.net/browse/$ticket)"
+  fi
+done <<< "$messages"

--- a/scripts/generate_release_notes.sh
+++ b/scripts/generate_release_notes.sh
@@ -13,7 +13,7 @@ echo "Generating release notes...\n"
 
 # Pull the differing commits between the demo and production tags
 # git log JSON formatter adapted from https://gist.github.com/textarcana/1306223
-commits=$(git log $demoGitTag..$prodGitTag \
+commits=$(git log $demoGitTag...$prodGitTag \
     --pretty=format:'{%n "message": "%s"%n},' \
     $@ | \
     perl -pe 'BEGIN{print "["}; END{print "]\n"}' | \


### PR DESCRIPTION
#### DESCRIPTION

Generates release notes that look like this:

[JN-971 Search exp query builder (#830)](https://broadworkbench.atlassian.net/browse/JN-971) [(View GitHub PR)](https://github.com/broadinstitute/juniper/pull/830)
[JN-904 sign in for unenrolled users logic (#834)](https://broadworkbench.atlassian.net/browse/JN-904) [(View GitHub PR)](https://github.com/broadinstitute/juniper/pull/834)
[JN-801 Admins can add users to the mailing list (members choice) (#825)](https://broadworkbench.atlassian.net/browse/JN-801) [(View GitHub PR)](https://github.com/broadinstitute/juniper/pull/825)
[JN-980 save preferred language during registration (#829)](https://broadworkbench.atlassian.net/browse/JN-980) [(View GitHub PR)](https://github.com/broadinstitute/juniper/pull/829)
[JN-969 fix portal icon (#833)](https://broadworkbench.atlassian.net/browse/JN-969) [(View GitHub PR)](https://github.com/broadinstitute/juniper/pull/833)
[JN-937 Prepare for production smarty key (#796)](https://broadworkbench.atlassian.net/browse/JN-937) [(View GitHub PR)](https://github.com/broadinstitute/juniper/pull/796)
[JN-794 Fix dangling foreign key when deleting notifications (#831)](https://broadworkbench.atlassian.net/browse/JN-794) [(View GitHub PR)](https://github.com/broadinstitute/juniper/pull/831)
[JN-979 Portal specific shortcodes (#826)](https://broadworkbench.atlassian.net/browse/JN-979) [(View GitHub PR)](https://github.com/broadinstitute/juniper/pull/826)
[JN-939 Playwright tests addition (#822)](https://broadworkbench.atlassian.net/browse/JN-939) [(View GitHub PR)](https://github.com/broadinstitute/juniper/pull/822)

This can be pasted directly into the prod release Jira ticket. It can also be pasted into a Google Doc but it's not so seamless (it doesn't resolve the markdown on-paste, so you have to add a space after each link in order to "trick" it into resolving the links- kind of annoying but I couldn't find a way around it, and it's still an improvement). You also have to enable markdown for the particular document under `Tools > Preferences > Automatically detect markdown`

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Run `./scripts/generate_release_notes.sh` and verify output is correct and can be pasted into a Jira ticket. Since demo and prod may be running the same tag at the time of testing, you might want to hardcode `demoGitTag` to an older one, i.e. 1.2.5 just to see what the output is