### PR TITLE
[JN-1104] Fix .svg Navbar logos

### DIFF
--- a/ui-participant/src/Navbar.tsx
+++ b/ui-participant/src/Navbar.tsx
@@ -62,7 +62,7 @@ export default function Navbar(props: NavbarProps) {
   return <nav {...props} className={classNames('navbar navbar-expand-lg navbar-light', props.className)}>
     <div className="container-fluid">
       <NavLink to="/" className="navbar-brand">
-        <img className="Navbar-logo" style={{ maxHeight: '30px' }}
+        <img className="Navbar-logo" style={{ height: '30px', maxHeight: '30px' }}
           src={getImageUrl(localContent.navLogoCleanFileName, localContent.navLogoVersion)} alt="logo"/>
       </NavLink>
       <button


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

gVasc was running into an issue using an .svg file as a navbar logo. The issue seems to be related to .svgs that contain inlined CSS. The solution is to add an explicit `height` property to the element so it doesn't get overriden.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Save the attached gVasc logo and upload to an existing portal locally
Confirm it renders

![gvasc-logo-draft](https://github.com/broadinstitute/juniper/assets/7257391/9083fbb4-0b55-4467-b965-485e52c2a629)
