### PR TITLE
[JN-1128] removing ourhealth specific text

### DIFF
--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/landingPage.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/landingPage.json
@@ -3,8 +3,8 @@
   "sectionDtos": [{
     "sectionType": "HERO_WITH_IMAGE",
     "sectionConfigJson": {
-      "title": "Help us understand cardiovascular disease risk among South Asian populations.",
-      "blurb": "The demo Heart Study studies health and genetic information of South Asians living in the United States to better prevent and manage cardiovascular disease risk.",
+      "title": "Help us understand cardiovascular disease risk.",
+      "blurb": "The Demo Heart Study studies health and genetic information to better prevent and manage cardiovascular disease risk.",
       "fullWidth": true,
       "image": { "cleanFileName": "family.png", "version": 1, "alt": "" },
       "imagePosition": "right",
@@ -38,7 +38,7 @@
     "sectionConfigJson": {
       "background": "#F2F2F2",
       "title": "Why is this needed?",
-      "blurb": "Although South Asians represent 23% of the global population and have twice the risk of cardiovascular disease compared to Europeans, they are **significantly underrepresented in genetic studies and research**. Available datasets are limited in size, cultural diversity, and diasporic representation.",
+      "blurb": "Cardiovascular disease is a significant cause of death in the United States and worldwide. Current genetic studies and research may be limited in size, cultural diversity.",
       "fullWidth": true,
       "buttons": [
         {"text": "Scientific Background",
@@ -54,7 +54,7 @@
     "sectionType": "HERO_WITH_IMAGE",
     "sectionConfigJson": {
       "title": "Who can join?",
-      "blurb": "Anyone who is:\n\n* Living in the United States\n * Older than 18 years old\n * Comfortable filling out surveys in English\n * Of South Asian Ancestry*\n\n&nbsp;\n\n*Self-identified ancestry from one of the South Asian countries defined by the American Heart Association as Bangladesh, Bhutan, India, the Maldives, Nepal, Pakistan, and Sri Lanka.",
+      "blurb": "Anyone who is:\n\n* Living in the United States\n * Older than 18 years old\n * Comfortable filling out surveys in English or Spanish\n.",
       "fullWidth": true,
       "buttons": [
         {"text": "Get Started",
@@ -104,15 +104,15 @@
       "questions": [
         {
           "question": "What is the Juniper Heart Demo study?",
-          "answer": "Juniper Heart Demo is a nonprofit research initiative that enables South Asian-identifying individuals to contribute to cardiovascular research by sharing their samples, their clinical information, and their voices."
+          "answer": "Juniper Heart Demo is a nonprofit research initiative that enables individuals to contribute to cardiovascular research by sharing their samples, their clinical information, and their voices."
         },
         {
           "question": "Why are we doing this study?",
-          "answer": "Individuals of South Asian ancestry are disproportionately affected by cardiometabolic diseases, including heart disease, stroke, and diabetes. However, they have historically been underrepresented in genetic studies. In the United States, South Asian ancestry is now considered a risk-enhancing factor for cardiovascular disease, highlighting an awareness but distinct knowledge gap. Juniper Heart Demo aims to address this gap by creating a cohort of South Asian individuals, from whom survey and genomic data will be analyzed to further our understanding of cardiovascular disease risk within this population."
+          "answer": "Individuals are disproportionately affected by cardiometabolic diseases, including heart disease, stroke, and diabetes. Risk-enhancing factors for cardiovascular disease are still being developed, highlighting an awareness but distinct knowledge gap. Juniper Heart Demo aims to address this gap by creating a cohort of individuals, from whom survey and genomic data will be analyzed to further our understanding of cardiovascular disease risk."
         },
         {
           "question": "How can I participate?",
-          "answer": "If you are over 18 years of age, live in the United States, and identify as South Asian, you can sign up by clicking [“Join”](/studies/heartdemo/join)."
+          "answer": "If you are over 18 years of age, live in the United States, you can sign up by clicking [“Join”](/studies/heartdemo/join)."
         },
         {
           "question": "What does Juniper Heart Demo do with the data?",

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
@@ -130,46 +130,18 @@
           "dev": "DEV_Study Eligibility"
         },
         "description": {
-          "default": "Thank you for your interest in participating in OurHealth. To get started, please answer these questions to make sure you’re eligible to participate.",
-          "es": "Gracias por su interés en participar en OurHealth. Para comenzar, responda estas preguntas para asegurarse de que es elegible para participar.",
-          "dev": "DEV_Thank you for your interest in participating in OurHealth. To get started, please answer these questions to make sure you’re eligible to participate."
+          "default": "Thank you for your interest in participating in Heart Demo Study. To get started, please answer these questions to make sure you’re eligible to participate.",
+          "es": "Gracias por su interés en participar en Heart Demo Study. Para comenzar, responda estas preguntas para asegurarse de que es elegible para participar.",
+          "dev": "DEV_Thank you for your interest in participating in Heart Demo Study. To get started, please answer these questions to make sure you’re eligible to participate."
         },
         "elements": [
           {
             "type": "radiogroup",
-            "name": "hd_hd_preenroll_southAsianAncestry",
-            "title": {
-              "default": "I identify as having South Asian ancestry from one or more of these countries: Bangladesh, Bhutan, India, the Maldives, Nepal, Pakistan, or Sri Lanka.",
-              "es": "Me identifico con ascendencia del sur de Asia de uno o más de estos países: Bangladesh, Bután, India, Maldivas, Nepal, Pakistán o Sri Lanka.",
-              "dev": "DEV_I identify as having South Asian ancestry from one or more of these countries: Bangladesh, Bhutan, India, the Maldives, Nepal, Pakistan, or Sri Lanka."
-            },
-            "isRequired": true,
-            "choices": [
-              {
-                "value": "yes",
-                "text": {
-                  "default": "Yes",
-                  "es": "Sí",
-                  "dev": "DEV_Yes"
-                }
-              },
-              {
-                "value": "no",
-                "text": {
-                  "default": "No",
-                  "es": "No",
-                  "dev": "DEV_No"
-                }
-              }
-            ]
-          },
-          {
-            "type": "radiogroup",
             "name": "hd_hd_preenroll_understandsEnglish",
             "title": {
-              "default": "I am comfortable reading or speaking English.",
-              "es": "Me siento cómodo leyendo o hablando inglés.",
-              "dev": "DEV_I am comfortable reading or speaking English."
+              "default": "I am comfortable reading or speaking English or Spanish.",
+              "es": "Me siento cómodo leyendo o hablando inglés o español.",
+              "dev": "DEV_I am comfortable reading or speaking English or Spanish."
             },
             "isRequired": true,
             "choices": [
@@ -253,7 +225,7 @@
     "calculatedValues": [
       {
         "name": "qualified",
-        "expression": "{hd_hd_preenroll_southAsianAncestry} = 'yes' && {hd_hd_preenroll_understandsEnglish} = 'yes' && {hd_hd_preenroll_isAdult} = 'yes' && {hd_hd_preenroll_livesInUS} = 'yes'",
+        "expression": "{hd_hd_preenroll_understandsEnglish} = 'yes' && {hd_hd_preenroll_isAdult} = 'yes' && {hd_hd_preenroll_livesInUS} = 'yes'",
         "includeIntoResult": true
       },
       {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

far from complete, but continues the process of removing OurHealth-specific language from the Demo study.  This was just enough to produce some fresh screenshots for the zendesk docs.  Not worth the full update yet, but wanted to get this in before merge conflicts result...

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. repopulate demo
2. go to https://sandbox.demo.localhost:3001/.  Confirm landing page and pre-enroll pages mention OurHealth less than they used to :)