### PR TITLE
[JN-1083] Temp fix for empty search expression

### DIFF
--- a/ui-admin/src/search/SearchQueryBuilder.tsx
+++ b/ui-admin/src/search/SearchQueryBuilder.tsx
@@ -43,6 +43,10 @@ export const SearchQueryBuilder = ({ studyEnvContext, onSearchExpressionChange }
       ruleProcessor: ruleProcessorEnrolleeSearchExpression
     }) : ''
 
+    if (enrolleeSearchExpression === '') {
+      return // do nothing; not optimal, but it's a quick fix until we implement antlr for rule parsing in the frontend
+    }
+
     onSearchExpressionChange(enrolleeSearchExpression)
   }, [query])
 

--- a/ui-admin/src/study/surveys/FormOptionsModal.tsx
+++ b/ui-admin/src/study/surveys/FormOptionsModal.tsx
@@ -102,9 +102,12 @@ export const FormOptions = ({ studyEnvContext, workingForm, updateWorkingForm }:
                       })}/></div>}
 
             <input type="text" className="form-control" value={(workingForm as Survey).eligibilityRule || ''}
-              onChange={e => updateWorkingForm({
-                ...workingForm, eligibilityRule: e.target.value
-              })}/>
+              onChange={e => {
+                updateWorkingForm({
+                  ...workingForm, eligibilityRule: e.target.value
+                })
+              }
+              }/>
           </div>
         </div>
     }

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { PortalEnvironment, Survey, VersionedForm } from 'api/api'
 
@@ -55,6 +55,13 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
 
   const [draft, setDraft] = useState<FormDraft | undefined>(
     !readOnly ? getDraft({ formDraftKey: FORM_DRAFT_KEY }) : undefined)
+
+  useEffect(() => {
+    console.log('draft')
+    console.log(draft)
+    console.log('currentForm')
+    console.log(currentForm)
+  }, [draft, currentForm])
 
   const [validationErrors, setValidationErrors] = useState<string[]>([])
   const isSaveEnabled = !!draft && isEmpty(validationErrors) && !saving
@@ -221,7 +228,7 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
           studyEnvContext={studyEnvContext}
           workingForm={{ ...currentForm, ...draft }}
           updateWorkingForm={(props: SaveableFormProps) => {
-            setDraft({ ...draft, ...props, date: Date.now() })
+            setDraft({ ...currentForm, ...draft, ...props, date: Date.now() })
           }}
           onDismiss={() => setShowAdvancedOptions(false)}/>
         }
@@ -235,7 +242,7 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
           onChange={(newValidationErrors, newContent) => {
             if (isEmpty(newValidationErrors)) {
               setShowErrors(false)
-              setDraft({ ...draft, content: JSON.stringify(newContent), date: Date.now() })
+              setDraft({ ...currentForm, ...draft, content: JSON.stringify(newContent), date: Date.now() })
             }
             setValidationErrors(newValidationErrors)
           }}

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 
 import { PortalEnvironment, Survey, VersionedForm } from 'api/api'
 
@@ -55,13 +55,6 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
 
   const [draft, setDraft] = useState<FormDraft | undefined>(
     !readOnly ? getDraft({ formDraftKey: FORM_DRAFT_KEY }) : undefined)
-
-  useEffect(() => {
-    console.log('draft')
-    console.log(draft)
-    console.log('currentForm')
-    console.log(currentForm)
-  }, [draft, currentForm])
 
   const [validationErrors, setValidationErrors] = useState<string[]>([])
   const isSaveEnabled = !!draft && isEmpty(validationErrors) && !saving


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

If you go to edit a survey with an eligibility rule, it shows as empty. If you then save, it strips the eligibility rule (yikes). This is only if you have the fancy query builder. This is because on the first render, the query builder has nothing, so it does an `onChange` call to make it empty.

Without doing fancy ref stuff, I figured just making it skip changing the eligibility rule if the string is empty is fine in the meantime, since once we have antlr it will work properly & this is only shown to prototype users/superusers anyway, so a wonky UX is fine in the meantime.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Create a survey with an eligibility rule
- Observe that the eligibility rule still shows up when you try to edit it