### PR TITLE
[JN-1056] Fix "eligible for kit" criteria

### DIFF
--- a/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
+++ b/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
@@ -84,13 +84,14 @@ export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvCont
   const numSelected = enrolleesSelected.length
   const enableActionButtons = numSelected > 0
 
-  const requiredSurveys = currentEnv.configuredSurveys
-    .filter(studyEnvSurvey => studyEnvSurvey.survey.required)
-  const hasCompletedAllRequiredSurveys = (enrollee: Enrollee) => {
+  const requiredResearchSurveys = currentEnv.configuredSurveys
+    .filter(studyEnvSurvey => studyEnvSurvey.survey.required && studyEnvSurvey.survey.surveyType === 'RESEARCH')
+  const hasCompletedAllRequiredResearchSurveys = (enrollee: Enrollee) => {
     return enrollee.participantTasks.filter(
       task => task.blocksHub && task.status === 'COMPLETE' && task.taskType === 'SURVEY'
-    ).length === requiredSurveys.length
+    ).length  === requiredResearchSurveys.length
   }
+
   const optionalSurveysCompleted = (enrollee: Enrollee) => {
     return enrollee.participantTasks.filter(
       task => !task.blocksHub && task.status === 'COMPLETE' && task.taskType === 'SURVEY'
@@ -136,7 +137,7 @@ export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvCont
   }, {
     header: 'Required surveys complete',
     id: 'requiredSurveysComplete',
-    accessorFn: enrollee => hasCompletedAllRequiredSurveys(enrollee),
+    accessorFn: enrollee => hasCompletedAllRequiredResearchSurveys(enrollee),
     meta: {
       columnType: 'boolean',
       filterOptions: [

--- a/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
+++ b/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
@@ -89,7 +89,7 @@ export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvCont
   const hasCompletedAllRequiredResearchSurveys = (enrollee: Enrollee) => {
     return enrollee.participantTasks.filter(
       task => task.blocksHub && task.status === 'COMPLETE' && task.taskType === 'SURVEY'
-    ).length  === requiredResearchSurveys.length
+    ).length === requiredResearchSurveys.length
   }
 
   const optionalSurveysCompleted = (enrollee: Enrollee) => {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

fixes a bug where the `Required surveys complete` column on the Kits page was not being calculated correctly. Since consents are now surveys, this column needs an additional filter to make sure that we're only checking if the participant has completed the required research surveys (whether or not the participant is consented is accounted for in a separate column)

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Create a new enrollee in OurHealth
* Complete all required surveys
* Verify that the user shows up on the Eligible for kit list: https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/kits/eligible

