### PR TITLE
[JN-989] View localized templates in email editor

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/portal/PortalController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/portal/PortalController.java
@@ -33,9 +33,9 @@ public class PortalController implements PortalApi {
   }
 
   @Override
-  public ResponseEntity<Object> get(String portalShortcode) {
+  public ResponseEntity<Object> get(String portalShortcode, String language) {
     AdminUser adminUser = requestService.requireAdminUser(request);
-    Portal portal = portalExtService.fullLoad(adminUser, portalShortcode);
+    Portal portal = portalExtService.fullLoad(adminUser, portalShortcode, language);
     return ResponseEntity.ok(portal);
   }
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/siteContent/SiteContentController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/siteContent/SiteContentController.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.Optional;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
@@ -34,10 +33,6 @@ public class SiteContentController implements SiteContentApi {
   @Override
   public ResponseEntity<Object> get(
       String portalShortcode, String stableId, Integer version, String language) {
-    if (StringUtils.isBlank(language)) {
-      // TODO (JN-863): Use the default language
-      language = "en";
-    }
     AdminUser adminUser = authUtilService.requireAdminUser(request);
     Optional<SiteContent> siteContent =
         siteContentExtService.get(portalShortcode, stableId, version, language, adminUser);

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/portal/PortalExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/portal/PortalExtService.java
@@ -41,7 +41,7 @@ public class PortalExtService {
 
   public Portal fullLoad(AdminUser user, String portalShortcode) {
     Portal portal = authUtilService.authUserToPortal(user, portalShortcode);
-    return portalService.fullLoad(portal, "en");
+    return portalService.fullLoad(portal, null);
   }
 
   /** gets all the portals the user has access to, and attaches the corresponding studies */

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/portal/PortalExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/portal/PortalExtService.java
@@ -39,9 +39,9 @@ public class PortalExtService {
     this.authUtilService = authUtilService;
   }
 
-  public Portal fullLoad(AdminUser user, String portalShortcode) {
+  public Portal fullLoad(AdminUser user, String portalShortcode, String language) {
     Portal portal = authUtilService.authUserToPortal(user, portalShortcode);
-    return portalService.fullLoad(portal, null);
+    return portalService.fullLoad(portal, language);
   }
 
   /** gets all the portals the user has access to, and attaches the corresponding studies */

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -95,6 +95,7 @@ paths:
       operationId: get
       parameters:
         - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: language, in: query, required: false, schema: { type: string } }
       responses:
         '200':
           description: portal object

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PortalController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PortalController.java
@@ -9,7 +9,6 @@ import bio.terra.pearl.core.service.portal.PortalDashboardConfigService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
 import bio.terra.pearl.core.service.portal.PortalService;
 import java.util.Optional;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
@@ -30,10 +29,6 @@ public class PortalController implements PortalApi {
 
   @Override
   public ResponseEntity<Object> get(String portalShortcode, String envName, String language) {
-    if (StringUtils.isBlank(language)) {
-      // TODO (JN-863): Use the default language
-      language = "en";
-    }
     EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
     Optional<Portal> portalOpt =
         portalService.loadWithParticipantSiteContent(portalShortcode, environmentName, language);

--- a/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalEnvironmentDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalEnvironmentDao.java
@@ -9,7 +9,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import bio.terra.pearl.core.model.portal.PortalEnvironmentConfig;
 import bio.terra.pearl.core.model.portal.PortalEnvironmentLanguage;
+import org.apache.commons.lang3.StringUtils;
 import org.jdbi.v3.core.Jdbi;
 import org.springframework.stereotype.Component;
 
@@ -57,11 +59,10 @@ public class PortalEnvironmentDao extends BaseMutableJdbiDao<PortalEnvironment> 
                                                                       String language) {
         Optional<PortalEnvironment> portalEnvOpt = findOne(shortcode, environmentName);
         portalEnvOpt.ifPresent(portalEnv -> {
-            portalEnv.setPortalEnvironmentConfig(
-                    portalEnvironmentConfigDao.find(portalEnv.getPortalEnvironmentConfigId()).orElse(null)
-            );
-            portalEnv.setSiteContent(siteContentDao.findOneFull(portalEnv.getSiteContentId(), language)
-                    .orElse(null));
+            PortalEnvironmentConfig envConfig = portalEnvironmentConfigDao.find(portalEnv.getPortalEnvironmentConfigId()).orElse(null);
+            portalEnv.setPortalEnvironmentConfig(envConfig);
+            String languageToLoad = StringUtils.defaultIfBlank(language, envConfig.getDefaultLanguage());
+            portalEnv.setSiteContent(siteContentDao.findOneFull(portalEnv.getSiteContentId(), languageToLoad).orElse(null));
             if (portalEnv.getPreRegSurveyId() != null) {
                 portalEnv.setPreRegSurvey(surveyDao.find(portalEnv.getPreRegSurveyId()).get());
             }

--- a/core/src/main/java/bio/terra/pearl/core/dao/site/SiteContentDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/site/SiteContentDao.java
@@ -51,9 +51,7 @@ public class SiteContentDao extends BaseVersionedJdbiDao<SiteContent> {
      * */
     public Optional<SiteContent> findOneFull(UUID siteContentId, String language) {
         Optional<SiteContent> siteContentOpt = find(siteContentId);
-        siteContentOpt.ifPresent(siteContent -> {
-            attachChildContent(siteContent, language);
-        });
+        siteContentOpt.ifPresent(siteContent -> attachChildContent(siteContent, language));
         return siteContentOpt;
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/model/portal/PortalEnvironmentConfig.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/portal/PortalEnvironmentConfig.java
@@ -28,4 +28,6 @@ public class PortalEnvironmentConfig extends BaseEntity {
     private boolean initialized = false;
     private String participantHostname; // needs to be configured for email links to work
     private String emailSourceAddress; // what goes in the 'from' field of emails to participants from this portal
+    @Builder.Default
+    private String defaultLanguage = "en";
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/site/SiteContent.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/site/SiteContent.java
@@ -19,8 +19,6 @@ public class SiteContent extends BaseEntity implements Versioned {
     private Integer publishedVersion;
     @Builder.Default
     private List<LocalizedSiteContent> localizedSiteContents = new ArrayList<>();
-    @Builder.Default
-    private String defaultLanguage = "en";
 
     // used to keep siteContents attached to a portal even if they are not on an environment currently
     private UUID portalId;

--- a/core/src/main/java/bio/terra/pearl/core/service/portal/PortalService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/portal/PortalService.java
@@ -18,6 +18,7 @@ import bio.terra.pearl.core.service.site.SiteMediaService;
 import bio.terra.pearl.core.service.study.PortalStudyService;
 import bio.terra.pearl.core.service.study.StudyService;
 import bio.terra.pearl.core.service.survey.SurveyService;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -111,9 +112,10 @@ public class PortalService extends CrudService<Portal, PortalDao> {
     }
 
     /** loads a portal environment with everything needed to render the participant-facing site */
-    public Optional<Portal> loadWithParticipantSiteContent(String shortcodeOrHostname,
-                                                                       EnvironmentName environmentName,
-                                                                       String language) {
+    public Optional<Portal> loadWithParticipantSiteContent(
+            String shortcodeOrHostname,
+            EnvironmentName environmentName,
+            String language) {
         Optional<Portal> portalOpt = dao.findOneByShortcodeOrHostname(shortcodeOrHostname);
         portalOpt.ifPresent(portal -> {
             Optional<PortalEnvironment> portalEnv = portalEnvironmentService

--- a/core/src/main/resources/db/changelog/changesets/2024_04_08_portal_env_default_language.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_04_08_portal_env_default_language.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: portal_env_config_default_language
+      author: mbemis
+      changes:
+        - addColumn:
+            tableName: portal_environment_config
+            columns:
+              - column: { name: default_language, type: text, constraints: { nullable: false }, defaultValue: 'en' }
+        - dropColumn:
+            tableName: site_content
+            columnName: default_language

--- a/core/src/main/resources/db/changelog/changesets/2024_04_08_portal_env_supported_languages_backfill.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_04_08_portal_env_supported_languages_backfill.yaml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: backfill_portal_env_languages
+      author: mbemis
+      changes:
+        - sql:
+            sql: "INSERT INTO portal_environment_language
+                    (portal_environment_id, created_at, last_updated_at, language_code, language_name)
+                  SELECT pe.id, NOW(), NOW(), 'en', 'English'
+                  FROM portal_environment pe
+                  WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM portal_environment_language pel
+                    WHERE pel.portal_environment_id = pe.id
+                  );"

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -245,6 +245,12 @@ databaseChangeLog:
   - include:
       file: changesets/2024_04_03_anonymous_user_responsible_entity.yaml
       relativeToChangelogFile: true        
+  - include:
+      file: changesets/2024_04_08_portal_env_default_language.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: changesets/2024_04_08_portal_env_supported_languages_backfill.yaml
+      relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/core/src/test/java/bio/terra/pearl/core/model/publishing/ConfigChangeTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/model/publishing/ConfigChangeTests.java
@@ -68,14 +68,15 @@ public class ConfigChangeTests {
                 .emailSourceAddress("blah@blah.com").build();
         List<ConfigChange> changeRecords = ConfigChange.allChanges(sourceConfig, destConfig,
                 PortalDiffService.CONFIG_IGNORE_PROPS);
-        assertThat(changeRecords, hasSize(6));
+        assertThat(changeRecords, hasSize(7));
         assertThat(changeRecords, hasItems(
                 new ConfigChange("emailSourceAddress", "blah@blah.com", (Object) null),
                 new ConfigChange("acceptingRegistration", false, (Object) null),
                 new ConfigChange("participantHostname", (Object) "bar", (Object) null),
                 new ConfigChange("initialized", false, (Object) null),
                 new ConfigChange("password", (Object) "broad_institute", (Object) null),
-                new ConfigChange("passwordProtected", true, (Object) null)
+                new ConfigChange("passwordProtected", true, (Object) null),
+                new ConfigChange("defaultLanguage", "en", (Object) null)
         ));
     }
 
@@ -88,14 +89,15 @@ public class ConfigChangeTests {
                 .emailSourceAddress("blah@blah.com").build();
         List<ConfigChange> changeRecords = ConfigChange.allChanges(sourceConfig, destConfig,
                 PortalDiffService.CONFIG_IGNORE_PROPS);
-        assertThat(changeRecords, hasSize(6));
+        assertThat(changeRecords, hasSize(7));
         assertThat(changeRecords, hasItems(
                 new ConfigChange("emailSourceAddress", (Object) null, (Object) "blah@blah.com"),
                 new ConfigChange("acceptingRegistration", (Object) null, false),
                 new ConfigChange("participantHostname", (Object) null, (Object) "bar"),
                 new ConfigChange("initialized", (Object) null, false),
                 new ConfigChange("password", (Object) null, (Object) "broad_institute"),
-                new ConfigChange("passwordProtected", (Object) null, true)
+                new ConfigChange("passwordProtected", (Object) null, true),
+                new ConfigChange("defaultLanguage", (Object) null, (Object) "en")
         ));
     }
 

--- a/core/src/test/java/bio/terra/pearl/core/service/site/SiteContentServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/site/SiteContentServiceTests.java
@@ -109,7 +109,6 @@ public class SiteContentServiceTests extends BaseSpringBootTest {
         form = siteContentService.find(form.getId()).get();
         assertThat(form.getPublishedVersion(), equalTo(1));
 
-        form.setDefaultLanguage("zzz");
         SiteContent newForm = siteContentService.createNewVersion(form);
 
         Assertions.assertNotEquals(newForm.getId(), form.getId());

--- a/core/src/test/java/bio/terra/pearl/core/service/workflow/RegistrationServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/workflow/RegistrationServiceTests.java
@@ -76,7 +76,6 @@ public class RegistrationServiceTests extends BaseSpringBootTest {
         String username = "test" + RandomStringUtils.randomAlphabetic(5) + "@test.com";
         RegistrationService.RegistrationResult result = registrationService.register(portalShortcode,
                 portalEnv.getEnvironmentName(), username, null, null);
-        //TODO (JN-863) - check instead that this matches the default portal language
-        Assertions.assertEquals("en", result.profile().getPreferredLanguage());
+        Assertions.assertEquals(portalEnv.getPortalEnvironmentConfig().getDefaultLanguage(), result.profile().getPreferredLanguage());
     }
 }

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/site/SiteContentFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/site/SiteContentFactory.java
@@ -17,8 +17,7 @@ public class SiteContentFactory {
     public SiteContent.SiteContentBuilder builder(String testName) {
         return SiteContent.builder()
                 .stableId(testName)
-                .version(1)
-                .defaultLanguage("en");
+                .version(1);
     }
 
     public SiteContent.SiteContentBuilder builderWithDependencies(String testName) {

--- a/populate/src/main/java/bio/terra/pearl/populate/service/extract/SiteContentExtractor.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/extract/SiteContentExtractor.java
@@ -138,8 +138,6 @@ public class SiteContentExtractor {
         @JsonIgnore @Override
         public List<LocalizedSiteContentPopDto> getLocalizedSiteContentDtos() { return null; }
         @JsonIgnore @Override
-        public String getDefaultLanguage() { return null; }
-        @JsonIgnore @Override
         public int getVersion() { return 0; }
     }
 

--- a/populate/src/main/resources/seed/portals/demo/portal.json
+++ b/populate/src/main/resources/seed/portals/demo/portal.json
@@ -15,7 +15,8 @@
         "passwordProtected": false,
         "password": "broad_institute",
         "initialized": true,
-        "emailSourceAddress": "support@juniper.terra.bio"
+        "emailSourceAddress": "support@juniper.terra.bio",
+        "defaultLanguage": "es"
       },
       "supportedLanguages": [{
         "languageName": "English",
@@ -60,7 +61,8 @@
         "passwordProtected": false,
         "password": "broad_institute",
         "initialized": true,
-        "emailSourceAddress": "support@juniper.terra.bio"
+        "emailSourceAddress": "support@juniper.terra.bio",
+        "defaultLanguage": "en"
       },
       "supportedLanguages": [{
         "languageName": "English",
@@ -76,7 +78,8 @@
         "passwordProtected": false,
         "password": "broad_institute",
         "initialized": true,
-        "emailSourceAddress": "support@juniper.terra.bio"
+        "emailSourceAddress": "support@juniper.terra.bio",
+        "defaultLanguage": "en"
       },
       "supportedLanguages": [{
         "languageName": "English",

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-1/siteContent.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-1/siteContent.json
@@ -1,7 +1,6 @@
 {
   "stableId": "hd_portalContent",
   "version": 1,
-  "defaultLanguage": "en",
   "localizedSiteContentDtos": [{
     "language": "en",
     "navLogoCleanFileName": "juniper-demo-logo.png",

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/siteContent.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/siteContent.json
@@ -1,7 +1,6 @@
 {
   "stableId": "hd_portalContent",
   "version": 2,
-  "defaultLanguage": "en",
   "localizedSiteContentDtos": [{
     "language": "en",
     "navLogoCleanFileName": "juniper-demo-logo.png",

--- a/populate/src/main/resources/seed/portals/hearthive/portal.json
+++ b/populate/src/main/resources/seed/portals/hearthive/portal.json
@@ -14,6 +14,10 @@
       "initialized" : true,
       "emailSourceAddress" : "info@thehearthive.org"
     },
+    "supportedLanguages": [{
+      "languageName": "English",
+      "languageCode": "en"
+    }],
     "triggers" : [ ],
     "participantDashboardAlerts" : [ ],
     "participantUserFiles" : [
@@ -34,6 +38,10 @@
       "initialized" : true,
       "emailSourceAddress" : "info@thehearthive.org"
     },
+    "supportedLanguages": [{
+      "languageName": "English",
+      "languageCode": "en"
+    }],
     "triggers" : [ ],
     "participantDashboardAlerts" : [ ],
     "participantUserFiles" : [ ],
@@ -51,6 +59,10 @@
       "participantHostname" : "thehearthive.org",
       "emailSourceAddress" : "info@thehearthive.org"
     },
+    "supportedLanguages": [{
+      "languageName": "English",
+      "languageCode": "en"
+    }],
     "triggers" : [ ],
     "participantDashboardAlerts" : [ ],
     "participantUserFiles" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-1/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-1/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 1,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-10/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-10/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 10,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-11/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-11/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 11,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-12/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-12/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 12,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-13/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-13/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 13,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-14/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-14/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 14,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-15/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-15/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 15,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-16/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-16/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 16,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-17/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-17/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 17,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-18/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-18/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 18,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-19/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-19/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 19,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-2/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-2/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 2,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-20/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-20/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 20,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-21/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-21/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 21,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-22/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-22/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 22,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-23/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-23/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 23,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-24/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-24/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 24,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-25/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-25/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 25,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-26/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-26/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 26,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-27/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-27/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 27,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-28/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-28/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 28,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-29/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-29/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 29,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-3/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-3/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 3,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-30/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-30/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 30,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-31/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-31/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 31,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-32/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-32/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 32,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-33/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-33/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 33,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-34/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-34/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 34,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-35/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-35/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 35,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-36/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-36/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 36,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-37/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-37/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 37,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-38/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-38/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 38,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-39/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-39/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 39,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-4/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-4/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 4,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-40/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-40/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 40,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-41/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-41/siteContent.json
@@ -3,7 +3,6 @@
   "version" : 41,
   "publishedVersion" : 1,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-42/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-42/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 42,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-43/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-43/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 43,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-44/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-44/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 44,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-45/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-45/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 45,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-46/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-46/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 46,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-47/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-47/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 47,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-48/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-48/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 48,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-49/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-49/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 49,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-5/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-5/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 5,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-50/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-50/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 50,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-51/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-51/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 51,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-52/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-52/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 52,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-53/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-53/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 53,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-54/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-54/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 54,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-55/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-55/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 55,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-56/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-56/siteContent.json
@@ -3,7 +3,6 @@
   "version" : 56,
   "publishedVersion" : 2,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-57/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-57/siteContent.json
@@ -3,7 +3,6 @@
   "version" : 57,
   "publishedVersion" : 3,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-58/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-58/siteContent.json
@@ -3,7 +3,6 @@
   "version" : 58,
   "publishedVersion" : 4,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-59/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-59/siteContent.json
@@ -3,7 +3,6 @@
   "version" : 59,
   "publishedVersion" : 5,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-6/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-6/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 6,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-60/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-60/siteContent.json
@@ -3,7 +3,6 @@
   "version" : 60,
   "publishedVersion" : 6,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-61/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-61/siteContent.json
@@ -3,7 +3,6 @@
   "version" : 61,
   "publishedVersion" : 7,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-62/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-62/siteContent.json
@@ -3,7 +3,6 @@
   "version" : 62,
   "publishedVersion" : 8,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-7/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-7/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 7,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-8/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-8/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 8,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-9/siteContent.json
+++ b/populate/src/main/resources/seed/portals/hearthive/siteContent/hh_portalContent-9/siteContent.json
@@ -2,7 +2,6 @@
   "stableId" : "hh_portalContent",
   "version" : 9,
   "localizedSiteContents" : [ ],
-  "defaultLanguage" : "en",
   "localizedSiteContentDtos" : [ {
     "language" : "en",
     "navbarItems" : [ ],

--- a/populate/src/main/resources/seed/portals/ourhealth/portal.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/portal.json
@@ -15,8 +15,13 @@
         "passwordProtected": false,
         "password": "broad_institute",
         "initialized": true,
-        "emailSourceAddress": "info@ourhealthstudy.org"
+        "emailSourceAddress": "info@ourhealthstudy.org",
+        "defaultLanguage": "en"
       },
+      "supportedLanguages": [{
+        "languageName": "English",
+        "languageCode": "en"
+      }],
       "siteContentPopDto": {
         "populateFileName": "siteContent/siteContent.json"
       },
@@ -45,16 +50,26 @@
         "acceptingRegistration": true,
         "passwordProtected": false,
         "password": "broad_institute",
-        "initialized": false
-      }
+        "initialized": false,
+        "defaultLanguage": "en"
+      },
+      "supportedLanguages": [{
+        "languageName": "English",
+        "languageCode": "en"
+      }]
     },{
       "environmentName": "live",
       "portalEnvironmentConfig": {
         "acceptingRegistration": true,
         "passwordProtected": false,
         "password": "broad_institute",
-        "initialized": false
-      }
+        "initialized": false,
+        "defaultLanguage": "en"
+      },
+      "supportedLanguages": [{
+        "languageName": "English",
+        "languageCode": "en"
+      }]
     }
   ],
   "adminUsers": [

--- a/populate/src/main/resources/seed/portals/ourhealth/siteContent/siteContent.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/siteContent/siteContent.json
@@ -1,7 +1,6 @@
 {
   "stableId": "oh_portalContent",
   "version": 1,
-  "defaultLanguage": "en",
   "localizedSiteContentDtos": [{
     "language": "en",
     "navLogoCleanFileName": "ourhealth-logo.png",

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateOurhealthTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateOurhealthTest.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -85,7 +86,7 @@ public class PopulateOurhealthTest extends BasePopulatePortalsTest {
 
     private void checkOurhealthSiteContent(UUID portalId) {
         PortalEnvironment portalEnv = portalEnvironmentService
-                .loadWithParticipantSiteContent("ourhealth", EnvironmentName.sandbox, "en").get();
+                .loadWithParticipantSiteContent("ourhealth", EnvironmentName.sandbox, null).get();
         Assertions.assertEquals(portalId, portalEnv.getPortalId());
         LocalizedSiteContent lsc = portalEnv.getSiteContent().getLocalizedSiteContents()
                 .stream().findFirst().get();

--- a/ui-admin/src/App.tsx
+++ b/ui-admin/src/App.tsx
@@ -48,7 +48,7 @@ function App() {
       <ConfigConsumer>
         { config =>
           <AuthProvider {...getOidcConfig(config.b2cTenantName, config.b2cClientId, config.b2cPolicyName)}>
-            <I18nProvider>
+            <I18nProvider defaultLanguage={'en'}>
               <UserProvider>
                 <div className="App d-flex flex-column min-vh-100">
                   <IdleStatusMonitor maxIdleSessionDuration={30 * 60 * 1000} idleWarningDuration={5 * 60 * 1000}/>

--- a/ui-admin/src/forms/FormPreview.tsx
+++ b/ui-admin/src/forms/FormPreview.tsx
@@ -13,7 +13,7 @@ import {
 
 import { FormPreviewOptions } from './FormPreviewOptions'
 import Api from '../api/api'
-import { useDefaultLanguage } from 'portal/useDefaultPortalLanguage'
+import { usePortalLanguage } from 'portal/useDefaultPortalLanguage'
 
 type FormPreviewProps = {
   formContent: FormContent
@@ -25,7 +25,7 @@ type FormPreviewProps = {
  */
 export const FormPreview = (props: FormPreviewProps) => {
   const { formContent, supportedLanguages } = props
-  const defaultLanguage = useDefaultLanguage()
+  const { defaultLanguage } = usePortalLanguage()
 
   const { i18n } = useI18n()
 

--- a/ui-admin/src/forms/FormPreview.tsx
+++ b/ui-admin/src/forms/FormPreview.tsx
@@ -13,7 +13,7 @@ import {
 
 import { FormPreviewOptions } from './FormPreviewOptions'
 import Api from '../api/api'
-import { useDefaultLanguage } from '../portal/useDefaultPortalLanguage'
+import { useDefaultLanguage } from 'portal/useDefaultPortalLanguage'
 
 type FormPreviewProps = {
   formContent: FormContent

--- a/ui-admin/src/forms/FormPreview.tsx
+++ b/ui-admin/src/forms/FormPreview.tsx
@@ -13,16 +13,19 @@ import {
 
 import { FormPreviewOptions } from './FormPreviewOptions'
 import Api from '../api/api'
+import { useDefaultLanguage } from '../portal/useDefaultPortalLanguage'
 
 type FormPreviewProps = {
   formContent: FormContent
   supportedLanguages: PortalEnvironmentLanguage[]
 }
 
-// TODO: Add JSDoc
-// eslint-disable-next-line jsdoc/require-jsdoc
+/**
+ * Renders a preview of a form/survey.
+ */
 export const FormPreview = (props: FormPreviewProps) => {
   const { formContent, supportedLanguages } = props
+  const defaultLanguage = useDefaultLanguage()
 
   const { i18n } = useI18n()
 
@@ -30,7 +33,7 @@ export const FormPreview = (props: FormPreviewProps) => {
     const model = surveyJSModelFromFormContent(formContent)
     model.setVariable('portalEnvironmentName', 'sandbox')
     model.ignoreValidation = true
-    model.locale = 'default'
+    model.locale = defaultLanguage.languageCode
     model.onServerValidateQuestions.add(createAddressValidator(addr => Api.validateAddress(addr), i18n))
     return model
   })

--- a/ui-admin/src/forms/FormPreviewOptions.tsx
+++ b/ui-admin/src/forms/FormPreviewOptions.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { PortalEnvironmentLanguage } from '@juniper/ui-core'
 import Select from 'react-select'
 import useReactSingleSelect from 'util/react-select-utils'
-import { useDefaultLanguage } from '../portal/useDefaultPortalLanguage'
+import { useDefaultLanguage } from 'portal/useDefaultPortalLanguage'
 
 type FormPreviewOptions = {
   ignoreValidation: boolean

--- a/ui-admin/src/forms/FormPreviewOptions.tsx
+++ b/ui-admin/src/forms/FormPreviewOptions.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { PortalEnvironmentLanguage } from '@juniper/ui-core'
 import Select from 'react-select'
 import useReactSingleSelect from 'util/react-select-utils'
+import { useDefaultLanguage } from '../portal/useDefaultPortalLanguage'
 
 type FormPreviewOptions = {
   ignoreValidation: boolean
@@ -18,9 +19,8 @@ type FormPreviewOptionsProps = {
 /** Controls for configuring the form editor's preview tab. */
 export const FormPreviewOptions = (props: FormPreviewOptionsProps) => {
   const { value, supportedLanguages, onChange } = props
-  // TODO (JN-863): Use the default language
-  const [selectedLanguage, setSelectedLanguage] = useState<PortalEnvironmentLanguage | undefined>(
-    supportedLanguages.find(lang => lang.languageCode === 'en'))
+  const defaultLanguage = useDefaultLanguage()
+  const [selectedLanguage, setSelectedLanguage] = useState<PortalEnvironmentLanguage | undefined>(defaultLanguage)
 
   const {
     onChange: languageOnChange, options: languageOptions,

--- a/ui-admin/src/forms/FormPreviewOptions.tsx
+++ b/ui-admin/src/forms/FormPreviewOptions.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { PortalEnvironmentLanguage } from '@juniper/ui-core'
 import Select from 'react-select'
 import useReactSingleSelect from 'util/react-select-utils'
-import { useDefaultLanguage } from 'portal/useDefaultPortalLanguage'
+import { usePortalLanguage } from 'portal/useDefaultPortalLanguage'
 
 type FormPreviewOptions = {
   ignoreValidation: boolean
@@ -19,7 +19,7 @@ type FormPreviewOptionsProps = {
 /** Controls for configuring the form editor's preview tab. */
 export const FormPreviewOptions = (props: FormPreviewOptionsProps) => {
   const { value, supportedLanguages, onChange } = props
-  const defaultLanguage = useDefaultLanguage()
+  const { defaultLanguage } = usePortalLanguage()
   const [selectedLanguage, setSelectedLanguage] = useState<PortalEnvironmentLanguage | undefined>(defaultLanguage)
 
   const {

--- a/ui-admin/src/portal/PortalEnvConfigView.tsx
+++ b/ui-admin/src/portal/PortalEnvConfigView.tsx
@@ -12,7 +12,7 @@ import useUpdateEffect from '../util/useUpdateEffect'
 import useReactSingleSelect from '../util/react-select-utils'
 import { PortalEnvironmentLanguage } from '@juniper/ui-core'
 import Select from 'react-select'
-import { useDefaultLanguage } from './useDefaultPortalLanguage'
+import { usePortalLanguage } from './useDefaultPortalLanguage'
 
 
 type PortalEnvConfigViewProps = {
@@ -28,7 +28,7 @@ const PortalEnvConfigView = ({ portalContext, portalEnv }: PortalEnvConfigViewPr
   const { user } = useUser()
   const { portal, reloadPortal } = portalContext
   const [isLoading, setIsLoading] = useState(false)
-  const defaultLanguage = useDefaultLanguage()
+  const { defaultLanguage } = usePortalLanguage()
   const [selectedLanguage, setSelectedLanguage] = useState<PortalEnvironmentLanguage | undefined>(defaultLanguage)
   /** update a given field in the config */
   const updateConfig = (propName: string, value: string | boolean) => {

--- a/ui-admin/src/portal/publish/PortalEnvPublishControl.test.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvPublishControl.test.tsx
@@ -13,7 +13,8 @@ test('renders a copy link', () => {
       initialized: true,
       acceptingRegistration: false,
       passwordProtected: false,
-      password: ''
+      password: '',
+      defaultLanguage: 'en'
     },
     supportedLanguages: []
   }
@@ -23,7 +24,8 @@ test('renders a copy link', () => {
       initialized: false,
       acceptingRegistration: false,
       passwordProtected: false,
-      password: ''
+      password: '',
+      defaultLanguage: 'en'
     },
     supportedLanguages: []
   }

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -43,8 +43,6 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
   } = props
   const { portalEnv } = portalEnvContext
   const initialContent = siteContent
-  // TODO (JN-863): Use the default language
-  const defaultLanguage = { languageCode: 'en', languageName: 'English' }
   const [activeTab, setActiveTab] = useState<string | null>('designer')
   const [selectedNavOpt, setSelectedNavOpt] = useState<NavbarOption>(landingPageOption)
   const [workingContent, setWorkingContent] = useState<SiteContent>(initialContent)
@@ -57,7 +55,7 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
   const [hasInvalidSection, setHasInvalidSection] = useState(false)
   const [selectedLanguage, setSelectedLanguage] = useState<PortalEnvironmentLanguage | undefined>(
     portalEnvContext.portalEnv.supportedLanguages.find(f =>
-      workingContent.localizedSiteContents[0]?.language === f.languageCode) || defaultLanguage)
+      workingContent.localizedSiteContents[0]?.language === f.languageCode))
   const localContent = workingContent.localizedSiteContents.find(lsc => lsc.language === selectedLanguage?.languageCode)
   const zoneConfig = useConfig()
   if (!localContent) {

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -369,4 +369,3 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
 }
 
 export default SiteContentEditor
-

--- a/ui-admin/src/portal/siteContent/SiteContentLoader.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentLoader.tsx
@@ -7,13 +7,16 @@ import { failureNotification, successNotification } from 'util/notifications'
 import LoadingSpinner from 'util/LoadingSpinner'
 import SiteContentEditor from './SiteContentEditor'
 import { previewApi } from 'util/apiContextUtils'
+import { useDefaultLanguage } from '../useDefaultPortalLanguage'
 
 /** logic for loading, changing, and saving SiteContent objects */
 const SiteContentLoader = ({ portalEnvContext }: {portalEnvContext: PortalEnvContext}) => {
   const { portal, portalEnv } = portalEnvContext
   const portalShortcode = portal.shortcode
   const [isLoading, setIsLoading] = useState(true)
+  const defaultLanguage = useDefaultLanguage()
   const [siteContent, setSiteContent] = useState(portalEnv.siteContent)
+
   if (!siteContent) {
     return <div>no site content configured</div>
   }
@@ -78,7 +81,7 @@ const SiteContentLoader = ({ portalEnvContext }: {portalEnvContext: PortalEnvCon
     if (!portalEnv.siteContent) {
       return
     }
-    loadSiteContent(portalEnv.siteContent.stableId, portalEnv.siteContent.version)
+    loadSiteContent(portalEnv.siteContent.stableId, portalEnv.siteContent.version, defaultLanguage?.languageCode)
   }, [portalEnv.environmentName, portalShortcode])
 
   return <>

--- a/ui-admin/src/portal/siteContent/SiteContentLoader.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentLoader.tsx
@@ -7,14 +7,14 @@ import { failureNotification, successNotification } from 'util/notifications'
 import LoadingSpinner from 'util/LoadingSpinner'
 import SiteContentEditor from './SiteContentEditor'
 import { previewApi } from 'util/apiContextUtils'
-import { useDefaultLanguage } from '../useDefaultPortalLanguage'
+import { usePortalLanguage } from '../useDefaultPortalLanguage'
 
 /** logic for loading, changing, and saving SiteContent objects */
 const SiteContentLoader = ({ portalEnvContext }: {portalEnvContext: PortalEnvContext}) => {
   const { portal, portalEnv } = portalEnvContext
   const portalShortcode = portal.shortcode
   const [isLoading, setIsLoading] = useState(true)
-  const defaultLanguage = useDefaultLanguage()
+  const { defaultLanguage } = usePortalLanguage()
   const [siteContent, setSiteContent] = useState(portalEnv.siteContent)
 
   if (!siteContent) {

--- a/ui-admin/src/portal/useDefaultPortalLanguage.ts
+++ b/ui-admin/src/portal/useDefaultPortalLanguage.ts
@@ -1,10 +1,10 @@
 import { useContext } from 'react'
 import { PortalContext } from './PortalProvider'
 import { useParams } from 'react-router-dom'
-import { StudyParams } from '../study/StudyRouter'
+import { StudyParams } from 'study/StudyRouter'
 
 /**
- *
+ * Returns the default language for the current portal environment.
  */
 export function useDefaultLanguage() {
   const { portal } = useContext(PortalContext)

--- a/ui-admin/src/portal/useDefaultPortalLanguage.ts
+++ b/ui-admin/src/portal/useDefaultPortalLanguage.ts
@@ -1,0 +1,28 @@
+import { useContext } from 'react'
+import { PortalContext } from './PortalProvider'
+import { useParams } from 'react-router-dom'
+import { StudyParams } from '../study/StudyRouter'
+
+/**
+ *
+ */
+export function useDefaultLanguage() {
+  const { portal } = useContext(PortalContext)
+  const params = useParams<StudyParams>()
+  const envName: string | undefined = params.studyEnv
+
+  const defaultLanguage = portal?.portalEnvironments.find(env =>
+    env.environmentName === envName)?.portalEnvironmentConfig.defaultLanguage
+
+  const language = portal?.portalEnvironments.find(env =>
+    env.environmentName === envName)?.supportedLanguages.find(lang => lang.languageCode === defaultLanguage)
+
+  if (!language) {
+    return {
+      languageCode: 'en',
+      languageName: 'English'
+    }
+  }
+
+  return language
+}

--- a/ui-admin/src/portal/useDefaultPortalLanguage.ts
+++ b/ui-admin/src/portal/useDefaultPortalLanguage.ts
@@ -6,7 +6,7 @@ import { StudyParams } from 'study/StudyRouter'
 /**
  * Returns the default language for the current portal environment.
  */
-export function useDefaultLanguage() {
+export function usePortalLanguage() {
   const { portal } = useContext(PortalContext)
   const params = useParams<StudyParams>()
   const envName: string | undefined = params.studyEnv
@@ -14,15 +14,20 @@ export function useDefaultLanguage() {
   const defaultLanguage = portal?.portalEnvironments.find(env =>
     env.environmentName === envName)?.portalEnvironmentConfig.defaultLanguage
 
-  const language = portal?.portalEnvironments.find(env =>
-    env.environmentName === envName)?.supportedLanguages.find(lang => lang.languageCode === defaultLanguage)
+  const supportedLanguages = portal?.portalEnvironments.find(env =>
+    env.environmentName === envName)?.supportedLanguages || []
+
+  const language = supportedLanguages.find(lang => lang.languageCode === defaultLanguage)
 
   if (!language) {
     return {
-      languageCode: 'en',
-      languageName: 'English'
+      defaultLanguage: {
+        languageCode: 'en',
+        languageName: 'English'
+      },
+      supportedLanguages
     }
   }
 
-  return language
+  return { defaultLanguage: language, supportedLanguages }
 }

--- a/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
+++ b/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
@@ -31,7 +31,7 @@ export default function EmailTemplateEditor({ emailTemplate, updateEmailTemplate
         classic: true
       })
     }
-  }, [emailTemplate, selectedLanguage])
+  }, [localizedEmailTemplate, selectedLanguage])
 
   if (!localizedEmailTemplate) {
     return <div>no localized template found for {selectedLanguage?.languageCode}</div>

--- a/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
+++ b/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
@@ -3,6 +3,7 @@ import EmailEditor, { EditorRef, EmailEditorProps } from 'react-email-editor'
 import { EmailTemplate } from '@juniper/ui-core'
 import { Tab, Tabs } from 'react-bootstrap'
 import { getMediaBaseUrl } from 'api/api'
+import { useDefaultLanguage } from '../../portal/useDefaultPortalLanguage'
 
 export type EmailTemplateEditorProps = {
   emailTemplate: EmailTemplate,
@@ -18,7 +19,13 @@ export default function EmailTemplateEditor({ emailTemplate, updateEmailTemplate
   const emailTemplateRef = useRef(emailTemplate)
   emailTemplateRef.current = emailTemplate
   const [activeTab, setActiveTab] = useState<string | null>('designer')
-  const localizedEmailTemplate = emailTemplate.localizedEmailTemplates[0]
+  const defaultLanguage = useDefaultLanguage()
+  const localizedEmailTemplate = emailTemplate.localizedEmailTemplates.find(template =>
+    template.language === defaultLanguage.languageCode)
+
+  if (!localizedEmailTemplate) {
+    return <div>no localized template found for {defaultLanguage.languageCode}</div>
+  }
 
   const replacePlaceholders = (html: string) => {
     return html.replaceAll('${siteMediaBaseUrl}', location.origin + getMediaBaseUrl(portalShortcode))

--- a/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
+++ b/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
@@ -31,7 +31,7 @@ export default function EmailTemplateEditor({ emailTemplate, updateEmailTemplate
         classic: true
       })
     }
-  }, [localizedEmailTemplate, selectedLanguage])
+  }, [emailTemplate, selectedLanguage])
 
   if (!localizedEmailTemplate) {
     return <div>no localized template found for {selectedLanguage?.languageCode}</div>

--- a/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
+++ b/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
@@ -3,7 +3,7 @@ import EmailEditor, { EditorRef, EmailEditorProps } from 'react-email-editor'
 import { EmailTemplate } from '@juniper/ui-core'
 import { Tab, Tabs } from 'react-bootstrap'
 import { getMediaBaseUrl } from 'api/api'
-import { useDefaultLanguage } from '../../portal/useDefaultPortalLanguage'
+import { useDefaultLanguage } from 'portal/useDefaultPortalLanguage'
 
 export type EmailTemplateEditorProps = {
   emailTemplate: EmailTemplate,

--- a/ui-admin/src/study/notifications/TriggerView.test.tsx
+++ b/ui-admin/src/study/notifications/TriggerView.test.tsx
@@ -6,9 +6,27 @@ import TriggerView from './TriggerView'
 import { waitFor, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ReactNotifications } from 'react-notifications-component'
+import { usePortalLanguage } from '../../portal/useDefaultPortalLanguage'
+import { asMockedFn } from '@juniper/ui-core'
 
+
+jest.mock('portal/useDefaultPortalLanguage', () => ({
+  usePortalLanguage: jest.fn()
+}))
 
 test('enables updating of email templates', async () => {
+  const portalContext = mockPortalContext()
+  asMockedFn(usePortalLanguage).mockReturnValue({
+    defaultLanguage: {
+      languageCode: 'en',
+      languageName: 'English'
+    },
+    supportedLanguages: [{
+      languageCode: 'en',
+      languageName: 'English'
+    }]
+  })
+
   const studyEnvContext = mockStudyEnvContext()
   const trigger = {
     ...mockTrigger()
@@ -20,7 +38,7 @@ test('enables updating of email templates', async () => {
 
   renderWithRouter(<div>
     <ReactNotifications />
-    <TriggerView studyEnvContext={studyEnvContext} portalContext={mockPortalContext()}
+    <TriggerView studyEnvContext={studyEnvContext} portalContext={portalContext}
       onDelete={jest.fn()}/>
   </div>, [`/${trigger.id}`], ':configId')
 
@@ -28,6 +46,7 @@ test('enables updating of email templates', async () => {
   expect(findSpy).toHaveBeenCalledWith(studyEnvContext.portal.shortcode, studyEnvContext.study.shortcode,
     studyEnvContext.currentEnv.environmentName, trigger.id)
 
+  await waitFor(() => expect(screen.queryByText('Subject')).toBeInTheDocument())
   await userEvent.type(screen.getByLabelText('Subject'), 'blah')
   await userEvent.click(screen.getByText('Save'))
   expect(saveSpy).toHaveBeenCalledTimes(1)

--- a/ui-admin/src/study/notifications/TriggerView.test.tsx
+++ b/ui-admin/src/study/notifications/TriggerView.test.tsx
@@ -15,7 +15,6 @@ jest.mock('portal/useDefaultPortalLanguage', () => ({
 }))
 
 test('enables updating of email templates', async () => {
-  const portalContext = mockPortalContext()
   asMockedFn(usePortalLanguage).mockReturnValue({
     defaultLanguage: {
       languageCode: 'en',
@@ -38,7 +37,7 @@ test('enables updating of email templates', async () => {
 
   renderWithRouter(<div>
     <ReactNotifications />
-    <TriggerView studyEnvContext={studyEnvContext} portalContext={portalContext}
+    <TriggerView studyEnvContext={studyEnvContext} portalContext={mockPortalContext()}
       onDelete={jest.fn()}/>
   </div>, [`/${trigger.id}`], ':configId')
 

--- a/ui-admin/src/study/notifications/TriggerView.tsx
+++ b/ui-admin/src/study/notifications/TriggerView.tsx
@@ -11,6 +11,9 @@ import { LoadedPortalContextT } from 'portal/PortalProvider'
 import LoadingSpinner from 'util/LoadingSpinner'
 import EmailTemplateEditor from './EmailTemplateEditor'
 import { Modal } from 'react-bootstrap'
+import useReactSingleSelect from '../../util/react-select-utils'
+import { PortalEnvironmentLanguage } from '@juniper/ui-core'
+import { usePortalLanguage } from '../../portal/useDefaultPortalLanguage'
 
 const configTypeOptions = [{ label: 'Event', value: 'EVENT' }, { label: 'Task reminder', value: 'TASK_REMINDER' },
   { label: 'Ad hoc', value: 'AD_HOC' }]
@@ -30,9 +33,23 @@ export default function TriggerView({ studyEnvContext, portalContext, onDelete }
                                                    onDelete: () => void
                                                  }) {
   const { currentEnv, portal, study, currentEnvPath } = studyEnvContext
+  const { defaultLanguage, supportedLanguages } = usePortalLanguage()
   const [showSendModal, setShowSendModal] = useState(false)
   const [showDeleteModal, setShowDeleteModal] = useState(false)
+  const [selectedLanguage, setSelectedLanguage] = useState<PortalEnvironmentLanguage | undefined>(defaultLanguage)
+
   const navigate = useNavigate()
+  const {
+    onChange: languageOnChange, options: languageOptions,
+    selectedOption: selectedLanguageOption, selectInputId: selectLanguageInputId
+  } =
+      useReactSingleSelect(
+        supportedLanguages,
+        (language: PortalEnvironmentLanguage) => ({ label: language.languageName, value: language }),
+        setSelectedLanguage,
+        selectedLanguage
+      )
+
 
   const configId = useParams().configId
   const [config, setConfig] = useState<Trigger>()
@@ -109,8 +126,20 @@ export default function TriggerView({ studyEnvContext, portalContext, onDelete }
         </label>
       </div>
 
+      { supportedLanguages.length > 1 && <div style={{ width: 200 }}>
+        <label className="form-label">Language
+          <Select options={languageOptions} value={selectedLanguageOption} inputId={selectLanguageInputId}
+            aria-label={'Select a language'}
+            onChange={e => {
+              languageOnChange(e)
+              // loadSiteContent(workingContent.stableId, workingContent.version, e?.value.languageCode)
+            }}/>
+        </label>
+      </div> }
+
       {hasTemplate &&
           <EmailTemplateEditor emailTemplate={workingConfig.emailTemplate}
+            selectedLanguage={selectedLanguage}
             portalShortcode={portal.shortcode}
             updateEmailTemplate={updatedTemplate => setWorkingConfig(currentConfig => {
               // we have to use currentConfig since the template editor might call a stale version of this handler

--- a/ui-admin/src/study/notifications/TriggerView.tsx
+++ b/ui-admin/src/study/notifications/TriggerView.tsx
@@ -50,7 +50,6 @@ export default function TriggerView({ studyEnvContext, portalContext, onDelete }
         selectedLanguage
       )
 
-
   const configId = useParams().configId
   const [config, setConfig] = useState<Trigger>()
   const [workingConfig, setWorkingConfig] = useState<Trigger>()

--- a/ui-admin/src/study/notifications/TriggerView.tsx
+++ b/ui-admin/src/study/notifications/TriggerView.tsx
@@ -11,9 +11,9 @@ import { LoadedPortalContextT } from 'portal/PortalProvider'
 import LoadingSpinner from 'util/LoadingSpinner'
 import EmailTemplateEditor from './EmailTemplateEditor'
 import { Modal } from 'react-bootstrap'
-import useReactSingleSelect from '../../util/react-select-utils'
+import useReactSingleSelect from 'util/react-select-utils'
 import { PortalEnvironmentLanguage } from '@juniper/ui-core'
-import { usePortalLanguage } from '../../portal/useDefaultPortalLanguage'
+import { usePortalLanguage } from 'portal/useDefaultPortalLanguage'
 
 const configTypeOptions = [{ label: 'Event', value: 'EVENT' }, { label: 'Task reminder', value: 'TASK_REMINDER' },
   { label: 'Ad hoc', value: 'AD_HOC' }]
@@ -132,7 +132,6 @@ export default function TriggerView({ studyEnvContext, portalContext, onDelete }
             aria-label={'Select a language'}
             onChange={e => {
               languageOnChange(e)
-              // loadSiteContent(workingContent.stableId, workingContent.version, e?.value.languageCode)
             }}/>
         </label>
       </div> }

--- a/ui-admin/src/test-utils/mock-site-content.tsx
+++ b/ui-admin/src/test-utils/mock-site-content.tsx
@@ -5,7 +5,6 @@ import { HtmlSection } from '@juniper/ui-core/build/types/landingPageConfig'
 export const mockSiteContent = (): SiteContent => {
   return {
     id: 'fakeId1',
-    defaultLanguage: 'en',
     stableId: 'fakeId1',
     version: 1,
     localizedSiteContents: [

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -85,7 +85,8 @@ export const mockPortalEnvironment: (envName: string) => PortalEnvironment = (en
     initialized: true,
     password: 'broad_institute',
     passwordProtected: false,
-    acceptingRegistration: true
+    acceptingRegistration: true,
+    defaultLanguage: 'en'
   },
   environmentName: envName,
   supportedLanguages: [

--- a/ui-core/src/participant/I18nProvider.tsx
+++ b/ui-core/src/participant/I18nProvider.tsx
@@ -32,12 +32,15 @@ const SELECTED_LANGUAGE_KEY = 'selectedLanguage'
 /**
  * Provider for the current users i18n context.
  */
-export function I18nProvider({ portalShortcode, children }: { portalShortcode?: string, children: React.ReactNode }) {
+export function I18nProvider({ defaultLanguage, portalShortcode, children }: {
+  defaultLanguage: string, portalShortcode?: string, children: React.ReactNode
+}) {
   const Api = useApiContext()
   const [isLoading, setIsLoading] = useState(true)
   const [isError, setIsError] = useState(false)
   const [languageTexts, setLanguageTexts] = useState<Record<string, string>>({})
-  const [selectedLanguage, setSelectedLanguage] = useState(localStorage.getItem(SELECTED_LANGUAGE_KEY) || 'en')
+  const [selectedLanguage, setSelectedLanguage] = useState(
+    localStorage.getItem(SELECTED_LANGUAGE_KEY) || defaultLanguage)
 
   const changeLanguage = (language: string) => {
     setSelectedLanguage(language)
@@ -46,7 +49,7 @@ export function I18nProvider({ portalShortcode, children }: { portalShortcode?: 
 
   useEffect(() => {
     reloadLanguageTexts(selectedLanguage)
-  }, [])
+  }, [selectedLanguage])
 
   const reloadLanguageTexts = (selectedLanguage: string) => {
     setIsLoading(true)

--- a/ui-core/src/types/landingPageConfig.ts
+++ b/ui-core/src/types/landingPageConfig.ts
@@ -1,6 +1,5 @@
 export type SiteContent = {
   id: string
-  defaultLanguage: string
   localizedSiteContents: LocalSiteContent[]
   stableId: string
   version: number

--- a/ui-core/src/types/portal.ts
+++ b/ui-core/src/types/portal.ts
@@ -34,7 +34,8 @@ export type PortalEnvironmentConfig = {
   password: string
   passwordProtected: boolean
   participantHostname?: string
-  emailSourceAddress?: string
+  emailSourceAddress?: string,
+  defaultLanguage: string
 }
 
 export {}

--- a/ui-participant/src/App.tsx
+++ b/ui-participant/src/App.tsx
@@ -46,7 +46,7 @@ const ScrollToTop = () => {
  */
 function App() {
   const [cookiesAcknowledged, setCookiesAcknowledged] = useCookiesAcknowledged()
-  const { localContent, portal } = usePortalEnv()
+  const { localContent, portal, portalEnv } = usePortalEnv()
 
   const brandConfig: BrandConfiguration = {}
   if (localContent.primaryBrandColor) {
@@ -106,7 +106,8 @@ function App() {
                     ...getAuthProviderProps(config.b2cTenantName, config.b2cClientId, config.b2cPolicyName)
                   }>
                     <UserProvider>
-                      <I18nProvider portalShortcode={portal.shortcode}>
+                      <I18nProvider defaultLanguage={portalEnv.portalEnvironmentConfig.defaultLanguage}
+                        portalShortcode={portal.shortcode}>
                         <Suspense fallback={<PageLoadingIndicator/>}>
                           <IdleStatusMonitor
                             maxIdleSessionDuration={30 * 60 * 1000} idleWarningDuration={5 * 60 * 1000}/>

--- a/ui-participant/src/Navbar.tsx
+++ b/ui-participant/src/Navbar.tsx
@@ -26,8 +26,6 @@ export default function Navbar(props: NavbarProps) {
   const { user, profile, ppUser } = useUser()
   const navLinks = localContent.navbarItems
 
-  const languageOptions = portalEnv.supportedLanguages
-
   async function updatePreferredLanguage(selectedLanguage: string) {
     if (profile && ppUser) {
       await Api.updateProfile({
@@ -81,7 +79,7 @@ export default function Navbar(props: NavbarProps) {
         </ul>
         <ul className="navbar-nav ms-auto">
           <LanguageDropdown
-            languageOptions={languageOptions}
+            languageOptions={portalEnv.supportedLanguages}
             selectedLanguage={selectedLanguage}
             changeLanguage={changeLanguageAndUpdate}
             reloadPortal={reloadPortal}

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -204,9 +204,10 @@ export default {
     return await this.processJsonResponse(response)
   },
 
-  async getPortal(selectedLanguage: string): Promise<Portal> {
+  async getPortal(language?: string): Promise<Portal> {
     const { shortcodeOrHostname, envName } = currentEnvSpec
-    const url = `${API_ROOT}/public/portals/v1/${shortcodeOrHostname}/env/${envName}?language=${selectedLanguage}`
+    const params = queryString.stringify({ language })
+    const url = `${API_ROOT}/public/portals/v1/${shortcodeOrHostname}/env/${envName}?${params}`
     const response = await fetch(url, this.getGetInit())
     const parsedResponse: Portal = await this.processJsonResponse(response)
     updateEnvSpec(parsedResponse.shortcode)

--- a/ui-participant/src/hub/consent/ConsentView.tsx
+++ b/ui-participant/src/hub/consent/ConsentView.tsx
@@ -42,7 +42,7 @@ function RawConsentView({ form, enrollee, resumableData, pager, studyShortcode, 
   const { selectedLanguage } = useI18n()
   const { updateEnrollee } = useUser()
 
-  surveyModel.locale = selectedLanguage
+  surveyModel.locale = selectedLanguage || 'default'
 
   if (surveyModel && isEditingPrevious) {
     // consent responses are not editable -- they must be withdrawn via separate workflow

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -147,7 +147,7 @@ export function RawSurveyView({
 
   useAutosaveEffect(saveDiff, AUTO_SAVE_INTERVAL)
 
-  surveyModel.locale = selectedLanguage
+  surveyModel.locale = selectedLanguage || 'default'
 
   return (
     <>

--- a/ui-participant/src/landing/registration/Preregistration.tsx
+++ b/ui-participant/src/landing/registration/Preregistration.tsx
@@ -16,7 +16,7 @@ export default function PreRegistration({ registrationContext }: { registrationC
   const { surveyModel, refreshSurvey, SurveyComponent } =
     useSurveyJSModel(survey, null, handleComplete, pager)
 
-  surveyModel.locale = selectedLanguage
+  surveyModel.locale = selectedLanguage || 'default'
 
   /** submit the form */
   function handleComplete() {

--- a/ui-participant/src/providers/PortalProvider.tsx
+++ b/ui-participant/src/providers/PortalProvider.tsx
@@ -40,7 +40,8 @@ export default function PortalProvider({ children }: { children: React.ReactNode
   }, [])
 
   const reloadPortal = () => {
-    const selectedLanguage = localStorage.getItem('selectedLanguage') || 'en'
+    const savedLanguage = localStorage.getItem('selectedLanguage')
+    const selectedLanguage = savedLanguage === null ? undefined : savedLanguage
     setIsLoading(true)
     Api.getPortal(selectedLanguage).then(result => {
       setEnvState(result)

--- a/ui-participant/src/studies/enroll/PreEnroll.tsx
+++ b/ui-participant/src/studies/enroll/PreEnroll.tsx
@@ -30,7 +30,7 @@ export default function PreEnrollView({ enrollContext, survey }:
     { extraCssClasses: { container: 'my-0' } }
   )
 
-  surveyModel.locale = selectedLanguage
+  surveyModel.locale = selectedLanguage || 'default'
 
   /** submit the form */
   function handleComplete() {

--- a/ui-participant/src/test-utils/ProvideFullTestUserContext.tsx
+++ b/ui-participant/src/test-utils/ProvideFullTestUserContext.tsx
@@ -34,7 +34,8 @@ export default function ProvideFullTestUserContext(
             initialized: true,
             acceptingRegistration: false,
             passwordProtected: false,
-            password: ''
+            password: '',
+            defaultLanguage: ''
           },
           supportedLanguages: [],
           siteContent: {

--- a/ui-participant/src/test-utils/test-portal-factory.tsx
+++ b/ui-participant/src/test-utils/test-portal-factory.tsx
@@ -61,7 +61,8 @@ export const mockPortalEnvironmentConfig = (): PortalEnvironmentConfig => {
     acceptingRegistration: true,
     initialized: true,
     password: 'password',
-    passwordProtected: false
+    passwordProtected: false,
+    defaultLanguage: 'en'
   }
 }
 
@@ -69,7 +70,6 @@ export const mockPortalEnvironmentConfig = (): PortalEnvironmentConfig => {
 export const mockSiteContent = (): SiteContent => {
   return {
     id: 'fakeID1',
-    defaultLanguage: 'en',
     localizedSiteContents: [mockLocalSiteContent()],
     stableId: 'mockContent',
     version: 1,


### PR DESCRIPTION
#### DESCRIPTION

Minimally invasive change that supports viewing (but not editing) email templates in other languages. Note that the base of this PR is https://github.com/broadinstitute/juniper/pull/841

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Populate demo
* View the email templates: https://localhost:3000/demo/studies/heartdemo/env/sandbox/notificationContent
* Click into one of them, confirm you see the template for the default language when the page loads, and confirm that you can cycle through the other languages