### PR TITLE
[JN-1078] survey question constraint

### DIFF
--- a/core/src/main/resources/db/changelog/changesets/2024_05_15_question_def_constraint.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_05_15_question_def_constraint.yaml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  - changeSet:
+      id: "question_def_constraint"
+      author: dbush
+      changes:
+        - dropUniqueConstraint: # drop this constraint, surveys are now portal-scoped
+            tableName: survey_question_definition
+            constraintName: uc_survey_question_definition_version
+        - addUniqueConstraint:
+            tableName: survey_question_definition
+            constraintName: uc_survey_question_definition_survey
+            columnNames: survey_id, question_stable_id
+        - dropIndex: # this isn't how we fetch these anymore, we get them by surveyId
+            tableName: survey_question_definition
+            indexName: idx_survey_question_definition_stable_id_version
+        - createIndex:
+            tableName: survey_question_definition
+            indexName: idx_survey_question_definition_survey
+            columns:
+              - column:
+                  name: survey_id
+

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -269,6 +269,9 @@ databaseChangeLog:
   - include:
       file: changesets/2024_05_08_dsm_env_config.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2024_05_15_question_def_constraint.yaml
+      relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyServiceTests.java
@@ -181,7 +181,36 @@ public class SurveyServiceTests extends BaseSpringBootTest {
     @Transactional
     public void testGetSurveyQuestionDefinitions(TestInfo info) {
         Survey survey = surveyFactory.buildPersisted(getTestName(info));
-        String surveyContent = """
+
+        survey.setContent(twoQuestionSurveyContent);
+
+        List<SurveyQuestionDefinition> actual = surveyService.getSurveyQuestionDefinitions(survey);
+        Assertions.assertEquals(4, actual.size());
+    }
+
+    @Test
+    @Transactional
+    public void testCreateSurveyQuestionDefinitionsSameShortcode(TestInfo info) {
+        String sharedStableId = "someSurvey" + RandomStringUtils.randomAlphabetic(4);
+        Survey survey = surveyFactory.builderWithDependencies(getTestName(info))
+                .stableId(sharedStableId)
+                .content(twoQuestionSurveyContent)
+                        .build();
+        surveyService.create(survey);
+
+        Survey survey2 = surveyFactory.builderWithDependencies(getTestName(info))
+                .stableId(sharedStableId)
+                .content(twoQuestionSurveyContent)
+                .build();
+        surveyService.create(survey2);
+
+        List<SurveyQuestionDefinition> actual = surveyService.getSurveyQuestionDefinitions(survey);
+        Assertions.assertEquals(4, actual.size());
+        List<SurveyQuestionDefinition> actual2 = surveyService.getSurveyQuestionDefinitions(survey2);
+        Assertions.assertEquals(4, actual2.size());
+    }
+
+    private final String twoQuestionSurveyContent = """
                 {
                 	"title": "The Basics",
                 	"showQuestionNumbers": "off",
@@ -219,11 +248,6 @@ public class SurveyServiceTests extends BaseSpringBootTest {
                 	}]
                 }""";
 
-        survey.setContent(surveyContent);
-
-        List<SurveyQuestionDefinition> actual = surveyService.getSurveyQuestionDefinitions(survey);
-        Assertions.assertEquals(4, actual.size());
-    }
 
     @Test
     @Transactional


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Now that survey stableIds are scoped by portal, we needed to update our question definition constraints

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. run unit tests