### PR TITLE
[JN-1082] fixing consent event handling

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/consent/ConsentStatusProcessor.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/consent/ConsentStatusProcessor.java
@@ -1,14 +1,14 @@
 package bio.terra.pearl.core.service.consent;
 
-import bio.terra.pearl.core.model.audit.DataAuditInfo;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
 import bio.terra.pearl.core.model.workflow.TaskStatus;
 import bio.terra.pearl.core.model.workflow.TaskType;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
-import bio.terra.pearl.core.service.search.EnrolleeSearchExpressionParser;
+import bio.terra.pearl.core.service.survey.event.EnrolleeSurveyEvent;
 import bio.terra.pearl.core.service.workflow.DispatcherOrder;
 import bio.terra.pearl.core.service.workflow.EnrolleeEvent;
+import bio.terra.pearl.core.service.workflow.EventService;
 import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -17,44 +17,44 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-/** Holds logic for building and processing consent tasks, and event listeners for triggering updates */
+/** Holds logic for updating whether or not an enrollee is consented */
 @Service
 @Slf4j
-public class ConsentTaskDispatcher {
-    private ParticipantTaskService participantTaskService;
-    private EnrolleeService enrolleeService;
-    private EnrolleeSearchExpressionParser enrolleeSearchExpressionParser;
+public class ConsentStatusProcessor {
+    private final ParticipantTaskService participantTaskService;
+    private final EnrolleeService enrolleeService;
+    private final EventService eventService;
 
-    public ConsentTaskDispatcher(ParticipantTaskService participantTaskService,
-                                 EnrolleeService enrolleeService,
-                                 EnrolleeSearchExpressionParser enrolleeSearchExpressionParser) {
+    public ConsentStatusProcessor(ParticipantTaskService participantTaskService,
+                                  EnrolleeService enrolleeService,
+                                  EventService eventService) {
         this.participantTaskService = participantTaskService;
         this.enrolleeService = enrolleeService;
-        this.enrolleeSearchExpressionParser = enrolleeSearchExpressionParser;
+        this.eventService = eventService;
     }
 
     /**
-     * We want to listen to enrollee creation events and consent response events.  (but not survey events)
-     * see https://stackoverflow.com/questions/45884537/use-eventlistener-annotation-on-multiple-events-in-spring
-     * for why we use two separate listening methods to accomplish that
+     * Listen for survey events, and if the event was consent-related, update the enrollee's consent status
      */
     @EventListener
-    @Order(DispatcherOrder.CONSENT_TASK)
-    public void handleEvent(EnrolleeConsentEvent enrolleeEvent) {
-        updateConsentTasks(enrolleeEvent);
-    }
-
-    public void updateConsentTasks(EnrolleeEvent enrolleeEvent) {
-        updateEnrolleeConsented(enrolleeEvent.getEnrollee(), enrolleeEvent.getEnrollee().getParticipantTasks());
+    @Order(DispatcherOrder.CONSENT_PROCESSOR)
+    public void handleEvent(EnrolleeSurveyEvent enrolleeEvent) {
+        /** for now, only updates to consent tasks have the possibility to update consent status */
+        if (enrolleeEvent.getParticipantTask().getTaskType() == TaskType.CONSENT) {
+            updateEnrolleeConsented(enrolleeEvent.getEnrollee(), enrolleeEvent.getEnrollee().getParticipantTasks(), enrolleeEvent);
+        }
     }
 
     /** check the enrollee's current consent status, and update it if needed.  this will handle both
      * updating the DB and the enrollee object in-place */
-    public Enrollee updateEnrolleeConsented(Enrollee enrollee, List<ParticipantTask> participantTasks) {
+    public Enrollee updateEnrolleeConsented(Enrollee enrollee, List<ParticipantTask> participantTasks, EnrolleeEvent enrolleeEvent) {
         boolean consentStatus = checkIsEnrolleeConsented(participantTasks);
         if (enrollee.isConsented() != consentStatus) {
             enrollee.setConsented(consentStatus);
             enrolleeService.updateConsented(enrollee.getId(), consentStatus);
+            if (enrollee.isConsented()) {
+                eventService.publishEnrolleeConsentEvent(enrollee, enrolleeEvent.getPortalParticipantUser());
+            }
         }
         return enrollee;
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/consent/EnrolleeConsentEvent.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/consent/EnrolleeConsentEvent.java
@@ -6,9 +6,9 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
+/** event for a participant's status changing to consented */
 @Getter
 @Setter
 @SuperBuilder
 public class EnrolleeConsentEvent extends EnrolleeEvent {
-    private SurveyResponse surveyResponse;
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -10,7 +10,6 @@ import bio.terra.pearl.core.model.survey.Answer;
 import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
-import bio.terra.pearl.core.model.survey.SurveyType;
 import bio.terra.pearl.core.model.survey.SurveyWithResponse;
 import bio.terra.pearl.core.model.workflow.HubResponse;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
@@ -19,14 +18,11 @@ import bio.terra.pearl.core.model.workflow.TaskType;
 import bio.terra.pearl.core.service.CascadeProperty;
 import bio.terra.pearl.core.service.ImmutableEntityService;
 import bio.terra.pearl.core.service.exception.NotFoundException;
-import bio.terra.pearl.core.service.participant.EnrolleeService;
-import bio.terra.pearl.core.service.portal.PortalService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
 import bio.terra.pearl.core.service.survey.event.EnrolleeSurveyEvent;
 import bio.terra.pearl.core.service.workflow.DataChangeRecordService;
 import bio.terra.pearl.core.service.workflow.EventService;
 import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -156,11 +152,8 @@ public class SurveyResponseService extends ImmutableEntityService<SurveyResponse
 
         // now update the task status and response id
         task = updateTaskToResponse(task, response, updatedAnswers, auditInfo);
+        EnrolleeSurveyEvent event = eventService.publishEnrolleeSurveyEvent(enrollee, response, ppUser, task);
 
-        EnrolleeSurveyEvent event = eventService.publishEnrolleeSurveyEvent(enrollee, response, ppUser);
-        if (survey.getSurveyType().equals(SurveyType.CONSENT)) {
-            eventService.publishEnrolleeConsentEvent(enrollee, ppUser, response, task);
-        }
         logger.info("SurveyResponse received -- enrollee: {}, surveyStabledId: {}", enrollee.getShortcode(), survey.getStableId());
         HubResponse<SurveyResponse> hubResponse = eventService.buildHubResponse(event, response);
         return hubResponse;

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/event/EnrolleeSurveyEvent.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/event/EnrolleeSurveyEvent.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.service.survey.event;
 
 import bio.terra.pearl.core.model.survey.SurveyResponse;
+import bio.terra.pearl.core.model.workflow.ParticipantTask;
 import bio.terra.pearl.core.service.workflow.EnrolleeEvent;
 import lombok.Getter;
 import lombok.Setter;
@@ -14,4 +15,5 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 public class EnrolleeSurveyEvent extends EnrolleeEvent {
     private SurveyResponse surveyResponse;
+    private ParticipantTask participantTask; // the task corresponding to the response
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/DispatcherOrder.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/DispatcherOrder.java
@@ -11,7 +11,7 @@ package bio.terra.pearl.core.service.workflow;
   */
 
 public class DispatcherOrder {
-    public static final int CONSENT_TASK = 5;
+    public static final int CONSENT_PROCESSOR = 5;
     public static final int SURVEY_TASK = 10;
     public static final int KIT_TASK = 20;
     // notifications should be processed last so they can include all previous processing

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
@@ -66,28 +66,26 @@ public class EventService extends ImmutableEntityService<Event, EventDao> {
     }
 
     public EnrolleeConsentEvent publishEnrolleeConsentEvent(Enrollee enrollee,
-                                                            PortalParticipantUser ppUser, SurveyResponse response,
-                                                            ParticipantTask task) {
+                                                            PortalParticipantUser ppUser) {
         EnrolleeConsentEvent event = EnrolleeConsentEvent.builder()
-                .surveyResponse(response)
                 .enrollee(enrollee)
                 .portalParticipantUser(ppUser)
                 .build();
         populateEvent(event);
-        log.info("consent event for enrollee {}, studyEnv {} - form {}, consented - {}",
-                enrollee.getShortcode(), enrollee.getStudyEnvironmentId(),
-                response.getSurveyId(), TaskStatus.COMPLETE.equals(task.getStatus()));
+        log.info("consent event for enrollee {}, studyEnv {}, consented - {}",
+                enrollee.getShortcode(), enrollee.getStudyEnvironmentId(), enrollee.isConsented());
         saveEvent(EventClass.ENROLLEE_CONSENT_EVENT, ppUser.getPortalEnvironmentId(), enrollee);
         applicationEventPublisher.publishEvent(event);
         return event;
     }
 
     public EnrolleeSurveyEvent publishEnrolleeSurveyEvent(Enrollee enrollee, SurveyResponse response,
-                                                          PortalParticipantUser ppUser) {
+                                                          PortalParticipantUser ppUser, ParticipantTask task) {
         EnrolleeSurveyEvent event = EnrolleeSurveyEvent.builder()
                 .surveyResponse(response)
                 .enrollee(enrollee)
                 .portalParticipantUser(ppUser)
+                .participantTask(task)
                 .build();
         populateEvent(event);
         log.info("survey event for enrollee {}, studyEnv {} - formId {}, completed {}",

--- a/core/src/test/java/bio/terra/pearl/core/service/workflow/EventServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/workflow/EventServiceTests.java
@@ -35,9 +35,7 @@ public class EventServiceTests extends BaseSpringBootTest {
         Assertions.assertEquals(0, eventService.findAll().size());
         eventService.publishEnrolleeConsentEvent(
                 bundle.enrollee(),
-                bundle.portalParticipantUser(),
-                SurveyResponse.builder().build(),
-                ParticipantTask.builder().status(TaskStatus.NEW).build()
+                bundle.portalParticipantUser()
                 );
 
         List<Event> createdEvents = eventService.findAll();
@@ -50,7 +48,6 @@ public class EventServiceTests extends BaseSpringBootTest {
     @Test
     @Transactional
     public void testPersistsEnrolleeCreationEvent() {
-
         EnrolleeFactory.EnrolleeBundle bundle = enrolleeFactory.buildWithPortalUser("testPersistsEnrolleeCreationEvent");
         Assertions.assertEquals(0, eventService.findAll().size());
         eventService.publishEnrolleeCreationEvent(
@@ -73,7 +70,8 @@ public class EventServiceTests extends BaseSpringBootTest {
         eventService.publishEnrolleeSurveyEvent(
                 bundle.enrollee(),
                 SurveyResponse.builder().build(),
-                bundle.portalParticipantUser());
+                bundle.portalParticipantUser(),
+                new ParticipantTask());
 
         List<Event> createdEvents = eventService.findAll();
         Assertions.assertEquals(1, createdEvents.size());


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

This was a lingering bug from the consent form -> survey refactor.  We weren't correcting for the fact that consent forms didn't used to be able to be saved in-progress, and so consent events were firing for in-progress forms, instead of just completed forms.  This does some renaming/rearranging to make the handling of consent events more explicit.  

I spent a good deal of time trying to find a nice way to log spring events in tests, so that it would be easy for a test to say "assert that an event of <Class> was published X times".  But I couldn't find a nice thread-safe way to do that.  So instead the test checks the database for the event history.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy ApiParticipantApp
2. log in to ourhealth as `newbie@test.com`
3. start filling out a couple questions in the consent form
4. stop before hitting complete
5. check your email, confirm you have not gotten a "Thank you" email