### PR TITLE
[JN-1002] Fix admin welcome emails

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/notification/EmailTemplateDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/notification/EmailTemplateDao.java
@@ -4,6 +4,7 @@ import bio.terra.pearl.core.dao.BaseVersionedJdbiDao;
 import bio.terra.pearl.core.model.notification.EmailTemplate;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import bio.terra.pearl.core.model.notification.LocalizedEmailTemplate;
@@ -31,6 +32,17 @@ public class EmailTemplateDao extends BaseVersionedJdbiDao<EmailTemplate> {
             attachAllLocalizedTemplates(emailTemplate);
         }
         return emailTemplates;
+    }
+
+    public Optional<EmailTemplate> findAdminTemplateByStableId(String stableId, int version) {
+        return jdbi.withHandle(
+                handle ->
+                        handle
+                                .createQuery("SELECT * FROM email_template WHERE stable_id = :stableId AND version = :version AND portal_id IS NULL")
+                                .bind("stableId", stableId)
+                                .bind("version", version)
+                                .mapToBean(EmailTemplate.class)
+                                .findOne());
     }
 
     public EmailTemplate attachLocalizedTemplate(EmailTemplate emailTemplate, String language) {

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/email/AdminEmailService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/email/AdminEmailService.java
@@ -72,7 +72,7 @@ public class AdminEmailService {
    * for now, this is trivial, but later admin emails may contain other context
    */
   public NotificationContextInfo loadContextInfo(String templateStableId, int version, Portal portal) {
-    EmailTemplate emailTemplate = emailTemplateService.findByStableId(templateStableId, version, null).get();
+    EmailTemplate emailTemplate = emailTemplateService.findAdminTemplateByStableId(templateStableId, version).get();
     emailTemplateService.attachLocalizedTemplates(emailTemplate);
     return new NotificationContextInfo(
         portal,

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/email/EmailTemplateService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/email/EmailTemplateService.java
@@ -6,6 +6,7 @@ import bio.terra.pearl.core.model.notification.LocalizedEmailTemplate;
 import bio.terra.pearl.core.service.VersionedEntityService;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
 
@@ -44,5 +45,9 @@ public class EmailTemplateService extends VersionedEntityService<EmailTemplate, 
 
     public void deleteByPortalId(UUID portalId) {
         dao.deleteByPortalId(portalId);
+    }
+
+    public Optional<EmailTemplate> findAdminTemplateByStableId(String stableId, int version) {
+        return dao.findAdminTemplateByStableId(stableId, version);
     }
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/email/EmailTemplateServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/email/EmailTemplateServiceTests.java
@@ -2,11 +2,15 @@ package bio.terra.pearl.core.service.notification.email;
 
 import bio.terra.pearl.core.BaseSpringBootTest;
 import bio.terra.pearl.core.factory.notification.EmailTemplateFactory;
+import bio.terra.pearl.core.factory.portal.PortalFactory;
 import bio.terra.pearl.core.model.notification.EmailTemplate;
+import bio.terra.pearl.core.model.portal.Portal;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -16,6 +20,8 @@ public class EmailTemplateServiceTests extends BaseSpringBootTest {
     private EmailTemplateFactory emailTemplateFactory;
     @Autowired
     private EmailTemplateService emailTemplateService;
+    @Autowired
+    private PortalFactory portalFactory;
 
     @Test
     @Transactional
@@ -25,5 +31,31 @@ public class EmailTemplateServiceTests extends BaseSpringBootTest {
         emailTemplateService.assignPublishedVersion(form.getId());
         form = emailTemplateService.find(form.getId()).get();
         assertThat(form.getPublishedVersion(), equalTo(1));
+    }
+
+    @Test
+    @Transactional
+    public void testFindAdminEmails(TestInfo info) {
+        EmailTemplate template = EmailTemplate.builder()
+                .name("Admin Welcome Email")
+                .stableId("admin_welcome_email")
+                .version(1)
+                .portalId(null).build();
+        emailTemplateService.create(template);
+
+        //Create another portal-specific template with the same stable id to confirm that we don't collide
+        Portal portal = portalFactory.buildPersisted(getTestName(info));
+        EmailTemplate portalTemplate = EmailTemplate.builder()
+                .name("Portal Welcome Email")
+                .stableId("admin_welcome_email")
+                .version(1)
+                .portalId(portal.getId()).build();
+        emailTemplateService.create(portalTemplate);
+
+        EmailTemplate adminTemplate = emailTemplateService.findAdminTemplateByStableId("admin_welcome_email", 1).get();
+        assertThat(adminTemplate.getStableId(), equalTo("admin_welcome_email"));
+        assertThat(adminTemplate.getVersion(), equalTo(1));
+        assertThat(adminTemplate.getPortalId(), equalTo(null));
+        assertThat(adminTemplate.getName(), equalTo("Admin Welcome Email"));
     }
 }


### PR DESCRIPTION
#### DESCRIPTION

Quick fix for admin welcome emails, which would throw an exception:

```
Unexpected exception occurred invoking async method:
public void bio.terra.pearl.core.service.notification.email.AdminEmailService.sendWelcomeEmail(bio.terra.pearl.core.model.portal.Portal,bio.terra.pearl.core.model.admin.AdminUser)
java.util.NoSuchElementException: No value present
at java.base/java.util.Optional.get(Optional.java:143)
```

The query generated by `findByThreeProperties` doesn't handle null values correctly. This could also be fixed directly in the BaseJdbiDao methods, but I didn't want to assume that this was the intended behavior for everything, and it would also introduce a lot of inconsistency with the other DAO methods unless we refactored all of the queries.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Restart Admin Api
* Try adding a new admin user: https://localhost:3000/demo/studies/heartdemo/users
* Confirm that you get the welcome email

