### PR TITLE
JN-1090 migration

### DIFF
--- a/pepper-import/build.gradle
+++ b/pepper-import/build.gradle
@@ -18,14 +18,14 @@ repositories {
 dependencies {
     implementation project(':core')
     implementation project(':populate')
-    implementation 'org.springframework.boot:spring-boot-starter:3.1.2'
+    implementation 'org.springframework.boot:spring-boot-starter:3.2.5'
     implementation group: 'org.jdbi', name: 'jdbi3-spring5', version: '3.34.0'
     implementation group: 'org.jdbi', name: 'jdbi3-sqlobject', version: '3.34.0'
     implementation group: 'org.jdbi', name: 'jdbi3-postgres', version: '3.34.0'
     implementation 'org.apache.commons:commons-text:1.10.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:3.1.2'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:3.1.2'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:3.2.5'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:3.2.5'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
     implementation 'org.yaml:snakeyaml:2.0'
     implementation 'com.typesafe:config:1.4.1'
@@ -37,7 +37,6 @@ dependencies {
     implementation files('libs/pepper-apis/studybuilder-cli-1.0.0-SNAPSHOT.jar')
 
 
-
     testImplementation 'org.apache.commons:commons-text:1.10.0'
     testImplementation 'org.hamcrest:hamcrest:2.2'
     testImplementation 'com.github.seregamorph:hamcrest-more-matchers:0.1'
@@ -45,7 +44,7 @@ dependencies {
 }
 
 test {
-    useJUnitPlatform ()
+    useJUnitPlatform()
     finalizedBy jacocoTestReport // report is always generated after tests run
 }
 

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
@@ -23,6 +23,7 @@ import org.broadinstitute.ddp.model.activity.definition.FormBlockDef;
 import org.broadinstitute.ddp.model.activity.definition.FormSectionDef;
 import org.broadinstitute.ddp.model.activity.definition.GroupBlockDef;
 import org.broadinstitute.ddp.model.activity.definition.i18n.Translation;
+import org.broadinstitute.ddp.model.activity.definition.question.BoolQuestionDef;
 import org.broadinstitute.ddp.model.activity.definition.question.PicklistOptionDef;
 import org.broadinstitute.ddp.model.activity.definition.question.PicklistQuestionDef;
 import org.broadinstitute.ddp.model.activity.definition.question.QuestionDef;
@@ -141,6 +142,21 @@ public class ActivityImporter {
                         questionText = i18nContentRenderer.renderToString(textQuestionDef.getPlaceholderTemplate().getTemplateText(), allLangMap.get(lang));
                     }
                 }
+                if (questionText.contains("$")) {
+                    //get txt from variable
+                    if (pepperQuestionDef.getQuestionType().equals(QuestionType.TEXT)) {
+                        TextQuestionDef textQuestionDef = (TextQuestionDef) pepperQuestionDef;
+                        Translation translation = textQuestionDef.getPromptTemplate().getVariables().stream().findAny().get().getTranslation(lang).orElse(null);
+                        if (translation != null) {
+                            questionText = translation.getText();
+                        }
+                    }
+                    if (pepperQuestionDef.getQuestionType().equals(QuestionType.BOOLEAN)) {
+                        BoolQuestionDef boolQuestionDef = (BoolQuestionDef) pepperQuestionDef;
+                        questionText = boolQuestionDef.getPromptTemplate().getVariables().stream().findFirst().get().getTranslation(lang).get().getText();
+                    }
+                }
+
                 titleMap.put(lang, questionText);
             }
             String questionType = pepperQuestionDef.getQuestionType().name();

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
@@ -5,7 +5,6 @@ import bio.terra.pearl.core.service.participant.RandomUtilService;
 import bio.terra.pearl.pepper.dto.SurveyJSContent;
 import bio.terra.pearl.pepper.dto.SurveyJSQuestion;
 import bio.terra.pearl.populate.dto.survey.SurveyPopDto;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -59,7 +58,7 @@ public class ActivityImporter {
         this.randomUtilService = randomUtilService;
     }
 
-    public Survey parsePepperForm(Config varsConfig, Path dirPath, Path path) throws JsonProcessingException {
+    public Survey parsePepperForm(Config varsConfig, Path dirPath, Path path) {
         File file = dirPath.resolve(path).toFile();
         if (!file.exists()) {
             throw new RuntimeException("Activity definition file is missing: " + file);
@@ -90,7 +89,7 @@ public class ActivityImporter {
         return activityDef;
     }
 
-    public SurveyPopDto convert(FormActivityDef activityDef, Map<String, Map<String, Object>> allLangMap) throws JsonProcessingException {
+    public SurveyPopDto convert(FormActivityDef activityDef, Map<String, Map<String, Object>> allLangMap) {
         SurveyPopDto survey = SurveyPopDto.builder()
                 .stableId(activityDef.getActivityCode())
                 .version(1)

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
@@ -14,6 +14,8 @@ import com.google.gson.Gson;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigResolveOptions;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.content.I18nContentRenderer;
@@ -22,6 +24,7 @@ import org.broadinstitute.ddp.model.activity.definition.FormActivityDef;
 import org.broadinstitute.ddp.model.activity.definition.FormBlockDef;
 import org.broadinstitute.ddp.model.activity.definition.FormSectionDef;
 import org.broadinstitute.ddp.model.activity.definition.GroupBlockDef;
+import org.broadinstitute.ddp.model.activity.definition.i18n.Translation;
 import org.broadinstitute.ddp.model.activity.definition.question.PicklistOptionDef;
 import org.broadinstitute.ddp.model.activity.definition.question.PicklistQuestionDef;
 import org.broadinstitute.ddp.model.activity.definition.question.QuestionDef;
@@ -50,6 +53,8 @@ public class ActivityImporter {
     private final I18nContentRenderer i18nContentRenderer = new I18nContentRenderer();
     private final RandomUtilService randomUtilService;
     private final String[] languages = {"en", "es", "de", "fr", "hi", "it", "ja", "pl", "pt", "ru", "tr", "zh"};
+    public List<CalculatedValue> calculatedValues = new ArrayList<>();
+
 
     public ActivityImporter(ObjectMapper objectMapper, RandomUtilService randomUtilService) {
         this.objectMapper = objectMapper;
@@ -96,6 +101,7 @@ public class ActivityImporter {
 
         ObjectNode root = objectMapper.createObjectNode();
         ArrayNode pages = root.putArray("pages");
+        ArrayNode calculatedVals = root.putArray("calculatedValues");
         for (FormSectionDef section : activityDef.getAllSections()) {
             ObjectNode page = objectMapper.createObjectNode();
             pages.add(page);
@@ -121,88 +127,104 @@ public class ActivityImporter {
 
                 //todo .. add expressions / calculatedValues
                 //todo dynamic text.. conditional logic..
-                for (QuestionDef pepperQuestionDef : blockDef.getQuestions().toList()) {
-                    //Map<String, String> questionTxtTrans = new HashMap<>();
-                    Map<String, String> titleMap = new HashMap<>();
-                    for (String lang : allLangMap.keySet()) {
-                        String questionText = i18nContentRenderer.renderToString(pepperQuestionDef.getPromptTemplate().getTemplateText(), allLangMap.get(lang));
-                        if (StringUtils.isEmpty(questionText)) {
-                            if (pepperQuestionDef.getQuestionType().equals(QuestionType.TEXT)) {
-                                TextQuestionDef textQuestionDef = (TextQuestionDef) pepperQuestionDef;
-                                questionText = i18nContentRenderer.renderToString(textQuestionDef.getPlaceholderTemplate().getTemplateText(), allLangMap.get(lang));
-                            }
-                        }
-                        titleMap.put(lang, questionText);
-                    }
-                    String questionType = pepperQuestionDef.getQuestionType().name();
-                    String inputType = null;
-                    if (questionType.equalsIgnoreCase("DATE")) {
-                        questionType = "TEXT";
-                        inputType = "DATE";
-                    }
-                    List<SurveyJSQuestion.Choice> choices = null;
-                    if (questionType.equalsIgnoreCase("PICKLIST")) {
-                        choices = new ArrayList<>();
-                        questionType = "dropdown";
-                        inputType = null;
-                        PicklistQuestionDef picklistQuestionDef = (PicklistQuestionDef) pepperQuestionDef;
-                        if (picklistQuestionDef.getRenderMode() == PicklistRenderMode.LIST
-                                && picklistQuestionDef.getSelectMode() == PicklistSelectMode.SINGLE
-                                && picklistQuestionDef.getRenderMode() != PicklistRenderMode.DROPDOWN) {
-                            questionType = "radiogroup";
-                        }
-                        if (picklistQuestionDef.getRenderMode() == PicklistRenderMode.LIST && picklistQuestionDef.getSelectMode() == PicklistSelectMode.MULTIPLE) {
-                            questionType = "checkbox";
-                        }
-                        for (PicklistOptionDef option : picklistQuestionDef.getPicklistOptions()) {
-                            ObjectNode choiceNode = objectMapper.createObjectNode();
-                            choiceNode.put("value", option.getStableId());
-                            String optTxt = i18nContentRenderer.renderToString(option.getOptionLabelTemplate().getTemplateText(), allLangMap.get("en"));
-                            if (optTxt != null && optTxt.startsWith("$")) {
-                                optTxt = option.getOptionLabelTemplate().getVariables().stream().findAny().get().getTranslation("en").get().getText();
-                            }
-                            choices.add(new SurveyJSQuestion.Choice(optTxt, option.getStableId()));
-                        }
-                    }
-
-                    //todo calculated values
-                    List<SurveyJSQuestion.CalculatedValue> calculatedValues = null;
-                    if (!StringUtils.isEmpty(blockDef.getShownExpr())) {
-                        calculatedValues = new ArrayList<>();
-                        //populate calculated values
-                        String name = null; //todo
-                        String expression = blockDef.getShownExpr();
-                        //todo for now using pepper expressions. need to convert pepper expression into SurveyJS format
-                        SurveyJSQuestion.CalculatedValue calculatedValue = new SurveyJSQuestion.CalculatedValue(name, expression, "true");
-                        calculatedValues.add(calculatedValue);
-                    }
-
-                    SurveyJSQuestion surveyJSQuestion = SurveyJSQuestion.builder()
-                            .name(pepperQuestionDef.getStableId())
-                            .type(questionType)
-                            .title(titleMap)
-                            .required(false) //todo
-                            //.isRequired() //todo
-                            .inputType(inputType)
-                            .choices(choices)
-                            .calculatedValues(calculatedValues)
-                            .build();
-
-                    JsonNode questionNode = objectMapper.valueToTree(surveyJSQuestion);
-                    elements.add(questionNode);
-                }
+                elements.addAll(convertBlockQuestions(allLangMap, blockDef));
             }
         }
+        for (CalculatedValue cval : calculatedValues) {
+            ObjectNode calcVal = objectMapper.createObjectNode();
+            calcVal.put("name", cval.name);
+            calcVal.put("expression", cval.expression);
+            calcVal.put("expression", cval.expression);
+            calculatedVals.add(calcVal);
+        }
+
         survey.setJsonContent(root);
         return survey;
+    }
+
+    private List<JsonNode> convertBlockQuestions(Map<String, Map<String, Object>> allLangMap, FormBlockDef blockDef) {
+        List<JsonNode> questionNodes = new ArrayList<>();
+        for (QuestionDef pepperQuestionDef : blockDef.getQuestions().toList()) {
+            //Map<String, String> questionTxtTrans = new HashMap<>();
+            Map<String, String> titleMap = new HashMap<>();
+            for (String lang : allLangMap.keySet()) {
+                String questionText = i18nContentRenderer.renderToString(pepperQuestionDef.getPromptTemplate().getTemplateText(), allLangMap.get(lang));
+                if (StringUtils.isEmpty(questionText)) {
+                    if (pepperQuestionDef.getQuestionType().equals(QuestionType.TEXT)) {
+                        TextQuestionDef textQuestionDef = (TextQuestionDef) pepperQuestionDef;
+                        questionText = i18nContentRenderer.renderToString(textQuestionDef.getPlaceholderTemplate().getTemplateText(), allLangMap.get(lang));
+                    }
+                }
+                titleMap.put(lang, questionText);
+            }
+            String questionType = pepperQuestionDef.getQuestionType().name();
+            String inputType = null;
+            if (questionType.equalsIgnoreCase("DATE")) {
+                questionType = "TEXT";
+                inputType = "DATE";
+            }
+            List<SurveyJSQuestion.Choice> choices = null;
+            if (questionType.equalsIgnoreCase("PICKLIST")) {
+                choices = new ArrayList<>();
+                questionType = "dropdown";
+                inputType = null;
+                PicklistQuestionDef picklistQuestionDef = (PicklistQuestionDef) pepperQuestionDef;
+                if (picklistQuestionDef.getRenderMode() == PicklistRenderMode.LIST
+                        && picklistQuestionDef.getSelectMode() == PicklistSelectMode.SINGLE
+                        && picklistQuestionDef.getRenderMode() != PicklistRenderMode.DROPDOWN) {
+                    questionType = "radiogroup";
+                }
+                if (picklistQuestionDef.getRenderMode() == PicklistRenderMode.LIST && picklistQuestionDef.getSelectMode() == PicklistSelectMode.MULTIPLE) {
+                    questionType = "checkbox";
+                }
+                for (PicklistOptionDef option : picklistQuestionDef.getPicklistOptions()) {
+                    ObjectNode choiceNode = objectMapper.createObjectNode();
+                    choiceNode.put("value", option.getStableId());
+                    Map<String, String> choiceTranslations = new HashMap<>();
+                    for (String lang : allLangMap.keySet()) {
+                        String optTxt = i18nContentRenderer.renderToString(option.getOptionLabelTemplate().getTemplateText(), allLangMap.get(lang));
+                        if (optTxt != null && optTxt.startsWith("$")) {
+                            Translation translation = option.getOptionLabelTemplate().getVariables().stream().findAny().get().getTranslation(lang).orElse(null);
+                            if (translation != null) {
+                                optTxt = option.getOptionLabelTemplate().getVariables().stream().findAny().get().getTranslation(lang).get().getText();
+                                choiceTranslations.put(lang, optTxt);
+                            }
+                        }
+                    }
+                    choices.add(new SurveyJSQuestion.Choice(choiceTranslations, option.getStableId()));
+                }
+            }
+
+            //todo calculated values
+            if (!StringUtils.isEmpty(blockDef.getShownExpr())) {
+                //populate calculated values
+                String name = pepperQuestionDef.getStableId(); //todo.. change as per SurveyJS
+                String expression = blockDef.getShownExpr();
+                //todo for now using pepper expressions. need to convert pepper expression into SurveyJS format
+                CalculatedValue calculatedValue = new CalculatedValue(name, expression, "true");
+                calculatedValues.add(calculatedValue);
+            }
+
+            SurveyJSQuestion surveyJSQuestion = SurveyJSQuestion.builder()
+                    .name(pepperQuestionDef.getStableId())
+                    .type(questionType)
+                    .title(titleMap)
+                    .required(false) //todo
+                    //.isRequired() //todo
+                    .inputType(inputType)
+                    .choices(choices)
+                    .build();
+
+            JsonNode questionNode = objectMapper.valueToTree(surveyJSQuestion);
+            questionNodes.add(questionNode);
+        }
+        return questionNodes;
     }
 
     private JsonNode getJsonNodeForContentBlock(Map<String, Map<String, Object>> allLangMap, ContentBlockDef blockDef) {
         ContentBlockDef contentBlockDef = blockDef;
         String titleTemplateTxt = contentBlockDef.getTitleTemplate() != null ? contentBlockDef.getTitleTemplate().getTemplateText() : null;
         String bodyTemplateTxt = contentBlockDef.getBodyTemplate() != null ? contentBlockDef.getBodyTemplate().getTemplateText() : null;
-        //log.info("Title template: {}", titleTemplateTxt); //todo title template ?
-        //log.info("Body template: {}", bodyTemplateTxt);
         Map<String, String> titleMap = new HashMap<>();
         for (String lang : allLangMap.keySet()) {
             String tmplText = i18nContentRenderer.renderToString(bodyTemplateTxt, allLangMap.get(lang));
@@ -217,5 +239,14 @@ public class ActivityImporter {
         JsonNode contentNode = objectMapper.valueToTree(surveyJSContent);
         return contentNode;
     }
+
+    @AllArgsConstructor
+    @Data
+    public static class CalculatedValue {
+        public String name;
+        public String expression;
+        public String includeIntoResult;
+    }
+
 
 }

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
@@ -125,8 +125,7 @@ public class ActivityImporter {
                     }
                 }
 
-                //todo .. add expressions / calculatedValues
-                //todo dynamic text.. conditional logic..
+                //need to handle expressions / calculatedValues .. dynamic text.. conditional logic.
                 elements.addAll(convertBlockQuestions(allLangMap, blockDef));
             }
         }
@@ -134,7 +133,7 @@ public class ActivityImporter {
             ObjectNode calcVal = objectMapper.createObjectNode();
             calcVal.put("name", cval.name);
             calcVal.put("expression", cval.expression);
-            calcVal.put("expression", cval.expression);
+            calcVal.put("includeIntoResult", cval.includeIntoResult);
             calculatedVals.add(calcVal);
         }
 
@@ -145,7 +144,6 @@ public class ActivityImporter {
     private List<JsonNode> convertBlockQuestions(Map<String, Map<String, Object>> allLangMap, FormBlockDef blockDef) {
         List<JsonNode> questionNodes = new ArrayList<>();
         for (QuestionDef pepperQuestionDef : blockDef.getQuestions().toList()) {
-            //Map<String, String> questionTxtTrans = new HashMap<>();
             Map<String, String> titleMap = new HashMap<>();
             for (String lang : allLangMap.keySet()) {
                 String questionText = i18nContentRenderer.renderToString(pepperQuestionDef.getPromptTemplate().getTemplateText(), allLangMap.get(lang));
@@ -195,10 +193,10 @@ public class ActivityImporter {
                 }
             }
 
-            //todo calculated values
+            //calculated values
             if (!StringUtils.isEmpty(blockDef.getShownExpr())) {
                 //populate calculated values
-                String name = pepperQuestionDef.getStableId(); //todo.. change as per SurveyJS
+                String name = pepperQuestionDef.getStableId(); //change as per SurveyJS
                 String expression = blockDef.getShownExpr();
                 //todo for now using pepper expressions. need to convert pepper expression into SurveyJS format
                 CalculatedValue calculatedValue = new CalculatedValue(name, expression, "true");
@@ -223,7 +221,7 @@ public class ActivityImporter {
 
     private JsonNode getJsonNodeForContentBlock(Map<String, Map<String, Object>> allLangMap, ContentBlockDef blockDef) {
         ContentBlockDef contentBlockDef = blockDef;
-        String titleTemplateTxt = contentBlockDef.getTitleTemplate() != null ? contentBlockDef.getTitleTemplate().getTemplateText() : null;
+        String titleTemplateTxt = contentBlockDef.getTitleTemplate() != null ? contentBlockDef.getTitleTemplate().getTemplateText() : null; //where to set this title txt ?
         String bodyTemplateTxt = contentBlockDef.getBodyTemplate() != null ? contentBlockDef.getBodyTemplate().getTemplateText() : null;
         Map<String, String> titleMap = new HashMap<>();
         for (String lang : allLangMap.keySet()) {
@@ -232,7 +230,7 @@ public class ActivityImporter {
         }
         String name = contentBlockDef.getBodyTemplate().getVariables().stream().findAny().get().getName();
         SurveyJSContent surveyJSContent = SurveyJSContent.builder()
-                .name(name) //todo generate name
+                .name(name)
                 .type("html")
                 .html(titleMap)
                 .build();
@@ -247,6 +245,5 @@ public class ActivityImporter {
         public String expression;
         public String includeIntoResult;
     }
-
 
 }

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
@@ -26,6 +26,7 @@ import org.broadinstitute.ddp.model.activity.definition.question.PicklistOptionD
 import org.broadinstitute.ddp.model.activity.definition.question.PicklistQuestionDef;
 import org.broadinstitute.ddp.model.activity.definition.question.QuestionDef;
 import org.broadinstitute.ddp.model.activity.definition.question.TextQuestionDef;
+import org.broadinstitute.ddp.model.activity.definition.template.TemplateVariable;
 import org.broadinstitute.ddp.model.activity.types.BlockType;
 import org.broadinstitute.ddp.model.activity.types.PicklistRenderMode;
 import org.broadinstitute.ddp.model.activity.types.PicklistSelectMode;
@@ -213,7 +214,7 @@ public class ActivityImporter {
         }
 
         if (questionText.contains("$")) {
-            //get txt from variable
+            //get txt from variables
             if (pepperQuestionDef.getQuestionType().equals(QuestionType.TEXT)) {
                 TextQuestionDef textQuestionDef = (TextQuestionDef) pepperQuestionDef;
                 Translation translation = textQuestionDef.getPromptTemplate().getVariables().stream().findAny().get().getTranslation(lang).orElse(null);
@@ -257,9 +258,20 @@ public class ActivityImporter {
         String bodyTemplateTxt = contentBlockDef.getBodyTemplate() != null ? contentBlockDef.getBodyTemplate().getTemplateText() : null;
         Map<String, String> htmlTxtMap = new HashMap<>();
         Map<String, String> titleTxtMap = new HashMap<>();
+        if (!StringUtils.isEmpty(bodyTemplateTxt) && bodyTemplateTxt.contains("$")) {
+            //get txt from variables
+            for (TemplateVariable var : contentBlockDef.getBodyTemplate().getVariables()) {
+                List<Translation> translations = var.getTranslations();
+                for (Translation t : translations) {
+                    htmlTxtMap.put(t.getLanguageCode(), t.getText());
+                }
+            }
+        }
         for (String lang : allLangMap.keySet()) {
             String tmplText = i18nContentRenderer.renderToString(bodyTemplateTxt, allLangMap.get(lang));
-            htmlTxtMap.put(lang, tmplText);
+            if (!StringUtils.isEmpty(tmplText) && !tmplText.contains("$")) {
+                htmlTxtMap.put(lang, tmplText);
+            }
             if (!StringUtils.isEmpty(titleTemplateTxt)) {
                 String titleText = i18nContentRenderer.renderToString(titleTemplateTxt, allLangMap.get(lang));
                 titleTxtMap.put(lang, titleText);

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
@@ -160,8 +160,8 @@ public class ActivityImporter {
                     .name(pepperQuestionDef.getStableId())
                     .type(questionType)
                     .title(titleMap)
-                    .required(false) //todo
-                    //.isRequired() //todo
+                    .required(false)
+                    //.isRequired() //revisit
                     .inputType(inputType)
                     .choices(choices)
                     .visibleIf(blockDef.getShownExpr())
@@ -177,7 +177,6 @@ public class ActivityImporter {
         String questionType = pepperQuestionDef.getQuestionType().name();
         if (questionType.equalsIgnoreCase("DATE")) {
             questionType = "TEXT";
-            //inputType = "DATE";
         }
         if (questionType.equalsIgnoreCase("AGREEMENT")) {
             questionType = "boolean";
@@ -185,7 +184,6 @@ public class ActivityImporter {
         List<SurveyJSQuestion.Choice> choices = null;
         if (questionType.equalsIgnoreCase("PICKLIST")) {
             questionType = "dropdown";
-            //inputType = null;
             PicklistQuestionDef picklistQuestionDef = (PicklistQuestionDef) pepperQuestionDef;
             if (picklistQuestionDef.getRenderMode() == PicklistRenderMode.LIST
                     && picklistQuestionDef.getSelectMode() == PicklistSelectMode.SINGLE

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
@@ -35,6 +35,7 @@ import org.springframework.stereotype.Service;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -200,19 +201,24 @@ public class ActivityImporter {
     }
 
     private Map<String, String> getQuestionTxt(QuestionDef pepperQuestionDef) {
-        Map<String, String> titleMap = new HashMap<>();
-        for (TemplateVariable var : pepperQuestionDef.getPromptTemplate().getVariables()) {
+        return getVariableTranslationsTxt(pepperQuestionDef.getPromptTemplate().getVariables());
+    }
+
+    private Map<String, String> getVariableTranslationsTxt(Collection<TemplateVariable> templateVariables) {
+        Map<String, String> txtMap = new HashMap<>();
+        for (TemplateVariable var : templateVariables) {
             List<Translation> translations = var.getTranslations();
             translations.forEach(t -> {
-                if (titleMap.containsKey(t.getLanguageCode())) {
-                    titleMap.put(t.getLanguageCode(), titleMap.get(t.getLanguageCode()) + "\n" + t.getText());
+                if (txtMap.containsKey(t.getLanguageCode())) {
+                    txtMap.put(t.getLanguageCode(), txtMap.get(t.getLanguageCode()) + "\n" + t.getText());
                 } else {
-                    titleMap.put(t.getLanguageCode(), t.getText());
+                    txtMap.put(t.getLanguageCode(), t.getText());
                 }
             });
         }
-        return titleMap;
+        return txtMap;
     }
+
 
     private List<SurveyJSQuestion.Choice> getPicklistChoices(PicklistQuestionDef picklistQuestionDef, Map<String, Map<String, Object>> allLangMap) {
         List<SurveyJSQuestion.Choice> choices = new ArrayList<>();
@@ -244,30 +250,11 @@ public class ActivityImporter {
         Map<String, String> titleTxtMap = new HashMap<>();
         if (!StringUtils.isEmpty(bodyTemplateTxt) && bodyTemplateTxt.contains("$")) {
             //get txt from variables
-            for (TemplateVariable var : contentBlockDef.getBodyTemplate().getVariables()) {
-                List<Translation> translations = var.getTranslations();
-                translations.forEach(t -> {
-                    if (htmlTxtMap.containsKey(t.getLanguageCode())) {
-                        htmlTxtMap.put(t.getLanguageCode(), htmlTxtMap.get(t.getLanguageCode()) + "\n" + t.getText());
-                    } else {
-                        htmlTxtMap.put(t.getLanguageCode(), t.getText());
-                    }
-                });
-            }
+            htmlTxtMap = getVariableTranslationsTxt(contentBlockDef.getBodyTemplate().getVariables());
         }
 
         if (!StringUtils.isEmpty(titleTemplateTxt) && titleTemplateTxt.contains("$")) {
-            //get txt from variables
-            for (TemplateVariable var : contentBlockDef.getTitleTemplate().getVariables()) {
-                List<Translation> translations = var.getTranslations();
-                for (Translation t : translations) {
-                    if (titleTxtMap.containsKey(t.getLanguageCode())) {
-                        titleTxtMap.put(t.getLanguageCode(), titleTxtMap.get(t.getLanguageCode()) + "\n" + t.getText());
-                    } else {
-                        titleTxtMap.put(t.getLanguageCode(), t.getText());
-                    }
-                }
-            }
+            titleTxtMap = getVariableTranslationsTxt(contentBlockDef.getTitleTemplate().getVariables());
         }
 
         String name = contentBlockDef.getBodyTemplate().getVariables().stream().findAny().get().getName();

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
@@ -161,6 +161,9 @@ public class ActivityImporter {
                 questionType = "TEXT";
                 inputType = "DATE";
             }
+            if (questionType.equalsIgnoreCase("AGREEMENT")) {
+                questionType = "boolean";
+            }
             List<SurveyJSQuestion.Choice> choices = null;
             if (questionType.equalsIgnoreCase("PICKLIST")) {
                 choices = new ArrayList<>();
@@ -223,16 +226,22 @@ public class ActivityImporter {
         ContentBlockDef contentBlockDef = blockDef;
         String titleTemplateTxt = contentBlockDef.getTitleTemplate() != null ? contentBlockDef.getTitleTemplate().getTemplateText() : null; //where to set this title txt ?
         String bodyTemplateTxt = contentBlockDef.getBodyTemplate() != null ? contentBlockDef.getBodyTemplate().getTemplateText() : null;
-        Map<String, String> titleMap = new HashMap<>();
+        Map<String, String> htmlTxtMap = new HashMap<>();
+        Map<String, String> titleTxtMap = new HashMap<>();
         for (String lang : allLangMap.keySet()) {
             String tmplText = i18nContentRenderer.renderToString(bodyTemplateTxt, allLangMap.get(lang));
-            titleMap.put(lang, tmplText);
+            htmlTxtMap.put(lang, tmplText);
+            if (!StringUtils.isEmpty(titleTemplateTxt)) {
+                String titleText = i18nContentRenderer.renderToString(titleTemplateTxt, allLangMap.get(lang));
+                titleTxtMap.put(lang, titleText);
+            }
         }
         String name = contentBlockDef.getBodyTemplate().getVariables().stream().findAny().get().getName();
         SurveyJSContent surveyJSContent = SurveyJSContent.builder()
                 .name(name)
                 .type("html")
-                .html(titleMap)
+                .html(htmlTxtMap)
+                .title(titleTxtMap.isEmpty() ? null : titleTxtMap)
                 .build();
         JsonNode contentNode = objectMapper.valueToTree(surveyJSContent);
         return contentNode;

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
@@ -142,7 +142,7 @@ public class ActivityImporter {
                 inputType = "DATE";
             }
             List<SurveyJSQuestion.Choice> choices = null;
-            if (questionType.equalsIgnoreCase("PICKLIST")) {
+            if (pepperQuestionDef.getQuestionType().name().equalsIgnoreCase("PICKLIST")) {
                 choices = getPicklistChoices((PicklistQuestionDef) pepperQuestionDef, allLangMap);
             }
 

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
@@ -1,57 +1,80 @@
 package bio.terra.pearl.pepper;
 
 import bio.terra.pearl.core.model.survey.Survey;
-import bio.terra.pearl.core.model.survey.SurveyQuestionDefinition;
-import bio.terra.pearl.core.service.exception.internal.IOInternalException;
+import bio.terra.pearl.core.service.participant.RandomUtilService;
+import bio.terra.pearl.pepper.dto.SurveyJSContent;
+import bio.terra.pearl.pepper.dto.SurveyJSQuestion;
 import bio.terra.pearl.populate.dto.survey.SurveyPopDto;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.gson.Gson;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigResolveOptions;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.content.I18nContentRenderer;
-import org.broadinstitute.ddp.model.activity.definition.ActivityDef;
+import org.broadinstitute.ddp.model.activity.definition.ContentBlockDef;
 import org.broadinstitute.ddp.model.activity.definition.FormActivityDef;
 import org.broadinstitute.ddp.model.activity.definition.FormBlockDef;
 import org.broadinstitute.ddp.model.activity.definition.FormSectionDef;
+import org.broadinstitute.ddp.model.activity.definition.GroupBlockDef;
+import org.broadinstitute.ddp.model.activity.definition.question.PicklistOptionDef;
+import org.broadinstitute.ddp.model.activity.definition.question.PicklistQuestionDef;
 import org.broadinstitute.ddp.model.activity.definition.question.QuestionDef;
-import org.broadinstitute.ddp.model.activity.instance.FormSection;
-import org.broadinstitute.ddp.studybuilder.ActivityBuilder;
+import org.broadinstitute.ddp.model.activity.definition.question.TextQuestionDef;
+import org.broadinstitute.ddp.model.activity.types.BlockType;
+import org.broadinstitute.ddp.model.activity.types.PicklistRenderMode;
+import org.broadinstitute.ddp.model.activity.types.PicklistSelectMode;
+import org.broadinstitute.ddp.model.activity.types.QuestionType;
+import org.broadinstitute.ddp.studybuilder.translation.I18nReader;
+import org.broadinstitute.ddp.studybuilder.translation.TranslationsProcessingData;
 import org.broadinstitute.ddp.util.ConfigUtil;
 import org.broadinstitute.ddp.util.GsonUtil;
-import com.google.gson.Gson;
 import org.springframework.stereotype.Service;
 
-import javax.json.Json;
 import java.io.File;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 public class ActivityImporter {
     private final Gson gson = GsonUtil.standardGson();
     private final ObjectMapper objectMapper;
     private final I18nContentRenderer i18nContentRenderer = new I18nContentRenderer();
+    private final RandomUtilService randomUtilService;
+    private final String[] languages = {"en", "es", "de", "fr", "hi", "it", "ja", "pl", "pt", "ru", "tr", "zh"};
 
-    public ActivityImporter(ObjectMapper objectMapper) {
+    public ActivityImporter(ObjectMapper objectMapper, RandomUtilService randomUtilService) {
         this.objectMapper = objectMapper;
+        this.randomUtilService = randomUtilService;
     }
 
-    public Survey parsePepperForm(Config varsConfig, Path dirPath, Path path) {
+    public Survey parsePepperForm(Config varsConfig, Path dirPath, Path path) throws JsonProcessingException {
         File file = dirPath.resolve(path).toFile();
         if (!file.exists()) {
             throw new RuntimeException("Activity definition file is missing: " + file);
         }
 
+        I18nReader i18nReader = new I18nReader();
+        Map<String, TranslationsProcessingData.TranslationData> i18nTranslations = i18nReader.readTranslationsFromFilesInSpecifiedFolder(dirPath + "/i18n");
+
         FormActivityDef activityDef = buildActivity(file, FormActivityDef.class, varsConfig);
-        // for now just read english translations
+        Map<String, Map<String, Object>> languageTranslations = new HashMap<>();
+        for (String language : languages) {
+            Map<String, Object> langMap = varsConfig.getConfig("i18n." + language).entrySet().stream()
+                    .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()));
+            languageTranslations.put(language, langMap);
+        }
+
         Map<String, Object> langMap = varsConfig.getConfig("i18n.en").entrySet().stream()
                 .collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()));
         return convert(activityDef, langMap);
@@ -59,10 +82,10 @@ public class ActivityImporter {
 
     public <T> T buildActivity(File file, Class<T> targetClass, Config varsConfig) {
         Config definition = ConfigFactory.parseFile(file)
-            // going to resolve first the external global variables that might be used in this configuration
-            // using setAllowUnresolved = true so we can do a second pass that will allow us to resolve variables
-            // within the configuration
-            .resolveWith(varsConfig, ConfigResolveOptions.defaults().setAllowUnresolved(false));
+                // going to resolve first the external global variables that might be used in this configuration
+                // using setAllowUnresolved = true so we can do a second pass that will allow us to resolve variables
+                // within the configuration
+                .resolveWith(varsConfig, ConfigResolveOptions.defaults().setAllowUnresolved(false));
         if (definition.isEmpty()) {
             throw new RuntimeException("Activity definition file is empty: " + file);
         }
@@ -71,34 +94,106 @@ public class ActivityImporter {
         return activityDef;
     }
 
-    public SurveyPopDto convert(FormActivityDef activityDef, Map<String, Object> langMap) {
+    public SurveyPopDto convert(FormActivityDef activityDef, Map<String, Object> langMap) throws JsonProcessingException {
         SurveyPopDto survey = SurveyPopDto.builder()
-                            .stableId(activityDef.getActivityCode())
-                            .version(1)
-                            .name(activityDef.getTag())
-                            .build();
+                .stableId(activityDef.getActivityCode())
+                .version(1)
+                .name(activityDef.getTag())
+                .build();
 
         ObjectNode root = objectMapper.createObjectNode();
         ArrayNode pages = root.putArray("pages");
-        for (FormSectionDef section: activityDef.getSections()) {
+        for (FormSectionDef section : activityDef.getAllSections()) {
             ObjectNode page = objectMapper.createObjectNode();
             pages.add(page);
             ArrayNode elements = objectMapper.createArrayNode();
             page.set("elements", elements);
             for (FormBlockDef blockDef : section.getBlocks()) {
-                ObjectNode panel = objectMapper.createObjectNode();
-                elements.add(panel);
-                ArrayNode panelElements = objectMapper.createArrayNode();
-                panel.set("elements", panelElements);
+                //content blocks
+                if (blockDef.getBlockType().equals(BlockType.CONTENT)) {
+                    JsonNode contentNode = getJsonNodeForContentBlock(langMap, (ContentBlockDef) blockDef);
+                    elements.add(contentNode);
+                }
+
+                if (blockDef.getBlockType().equals(BlockType.GROUP)) {
+                    GroupBlockDef groupBlockDef = ((GroupBlockDef) blockDef);
+                    List<FormBlockDef> nestedBlockdefs = groupBlockDef.getNested();
+                    for (FormBlockDef nestedBlockDef : nestedBlockdefs) {
+                        if (nestedBlockDef.getBlockType().equals(BlockType.CONTENT)) {
+                            JsonNode contentNode = getJsonNodeForContentBlock(langMap, (ContentBlockDef) nestedBlockDef);
+                            elements.add(contentNode);
+                        }
+                    }
+                }
+
+                //todo .. add expressions / calculatedValues
+                //todo dynamic text.. conditional logic..
                 for (QuestionDef pepperQuestionDef : blockDef.getQuestions().toList()) {
                     String questionText = i18nContentRenderer.renderToString(pepperQuestionDef.getPromptTemplate().getTemplateText(), langMap);
-                    SurveyQuestionDefinition questionDef = SurveyQuestionDefinition.builder()
-                            .questionStableId(pepperQuestionDef.getStableId())
-                            .questionText(questionText)
-                            .questionType(pepperQuestionDef.getQuestionType().name())
+                    if (StringUtils.isEmpty(questionText)) {
+                        if (pepperQuestionDef.getQuestionType().equals(QuestionType.TEXT)) {
+                            TextQuestionDef textQuestionDef = (TextQuestionDef) pepperQuestionDef;
+                            questionText = i18nContentRenderer.renderToString(textQuestionDef.getPlaceholderTemplate().getTemplateText(), langMap);
+                        }
+                    }
+                    Map<String, String> titleMap = new HashMap<>();
+                    titleMap.put("en", questionText);
+                    String questionType = pepperQuestionDef.getQuestionType().name();
+                    String inputType = null;
+                    if (questionType.equalsIgnoreCase("DATE")) {
+                        questionType = "TEXT";
+                        inputType = "DATE";
+                    }
+                    List<SurveyJSQuestion.Choice> choices = null;
+                    if (questionType.equalsIgnoreCase("PICKLIST")) {
+                        choices = new ArrayList<>();
+                        questionType = "dropdown";
+                        inputType = null;
+                        PicklistQuestionDef picklistQuestionDef = (PicklistQuestionDef) pepperQuestionDef;
+                        if (picklistQuestionDef.getRenderMode() == PicklistRenderMode.LIST
+                                && picklistQuestionDef.getSelectMode() == PicklistSelectMode.SINGLE
+                                && picklistQuestionDef.getRenderMode() != PicklistRenderMode.DROPDOWN) {
+                            questionType = "radiogroup";
+                        }
+                        if (picklistQuestionDef.getRenderMode() == PicklistRenderMode.LIST && picklistQuestionDef.getSelectMode() == PicklistSelectMode.MULTIPLE) {
+                            questionType = "checkbox";
+                        }
+                        for (PicklistOptionDef option : picklistQuestionDef.getPicklistOptions()) {
+                            ObjectNode choiceNode = objectMapper.createObjectNode();
+                            choiceNode.put("value", option.getStableId());
+                            String optTxt = i18nContentRenderer.renderToString(option.getOptionLabelTemplate().getTemplateText(), langMap);
+                            if (optTxt != null && optTxt.startsWith("$")) {
+                                optTxt = option.getOptionLabelTemplate().getVariables().stream().findAny().get().getTranslation("en").get().getText();
+                            }
+                            choices.add(new SurveyJSQuestion.Choice(optTxt, option.getStableId()));
+                        }
+                    }
+
+                    //todo calculated values
+                    List<SurveyJSQuestion.CalculatedValue> calculatedValues = null;
+                    if (!StringUtils.isEmpty(blockDef.getShownExpr())) {
+                        calculatedValues = new ArrayList<>();
+                        //populate calculated values
+                        String name = null; //todo
+                        String expression = blockDef.getShownExpr();
+                        //todo for now using pepper expressions. need to convert pepper expression into SurveyJS format
+                        SurveyJSQuestion.CalculatedValue calculatedValue = new SurveyJSQuestion.CalculatedValue(name, expression, "true");
+                        calculatedValues.add(calculatedValue);
+                    }
+
+                    SurveyJSQuestion surveyJSQuestion = SurveyJSQuestion.builder()
+                            .name(pepperQuestionDef.getStableId())
+                            .type(questionType)
+                            .title(titleMap)
+                            .required(false) //todo
+                            //.isRequired() //todo
+                            .inputType(inputType)
+                            .choices(choices)
+                            .calculatedValues(calculatedValues)
                             .build();
-                    JsonNode questionNode = objectMapper.valueToTree(questionDef);
-                    panelElements.add(questionNode);
+
+                    JsonNode questionNode = objectMapper.valueToTree(surveyJSQuestion);
+                    elements.add(questionNode);
                 }
             }
         }
@@ -106,6 +201,23 @@ public class ActivityImporter {
         return survey;
     }
 
-
+    private JsonNode getJsonNodeForContentBlock(Map<String, Object> langMap, ContentBlockDef blockDef) {
+        ContentBlockDef contentBlockDef = blockDef;
+        String titleTemplateTxt = contentBlockDef.getTitleTemplate() != null ? contentBlockDef.getTitleTemplate().getTemplateText() : null;
+        String bodyTemplateTxt = contentBlockDef.getBodyTemplate() != null ? contentBlockDef.getBodyTemplate().getTemplateText() : null;
+        //log.info("Title template: {}", titleTemplateTxt); //todo title template ?
+        //log.info("Body template: {}", bodyTemplateTxt);
+        String tmplText = i18nContentRenderer.renderToString(bodyTemplateTxt, langMap);
+        Map<String, String> titleMap = new HashMap<>();
+        titleMap.put("en", tmplText);
+        String name = contentBlockDef.getBodyTemplate().getVariables().stream().findAny().get().getName();
+        SurveyJSContent surveyJSContent = SurveyJSContent.builder()
+                .name(name) //todo generate name
+                .type("html")
+                .html(titleMap)
+                .build();
+        JsonNode contentNode = objectMapper.valueToTree(surveyJSContent);
+        return contentNode;
+    }
 
 }

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
@@ -24,6 +24,7 @@ import org.broadinstitute.ddp.model.activity.definition.i18n.Translation;
 import org.broadinstitute.ddp.model.activity.definition.question.PicklistOptionDef;
 import org.broadinstitute.ddp.model.activity.definition.question.PicklistQuestionDef;
 import org.broadinstitute.ddp.model.activity.definition.question.QuestionDef;
+import org.broadinstitute.ddp.model.activity.definition.question.TextQuestionDef;
 import org.broadinstitute.ddp.model.activity.definition.template.TemplateVariable;
 import org.broadinstitute.ddp.model.activity.types.BlockType;
 import org.broadinstitute.ddp.model.activity.types.PicklistRenderMode;
@@ -201,7 +202,14 @@ public class ActivityImporter {
     }
 
     private Map<String, String> getQuestionTxt(QuestionDef pepperQuestionDef) {
-        return getVariableTranslationsTxt(pepperQuestionDef.getPromptTemplate().getVariables());
+        Map<String, String> txtMap = getVariableTranslationsTxt(pepperQuestionDef.getPromptTemplate().getVariables());
+        if (txtMap.isEmpty() && pepperQuestionDef.getQuestionType().name().equalsIgnoreCase("TEXT")) {
+            TextQuestionDef textQuestionDef = (TextQuestionDef) pepperQuestionDef;
+            //try placeholder template
+            txtMap = getVariableTranslationsTxt(textQuestionDef.getPlaceholderTemplate().getVariables());
+        }
+
+        return txtMap;
     }
 
     private Map<String, String> getVariableTranslationsTxt(Collection<TemplateVariable> templateVariables) {

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
@@ -1,7 +1,6 @@
 package bio.terra.pearl.pepper;
 
 import bio.terra.pearl.core.model.survey.Survey;
-import bio.terra.pearl.core.service.participant.RandomUtilService;
 import bio.terra.pearl.pepper.dto.SurveyJSContent;
 import bio.terra.pearl.pepper.dto.SurveyJSQuestion;
 import bio.terra.pearl.populate.dto.survey.SurveyPopDto;
@@ -49,13 +48,11 @@ public class ActivityImporter {
     private final Gson gson = GsonUtil.standardGson();
     private final ObjectMapper objectMapper;
     private final I18nContentRenderer i18nContentRenderer = new I18nContentRenderer();
-    private final RandomUtilService randomUtilService;
     private final String[] languages = {"en", "es", "de", "fr", "hi", "it", "ja", "pl", "pt", "ru", "tr", "zh"};
 
 
-    public ActivityImporter(ObjectMapper objectMapper, RandomUtilService randomUtilService) {
+    public ActivityImporter(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
-        this.randomUtilService = randomUtilService;
     }
 
     public Survey parsePepperForm(Config varsConfig, Path dirPath, Path path) {
@@ -210,12 +207,11 @@ public class ActivityImporter {
 
     private String getQuestionTxt(Map<String, Map<String, Object>> allLangMap, QuestionDef pepperQuestionDef, String lang) {
         String questionText = i18nContentRenderer.renderToString(pepperQuestionDef.getPromptTemplate().getTemplateText(), allLangMap.get(lang));
-        if (StringUtils.isEmpty(questionText)) {
-            if (pepperQuestionDef.getQuestionType().equals(QuestionType.TEXT)) {
-                TextQuestionDef textQuestionDef = (TextQuestionDef) pepperQuestionDef;
-                questionText = i18nContentRenderer.renderToString(textQuestionDef.getPlaceholderTemplate().getTemplateText(), allLangMap.get(lang));
-            }
+        if (StringUtils.isEmpty(questionText) && pepperQuestionDef.getQuestionType().equals(QuestionType.TEXT)) {
+            TextQuestionDef textQuestionDef = (TextQuestionDef) pepperQuestionDef;
+            questionText = i18nContentRenderer.renderToString(textQuestionDef.getPlaceholderTemplate().getTemplateText(), allLangMap.get(lang));
         }
+
         if (questionText.contains("$")) {
             //get txt from variable
             if (pepperQuestionDef.getQuestionType().equals(QuestionType.TEXT)) {
@@ -276,8 +272,7 @@ public class ActivityImporter {
                 .html(htmlTxtMap)
                 .title(titleTxtMap.isEmpty() ? null : titleTxtMap)
                 .build();
-        JsonNode contentNode = objectMapper.valueToTree(surveyJSContent);
-        return contentNode;
+        return objectMapper.valueToTree(surveyJSContent);
     }
 
 }

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/PepperImportCliApp.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/PepperImportCliApp.java
@@ -2,7 +2,6 @@ package bio.terra.pearl.pepper;
 
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.service.exception.internal.IOInternalException;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -38,7 +37,7 @@ public class PepperImportCliApp implements CommandLineRunner {
     private ObjectMapper objectMapper;
 
     @Override
-    public void run(String... args) throws JsonProcessingException {
+    public void run(String... args) {
         log.info("EXECUTING : command line importer");
         // these vars should be read from command line or a conf file eventually
         String studyDir = "atcp";

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/PepperImportCliApp.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/PepperImportCliApp.java
@@ -1,14 +1,8 @@
 package bio.terra.pearl.pepper;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.service.exception.internal.IOInternalException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -18,6 +12,10 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 /**
  * CLI importer -- see the "run" method for argument descriptions.
  */
@@ -25,49 +23,53 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @Slf4j
 public class PepperImportCliApp implements CommandLineRunner {
 
-  public static final String ABSOLUTE_SEED_ROOT = "pepper-import/src/main/resources/pepper";
-  public static final String OUTPUT_ROOT = "pepper-import/out";
-  public static void main(String[] args) {
-    SpringApplication.run(PepperImportCliApp.class, args);
-  }
+    public static final String ABSOLUTE_SEED_ROOT = "pepper-import/src/main/resources/pepper";
+    public static final String OUTPUT_ROOT = "pepper-import/out";
 
-  public static String SUBSTITUTIONS_FILE = "substitutions.conf";
-
-  @Autowired
-  private ActivityImporter activityImporter;
-  @Autowired
-  private ObjectMapper objectMapper;
-
-  @Override
-  public void run(String... args) {
-    log.info("EXECUTING : command line importer");
-    // these two vars should be read from command line eventually
-    String studyDir = "atcp";
-    String formFile = "prequal.conf";
-
-    Config varsCfg = ConfigFactory.parseFile(getFilePath("studies/%s/%s".formatted(studyDir, SUBSTITUTIONS_FILE), ABSOLUTE_SEED_ROOT).toFile());
-
-
-    Survey survey = activityImporter.parsePepperForm(varsCfg, getFilePath("studies/" + studyDir, ABSOLUTE_SEED_ROOT), Path.of(formFile));
-    try {
-      Path outFilePath = getFilePath(formFile, OUTPUT_ROOT);
-      String surveyString = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(survey);
-      Files.write(outFilePath, surveyString.getBytes());
-    } catch (IOException e) {
-      throw new IOInternalException("couldn't write survey", e);
+    public static void main(String[] args) {
+        SpringApplication.run(PepperImportCliApp.class, args);
     }
-  }
+
+    public static String SUBSTITUTIONS_FILE = "substitutions.conf";
+
+    @Autowired
+    private ActivityImporter activityImporter;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Override
+    public void run(String... args) throws JsonProcessingException {
+        log.info("EXECUTING : command line importer");
+        // these two vars should be read from command line eventually
+        String studyDir = "atcp";
+        //String[] formFiles = {"registration.conf"};
+        String[] formFiles = {"prequal.conf", "registration.conf", "self-consent.conf", "self-consent-edit.conf", "assent.conf",
+                "medical-history.conf", "contacting-physician.conf", "review-and-submission.conf", "genome-study.conf", "stay-informed.conf"};
+
+        Config varsCfg = ConfigFactory.parseFile(getFilePath("studies/%s/%s".formatted(studyDir, SUBSTITUTIONS_FILE), ABSOLUTE_SEED_ROOT).toFile());
+
+        for (String formFile : formFiles) {
+            Survey survey = activityImporter.parsePepperForm(varsCfg, getFilePath("studies/" + studyDir, ABSOLUTE_SEED_ROOT), Path.of(formFile));
+            try {
+                Path outFilePath = getFilePath(formFile, OUTPUT_ROOT);
+                String surveyString = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(survey);
+                Files.write(outFilePath, surveyString.getBytes());
+            } catch (IOException e) {
+                throw new IOInternalException("couldn't write survey", e);
+            }
+        }
+    }
 
 
-  /**
-   * Get the absolute path for a file.
-   * depending on whether you are running gradle or spring boot, the root directory could either be
-   * the root folder or pepper-import.  So strip out pepper-import if it's there
-   */
-  public static Path getFilePath(String path, String root) {
+    /**
+     * Get the absolute path for a file.
+     * depending on whether you are running gradle or spring boot, the root directory could either be
+     * the root folder or pepper-import.  So strip out pepper-import if it's there
+     */
+    public static Path getFilePath(String path, String root) {
 
-    String projectDir = System.getProperty("user.dir").replace("/pepper-import", "");
-    String pathName = projectDir + "/" + root + "/" + path;
-    return Path.of(pathName);
-  }
+        String projectDir = System.getProperty("user.dir").replace("/pepper-import", "");
+        String pathName = projectDir + "/" + root + "/" + path;
+        return Path.of(pathName);
+    }
 }

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/PepperImportCliApp.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/PepperImportCliApp.java
@@ -40,11 +40,10 @@ public class PepperImportCliApp implements CommandLineRunner {
     @Override
     public void run(String... args) throws JsonProcessingException {
         log.info("EXECUTING : command line importer");
-        // these two vars should be read from command line eventually
+        // these vars should be read from command line or a conf file eventually
         String studyDir = "atcp";
-        //String[] formFiles = {"registration.conf"};
         String[] formFiles = {"prequal.conf", "registration.conf", "self-consent.conf", "self-consent-edit.conf", "assent.conf",
-                "medical-history.conf", "contacting-physician.conf", "review-and-submission.conf", "genome-study.conf", "stay-informed.conf"};
+                "medical-history.conf", "contacting-physician.conf", "review-and-submission.conf", "genome-study.conf", "blood-type.conf", "stay-informed.conf"};
 
         Config varsCfg = ConfigFactory.parseFile(getFilePath("studies/%s/%s".formatted(studyDir, SUBSTITUTIONS_FILE), ABSOLUTE_SEED_ROOT).toFile());
 

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJSContent.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJSContent.java
@@ -15,5 +15,6 @@ public class SurveyJSContent {
     public String type;
     public String name;
     public Map<String, String> html;
+    public Map<String, String> title;
 
 }

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJSContent.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJSContent.java
@@ -1,0 +1,20 @@
+package bio.terra.pearl.pepper.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SurveyJSContent {
+    public String type;
+    public String name;
+    public Map<String, String> html;
+
+
+}

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJSContent.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJSContent.java
@@ -16,5 +16,4 @@ public class SurveyJSContent {
     public String name;
     public Map<String, String> html;
 
-
 }

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJSQuestion.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJSQuestion.java
@@ -1,0 +1,40 @@
+package bio.terra.pearl.pepper.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SurveyJSQuestion {
+    public String name;
+    public String type;
+    public String inputType;
+    public Map<String, String> title;
+    public boolean required;
+    //public boolean isRequired;
+    public List<Choice> choices;
+    public List<CalculatedValue> calculatedValues;
+
+    @AllArgsConstructor
+    @Data
+    public static class Choice {
+        public String text;
+        public String value;
+    }
+
+    @AllArgsConstructor
+    @Data
+    public static class CalculatedValue {
+        public String name;
+        public String expression;
+        public String includeIntoResult;
+    }
+
+}

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJSQuestion.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJSQuestion.java
@@ -20,21 +20,12 @@ public class SurveyJSQuestion {
     public boolean required;
     //public boolean isRequired;
     public List<Choice> choices;
-    public List<CalculatedValue> calculatedValues;
 
     @AllArgsConstructor
     @Data
     public static class Choice {
-        public String text;
+        public Map<String, String> text;
         public String value;
-    }
-
-    @AllArgsConstructor
-    @Data
-    public static class CalculatedValue {
-        public String name;
-        public String expression;
-        public String includeIntoResult;
     }
 
 }

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJSQuestion.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJSQuestion.java
@@ -20,6 +20,7 @@ public class SurveyJSQuestion {
     public boolean required;
     //public boolean isRequired;
     public List<Choice> choices;
+    public String visibleIf;
 
     @AllArgsConstructor
     @Data

--- a/pepper-import/src/main/resources/pepper/studies/atcp/i18n/en.json
+++ b/pepper-import/src/main/resources/pepper/studies/atcp/i18n/en.json
@@ -10,7 +10,6 @@
   "prequal_first_name_req_hint": "First name cannot be empty",
   "prequal_req_hint": "Please choose one of the above options.",
   "prequal_last_name_req_hint": "Last name cannot be empty",
-
   "registration_name": "Registration",
   "registration_title": "Registration",
   "registration_summary_created": "Registration",
@@ -46,8 +45,6 @@
   "registration_choose_state_province": "Choose state/province...",
   "registration_country_label": "Choose country...",
   "registration_which_name": "If you are a parent/legal guardian of a child(ren) with A-T, please create the account under your name. Once your account is created, you will be able to register your child(ren) with A-T as Participants.",
-
-
   "consent_agreement_indicates_li1": "Researchers may use my health information, medical information, the results of the DNA sequencing (as indicated in the checkboxes on the next page) and any other data I share via this platform for future research studies - including studies that have not yet been designed; studies for A-T; studies involving diseases other than A-T, and/or studies that may be for commercial purposes, subject to review and approval by the A-T data access committee. This information will be stored without identification information on a cloud-computing storage system administered by Broad Institute.",
   "consent_agreement_indicates_li2": "Researchers may share this information with qualified researchers in a manner that does not include my name, social security number, or any other information that could be used to readily identify me, to be used by other qualified researchers to perform future research studies, including studies that have not yet been designed, studies for A-T; studies involving diseases other than A-T, and studies that may be for commercial purposes.",
   "consent_agreement_title": "This is what I agree to:",
@@ -55,14 +52,15 @@
   "consent_benefits_title": "4. Will I benefit from participating?",
   "consent_contact_detail_p1": "If you have any questions, concerns, or complaints please send an email to",
   "consent_contact_detail_p2": "or call the phone number on the first page of this form, and ask to speak with one of the Global A-T Family Data Platform staff trained on the platform about this initiative and the data platform or if you feel you have experienced a research-related issue. <br><br>If you have questions about your rights as a research subject or if you have questions, concerns, or complaints about the research, you may contact:",
-  "consent_contact_detail_br1": "North Star Review Board",
-  "consent_contact_detail_br2": "",
-  "consent_contact_detail_br3": "",
-  "consent_contact_detail_br4": "",
+  "consent_contact_detail_p2": "or call the phone number on the first page of this form, and ask to speak with one of the Global A-T Family Data Platform staff trained on the platform about this initiative and the data platform or if you feel you have experienced a research-related issue. If you have questions about your rights as a research subject or if you have questions, concerns, or complaints about the research, you may contact:",
+  "consent_contact_detail_br1": "Western Institutional Review Board® (WIRB®)",
+  "consent_contact_detail_br2": "1019 39th Avenue SE Suite 120",
+  "consent_contact_detail_br3": "Puyallup, Washington  98374-2115",
+  "consent_contact_detail_br4": "Telephone:  1-800-562-4789 or 360-252-2500",
   "consent_contact_detail_email_help": "E-mail: ",
-  "consent_contact_detail_actual_email": "<a class=\"Link\" href=\"mailto:info@northstarreviewboard.org\">info@northstarreviewboard.org</a>",
-  "consent_contact_detail_br5": "North Star is a group of people who perform independent review of research.",
-  "consent_contact_detail_end": "North Star will not be able to answer some study-specific questions, such as questions about appointment times. However, you may contact North Star if the research staff cannot be reached or if you wish to talk to someone other than the research staff.",
+  "consent_contact_detail_actual_email": "Help@wirb.com",
+  "consent_contact_detail_br5": "WIRB is a group of people who perform independent review of research.",
+  "consent_contact_detail_end": "WIRB will not be able to answer some study-specific questions, such as questions about appointment times. However, you may contact WIRB if the research staff cannot be reached or if you wish to talk to someone other than the research staff.",
   "consent_contact_my_physician": "Study staff may contact my physician if a researcher reports genetic analysis results about my A-T mutations.",
   "consent_contact_title": "9. What if I have questions?",
   "consent_cost_detail": "No.",
@@ -78,7 +76,6 @@
   "consent_download_indicates_arrow_down": "arrow_circle_down",
   "consent_download_indicates_a_end": "Download Complete Consent Form",
   "consent_download_indicates_p3": "Please click \"Next\" to continue the consent process.",
-
   "consent_make_changes_intro": "If you would like to change what you consented to or withdraw your information for use in future studies, please let us know by submitting the following form. Our study staff will contact you and help you make the changes.",
   "consent_make_changes_contact": "You may also contact Jennifer Thornton, the Principal Investigator of the data repository, at:",
   "consent_make_changes_contact_email": "support@atfamilies.org",
@@ -134,7 +131,6 @@
   "consent_voluntary_title": "3. Do I have to participate in this initiative?",
   "consent_withdraw_detail": "Yes, you can withdraw from this research study at any time, and your data will no longer be shared with researchers in future research studies. However, any of your information that has already been shared with investigators cannot be withdrawn from their studies.",
   "consent_withdraw_title": "8. Can I stop taking part in this research initiative?",
-
   "assent_attest": "I attest that the participant named above had enough time to consider this information, had an opportunity to ask questions, and voluntarily agreed to be in this study.",
   "assent_benefits_details": "This research is not likely to help you. We do hope to learn something from this research though. And some day we hope it will help other kids who have issues like you do.",
   "assent_benefits_title": "Could this research help me?",
@@ -201,7 +197,6 @@
   "assent_title": "Assent for Kids",
   "assent_voluntary_details": "You can ask the researchers questions before you make up your mind. You can also talk to your mom or dad or anyone you want to about the study. You can ask to read the information the doctor gives your mom or dad about this study.",
   "assent_voluntary_title": "You do not have to be in the study if you don't want to.",
-
   "contacting_physician_name": "Contacting Physician",
   "contacting_physician_title": "Contacting Physician",
   "contacting_physician_summary_created": "Contacting Physician",
@@ -227,7 +222,6 @@
   "contacting_physician_prompt_mail": "Physician's Complete Mailing Address*",
   "contacting_physician_prompt_phone": "Physician's Phone*",
   "contacting_physician_title_p1": "Our staff may contact $ddp.participantFirstName()'s doctor with information about $ddp.participantFirstName()'s data (if you so consented) or to confirm the A-T diagnosis. To enable that, please complete the following form with $ddp.participantFirstName()'s physician's information (the doctor who plays the most central role in $ddp.participantFirstName()'s care.",
-
   "medical_history_age_months_range_hint": "Please enter month between 1 and 12",
   "medical_history_age_placeholder_months": "Months",
   "medical_history_age_placeholder_years": "Years",
@@ -454,7 +448,6 @@
   "medical_summary_created": "Medical History",
   "medical_summary_in_progress": "Medical History",
   "medical_title": "Medical History",
-
   "genome_ethnicity_african_african_american": "African/African american",
   "genome_ethnicity_caucasian": "Caucasian",
   "genome_ethnicity_east_asian": "East Asian",
@@ -482,7 +475,6 @@
   "genome_summary_created": "Genome Study",
   "genome_summary_in_progress": "Genome Study",
   "genome_title": "Genome Study",
-
   "feeding_name": "Feeding Survey",
   "feeding_title": "Feeding Survey",
   "feeding_summary_created": "Feeding Survey",
@@ -527,12 +519,10 @@
   "feed_pa_help_concern_prompt": "How often do others help $ddp.participantFirstName() finish meals because of concerns about getting enough to eat or drink? ",
   "feed_pa_poor_appetite_prompt": "How often does $ddp.participantFirstName() have a poor appetite (are not hungry) that limits intake?",
   "feed_pa_medication_prompt": "How often does $ddp.participantFirstName() take medications by mouth on their own?",
-
   "picklist_options_yes": "Yes",
   "picklist_options_no": "No",
   "picklist_options_dont_know": "Don't know",
   "required_field_hint": "* Required field",
-
   "review_title": "Review & Submission",
   "review_summary": "Review & Submission",
   "review_created": "Review & Submission",
@@ -540,7 +530,6 @@
   "review_in_progress": "Review & Submission",
   "review_introduction_p1": "Please review the information you provided during this enrollment process and submit when you have confirmed that it is correct.",
   "review_introduction_p2": "We look forward to learning about your experiences with A-T.",
-
   "stay_informed_email": "Your email address",
   "stay_informed_email_placeholder": "name@email.com",
   "stay_informed_email_req_hint": "Please provide an email address.",
@@ -552,7 +541,6 @@
   "stay_informed_lastname_req_hint": "Your Last Name is required.",
   "stay_informed_name": "Stay Informed",
   "stay_informed_readonly_hint": "Thank you for submitting your survey.",
-
   "blood_type_name": "Blood Type Survey",
   "blood_type_title": "Blood Type Survey",
   "blood_type_summary_created": "Blood Type Survey",
@@ -569,7 +557,6 @@
   "blood_type_dk": "I'm not sure",
   "blood_type_rh_pos": "+ (positive)",
   "blood_type_rh_neg": "- (negative)",
-
   "support_email": "support@atfamilies.org",
   "support_phone": "+1 954-481-6611"
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)
Support migration from pepper to Juniper.
Pepper Import code to look at pepper study (current focus: AT) and generate SurveyJS conf files to be imported/used to create surveys in Juniper


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Run PepperImportCliApp App 
O/P will be ATCP survey files under /out directory in SurveyJS format.

Not everything needed is automated and need manual tweaks  
Manual edits:
Search and replace in all out/*.conf files 
"required" with "isRequired"

Generated files: jsonContent can be used to validate in https://surveyjs.io/create-free-survey
OR
use 1 or more generated files to create new surveys in existing study or new study
Some text translations need edits and few other like below stuff should be handled manually 
Need styling cleanup, text formatting, Expressions, Dynamic text, calculated values, header/footer text, tool tips, validations, 
correct/update "visibleIf" expressions to reflect to SurveyJS format.

All the manual edits and improvements needed to this PepperImportCli will be included in a Document as part of handover.

