### PR TITLE
[JN-1093] Admin landing page redesign

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/portal/PortalController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/portal/PortalController.java
@@ -1,7 +1,7 @@
 package bio.terra.pearl.api.admin.controller.portal;
 
 import bio.terra.pearl.api.admin.api.PortalApi;
-import bio.terra.pearl.api.admin.model.PortalShallowDto;
+import bio.terra.pearl.api.admin.models.dto.PortalShallowDto;
 import bio.terra.pearl.api.admin.service.AuthUtilService;
 import bio.terra.pearl.api.admin.service.portal.PortalExtService;
 import bio.terra.pearl.core.model.admin.AdminUser;
@@ -40,7 +40,7 @@ public class PortalController implements PortalApi {
   }
 
   @Override
-  public ResponseEntity<List<PortalShallowDto>> getAll() {
+  public ResponseEntity<Object> getAll() {
     AdminUser adminUser = requestService.requireAdminUser(request);
 
     List<Portal> portals = portalExtService.getAll(adminUser);

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/models/dto/PortalShallowDto.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/models/dto/PortalShallowDto.java
@@ -1,0 +1,22 @@
+package bio.terra.pearl.api.admin.models.dto;
+
+import bio.terra.pearl.core.model.portal.PortalEnvironment;
+import bio.terra.pearl.core.model.study.PortalStudy;
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+public class PortalShallowDto {
+  private UUID id;
+  private String shortcode;
+  private String name;
+  private List<PortalStudy> portalStudies;
+  private List<PortalEnvironment> portalEnvironments;
+}

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/portal/PortalExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/portal/PortalExtService.java
@@ -49,6 +49,7 @@ public class PortalExtService {
     // no additional auth checks needed -- the underlying service filters out portals the user does
     // not have access to
     List<Portal> portals = portalService.findByAdminUser(user);
+    portalService.attachPortalEnvironments(portals);
     portalService.attachStudies(portals);
     return portals;
   }

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -85,7 +85,7 @@ paths:
       responses:
         '200':
           description: list of portal objects
-          content: { application/json: { schema: { type: array, items: { $ref: '#/components/schemas/PortalShallowDto' } } } }
+          content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}:
@@ -1791,14 +1791,6 @@ components:
           type: string
         statusCode:
           type: integer
-    PortalShallowDto:
-      type: object
-      properties:
-        id: { type: string, format: uuid }
-        shortcode: { type: string }
-        name: { type: string }
-        portalStudies: { type: array }
-        portalEnvironments: { type: array }
     PortalDto:
       type: object
     CreateDataset:

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -1798,6 +1798,7 @@ components:
         shortcode: { type: string }
         name: { type: string }
         portalStudies: { type: array }
+        portalEnvironments: { type: array }
     PortalDto:
       type: object
     CreateDataset:

--- a/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
@@ -242,6 +242,10 @@ public abstract class BaseJdbiDao<T extends BaseEntity> {
         );
     }
 
+    /* fetches all the entities with a child attached.  For example, if the parent table has a column "portal_environment_config_id" and
+     * a field portalEnvironmentConfig, this method could be used to fetch the portal environments with the configs already hydrated
+     * and do so in a single SQL query instead of performing n queries to attach children to n parents
+     */
     protected List<T> findAllByPropertyWithChildren(String columnName, Object columnValue, String childIdPropertyName,
                                                     String childPropertyName, BaseJdbiDao childDao) {
         List<String> parentCols = getQueryColumns.stream().map(col -> "a." + col + " a_" + col)

--- a/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
@@ -242,6 +242,34 @@ public abstract class BaseJdbiDao<T extends BaseEntity> {
         );
     }
 
+    protected List<T> findAllByPropertyWithChildren(String columnName, Object columnValue, String childIdPropertyName,
+                                                    String childPropertyName, BaseJdbiDao childDao) {
+        List<String> parentCols = getQueryColumns.stream().map(col -> "a." + col + " a_" + col)
+                .collect(Collectors.toList());
+        List<String> childCols = ((List<String>) childDao.getQueryColumns).stream().map(col -> "b." + col + " b_" + col)
+                .collect(Collectors.toList());
+        return jdbi.withHandle(handle ->
+                handle.createQuery("select " + String.join(", ", parentCols) + ", "
+                        + String.join(", ", childCols)
+                        + " from " + tableName + " a left join " + childDao.tableName
+                        + " b on a." + toSnakeCase(childIdPropertyName) + " = b.id"
+                        + " where a." + toSnakeCase(columnName) + " = :columnValue")
+                        .bind("columnValue", columnValue)
+                        .registerRowMapper(clazz, getRowMapper("a"))
+                        .registerRowMapper(childDao.clazz, childDao.getRowMapper("b"))
+                        .reduceRows((Map<UUID, T> map, RowView rowView) -> {
+                            T parent = map.computeIfAbsent(
+                                    rowView.getColumn("a_id", UUID.class),
+                                    rowId -> rowView.getRow(clazz));
+                            if (rowView.getColumn("b_id", UUID.class) != null) {
+                                PropertyAccessor accessor = PropertyAccessorFactory.forBeanPropertyAccess(parent);
+                                accessor.setPropertyValue(childPropertyName, rowView.getRow(childDao.getClazz()));
+                            }
+                        })
+                        .toList()
+        );
+    }
+
     public Optional<T> findByProperty(String columnName, Object columnValue) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("select * from " + tableName + " where " + columnName + " = :columnValue;")

--- a/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalDao.java
@@ -96,8 +96,7 @@ public class PortalDao extends BaseMutableJdbiDao<Portal> {
         for(Portal portal : portals) {
             UUID portalId = portal.getId();
             List<PortalEnvironment> portalEnvironments = portalEnvironmentDao.findByPortal(portalId);
-            List<PortalEnvironment> matches = portalEnvironments.stream().filter(portalEnv -> portalEnv.getPortalId().equals(portal.getId())).toList();
-            portal.getPortalEnvironments().addAll(matches);
+            portal.getPortalEnvironments().addAll(portalEnvironments);
         }
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalDao.java
@@ -21,7 +21,6 @@ public class PortalDao extends BaseMutableJdbiDao<Portal> {
     private PortalStudyDao portalStudyDao;
     private StudyDao studyDao;
     private PortalAdminUserDao portalAdminUserDao;
-    private PortalLanguageDao portalLanguageDao;
 
     @Override
     protected Class<Portal> getClazz() {
@@ -29,14 +28,12 @@ public class PortalDao extends BaseMutableJdbiDao<Portal> {
     }
 
     public PortalDao(Jdbi jdbi, PortalEnvironmentDao portalEnvironmentDao,
-                     PortalStudyDao portalStudyDao, StudyDao studyDao, PortalAdminUserDao portalAdminUserDao,
-                     PortalLanguageDao portalLanguageDao) {
+                     PortalStudyDao portalStudyDao, StudyDao studyDao, PortalAdminUserDao portalAdminUserDao) {
         super(jdbi);
         this.portalEnvironmentDao = portalEnvironmentDao;
         this.portalStudyDao = portalStudyDao;
         this.studyDao = studyDao;
         this.portalAdminUserDao = portalAdminUserDao;
-        this.portalLanguageDao = portalLanguageDao;
     }
 
     public Optional<Portal> findOneByShortcode(String shortcode) {
@@ -93,6 +90,15 @@ public class PortalDao extends BaseMutableJdbiDao<Portal> {
             portal.getPortalStudies().add(portalStudy);
         }
         return portal;
+    }
+
+    public void attachPortalEnvironments(List<Portal> portals) {
+        for(Portal portal : portals) {
+            UUID portalId = portal.getId();
+            List<PortalEnvironment> portalEnvironments = portalEnvironmentDao.findByPortal(portalId);
+            List<PortalEnvironment> matches = portalEnvironments.stream().filter(portalEnv -> portalEnv.getPortalId().equals(portal.getId())).toList();
+            portal.getPortalEnvironments().addAll(matches);
+        }
     }
 
     public void attachStudies(List<Portal> portals) {

--- a/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalDao.java
@@ -77,7 +77,7 @@ public class PortalDao extends BaseMutableJdbiDao<Portal> {
      * This isn't terribly optimized yet
      * */
     public Portal fullLoad(Portal portal, String language) {
-        List<PortalEnvironment> portalEnvs = portalEnvironmentDao.findByPortal(portal.getId());
+        List<PortalEnvironment> portalEnvs = portalEnvironmentDao.findByPortalWithConfigs(portal.getId());
         for (PortalEnvironment portalEnv : portalEnvs) {
             portal.getPortalEnvironments().add(
                     portalEnvironmentDao.loadWithSiteContent(portal.getShortcode(),
@@ -95,7 +95,7 @@ public class PortalDao extends BaseMutableJdbiDao<Portal> {
     public void attachPortalEnvironments(List<Portal> portals) {
         for(Portal portal : portals) {
             UUID portalId = portal.getId();
-            List<PortalEnvironment> portalEnvironments = portalEnvironmentDao.findByPortal(portalId);
+            List<PortalEnvironment> portalEnvironments = portalEnvironmentDao.findByPortalWithConfigs(portalId);
             portal.getPortalEnvironments().addAll(portalEnvironments);
         }
     }

--- a/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalEnvironmentDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalEnvironmentDao.java
@@ -37,7 +37,7 @@ public class PortalEnvironmentDao extends BaseMutableJdbiDao<PortalEnvironment> 
         return PortalEnvironment.class;
     }
 
-    public List<PortalEnvironment> findByPortal(UUID portalId) {
+    public List<PortalEnvironment> findByPortalWithConfigs(UUID portalId) {
         return findAllByPropertyWithChildren("portal_id", portalId, "portalEnvironmentConfigId",
                 "portalEnvironmentConfig", portalEnvironmentConfigDao);
     }

--- a/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalEnvironmentDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalEnvironmentDao.java
@@ -38,7 +38,8 @@ public class PortalEnvironmentDao extends BaseMutableJdbiDao<PortalEnvironment> 
     }
 
     public List<PortalEnvironment> findByPortal(UUID portalId) {
-        return findAllByProperty("portal_id", portalId);
+        return findAllByPropertyWithChildren("portal_id", portalId, "portalEnvironmentConfigId",
+                "portalEnvironmentConfig", portalEnvironmentConfigDao);
     }
 
     public Optional<PortalEnvironment> findOne(String shortcode, EnvironmentName environmentName) {

--- a/core/src/main/java/bio/terra/pearl/core/service/portal/PortalEnvironmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/portal/PortalEnvironmentService.java
@@ -65,7 +65,7 @@ public class PortalEnvironmentService extends CrudService<PortalEnvironment, Por
     }
 
     public List<PortalEnvironment> findByPortal(UUID portalId) {
-        return dao.findByPortal(portalId);
+        return dao.findByPortalWithConfigs(portalId);
     }
 
     public Optional<PortalEnvironment> findOne(String portalShortcode, EnvironmentName environmentName) {

--- a/core/src/main/java/bio/terra/pearl/core/service/portal/PortalService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/portal/PortalService.java
@@ -132,6 +132,10 @@ public class PortalService extends CrudService<Portal, PortalDao> {
         return dao.findByAdminUserId(user.getId());
     }
 
+    public void attachPortalEnvironments(List<Portal> portals) {
+        dao.attachPortalEnvironments(portals);
+    }
+
     public void attachStudies(List<Portal> portals) {
         dao.attachStudies(portals);
     }

--- a/ui-admin/src/HomePage.test.tsx
+++ b/ui-admin/src/HomePage.test.tsx
@@ -1,29 +1,27 @@
 import { render, screen } from '@testing-library/react'
 import React from 'react'
 import HomePage from './HomePage'
-import { makeMockPortal, makeMockPortalStudy } from './test-utils/mocking-utils'
+import { makeMockPortal } from './test-utils/mocking-utils'
 import { useNavContext } from './navbar/NavContextProvider'
 import { setupRouterTest } from '@juniper/ui-core'
+import userEvent from '@testing-library/user-event'
 
 jest.mock('./navbar/NavContextProvider')
 
 describe('HomePage', () => {
-  it('renders the study list in alphabetical order', () => {
-    const portalList = [
-      makeMockPortal('Z Portal', [
-        makeMockPortalStudy('Z Study', 'studyZ'),
-        makeMockPortalStudy('A Study', 'studyA'),
-        makeMockPortalStudy('M Study 1', 'studyM1')
-      ], 'studyZ shortcode'),
-      makeMockPortal('A Portal', [
-        makeMockPortalStudy('M Study 2', 'studyM2')
-      ], 'studyA shortcode')
-    ]
+  const mockPortalList = [
+    makeMockPortal('E Portal', [], 'eshortcode'),
+    makeMockPortal('A Portal', [], 'ashortcode'),
+    makeMockPortal('D Portal', [], 'dshortcode'),
+    makeMockPortal('C Portal', [], 'cshortcode'),
+    makeMockPortal('B Portal', [], 'bshortcode')
+  ]
 
+  it('renders the portal list in alphabetical order', () => {
     const mockContextValue = {
       breadCrumbs: [],
       setBreadCrumbs: jest.fn(),
-      portalList,
+      portalList: mockPortalList,
       setPortalList: jest.fn()
     }
 
@@ -32,13 +30,86 @@ describe('HomePage', () => {
     const { RoutedComponent } = setupRouterTest(<HomePage/>)
     render(RoutedComponent)
 
-    expect(screen.getByText('My Studies')).toBeInTheDocument()
+    expect(screen.getByText('Select a portal')).toBeInTheDocument()
 
-    const studies = screen.queryAllByText(/Study/)
+    const studies = screen.queryAllByText(/Portal/)
 
-    expect(studies[0]).toHaveTextContent('M Study 2') // the study from "A Portal"
-    expect(studies[1]).toHaveTextContent('A Study') // the remaining three studies from "Z Portal"
-    expect(studies[2]).toHaveTextContent('M Study 1')
-    expect(studies[3]).toHaveTextContent('Z Study')
+    expect(studies[0]).toHaveTextContent('A Portal')
+    expect(studies[1]).toHaveTextContent('B Portal')
+    expect(studies[2]).toHaveTextContent('C Portal')
+    expect(studies[3]).toHaveTextContent('D Portal')
+    expect(studies[4]).toHaveTextContent('E Portal')
+  })
+
+  it('filters the portal list by search input', async () => {
+    const mockContextValue = {
+      breadCrumbs: [],
+      setBreadCrumbs: jest.fn(),
+      portalList: mockPortalList,
+      setPortalList: jest.fn()
+    }
+
+    ;(useNavContext as jest.Mock).mockReturnValue(mockContextValue)
+
+    const { RoutedComponent } = setupRouterTest(<HomePage/>)
+    render(RoutedComponent)
+
+    expect(screen.getByText('Select a portal')).toBeInTheDocument()
+
+    await userEvent.type(screen.getByTitle('Search for portals or studies'), 'c port')
+    await userEvent.click(screen.getByTitle('submit search'))
+
+    const studies = screen.queryAllByText(/Portal/)
+
+    expect(studies).toHaveLength(1)
+    expect(studies[0]).toHaveTextContent('C Portal')
+  })
+
+  it('displays a warning message if the user does not have access to any portals', () => {
+    const mockContextValue = {
+      breadCrumbs: [],
+      setBreadCrumbs: jest.fn(),
+      portalList: [],
+      setPortalList: jest.fn()
+    }
+
+    ;(useNavContext as jest.Mock).mockReturnValue(mockContextValue)
+
+    const { RoutedComponent } = setupRouterTest(<HomePage/>)
+    render(RoutedComponent)
+
+    expect(screen.getByText('You do not have access to any portals or studies. ' +
+        'If this is an error, please contact', { exact: false })).toBeInTheDocument()
+  })
+
+  it('toggles to a list view', async () => {
+    const mockContextValue = {
+      breadCrumbs: [],
+      setBreadCrumbs: jest.fn(),
+      portalList: mockPortalList,
+      setPortalList: jest.fn()
+    }
+
+    ;(useNavContext as jest.Mock).mockReturnValue(mockContextValue)
+
+    const { RoutedComponent } = setupRouterTest(<HomePage/>)
+    render(RoutedComponent)
+
+    const gridButton = screen.getByText('Grid')
+    const listButton = screen.getByText('List')
+
+    expect(gridButton).toHaveClass('btn-dark')
+    expect(listButton).toHaveClass('btn-light')
+
+    await userEvent.click(listButton)
+
+    expect(gridButton).toHaveClass('btn-light')
+    expect(listButton).toHaveClass('btn-dark')
+
+    expect(screen.getByText('Portal Name')).toBeInTheDocument()
+    expect(screen.getByText('Status')).toBeInTheDocument()
+    expect(screen.getByText('Website')).toBeInTheDocument()
+    expect(screen.getByText('Total Studies')).toBeInTheDocument()
+    expect(screen.getByText('Created')).toBeInTheDocument()
   })
 })

--- a/ui-admin/src/HomePage.tsx
+++ b/ui-admin/src/HomePage.tsx
@@ -155,7 +155,9 @@ function PortalList({ portalList }: { portalList: Portal[] }) {
     getSortedRowModel: getSortedRowModel()
   })
 
-  return basicTableLayout(table, { tableClass: 'table' })
+  return <div className="py-2 px-5 border rounded shadow-sm">
+    {basicTableLayout(table, { tableClass: 'table' })}
+  </div>
 }
 
 

--- a/ui-admin/src/HomePage.tsx
+++ b/ui-admin/src/HomePage.tsx
@@ -101,9 +101,11 @@ function PortalList({ portalList }: { portalList: Portal[] }) {
     header: 'Portal Name',
     accessorKey: 'name',
     cell: ({ row }) => (
-      <div className="d-flex align-items-center">
-        <img src={getMediaUrl(row.original.shortcode, 'favicon.ico', 'latest')}
-          style={{ maxHeight: '1.5em', maxWidth: '1.5rem' }} className="me-3" alt={row.original.name}/>
+      <div className="d-flex">
+        <div className='d-flex align-items-center justify-content-center' style={{ width: '1.5em', height: '1.5em' }}>
+          <img src={getMediaUrl(row.original.shortcode, 'favicon.ico', 'latest')}
+            style={{ maxHeight: '100%', maxWidth: '100%' }} className="me-3" alt={row.original.name}/>
+        </div>
         <Link to={portalHomePath(row.original.shortcode)}>
           {row.original.name}
         </Link>
@@ -112,8 +114,8 @@ function PortalList({ portalList }: { portalList: Portal[] }) {
     header: 'Status',
     cell: ({ row }) => {
       const portal = row.original
-      return portal.portalEnvironments?.length === 3  &&
-        <><FontAwesomeIcon icon={faCircle} className={'fa-xs text-success'}/> Live</>
+      return portal.portalEnvironments?.length === 3 &&
+          <><FontAwesomeIcon icon={faCircle} className={'fa-xs text-success'}/> Live</>
     }
   }, {
     header: 'Website',

--- a/ui-admin/src/HomePage.tsx
+++ b/ui-admin/src/HomePage.tsx
@@ -1,88 +1,160 @@
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { studyParticipantsPath } from './portal/PortalRouter'
+import { portalHomePath } from './portal/PortalRouter'
 import { useNavContext } from './navbar/NavContextProvider'
-import { getMediaUrl } from './api/api'
+import Api, { getMediaUrl } from './api/api'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faEllipsisH, faPlus } from '@fortawesome/free-solid-svg-icons'
-import { Button, IconButton } from './components/forms/Button'
-import CreateNewStudyModal from './study/CreateNewStudyModal'
-import { useUser } from './user/UserProvider'
-import DeleteStudyModal from './study/adminTasks/DeleteStudyModal'
-import { Study } from '@juniper/ui-core/build/types/study'
-import CreateNewCohortModal from './study/CreateNewCohortModal'
+import { faCircle, faExternalLink, faList, faSearch, faTableCellsLarge } from '@fortawesome/free-solid-svg-icons'
 import { Portal } from '@juniper/ui-core/build/types/portal'
+import { basicTableLayout } from './util/tableUtils'
+import { ColumnDef, getCoreRowModel, getSortedRowModel, SortingState, useReactTable } from '@tanstack/react-table'
+import { useConfig } from './providers/ConfigProvider'
+import { instantToDateString } from '@juniper/ui-core'
 
 /** Shows a user the list of portals available to them */
 function HomePage() {
-  const { portalList, reload } = useNavContext()
-  const { user } = useUser()
-  const [showNewStudyModal, setShowNewStudyModal] = useState(false)
-  const [showNewCohortModal, setShowNewCohortModal] = useState(false)
-  const [showDeleteStudyModal, setShowDeleteStudyModal] = useState(false)
-  const [selectedStudy, setSelectedStudy] = useState<Study>()
-  const [selectedPortal, setSelectedPortal] = useState<Portal>()
+  const { portalList } = useNavContext()
+  const [portalSearch, setPortalSearch] = useState('')
+  const [view, setView] = useState<'grid' | 'list'>('grid')
+  const filteredPortalList = useMemo(() => portalList.filter(portal =>
+    portal.name.toLowerCase().includes(portalSearch.toLowerCase()) ||
+    portal.portalStudies.some(portalStudy => portalStudy.study.name.toLowerCase().includes(portalSearch.toLowerCase()))
+  ), [portalList, portalSearch])
 
-  return <div className="container">
-    <h1 className="h2">Juniper Home</h1>
-    <div className="ms-5 mt-4">
-      <h2 className="h4">My Studies</h2>
-      <ul className="list-group list-group-flush fs-5 list-unstyled">
-        { portalList.sort((a, b) => a.name.localeCompare(b.name)).flatMap(portal =>
-          <li key = {portal.shortcode} className="mt-3">
-            <span className={'mt-2'}>{portal.name}</span>
-            <ul className="list-group list-group-flush ">
-              { portal.portalStudies.sort((a, b) => a.study.name.localeCompare(b.study.name)).map(portalStudy => {
-                const study = portalStudy.study
-                return <li key={`${portal.shortcode}-${study.shortcode}`}
-                  className="list-group-item my-1 border border-secondary-subtle rounded">
-                  <Link to={studyParticipantsPath(portal.shortcode, study.shortcode, 'live')}>
-                    <img
-                      src={getMediaUrl(portal.shortcode, 'favicon.ico', 'latest')}
-                      className="me-3" style={{ maxHeight: '1.5em' }}/>
-                    {study.name}
-                  </Link>
-                  <span className="dropdown">
-                    <span className="nav-item dropdown ms-1">
-                      <IconButton icon={faEllipsisH} data-bs-toggle="dropdown"
-                        aria-expanded="false" aria-label="configure study"/>
-                      <div className="dropdown-menu">
-                        <ul className="list-unstyled">
-                          <li>
-                            <button className="dropdown-item"
-                              onClick={
-                                () => {
-                                  setShowDeleteStudyModal(!showDeleteStudyModal)
-                                  setSelectedStudy(study)
-                                  setSelectedPortal(portal)
-                                }}>Delete
-                            </button>
-                            {selectedStudy && showDeleteStudyModal && selectedPortal &&
-                              <DeleteStudyModal study={selectedStudy}
-                                portal={selectedPortal}
-                                onDismiss={() => setShowDeleteStudyModal(false)}
-                                reload={reload}/>}
-                          </li>
-                        </ul>
-                      </div>
-                    </span>
-                  </span>
-                </li>
-              })}
-            </ul>
-          </li>
-        )}
-      </ul>
-      {user?.superuser && <Button variant='secondary' onClick={() => setShowNewStudyModal(true)}>
-        <FontAwesomeIcon icon={faPlus}/> Add a study
-      </Button> }
-      {user?.superuser && <Button variant='secondary' onClick={() => setShowNewCohortModal(true)}>
-        <FontAwesomeIcon icon={faPlus}/> Create a cohort
-      </Button> }
+  return <div className="container" style={{ minHeight: '100vh' }}>
+    <h1 className="h2 d-flex justify-content-center pb-2">Select a portal</h1>
+    <div className="d-flex align-items-center pb-2">
+      <form className="rounded-5 m-auto" onSubmit={e => {
+        e.preventDefault()
+      }} style={{
+        border: '1px solid #bbb',
+        backgroundColor: '#fff',
+        padding: '0.25em 0.75em 0em'
+      }}>
+        <button type="submit" title="submit search" className="btn btn-secondary">
+          <FontAwesomeIcon icon={faSearch}/>
+        </button>
+        <input type="text" value={portalSearch} size={50}
+          title={'Search for portals or studies'}
+          style={{ border: 'none', outline: 'none' }}
+          placeholder={'Search for portals or studies'}
+          onChange={e => setPortalSearch(e.target.value)}/>
+      </form>
+      <div className="btn-group position-absolute end-0 px-3">
+        <button id="grid" className={`btn btn-sm ${view === 'grid' ? 'btn-dark' : 'btn-light'}`}
+          onClick={() => setView('grid')}>
+          <FontAwesomeIcon icon={faTableCellsLarge}/> Grid
+        </button>
+        <button id="list" className={`btn btn-sm ${view === 'list' ? 'btn-dark' : 'btn-light'}`}
+          onClick={() => setView('list')}>
+          <FontAwesomeIcon icon={faList}/> List
+        </button>
+      </div>
     </div>
-    { showNewStudyModal && <CreateNewStudyModal onDismiss={() => setShowNewStudyModal(false)}/> }
-    { showNewCohortModal && <CreateNewCohortModal onDismiss={() => setShowNewCohortModal(false)}/> }
+
+    {portalList.length === 0 ?
+      <div className="d-flex justify-content-center mt-3">
+        <div className="alert alert-warning" role="alert">
+            You do not have access to any portals or studies. If this is an error, please
+            contact <a href="mailto:support@juniper.terra.bio">support@juniper.terra.bio</a>
+        </div>
+      </div> :
+      <div className='d-flex justify-content-center py-4'>
+        <div style={{ width: '90%' }}>
+          {view === 'grid' ?
+            <PortalGrid portalList={filteredPortalList}/> :
+            <PortalList portalList={filteredPortalList}/>
+          }
+        </div>
+      </div>
+    }
   </div>
 }
+
+function PortalGrid({ portalList }: { portalList: Portal[] }) {
+  return (
+    <div className="d-flex flex-wrap justify-content-center">
+      {portalList.map(portal => (
+        <Link key={portal.shortcode} to={portalHomePath(portal.shortcode)}>
+          <div className="card m-2 shadow-sm d-flex flex-column" style={{ width: '200px', height: '200px' }}>
+            <div className="card-body p-0">
+              <h6 className="card-title m-2 fw-bold">{portal.name}</h6>
+            </div>
+            <div className="d-flex flex-grow-1 m-auto"
+              style={{ width: '100%', maxWidth: '150px', maxHeight: '150px' }}>
+              <img src={getMediaUrl(portal.shortcode, 'favicon.ico', 'latest')}
+                className="card-img-top"
+                alt={portal.name} style={{ objectFit: 'contain', maxWidth: '100%', maxHeight: '80%' }}/>
+            </div>
+          </div>
+        </Link>
+      ))}
+    </div>
+  )
+}
+
+function PortalList({ portalList }: { portalList: Portal[] }) {
+  const zoneConfig = useConfig()
+  const [sorting, setSorting] = React.useState<SortingState>([])
+
+  const columns: ColumnDef<Portal>[] = [{
+    header: 'Portal Name',
+    accessorKey: 'name',
+    cell: ({ row }) => (
+      <div className="d-flex align-items-center">
+        <img src={getMediaUrl(row.original.shortcode, 'favicon.ico', 'latest')}
+          style={{ maxHeight: '1.5em', maxWidth: '1.5rem' }} className="me-3" alt={row.original.name}/>
+        <Link to={portalHomePath(row.original.shortcode)}>
+          {row.original.name}
+        </Link>
+      </div>)
+  }, {
+    header: 'Status',
+    cell: ({ row }) => {
+      const portal = row.original
+      return portal.portalEnvironments?.length === 3  &&
+        <><FontAwesomeIcon icon={faCircle} className={'fa-xs text-success'}/> Live</>
+    }
+  }, {
+    header: 'Website',
+    cell: ({ row }) => {
+      const portal = row.original
+      const portalEnv = portal.portalEnvironments?.find(pe => pe.environmentName === 'live')
+      return (
+        portalEnv ?
+          <a href={Api.getParticipantLink(portalEnv.portalEnvironmentConfig, zoneConfig.participantUiHostname,
+            portal.shortcode, portalEnv.environmentName)} target="_blank">
+                Participant website <FontAwesomeIcon icon={faExternalLink}/>
+          </a> :
+          <span className="text-muted">Website not initialized</span>)
+    }
+  }, {
+    header: 'Total Studies',
+    accessorFn: portal => portal.portalStudies.length
+  }, {
+    header: 'Created',
+    accessorFn: portal => {
+      //Sandbox was the very first environment created, so we'll run with that.
+      //'Date Launched' could potentially be a better field to use, though
+      const createdDate = portal.portalEnvironments?.find(pe =>
+        pe.environmentName === 'sandbox')?.createdAt
+      return instantToDateString(createdDate)
+    }
+  }]
+
+  const table = useReactTable({
+    data: portalList,
+    columns,
+    state: {
+      sorting
+    },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel()
+  })
+
+  return basicTableLayout(table, { tableClass: 'table' })
+}
+
 
 export default HomePage

--- a/ui-admin/src/HomePage.tsx
+++ b/ui-admin/src/HomePage.tsx
@@ -114,8 +114,12 @@ function PortalList({ portalList }: { portalList: Portal[] }) {
     header: 'Status',
     cell: ({ row }) => {
       const portal = row.original
-      return portal.portalEnvironments?.length === 3 &&
-          <><FontAwesomeIcon icon={faCircle} className={'fa-xs text-success'}/> Live</>
+      const livePortalEnv = portal.portalEnvironments?.find(pe => pe.environmentName === 'live')
+      return livePortalEnv && <>
+        {livePortalEnv.portalEnvironmentConfig?.acceptingRegistration ?
+          <><FontAwesomeIcon icon={faCircle} className={'fa-xs text-success'}/> Live</> :
+          <><FontAwesomeIcon icon={faCircle} className={'fa-xs text-muted'}/> Closed</>}
+      </>
     }
   }, {
     header: 'Website',

--- a/ui-admin/src/HomePage.tsx
+++ b/ui-admin/src/HomePage.tsx
@@ -127,11 +127,11 @@ function PortalList({ portalList }: { portalList: Portal[] }) {
     header: 'Website',
     cell: ({ row }) => {
       const portal = row.original
-      const portalEnv = portal.portalEnvironments?.find(pe => pe.environmentName === 'live')
+      const livePortalEnv = portal.portalEnvironments?.find(pe => pe.environmentName === 'live')
       return (
-        portalEnv ?
-          <a href={Api.getParticipantLink(portalEnv.portalEnvironmentConfig, zoneConfig.participantUiHostname,
-            portal.shortcode, portalEnv.environmentName)} target="_blank">
+        livePortalEnv ?
+          <a href={Api.getParticipantLink(livePortalEnv.portalEnvironmentConfig, zoneConfig.participantUiHostname,
+            portal.shortcode, livePortalEnv.environmentName)} target="_blank">
                 Participant website <FontAwesomeIcon icon={faExternalLink}/>
           </a> :
           <span className="text-muted">Website not initialized</span>)
@@ -142,8 +142,8 @@ function PortalList({ portalList }: { portalList: Portal[] }) {
   }, {
     header: 'Created',
     accessorFn: portal => {
-      //Sandbox was the very first environment created, so we'll run with that.
-      //'Date Launched' could potentially be a better field to use, though
+      // Sandbox was the very first environment created, so we'll use that to determine createdDate.
+      //'Date Launched' could potentially be a better field to display, though
       const createdDate = portal.portalEnvironments?.find(pe =>
         pe.environmentName === 'sandbox')?.createdAt
       return instantToDateString(createdDate)

--- a/ui-admin/src/HomePage.tsx
+++ b/ui-admin/src/HomePage.tsx
@@ -19,7 +19,9 @@ function HomePage() {
   const filteredPortalList = useMemo(() => portalList.filter(portal =>
     portal.name.toLowerCase().includes(portalSearch.toLowerCase()) ||
     portal.portalStudies.some(portalStudy => portalStudy.study.name.toLowerCase().includes(portalSearch.toLowerCase()))
-  ), [portalList, portalSearch])
+  )
+    .sort((a, b) => a.name.localeCompare(b.name)),
+  [portalList, portalSearch])
 
   return <div className="container" style={{ minHeight: '100vh' }}>
     <h1 className="h2 d-flex justify-content-center pb-2">Select a portal</h1>

--- a/ui-admin/src/navbar/AdminSidebar.tsx
+++ b/ui-admin/src/navbar/AdminSidebar.tsx
@@ -33,7 +33,7 @@ const AdminSidebar = ({ config }: { config: Config }) => {
     studyList = portalList.flatMap(portal => portal.portalStudies.map(ps => ps.study))
   }
 
-  if (!user) {
+  if (!user || (!user.superuser && !portalShortcode)) {
     return <div></div>
   }
   const currentStudy = studyList.find(study => study.shortcode === studyShortcode)

--- a/ui-admin/src/portal/PortalDashboard.tsx
+++ b/ui-admin/src/portal/PortalDashboard.tsx
@@ -1,19 +1,95 @@
-import React from 'react'
+import React, { useState } from 'react'
 
-import { Portal } from 'api/api'
-import PortalEnvView from './PortalEnvView'
-const ENV_SORT_ORDER = ['sandbox', 'irb', 'live']
+import { getMediaUrl, Portal, Study } from 'api/api'
+import { renderPageHeader } from 'util/pageUtils'
+import DeleteStudyModal from 'study/adminTasks/DeleteStudyModal'
+import { useNavContext } from 'navbar/NavContextProvider'
+import { faEllipsisH, faPlus } from '@fortawesome/free-solid-svg-icons'
+import { Button, IconButton } from 'components/forms/Button'
+import { studyParticipantsPath } from './PortalRouter'
+import { Link } from 'react-router-dom'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { useUser } from 'user/UserProvider'
+import CreateNewStudyModal from 'study/CreateNewStudyModal'
+
 /** Page an admin user sees immediately after logging in */
 export default function PortalDashboard({ portal }: {portal: Portal}) {
-  const sortedEnvs = portal.portalEnvironments.sort((pa, pb) =>
-    ENV_SORT_ORDER.indexOf(pa.environmentName) - ENV_SORT_ORDER.indexOf(pb.environmentName))
+  const { user } = useUser()
+  const [showNewStudyModal, setShowNewStudyModal] = useState(false)
   return <div className="p-4 container">
     <div className="row">
-      <ul className="list-unstyled">
-        { sortedEnvs.map(portalEnv => <li key={portalEnv.environmentName}>
-          <PortalEnvView portalEnv={portalEnv} portal={portal}/>
-        </li>)}
-      </ul>
+      {renderPageHeader(portal.name)}
+      <div className="d-flex mt-2">
+        <div className="w-100 pe-5">
+          <ul className="list-group list-group-flush fs-5 list-unstyled">
+            <li key={portal.shortcode}>
+              <span className={'mt-2'}>Studies</span>
+              {portal.portalStudies.length === 0 &&
+                  <ul className="list-group list-group-flush fst-italic my-1">
+                    <li className="list-group-item my-1 border border-secondary-subtle text-muted rounded">
+                      No studies
+                    </li>
+                  </ul>}
+              <ul className="list-group list-group-flush ">
+                {portal.portalStudies.sort((a, b) => a.study.name.localeCompare(b.study.name)).map(portalStudy => {
+                  const study = portalStudy.study
+                  return <li key={`${portal.shortcode}-${study.shortcode}`}
+                    className="list-group-item my-1 border border-secondary-subtle rounded">
+                    <Link to={studyParticipantsPath(portal.shortcode, study.shortcode, 'live')}>
+                      <img
+                        src={getMediaUrl(portal.shortcode, 'favicon.ico', 'latest')}
+                        className="me-3" style={{ maxHeight: '1.5em' }} alt={study.name}/>
+                      {study.name}
+                    </Link>
+                    <StudyOptions study={study} portal={portal}/>
+                  </li>
+                })}
+              </ul>
+            </li>
+          </ul>
+          {user?.superuser && <Button variant='secondary' onClick={() => setShowNewStudyModal(true)}>
+            <FontAwesomeIcon icon={faPlus}/> Add a study
+          </Button>}
+        </div>
+        {showNewStudyModal && <CreateNewStudyModal portal={portal} onDismiss={() => setShowNewStudyModal(false)}/>}
+      </div>
     </div>
   </div>
+}
+
+/**
+ *
+ */
+export function StudyOptions({ study, portal }: { study: Study, portal: Portal }) {
+  const [showDeleteStudyModal, setShowDeleteStudyModal] = useState(false)
+  const [selectedStudy, setSelectedStudy] = useState<Study>()
+  const [selectedPortal, setSelectedPortal] = useState<Portal>()
+  const { reload } = useNavContext()
+
+  return <span className="dropdown">
+    <span className="nav-item dropdown ms-1">
+      <IconButton icon={faEllipsisH} data-bs-toggle="dropdown"
+        aria-expanded="false" aria-label="Configure Study"/>
+      <div className="dropdown-menu">
+        <ul className="list-unstyled">
+          <li>
+            <button className="dropdown-item"
+              onClick={
+                () => {
+                  setShowDeleteStudyModal(!showDeleteStudyModal)
+                  setSelectedStudy(study)
+                  setSelectedPortal(portal)
+                }}>Delete
+            </button>
+            {selectedStudy && showDeleteStudyModal && selectedPortal &&
+                <DeleteStudyModal study={selectedStudy}
+                  portal={selectedPortal}
+                  reload={reload}
+                  onDismiss={() => setShowDeleteStudyModal(false)}/>
+            }
+          </li>
+        </ul>
+      </div>
+    </span>
+  </span>
 }

--- a/ui-admin/src/portal/PortalDashboard.tsx
+++ b/ui-admin/src/portal/PortalDashboard.tsx
@@ -58,7 +58,7 @@ export default function PortalDashboard({ portal }: {portal: Portal}) {
 }
 
 /**
- *
+ * Dropdown menu for study options
  */
 export function StudyOptions({ study, portal }: { study: Study, portal: Portal }) {
   const [showDeleteStudyModal, setShowDeleteStudyModal] = useState(false)

--- a/ui-admin/src/portal/publish/PortalEnvPublishControl.test.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvPublishControl.test.tsx
@@ -16,7 +16,8 @@ test('renders a copy link', () => {
       password: '',
       defaultLanguage: 'en'
     },
-    supportedLanguages: []
+    supportedLanguages: [],
+    createdAt: 0
   }
   const irbEnv :PortalEnvironment = {
     environmentName: 'irb',
@@ -27,7 +28,8 @@ test('renders a copy link', () => {
       password: '',
       defaultLanguage: 'en'
     },
-    supportedLanguages: []
+    supportedLanguages: [],
+    createdAt: 0
   }
   const portal: Portal = {
     id: '11111111-1111-1111-1111-111111111111',

--- a/ui-admin/src/study/CreateNewStudyModal.test.tsx
+++ b/ui-admin/src/study/CreateNewStudyModal.test.tsx
@@ -3,11 +3,12 @@ import { render, screen } from '@testing-library/react'
 import React from 'react'
 import CreateNewStudyModal from './CreateNewStudyModal'
 import userEvent from '@testing-library/user-event'
+import { mockPortal } from '../test-utils/mocking-utils'
 
 describe('CreateNewStudyModal', () => {
   test('enables Create button when survey name and stable ID are filled out', async () => {
     const user = userEvent.setup()
-    render(<CreateNewStudyModal onDismiss={jest.fn()}/>)
+    render(<CreateNewStudyModal onDismiss={jest.fn()} portal={mockPortal()}/>)
 
     const nameInput = screen.getByLabelText('Study name')
     const stableIdInput = screen.getByLabelText('Study shortcode')

--- a/ui-admin/src/study/CreateNewStudyModal.test.tsx
+++ b/ui-admin/src/study/CreateNewStudyModal.test.tsx
@@ -10,8 +10,8 @@ describe('CreateNewStudyModal', () => {
     const user = userEvent.setup()
     render(<CreateNewStudyModal onDismiss={jest.fn()} portal={mockPortal()}/>)
 
-    const nameInput = screen.getByLabelText('Study name')
-    const stableIdInput = screen.getByLabelText('Study shortcode')
+    const nameInput = screen.getByLabelText('Study Name')
+    const stableIdInput = screen.getByLabelText('Study Shortcode')
     expect(screen.getByText('Create')).toHaveAttribute('aria-disabled', 'true')
     await user.type(nameInput, 'Test study')
     await user.type(stableIdInput, 'teststudy')

--- a/ui-admin/src/study/CreateNewStudyModal.tsx
+++ b/ui-admin/src/study/CreateNewStudyModal.tsx
@@ -3,7 +3,6 @@ import Modal from 'react-bootstrap/Modal'
 import { useNavContext } from '../navbar/NavContextProvider'
 import Select from 'react-select'
 import { Portal } from '@juniper/ui-core'
-import useReactSingleSelect from 'util/react-select-utils'
 import LoadingSpinner from '../util/LoadingSpinner'
 import Api, { StudyTemplate } from '../api/api'
 import { doApiLoad } from '../api/api-utils'
@@ -13,8 +12,8 @@ import InfoPopup from 'components/forms/InfoPopup'
 import { Button } from 'components/forms/Button'
 
 /** allows users to select a portal and then create a study within that portal */
-export default function CreateNewStudyModal({ onDismiss }: {onDismiss: () => void}) {
-  const { portalList, reload } = useNavContext()
+export default function CreateNewStudyModal({ portal, onDismiss }: { portal: Portal, onDismiss: () => void }) {
+  const { reload } = useNavContext()
   const [studyName, setStudyName] = useState('')
   const [studyShortcode, setStudyShortcode] = useState('')
   const [template, setTemplate] = useState<{ value: string, label: string } | undefined>(
@@ -23,19 +22,11 @@ export default function CreateNewStudyModal({ onDismiss }: {onDismiss: () => voi
   const templateOptions = [
     { value: 'BASIC', label: 'Basic' }
   ]
-  const [selectedPortal, setSelectedPortal] = useState<Portal | undefined>(portalList[0])
-  const { onChange, options, selectedOption, selectInputId } =
-        useReactSingleSelect(
-          portalList,
-          (portal: Portal) => ({ label: portal.name, value: portal }),
-          setSelectedPortal,
-          selectedPortal)
 
   const [isLoading, setIsLoading] = useState(false)
   const createStudy = async () => {
-    if (!selectedPortal) { return }
     doApiLoad(async () => {
-      await Api.createStudy(selectedPortal.shortcode, {
+      await Api.createStudy(portal.shortcode, {
         shortcode: studyShortcode, name: studyName, template: template?.value as StudyTemplate
       })
       Store.addNotification(successNotification('Study created'))
@@ -48,18 +39,14 @@ export default function CreateNewStudyModal({ onDismiss }: {onDismiss: () => voi
       <Modal.Title>Create study</Modal.Title>
     </Modal.Header>
     <Modal.Body>
-      <form onSubmit={e => e.preventDefault()} className="py-3">
-        <label htmlFor={selectInputId}>
-                    Portal:
-        </label>
-        <Select inputId={selectInputId} options={options} value={selectedOption} onChange={onChange}/>
-        <label className="form-label mt-3" htmlFor="studyName">
-                    Study name
+      <form onSubmit={e => e.preventDefault()}>
+        <label className="form-label" htmlFor="studyName">
+          Study Name
         </label>
         <input type="text" size={20} id="studyName" className="form-control" value={studyName}
           onChange={e => setStudyName(e.target.value)}/>
         <label className="form-label mt-3" htmlFor="studyShortcode">
-                    Study shortcode
+          Study Shortcode
         </label>
         <InfoPopup content={`Unique identifier that will be used in urls and data exports to 
                     indicate this study.  Must be all lowercase with no spaces`}/>

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -89,7 +89,8 @@ export const mockPortalEnvironment: (envName: string) => PortalEnvironment = (en
   supportedLanguages: [
     { languageCode: 'en', languageName: 'English' },
     { languageCode: 'es', languageName: 'Spanish' }
-  ]
+  ],
+  createdAt: 0
 })
 
 

--- a/ui-core/src/types/portal.ts
+++ b/ui-core/src/types/portal.ts
@@ -25,7 +25,8 @@ export type PortalEnvironment = {
   supportedLanguages: PortalEnvironmentLanguage[]
   siteContent?: SiteContent
   preRegSurvey?: Survey
-  preRegSurveyId?: string
+  preRegSurveyId?: string,
+  createdAt: number
 }
 
 export type PortalEnvironmentConfig = {

--- a/ui-participant/src/test-utils/ProvideFullTestUserContext.tsx
+++ b/ui-participant/src/test-utils/ProvideFullTestUserContext.tsx
@@ -32,6 +32,7 @@ export default function ProvideFullTestUserContext(
       shortcode: '',
       portalEnvironments: [
         {
+          createdAt: 0,
           environmentName: 'sandbox',
           portalEnvironmentConfig: {
             initialized: true,

--- a/ui-participant/src/test-utils/test-portal-factory.tsx
+++ b/ui-participant/src/test-utils/test-portal-factory.tsx
@@ -52,6 +52,7 @@ export const mockStudyEnv = (): StudyEnvironment => {
 /** mock environment with a siteContent */
 export const mockPortalEnvironment = (): PortalEnvironment => {
   return {
+    createdAt: 0,
     environmentName: 'sandbox',
     portalEnvironmentConfig: mockPortalEnvironmentConfig(),
     siteContent: mockSiteContent(),

--- a/ui-participant/src/test-utils/test-proxy-environment.tsx
+++ b/ui-participant/src/test-utils/test-proxy-environment.tsx
@@ -7,6 +7,7 @@ export const mockPortal: Portal = {
   shortcode: 'TESTPORTAL',
   portalEnvironments: [
     {
+      createdAt: 0,
       environmentName: 'sandbox',
       portalEnvironmentConfig: {
         initialized: true,


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Implements two new views for the admin landing page

Grid view
<img width="1191" alt="Screenshot 2024-06-03 at 12 13 35 AM" src="https://github.com/broadinstitute/juniper/assets/7257391/0bb7cde4-a08e-4e41-9028-711587545e21">

List view
<img width="1197" alt="Screenshot 2024-06-04 at 4 56 46 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/6d8b150e-ca9b-44cd-9073-846080ce6a8c">

Portal dashboard. Not much here yet- but we'll add some portal-level widgets as we move portal stuff out of the study sidebar:
<img width="1193" alt="Screenshot 2024-06-03 at 12 13 53 AM" src="https://github.com/broadinstitute/juniper/assets/7257391/9ac29f2d-3237-429d-bf9f-25b439f62ec9">

For non-super admins, when on the homepage, the sidebar is hidden (there's nothing for them to see anyway). If a user only has one portal, they'll still be automatically redirected to it:
<img width="1153" alt="Screenshot 2024-06-03 at 12 14 08 AM" src="https://github.com/broadinstitute/juniper/assets/7257391/4ea8c9c5-0252-416f-b9ae-e9ded7d0883d">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Populate a bunch of new studies
* Log in as a super-user and try out the new grid and list views for the portal home
* Make sure there aren't any related regressions
* Log in as a regular study staff user with only one portal and verify that they are redirected to their primary study when logging in
* Click back to landing page and verify that the sidebar is hidden