### PR TITLE
[JN-987] Survey language preview UX tweak

### DIFF
--- a/ui-admin/src/forms/FormPreview.test.tsx
+++ b/ui-admin/src/forms/FormPreview.test.tsx
@@ -170,7 +170,7 @@ describe('FormPreview', () => {
             />
           </MockI18nProvider>)
 
-        const languageSelector = screen.getByLabelText('Language')
+        const languageSelector = screen.getByLabelText('Language Preview')
         await act(() => user.click(languageSelector))
         await act(() => user.click(screen.getByText('Spanish')))
 

--- a/ui-admin/src/forms/FormPreviewOptions.tsx
+++ b/ui-admin/src/forms/FormPreviewOptions.tsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react'
 import { PortalEnvironmentLanguage } from '@juniper/ui-core'
 import Select from 'react-select'
 import useReactSingleSelect from 'util/react-select-utils'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faGlobe } from '@fortawesome/free-solid-svg-icons'
 
 type FormPreviewOptions = {
   ignoreValidation: boolean
@@ -72,7 +74,7 @@ export const FormPreviewOptions = (props: FormPreviewOptionsProps) => {
         would be hidden by survey branching logic.
       </p>
       { languageOptions.length > 1 && <><div className="form-group">
-        <label htmlFor={selectLanguageInputId}>Language</label>
+        <label htmlFor={selectLanguageInputId}><FontAwesomeIcon icon={faGlobe}/> Language Preview</label>
         <Select
           inputId={selectLanguageInputId}
           options={languageOptions}


### PR DESCRIPTION
#### DESCRIPTION

Quick UX tweak suggested by Erin in https://broadworkbench.atlassian.net/browse/JN-987

Before
<img width="304" alt="Screenshot 2024-04-16 at 12 41 54 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/4050e5d8-ad8a-4572-a07b-a09bc0942f3d">

After
<img width="312" alt="Screenshot 2024-04-16 at 12 40 11 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/09e81be4-b4a5-403b-90ce-fbb73de46864">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Go to the preview tab in https://localhost:3000/demo/studies/heartdemo/env/sandbox/forms/surveys/hd_hd_basicInfo and confirm that you see the new design