### PR TITLE
[JN-968] adding pre-populated country to pre-enroll

### DIFF
--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
@@ -32,6 +32,12 @@
       "targetType": "PROFILE",
       "targetField": "familyName",
       "mapType": "STRING_TO_STRING"
+    },
+    {
+      "questionStableId": "country",
+      "targetType": "PROFILE",
+      "targetField": "mailingAddress.country",
+      "mapType": "STRING_TO_STRING"
     }
   ],
   "jsonContent": {
@@ -241,6 +247,11 @@
       {
         "name": "qualified",
         "expression": "{hd_hd_preenroll_southAsianAncestry} = 'yes' && {hd_hd_preenroll_understandsEnglish} = 'yes' && {hd_hd_preenroll_isAdult} = 'yes' && {hd_hd_preenroll_livesInUS} = 'yes'",
+        "includeIntoResult": true
+      },
+      {
+        "name": "country",
+        "expression": "iif({hd_hd_preenroll_livesInUS} = 'yes', 'US', '')",
         "includeIntoResult": true
       }
     ]


### PR DESCRIPTION
#### DESCRIPTION

This auto-populates the user's country based on pre-enroll survey data.  This is needed for kit shipping to work with address overrides (we need a country specified, but it's not asked in the 'basics' survey).  Once this is approved and the pre-enroll mapping change is released, I'll update OurHealth's pre-enroll survey to include this.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. repopulate demo
2. register a new demo participant
3. in the admin tool, confirm their address country is set to US.