### PR TITLE
JN-1009  null-safing caluclated value parsing

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyParseUtils.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyParseUtils.java
@@ -128,7 +128,8 @@ public class SurveyParseUtils {
         List<JsonNode> calculatedValues = new ArrayList<>();
         if (surveyJsDef.has("calculatedValues")) {
             for (JsonNode val : surveyJsDef.get("calculatedValues")) {
-                if (Boolean.TRUE.equals(val.get("includeIntoResult").asBoolean())) {
+                JsonNode includeIntoResult = val.get("includeIntoResult");
+                if (includeIntoResult != null && Boolean.TRUE.equals(includeIntoResult.asBoolean())) {
                     calculatedValues.add(val);
                 }
             }


### PR DESCRIPTION
#### DESCRIPTION

This fixes a bug where we couldn't convert some consent forms to surveys due to calculated value parsing

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy ApiAdminApp 
2. create a survey with a `calculatedValues` property in its json that includes a calculated value without an "includeIntoResult" property.  e.g.
```
   "calculatedValues": [{
       "name": "transientThing",
       "expression": "1 + 2"
     }]
```
3. confirm the survey can be saved