### PR TITLE
[JN-1000] Export proxy relationships

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/export/ExportController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/export/ExportController.java
@@ -46,6 +46,7 @@ public class ExportController implements ExportApi {
       Boolean splitOptionsIntoColumns,
       Boolean stableIdsForOptions,
       Boolean includeOnlyMostRecent,
+      Boolean includeProxiesAsRows,
       String fileFormat,
       Integer limit) {
     EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
@@ -56,6 +57,7 @@ public class ExportController implements ExportApi {
             splitOptionsIntoColumns != null ? splitOptionsIntoColumns : false,
             stableIdsForOptions != null ? stableIdsForOptions : false,
             includeOnlyMostRecent != null ? includeOnlyMostRecent : false,
+            includeProxiesAsRows != null ? includeProxiesAsRows : false,
             fileFormat != null ? ExportFileFormat.valueOf(fileFormat) : ExportFileFormat.TSV,
             limit);
 
@@ -74,6 +76,7 @@ public class ExportController implements ExportApi {
       Boolean splitOptionsIntoColumns,
       Boolean stableIdsForOptions,
       Boolean includeOnlyMostRecent,
+      Boolean includeProxiesAsRows,
       String fileFormat) {
     EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
     AdminUser user = authUtilService.requireAdminUser(request);
@@ -82,6 +85,7 @@ public class ExportController implements ExportApi {
             splitOptionsIntoColumns != null ? splitOptionsIntoColumns : false,
             stableIdsForOptions != null ? stableIdsForOptions : false,
             includeOnlyMostRecent != null ? includeOnlyMostRecent : false,
+            includeProxiesAsRows != null ? includeProxiesAsRows : false,
             fileFormat != null ? ExportFileFormat.valueOf(fileFormat) : ExportFileFormat.TSV,
             null);
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/export/ExportController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/export/ExportController.java
@@ -53,13 +53,16 @@ public class ExportController implements ExportApi {
     AdminUser user = authUtilService.requireAdminUser(request);
 
     ExportOptions exportOptions =
-        new ExportOptions(
-            splitOptionsIntoColumns != null ? splitOptionsIntoColumns : false,
-            stableIdsForOptions != null ? stableIdsForOptions : false,
-            includeOnlyMostRecent != null ? includeOnlyMostRecent : false,
-            includeProxiesAsRows != null ? includeProxiesAsRows : false,
-            fileFormat != null ? ExportFileFormat.valueOf(fileFormat) : ExportFileFormat.TSV,
-            limit);
+        ExportOptions.builder()
+            .splitOptionsIntoColumns(
+                splitOptionsIntoColumns != null ? splitOptionsIntoColumns : false)
+            .stableIdsForOptions(stableIdsForOptions != null ? stableIdsForOptions : false)
+            .onlyIncludeMostRecent(includeOnlyMostRecent != null ? includeOnlyMostRecent : false)
+            .includeProxiesAsRows(includeProxiesAsRows != null ? includeProxiesAsRows : false)
+            .fileFormat(
+                fileFormat != null ? ExportFileFormat.valueOf(fileFormat) : ExportFileFormat.TSV)
+            .limit(limit)
+            .build();
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     enrolleeExportExtService.export(
@@ -81,13 +84,16 @@ public class ExportController implements ExportApi {
     EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
     AdminUser user = authUtilService.requireAdminUser(request);
     ExportOptions exportOptions =
-        new ExportOptions(
-            splitOptionsIntoColumns != null ? splitOptionsIntoColumns : false,
-            stableIdsForOptions != null ? stableIdsForOptions : false,
-            includeOnlyMostRecent != null ? includeOnlyMostRecent : false,
-            includeProxiesAsRows != null ? includeProxiesAsRows : false,
-            fileFormat != null ? ExportFileFormat.valueOf(fileFormat) : ExportFileFormat.TSV,
-            null);
+        ExportOptions.builder()
+            .splitOptionsIntoColumns(
+                splitOptionsIntoColumns != null ? splitOptionsIntoColumns : false)
+            .stableIdsForOptions(stableIdsForOptions != null ? stableIdsForOptions : false)
+            .onlyIncludeMostRecent(includeOnlyMostRecent != null ? includeOnlyMostRecent : false)
+            .includeProxiesAsRows(includeProxiesAsRows != null ? includeProxiesAsRows : false)
+            .fileFormat(
+                fileFormat != null ? ExportFileFormat.valueOf(fileFormat) : ExportFileFormat.TSV)
+            .limit(null)
+            .build();
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     enrolleeExportExtService.exportDictionary(

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -1035,6 +1035,7 @@ paths:
         - { name: splitOptionsIntoColumns, in: query, required: false, schema: { type: boolean, default: false } }
         - { name: stableIdsForOptions, in: query, required: false, schema: { type: boolean, default: false } }
         - { name: onlyIncludeMostRecent, in: query, required: false, schema: { type: boolean, default: true } }
+        - { name: includeProxiesAsRows, in: query, required: false, schema: { type: boolean, default: true } }
         - { name: fileFormat, in: query, required: false, schema: { type: string, default: "TSV" } }
         - { name: limit, in: query, required: false, schema: { type: integer } }
       responses:
@@ -1055,6 +1056,7 @@ paths:
         - { name: splitOptionsIntoColumns, in: query, required: false, schema: { type: boolean, default: false } }
         - { name: stableIdsForOptions, in: query, required: false, schema: { type: boolean, default: false } }
         - { name: onlyIncludeMostRecent, in: query, required: false, schema: { type: boolean, default: true } }
+        - { name: includeProxiesAsRows, in: query, required: false, schema: { type: boolean, default: true } }
         - { name: fileFormat, in: query, required: false, schema: { type: string, default: "TSV" } }
       responses:
         '200':

--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeDao.java
@@ -1,10 +1,5 @@
 package bio.terra.pearl.core.dao.participant;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Stream;
-
 import bio.terra.pearl.core.dao.BaseMutableJdbiDao;
 import bio.terra.pearl.core.dao.consent.ConsentResponseDao;
 import bio.terra.pearl.core.dao.kit.KitRequestDao;
@@ -17,6 +12,11 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.Query;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
 
 @Component
 public class EnrolleeDao extends BaseMutableJdbiDao<Enrollee> {

--- a/core/src/main/java/bio/terra/pearl/core/model/participant/EnrolleeRelation.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/participant/EnrolleeRelation.java
@@ -1,18 +1,13 @@
 package bio.terra.pearl.core.model.participant;
 
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-
 import bio.terra.pearl.core.model.BaseEntity;
-import bio.terra.pearl.core.model.consent.ConsentResponse;
-import bio.terra.pearl.core.model.survey.SurveyResponse;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
+
+import java.time.Instant;
+import java.util.UUID;
 
 /** represents a relation between two enrollees.
  * this relationship is directional from the enrollee to the targetEnrollee
@@ -27,6 +22,7 @@ public class EnrolleeRelation extends BaseEntity {
     private UUID enrolleeId;
     private UUID targetEnrolleeId; // note the targetEnrollee does not necessary have to be a subject
     private Enrollee targetEnrollee;
+    private Enrollee enrollee;
     private RelationshipType relationshipType;
     private Instant beginDate;
     private Instant endDate;

--- a/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoExportService.java
@@ -168,7 +168,12 @@ public class DataRepoExportService {
     }
 
     public String uploadCsvToAzureStorage(UUID studyEnvironmentId, UUID datasetId) {
-        ExportOptions exportOptions = new ExportOptions(false, false, false, false, ExportFileFormat.TSV, null);
+        ExportOptions exportOptions = ExportOptions
+                .builder()
+                .onlyIncludeMostRecent(false)
+                .fileFormat(ExportFileFormat.TSV)
+                .limit(null)
+                .build();
 
         //Even though this is actually formatted as a TSV, TDR only accepts files ending in .csv or .json.
         //In the DataRepoClient call, we specify that the CSV delimiter is "\t", which will make it all work fine.
@@ -216,7 +221,12 @@ public class DataRepoExportService {
     }
 
     public Set<TdrColumn> generateDatasetSchema(UUID studyEnvironmentId) {
-        ExportOptions exportOptions = new ExportOptions(false, false, false, false, ExportFileFormat.TSV, null);
+        ExportOptions exportOptions = ExportOptions
+                .builder()
+                .onlyIncludeMostRecent(false)
+                .fileFormat(ExportFileFormat.TSV)
+                .limit(null)
+                .build();
 
         //Backtrack from studyEnvironmentId to get the portalId, so we can export the study environment data
         StudyEnvironment studyEnv = studyEnvironmentDao.find(studyEnvironmentId).orElseThrow(() -> new NotFoundException("Study environment not found."));
@@ -230,7 +240,7 @@ public class DataRepoExportService {
                     studyEnvironmentId,
                     moduleFormatters,
                     false,
-                    exportOptions.limit());
+                    exportOptions.getLimit());
 
             TsvExporter tsvExporter = new TsvExporter(moduleFormatters, enrolleeMaps);
 

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportData.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportData.java
@@ -1,18 +1,19 @@
 package bio.terra.pearl.core.service.export;
 
 import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.participant.EnrolleeRelation;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.model.participant.Profile;
 import bio.terra.pearl.core.model.survey.Answer;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
 import bio.terra.pearl.core.service.kit.KitRequestDto;
-import java.util.List;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.List;
 
 @Getter @Setter @Builder @AllArgsConstructor
 public class EnrolleeExportData {
@@ -23,4 +24,5 @@ public class EnrolleeExportData {
     private List<ParticipantTask> tasks;
     private List<SurveyResponse> responses;
     private List<KitRequestDto> kitRequests;
+    private List<EnrolleeRelation> enrolleeRelations;
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
@@ -83,8 +83,8 @@ public class EnrolleeExportService {
      * */
     public void export(ExportOptions exportOptions, UUID studyEnvironmentId, OutputStream os) {
         List<ModuleFormatter> moduleFormatters = generateModuleInfos(exportOptions, studyEnvironmentId);
-        List<Map<String, String>> enrolleeMaps = generateExportMaps(studyEnvironmentId, moduleFormatters, exportOptions.includeProxiesAsRows(), exportOptions.limit());
-        BaseExporter exporter = getExporter(exportOptions.fileFormat(), moduleFormatters, enrolleeMaps);
+        List<Map<String, String>> enrolleeMaps = generateExportMaps(studyEnvironmentId, moduleFormatters, exportOptions.isIncludeProxiesAsRows(), exportOptions.getLimit());
+        BaseExporter exporter = getExporter(exportOptions.getFileFormat(), moduleFormatters, enrolleeMaps);
         exporter.export(os);
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -42,7 +42,7 @@ public class EnrolleeImportService {
     /**
      * for now, we only support importing from a specific style of export.
      */
-    ExportOptions IMPORT_OPTIONS = new ExportOptions(false, true, true, ExportFileFormat.TSV, null);
+    ExportOptions IMPORT_OPTIONS = new ExportOptions(false, true, true, false, ExportFileFormat.TSV, null);
 
     private final RegistrationService registrationService;
     private final EnrollmentService enrollmentService;

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -42,7 +42,13 @@ public class EnrolleeImportService {
     /**
      * for now, we only support importing from a specific style of export.
      */
-    ExportOptions IMPORT_OPTIONS = new ExportOptions(false, true, true, false, ExportFileFormat.TSV, null);
+    ExportOptions IMPORT_OPTIONS = ExportOptions
+            .builder()
+            .stableIdsForOptions(true)
+            .onlyIncludeMostRecent(true)
+            .fileFormat(ExportFileFormat.TSV)
+            .limit(null)
+            .build();
 
     private final RegistrationService registrationService;
     private final EnrollmentService enrollmentService;

--- a/core/src/main/java/bio/terra/pearl/core/service/export/ExportOptions.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/ExportOptions.java
@@ -1,18 +1,25 @@
 package bio.terra.pearl.core.service.export;
 
-import lombok.Builder;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 
-public record ExportOptions(
-        boolean splitOptionsIntoColumns,
-        boolean stableIdsForOptions,
-        boolean onlyIncludeMostRecent,
-        boolean includeProxiesAsRows,
-        ExportFileFormat fileFormat,
-        Integer limit) {
+
+@SuperBuilder
+@Getter
+public final class ExportOptions {
+    private final boolean splitOptionsIntoColumns;
+    private final boolean stableIdsForOptions;
+    private final boolean onlyIncludeMostRecent;
+    private final boolean includeProxiesAsRows;
+    private final ExportFileFormat fileFormat;
+    private final Integer limit;
+
     public ExportOptions() {
-        this(false, false, true, false, ExportFileFormat.TSV, null);
+        this.splitOptionsIntoColumns = false;
+        this.stableIdsForOptions = false;
+        this.onlyIncludeMostRecent = true;
+        this.includeProxiesAsRows = false;
+        this.fileFormat = ExportFileFormat.TSV;
+        this.limit = null;
     }
-
-    @Builder
-    public ExportOptions {}
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/ExportOptions.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/ExportOptions.java
@@ -1,13 +1,16 @@
 package bio.terra.pearl.core.service.export;
 
-import bio.terra.pearl.core.service.export.ExportFileFormat;
 import lombok.Builder;
 
-public record ExportOptions (boolean splitOptionsIntoColumns, boolean stableIdsForOptions, boolean onlyIncludeMostRecent,
-                             ExportFileFormat fileFormat,
-                             Integer limit) {
+public record ExportOptions(
+        boolean splitOptionsIntoColumns,
+        boolean stableIdsForOptions,
+        boolean onlyIncludeMostRecent,
+        boolean includeProxiesAsRows,
+        ExportFileFormat fileFormat,
+        Integer limit) {
     public ExportOptions() {
-        this(false, false, true, ExportFileFormat.TSV, null);
+        this(false, false, true, false, ExportFileFormat.TSV, null);
     }
 
     @Builder

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/item/AnswerItemFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/item/AnswerItemFormatter.java
@@ -1,12 +1,16 @@
 package bio.terra.pearl.core.service.export.formatters.item;
 
-import bio.terra.pearl.core.model.survey.*;
+import bio.terra.pearl.core.model.survey.Answer;
+import bio.terra.pearl.core.model.survey.AnswerType;
+import bio.terra.pearl.core.model.survey.QuestionChoice;
+import bio.terra.pearl.core.model.survey.SurveyQuestionDefinition;
+import bio.terra.pearl.core.model.survey.SurveyResponse;
 import bio.terra.pearl.core.service.export.BaseExporter;
 import bio.terra.pearl.core.service.export.DataValueExportType;
 import bio.terra.pearl.core.service.export.ExportOptions;
 import bio.terra.pearl.core.service.export.formatters.ExportFormatUtils;
-import bio.terra.pearl.core.service.export.formatters.module.SurveyFormatter;
 import bio.terra.pearl.core.service.export.formatters.module.ModuleFormatter;
+import bio.terra.pearl.core.service.export.formatters.module.SurveyFormatter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -14,9 +18,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @SuperBuilder
 @Getter
@@ -68,10 +74,10 @@ public class AnswerItemFormatter extends ItemFormatter<SurveyResponse> {
                 throw new IllegalStateException("Error parsing choices for question " + questionDef.getQuestionStableId(), e);
             }
         }
-        boolean splitOptions = exportOptions.splitOptionsIntoColumns() && choices.size() > 0 && questionDef.isAllowMultiple();
+        boolean splitOptions = exportOptions.isSplitOptionsIntoColumns() && choices.size() > 0 && questionDef.isAllowMultiple();
         baseColumnKey = questionDef.getQuestionStableId();
         questionStableId = questionDef.getQuestionStableId();
-        stableIdsForOptions = exportOptions.stableIdsForOptions();
+        stableIdsForOptions = exportOptions.isStableIdsForOptions();
         splitOptionsIntoColumns = splitOptions;
         allowMultiple = questionDef.isAllowMultiple();
         this.choices = choices;

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeFormatter.java
@@ -2,7 +2,6 @@ package bio.terra.pearl.core.service.export.formatters.module;
 
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.service.export.EnrolleeExportData;
-import bio.terra.pearl.core.service.export.formatters.ExportFormatUtils;
 import bio.terra.pearl.core.service.export.ExportOptions;
 import bio.terra.pearl.core.service.export.formatters.item.PropertyItemFormatter;
 
@@ -11,11 +10,16 @@ import java.util.stream.Collectors;
 
 public class EnrolleeFormatter extends BeanModuleFormatter<Enrollee> {
     public static final String ENROLLEE_MODULE_NAME = "enrollee";
-    public static final List<String> INCLUDED_PROPERTIES = List.of("shortcode", "consented", "createdAt");
+    public static final List<String> INCLUDED_PROPERTIES = List.of(
+            "shortcode", "consented", "createdAt"
+    );
 
     public EnrolleeFormatter(ExportOptions exportOptions) {
         itemFormatters = INCLUDED_PROPERTIES.stream().map(propName -> new PropertyItemFormatter<Enrollee>(propName, Enrollee.class))
                 .collect(Collectors.toList());
+        if (exportOptions.includeProxiesAsRows()) {
+            itemFormatters.add(new PropertyItemFormatter<>("subject", Enrollee.class));
+        }
         moduleName = ENROLLEE_MODULE_NAME;
         displayName = "Enrollee";
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeFormatter.java
@@ -11,15 +11,12 @@ import java.util.stream.Collectors;
 public class EnrolleeFormatter extends BeanModuleFormatter<Enrollee> {
     public static final String ENROLLEE_MODULE_NAME = "enrollee";
     public static final List<String> INCLUDED_PROPERTIES = List.of(
-            "shortcode", "consented", "createdAt"
+            "shortcode", "consented", "createdAt", "subject"
     );
 
     public EnrolleeFormatter(ExportOptions exportOptions) {
         itemFormatters = INCLUDED_PROPERTIES.stream().map(propName -> new PropertyItemFormatter<Enrollee>(propName, Enrollee.class))
                 .collect(Collectors.toList());
-        if (exportOptions.includeProxiesAsRows()) {
-            itemFormatters.add(new PropertyItemFormatter<>("subject", Enrollee.class));
-        }
         moduleName = ENROLLEE_MODULE_NAME;
         displayName = "Enrollee";
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeRelationFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeRelationFormatter.java
@@ -24,10 +24,11 @@ public class EnrolleeRelationFormatter extends ModuleFormatter<EnrolleeRelation,
         displayName = "Proxy Relations";
     }
 
+    // near-duplicate of toStringMap in KitRequestFormatter, potentially could
+    // extract helper methods if more similar formatters arise
     @Override
     public Map<String, String> toStringMap(EnrolleeExportData enrolleeData) {
         List<EnrolleeRelation> relations = enrolleeData.getEnrolleeRelations();
-        // sort the kits oldest first
         relations = relations.stream()
                 .sorted(Comparator.comparing(EnrolleeRelation::getCreatedAt)).toList();
         Map<String, String> outputMap = new HashMap<>();

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeRelationFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeRelationFormatter.java
@@ -1,0 +1,44 @@
+package bio.terra.pearl.core.service.export.formatters.module;
+
+import bio.terra.pearl.core.model.participant.EnrolleeRelation;
+import bio.terra.pearl.core.service.export.EnrolleeExportData;
+import bio.terra.pearl.core.service.export.formatters.item.PropertyItemFormatter;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class EnrolleeRelationFormatter extends ModuleFormatter<EnrolleeRelation, PropertyItemFormatter<EnrolleeRelation>> {
+    private static final String MODULE_NAME = "proxy";
+    private static final List<String> INCLUDED_PROPERTIES =
+        List.of("enrollee.shortcode", "relationshipType", "beginDate", "endDate");
+
+    public EnrolleeRelationFormatter() {
+        itemFormatters = INCLUDED_PROPERTIES.stream()
+                .map(propName -> new PropertyItemFormatter<>(propName, EnrolleeRelation.class))
+                .collect(Collectors.toList());
+        // we have to handle kitType separately because we'll need to match it to the kitType name
+        moduleName = MODULE_NAME;
+        displayName = "Proxy Relations";
+    }
+
+    @Override
+    public Map<String, String> toStringMap(EnrolleeExportData enrolleeData) {
+        List<EnrolleeRelation> relations = enrolleeData.getEnrolleeRelations();
+        // sort the kits oldest first
+        relations = relations.stream()
+                .sorted(Comparator.comparing(EnrolleeRelation::getCreatedAt)).toList();
+        Map<String, String> outputMap = new HashMap<>();
+        for (int i = 0; i < relations.size(); i++) {
+            for (PropertyItemFormatter<EnrolleeRelation> itemInfo : getItemFormatters()) {
+                String value = itemInfo.getExportString(relations.get(i));
+                String columnName = getColumnKey(itemInfo, false, null, i + 1);
+                outputMap.put(columnName, value);
+            }
+        }
+        maxNumRepeats = Math.max(maxNumRepeats, relations.size());
+        return outputMap;
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeRelationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeRelationService.java
@@ -40,6 +40,17 @@ public class EnrolleeRelationService extends DataAuditedService<EnrolleeRelation
         return filterValid(dao.findByTargetEnrolleeId(enrolleeId));
     }
 
+    public List<EnrolleeRelation> findByTargetEnrolleeIdWithEnrollees(UUID enrolleeId) {
+        Enrollee target = this.enrolleeService.find(enrolleeId).orElse(null);
+        List<EnrolleeRelation> relations = findByTargetEnrolleeId(enrolleeId);
+
+        return relations.stream().map(relation -> {
+            relation.setTargetEnrollee(target);
+            relation.setEnrollee(this.enrolleeService.find(relation.getEnrolleeId()).orElse(null));
+            return relation;
+        }).toList();
+    }
+
     public boolean isUserProxyForAnyOf(UUID participantUserId, List<UUID> enrolleeIds) {
         return !dao.findEnrolleeRelationsByProxyParticipantUser(participantUserId, enrolleeIds)
                 .stream().filter(enrolleeRelation -> isRelationshipValid(enrolleeRelation)).collect(Collectors.toList()).isEmpty();

--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeExportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeExportServiceTests.java
@@ -72,9 +72,14 @@ public class EnrolleeExportServiceTests extends BaseSpringBootTest {
         StudyEnvironment studyEnv = studyEnvBundle.getStudyEnv();
         EnrolleeFactory.EnrolleeAndProxy enrolleeWithProxy = enrolleeFactory.buildProxyAndGovernedEnrollee(testName, studyEnvBundle.getPortalEnv(), studyEnvBundle.getStudyEnv());
         Enrollee regularEnrollee = enrolleeFactory.buildPersisted(testName, studyEnv, new Profile());
-        List<ModuleFormatter> exportModuleInfoWithProxies = enrolleeExportService.generateModuleInfos(new ExportOptions(
-                false, false, true, true, ExportFileFormat.TSV, null
-        ), studyEnv.getId());
+        List<ModuleFormatter> exportModuleInfoWithProxies = enrolleeExportService.generateModuleInfos(ExportOptions
+                        .builder()
+                        .includeProxiesAsRows(true)
+                        .onlyIncludeMostRecent(true)
+                        .fileFormat(ExportFileFormat.TSV)
+                        .limit(null)
+                        .build(),
+                studyEnv.getId());
 
         List<Map<String, String>> exportMapsWithProxies = enrolleeExportService.generateExportMaps(studyEnv.getId(), exportModuleInfoWithProxies, true, null);
         assertThat(exportMapsWithProxies, hasSize(3));
@@ -88,18 +93,16 @@ public class EnrolleeExportServiceTests extends BaseSpringBootTest {
         assertThat(exportMapsWithProxies.get(2).get("enrollee.shortcode"), equalTo(enrolleeWithProxy.proxy().getShortcode()));
         assertThat(exportMapsWithProxies.get(2).get("enrollee.subject"), equalTo("false"));
 
-        List<ModuleFormatter> exportModuleInfoNoProxies = enrolleeExportService.generateModuleInfos(new ExportOptions(
-                false, false, true, false, ExportFileFormat.TSV, null
-        ), studyEnv.getId());
+        List<ModuleFormatter> exportModuleInfoNoProxies = enrolleeExportService.generateModuleInfos(new ExportOptions(), studyEnv.getId());
 
         List<Map<String, String>> exportMapsNoProxies = enrolleeExportService.generateExportMaps(studyEnv.getId(), exportModuleInfoNoProxies, false, null);
         assertThat(exportMapsNoProxies, hasSize(2));
 
         assertThat(exportMapsNoProxies.get(0).get("enrollee.shortcode"), equalTo(regularEnrollee.getShortcode()));
-        assertThat(exportMapsNoProxies.get(0).containsKey("enrollee.subject"), equalTo(false));
+        assertThat(exportMapsNoProxies.get(1).get("enrollee.subject"), equalTo("true"));
 
         assertThat(exportMapsNoProxies.get(1).get("enrollee.shortcode"), equalTo(enrolleeWithProxy.governedEnrollee().getShortcode()));
-        assertThat(exportMapsNoProxies.get(1).containsKey("enrollee.subject"), equalTo(false));
+        assertThat(exportMapsNoProxies.get(1).get("enrollee.subject"), equalTo("true"));
 
     }
 

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/EnrolleeFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/EnrolleeFormatterTests.java
@@ -4,10 +4,11 @@ import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.service.export.EnrolleeExportData;
 import bio.terra.pearl.core.service.export.ExportOptions;
 import bio.terra.pearl.core.service.export.formatters.module.EnrolleeFormatter;
-import bio.terra.pearl.core.service.export.formatters.module.ModuleFormatter;
+import org.junit.jupiter.api.Test;
+
 import java.time.Instant;
 import java.util.Map;
-import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -20,7 +21,7 @@ public class EnrolleeFormatterTests {
                 .createdAt(Instant.parse("2023-08-21T05:17:25.00Z"))
                 .build();
         EnrolleeFormatter moduleFormatter = new EnrolleeFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(enrollee, null, null, null, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(enrollee, null, null, null, null, null, null, null);
         Map<String, String> valueMap = moduleFormatter.toStringMap(exportData);
 
         assertThat(valueMap.get("enrollee.shortcode"), equalTo("TESTER"));

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/KitRequestFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/KitRequestFormatterTests.java
@@ -38,7 +38,7 @@ public class KitRequestFormatterTests {
                 .createdAt(Instant.now().minus(1, java.time.temporal.ChronoUnit.DAYS))
                 .build()
         );
-        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null, null, null, kitRequests);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null, null, null, kitRequests, null);
         Map<String, String> valueMap = moduleFormatter.toStringMap(exportData);
 
         // the older kit should be first

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ParticipantUserFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ParticipantUserFormatterTests.java
@@ -22,7 +22,7 @@ public class ParticipantUserFormatterTests {
                 .createdAt(Instant.parse("2023-08-21T05:17:25.00Z"))
                 .build();
         ParticipantUserFormatter moduleFormatter = new ParticipantUserFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(null, participantUser, null, null, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, participantUser, null, null, null, null, null, null);
         Map<String, String> valueMap = moduleFormatter.toStringMap(exportData);
 
         assertThat(valueMap.get("account.username"), equalTo(participantUser.getUsername()));

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ProfileFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ProfileFormatterTests.java
@@ -26,7 +26,7 @@ public class ProfileFormatterTests {
                         .build())
                 .build();
         ProfileFormatter moduleFormatter = new ProfileFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(null, null, profile, null, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, profile, null, null, null, null, null);
         Map<String, String> enrolleeMap = moduleFormatter.toStringMap(exportData);
 
         assertThat(enrolleeMap.get("profile.familyName"), equalTo("Tester"));
@@ -42,7 +42,7 @@ public class ProfileFormatterTests {
                 .familyName("Tester")
                 .build();
         ProfileFormatter moduleFormatter = new ProfileFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(null, null, profile, null, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, profile, null, null, null, null, null);
         Map<String, String> enrolleeMap = moduleFormatter.toStringMap(exportData);
 
         assertThat(enrolleeMap.get("profile.familyName"), equalTo("Tester"));

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatterTests.java
@@ -10,16 +10,16 @@ import bio.terra.pearl.core.service.export.ExportOptions;
 import bio.terra.pearl.core.service.export.formatters.item.AnswerItemFormatter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 public class SurveyFormatterTests extends BaseSpringBootTest {
     @Autowired
@@ -43,7 +43,7 @@ public class SurveyFormatterTests extends BaseSpringBootTest {
                 .stringValue("easyValue")
                 .build();
         EnrolleeExportData enrolleeExportData = new EnrolleeExportData(null, null, null,
-                List.of(answer), null, List.of(testResponse), null);
+                List.of(answer), null, List.of(testResponse), null, null);
         Map<String, String> valueMap = moduleFormatter.toStringMap(enrolleeExportData);
 
         assertThat(valueMap.get("oh_surveyA.oh_surveyA_q1"), equalTo("easyValue"));

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
@@ -1,17 +1,13 @@
 package bio.terra.pearl.populate;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.consent.ConsentForm;
 import bio.terra.pearl.core.model.notification.EmailTemplate;
-import bio.terra.pearl.core.model.participant.*;
+import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.participant.ParticipantUser;
+import bio.terra.pearl.core.model.participant.PortalParticipantUser;
+import bio.terra.pearl.core.model.participant.Profile;
+import bio.terra.pearl.core.model.participant.RelationshipType;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.site.SiteContent;
@@ -28,6 +24,19 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 
 /** confirm demo portal populates as expected */
 public class PopulateDemoTest extends BasePopulatePortalsTest {
@@ -145,9 +154,9 @@ public class PopulateDemoTest extends BasePopulatePortalsTest {
     }
 
     private void checkExportContent(UUID sandboxEnvironmentId) throws Exception {
-        ExportOptions options = new ExportOptions(false, false, true, ExportFileFormat.TSV, null);
+        ExportOptions options = new ExportOptions(false, false, true, false, ExportFileFormat.TSV, null);
         List<ModuleFormatter> moduleInfos = enrolleeExportService.generateModuleInfos(options, sandboxEnvironmentId);
-        List<Map<String, String>> exportData = enrolleeExportService.generateExportMaps(sandboxEnvironmentId, moduleInfos, options.limit());
+        List<Map<String, String>> exportData = enrolleeExportService.generateExportMaps(sandboxEnvironmentId, moduleInfos, false, options.limit());
 
         assertThat(exportData, hasSize(9));
         Map<String, String> oldVersionMap = exportData.stream().filter(map -> "HDVERS".equals(map.get("enrollee.shortcode")))

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
@@ -154,9 +154,14 @@ public class PopulateDemoTest extends BasePopulatePortalsTest {
     }
 
     private void checkExportContent(UUID sandboxEnvironmentId) throws Exception {
-        ExportOptions options = new ExportOptions(false, false, true, false, ExportFileFormat.TSV, null);
+        ExportOptions options = ExportOptions
+                .builder()
+                .onlyIncludeMostRecent(true)
+                .fileFormat(ExportFileFormat.TSV)
+                .limit(null)
+                .build();
         List<ModuleFormatter> moduleInfos = enrolleeExportService.generateModuleInfos(options, sandboxEnvironmentId);
-        List<Map<String, String>> exportData = enrolleeExportService.generateExportMaps(sandboxEnvironmentId, moduleInfos, false, options.limit());
+        List<Map<String, String>> exportData = enrolleeExportService.generateExportMaps(sandboxEnvironmentId, moduleInfos, false, options.getLimit());
 
         assertThat(exportData, hasSize(9));
         Map<String, String> oldVersionMap = exportData.stream().filter(map -> "HDVERS".equals(map.get("enrollee.shortcode")))

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateOurhealthTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateOurhealthTest.java
@@ -115,9 +115,9 @@ public class PopulateOurhealthTest extends BasePopulatePortalsTest {
 
     private void checkExportContent(UUID sandboxEnvironmentId) {
         // test the analysis-friendly export as that is the most important for data integrity, and the least visible via admin tool
-        ExportOptions options = new ExportOptions(true, true, true, ExportFileFormat.TSV, null);
+        ExportOptions options = new ExportOptions(true, true, true, false, ExportFileFormat.TSV, null);
         List<ModuleFormatter> moduleInfos = enrolleeExportService.generateModuleInfos(options, sandboxEnvironmentId);
-        List<Map<String, String>> exportData = enrolleeExportService.generateExportMaps(sandboxEnvironmentId, moduleInfos, options.limit());
+        List<Map<String, String>> exportData = enrolleeExportService.generateExportMaps(sandboxEnvironmentId, moduleInfos, false, options.limit());
 
         assertThat(exportData, hasSize(6));
         Map<String, String> jsalkMap = exportData.stream().filter(map -> "OHSALK".equals(map.get("enrollee.shortcode")))
@@ -131,7 +131,7 @@ public class PopulateOurhealthTest extends BasePopulatePortalsTest {
     }
 
     private void checkDataDictionary(UUID portalId, UUID sandboxEnvironmentId) throws Exception {
-        ExportOptions options = new ExportOptions(false, false, true, ExportFileFormat.TSV, null);
+        ExportOptions options = new ExportOptions(false, false, true, false, ExportFileFormat.TSV, null);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         dictionaryExportService.exportDictionary(options, portalId, sandboxEnvironmentId, baos);
         baos.flush();

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateOurhealthTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateOurhealthTest.java
@@ -115,9 +115,16 @@ public class PopulateOurhealthTest extends BasePopulatePortalsTest {
 
     private void checkExportContent(UUID sandboxEnvironmentId) {
         // test the analysis-friendly export as that is the most important for data integrity, and the least visible via admin tool
-        ExportOptions options = new ExportOptions(true, true, true, false, ExportFileFormat.TSV, null);
+        ExportOptions options = ExportOptions
+                .builder()
+                .splitOptionsIntoColumns(true)
+                .stableIdsForOptions(true)
+                .onlyIncludeMostRecent(true)
+                .fileFormat(ExportFileFormat.TSV)
+                .limit(null)
+                .build();
         List<ModuleFormatter> moduleInfos = enrolleeExportService.generateModuleInfos(options, sandboxEnvironmentId);
-        List<Map<String, String>> exportData = enrolleeExportService.generateExportMaps(sandboxEnvironmentId, moduleInfos, false, options.limit());
+        List<Map<String, String>> exportData = enrolleeExportService.generateExportMaps(sandboxEnvironmentId, moduleInfos, false, options.getLimit());
 
         assertThat(exportData, hasSize(6));
         Map<String, String> jsalkMap = exportData.stream().filter(map -> "OHSALK".equals(map.get("enrollee.shortcode")))
@@ -131,7 +138,12 @@ public class PopulateOurhealthTest extends BasePopulatePortalsTest {
     }
 
     private void checkDataDictionary(UUID portalId, UUID sandboxEnvironmentId) throws Exception {
-        ExportOptions options = new ExportOptions(false, false, true, false, ExportFileFormat.TSV, null);
+        ExportOptions options = ExportOptions
+                .builder()
+                .onlyIncludeMostRecent(true)
+                .fileFormat(ExportFileFormat.TSV)
+                .limit(null)
+                .build();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         dictionaryExportService.exportDictionary(options, portalId, sandboxEnvironmentId, baos);
         baos.flush();

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -305,6 +305,7 @@ export type ExportOptions = {
   splitOptionsIntoColumns?: boolean,
   stableIdsForOptions?: boolean,
   onlyIncludeMostRecent?: boolean,
+  includeProxiesAsRows?: boolean,
   limit?: number
 }
 

--- a/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
@@ -74,7 +74,9 @@ const ExportDataBrowser = ({ studyEnvContext }: {studyEnvContext: StudyEnvContex
     const response = await Api.exportEnrollees(
       studyEnvContext.portal.shortcode,
       studyEnvContext.study.shortcode,
-      studyEnvContext.currentEnv.environmentName, { fileFormat: 'JSON', limit: 10 })
+      studyEnvContext.currentEnv.environmentName, {
+        fileFormat: 'JSON', limit: 10, includeProxiesAsRows: false
+      })
     const result = await response.json()
     if (!response.ok) {
       Store.addNotification(failureNotification('Failed to load export data', result.message))

--- a/ui-admin/src/study/participants/export/ExportDataControl.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataControl.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
 import Modal from 'react-bootstrap/Modal'
 import LoadingSpinner from 'util/LoadingSpinner'
-import Api from 'api/api'
+import Api, { ExportOptions } from 'api/api'
 import { currentIsoDate } from '@juniper/ui-core'
 import { Link } from 'react-router-dom'
 import { saveBlobAsDownload } from 'util/downloadUtils'
@@ -24,14 +24,16 @@ const ExportDataControl = ({ studyEnvContext, show, setShow }: {studyEnvContext:
   const [humanReadable, setHumanReadable] = useState(true)
   const [onlyIncludeMostRecent, setOnlyIncludeMostRecent] = useState(true)
   const [fileFormat, setFileFormat] = useState(FILE_FORMATS[0])
+  const [includeProxiesAsRows, setIncludeProxiesAsRows] = useState(false)
 
   const [isLoading, setIsLoading] = useState(false)
 
-  const optionsFromState = () => {
+  const optionsFromState = (): ExportOptions => {
     return {
       onlyIncludeMostRecent,
       splitOptionsIntoColumns: !humanReadable,
       stableIdsForOptions: !humanReadable,
+      includeProxiesAsRows,
       fileFormat: fileFormat.value
     }
   }
@@ -72,7 +74,9 @@ const ExportDataControl = ({ studyEnvContext, show, setShow }: {studyEnvContext:
     <Modal.Body>
       <form onSubmit={e => e.preventDefault()}>
         <div className="py-2">
-          <span className="fw-bold">Data format</span><br/>
+          <p className="fw-bold mb-1">
+            Data format
+          </p>
           <label className="me-3">
             <input type="radio" name="humanReadable" value="true" checked={humanReadable}
               onChange={humanReadableChanged} className="me-1"/> Human-readable
@@ -83,7 +87,9 @@ const ExportDataControl = ({ studyEnvContext, show, setShow }: {studyEnvContext:
           </label>
         </div>
         <div className="py-2">
-          <span className="fw-bold">Completions included of a survey (for recurring surveys)</span><br/>
+          <p className="fw-bold mb-1">
+            Completions included of a survey (for recurring surveys)
+          </p>
           <label className="me-3">
             <input type="radio" name="onlyIncludeMostRecent" value="true" checked={onlyIncludeMostRecent}
               onChange={includeRecentChanged} className="me-1" disabled={true}/>
@@ -93,6 +99,16 @@ const ExportDataControl = ({ studyEnvContext, show, setShow }: {studyEnvContext:
             <input type="radio" name="onlyIncludeMostRecent" value="false" checked={!onlyIncludeMostRecent}
               onChange={includeRecentChanged} className="me-1" disabled={true}/>
             Include all completions
+          </label>
+        </div>
+        <div className="py-2">
+          <p className="fw-bold mb-1">
+            Proxy Options
+          </p>
+          <label>
+            <input type="checkbox" name="includeProxiesAsRows" checked={includeProxiesAsRows}
+              onChange={() => setIncludeProxiesAsRows(!includeProxiesAsRows)} className="me-1"/>
+            Include proxies as rows
           </label>
         </div>
         <div className="py-2">


### PR DESCRIPTION
#### DESCRIPTION

Adds proxy relations to the data export. In addition, you can now request to include proxies as distinct rows in the data export, unchecked by default. If checked, then the `enrollee.subject` row will be included, otherwise it won't.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Export data with and without enrollees and ensure data looks as expected
