### PR TITLE
[JN-1077] adding stableId to survey form editor

### DIFF
--- a/ui-admin/src/study/surveys/SurveyEditorView.test.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.test.tsx
@@ -8,7 +8,7 @@ import { renderWithRouter } from '../../test-utils/router-testing-utils'
 import userEvent from '@testing-library/user-event'
 
 describe('SurveyEditorView', () => {
-  const mockForm: Survey = {
+  const mockForm = ():Survey => ({
     ...defaultSurvey,
     createdAt: 0,
     lastUpdatedAt: 0,
@@ -18,17 +18,17 @@ describe('SurveyEditorView', () => {
     stableId: 'testStableId',
     name: 'Test survey',
     surveyType: 'RESEARCH'
-  }
+  })
 
   test('shows the user a LoadedLocalDraftModal when a draft is loaded', async () => {
     //Arrange
-    const FORM_DRAFT_KEY = getFormDraftKey({ form: mockForm })
+    const FORM_DRAFT_KEY = getFormDraftKey({ form: mockForm() })
     localStorage.setItem(FORM_DRAFT_KEY, JSON.stringify({}))
 
     jest.spyOn(Storage.prototype, 'getItem')
     renderWithRouter(<SurveyEditorView
       studyEnvContext={mockStudyEnvContext()}
-      currentForm={mockForm}
+      currentForm={mockForm()}
       onCancel={jest.fn()}
       onSave={jest.fn()}
     />)
@@ -40,13 +40,13 @@ describe('SurveyEditorView', () => {
 
   test('checks local storage for a draft', async () => {
     //Arrange
-    const FORM_DRAFT_KEY = getFormDraftKey({ form: mockForm })
+    const FORM_DRAFT_KEY = getFormDraftKey({ form: mockForm() })
 
     jest.spyOn(Storage.prototype, 'getItem')
 
     renderWithRouter(<SurveyEditorView
       studyEnvContext={mockStudyEnvContext()}
-      currentForm={mockForm}
+      currentForm={mockForm()}
       onCancel={jest.fn()}
       onSave={jest.fn()}
     />)
@@ -59,24 +59,48 @@ describe('SurveyEditorView', () => {
   test('shows a dropdown with options', async () => {
     renderWithRouter(<SurveyEditorView
       studyEnvContext={mockStudyEnvContext()}
-      currentForm={mockForm}
+      currentForm={mockForm()}
       onCancel={jest.fn()}
       onSave={jest.fn()}
     />)
     expect(screen.getByLabelText('form options menu')).toBeInTheDocument()
     await userEvent.click(screen.getByLabelText('form options menu'))
     await userEvent.click(screen.getByText('Configuration'))
-    expect(screen.getByText(`${mockForm.name} - configuration`)).toBeInTheDocument()
+    expect(screen.getByText(`${mockForm().name} - configuration`)).toBeInTheDocument()
   })
 
   test('allows the user to download the JSON file', async () => {
     renderWithRouter(<SurveyEditorView
       studyEnvContext={mockStudyEnvContext()}
-      currentForm={mockForm}
+      currentForm={mockForm()}
       onCancel={jest.fn()}
       onSave={jest.fn()}
     />)
     await userEvent.click(screen.getByLabelText('form options menu'))
     expect(screen.getByText('Download form JSON')).toBeInTheDocument()
+  })
+
+  test('shows stableId and version', async () => {
+    const stableId = 'testStableId'
+    renderWithRouter(<SurveyEditorView
+      studyEnvContext={mockStudyEnvContext()}
+      currentForm={{ ...mockForm(), stableId }}
+      onCancel={jest.fn()}
+      onSave={jest.fn()}
+    />)
+    expect(screen.getByText('testStableId v12')).toBeInTheDocument()
+    expect(screen.queryByText('published')).not.toBeInTheDocument()
+  })
+
+  test('shows published version if applicable', async () => {
+    const stableId = 'testStableId'
+    renderWithRouter(<SurveyEditorView
+      studyEnvContext={mockStudyEnvContext()}
+      currentForm={{ ...mockForm(), stableId, publishedVersion: 2 }}
+      onCancel={jest.fn()}
+      onSave={jest.fn()}
+    />)
+    expect(screen.getByText('testStableId v12')).toBeInTheDocument()
+    expect(screen.getByText('- published v2')).toBeInTheDocument()
   })
 })

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -119,7 +119,7 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
         <div className="d-flex flex-grow-1">
           <h5>{currentForm.name}
             <span className="fs-6 text-muted fst-italic me-2 ms-2">
-              (v{currentForm.version}
+              (<span>{currentForm.stableId} v{currentForm.version}</span>
               { currentForm.publishedVersion && <span className="ms-1">
                 - published v{currentForm.publishedVersion}
               </span> }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Shows the stableId in the form editor for admin reference

<img width="1168" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/18c326be-0269-49a3-bebf-91bc538d60ae">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/forms/surveys/oh_oh_cardioHx
2. confirm you see the stableId next to the survey title