### PR TITLE
[JN-989] View localized templates in email editor

### DIFF
--- a/ui-admin/src/forms/FormPreview.tsx
+++ b/ui-admin/src/forms/FormPreview.tsx
@@ -13,7 +13,7 @@ import {
 
 import { FormPreviewOptions } from './FormPreviewOptions'
 import Api from '../api/api'
-import { usePortalLanguage } from '../portal/useDefaultPortalLanguage'
+import { usePortalLanguage } from '../portal/usePortalLanguage'
 
 type FormPreviewProps = {
   formContent: FormContent

--- a/ui-admin/src/forms/FormPreview.tsx
+++ b/ui-admin/src/forms/FormPreview.tsx
@@ -12,8 +12,8 @@ import {
 } from '@juniper/ui-core'
 
 import { FormPreviewOptions } from './FormPreviewOptions'
-import Api from '../api/api'
-import { usePortalLanguage } from '../portal/usePortalLanguage'
+import Api from 'api/api'
+import { usePortalLanguage } from 'portal/usePortalLanguage'
 
 type FormPreviewProps = {
   formContent: FormContent

--- a/ui-admin/src/forms/FormPreview.tsx
+++ b/ui-admin/src/forms/FormPreview.tsx
@@ -13,7 +13,7 @@ import {
 
 import { FormPreviewOptions } from './FormPreviewOptions'
 import Api from '../api/api'
-import { useDefaultLanguage } from 'portal/useDefaultPortalLanguage'
+import { usePortalLanguage } from '../portal/useDefaultPortalLanguage'
 
 type FormPreviewProps = {
   formContent: FormContent
@@ -25,7 +25,7 @@ type FormPreviewProps = {
  */
 export const FormPreview = (props: FormPreviewProps) => {
   const { formContent, supportedLanguages } = props
-  const defaultLanguage = useDefaultLanguage()
+  const { defaultLanguage } = usePortalLanguage()
 
   const { i18n } = useI18n()
 

--- a/ui-admin/src/forms/FormPreviewOptions.tsx
+++ b/ui-admin/src/forms/FormPreviewOptions.tsx
@@ -4,7 +4,7 @@ import Select from 'react-select'
 import useReactSingleSelect from 'util/react-select-utils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faGlobe } from '@fortawesome/free-solid-svg-icons'
-import { usePortalLanguage } from '../portal/usePortalLanguage'
+import { usePortalLanguage } from 'portal/usePortalLanguage'
 
 type FormPreviewOptions = {
   ignoreValidation: boolean

--- a/ui-admin/src/forms/FormPreviewOptions.tsx
+++ b/ui-admin/src/forms/FormPreviewOptions.tsx
@@ -20,8 +20,8 @@ type FormPreviewOptionsProps = {
 
 /** Controls for configuring the form editor's preview tab. */
 export const FormPreviewOptions = (props: FormPreviewOptionsProps) => {
-  const { value, onChange } = props
-  const { defaultLanguage, supportedLanguages } = usePortalLanguage()
+  const { value, supportedLanguages, onChange } = props
+  const { defaultLanguage } = usePortalLanguage()
   const [selectedLanguage, setSelectedLanguage] = useState<PortalEnvironmentLanguage | undefined>(defaultLanguage)
 
   const {

--- a/ui-admin/src/forms/FormPreviewOptions.tsx
+++ b/ui-admin/src/forms/FormPreviewOptions.tsx
@@ -4,7 +4,7 @@ import Select from 'react-select'
 import useReactSingleSelect from 'util/react-select-utils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faGlobe } from '@fortawesome/free-solid-svg-icons'
-import { useDefaultLanguage } from 'portal/useDefaultPortalLanguage'
+import { usePortalLanguage } from '../portal/useDefaultPortalLanguage'
 
 type FormPreviewOptions = {
   ignoreValidation: boolean
@@ -20,8 +20,8 @@ type FormPreviewOptionsProps = {
 
 /** Controls for configuring the form editor's preview tab. */
 export const FormPreviewOptions = (props: FormPreviewOptionsProps) => {
-  const { value, supportedLanguages, onChange } = props
-  const defaultLanguage = useDefaultLanguage()
+  const { value, onChange } = props
+  const { defaultLanguage, supportedLanguages } = usePortalLanguage()
   const [selectedLanguage, setSelectedLanguage] = useState<PortalEnvironmentLanguage | undefined>(defaultLanguage)
 
   const {

--- a/ui-admin/src/forms/FormPreviewOptions.tsx
+++ b/ui-admin/src/forms/FormPreviewOptions.tsx
@@ -4,7 +4,7 @@ import Select from 'react-select'
 import useReactSingleSelect from 'util/react-select-utils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faGlobe } from '@fortawesome/free-solid-svg-icons'
-import { usePortalLanguage } from '../portal/useDefaultPortalLanguage'
+import { usePortalLanguage } from '../portal/usePortalLanguage'
 
 type FormPreviewOptions = {
   ignoreValidation: boolean

--- a/ui-admin/src/portal/PortalEnvConfigView.tsx
+++ b/ui-admin/src/portal/PortalEnvConfigView.tsx
@@ -12,7 +12,7 @@ import useUpdateEffect from '../util/useUpdateEffect'
 import useReactSingleSelect from '../util/react-select-utils'
 import { PortalEnvironmentLanguage } from '@juniper/ui-core'
 import Select from 'react-select'
-import { useDefaultLanguage } from './useDefaultPortalLanguage'
+import { usePortalLanguage } from './useDefaultPortalLanguage'
 
 
 type PortalEnvConfigViewProps = {
@@ -28,7 +28,7 @@ const PortalEnvConfigView = ({ portalContext, portalEnv }: PortalEnvConfigViewPr
   const { user } = useUser()
   const { portal, reloadPortal } = portalContext
   const [isLoading, setIsLoading] = useState(false)
-  const defaultLanguage = useDefaultLanguage()
+  const { defaultLanguage } = usePortalLanguage()
   const [selectedLanguage, setSelectedLanguage] = useState<PortalEnvironmentLanguage | undefined>(defaultLanguage)
   /** update a given field in the config */
   const updateConfig = (propName: string, value: string | boolean) => {

--- a/ui-admin/src/portal/PortalEnvConfigView.tsx
+++ b/ui-admin/src/portal/PortalEnvConfigView.tsx
@@ -12,7 +12,7 @@ import useUpdateEffect from '../util/useUpdateEffect'
 import useReactSingleSelect from '../util/react-select-utils'
 import { PortalEnvironmentLanguage } from '@juniper/ui-core'
 import Select from 'react-select'
-import { usePortalLanguage } from './useDefaultPortalLanguage'
+import { usePortalLanguage } from './usePortalLanguage'
 
 
 type PortalEnvConfigViewProps = {

--- a/ui-admin/src/portal/siteContent/SiteContentLoader.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentLoader.tsx
@@ -7,7 +7,7 @@ import { failureNotification, successNotification } from 'util/notifications'
 import LoadingSpinner from 'util/LoadingSpinner'
 import SiteContentEditor from './SiteContentEditor'
 import { previewApi } from 'util/apiContextUtils'
-import { usePortalLanguage } from '../useDefaultPortalLanguage'
+import { usePortalLanguage } from '../usePortalLanguage'
 
 /** logic for loading, changing, and saving SiteContent objects */
 const SiteContentLoader = ({ portalEnvContext }: {portalEnvContext: PortalEnvContext}) => {

--- a/ui-admin/src/portal/siteContent/SiteContentLoader.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentLoader.tsx
@@ -7,14 +7,14 @@ import { failureNotification, successNotification } from 'util/notifications'
 import LoadingSpinner from 'util/LoadingSpinner'
 import SiteContentEditor from './SiteContentEditor'
 import { previewApi } from 'util/apiContextUtils'
-import { useDefaultLanguage } from '../useDefaultPortalLanguage'
+import { usePortalLanguage } from '../useDefaultPortalLanguage'
 
 /** logic for loading, changing, and saving SiteContent objects */
 const SiteContentLoader = ({ portalEnvContext }: {portalEnvContext: PortalEnvContext}) => {
   const { portal, portalEnv } = portalEnvContext
   const portalShortcode = portal.shortcode
   const [isLoading, setIsLoading] = useState(true)
-  const defaultLanguage = useDefaultLanguage()
+  const { defaultLanguage } = usePortalLanguage()
   const [siteContent, setSiteContent] = useState(portalEnv.siteContent)
 
   if (!siteContent) {

--- a/ui-admin/src/portal/useDefaultPortalLanguage.ts
+++ b/ui-admin/src/portal/useDefaultPortalLanguage.ts
@@ -1,27 +1,33 @@
 import { useContext } from 'react'
 import { PortalContext } from './PortalProvider'
-import { useStudyEnvParamsFromPath } from '../study/StudyEnvironmentRouter'
+import { useParams } from 'react-router-dom'
+import { StudyParams } from 'study/StudyRouter'
 
 /**
  * Returns the default language for the current portal environment.
  */
-export function useDefaultLanguage() {
+export function usePortalLanguage() {
   const { portal } = useContext(PortalContext)
-  const studyEnvParams = useStudyEnvParamsFromPath()
-  const envName: string | undefined = studyEnvParams.envName
+  const params = useParams<StudyParams>()
+  const envName: string | undefined = params.studyEnv
 
   const defaultLanguage = portal?.portalEnvironments.find(env =>
     env.environmentName === envName)?.portalEnvironmentConfig.defaultLanguage
 
-  const language = portal?.portalEnvironments.find(env =>
-    env.environmentName === envName)?.supportedLanguages.find(lang => lang.languageCode === defaultLanguage)
+  const supportedLanguages = portal?.portalEnvironments.find(env =>
+    env.environmentName === envName)?.supportedLanguages || []
+
+  const language = supportedLanguages.find(lang => lang.languageCode === defaultLanguage)
 
   if (!language) {
     return {
-      languageCode: 'en',
-      languageName: 'English'
+      defaultLanguage: {
+        languageCode: 'en',
+        languageName: 'English'
+      },
+      supportedLanguages
     }
   }
 
-  return language
+  return { defaultLanguage: language, supportedLanguages }
 }

--- a/ui-admin/src/portal/usePortalLanguage.ts
+++ b/ui-admin/src/portal/usePortalLanguage.ts
@@ -1,15 +1,14 @@
-import { useContext } from 'react'
+import { useStudyEnvParamsFromPath } from '../study/StudyEnvironmentRouter'
 import { PortalContext } from './PortalProvider'
-import { useParams } from 'react-router-dom'
-import { StudyParams } from 'study/StudyRouter'
+import { useContext } from 'react'
 
 /**
  * Returns the default language for the current portal environment.
  */
 export function usePortalLanguage() {
   const { portal } = useContext(PortalContext)
-  const params = useParams<StudyParams>()
-  const envName: string | undefined = params.studyEnv
+  const studyEnvParams = useStudyEnvParamsFromPath()
+  const envName: string | undefined = studyEnvParams.envName
 
   const defaultLanguage = portal?.portalEnvironments.find(env =>
     env.environmentName === envName)?.portalEnvironmentConfig.defaultLanguage

--- a/ui-admin/src/study/notifications/EmailTemplateEditor.test.tsx
+++ b/ui-admin/src/study/notifications/EmailTemplateEditor.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import EmailTemplateEditor from './EmailTemplateEditor'
+import { screen, render } from '@testing-library/react'
+import { mockEmailTemplate } from 'test-utils/mocking-utils'
+import { asMockedFn } from '@juniper/ui-core'
+import { usePortalLanguage } from 'portal/useDefaultPortalLanguage'
+
+jest.mock('portal/useDefaultPortalLanguage', () => ({
+  usePortalLanguage: jest.fn()
+}))
+
+describe('EmailTemplateEditor', () => {
+  it('should render a language dropdown when there are multiple languages', () => {
+    asMockedFn(usePortalLanguage).mockReturnValue({
+      defaultLanguage: {
+        languageCode: 'en',
+        languageName: 'English'
+      },
+      supportedLanguages: [{
+        languageCode: 'en',
+        languageName: 'English'
+      }, {
+        languageCode: 'es',
+        languageName: 'Español'
+      }]
+    })
+
+    render(
+      <EmailTemplateEditor
+        emailTemplate={mockEmailTemplate()}
+        portalShortcode={'foo'}
+        updateEmailTemplate={() => jest.fn()}
+      />
+    )
+
+    expect(screen.getByLabelText('Select a language')).toBeInTheDocument()
+  })
+
+  it('should not render a language dropdown when there is only one language', () => {
+    asMockedFn(usePortalLanguage).mockReturnValue({
+      defaultLanguage: {
+        languageCode: 'en',
+        languageName: 'English'
+      },
+      supportedLanguages: [{
+        languageCode: 'en',
+        languageName: 'English'
+      }]
+    })
+
+    render(
+      <EmailTemplateEditor
+        emailTemplate={mockEmailTemplate()}
+        portalShortcode={'foo'}
+        updateEmailTemplate={() => jest.fn()}
+      />
+    )
+
+    expect(screen.queryByLabelText('Select a language')).not.toBeInTheDocument()
+  })
+})

--- a/ui-admin/src/study/notifications/EmailTemplateEditor.test.tsx
+++ b/ui-admin/src/study/notifications/EmailTemplateEditor.test.tsx
@@ -3,9 +3,9 @@ import EmailTemplateEditor from './EmailTemplateEditor'
 import { screen, render } from '@testing-library/react'
 import { mockEmailTemplate } from 'test-utils/mocking-utils'
 import { asMockedFn } from '@juniper/ui-core'
-import { usePortalLanguage } from 'portal/useDefaultPortalLanguage'
+import { usePortalLanguage } from 'portal/usePortalLanguage'
 
-jest.mock('portal/useDefaultPortalLanguage', () => ({
+jest.mock('portal/usePortalLanguage', () => ({
   usePortalLanguage: jest.fn()
 }))
 

--- a/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
+++ b/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
@@ -3,7 +3,7 @@ import EmailEditor, { EditorRef, EmailEditorProps } from 'react-email-editor'
 import { EmailTemplate, PortalEnvironmentLanguage } from '@juniper/ui-core'
 import { Tab, Tabs } from 'react-bootstrap'
 import { getMediaBaseUrl } from 'api/api'
-import { usePortalLanguage } from 'portal/useDefaultPortalLanguage'
+import { usePortalLanguage } from 'portal/usePortalLanguage'
 import useReactSingleSelect from '../../util/react-select-utils'
 import Select from 'react-select'
 

--- a/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
+++ b/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import EmailEditor, { EditorRef, EmailEditorProps } from 'react-email-editor'
 import { EmailTemplate, PortalEnvironmentLanguage } from '@juniper/ui-core'
 import { Tab, Tabs } from 'react-bootstrap'
@@ -25,6 +25,16 @@ export default function EmailTemplateEditor({ emailTemplate, updateEmailTemplate
   const [selectedLanguage, setSelectedLanguage] = useState<PortalEnvironmentLanguage | undefined>(defaultLanguage)
   const localizedEmailTemplate = emailTemplate.localizedEmailTemplates.find(template =>
     template.language === selectedLanguage?.languageCode)
+
+  useEffect(() => {
+    if (emailEditorRef.current?.editor && localizedEmailTemplate) {
+      emailEditorRef.current.editor.loadDesign({
+        // @ts-ignore
+        html: replacePlaceholders(localizedEmailTemplate.body),
+        classic: true
+      })
+    }
+  }, [localizedEmailTemplate])
 
   const {
     onChange: languageOnChange, options: languageOptions,
@@ -80,11 +90,15 @@ export default function EmailTemplateEditor({ emailTemplate, updateEmailTemplate
                 ({emailTemplate.stableId} {templateVersionString})
       </div>
     </div>
-    <Select options={languageOptions} value={selectedLanguageOption} inputId={selectLanguageInputId}
-      aria-label={'Select a language'}
-      onChange={e => {
-        languageOnChange(e)
-      }}/>
+    { supportedLanguages.length > 1 && <div style={{ width: 200 }}>
+      <label className="form-label">Language
+        <Select options={languageOptions} value={selectedLanguageOption} inputId={selectLanguageInputId}
+          aria-label={'Select a language'}
+          onChange={e => {
+            languageOnChange(e)
+          }}/>
+      </label>
+    </div> }
     <div>
       <label className="form-label">Subject
         <input className="form-control" type="text" size={100} value={localizedEmailTemplate.subject}

--- a/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
+++ b/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
@@ -1,9 +1,11 @@
 import React, { useRef, useState } from 'react'
 import EmailEditor, { EditorRef, EmailEditorProps } from 'react-email-editor'
-import { EmailTemplate } from '@juniper/ui-core'
+import { EmailTemplate, PortalEnvironmentLanguage } from '@juniper/ui-core'
 import { Tab, Tabs } from 'react-bootstrap'
 import { getMediaBaseUrl } from 'api/api'
-import { useDefaultLanguage } from 'portal/useDefaultPortalLanguage'
+import { usePortalLanguage } from 'portal/useDefaultPortalLanguage'
+import useReactSingleSelect from '../../util/react-select-utils'
+import Select from 'react-select'
 
 export type EmailTemplateEditorProps = {
   emailTemplate: EmailTemplate,
@@ -19,9 +21,21 @@ export default function EmailTemplateEditor({ emailTemplate, updateEmailTemplate
   const emailTemplateRef = useRef(emailTemplate)
   emailTemplateRef.current = emailTemplate
   const [activeTab, setActiveTab] = useState<string | null>('designer')
-  const defaultLanguage = useDefaultLanguage()
+  const { defaultLanguage, supportedLanguages } = usePortalLanguage()
+  const [selectedLanguage, setSelectedLanguage] = useState<PortalEnvironmentLanguage | undefined>(defaultLanguage)
   const localizedEmailTemplate = emailTemplate.localizedEmailTemplates.find(template =>
-    template.language === defaultLanguage.languageCode)
+    template.language === selectedLanguage?.languageCode)
+
+  const {
+    onChange: languageOnChange, options: languageOptions,
+    selectedOption: selectedLanguageOption, selectInputId: selectLanguageInputId
+  } =
+      useReactSingleSelect(
+        supportedLanguages,
+        (language: PortalEnvironmentLanguage) => ({ label: language.languageName, value: language }),
+        setSelectedLanguage,
+        selectedLanguage
+      )
 
   if (!localizedEmailTemplate) {
     return <div>no localized template found for {defaultLanguage.languageCode}</div>
@@ -66,6 +80,11 @@ export default function EmailTemplateEditor({ emailTemplate, updateEmailTemplate
                 ({emailTemplate.stableId} {templateVersionString})
       </div>
     </div>
+    <Select options={languageOptions} value={selectedLanguageOption} inputId={selectLanguageInputId}
+      aria-label={'Select a language'}
+      onChange={e => {
+        languageOnChange(e)
+      }}/>
     <div>
       <label className="form-label">Subject
         <input className="form-control" type="text" size={100} value={localizedEmailTemplate.subject}

--- a/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
+++ b/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
@@ -4,7 +4,7 @@ import { EmailTemplate, PortalEnvironmentLanguage } from '@juniper/ui-core'
 import { Tab, Tabs } from 'react-bootstrap'
 import { getMediaBaseUrl } from 'api/api'
 import { usePortalLanguage } from 'portal/usePortalLanguage'
-import useReactSingleSelect from '../../util/react-select-utils'
+import useReactSingleSelect from 'util/react-select-utils'
 import Select from 'react-select'
 
 export type EmailTemplateEditorProps = {


### PR DESCRIPTION
#### DESCRIPTION

Minimally invasive change that supports viewing (but not editing) email templates in other languages. Note that the base of this PR is https://github.com/broadinstitute/juniper/pull/841

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Populate demo
View the email templates: https://localhost:3000/demo/studies/heartdemo/env/sandbox/notificationContent
Click into one of them, confirm you see the template for the default language when the page loads, and confirm that you can cycle through the other languages

* Note that supporting editing was out of scope at this time

