### PR TITLE
[JN-1087] Allow proxies to join the study after the fact

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
@@ -130,16 +130,37 @@ public class EnrollmentService {
             throw new IllegalArgumentException("study %s is not accepting enrollment".formatted(studyShortcode));
         }
         PreEnrollmentResponse preEnrollResponse = validatePreEnrollResponse(operator, studyEnv, preEnrollResponseId, user.getId(), isSubject);
-        Enrollee enrollee;
 
-        enrollee = Enrollee.builder()
-                .studyEnvironmentId(studyEnv.getId())
-                .participantUserId(user.getId())
-                .profileId(ppUser.getProfileId())
-                .preEnrollmentResponseId(preEnrollResponseId)
-                .subject(isSubject)
-                .build();
-        enrollee = enrolleeService.create(enrollee);
+        // if the user is signed up, but not a subject, we can just return the existing enrollee,
+        // otherwise create a new one for them
+        Enrollee enrollee = enrolleeService
+                .findByParticipantUserIdAndStudyEnv(user.getId(), studyShortcode, envName)
+                .filter(e -> {
+                    System.out.println(e.getShortcode());
+                    System.out.println("e.isSubject() = " + e.isSubject());
+                    // if the user isn't a subject, but is now, update the enrollee
+                    if (isSubject && !e.isSubject()) {
+                        e.setSubject(true);
+                        e.setPreEnrollmentResponseId(preEnrollResponseId);
+                        enrolleeService.update(e);
+                        return true;
+                    }
+
+                    // all other cases are duplicate enrollment, which is an error
+                    throw new IllegalArgumentException("user already exists");
+                })
+                .orElseGet(() -> {
+                    Enrollee newEnrollee;
+                    newEnrollee = Enrollee.builder()
+                            .studyEnvironmentId(studyEnv.getId())
+                            .participantUserId(user.getId())
+                            .profileId(ppUser.getProfileId())
+                            .preEnrollmentResponseId(preEnrollResponseId)
+                            .subject(isSubject)
+                            .build();
+                    return enrolleeService.create(newEnrollee);
+                });
+
 
         if (preEnrollResponse != null) {
             preEnrollResponse.setCreatingParticipantUserId(user.getId());

--- a/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentServiceTests.java
@@ -3,10 +3,14 @@ package bio.terra.pearl.core.service.workflow;
 import bio.terra.pearl.core.BaseSpringBootTest;
 import bio.terra.pearl.core.factory.DaoTestUtils;
 import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
+import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
 import bio.terra.pearl.core.factory.participant.ParticipantUserFactory;
 import bio.terra.pearl.core.factory.portal.PortalEnvironmentFactory;
 import bio.terra.pearl.core.factory.survey.AnswerFactory;
 import bio.terra.pearl.core.factory.survey.SurveyFactory;
+import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.participant.ParticipantUser;
+import bio.terra.pearl.core.model.participant.PortalParticipantUser;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.study.StudyEnvironmentConfig;
@@ -15,6 +19,9 @@ import bio.terra.pearl.core.model.survey.ParsedPreEnrollResponse;
 import bio.terra.pearl.core.model.survey.PreEnrollmentResponse;
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.model.workflow.HubResponse;
+import bio.terra.pearl.core.service.participant.EnrolleeService;
+import bio.terra.pearl.core.service.participant.ParticipantUserService;
+import bio.terra.pearl.core.service.participant.PortalParticipantUserService;
 import bio.terra.pearl.core.service.portal.PortalService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentConfigService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
@@ -30,10 +37,36 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 
 public class EnrollmentServiceTests extends BaseSpringBootTest {
+    @Autowired
+    private EnrollmentService enrollmentService;
+    @Autowired
+    private StudyEnvironmentFactory studyEnvironmentFactory;
+    @Autowired
+    private PortalEnvironmentFactory portalEnvironmentFactory;
+    @Autowired
+    private SurveyFactory surveyFactory;
+    @Autowired
+    private StudyEnvironmentService studyEnvironmentService;
+    @Autowired
+    private StudyEnvironmentConfigService studyEnvironmentConfigService;
+    @Autowired
+    private ParticipantUserFactory participantUserFactory;
+    @Autowired
+    private StudyService studyService;
+    @Autowired
+    private PortalService portalService;
+    @Autowired
+    private EnrolleeFactory enrolleeFactory;
+    @Autowired
+    private PortalParticipantUserService portalParticipantUserService;
+    @Autowired
+    private ParticipantUserService participantUserService;
+    @Autowired
+    private EnrolleeService enrolleeService;
+
     @Test
     @Transactional
     public void testAnonymousPreEnroll(TestInfo testInfo) throws JsonProcessingException {
@@ -111,23 +144,41 @@ public class EnrollmentServiceTests extends BaseSpringBootTest {
         });
     }
 
-    @Autowired
-    private EnrollmentService enrollmentService;
-    @Autowired
-    private StudyEnvironmentFactory studyEnvironmentFactory;
-    @Autowired
-    private PortalEnvironmentFactory portalEnvironmentFactory;
-    @Autowired
-    private SurveyFactory surveyFactory;
-    @Autowired
-    private StudyEnvironmentService studyEnvironmentService;
-    @Autowired
-    private StudyEnvironmentConfigService studyEnvironmentConfigService;
-    @Autowired
-    private ParticipantUserFactory participantUserFactory;
-    @Autowired
-    private StudyService studyService;
-    @Autowired
-    private PortalService portalService;
+    @Test
+    @Transactional
+    public void testEnrollProxy(TestInfo testInfo) throws JsonProcessingException {
+        PortalEnvironment portalEnv = portalEnvironmentFactory.buildPersisted(getTestName(testInfo));
+        StudyEnvironment studyEnv = studyEnvironmentFactory.buildPersisted(portalEnv, getTestName(testInfo));
+
+        EnrolleeFactory.EnrolleeAndProxy enrolleeAndProxy = enrolleeFactory.buildProxyAndGovernedEnrollee(getTestName(testInfo), portalEnv, studyEnv);
+        Enrollee proxy = enrolleeAndProxy.proxy();
+        PortalParticipantUser ppUser = portalParticipantUserService.findForEnrollee(proxy);
+        ParticipantUser user = participantUserService.find(ppUser.getParticipantUserId()).orElseThrow();
+
+        String studyShortcode = studyService.find(studyEnv.getStudyId()).get().getShortcode();
+
+        Survey survey = surveyFactory.buildPersisted(getTestName(testInfo), portalEnv.getPortalId());
+        studyEnv.setPreEnrollSurveyId(survey.getId());
+        studyEnvironmentService.update(studyEnv);
+
+        List<Answer> answers = AnswerFactory.fromMap(Map.of(
+                "qualified", true,
+                "areOver18", "yes"
+        ));
+        ParsedPreEnrollResponse response = ParsedPreEnrollResponse.builder()
+                .studyEnvironmentId(studyEnv.getId())
+                .answers(answers)
+                .qualified(true).build();
+
+        PreEnrollmentResponse savedResponse = enrollmentService.createAnonymousPreEnroll(survey.getPortalId(), studyEnv.getId(), survey.getStableId(), survey.getVersion(), response);
+
+        // now, enroll subject as proxy
+        enrollmentService.enroll(ppUser, studyEnv.getEnvironmentName(), studyShortcode, user, ppUser,
+                savedResponse.getId(), true);
+
+        Enrollee proxyAfterSubjectEnroll = enrolleeService.find(proxy.getId()).orElseThrow();
+        assertThat(proxyAfterSubjectEnroll.isSubject(), equalTo(true));
+        assertThat(proxyAfterSubjectEnroll.getPreEnrollmentResponseId(), equalTo(savedResponse.getId()));
+    }
 
 }

--- a/populate/src/main/resources/seed/i18n/dev/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/dev/languageTexts.json
@@ -84,5 +84,6 @@
   {"keyName": "hubUpdateAlreadyEnrolledTitle", "text": "DEV_You are already enrolled in ${studyName}.", "language": "dev"},
   {"keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle", "text": "DEV_This user is already enrolled in ${studyName}.", "language": "dev"},
   {"keyName": "cookieAlertTitle", "text": "DEV_Cookies", "language": "dev"},
-  {"keyName": "cookieAlertDetail", "text": "DEV_This site uses internet tokens called &quot;cookies&quot; to enable the proper functioning and security of our website, and to improve your experience while you use it. All of the cookies we use are strictly necessary cookies. This type of cookie does not collect any personally identifiable information about you and does not track your browsing habits. To learn more, [read our Privacy Policy](/privacy).", "language": "dev"}
+  {"keyName": "cookieAlertDetail", "text": "DEV_This site uses internet tokens called &quot;cookies&quot; to enable the proper functioning and security of our website, and to improve your experience while you use it. All of the cookies we use are strictly necessary cookies. This type of cookie does not collect any personally identifiable information about you and does not track your browsing habits. To learn more, [read our Privacy Policy](/privacy).", "language": "dev"},
+  {"keyName": "joinStudy", "text": "DEV_Join Study", "language": "dev"}
 ]

--- a/populate/src/main/resources/seed/i18n/en/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/en/languageTexts.json
@@ -84,5 +84,6 @@
   {"keyName": "hubUpdateAlreadyEnrolledTitle", "text": "You are already enrolled in ${studyName}.", "language": "en"},
   {"keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle", "text": "This user is already enrolled in ${studyName}.", "language": "en"},
   {"keyName": "cookieAlertTitle", "text": "Cookies", "language": "en"},
-  {"keyName": "cookieAlertDetail", "text": "This site uses internet tokens called &quot;cookies&quot; to enable the proper functioning and security of our website, and to improve your experience while you use it. All of the cookies we use are strictly necessary cookies. This type of cookie does not collect any personally identifiable information about you and does not track your browsing habits. To learn more, [read our Privacy Policy](/privacy).", "language": "en"}
+  {"keyName": "cookieAlertDetail", "text": "This site uses internet tokens called &quot;cookies&quot; to enable the proper functioning and security of our website, and to improve your experience while you use it. All of the cookies we use are strictly necessary cookies. This type of cookie does not collect any personally identifiable information about you and does not track your browsing habits. To learn more, [read our Privacy Policy](/privacy).", "language": "en"},
+  {"keyName": "joinStudy", "text": "Join Study", "language": "en"}
 ]

--- a/populate/src/main/resources/seed/i18n/es/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/es/languageTexts.json
@@ -84,5 +84,6 @@
   {"keyName": "hubUpdateAlreadyEnrolledTitle", "text": "Ya estás inscrito en ${studyName}.", "language": "es"},
   {"keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle", "text": "Este usuario ya está inscrito en ${studyName}.", "language": "es"},
   {"keyName": "cookieAlertTitle", "text": "Galletas", "language": "es"},
-  {"keyName": "cookieAlertDetail", "text": "Este sitio utiliza tokens de Internet llamados &quot;cookies&quot; para permitir el correcto funcionamiento y seguridad de nuestro sitio web, y para mejorar su experiencia mientras lo utiliza. Todas las cookies que utilizamos son cookies estrictamente necesarias. Este tipo de cookie no recopila ninguna información de identificación personal sobre usted y no rastrea sus hábitos de navegación. Para obtener más información, [lea nuestra Política de privacidad](/privacy).", "language": "es"}
+  {"keyName": "cookieAlertDetail", "text": "Este sitio utiliza tokens de Internet llamados &quot;cookies&quot; para permitir el correcto funcionamiento y seguridad de nuestro sitio web, y para mejorar su experiencia mientras lo utiliza. Todas las cookies que utilizamos son cookies estrictamente necesarias. Este tipo de cookie no recopila ninguna información de identificación personal sobre usted y no rastrea sus hábitos de navegación. Para obtener más información, [lea nuestra Política de privacidad](/privacy).", "language": "es"},
+  {"keyName": "joinStudy", "text": "Unirse al Estudio", "language": "es"}
 ]

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
@@ -87,8 +87,8 @@
                 }
               }
             ],
-            "enableIf": "{isProxyEnrollment} != true",
-            "defaultValueExpression": "iif({isProxyEnrollment} = true, 'true', '')"
+            "enableIf": "{isProxyEnrollment} != true && {isSubjectEnrollment} != true",
+            "defaultValueExpression": "iif({isProxyEnrollment} = true, 'true', iif({isSubjectEnrollment} = true, 'false', ''))"
           },
           {
             "type": "text",
@@ -110,13 +110,15 @@
             "type": "text",
             "isRequired": true,
             "name": "governed_given_name",
-            "title": "Given Name"
+            "title": "Given Name",
+            "defaultValueExpression": "{profile.givenName}"
           },
           {
             "type": "text",
             "isRequired": true,
             "name": "governed_family_name",
-            "title": "Family Name"
+            "title": "Family Name",
+            "defaultValueExpression": "{profile.familyName}"
           }
         ]
       },

--- a/ui-participant/src/Navbar.tsx
+++ b/ui-participant/src/Navbar.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useId, useRef } from 'react'
 import { Link, NavLink, useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import { HashLink } from 'react-router-hash-link'
 
-import Api, { getEnvSpec, getImageUrl, NavbarItem, PortalStudy } from 'api/api'
+import Api, { getEnvSpec, getImageUrl, NavbarItem, PortalStudy, Study } from 'api/api'
 import { MailingListModal, PortalEnvironmentLanguage, useI18n } from '@juniper/ui-core'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { useUser } from 'providers/UserProvider'
@@ -170,12 +170,24 @@ export function CustomNavLink({ navLink }: { navLink: NavbarItem }) {
   return <></>
 }
 
+/**
+ * Returns the join link for a specific study
+ */
+export const getJoinLink = (study: Study, opts?: { isProxyEnrollment?: boolean, ppUserId?: string }) => {
+  const { isProxyEnrollment, ppUserId } = opts || {}
+  const joinPath = `/studies/${study.shortcode}/join`
+  if (isProxyEnrollment || ppUserId) {
+    return `${joinPath}?${isProxyEnrollment ? 'isProxyEnrollment=true' : ''}${ppUserId ? `&ppUserId=${ppUserId}` : ''}`
+  }
+  return joinPath
+}
+
 /** the default join link -- will be rendered in the top right corner */
 export const getMainJoinLink = (portalStudies: PortalStudy[]) => {
   const joinable = filterUnjoinableStudies(portalStudies)
   /** if there's only one joinable study, link directly to it */
   const joinPath = joinable.length === 1
-    ? `/studies/${joinable[0].study.shortcode}/join`
+    ? getJoinLink(joinable[0].study)
     : '/join'
   return joinPath
 }

--- a/ui-participant/src/hub/HubPage.tsx
+++ b/ui-participant/src/hub/HubPage.tsx
@@ -13,6 +13,9 @@ import OutreachTasks from './OutreachTasks'
 import { useActiveUser } from 'providers/ActiveUserProvider'
 import { useUser } from 'providers/UserProvider'
 import ParticipantSelector from '../participant/ParticipantSelector'
+import classNames from 'classnames'
+import { NavLink } from 'react-router-dom'
+import { getJoinLink } from '../Navbar'
 
 
 /** renders the logged-in hub page */
@@ -36,7 +39,9 @@ export default function HubPage() {
   }, [])
 
   const loadDashboardAlerts = async () => {
-    if (!portalEnv) { return }
+    if (!portalEnv) {
+      return
+    }
     const alerts = await Api.getPortalEnvDashboardAlerts(portal.shortcode, portalEnv.environmentName)
     setNoActivitiesAlert({
       ...{
@@ -54,7 +59,7 @@ export default function HubPage() {
 
   return (
     <>
-      <DocumentTitle title={i18n('navbarDashboard')} />
+      <DocumentTitle title={i18n('navbarDashboard')}/>
       <div
         className="hub-dashboard-background flex-grow-1 mb-2"
         style={{ background: 'var(--dashboard-background-color)' }}
@@ -114,15 +119,35 @@ const StudySection = (props: StudySectionProps) => {
     portal
   } = props
 
+  const { ppUsers } = useUser()
+  const ppUser = ppUsers.find(ppUser => ppUser.profileId === enrollee.profileId)
+
+  const { i18n } = useI18n()
+
   const matchedStudy = portal.portalStudies
     .find(pStudy => pStudy.study.studyEnvironments[0].id === enrollee.studyEnvironmentId)?.study as Study
 
+  if (!ppUser) {
+    return <></>
+  }
   return (
     <>
       <h1 className="mb-4">{matchedStudy.name}</h1>
-      {enrollee.kitRequests.length > 0 && <KitBanner kitRequests={enrollee.kitRequests} />}
-      <StudyResearchTasks enrollee={enrollee} studyShortcode={matchedStudy.shortcode}
-        participantTasks={enrollee.participantTasks} />
+      {enrollee.kitRequests.length > 0 && <KitBanner kitRequests={enrollee.kitRequests}/>}
+      {enrollee.subject
+        ? <StudyResearchTasks enrollee={enrollee} studyShortcode={matchedStudy.shortcode}
+          participantTasks={enrollee.participantTasks}/>
+        : <div>
+          <NavLink
+            className={classNames(
+              'btn btn-primary',
+              'mb-3 mb-lg-0 ms-lg-3'
+            )}
+            to={`${getJoinLink(matchedStudy, { ppUserId: ppUser.id })}`}
+          >
+            {i18n('navbarJoin')}
+          </NavLink>
+        </div>}
     </>
   )
 }

--- a/ui-participant/src/hub/HubPage.tsx
+++ b/ui-participant/src/hub/HubPage.tsx
@@ -120,16 +120,13 @@ const StudySection = (props: StudySectionProps) => {
   } = props
 
   const { ppUsers } = useUser()
-  const ppUser = ppUsers.find(ppUser => ppUser.profileId === enrollee.profileId)
+  const ppUser = ppUsers?.find(ppUser => ppUser.profileId === enrollee.profileId)
 
   const { i18n } = useI18n()
 
   const matchedStudy = portal.portalStudies
     .find(pStudy => pStudy.study.studyEnvironments[0].id === enrollee.studyEnvironmentId)?.study as Study
 
-  if (!ppUser) {
-    return <></>
-  }
   return (
     <>
       <h1 className="mb-4">{matchedStudy.name}</h1>
@@ -141,7 +138,7 @@ const StudySection = (props: StudySectionProps) => {
           {/* if the user is not a subject, prompt them to enroll */}
           <Link
             className="btn rounded-pill ps-4 pe-4 fw-bold btn-primary"
-            to={`${getJoinLink(matchedStudy, { ppUserId: ppUser.id })}`}
+            to={`${getJoinLink(matchedStudy, { ppUserId: ppUser?.id })}`}
           >
             {i18n('joinStudy')}
           </Link>

--- a/ui-participant/src/hub/HubPage.tsx
+++ b/ui-participant/src/hub/HubPage.tsx
@@ -13,8 +13,7 @@ import OutreachTasks from './OutreachTasks'
 import { useActiveUser } from 'providers/ActiveUserProvider'
 import { useUser } from 'providers/UserProvider'
 import ParticipantSelector from '../participant/ParticipantSelector'
-import classNames from 'classnames'
-import { NavLink } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { getJoinLink } from '../Navbar'
 
 
@@ -56,6 +55,7 @@ export default function HubPage() {
   const hubUpdate = useHubUpdate()
   const [showMessage, setShowMessage] = useState(true)
   const hasActiveTasks = enrollees.some(enrollee => enrollee.participantTasks.some(task => isTaskActive(task)))
+  const hasSubjectEnrollee = enrollees.some(enrollee => enrollee.subject)
 
   return (
     <>
@@ -64,7 +64,7 @@ export default function HubPage() {
         className="hub-dashboard-background flex-grow-1 mb-2"
         style={{ background: 'var(--dashboard-background-color)' }}
       >
-        {!hasActiveTasks && noActivitiesAlert && <HubMessageAlert
+        {!hasActiveTasks && hasSubjectEnrollee && noActivitiesAlert && <HubMessageAlert
           message={{
             title: noActivitiesAlert.title,
             detail: noActivitiesAlert.detail,
@@ -137,16 +137,14 @@ const StudySection = (props: StudySectionProps) => {
       {enrollee.subject
         ? <StudyResearchTasks enrollee={enrollee} studyShortcode={matchedStudy.shortcode}
           participantTasks={enrollee.participantTasks}/>
-        : <div>
-          <NavLink
-            className={classNames(
-              'btn btn-primary',
-              'mb-3 mb-lg-0 ms-lg-3'
-            )}
+        : <div className="py-3 text-center mb-4" style={{ background: 'var(--brand-color-shift-90)' }}>
+          {/* if the user is not a subject, prompt them to enroll */}
+          <Link
+            className="btn rounded-pill ps-4 pe-4 fw-bold btn-primary"
             to={`${getJoinLink(matchedStudy, { ppUserId: ppUser.id })}`}
           >
-            {i18n('navbarJoin')}
-          </NavLink>
+            {i18n('joinStudy')}
+          </Link>
         </div>}
     </>
   )

--- a/ui-participant/src/hub/HubPageWithProxies.test.tsx
+++ b/ui-participant/src/hub/HubPageWithProxies.test.tsx
@@ -69,6 +69,7 @@ describe('HubPage with proxies', () => {
     expect(await screen.findByLabelText('{selectParticipant}')).toHaveTextContent('Jonas Salk {youInParens}')
     expect(screen.queryByText('{test-demographics-survey:0}')).toBeNull()
     expect(screen.queryByText('{test-consent-survey:0}')).toBeNull()
+    expect(screen.queryByText('{joinStudy}')).toBeInTheDocument() // should be a join study link
     selectParticipant('Jonathan Salk')
     expect(await screen.findByLabelText('{selectParticipant}')).toHaveTextContent('Jonathan Salk')
     expect(screen.queryByText('{test-demographics-survey:0}')).toBeNull()

--- a/ui-participant/src/hub/HubPageWithProxies.test.tsx
+++ b/ui-participant/src/hub/HubPageWithProxies.test.tsx
@@ -43,7 +43,7 @@ describe('HubPage with proxies', () => {
     await waitFor(
       async () => expect(
         await screen.findByLabelText('{selectParticipant}')
-      ).toHaveTextContent('Jonas Salk {youInParens}'))
+      ).toHaveTextContent('Peter Salk'))
   })
   it('switches between proxies', async () => {
     const { RoutedComponent } = setupRouterTest(
@@ -61,13 +61,13 @@ describe('HubPage with proxies', () => {
     )
     render(RoutedComponent)
 
+    expect(await screen.findByLabelText('{selectParticipant}')).toHaveTextContent('Peter Salk')
+    expect(screen.queryByText('{test-demographics-survey:0}')).toBeInTheDocument()
+    expect(screen.queryByText('{test-consent-survey:0}')).toBeNull()
+    selectParticipant('Jonas Salk {youInParens}')
     await waitFor(() => expect(screen.getByText('Test Study')).toBeInTheDocument())
     expect(await screen.findByLabelText('{selectParticipant}')).toHaveTextContent('Jonas Salk {youInParens}')
     expect(screen.queryByText('{test-demographics-survey:0}')).toBeNull()
-    expect(screen.queryByText('{test-consent-survey:0}')).toBeNull()
-    selectParticipant('Peter Salk')
-    expect(await screen.findByLabelText('{selectParticipant}')).toHaveTextContent('Peter Salk')
-    expect(screen.queryByText('{test-demographics-survey:0}')).toBeInTheDocument()
     expect(screen.queryByText('{test-consent-survey:0}')).toBeNull()
     selectParticipant('Jonathan Salk')
     expect(await screen.findByLabelText('{selectParticipant}')).toHaveTextContent('Jonathan Salk')

--- a/ui-participant/src/studies/enroll/PreEnroll.tsx
+++ b/ui-participant/src/studies/enroll/PreEnroll.tsx
@@ -16,7 +16,7 @@ const ENROLLMENT_QUALIFIED_VARIABLE = 'qualified'
 /** Renders a pre-enrollment form, and handles submitting the user-inputted response */
 export default function PreEnrollView({ enrollContext, survey }:
                                         { enrollContext: StudyEnrollContext, survey: Survey }) {
-  const { studyEnv, updatePreEnrollResponseId, isProxyEnrollment } = enrollContext
+  const { studyEnv, updatePreEnrollResponseId, isProxyEnrollment, isSubjectEnrollment } = enrollContext
   const { selectedLanguage } = useI18n()
   const navigate = useNavigate()
   // for now, we assume all pre-screeners are a single page
@@ -26,7 +26,7 @@ export default function PreEnrollView({ enrollContext, survey }:
     null,
     handleComplete,
     pager,
-    { extraCssClasses: { container: 'my-0' }, extraVariables: { isProxyEnrollment } }
+    { extraCssClasses: { container: 'my-0' }, extraVariables: { isProxyEnrollment, isSubjectEnrollment } }
   )
 
   surveyModel.locale = selectedLanguage || 'default'

--- a/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
+++ b/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
@@ -59,13 +59,13 @@ function StudyEnrollOutletMatched(props: StudyEnrollOutletMatchedProps) {
 
   const [searchParams] = useSearchParams()
   const isProxyEnrollment = searchParams.get('isProxyEnrollment') === 'true'
-  const governedPpUserId = searchParams.get('governedPpUserId')
+  const ppUserId = searchParams.get('ppUserId')
 
   const { user, ppUsers, enrollees, refreshLoginState } = useUser()
 
   // ppUser / enrollees for the user or the proxied user depending on the context
   const ppUser = isProxyEnrollment
-    ? ppUsers.find(ppUser => ppUser.id === governedPpUserId) // could be null if new user enrollment
+    ? ppUsers.find(ppUser => ppUser.id === ppUserId) // could be null if new user enrollment
     : ppUsers.find(ppUser => ppUser.participantUserId === user?.id)
 
   const enrolleesForUser = enrollees.filter(enrollee => enrollee.profileId === ppUser?.profileId)
@@ -101,7 +101,10 @@ function StudyEnrollOutletMatched(props: StudyEnrollOutletMatchedProps) {
 
   /** route to a page depending on where in the pre-enroll/registration process the user is */
   const determineNextRoute = async () => {
-    const isAlreadyEnrolled = !!enrolleesForUser.find(rollee => rollee.studyEnvironmentId === studyEnv.id)
+    // if the user is a proxy, they still can enroll in the study
+    const isAlreadyEnrolled = !!enrolleesForUser.find(
+      rollee => rollee.studyEnvironmentId === studyEnv.id && rollee.subject
+    )
     if (isAlreadyEnrolled) {
       const hubUpdate: HubUpdate = {
         message: {
@@ -125,7 +128,7 @@ function StudyEnrollOutletMatched(props: StudyEnrollOutletMatchedProps) {
         try {
           const hubUpdate = isProxyEnrollment
             ? await enrollProxyUserInStudy(
-              studyShortcode, studyName, preEnrollResponseId, governedPpUserId, refreshLoginState, i18n
+              studyShortcode, studyName, preEnrollResponseId, ppUserId, refreshLoginState, i18n
             )
             : await enrollCurrentUserInStudy(
               studyShortcode, studyName, preEnrollResponseId, refreshLoginState, i18n

--- a/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
+++ b/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
@@ -23,6 +23,7 @@ export type StudyEnrollContext = {
   preEnrollResponseId: string | null,
   updatePreEnrollResponseId: (newId: string | null) => void,
   isProxyEnrollment: boolean
+  isSubjectEnrollment: boolean
 }
 
 /** Handles routing and loading for enrollment in a study */
@@ -99,12 +100,13 @@ function StudyEnrollOutletMatched(props: StudyEnrollOutletMatchedProps) {
     }
   }, [])
 
+  const matchedEnrollee = enrolleesForUser.find(rollee => rollee.studyEnvironmentId === studyEnv.id)
+
   /** route to a page depending on where in the pre-enroll/registration process the user is */
   const determineNextRoute = async () => {
     // if the user is a proxy, they still can enroll in the study
-    const isAlreadyEnrolled = !!enrolleesForUser.find(
-      rollee => rollee.studyEnvironmentId === studyEnv.id && rollee.subject
-    )
+    const isAlreadyEnrolled = !!matchedEnrollee && matchedEnrollee.subject
+
     if (isAlreadyEnrolled) {
       const hubUpdate: HubUpdate = {
         message: {
@@ -158,6 +160,7 @@ function StudyEnrollOutletMatched(props: StudyEnrollOutletMatchedProps) {
     user,
     preEnrollResponseId,
     updatePreEnrollResponseId,
+    isSubjectEnrollment: !!matchedEnrollee && !matchedEnrollee.subject,
     isProxyEnrollment
   }
   const hasPreEnroll = !!enrollContext.studyEnv.preEnrollSurvey

--- a/ui-participant/src/test-utils/test-proxy-environment.tsx
+++ b/ui-participant/src/test-utils/test-proxy-environment.tsx
@@ -147,7 +147,7 @@ export const mockEnrolleesWithProxies: Enrollee[] = [
       sexAtBirth: 'M'
     },
     consented: true,
-    subject: false,
+    subject: true,
     consentResponses: [],
     createdAt: 0,
     kitRequests: [],
@@ -196,7 +196,7 @@ export const mockEnrolleesWithProxies: Enrollee[] = [
       sexAtBirth: 'M'
     },
     consented: true,
-    subject: false,
+    subject: true,
     consentResponses: [],
     createdAt: 0,
     kitRequests: [],


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Viewing your hub page as a proxy:

<img width="1511" alt="image" src="https://github.com/broadinstitute/juniper/assets/17440010/0d06129c-1a57-45af-b685-8224e1542e2d">

Pre-fills proxy and name questions when you click:

<img width="1511" alt="image" src="https://github.com/broadinstitute/juniper/assets/17440010/150943d2-2815-4fa8-a435-d8efa1789b82">

Mobile

<img width="376" alt="image" src="https://github.com/broadinstitute/juniper/assets/17440010/af8457f9-8efc-484d-ae65-43cb75a3561d">


Also, disables hub page messages if you are not a subject.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Repopulate demo
- Enroll as a proxy of another user
- Enroll yourself as a subject
- Verify you can find yourself in the participant list
- Verify in the admin tool that your most recent pre-enroll responses are attached
