### PR TITLE
[JN-1122] adding log detail to notification errors

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
@@ -91,7 +91,7 @@ public class EnrolleeEmailService implements NotificationSender {
                     // email starts, so the notification update will fail. This is expected and not a problem.
                     log.info("notification update failed for populated withdrawn participant -- this is expected");
                 } else {
-                    log.error("failed to update notification: {}", notification.getId());
+                    log.error("failed to update notification: {}, portal: {}, trigger: {}", notification.getId(), contextInfo.portal().getShortcode(), config.getId());
                 }
             }
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Just adding some extra log detail

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. add a `throw` before line 86 of EnrolleeEmailService
2. repopulate a portal
3. confirm fails show up with detail