### PR TITLE
[JN-1066] Show participant num tasks

### DIFF
--- a/ui-participant/src/participant/ParticipantSelector.tsx
+++ b/ui-participant/src/participant/ParticipantSelector.tsx
@@ -90,10 +90,9 @@ const ParticipantTaskCount = ({ enrollees }: { enrollees: Enrollee[] }) => {
 
   return <span
     className={classNames(
-      'float-end',
+      'alert-circle', 'float-end',
       numTasks === 0 ? 'bg-primary-subtle opacity-25' : 'bg-primary text-light'
     )}
-    style={{ borderRadius: '50%', height: '1.5rem', width: '1.5rem', textAlign: 'center' }}
   >
     {numTasks}
   </span>

--- a/ui-participant/src/participant/ParticipantSelector.tsx
+++ b/ui-participant/src/participant/ParticipantSelector.tsx
@@ -41,7 +41,7 @@ export default function ParticipantSelector() {
           {activeUserName}
         </span>
         <div className='flex-grow-1 d-flex justify-content-end align-items-center'>
-          <FontAwesomeIcon icon={faAngleDown} className={'ms-2'}/>
+          <FontAwesomeIcon icon={faAngleDown}/>
         </div>
       </button>
       <ul className="dropdown-menu participant-selector-dropdown mx-1 ms-md-0" id="participant-dropdown">

--- a/ui-participant/src/participant/ParticipantSelector.tsx
+++ b/ui-participant/src/participant/ParticipantSelector.tsx
@@ -41,7 +41,6 @@ export default function ParticipantSelector() {
           {activeUserName}
         </span>
         <div className='flex-grow-1 d-flex justify-content-end align-items-center'>
-          {/*<ParticipantTaskCount enrollees={enrollees}/>*/}
           <FontAwesomeIcon icon={faAngleDown} className={'ms-2'}/>
         </div>
       </button>

--- a/ui-participant/src/participant/ParticipantSelector.tsx
+++ b/ui-participant/src/participant/ParticipantSelector.tsx
@@ -8,13 +8,16 @@ import { Link } from 'react-router-dom'
 import { usePortalEnv } from '../providers/PortalProvider'
 import { findDefaultEnrollmentStudy } from '../login/RedirectFromOAuth'
 import { useI18n } from '@juniper/ui-core'
+import { sum } from 'lodash'
+import { Enrollee } from '../api/api'
+import classNames from 'classnames'
 
 /**
  * Dropdown selector which globally changes the currently active participant. In addition, provides related options,
  * e.g. "Add new participant" and "Manage Profiles".
  */
 export default function ParticipantSelector() {
-  const { ppUsers } = useUser()
+  const { ppUsers, enrollees } = useUser()
   const { setActiveUser, ppUser } = useActiveUser()
 
   const { i18n } = useI18n()
@@ -37,14 +40,17 @@ export default function ParticipantSelector() {
         <span className='mx-2 fs-5'>
           {activeUserName}
         </span>
-        <div className='flex-grow-1 d-flex justify-content-end'>
-          <FontAwesomeIcon icon={faAngleDown} />
+        <div className='flex-grow-1 d-flex justify-content-end align-items-center'>
+          {/*<ParticipantTaskCount enrollees={enrollees}/>*/}
+          <FontAwesomeIcon icon={faAngleDown} className={'ms-2'}/>
         </div>
       </button>
       <ul className="dropdown-menu participant-selector-dropdown mx-1 ms-md-0" id="participant-dropdown">
         {
           ppUsers.map(ppUser => {
             const name = useName(ppUser)
+            const ppUserEnrollees = enrollees.filter(e => e.profileId === ppUser.profileId)
+
             return (
               <li key={ppUser.id}>
                 <button className="dropdown-item" onClick={() => setActiveUser(ppUser.id)}>
@@ -52,6 +58,7 @@ export default function ParticipantSelector() {
                   <span className='ms-2'>
                     {name}
                   </span>
+                  <ParticipantTaskCount enrollees={ppUserEnrollees}/>
                 </button>
               </li>
             )
@@ -77,4 +84,18 @@ export default function ParticipantSelector() {
       </ul>
     </div>
   )
+}
+
+const ParticipantTaskCount = ({ enrollees }: { enrollees: Enrollee[] }) => {
+  const numTasks = sum(enrollees.map(e => e.participantTasks.length))
+
+  return <span
+    className={classNames(
+      'float-end',
+      numTasks === 0 ? 'bg-primary-subtle opacity-25' : 'bg-primary text-light'
+    )}
+    style={{ borderRadius: '50%', height: '1.5rem', width: '1.5rem', textAlign: 'center' }}
+  >
+    {numTasks}
+  </span>
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

One point of feedback from demoing proxies was to bring back the num tasks indicator

![image](https://github.com/broadinstitute/juniper/assets/17440010/143955da-40e9-4f62-9a1b-08c7ee705c9e)

Mobile

<img width="376" alt="image" src="https://github.com/broadinstitute/juniper/assets/17440010/1d7814d0-45fc-4615-b61c-6cd0c63d3787">



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
- Sign in as proxyFamily2@test.com or create your own proxy
- Confirm num tasks looks good & is functional
