### PR TITLE
[JN-1081] Fix signaturepad image display

### DIFF
--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
@@ -11,7 +11,7 @@ import userEvent from '@testing-library/user-event'
 
 describe('getDisplayValue', () => {
   it('renders a plaintext value', async () => {
-    const question: Question = { isVisible: true } as Question
+    const question: Question = { isVisible: true, getType: () => 'text' } as Question
     const answer: Answer = { stringValue: 'test123', questionStableId: 'testQ' } as Answer
     render(<span>{getDisplayValue(answer, question)}</span>)
     expect(screen.getByText('test123')).toBeTruthy()
@@ -20,6 +20,7 @@ describe('getDisplayValue', () => {
   it('renders a choice value', async () => {
     const question: Question = {
       isVisible: true,
+      getType: () => 'radiogroup',
       choices: [{
         text: 'option 1', value: 'option1Val'
       }, {
@@ -34,6 +35,7 @@ describe('getDisplayValue', () => {
   it('renders a free text other description', async () => {
     const question: Question = {
       isVisible: true,
+      getType: () => 'radiogroup',
       choices: [{
         text: 'option 1', value: 'option1Val'
       }, {
@@ -51,6 +53,7 @@ describe('getDisplayValue', () => {
   it('renders a choice array value', async () => {
     const question: Question = {
       isVisible: true,
+      getType: () => 'checkbox',
       choices: [{
         text: 'option 1', value: 'option1Val'
       }, {
@@ -95,7 +98,7 @@ test('shows the download/print modal', async () => {
 
 describe('ItemDisplay', () => {
   it('renders the language used to answer a question', async () => {
-    const question = { name: 'testQ', text: 'test question', isVisible: true }
+    const question = { name: 'testQ', text: 'test question', isVisible: true, getType: () => 'text' }
     const answer: Answer = {
       stringValue: 'test123',
       questionStableId: 'testQ',
@@ -115,7 +118,7 @@ describe('ItemDisplay', () => {
   })
 
   it('renders correctly if a viewedLanguage is not specified', async () => {
-    const question = { name: 'testQ', text: 'test question', isVisible: true }
+    const question = { name: 'testQ', text: 'test question', isVisible: true, getType: () => 'text' }
     const answer: Answer = {
       stringValue: 'test123',
       questionStableId: 'testQ',
@@ -134,7 +137,7 @@ describe('ItemDisplay', () => {
   })
 
   it('does not render a language name if it doesnt match a supported language', async () => {
-    const question = { name: 'testQ', text: 'test question', isVisible: true }
+    const question = { name: 'testQ', text: 'test question', isVisible: true, getType: () => 'text' }
     const answer: Answer = {
       stringValue: 'test123',
       questionStableId: 'testQ',

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
@@ -68,6 +68,18 @@ describe('getDisplayValue', () => {
     render(<span>{getDisplayValue(answer, question)}</span>)
     expect(screen.getByText('["option 2","option 4"]')).toBeTruthy()
   })
+
+  it('renders a signaturepad as an image', async () => {
+    const question = {
+      name: 'testQ', text: 'test question',
+      isVisible: true, type: 'signaturepad',
+      getType: () => 'signaturepad'
+    }
+    const answer: Answer = { stringValue: 'data:image/png;base64, test123', questionStableId: 'testQ' } as Answer
+    render(<span>{getDisplayValue(answer, question as unknown as Question)}</span>)
+    expect(screen.getByRole('img')).toHaveAttribute('src', 'data:image/png;base64, test123')
+    expect(screen.queryByText('data:image/png;base64, test123')).not.toBeInTheDocument()
+  })
 })
 
 test('shows the download/print modal', async () => {

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -150,7 +150,7 @@ export const getDisplayValue = (answer: Answer,
   if (answer.booleanValue !== undefined) {
     displayValue = answer.booleanValue ? 'True' : 'False'
   }
-  if (answer.questionStableId.endsWith('signature')) {
+  if (question.getType() === 'signaturepad') {
     displayValue = <img src={answer.stringValue}/>
   }
   if (answer.otherDescription) {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Fixes a bug on the admin survey response view that required the question stable id to end in "signature" in order to be rendered as an image. Switches to checking the question type instead.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Confirm that `signaturepad` image previews are still visible: https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants/HDBASC/surveys/hd_hd_consent