### PR TITLE
[JN-992] Add gvasc demo tenant

### DIFF
--- a/api-participant/src/main/resources/b2c-config.yml
+++ b/api-participant/src/main/resources/b2c-config.yml
@@ -14,3 +14,8 @@ b2c:
     clientId: 37d95cc4-7c71-465e-9fc2-66be9a54c202
     policyName: B2C_1A_ddp_participant_signup_signin_demo-dev
     changePasswordPolicyName: B2C_1A_ddp_participant_change_password_demo-dev
+  gvasc:
+    tenantName: gvascdev
+    clientId: 441d57d2-5f17-473b-8b19-a2ed523c09bf
+    policyName: B2C_1A_ddp_participant_signup_signin_gvasc-dev
+    changePasswordPolicyName: B2C_1A_ddp_participant_change_password_gvasc-dev


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Please review in tandem with https://github.com/broadinstitute/terraform-ap-deployments/pull/1543 and https://github.com/broadinstitute/terra-helmfile/pull/5488

NOTE: the logos are knowingly broken in the following screenshots. We do not have a logo from the gVASC team yet.


<img width="1512" alt="Screenshot 2024-05-03 at 2 22 51 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/89cdc49c-7759-44ec-bfe1-b007a2f02208">

<img width="811" alt="Screenshot 2024-05-03 at 2 23 21 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/70a2c984-028c-4052-a7e1-b6a1a422ba9f">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Note for team testing: just go to https://sandbox.gvasc.ddp-dev.envs.broadinstitute.org/ and test registration/login flow instead of testing with the following steps

* Restart participant API app
* Extract an existing portal: https://localhost:3000/populate/extractPortal
* Populate the portal with "gvasc" as the shortcode override
* Go to https://sandbox.gvasc.localhost:3001/
* Register, and verify that you see the above login screen and can register/get verification code emails
