### PR TITLE
[JN-1096] save anwer types on pre-enroll

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
@@ -135,11 +135,13 @@ public class EnrollmentService {
         // otherwise create a new one for them
         Enrollee enrollee = findOrCreateEnrolleeForEnrollment(user, ppUser, studyEnv, studyShortcode, preEnrollResponseId, isSubject);
 
+        System.out.println("HUH?");
         if (preEnrollResponse != null) {
             preEnrollResponse.setCreatingParticipantUserId(user.getId());
             preEnrollResponse.setPortalParticipantUserId(ppUser.getId());
             preEnrollmentResponseDao.update(preEnrollResponse);
 
+            System.out.println("We boutta backfill");
             // backfill the enrollee with the pre-enrollment response data
             this.backfillPreEnrollResponse(operator, enrollee, preEnrollResponse);
         }
@@ -181,6 +183,8 @@ public class EnrollmentService {
 
     private void backfillPreEnrollResponse(PortalParticipantUser operator, Enrollee enrollee, PreEnrollmentResponse preEnrollResponse) {
         if (Objects.isNull(preEnrollResponse) || StringUtil.isEmpty(preEnrollResponse.getFullData())) {
+            System.out.println("Oh nooooo");
+            System.out.println(preEnrollResponse.getFullData());
             return;
         }
 
@@ -381,6 +385,7 @@ public class EnrollmentService {
         if (preEnrollResponseId != null && isProxyEnrollment(environmentName, studyShortcode, preEnrollResponseId)) {
             return enrollAsProxy(environmentName, studyShortcode, user, portalParticipantUser, preEnrollResponseId);
         }
+        System.out.println("not proxy");
         return enroll(portalParticipantUser, environmentName, studyShortcode, user, portalParticipantUser, preEnrollResponseId, true);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
@@ -135,13 +135,11 @@ public class EnrollmentService {
         // otherwise create a new one for them
         Enrollee enrollee = findOrCreateEnrolleeForEnrollment(user, ppUser, studyEnv, studyShortcode, preEnrollResponseId, isSubject);
 
-        System.out.println("HUH?");
         if (preEnrollResponse != null) {
             preEnrollResponse.setCreatingParticipantUserId(user.getId());
             preEnrollResponse.setPortalParticipantUserId(ppUser.getId());
             preEnrollmentResponseDao.update(preEnrollResponse);
 
-            System.out.println("We boutta backfill");
             // backfill the enrollee with the pre-enrollment response data
             this.backfillPreEnrollResponse(operator, enrollee, preEnrollResponse);
         }
@@ -183,8 +181,6 @@ public class EnrollmentService {
 
     private void backfillPreEnrollResponse(PortalParticipantUser operator, Enrollee enrollee, PreEnrollmentResponse preEnrollResponse) {
         if (Objects.isNull(preEnrollResponse) || StringUtil.isEmpty(preEnrollResponse.getFullData())) {
-            System.out.println("Oh nooooo");
-            System.out.println(preEnrollResponse.getFullData());
             return;
         }
 
@@ -385,7 +381,6 @@ public class EnrollmentService {
         if (preEnrollResponseId != null && isProxyEnrollment(environmentName, studyShortcode, preEnrollResponseId)) {
             return enrollAsProxy(environmentName, studyShortcode, user, portalParticipantUser, preEnrollResponseId);
         }
-        System.out.println("not proxy");
         return enroll(portalParticipantUser, environmentName, studyShortcode, user, portalParticipantUser, preEnrollResponseId, true);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
@@ -192,6 +192,8 @@ public class EnrollmentService {
             throw new IllegalStateException("Invalid pre-enrollment response data: " + e.getMessage());
         }
 
+        answers.forEach(Answer::inferTypeIfMissing);
+
         PortalParticipantUser ppUser = portalParticipantUserService.findForEnrollee(enrollee);
 
         SurveyResponse surveyResponse =

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/participant/PortalParticipantUserFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/participant/PortalParticipantUserFactory.java
@@ -23,8 +23,6 @@ public class PortalParticipantUserFactory {
     StudyEnvironmentService studyEnvironmentService;
     @Autowired
     EnrolleeService enrolleeService;
-    @Autowired
-    ParticipantUserFactory participantUserFactory;
 
     /** creates a PortalParticipantUser for the given enrollee.  This will create a new portal and portal environment */
     public PortalParticipantUser buildPersisted(String testName, UUID enrolleeId) {

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/participant/PortalParticipantUserFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/participant/PortalParticipantUserFactory.java
@@ -8,9 +8,10 @@ import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.participant.PortalParticipantUserService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
-import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.UUID;
 
 @Component
 public class PortalParticipantUserFactory {
@@ -22,6 +23,8 @@ public class PortalParticipantUserFactory {
     StudyEnvironmentService studyEnvironmentService;
     @Autowired
     EnrolleeService enrolleeService;
+    @Autowired
+    ParticipantUserFactory participantUserFactory;
 
     /** creates a PortalParticipantUser for the given enrollee.  This will create a new portal and portal environment */
     public PortalParticipantUser buildPersisted(String testName, UUID enrolleeId) {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Saves answer types when backfilling the pre-enroll.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Fill out pre-enroll on heartdemo
- Execute `select question_stable_id, answer_type from answer where survey_stable_id='hd_hd_preenroll' order by created_at desc` locally to ensure that answer types exist on the latest pre-enroll response
