### PR TITLE
[JN-1076] trim stableids

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
@@ -18,12 +18,11 @@ import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
 import bio.terra.pearl.core.service.survey.SurveyService;
 import bio.terra.pearl.core.service.workflow.EventService;
+import java.util.List;
+import java.util.UUID;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.UUID;
 
 @Service
 public class SurveyExtService {

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
@@ -18,11 +18,12 @@ import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
 import bio.terra.pearl.core.service.survey.SurveyService;
 import bio.terra.pearl.core.service.workflow.EventService;
-import java.util.List;
-import java.util.UUID;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
 
 @Service
 public class SurveyExtService {

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyService.java
@@ -73,6 +73,7 @@ public class SurveyService extends VersionedEntityService<Survey, SurveyDao> {
         Instant now = Instant.now();
         survey.setCreatedAt(now);
         survey.setLastUpdatedAt(now);
+        survey.setStableId(survey.getStableId().trim());
         Survey savedSurvey = dao.create(survey);
         for (AnswerMapping answerMapping : survey.getAnswerMappings()) {
             answerMapping.setId(null);

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyServiceTests.java
@@ -7,12 +7,7 @@ import bio.terra.pearl.core.factory.portal.PortalFactory;
 import bio.terra.pearl.core.factory.survey.SurveyFactory;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.portal.Portal;
-import bio.terra.pearl.core.model.survey.AnswerMapping;
-import bio.terra.pearl.core.model.survey.AnswerMappingMapType;
-import bio.terra.pearl.core.model.survey.AnswerMappingTargetType;
-import bio.terra.pearl.core.model.survey.Survey;
-import bio.terra.pearl.core.model.survey.SurveyQuestionDefinition;
-import bio.terra.pearl.core.model.survey.SurveyType;
+import bio.terra.pearl.core.model.survey.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,10 +23,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.samePropertyValuesAs;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.springframework.test.util.AssertionErrors.fail;
@@ -377,6 +369,29 @@ public class SurveyServiceTests extends BaseSpringBootTest {
 
         Boolean result = SurveyParseUtils.getAnswerByStableId(jsonInput, "proxy_enrollment", Boolean.class, new ObjectMapper(), "stringValue");
         assertEquals(true, result);
+    }
+
+    @Test
+    void createStripsWhitespace(TestInfo info) {
+
+        Portal portal = portalFactory.buildPersisted(getTestName(info));
+
+        Survey survey = Survey
+                .builder()
+                .stableId("   \t\t   survey_1      ")
+                .content("""
+                        {
+                          "title": "The Basics",
+                          "pages": []
+                        }
+                        """)
+                .portalId(portal.getId())
+                .eligibilityRule("")
+                .build();
+
+        Survey savedSurvey = surveyService.create(survey);
+
+        assertEquals("survey_1", savedSurvey.getStableId());
     }
 
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Trims survey stable ids on create.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Observe tests
- Attempt to create your own stableid with whitespace