### PR TITLE
[JN-1054] fixing e2e tests

### DIFF
--- a/e2e-tests/src/models/juniper-page-base.ts
+++ b/e2e-tests/src/models/juniper-page-base.ts
@@ -32,7 +32,7 @@ export default abstract class JuniperPageBase implements JuniperPageInterface {
 
   /** Need more roles? See all roles on https://playwright.dev/docs/api/class-locator#locator-get-by-role  **/
   async clickByRole(role: 'button' | 'checkbox' | 'link' | 'radiogroup', name: string | RegExp): Promise<this> {
-    const link = this.page.getByRole(role, { name })
+    const link = this.page.getByRole(role, { name, exact: true })
     await link.click()
     return this
   }

--- a/e2e-tests/src/pages/ourhealth/study-dashboard.ts
+++ b/e2e-tests/src/pages/ourhealth/study-dashboard.ts
@@ -5,7 +5,7 @@ export enum Activities
 {
   Consent = 'OurHealth Consent',
   Basics = 'The Basics',
-  CardiometabolicMedicalHistory = 'Cardiometabolic Medical History',
+  CardiometabolicMedicalHistory = 'OurHealth Medical History',
   OtherMedicalHistory = 'Other Medical History',
   FamilyHistory = 'Family History',
   Medications = 'Medications',

--- a/ui-participant/src/hub/survey/SurveyAutoCompleteButton.test.tsx
+++ b/ui-participant/src/hub/survey/SurveyAutoCompleteButton.test.tsx
@@ -14,7 +14,7 @@ describe('SurveyAutoCompleteButton', () => {
       shortcode: 'demo'
     })
     render(<SurveyAutoCompleteButton surveyModel={null} />)
-    expect(screen.getByLabelText('automatically complete the survey')).toBeInTheDocument()
+    expect(screen.getByLabelText('automatically fill in the survey')).toBeInTheDocument()
   })
 
   it('should not render in live environment', () => {
@@ -24,6 +24,6 @@ describe('SurveyAutoCompleteButton', () => {
       shortcode: 'demo'
     })
     render(<SurveyAutoCompleteButton surveyModel={null} />)
-    expect(screen.queryByLabelText('automatically complete the survey')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('automatically fill in the survey')).not.toBeInTheDocument()
   })
 })

--- a/ui-participant/src/hub/survey/SurveyAutoCompleteButton.tsx
+++ b/ui-participant/src/hub/survey/SurveyAutoCompleteButton.tsx
@@ -34,9 +34,9 @@ export default function SurveyAutoCompleteButton({ surveyModel }: { surveyModel:
   if (envName === 'live') {
     return null
   }
-  return <button className="float-end btn" aria-label="automatically complete the survey"
-    title="Automatically complete the current survey. (Available only in sandbox & irb environments)"
+  return <button className="float-end btn" aria-label="automatically fill in the survey"
+    title="Automatically fill in the current survey. (Available only in sandbox & irb environments)"
     onClick={autoCompleteSurvey}>
-    Autocomplete: <FontAwesomeIcon icon={faWandSparkles}/>
+    Autofill: <FontAwesomeIcon icon={faWandSparkles}/>
   </button>
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

A couple of text changes broke e2e tests.  Notably, the addition of the autocomplete feature broke a test that tried to click on a "Complete" button.  I didn't realize that playwright was set to imprecise match mode, which is probably not what we want.   I also changed the name of the button to "Autofill" to avoid confusion since that button doesn't actually "Complete" the survey, it just fills it in.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. make sure apiAdmin, ApiParticipantApp, ui-admin and ui-participant are running, and demo is populated
2. in e2e-tests run `npx playwright test`
