### PR TITLE
[JN-1042] enrollee routes by id or shortcode

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeController.java
@@ -38,9 +38,9 @@ public class EnrolleeController implements EnrolleeApi {
 
   @Override
   public ResponseEntity<Object> find(
-      String portalShortcode, String studyShortcode, String envName, String enrolleeShortcode) {
+      String portalShortcode, String studyShortcode, String envName, String enrolleeShortcodeOrId) {
     AdminUser adminUser = authUtilService.requireAdminUser(request);
-    Enrollee enrollee = enrolleeExtService.findWithAdminLoad(adminUser, enrolleeShortcode);
+    Enrollee enrollee = enrolleeExtService.findWithAdminLoad(adminUser, enrolleeShortcodeOrId);
     return ResponseEntity.ok(enrollee);
   }
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/AuthUtilService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/AuthUtilService.java
@@ -110,11 +110,11 @@ public class AuthUtilService {
     List<PortalStudy> portalStudies = portalStudyService.findByEnrollee(enrolleeShortcode);
     List<UUID> portalIds = portalStudies.stream().map(PortalStudy::getPortalId).toList();
     if (!portalService.checkAdminInAtLeastOnePortal(user, portalIds)) {
-      throw new PermissionDeniedException(
+      throw new NotFoundException(
           "User %s does not have permissions on enrollee %s or enrollee does not exist"
               .formatted(user.getUsername(), enrolleeShortcode));
     }
-    return enrolleeService.findOneByShortcode(enrolleeShortcode).get();
+    return enrolleeService.findOneByShortcode(enrolleeShortcode).orElseThrow();
   }
 
   /** confirms that the Survey is accessible from the given portal */

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeExtService.java
@@ -8,6 +8,7 @@ import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.EnrolleeSearchFacet;
 import bio.terra.pearl.core.model.participant.EnrolleeSearchResult;
 import bio.terra.pearl.core.model.participant.WithdrawnEnrollee;
+import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.participant.WithdrawnEnrolleeService;
 import bio.terra.pearl.core.service.participant.search.EnrolleeSearchService;
@@ -17,6 +18,7 @@ import bio.terra.pearl.core.service.participant.search.facets.sql.SqlSearchableF
 import bio.terra.pearl.core.service.workflow.DataChangeRecordService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -72,7 +74,20 @@ public class EnrolleeExtService {
     return enrolleeService.findForKitManagement(studyShortcode, environmentName);
   }
 
-  public Enrollee findWithAdminLoad(AdminUser operator, String enrolleeShortcode) {
+  public Enrollee findWithAdminLoad(AdminUser operator, String enrolleeShortcodeOrId) {
+    String enrolleeShortcode = enrolleeShortcodeOrId;
+    if (enrolleeShortcode != null && enrolleeShortcode.length() > 16) {
+      // it's an id, not a shortcode
+      enrolleeShortcode =
+          enrolleeService
+              .find(UUID.fromString(enrolleeShortcode))
+              .orElseThrow(
+                  () ->
+                      new NotFoundException(
+                          "User %s does not have permissions on enrollee %s or enrollee does not exist"
+                              .formatted(operator.getUsername(), enrolleeShortcodeOrId)))
+              .getShortcode();
+    }
     Enrollee enrollee = authUtilService.authAdminUserToEnrollee(operator, enrolleeShortcode);
     return enrolleeService.loadForAdminView(enrollee);
   }

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeExtServiceTests.java
@@ -1,0 +1,59 @@
+package bio.terra.pearl.api.admin.service.enrollee;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import bio.terra.pearl.api.admin.BaseSpringBootTest;
+import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
+import bio.terra.pearl.core.factory.admin.PortalAdminUserFactory;
+import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
+import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.service.exception.NotFoundException;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class EnrolleeExtServiceTests extends BaseSpringBootTest {
+  @Autowired private StudyEnvironmentFactory studyEnvironmentFactory;
+  @Autowired private EnrolleeFactory enrolleeFactory;
+  @Autowired private EnrolleeExtService enrolleeExtService;
+  @Autowired private PortalAdminUserFactory portalAdminUserFactory;
+
+  @Test
+  public void testFindById(TestInfo info) {
+    StudyEnvironmentFactory.StudyEnvironmentBundle bundle =
+        studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.sandbox);
+    AdminUser operator =
+        portalAdminUserFactory
+            .buildPersistedWithPortals(getTestName(info), List.of(bundle.getPortal()))
+            .user();
+    EnrolleeFactory.EnrolleeBundle enrollee1 =
+        enrolleeFactory.buildWithPortalUser(
+            getTestName(info), bundle.getPortalEnv(), bundle.getStudyEnv());
+
+    Enrollee loadedEnrollee =
+        enrolleeExtService.findWithAdminLoad(operator, enrollee1.enrollee().getShortcode());
+    assertThat(loadedEnrollee.getId(), equalTo(enrollee1.enrollee().getId()));
+
+    loadedEnrollee =
+        enrolleeExtService.findWithAdminLoad(operator, enrollee1.enrollee().getId().toString());
+    assertThat(loadedEnrollee.getId(), equalTo(enrollee1.enrollee().getId()));
+
+    Assertions.assertThrows(
+        NotFoundException.class,
+        () -> {
+          enrolleeExtService.findWithAdminLoad(operator, UUID.randomUUID().toString());
+        });
+
+    Assertions.assertThrows(
+        NotFoundException.class,
+        () -> {
+          enrolleeExtService.findWithAdminLoad(operator, "BADCODE");
+        });
+  }
+}

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/participant/ProfileExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/participant/ProfileExtServiceTests.java
@@ -9,7 +9,7 @@ import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.audit.DataChangeRecord;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.Profile;
-import bio.terra.pearl.core.service.exception.PermissionDeniedException;
+import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.participant.ProfileService;
 import bio.terra.pearl.core.service.workflow.DataChangeRecordService;
 import java.util.List;
@@ -40,7 +40,7 @@ public class ProfileExtServiceTests extends BaseSpringBootTest {
     AdminUser operator = adminUserFactory.buildPersisted(getTestName(info), false);
 
     Assertions.assertThrows(
-        PermissionDeniedException.class,
+        NotFoundException.class,
         () -> {
           profileExtService.updateProfileForEnrollee(
               operator,

--- a/populate/src/main/java/bio/terra/pearl/populate/service/ParticipantNotePopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/ParticipantNotePopulator.java
@@ -34,7 +34,7 @@ public class ParticipantNotePopulator {
     }
 
     public ParticipantNote populate(Enrollee enrollee, ParticipantNotePopDto notePopDto) {
-        AdminUser creatingUser = adminUserDao.findByUsername(notePopDto.getCreatingAdminUsername()).get();
+        AdminUser creatingUser = adminUserDao.findByUsername(notePopDto.getCreatingAdminUsername()).orElseThrow();
         UUID kitRequestId = null;
         if (notePopDto.getKitRequestIndex() != null) {
             kitRequestId = enrollee.getKitRequests().get(notePopDto.getKitRequestIndex()).getId();

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
@@ -105,5 +105,25 @@
         "discardReason": ""
       }
     }
-  ]
+  ],
+  "participantNoteDtos": [{
+    "creatingAdminUsername": "staff@heartdemo.org",
+    "text": "Phone call: asked to delay kit shipment as they are travelling for next two months",
+    "kitRequestIndex": 0,
+    "submittedHoursAgo": 3
+  },{
+    "creatingAdminUsername": "power_user@heartdemo.org",
+    "text": "Reviewed survey responses, many are incomplete, send additional reminder email",
+    "submittedHoursAgo": 20,
+    "task": {
+      "assignedToUsername": "staff@heartdemo.or"
+    }
+  },{
+    "creatingAdminUsername": "staff@heartdemo.org",
+    "text": "Needs address change, call to confirm",
+    "submittedHoursAgo": 25,
+    "task": {
+      "assignedToUsername": "staff@heartdemo.org"
+    }
+  }]
 }

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
@@ -116,7 +116,7 @@
     "text": "Reviewed survey responses, many are incomplete, send additional reminder email",
     "submittedHoursAgo": 20,
     "task": {
-      "assignedToUsername": "staff@heartdemo.or"
+      "assignedToUsername": "staff@heartdemo.org"
     }
   },{
     "creatingAdminUsername": "staff@heartdemo.org",

--- a/ui-admin/src/study/participants/DataChangeRecords.tsx
+++ b/ui-admin/src/study/participants/DataChangeRecords.tsx
@@ -108,6 +108,12 @@ export default function DataChangeRecords({ enrollee, studyEnvContext }:
   }, [enrollee.shortcode])
   return <div>
     <h5>Audit history</h5>
+    <dl >
+      <dt className="fw-semibold">Enrollee internal ID</dt>
+      <dd>{enrollee.id}</dd>
+      <dt className="fw-semibold">Enrollee created</dt>
+      <dd>{instantToDefaultString(enrollee.createdAt)}</dd>
+    </dl>
     <LoadingSpinner isLoading={isLoading}>
       {basicTableLayout(table)}
     </LoadingSpinner>

--- a/ui-admin/src/study/participants/ParticipantsRouter.tsx
+++ b/ui-admin/src/study/participants/ParticipantsRouter.tsx
@@ -13,7 +13,7 @@ export default function ParticipantsRouter({ studyEnvContext }: {studyEnvContext
           participants</Link>
     </NavBreadcrumb>
     <Routes>
-      <Route path=":enrolleeShortcode/*" element={<EnrolleeView studyEnvContext={studyEnvContext}/>}/>
+      <Route path=":enrolleeShortcodeOrId/*" element={<EnrolleeView studyEnvContext={studyEnvContext}/>}/>
       <Route index element={<ParticipantList studyEnvContext={studyEnvContext}/>}/>
       <Route path="*" element={<div>Unknown participant page</div>}/>
     </Routes>

--- a/ui-admin/src/study/participants/enrolleeView/useRoutedEnrollee.ts
+++ b/ui-admin/src/study/participants/enrolleeView/useRoutedEnrollee.ts
@@ -1,12 +1,12 @@
 import { useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { StudyParams } from '../../StudyRouter'
 import Api, { Enrollee } from 'api/api'
 import { StudyEnvContextT } from '../../StudyEnvironmentRouter'
 import { useLoadingEffect } from 'api/api-utils'
 
 export type EnrolleeParams = StudyParams & {
-  enrolleeShortcode: string,
+  enrolleeShortcodeOrId: string,
   surveyStableId: string,
   consentStableId: string
 }
@@ -15,15 +15,26 @@ export type EnrolleeParams = StudyParams & {
 export default function useRoutedEnrollee(studyEnvContext: StudyEnvContextT) {
   const { portal, study, currentEnv } = studyEnvContext
   const params = useParams<EnrolleeParams>()
-  const enrolleeShortcode = params.enrolleeShortcode as string
+  const enrolleeShortcodeOrId = params.enrolleeShortcodeOrId as string
   const [enrollee, setEnrollee] = useState<Enrollee>()
+  const navigate = useNavigate()
+  const location = useLocation()
 
   const { isLoading, reload } = useLoadingEffect(async () => {
-    const result = await Api.getEnrollee(
-      portal.shortcode, study.shortcode, currentEnv.environmentName, enrolleeShortcode
-    )
-    setEnrollee(result)
-  }, [enrolleeShortcode])
+    let enrollee = location?.state?.enrollee
+    if (!enrollee) {
+      enrollee = await Api.getEnrollee(portal.shortcode, study.shortcode,
+        currentEnv.environmentName, enrolleeShortcodeOrId)
+    } else {
+      // clear the state so this page will update if we navigate to a new enrollee or refresh
+      window.history.replaceState({}, '')
+    }
+    if (enrollee.shortcode != enrolleeShortcodeOrId) {
+      // we got an id -- reroute to the shortcode path
+      navigate(location.pathname.replace(enrollee.id, enrollee.shortcode), { replace: true, state: { enrollee } })
+    }
+    setEnrollee(enrollee)
+  }, [enrolleeShortcodeOrId])
 
   return { isLoading, enrollee, reload }
 }

--- a/ui-admin/src/study/participants/enrolleeView/useRoutedEnrollee.ts
+++ b/ui-admin/src/study/participants/enrolleeView/useRoutedEnrollee.ts
@@ -23,14 +23,16 @@ export default function useRoutedEnrollee(studyEnvContext: StudyEnvContextT) {
   const { isLoading, reload } = useLoadingEffect(async () => {
     let enrollee = location?.state?.enrollee
     if (!enrollee) {
+      // if we haven't already loaded the enrollee, get it from the server
       enrollee = await Api.getEnrollee(portal.shortcode, study.shortcode,
         currentEnv.environmentName, enrolleeShortcodeOrId)
     } else {
-      // clear the state so this page will update if we navigate to a new enrollee or refresh
+      // if we have, clear the state so the enrollee will be reloaded if the page is refreshed
       window.history.replaceState({}, '')
     }
     if (enrollee.shortcode != enrolleeShortcodeOrId) {
-      // we got an id -- reroute to the shortcode path
+      // the page was routed by id rather than shortcode--use the shortcode route instead
+      // but put the enrollee in state so we don't double-fetch
       navigate(location.pathname.replace(enrollee.id, enrollee.shortcode), { replace: true, state: { enrollee } })
     }
     setEnrollee(enrollee)


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

There are places in the admin tool where we would like to link to an enrollee details view, but we only have the enrollee id.  This enables constructing links of the form `demo/studies/heartdemo/env/sandbox/participants/{enrolleeId}`.  Previously, you had to use enrollee shortcode.  

To make testing this feature easier, this also updates the Audit history page to show the enrollee id.  
<img width="719" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/f8f1a047-0123-43e7-b665-facff3762e37">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy apiAdminApp, make sure demo is populated
2. go to `https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants/HDSALK/changeRecords`
3. copy the enrollee id
4. go to the url `https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants/{enrolleeId}` with the enrollee id you copied
5. confirm it loads the detail view for Jonas Salk, and also that the url is updated in the browser to be `https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants/HDSALK`