### PR TITLE
[JN-1080] fixing answer type saves

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/survey/Answer.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/Answer.java
@@ -40,6 +40,22 @@ public class Answer extends BaseEntity {
         setValue(value);
     }
 
+    /** infers the type based on what value was set */
+    public void inferTypeIfMissing() {
+        if (answerType != null) {
+            return;
+        }
+        if (stringValue != null) {
+            answerType = AnswerType.STRING;
+        } else if (numberValue != null) {
+            answerType = AnswerType.NUMBER;
+        } else if (booleanValue != null) {
+            answerType = AnswerType.BOOLEAN;
+        } else if (objectValue != null) {
+            answerType = AnswerType.OBJECT;
+        }
+    }
+
     protected void setValue(Object value) {
         if (answerType.equals(AnswerType.STRING)) {
             stringValue = (String) value;

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -272,6 +272,7 @@ public class SurveyResponseService extends ImmutableEntityService<SurveyResponse
                 .oldValue(existing.valueAsString())
                 .newValue(updated.valueAsString()).build();
         changeRecords.add(change);
+        existing.inferTypeIfMissing();
         existing.setSurveyVersion(updated.getSurveyVersion());
         if (existing.getSurveyVersion() == 0)  {
             // if the frontend didn't specify a specific version,
@@ -293,6 +294,7 @@ public class SurveyResponseService extends ImmutableEntityService<SurveyResponse
             answer.setSurveyVersion(survey.getVersion());
         }
         answer.setEnrolleeId(response.getEnrolleeId());
+        answer.inferTypeIfMissing();
         return answerService.create(answer);
     }
 

--- a/core/src/main/resources/db/changelog/changesets/2024_05_15_answer_type_save.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_05_15_answer_type_save.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: "answer_type_save"
+      author: dbush
+      changes:
+        - sql:
+            sql: update answer set answer_type = 'OBJECT' where object_value is not null;
+        - sql:
+            sql: update answer set answer_type = 'BOOLEAN' where boolean_value is not null;
+        - sql:
+            sql: update answer set answer_type = 'NUMBER' where number_value is not null;
+        - sql:
+            sql: update answer set answer_type = 'STRING' where string_value is not null;
+

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -270,11 +270,10 @@ databaseChangeLog:
       file: changesets/2024_05_08_dsm_env_config.yaml
       relativeToChangelogFile: true
   - include:
-<<<<<<< db-save-answer-type
-      file: changesets/2024_05_15_answer_type_save.yaml
-=======
       file: changesets/2024_05_15_question_def_constraint.yaml
->>>>>>> development
+      relativeToChangelogFile: true
+  - include:
+      file: changesets/2024_05_15_answer_type_save.yaml
       relativeToChangelogFile: true
 
 

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -269,6 +269,9 @@ databaseChangeLog:
   - include:
       file: changesets/2024_05_08_dsm_env_config.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2024_05_15_answer_type_save.yaml
+      relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
@@ -131,6 +131,7 @@ public class SurveyResponseServiceTests extends BaseSpringBootTest {
         for (Answer updatedAnswer : updatedAnswers) {
             Answer savedAnswer = answerService.findForQuestion(savedResponse.getId(), updatedAnswer.getQuestionStableId()).get();
             assertThat(savedAnswer.getStringValue(), equalTo(updatedAnswer.getStringValue()));
+            assertThat(savedAnswer.getAnswerType(), equalTo(AnswerType.STRING));
         }
         assertThat(answerService.findByResponseAndQuestions(savedResponse.getId(), List.of("foo", "q3", "test1")), hasSize(3));
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

We just, um, weren't saving answer types.  Which isn't a big deal since they're strictly determined by the presence of the value columns.  But still... oops.   We eventually will want a DB constraint on this, but in the short term I'd rather have answers save without type than error.  

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  redeploy participantApiApp
2. go to https://sandbox.demo.localhost:3001/
3. log in as consented@test.com
4. start filling out a survey
5. in the database, confirm that `select count(*) from answer where answer_type is null;` is 0