### PR TITLE
[JN-1010] Add proxy enrollment flag

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/study/StudyEnvironmentExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/study/StudyEnvironmentExtService.java
@@ -63,6 +63,7 @@ public class StudyEnvironmentExtService {
     // flows
     existing.setPasswordProtected(update.isPasswordProtected());
     existing.setAcceptingEnrollment(update.isAcceptingEnrollment());
+    existing.setAcceptingProxyEnrollment(update.isAcceptingProxyEnrollment());
     existing.setPassword(update.getPassword());
     return studyEnvConfigService.update(existing);
   }

--- a/core/src/main/java/bio/terra/pearl/core/model/study/StudyEnvironmentConfig.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/study/StudyEnvironmentConfig.java
@@ -23,5 +23,8 @@ public class StudyEnvironmentConfig extends BaseEntity {
     private boolean acceptingEnrollment = true;
 
     @Builder.Default
+    private boolean acceptingProxyEnrollment = false;
+
+    @Builder.Default
     private boolean initialized = false;
 }

--- a/core/src/main/resources/db/changelog/changesets/2024_04_19_add_proxy_enrollment_config.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_04_19_add_proxy_enrollment_config.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: "add_proxy_enrollment_config"
+      author: connorlbark
+      changes:
+        - addColumn:
+            tableName: study_environment_config
+            columns:
+              - column: { name: accepting_proxy_enrollment, type: boolean }

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -254,6 +254,9 @@ databaseChangeLog:
   - include:
       file: changesets/2024_04_12_remove_sitemedia_uploadfilename.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2024_04_19_add_proxy_enrollment_config.yaml
+      relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentWorkflowTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentWorkflowTests.java
@@ -358,7 +358,8 @@ public class EnrollmentWorkflowTests extends BaseSpringBootTest {
         PreEnrollmentResponse preEnrollmentResponseProxy = preEnrollmentSurveyFactory.buildPersisted(getTestName(info), preEnrollmentSurvey.getId(), true, preEnrollmentSurveyResponseForProxy, userProxyBundle.ppUser().getId(), userProxyBundle.user().getId(), studyEnv.getId());
 
         // stops proxy enrollment even though question exists
-        Assertions.assertFalse(enrollmentService.isProxyEnrollment(envName, studyShortcode, preEnrollmentResponseProxy.getId()));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> enrollmentService.isProxyEnrollment(envName, studyShortcode, preEnrollmentResponseProxy.getId()));
 
     }
 

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
@@ -32,6 +32,7 @@
       "kitTypeNames": [ "SALIVA" ],
       "studyEnvironmentConfig": {
         "acceptingEnrollment": true,
+        "acceptingProxyEnrollment": true,
         "passwordProtected": false,
         "password": "broad_institute",
         "initialized": true
@@ -121,6 +122,7 @@
       "kitTypeNames": [ "SALIVA" ],
       "studyEnvironmentConfig": {
         "acceptingEnrollment": true,
+        "acceptingProxyEnrollment": true,
         "passwordProtected": false,
         "password": "broad_institute",
         "initialized": true
@@ -172,6 +174,7 @@
       "kitTypeNames": [ "SALIVA" ],
       "studyEnvironmentConfig": {
         "acceptingEnrollment": true,
+        "acceptingProxyEnrollment": true,
         "passwordProtected": false,
         "password": "broad_institute",
         "initialized": true

--- a/ui-admin/src/study/StudyDashboard.tsx
+++ b/ui-admin/src/study/StudyDashboard.tsx
@@ -1,4 +1,4 @@
-import React  from 'react'
+import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Study, StudyEnvironment } from 'api/api'
 import { Link } from 'react-router-dom'
@@ -68,9 +68,10 @@ function EnvironmentSummary({ studyEnv }: {studyEnv: StudyEnvironment}) {
   const config = studyEnv.studyEnvironmentConfig
   return <div>
     <label>Password protected:</label> {config.passwordProtected ? 'Yes' : 'No'}
-    { config.passwordProtected && <span className="detail ms-3">{config.password}</span> }
+    {config.passwordProtected && <span className="detail ms-3">{config.password}</span>}
     <br/>
     <label>Accepting enrollment:</label> {config.acceptingEnrollment ? 'Yes' : 'No'}<br/>
+    <label>Accepting proxy enrollment:</label> {config.acceptingProxyEnrollment ? 'Yes' : 'No'}<br/>
     <p>
       <Link to={`env/${studyEnv.environmentName}`}>View / Configure</Link>
     </p>

--- a/ui-admin/src/study/StudySettings.tsx
+++ b/ui-admin/src/study/StudySettings.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { StudyEnvContextT } from './StudyEnvironmentRouter'
-import { LoadedPortalContextT } from '../portal/PortalProvider'
-import PortalEnvConfigView from '../portal/PortalEnvConfigView'
+import { LoadedPortalContextT } from 'portal/PortalProvider'
+import PortalEnvConfigView from 'portal/PortalEnvConfigView'
 import { PortalEnvironment } from '@juniper/ui-core'
 import { doApiLoad } from 'api/api-utils'
 import { Button } from 'components/forms/Button'
@@ -11,8 +11,9 @@ import { Store } from 'react-notifications-component'
 import { successNotification } from 'util/notifications'
 import LoadingSpinner from 'util/LoadingSpinner'
 import { renderPageHeader } from 'util/pageUtils'
-import InfoPopup from '../components/forms/InfoPopup'
-import useUpdateEffect from '../util/useUpdateEffect'
+import InfoPopup from 'components/forms/InfoPopup'
+import useUpdateEffect from 'util/useUpdateEffect'
+import { userHasPermission, useUser } from 'user/UserProvider'
 
 /** shows settings for both a study and its containing portal */
 export default function StudySettings({ studyEnvContext, portalContext }:
@@ -33,6 +34,9 @@ export function StudyEnvConfigView({ studyEnvContext, portalContext }:
                                        {studyEnvContext: StudyEnvContextT, portalContext: LoadedPortalContextT}) {
   const [config, setConfig] = useState(studyEnvContext.currentEnv.studyEnvironmentConfig)
   const [isLoading, setIsLoading] = useState(false)
+
+  const { user } = useUser()
+
   /** update a given field in the config */
   const updateConfig = (propName: string, value: string | boolean) => {
     setConfig(set(propName, value))
@@ -76,15 +80,20 @@ export function StudyEnvConfigView({ studyEnvContext, portalContext }:
       </label>
     </div>
 
-    <div>
-      <label className="form-label">
-        accepting proxy enrollment <InfoPopup content={
-        `Enables enrolling as a proxy on behalf of a dependent. Note that you will need to make edits to 
+    {
+      // TODO: JN-1017 - Create zendesk article for proxy enrollment, link in info popup
+      userHasPermission(user, studyEnvContext.portal.id, 'prototype') && (
+        <div>
+          <label className="form-label">
+                accepting proxy enrollment <InfoPopup content={
+                `Enables enrolling as a proxy on behalf of a dependent. Note that you will need to make edits to 
           your pre-enrollment survey to fully enable proxy enrollment.`}/>
-        <input type="checkbox" checked={config.acceptingProxyEnrollment} className="ms-2"
-          onChange={e => updateConfig('acceptingProxyEnrollment', e.target.checked)}/>
-      </label>
-    </div>
+            <input type="checkbox" checked={config.acceptingProxyEnrollment} className="ms-2"
+              onChange={e => updateConfig('acceptingProxyEnrollment', e.target.checked)}/>
+          </label>
+        </div>
+      )
+    }
 
     <Button onClick={save}
       variant="primary" disabled={isLoading}

--- a/ui-admin/src/study/StudySettings.tsx
+++ b/ui-admin/src/study/StudySettings.tsx
@@ -76,6 +76,16 @@ export function StudyEnvConfigView({ studyEnvContext, portalContext }:
       </label>
     </div>
 
+    <div>
+      <label className="form-label">
+        accepting proxy enrollment <InfoPopup content={
+        `Enables enrolling as a proxy on behalf of a dependent. Note that you will need to make edits to 
+          your pre-enrollment survey to fully enable proxy enrollment.`}/>
+        <input type="checkbox" checked={config.acceptingProxyEnrollment} className="ms-2"
+          onChange={e => updateConfig('acceptingProxyEnrollment', e.target.checked)}/>
+      </label>
+    </div>
+
     <Button onClick={save}
       variant="primary" disabled={isLoading}
       tooltip={'Save'}>

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -158,7 +158,8 @@ export const mockStudyEnvContext: () => StudyEnvContextT = () => {
       initialized: true,
       password: 'blah',
       passwordProtected: false,
-      acceptingEnrollment: true
+      acceptingEnrollment: true,
+      acceptingProxyEnrollment: false
     }
   }
   return {

--- a/ui-core/src/types/study.ts
+++ b/ui-core/src/types/study.ts
@@ -22,6 +22,7 @@ export type StudyEnvironment = {
 
 export type StudyEnvironmentConfig = {
   acceptingEnrollment: boolean
+  acceptingProxyEnrollment: boolean
   initialized: boolean
   passwordProtected: boolean
   password: string

--- a/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
+++ b/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
@@ -17,7 +17,7 @@ import { enrollCurrentUserInStudy } from '../../util/enrolleeUtils'
 import { logError } from '../../util/loggingUtils'
 
 export type StudyEnrollContext = {
-  user: ParticipantUser,
+  user: ParticipantUser | null,
   studyEnv: StudyEnvironment,
   studyShortcode: string,
   preEnrollResponseId: string | null,
@@ -121,10 +121,6 @@ function StudyEnrollOutletMatched(props: StudyEnrollOutletMatchedProps) {
   useEffect(() => {
     determineNextRoute()
   }, [mustProvidePassword, preEnrollSatisfied, user?.username])
-
-  if (!user) {
-    return <></>
-  }
 
   const enrollContext: StudyEnrollContext = {
     studyShortcode, studyEnv, user, preEnrollResponseId, updatePreEnrollResponseId

--- a/ui-participant/src/test-utils/test-portal-factory.tsx
+++ b/ui-participant/src/test-utils/test-portal-factory.tsx
@@ -4,7 +4,9 @@ import {
   Portal,
   PortalEnvironment,
   PortalEnvironmentConfig,
-  SiteContent, Study, StudyEnvironment
+  SiteContent,
+  Study,
+  StudyEnvironment
 } from '@juniper/ui-core'
 
 /** mock portal object with one environment */
@@ -34,6 +36,7 @@ export const mockStudyEnv = (): StudyEnvironment => {
     environmentName: 'sandbox',
     studyEnvironmentConfig: {
       acceptingEnrollment: true,
+      acceptingProxyEnrollment: false,
       initialized: true,
       passwordProtected: false,
       password: 'password'


### PR DESCRIPTION
#### DESCRIPTION

Adds flag which enables and disables proxy enrollment. Right now, it just throws an error if you try to enroll as proxy with it disabled, but future features (add new participant button, etc.) will be dependent on this.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Enable and disable proxy enrollment
- When enabled, ensure proxy enrollment flow is normal
- When disable, ensure error is thrown when attempt to enroll as proxy (this shouldn't ever happen unless a study staff leaves the proxy question erroneously. It does leave the user in a hanging state where they are registered but have no enrollees, but since this all happens post-registration I can't imagine any other expected behavior.)