### PR TITLE
[JN-1086] sanitizing question stableIds

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/export/BaseExporter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/BaseExporter.java
@@ -44,7 +44,9 @@ public abstract class BaseExporter {
     protected List<String> getHeaderRow() {
         List<String> headers = new ArrayList<>();
         applyToEveryColumn((moduleFormatter, itemExportInfo, isOtherDescription, choice, moduleRepeatNum) -> {
-            headers.add(moduleFormatter.getColumnHeader(itemExportInfo, isOtherDescription, choice, moduleRepeatNum));
+            headers.add(
+                    sanitizeValue(moduleFormatter.getColumnHeader(itemExportInfo, isOtherDescription, choice, moduleRepeatNum), DEFAULT_EMPTY_STRING_VALUE)
+            );
         });
         return headers;
     }
@@ -53,7 +55,9 @@ public abstract class BaseExporter {
     protected List<String> getSubHeaderRow() {
         List<String> headers = new ArrayList<>();
         applyToEveryColumn((moduleFormatter, itemExportInfo, isOtherDescription, choice, moduleRepeatNum) -> {
-            headers.add(moduleFormatter.getColumnSubHeader(itemExportInfo, isOtherDescription, choice, moduleRepeatNum));
+            headers.add(
+                    sanitizeValue(moduleFormatter.getColumnSubHeader(itemExportInfo, isOtherDescription, choice, moduleRepeatNum), DEFAULT_EMPTY_STRING_VALUE)
+            );
         });
         return headers;
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyParseUtils.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyParseUtils.java
@@ -23,6 +23,8 @@ public class SurveyParseUtils {
     public static final String SURVEY_JS_NONE_TEXT_PROP = "noneText";
     public static final String DERIVED_QUESTION_TYPE = "derived";
     public static final Pattern EXPRESSION_DEPENDENCY = Pattern.compile(".*\\{(.+?)\\}.*");
+    /** should match sanitizeStableId in NewQuestionForm.tsx */
+    public static final Pattern INVALID_STABLE_ID = Pattern.compile("[^a-zA-Z\\-_\\d]");
 
     /**
      * recursively gets all questions from the given node
@@ -51,7 +53,6 @@ public class SurveyParseUtils {
                 .questionStableId(question.get("name").asText())
                 .exportOrder(globalOrder)
                 .build();
-        validateQuestionStableId(definition.getQuestionStableId());
         //The following fields may either be specified in the question itself,
         //or as part of a question template. Resolve the remaining fields against
         //the template (if applicable), so we have the full question definition.
@@ -86,12 +87,19 @@ public class SurveyParseUtils {
         return definition;
     }
 
+    /** confirm the question definition meets our (currently very permissive) requirements */
+    public static void validateQuestionDefinition(SurveyQuestionDefinition surveyQuestionDefinition) {
+        /** we don't care about the stableIds for html questions, since those aren't answered and aren't included in data exports */
+        if (!List.of("html").contains(surveyQuestionDefinition.getQuestionType())) {
+            validateQuestionStableId(surveyQuestionDefinition.getQuestionStableId());
+        }
+    }
     public static void validateQuestionStableId(String questionStableId) {
         if (questionStableId == null || questionStableId.isBlank()) {
             throw new IllegalArgumentException("Question stableId cannot be null or empty");
         }
-        if (questionStableId.matches(".*\\s.*")) {
-            throw new IllegalArgumentException("Question stableId cannot contain whitespace: '" + questionStableId + "'");
+        if (INVALID_STABLE_ID.matcher(questionStableId).matches()) {
+            throw new IllegalArgumentException("Question stableId must be alphanumeric, dashes or underscores: '" + questionStableId + "'");
         }
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyParseUtils.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyParseUtils.java
@@ -51,7 +51,7 @@ public class SurveyParseUtils {
                 .questionStableId(question.get("name").asText())
                 .exportOrder(globalOrder)
                 .build();
-
+        validateQuestionStableId(definition.getQuestionStableId());
         //The following fields may either be specified in the question itself,
         //or as part of a question template. Resolve the remaining fields against
         //the template (if applicable), so we have the full question definition.
@@ -84,6 +84,15 @@ public class SurveyParseUtils {
         }
 
         return definition;
+    }
+
+    public static void validateQuestionStableId(String questionStableId) {
+        if (questionStableId == null || questionStableId.isBlank()) {
+            throw new IllegalArgumentException("Question stableId cannot be null or empty");
+        }
+        if (questionStableId.matches(".*\\s.*")) {
+            throw new IllegalArgumentException("Question stableId cannot contain whitespace: '" + questionStableId + "'");
+        }
     }
 
     public static String unmarshalSurveyQuestionChoices(JsonNode question) {

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyService.java
@@ -134,8 +134,10 @@ public class SurveyService extends VersionedEntityService<Survey, SurveyDao> {
         List<SurveyQuestionDefinition> questionDefinitions = new ArrayList<>();
         for (int i = 0; i < questions.size(); i++) {
             JsonNode question = questions.get(i);
-            questionDefinitions.add(SurveyParseUtils.unmarshalSurveyQuestion(survey, question,
-                    questionTemplates, i,false));
+            SurveyQuestionDefinition questionDefinition = SurveyParseUtils.unmarshalSurveyQuestion(survey, question,
+                    questionTemplates, i,false);
+            SurveyParseUtils.validateQuestionDefinition(questionDefinition);
+            questionDefinitions.add(questionDefinition);
         }
 
         // add any questions from calculatedValues

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyServiceTests.java
@@ -210,6 +210,23 @@ public class SurveyServiceTests extends BaseSpringBootTest {
         Assertions.assertEquals(4, actual2.size());
     }
 
+    @Test
+    @Transactional
+    public void testCreateSurveyQuestionDefinitionsWhitespace(TestInfo info) {
+        Survey survey = surveyFactory.builderWithDependencies(getTestName(info))
+                .content("""
+                        {              	      
+                            "pages": [{
+                            "elements": [{
+                                "name": "oh_oh_basic firstName",
+                                "type": "text",
+                                "title": "First name",
+                                "isRequired": true
+                            }""")
+                .build();
+        Assertions.assertThrows(IllegalArgumentException.class, () -> surveyService.create(survey));
+    }
+
     private final String twoQuestionSurveyContent = """
                 {
                 	"title": "The Basics",

--- a/ui-admin/src/forms/designer/NewQuestionForm.test.tsx
+++ b/ui-admin/src/forms/designer/NewQuestionForm.test.tsx
@@ -5,13 +5,17 @@ import userEvent from '@testing-library/user-event'
 
 describe('NewQuestionForm', () => {
   test('renders the default view for a new question', () => {
-    //Arrange
     render(<NewQuestionForm onCreate={() => jest.fn()} questionTemplates={[]} readOnly={false} />)
 
-    //Assert
     screen.getByLabelText('Question stable ID')
     const questionTypeSelect = screen.getByLabelText('Question type')
     expect(questionTypeSelect).toHaveValue('Select a question type')
+  })
+
+  test('filters special characters in stableId', async () => {
+    render(<NewQuestionForm onCreate={() => jest.fn()} questionTemplates={[]} readOnly={false} />)
+    await userEvent.type(screen.getByLabelText('Question stable ID'), 'blah d#_* blah1')
+    expect(screen.getByLabelText('Question stable ID')).toHaveValue('blahd_blah1')
   })
 
   test('updates to the appropriate QuestionDesigner when a new question type is selected', async () => {

--- a/ui-admin/src/forms/designer/NewQuestionForm.tsx
+++ b/ui-admin/src/forms/designer/NewQuestionForm.tsx
@@ -34,11 +34,12 @@ export const NewQuestionForm = (props: NewQuestionFormProps) => {
       <div className="mb-3">
         <div className="mb-3">
           <TextInput
-            description='The unique stable identifier for the survey question'
+            description='The unique stable identifier for the survey question--
+            cannot contain spaces or special characters besides _ and -.'
             label='Question stable ID'
             value={questionName}
             onChange={value => {
-              setQuestion({ ...question, name: value })
+              setQuestion({ ...question, name: sanitizeStableId(value) })
             }}
           />
         </div>
@@ -163,4 +164,13 @@ export const NewQuestionForm = (props: NewQuestionFormProps) => {
       </Button>
     </div>
   )
+}
+
+/**
+ * this is mor lenient than our form stableId requirements
+ * (juniperSurveyUtils.generateStableId) as we need to support legacy DATSTAT and
+ * Pepper questions that have all caps and special characters in their stableIds.
+ */
+export function sanitizeStableId(text: string) {
+  return text.replace(/[^a-zA-Z\-_\d]/g, '')
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

General hardening with respect to question stableIds.  this prevents entering and saving stableIds with whitespace.  this also hardens the export to sanitize the headers to handle special characters there.  This was prompted by HeartHive realizing that their import had resulted in some questions with stableIds that had trailing whitespace.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
0. redeploy apiAdminApp
1. go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/forms/surveys/oh_oh_mental?selectedElementPath=pages%5B0%5D.elements%5B2%5D
2. hit "Add next question"
3. attempt to type whitespace or other special chars into the editor