### PR TITLE
[JN-1093] Fix mailing list e2e test and flaky unit test

### DIFF
--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
@@ -28,8 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -250,7 +249,7 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
         assertThat(participantTaskService.findByEnrolleeId(bundle.enrollee().getId()), hasSize(2));
         tasks = participantTaskService.findByEnrolleeId(bundle.enrollee().getId());
         // now the task should be added
-        assertThat(tasks.stream().map(ParticipantTask::getTargetStableId).toList(), contains("medForm", "followUp"));
+        assertThat(tasks.stream().map(ParticipantTask::getTargetStableId).toList(), containsInAnyOrder("medForm", "followUp"));
     }
 
 

--- a/e2e-tests/src/tests/e2e-utils.ts
+++ b/e2e-tests/src/tests/e2e-utils.ts
@@ -36,7 +36,7 @@ export async function adminLogin(page: Page, username?: string) {
   await page.locator('button:text("Log in")').click()
   // the after login page might be either the participant list or the home page depending on the number of portals
   await Promise.any([
-    expect(page.locator('h1')).toHaveText('Juniper Home'),
+    expect(page.locator('h1')).toHaveText('Select a portal'),
     expect(page.locator('h2')).toHaveText('Participant List')
   ])
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Broke this with the admin landing page redesign

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
Verify that e2e tests pass locally

`./scripts/run_dockerized.sh admin`
`./scripts/run_dockerized.sh participant`
`CI=true npm -w e2e-tests test`
