### PR TITLE
[JN-1074] Count Me In demo b2c tenant

### DIFF
--- a/api-participant/src/main/resources/b2c-config.yml
+++ b/api-participant/src/main/resources/b2c-config.yml
@@ -19,3 +19,8 @@ b2c:
     clientId: 441d57d2-5f17-473b-8b19-a2ed523c09bf
     policyName: B2C_1A_ddp_participant_signup_signin_gvasc-dev
     changePasswordPolicyName: B2C_1A_ddp_participant_change_password_gvasc-dev
+  cmi:
+    tenantName: junipercmidemo
+    clientId: 0cdfdafd-75fb-4e36-b6a2-c00e79c86bb0
+    policyName: B2C_1A_ddp_participant_signup_signin_cmi-dev
+    changePasswordPolicyName: B2C_1A_ddp_participant_change_password_cmi-dev


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

References the newly-created demo-only b2c tenant for the CMI template

Related PRs: https://github.com/broadinstitute/terra-helmfile/pull/5539 and https://github.com/broadinstitute/terraform-ap-deployments/pull/1561

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Extract the `cmi` portal from demo: https://admin-d2p.ddp-dev.envs.broadinstitute.org/populate/extractPortal
Populate that locally
Restart participant API
Go to https://sandbox.cmi.localhost:3001/ and attempt to register using b2c
Confirm you can register

