### PR TITLE
[JN-1043] Admin proxy view

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeRelationController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeRelationController.java
@@ -1,0 +1,48 @@
+package bio.terra.pearl.api.admin.controller.enrollee;
+
+import bio.terra.pearl.api.admin.api.EnrolleeRelationApi;
+import bio.terra.pearl.api.admin.service.AuthUtilService;
+import bio.terra.pearl.api.admin.service.enrollee.EnrolleeRelationExtService;
+import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.model.participant.EnrolleeRelation;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@Slf4j
+public class EnrolleeRelationController implements EnrolleeRelationApi {
+  private AuthUtilService authUtilService;
+  private EnrolleeRelationExtService enrolleeRelationExtService;
+  private HttpServletRequest request;
+  private ObjectMapper objectMapper;
+
+  public EnrolleeRelationController(
+      AuthUtilService authUtilService,
+      EnrolleeRelationExtService enrolleeRelationExtService,
+      ObjectMapper objectMapper,
+      HttpServletRequest request) {
+    this.authUtilService = authUtilService;
+    this.enrolleeRelationExtService = enrolleeRelationExtService;
+    this.objectMapper = objectMapper;
+    this.request = request;
+  }
+
+  @Override
+  public ResponseEntity<Object> findRelationsByTargetIdWithEnrollees(
+      String portalShortcode, String studyShortcode, String envName, String enrolleeShortcode) {
+    AdminUser adminUser = authUtilService.requireAdminUser(request);
+    List<EnrolleeRelation> relations =
+        enrolleeRelationExtService.findRelationsByTargetIdWithEnrollees(
+            portalShortcode,
+            studyShortcode,
+            EnvironmentName.valueOfCaseInsensitive(envName),
+            adminUser,
+            enrolleeShortcode);
+    return ResponseEntity.ok(relations);
+  }
+}

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeRelationController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeRelationController.java
@@ -33,15 +33,15 @@ public class EnrolleeRelationController implements EnrolleeRelationApi {
   }
 
   @Override
-  public ResponseEntity<Object> findRelationsByTargetIdWithEnrollees(
+  public ResponseEntity<Object> findRelationsForTargetEnrollee(
       String portalShortcode, String studyShortcode, String envName, String enrolleeShortcode) {
     AdminUser adminUser = authUtilService.requireAdminUser(request);
     List<EnrolleeRelation> relations =
-        enrolleeRelationExtService.findRelationsByTargetIdWithEnrollees(
+        enrolleeRelationExtService.findRelationsForTargetEnrollee(
+            adminUser,
             portalShortcode,
             studyShortcode,
             EnvironmentName.valueOfCaseInsensitive(envName),
-            adminUser,
             enrolleeShortcode);
     return ResponseEntity.ok(relations);
   }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeRelationExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeRelationExtService.java
@@ -5,7 +5,6 @@ import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.EnrolleeRelation;
-import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.participant.EnrolleeRelationService;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
@@ -31,25 +30,18 @@ public class EnrolleeRelationExtService {
     this.studyEnvironmentService = studyEnvironmentService;
   }
 
-  public List<EnrolleeRelation> findRelationsByTargetIdWithEnrollees(
+  public List<EnrolleeRelation> findRelationsForTargetEnrollee(
+      AdminUser operator,
       String portalShortcode,
       String studyShortcode,
       EnvironmentName environmentName,
-      AdminUser operator,
       String enrolleeShortcode) {
     authUtilService.authUserToStudy(operator, portalShortcode, studyShortcode);
 
-    StudyEnvironment studyEnvironment =
-        studyEnvironmentService
-            .findByStudy(studyShortcode, environmentName)
-            .orElseThrow(() -> new NotFoundException("Study environment not found"));
-
-    Enrollee found =
+    Enrollee enrollee =
         enrolleeService
-            .findOneByShortcode(enrolleeShortcode)
-            .filter(enrollee -> enrollee.getStudyEnvironmentId().equals(studyEnvironment.getId()))
+            .findByShortcodeAndStudyEnv(enrolleeShortcode, studyShortcode, environmentName)
             .orElseThrow(() -> new NotFoundException("Enrollee not found"));
-
-    return enrolleeRelationService.findByTargetEnrolleeIdWithEnrollees(found.getId());
+    return enrolleeRelationService.findByTargetEnrolleeIdWithEnrollees(enrollee.getId());
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeRelationExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeRelationExtService.java
@@ -1,0 +1,55 @@
+package bio.terra.pearl.api.admin.service.enrollee;
+
+import bio.terra.pearl.api.admin.service.AuthUtilService;
+import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.participant.EnrolleeRelation;
+import bio.terra.pearl.core.model.study.StudyEnvironment;
+import bio.terra.pearl.core.service.exception.NotFoundException;
+import bio.terra.pearl.core.service.participant.EnrolleeRelationService;
+import bio.terra.pearl.core.service.participant.EnrolleeService;
+import bio.terra.pearl.core.service.study.StudyEnvironmentService;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EnrolleeRelationExtService {
+  private final AuthUtilService authUtilService;
+  private final EnrolleeRelationService enrolleeRelationService;
+  private final EnrolleeService enrolleeService;
+  private final StudyEnvironmentService studyEnvironmentService;
+
+  public EnrolleeRelationExtService(
+      AuthUtilService authUtilService,
+      EnrolleeRelationService enrolleeRelationService,
+      EnrolleeService enrolleeService,
+      StudyEnvironmentService studyEnvironmentService) {
+    this.authUtilService = authUtilService;
+    this.enrolleeRelationService = enrolleeRelationService;
+    this.enrolleeService = enrolleeService;
+    this.studyEnvironmentService = studyEnvironmentService;
+  }
+
+  public List<EnrolleeRelation> findRelationsByTargetIdWithEnrollees(
+      String portalShortcode,
+      String studyShortcode,
+      EnvironmentName environmentName,
+      AdminUser operator,
+      String enrolleeShortcode) {
+    authUtilService.authUserToStudy(operator, portalShortcode, studyShortcode);
+
+    StudyEnvironment studyEnvironment =
+        studyEnvironmentService
+            .findByStudy(studyShortcode, environmentName)
+            .orElseThrow(() -> new NotFoundException("Study environment not found"));
+
+    Enrollee found =
+        enrolleeService
+            .findOneByShortcode(enrolleeShortcode)
+            .filter(enrollee -> enrollee.getStudyEnvironmentId().equals(studyEnvironment.getId()))
+            .orElseThrow(() -> new NotFoundException("Enrollee not found"));
+
+    return enrolleeRelationService.findByTargetEnrolleeIdWithEnrollees(found.getId());
+  }
+}

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -752,6 +752,22 @@ paths:
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/enrolleeRelations/byTarget/{enrolleeShortcode}:
+    get:
+      summary: Finds all of the relations that the given enrollee is a target of. Includes the full enrollee objects.
+      tags: [ enrolleeRelation ]
+      operationId: findRelationsByTargetIdWithEnrollees
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: studyShortcode, in: path, required: true, schema: { type: string } }
+        - { name: envName, in: path, required: true, schema: { type: string } }
+        - { name: enrolleeShortcode, in: path, required: true, schema: { type: string } }
+      responses:
+        '200':
+          description: Enrollee object
+          content: { application/json: { schema: { type: object } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/notifications/byEnrollee/{enrolleeShortcode}:
     get:
       summary: List the notifications sent/pending for an enrollee

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -756,7 +756,7 @@ paths:
     get:
       summary: Finds all of the relations that the given enrollee is a target of. Includes the full enrollee objects.
       tags: [ enrolleeRelation ]
-      operationId: findRelationsByTargetIdWithEnrollees
+      operationId: findRelationsForTargetEnrollee
       parameters:
         - { name: portalShortcode, in: path, required: true, schema: { type: string } }
         - { name: studyShortcode, in: path, required: true, schema: { type: string } }

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeRelationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeRelationService.java
@@ -21,13 +21,16 @@ import java.util.stream.Collectors;
 
 @Service
 public class EnrolleeRelationService extends DataAuditedService<EnrolleeRelation, EnrolleeRelationDao> {
-    EnrolleeService enrolleeService;
+    private final EnrolleeService enrolleeService;
+    private final ProfileService profileService;
     public EnrolleeRelationService(EnrolleeRelationDao enrolleeRelationDao,
                                    DataChangeRecordService dataChangeRecordService,
                                    @Lazy EnrolleeService enrolleeService,
-                                   ObjectMapper objectMapper) {
+                                   ObjectMapper objectMapper,
+                                   ProfileService profileService) {
         super(enrolleeRelationDao, dataChangeRecordService, objectMapper);
         this.enrolleeService = enrolleeService;
+        this.profileService = profileService;
     }
 
     public List<EnrolleeRelation> findByEnrolleeIdAndRelationType(UUID enrolleeId, RelationshipType relationshipType) {
@@ -43,12 +46,19 @@ public class EnrolleeRelationService extends DataAuditedService<EnrolleeRelation
     }
 
     public List<EnrolleeRelation> findByTargetEnrolleeIdWithEnrollees(UUID enrolleeId) {
-        Enrollee target = this.enrolleeService.find(enrolleeId).orElse(null);
+        Enrollee target = this.enrolleeService.find(enrolleeId).orElseThrow(() -> new NotFoundException("Enrollee not found"));
+        profileService
+                .loadWithMailingAddress(target.getProfileId())
+                .ifPresent(target::setProfile);
+
         List<EnrolleeRelation> relations = findByTargetEnrolleeId(enrolleeId);
 
         return relations.stream().map(relation -> {
             relation.setTargetEnrollee(target);
             relation.setEnrollee(this.enrolleeService.find(relation.getEnrolleeId()).orElse(null));
+            profileService
+                    .loadWithMailingAddress(relation.getEnrollee().getProfileId())
+                    .ifPresent(relation.getEnrollee()::setProfile);
             return relation;
         }).toList();
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeService.java
@@ -30,12 +30,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -299,6 +294,19 @@ public class EnrolleeService extends CrudService<Enrollee, EnrolleeDao> {
         StudyEnvironment studyEnv = studyEnvironmentService.findByStudy(studyShortcode, envName)
                 .orElseThrow(() -> new NotFoundException("Study environment %s %s not found".formatted(studyShortcode, envName)));
         return findByParticipantUserIdAndStudyEnvId(participantUserId, studyEnv.getId());
+    }
+
+    public Optional<Enrollee> findByShortcodeAndStudyEnv(String enrolleeShortcode, String studyShortcode, EnvironmentName envName) {
+        Optional<StudyEnvironment> studyEnvironment =
+                studyEnvironmentService
+                        .findByStudy(studyShortcode, envName);
+
+        return studyEnvironment.flatMap(
+                environment -> {
+                    return findOneByShortcode(enrolleeShortcode)
+                            .filter(enrollee -> enrollee.getStudyEnvironmentId().equals(environment.getId()));
+                });
+
     }
 
     public enum AllowedCascades implements CascadeProperty {

--- a/core/src/test/java/bio/terra/pearl/core/service/participant/EnrolleeRelationServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/participant/EnrolleeRelationServiceTest.java
@@ -10,7 +10,6 @@ import bio.terra.pearl.core.model.participant.PortalParticipantUser;
 import bio.terra.pearl.core.model.participant.RelationshipType;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
-import bio.terra.pearl.core.model.workflow.HubResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -244,5 +243,27 @@ class EnrolleeRelationServiceTest extends BaseSpringBootTest {
         Assertions.assertEquals(1,
                 enrolleeRelationService.findExclusiveProxiedEnrollees(proxyEnrollee.getId()).size());
 
+    }
+
+    @Test
+    @Transactional
+    void testFindByTargetEnrolleeIdWithEnrollees(TestInfo info) {
+        EnrolleeFactory.EnrolleeAndProxy hubResponse = enrolleeFactory.buildProxyAndGovernedEnrollee(getTestName(info), "proxyEmail@test.com");
+        Enrollee proxyEnrollee = hubResponse.proxy();
+        Enrollee governedEnrollee = hubResponse.governedEnrollee();
+
+        List<EnrolleeRelation> enrolleeRelations = enrolleeRelationService.findByTargetEnrolleeIdWithEnrollees(governedEnrollee.getId());
+
+        Assertions.assertEquals(1, enrolleeRelations.size());
+
+        EnrolleeRelation relation = enrolleeRelations.get(0);
+
+        Assertions.assertEquals(proxyEnrollee.getId(), relation.getEnrolleeId());
+        Assertions.assertEquals(governedEnrollee.getId(), relation.getTargetEnrolleeId());
+        Assertions.assertEquals(RelationshipType.PROXY, relation.getRelationshipType());
+        Assertions.assertEquals(proxyEnrollee.getId(), relation.getEnrollee().getId());
+        Assertions.assertEquals(governedEnrollee.getId(), relation.getTargetEnrollee().getId());
+        Assertions.assertNotNull(relation.getTargetEnrollee().getProfile());
+        Assertions.assertNotNull(relation.getEnrollee().getProfile());
     }
 }

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -101,6 +101,21 @@ export type Enrollee = {
   profile: Profile
 }
 
+type RelationshipType = 'PROXY'
+
+export type EnrolleeRelation = {
+  id: string
+  relationshipType: RelationshipType,
+  targetEnrolleeId: string,
+  targetEnrollee: Enrollee
+  enrolleeId: string
+  enrollee: Enrollee
+  createdAt: number
+  lastUpdatedAt: number
+  beginDate: number
+  endDate: number
+}
+
 export type Profile = {
   givenName: string,
   familyName: string,
@@ -922,6 +937,18 @@ export default {
     envName: string
   ): Promise<Enrollee[]> {
     const url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/enrolleesWithKits`
+    const response = await fetch(url, this.getGetInit())
+    return await this.processJsonResponse(response)
+  },
+
+  async findRelationsByTargetShortcode(
+    portalShortcode: string,
+    studyShortcode: string,
+    envName: EnvironmentName,
+    enrolleeShortcode: string): Promise<EnrolleeRelation[]> {
+    const url = (
+        `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/enrolleeRelations/byTarget/${enrolleeShortcode}`
+    )
     const response = await fetch(url, this.getGetInit())
     return await this.processJsonResponse(response)
   },

--- a/ui-admin/src/components/Card.tsx
+++ b/ui-admin/src/components/Card.tsx
@@ -3,7 +3,7 @@ import { isEmpty } from 'lodash'
 
 
 /**
- *
+ * Stylized card component for displaying read-only or editable data.
  */
 export function Card({ children }: { children: React.ReactNode }) {
   return <div className="card w-75 border shadow-sm mb-3">
@@ -12,7 +12,7 @@ export function Card({ children }: { children: React.ReactNode }) {
 }
 
 /**
- *
+ * Header of the card, usually used with CardTitle to display the title of the card.
  */
 export function CardHeader({ children }: { children: React.ReactNode }) {
   return <div className="card-header border-bottom bg-white d-flex flex-row align-items-center">
@@ -21,14 +21,14 @@ export function CardHeader({ children }: { children: React.ReactNode }) {
 }
 
 /**
- *
+ * Title of the card.
  */
 export function CardTitle({ title }: { title: string }) {
   return <div className="fw-bold lead my-1">{title}</div>
 }
 
 /**
- *
+ * Body of the card, usually used with CardRow or CardValueRow to display the data.
  */
 export function CardBody({ children }: { children: React.ReactNode }) {
   return <div className="card-body d-flex flex-row flex-wrap">
@@ -37,7 +37,7 @@ export function CardBody({ children }: { children: React.ReactNode }) {
 }
 
 /**
- * One row of the profile's data.
+ * One row of data in the card, where the title is on the left-hand side and the values are on the right.
  */
 export function CardRow(
   { title, children }: {
@@ -58,6 +58,7 @@ export function CardRow(
 
 /**
  * Row of readonly data, where the title takes the leftmost portion and the values are on the rightmost.
+ * If the value(s) provided are empty, then "None provided" is displayed.
  */
 export function CardValueRow(
   { title, values }: {

--- a/ui-admin/src/components/Card.tsx
+++ b/ui-admin/src/components/Card.tsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import { isEmpty } from 'lodash'
+
+
+/**
+ *
+ */
+export function Card({ children }: { children: React.ReactNode }) {
+  return <div className="card w-75 border shadow-sm mb-3">
+    {children}
+  </div>
+}
+
+/**
+ *
+ */
+export function CardHeader({ children }: { children: React.ReactNode }) {
+  return <div className="card-header border-bottom bg-white d-flex flex-row align-items-center">
+    {children}
+  </div>
+}
+
+/**
+ *
+ */
+export function CardTitle({ title }: { title: string }) {
+  return <div className="fw-bold lead my-1">{title}</div>
+}
+
+/**
+ *
+ */
+export function CardBody({ children }: { children: React.ReactNode }) {
+  return <div className="card-body d-flex flex-row flex-wrap">
+    {children}
+  </div>
+}
+
+/**
+ * One row of the profile's data.
+ */
+export function CardRow(
+  { title, children }: {
+        title: string,
+        children: React.ReactNode
+    }
+) {
+  return <>
+    <div className="w-25 fw-bold mb-4 mt-2" aria-label={title}>
+      {title}
+    </div>
+    <div className="w-75 mb-4">
+      {children}
+    </div>
+  </>
+}
+
+
+/**
+ * Row of readonly data, where the title takes the leftmost portion and the values are on the rightmost.
+ */
+export function CardValueRow(
+  { title, values }: {
+        title: string,
+        values: string[]
+    }
+) {
+  return <CardRow title={title}>
+    {(isEmpty(values) || values.every(isEmpty)) && <p className="fst-italic mb-0 mt-2 text-muted">None provided</p>}
+    {
+      values.filter(val => !isEmpty(val)).map((val, idx) => (
+        <p key={idx} className={`mb-0 ${idx == 0 ? 'mt-2' : ''}`}>{val}</p>
+      ))
+    }
+  </CardRow>
+}

--- a/ui-admin/src/components/InfoCard.tsx
+++ b/ui-admin/src/components/InfoCard.tsx
@@ -4,6 +4,47 @@ import { isEmpty } from 'lodash'
 
 /**
  * Stylized card component for displaying read-only or editable data.
+ * The components in this file can/should be nested similarly to the
+ * React modal component.
+ *
+ * Example usage:
+ * ```tsx
+ * <InfoCard>
+ *   <InfoCardHeader>
+ *     <InfoCardTitle title={'Basic Information'}/>
+ *   </InfoCardHeader>
+ *   <InfoCardBody>
+ *     <InfoCardValue
+ *       title={'Name'}
+ *       values={[formatName(enrollee.profile)]}
+ *     />
+ *     <InfoCardValue
+ *       title={'Birthdate'}
+ *       values={[dateToDefaultString(enrollee.profile.birthDate) || '']}
+ *     />
+ *   </InfoCardBody>
+ * </InfoCard>
+ * ```
+ *
+ * If you want to customize the way a row looks, you can use the `InfoCardRow` component
+ * directly. For example:
+ * ```tsx
+ * <InfoCard>
+ *   <InfoCardHeader>
+ *     <InfoCardTitle title={'Basic Information'}/>
+ *   </InfoCardHeader>
+ *   <InfoCardBody>
+ *     <InfoCardValue
+ *       title={'Name'}
+ *       values={[formatName(enrollee.profile)]}
+ *     />
+ *     <InfoCardRow title={'Birthdate'}>
+ *         <p>My custom birthday row:</p>
+ *         <p>{dateToDefaultString(enrollee.profile.birthDate) || ''}</p>
+ *     <InfoCardRow/>
+ *   </InfoCardBody>
+ * </InfoCard>
+ * ```
  */
 export function InfoCard({ children }: { children: React.ReactNode }) {
   return <div className="card w-75 border shadow-sm mb-3">

--- a/ui-admin/src/components/InfoCard.tsx
+++ b/ui-admin/src/components/InfoCard.tsx
@@ -5,7 +5,7 @@ import { isEmpty } from 'lodash'
 /**
  * Stylized card component for displaying read-only or editable data.
  */
-export function Card({ children }: { children: React.ReactNode }) {
+export function InfoCard({ children }: { children: React.ReactNode }) {
   return <div className="card w-75 border shadow-sm mb-3">
     {children}
   </div>
@@ -14,7 +14,7 @@ export function Card({ children }: { children: React.ReactNode }) {
 /**
  * Header of the card, usually used with CardTitle to display the title of the card.
  */
-export function CardHeader({ children }: { children: React.ReactNode }) {
+export function InfoCardHeader({ children }: { children: React.ReactNode }) {
   return <div className="card-header border-bottom bg-white d-flex flex-row align-items-center">
     {children}
   </div>
@@ -23,14 +23,14 @@ export function CardHeader({ children }: { children: React.ReactNode }) {
 /**
  * Title of the card.
  */
-export function CardTitle({ title }: { title: string }) {
+export function InfoCardTitle({ title }: { title: string }) {
   return <div className="fw-bold lead my-1">{title}</div>
 }
 
 /**
  * Body of the card, usually used with CardRow or CardValueRow to display the data.
  */
-export function CardBody({ children }: { children: React.ReactNode }) {
+export function InfoCardBody({ children }: { children: React.ReactNode }) {
   return <div className="card-body d-flex flex-row flex-wrap">
     {children}
   </div>
@@ -39,7 +39,7 @@ export function CardBody({ children }: { children: React.ReactNode }) {
 /**
  * One row of data in the card, where the title is on the left-hand side and the values are on the right.
  */
-export function CardRow(
+export function InfoCardRow(
   { title, children }: {
         title: string,
         children: React.ReactNode
@@ -60,18 +60,18 @@ export function CardRow(
  * Row of readonly data, where the title takes the leftmost portion and the values are on the rightmost.
  * If the value(s) provided are empty, then "None provided" is displayed.
  */
-export function CardValueRow(
+export function InfoCardValue(
   { title, values }: {
         title: string,
         values: string[]
     }
 ) {
-  return <CardRow title={title}>
+  return <InfoCardRow title={title}>
     {(isEmpty(values) || values.every(isEmpty)) && <p className="fst-italic mb-0 mt-2 text-muted">None provided</p>}
     {
       values.filter(val => !isEmpty(val)).map((val, idx) => (
         <p key={idx} className={`mb-0 ${idx == 0 ? 'mt-2' : ''}`}>{val}</p>
       ))
     }
-  </CardRow>
+  </InfoCardRow>
 }

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeOverview.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeOverview.tsx
@@ -13,7 +13,7 @@ export default function EnrolleeOverview({ enrollee, studyEnvContext, onUpdate }
         {enrollee: Enrollee, studyEnvContext: StudyEnvContextT, onUpdate: () => void}) {
   const [relations, setRelations] = React.useState<EnrolleeRelation[]>([])
 
-  const { isLoading } = useLoadingEffect(async () => {
+  const { isLoading: isLoadingRelations } = useLoadingEffect(async () => {
     const relations = await Api.findRelationsByTargetShortcode(
       studyEnvContext.portal.shortcode,
       studyEnvContext.study.shortcode,
@@ -22,14 +22,14 @@ export default function EnrolleeOverview({ enrollee, studyEnvContext, onUpdate }
     setRelations(relations)
   })
 
-  if (isLoading) {
+  if (isLoadingRelations) {
     return <LoadingSpinner/>
   }
 
   return <div>
     <InfoCard>
       <InfoCardHeader>
-        <InfoCardTitle title={'Overview'}/>
+        <InfoCardTitle title={'Basic Information'}/>
       </InfoCardHeader>
       <InfoCardBody>
         <InfoCardValue

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeOverview.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeOverview.tsx
@@ -1,29 +1,67 @@
 import React from 'react'
-import { Enrollee } from 'api/api'
+import Api, { Enrollee, EnrolleeRelation, Profile } from 'api/api'
 import { StudyEnvContextT } from '../../StudyEnvironmentRouter'
 import ParticipantNotesView from './ParticipantNotesView'
 import { dateToDefaultString } from '@juniper/ui-core'
 import KitRequests from '../KitRequests'
+import { Card, CardBody, CardHeader, CardTitle, CardValueRow } from '../../../components/Card'
+import { useLoadingEffect } from '../../../api/api-utils'
 
 /** Shows minimal identifying information, and then kits and notes */
 export default function EnrolleeOverview({ enrollee, studyEnvContext, onUpdate }:
         {enrollee: Enrollee, studyEnvContext: StudyEnvContextT, onUpdate: () => void}) {
+  const [relations, setRelations] = React.useState<EnrolleeRelation[]>([])
+
+  useLoadingEffect(async () => {
+    const relations = await Api.findRelationsByTargetShortcode(
+      studyEnvContext.portal.shortcode,
+      studyEnvContext.study.shortcode,
+      studyEnvContext.currentEnv.environmentName,
+      enrollee.shortcode)
+    setRelations(relations)
+  })
+
   return <div>
-    <div className="mb-5">
-      <label className="form-label">
-                Given name: <input className="form-control" type="text"
-          readOnly={true} value={enrollee.profile.givenName}/>
-      </label>
-      <label className="form-label ms-2">
-                Family name: <input className="form-control" type="text"
-          readOnly={true} value={enrollee.profile.familyName}/>
-      </label>
-      <label className="form-label ms-2">
-                Birthdate:
-        <input className="form-control" type="text"
-          readOnly={true} value={dateToDefaultString(enrollee.profile.birthDate)}/>
-      </label>
-    </div>
+    <Card>
+      <CardHeader>
+        <CardTitle title={'Overview'}/>
+      </CardHeader>
+      <CardBody>
+        <CardValueRow
+          title={'Name'}
+          values={[formatName(enrollee.profile)]}
+        />
+        <CardValueRow
+          title={'Birthdate'}
+          values={[dateToDefaultString(enrollee.profile.birthDate) || '']}
+        />
+      </CardBody>
+    </Card>
+
+    {
+      relations
+        .filter(relation => relation.relationshipType === 'PROXY')
+        .map(relation => {
+          return <Card>
+            <CardHeader>
+              <CardTitle title={'Proxy'}/>
+            </CardHeader>
+            <CardBody>
+              <CardValueRow
+                title={'Name'}
+                values={
+                  [formatName(relation.enrollee.profile)]
+                }
+              />
+              <CardValueRow
+                title={'Contact Email'}
+                values={[relation.enrollee?.profile?.contactEmail || '']}
+              />
+            </CardBody>
+          </Card>
+        })}
+
+
     <div className="mb-5">
       <ParticipantNotesView notes={enrollee.participantNotes} enrollee={enrollee}
         studyEnvContext={studyEnvContext} onUpdate={onUpdate}/>
@@ -32,4 +70,8 @@ export default function EnrolleeOverview({ enrollee, studyEnvContext, onUpdate }
 
     <KitRequests enrollee={enrollee} studyEnvContext={studyEnvContext} onUpdate={onUpdate}/>
   </div>
+}
+
+const formatName = (profile: Profile) => {
+  return `${profile.givenName || ''} ${profile.familyName || ''}`.trim()
 }

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeOverview.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeOverview.tsx
@@ -22,10 +22,6 @@ export default function EnrolleeOverview({ enrollee, studyEnvContext, onUpdate }
     setRelations(relations)
   })
 
-  if (isLoadingRelations) {
-    return <LoadingSpinner/>
-  }
-
   return <div>
     <InfoCard>
       <InfoCardHeader>
@@ -43,6 +39,7 @@ export default function EnrolleeOverview({ enrollee, studyEnvContext, onUpdate }
       </InfoCardBody>
     </InfoCard>
 
+    {isLoadingRelations && <LoadingSpinner/>}
     {
       relations
         .filter(relation => relation.relationshipType === 'PROXY')

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeOverview.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeOverview.tsx
@@ -4,15 +4,16 @@ import { StudyEnvContextT } from '../../StudyEnvironmentRouter'
 import ParticipantNotesView from './ParticipantNotesView'
 import { dateToDefaultString } from '@juniper/ui-core'
 import KitRequests from '../KitRequests'
-import { Card, CardBody, CardHeader, CardTitle, CardValueRow } from '../../../components/Card'
+import { InfoCard, InfoCardBody, InfoCardHeader, InfoCardTitle, InfoCardValue } from '../../../components/InfoCard'
 import { useLoadingEffect } from '../../../api/api-utils'
+import LoadingSpinner from '../../../util/LoadingSpinner'
 
 /** Shows minimal identifying information, and then kits and notes */
 export default function EnrolleeOverview({ enrollee, studyEnvContext, onUpdate }:
         {enrollee: Enrollee, studyEnvContext: StudyEnvContextT, onUpdate: () => void}) {
   const [relations, setRelations] = React.useState<EnrolleeRelation[]>([])
 
-  useLoadingEffect(async () => {
+  const { isLoading } = useLoadingEffect(async () => {
     const relations = await Api.findRelationsByTargetShortcode(
       studyEnvContext.portal.shortcode,
       studyEnvContext.study.shortcode,
@@ -21,44 +22,48 @@ export default function EnrolleeOverview({ enrollee, studyEnvContext, onUpdate }
     setRelations(relations)
   })
 
+  if (isLoading) {
+    return <LoadingSpinner/>
+  }
+
   return <div>
-    <Card>
-      <CardHeader>
-        <CardTitle title={'Overview'}/>
-      </CardHeader>
-      <CardBody>
-        <CardValueRow
+    <InfoCard>
+      <InfoCardHeader>
+        <InfoCardTitle title={'Overview'}/>
+      </InfoCardHeader>
+      <InfoCardBody>
+        <InfoCardValue
           title={'Name'}
           values={[formatName(enrollee.profile)]}
         />
-        <CardValueRow
+        <InfoCardValue
           title={'Birthdate'}
           values={[dateToDefaultString(enrollee.profile.birthDate) || '']}
         />
-      </CardBody>
-    </Card>
+      </InfoCardBody>
+    </InfoCard>
 
     {
       relations
         .filter(relation => relation.relationshipType === 'PROXY')
         .map(relation => {
-          return <Card>
-            <CardHeader>
-              <CardTitle title={'Proxy'}/>
-            </CardHeader>
-            <CardBody>
-              <CardValueRow
+          return <InfoCard>
+            <InfoCardHeader>
+              <InfoCardTitle title={'Proxy'}/>
+            </InfoCardHeader>
+            <InfoCardBody>
+              <InfoCardValue
                 title={'Name'}
                 values={
                   [formatName(relation.enrollee.profile)]
                 }
               />
-              <CardValueRow
+              <InfoCardValue
                 title={'Contact Email'}
                 values={[relation.enrollee?.profile?.contactEmail || '']}
               />
-            </CardBody>
-          </Card>
+            </InfoCardBody>
+          </InfoCard>
         })}
 
 

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeProfile.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeProfile.tsx
@@ -18,7 +18,14 @@ import { Store } from 'react-notifications-component'
 import { successNotification } from 'util/notifications'
 import { doApiLoad } from 'api/api-utils'
 import EditMailingAddress from 'address/EditMailingAddress'
-import { Card, CardBody, CardHeader, CardRow, CardTitle, CardValueRow } from '../../../components/Card'
+import {
+  InfoCard,
+  InfoCardBody,
+  InfoCardHeader,
+  InfoCardRow,
+  InfoCardTitle,
+  InfoCardValue
+} from '../../../components/InfoCard'
 
 /**
  * Shows the enrollee profile and allows editing from the admin side
@@ -60,9 +67,9 @@ export default function EnrolleeProfile({ enrollee, studyEnvContext, onUpdate }:
   }
 
   return <div>
-    <Card>
-      <CardHeader>
-        <CardTitle title={editMode ? 'Edit Profile' : 'Profile'}/>
+    <InfoCard>
+      <InfoCardHeader>
+        <InfoCardTitle title={editMode ? 'Edit Profile' : 'Profile'}/>
         {!editMode && <button className="mx-2 btn btn-light text-primary" onClick={() => setEditMode(true)}>
           <FontAwesomeIcon icon={faPencil} className={'me-2'}/>
           Edit
@@ -74,13 +81,13 @@ export default function EnrolleeProfile({ enrollee, studyEnvContext, onUpdate }:
           </button>
           <button className="btn btn-outline-primary" onClick={() => setEditMode(false)}>Cancel</button>
         </div>}
-      </CardHeader>
-      <CardBody>
+      </InfoCardHeader>
+      <InfoCardBody>
         {editMode
           ? <EditableProfile profile={editedProfile} setProfile={onProfileUpdate}/>
           : <ReadOnlyProfile profile={enrollee.profile} supportedLanguages={supportedLanguages}/>}
-      </CardBody>
-    </Card>
+      </InfoCardBody>
+    </InfoCard>
 
     {
       showJustifyAndSaveModal && (
@@ -108,18 +115,18 @@ function ReadOnlyProfile(
   const mailingAddress = profile.mailingAddress
 
   return <>
-    <CardValueRow title={'Name'}
+    <InfoCardValue title={'Name'}
       values={[
                    `${profile.givenName || ''} ${profile.familyName || ''}`.trim()
       ]}/>
-    <CardValueRow title={'Birthdate'} values={[dateToDefaultString(profile.birthDate)]}/>
+    <InfoCardValue title={'Birthdate'} values={[dateToDefaultString(profile.birthDate)]}/>
     <ReadOnlyMailingAddress title={'Primary Address'} mailingAddress={mailingAddress}/>
-    <CardValueRow title={'Email'} values={[profile.contactEmail]}/>
-    <CardValueRow title={'Phone'} values={[profile.phoneNumber]}/>
-    <CardValueRow title={'Notifications'} values={[profile.doNotEmail ? 'Off' : 'On']}/>
-    <CardValueRow title={'Do Not Solicit'} values={[profile.doNotEmailSolicit ? 'On' : 'Off']}/>
+    <InfoCardValue title={'Email'} values={[profile.contactEmail]}/>
+    <InfoCardValue title={'Phone'} values={[profile.phoneNumber]}/>
+    <InfoCardValue title={'Notifications'} values={[profile.doNotEmail ? 'Off' : 'On']}/>
+    <InfoCardValue title={'Do Not Solicit'} values={[profile.doNotEmailSolicit ? 'On' : 'Off']}/>
     { supportedLanguages.length > 0 &&
-        <CardValueRow title={'Preferred Language'} values={[supportedLanguages.find(lang =>
+        <InfoCardValue title={'Preferred Language'} values={[supportedLanguages.find(lang =>
           lang.languageCode === profile.preferredLanguage)?.languageName || '']}/>
     }
   </>
@@ -155,7 +162,7 @@ function EditableProfile(
   }
 
   return <>
-    <CardRow title={'Name'}>
+    <InfoCardRow title={'Name'}>
       <div className='row'>
         <div className='col'>
           <input className="form-control" type="text" value={profile.givenName || ''}
@@ -168,8 +175,8 @@ function EditableProfile(
             onChange={e => onFieldChange('familyName', e.target.value)}/>
         </div>
       </div>
-    </CardRow>
-    <CardRow title={'Birthdate'}>
+    </InfoCardRow>
+    <InfoCardRow title={'Birthdate'}>
       <div className='row'>
         <div className="col">
           <input className="form-control" type="date"
@@ -179,22 +186,22 @@ function EditableProfile(
         </div>
         <div className="col"/>
       </div>
-    </CardRow>
+    </InfoCardRow>
     <EditMailingAddressRow
       title={'Primary Address'} mailingAddress={profile.mailingAddress}
       onFieldChange={onFieldChange}
     />
-    <CardRow title={'Email'}>
+    <InfoCardRow title={'Email'}>
       <input className="form-control" type="text" value={profile.contactEmail || ''}
         placeholder={'Contact Email'} aria-label={'Contact Email'}
         onChange={e => onFieldChange('contactEmail', e.target.value)}/>
-    </CardRow>
-    <CardRow title={'Phone'}>
+    </InfoCardRow>
+    <InfoCardRow title={'Phone'}>
       <input className="form-control" type="text" value={profile.phoneNumber || ''}
         placeholder={'Phone Number'} aria-label={'Phone'}
         onChange={e => onFieldChange('phoneNumber', e.target.value)}/>
-    </CardRow>
-    <CardRow title={'Notifications'}>
+    </InfoCardRow>
+    <InfoCardRow title={'Notifications'}>
       <div className='row mt-2'>
         <div className="col-auto">
           <div className="form-check">
@@ -218,7 +225,7 @@ function EditableProfile(
           </div>
         </div>
       </div>
-    </CardRow>
+    </InfoCardRow>
   </>
 }
 
@@ -251,7 +258,7 @@ export function ReadOnlyMailingAddress(
 
     return outPieces.join(' ').trim()
   }
-  return <CardValueRow title={title} values={[
+  return <InfoCardValue title={title} values={[
     mailingAddress.street1 || '',
     mailingAddress.street2 || '',
     createCityStatePostalRow(),
@@ -275,9 +282,9 @@ function EditMailingAddressRow(
     onFieldChange('mailingAddress', editableMailingAddress)
   }, [editableMailingAddress])
 
-  return <CardRow title={title}>
+  return <InfoCardRow title={title}>
     <EditMailingAddress
       mailingAddress={editableMailingAddress}
       setMailingAddress={setEditableMailingAddress}/>
-  </CardRow>
+  </InfoCardRow>
 }

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeProfile.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeProfile.tsx
@@ -18,14 +18,7 @@ import { Store } from 'react-notifications-component'
 import { successNotification } from 'util/notifications'
 import { doApiLoad } from 'api/api-utils'
 import EditMailingAddress from 'address/EditMailingAddress'
-import {
-  InfoCard,
-  InfoCardBody,
-  InfoCardHeader,
-  InfoCardRow,
-  InfoCardTitle,
-  InfoCardValue
-} from '../../../components/InfoCard'
+import { InfoCard, InfoCardBody, InfoCardHeader, InfoCardRow, InfoCardTitle, InfoCardValue } from 'components/InfoCard'
 
 /**
  * Shows the enrollee profile and allows editing from the admin side

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeProfile.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeProfile.tsx
@@ -18,6 +18,7 @@ import { Store } from 'react-notifications-component'
 import { successNotification } from 'util/notifications'
 import { doApiLoad } from 'api/api-utils'
 import EditMailingAddress from 'address/EditMailingAddress'
+import { Card, CardBody, CardHeader, CardRow, CardTitle, CardValueRow } from '../../../components/Card'
 
 /**
  * Shows the enrollee profile and allows editing from the admin side
@@ -59,27 +60,27 @@ export default function EnrolleeProfile({ enrollee, studyEnvContext, onUpdate }:
   }
 
   return <div>
-    <div className="card w-75 border shadow-sm mb-3">
-      <div className="card-header border-bottom bg-white d-flex flex-row align-items-center">
-        <div className="fw-bold lead">{editMode ? 'Edit Profile' : 'Profile'}</div>
+    <Card>
+      <CardHeader>
+        <CardTitle title={editMode ? 'Edit Profile' : 'Profile'}/>
         {!editMode && <button className="mx-2 btn btn-light text-primary" onClick={() => setEditMode(true)}>
           <FontAwesomeIcon icon={faPencil} className={'me-2'}/>
-            Edit
+          Edit
         </button>}
         {editMode && <div className="flex-grow-1 d-flex justify-content-end">
           <button className="btn btn-primary mx-2 " disabled={!isDirty}
             onClick={() => setShowJustifyAndSaveModal(true)}>
-                Next: Add Justification
+            Next: Add Justification
           </button>
           <button className="btn btn-outline-primary" onClick={() => setEditMode(false)}>Cancel</button>
         </div>}
-      </div>
-      <div className="card-body d-flex flex-row flex-wrap">
+      </CardHeader>
+      <CardBody>
         {editMode
           ? <EditableProfile profile={editedProfile} setProfile={onProfileUpdate}/>
           : <ReadOnlyProfile profile={enrollee.profile} supportedLanguages={supportedLanguages}/>}
-      </div>
-    </div>
+      </CardBody>
+    </Card>
 
     {
       showJustifyAndSaveModal && (
@@ -107,18 +108,18 @@ function ReadOnlyProfile(
   const mailingAddress = profile.mailingAddress
 
   return <>
-    <ReadOnlyRow title={'Name'}
+    <CardValueRow title={'Name'}
       values={[
                    `${profile.givenName || ''} ${profile.familyName || ''}`.trim()
       ]}/>
-    <ReadOnlyRow title={'Birthdate'} values={[dateToDefaultString(profile.birthDate)]}/>
+    <CardValueRow title={'Birthdate'} values={[dateToDefaultString(profile.birthDate)]}/>
     <ReadOnlyMailingAddress title={'Primary Address'} mailingAddress={mailingAddress}/>
-    <ReadOnlyRow title={'Email'} values={[profile.contactEmail]}/>
-    <ReadOnlyRow title={'Phone'} values={[profile.phoneNumber]}/>
-    <ReadOnlyRow title={'Notifications'} values={[profile.doNotEmail ? 'Off' : 'On']}/>
-    <ReadOnlyRow title={'Do Not Solicit'} values={[profile.doNotEmailSolicit ? 'On' : 'Off']}/>
+    <CardValueRow title={'Email'} values={[profile.contactEmail]}/>
+    <CardValueRow title={'Phone'} values={[profile.phoneNumber]}/>
+    <CardValueRow title={'Notifications'} values={[profile.doNotEmail ? 'Off' : 'On']}/>
+    <CardValueRow title={'Do Not Solicit'} values={[profile.doNotEmailSolicit ? 'On' : 'Off']}/>
     { supportedLanguages.length > 0 &&
-        <ReadOnlyRow title={'Preferred Language'} values={[supportedLanguages.find(lang =>
+        <CardValueRow title={'Preferred Language'} values={[supportedLanguages.find(lang =>
           lang.languageCode === profile.preferredLanguage)?.languageName || '']}/>
     }
   </>
@@ -154,7 +155,7 @@ function EditableProfile(
   }
 
   return <>
-    <FormRow title={'Name'}>
+    <CardRow title={'Name'}>
       <div className='row'>
         <div className='col'>
           <input className="form-control" type="text" value={profile.givenName || ''}
@@ -167,8 +168,8 @@ function EditableProfile(
             onChange={e => onFieldChange('familyName', e.target.value)}/>
         </div>
       </div>
-    </FormRow>
-    <FormRow title={'Birthdate'}>
+    </CardRow>
+    <CardRow title={'Birthdate'}>
       <div className='row'>
         <div className="col">
           <input className="form-control" type="date"
@@ -178,22 +179,22 @@ function EditableProfile(
         </div>
         <div className="col"/>
       </div>
-    </FormRow>
+    </CardRow>
     <EditMailingAddressRow
       title={'Primary Address'} mailingAddress={profile.mailingAddress}
       onFieldChange={onFieldChange}
     />
-    <FormRow title={'Email'}>
+    <CardRow title={'Email'}>
       <input className="form-control" type="text" value={profile.contactEmail || ''}
         placeholder={'Contact Email'} aria-label={'Contact Email'}
         onChange={e => onFieldChange('contactEmail', e.target.value)}/>
-    </FormRow>
-    <FormRow title={'Phone'}>
+    </CardRow>
+    <CardRow title={'Phone'}>
       <input className="form-control" type="text" value={profile.phoneNumber || ''}
         placeholder={'Phone Number'} aria-label={'Phone'}
         onChange={e => onFieldChange('phoneNumber', e.target.value)}/>
-    </FormRow>
-    <FormRow title={'Notifications'}>
+    </CardRow>
+    <CardRow title={'Notifications'}>
       <div className='row mt-2'>
         <div className="col-auto">
           <div className="form-check">
@@ -217,28 +218,10 @@ function EditableProfile(
           </div>
         </div>
       </div>
-    </FormRow>
+    </CardRow>
   </>
 }
 
-/**
- * Row of readonly data, where the title takes the leftmost portion and the values are on the rightmost.
- */
-function ReadOnlyRow(
-  { title, values }: {
-    title: string,
-    values: string[]
-  }
-) {
-  return <FormRow title={title}>
-    {(isEmpty(values) || values.every(isEmpty)) && <p className="fst-italic mb-0 mt-2 text-muted">None provided</p>}
-    {
-      values.filter(val => !isEmpty(val)).map((val, idx) => (
-        <p key={idx} className={`mb-0 ${idx == 0 ? 'mt-2' : ''}`}>{val}</p>
-      ))
-    }
-  </FormRow>
-}
 
 /**
  * Displays the given mailing address as a row within the profile
@@ -268,31 +251,12 @@ export function ReadOnlyMailingAddress(
 
     return outPieces.join(' ').trim()
   }
-  return <ReadOnlyRow title={title} values={[
+  return <CardValueRow title={title} values={[
     mailingAddress.street1 || '',
     mailingAddress.street2 || '',
     createCityStatePostalRow(),
     mailingAddress.country || ''
   ]}/>
-}
-
-/**
- * One row of the profile's data.
- */
-function FormRow(
-  { title, children }: {
-    title: string,
-    children: React.ReactNode
-  }
-) {
-  return <>
-    <div className="w-25 fw-bold mb-4 mt-2" aria-label={title}>
-      {title}
-    </div>
-    <div className="w-75 mb-4">
-      {children}
-    </div>
-  </>
 }
 
 
@@ -311,9 +275,9 @@ function EditMailingAddressRow(
     onFieldChange('mailingAddress', editableMailingAddress)
   }, [editableMailingAddress])
 
-  return <FormRow title={title}>
+  return <CardRow title={title}>
     <EditMailingAddress
       mailingAddress={editableMailingAddress}
       setMailingAddress={setEditableMailingAddress}/>
-  </FormRow>
+  </CardRow>
 }

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeView.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeView.tsx
@@ -208,7 +208,7 @@ export function LoadedEnrolleeView({ enrollee, studyEnvContext, onUpdate }:
               </li>
             </ul>
           </div>
-          <div className="participantTabContent flex-grow-1 bg-white p-3">
+          <div className="participantTabContent flex-grow-1 bg-white p-3 pt-0">
             <ErrorBoundary>
               <Routes>
                 <Route path="profile" element={<EnrolleeProfile enrollee={enrollee}


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds the ability to quickly view an enrollee's proxy. Also, cleans up the enrollee overview to not use the raw HTML inputs and instead the new fancy card that Erin uses in her design.

<img width="1512" alt="image" src="https://github.com/broadinstitute/juniper/assets/17440010/803befb3-a826-40c7-951f-67c7901c67cc">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Sign up a user with a proxy
- Go to the user's account, observe that the proxy shows up
- Go to a non-proxied account and observe correct behavior.