### PR TITLE
[JN-1132] site content language selector

### DIFF
--- a/ui-admin/src/portal/siteContent/SiteContentEditor.test.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.test.tsx
@@ -141,14 +141,35 @@ test('delete page button is disabled when Landing page is selected', async () =>
 test('renders a language selector when there are multiple languages', async () => {
   const siteContent = mockSiteContent()
   const portalEnvContext = mockPortalEnvContext('sandbox')
-  const { RoutedComponent } = setupRouterTest(
+  renderWithRouter(
     <SiteContentEditor siteContent={siteContent} previewApi={emptyApi} readOnly={false}
       loadSiteContent={jest.fn()} createNewVersion={jest.fn()} switchToVersion={jest.fn()}
       portalEnvContext={portalEnvContext}/>)
-  render(RoutedComponent)
 
   const languageSelector = screen.getByLabelText('Select a language')
   expect(languageSelector).toBeInTheDocument()
+})
+
+test('shows no content if nothing for a selected language', async () => {
+  const siteContent = mockSiteContent()
+  const portalEnvContext = mockPortalEnvContext('sandbox')
+  renderWithRouter(
+    <SiteContentEditor siteContent={siteContent} previewApi={emptyApi} readOnly={false}
+      loadSiteContent={jest.fn()} createNewVersion={jest.fn()} switchToVersion={jest.fn()}
+      portalEnvContext={portalEnvContext}/>)
+  expect(screen.queryByText('No content has been configured for this language.')).not.toBeInTheDocument()
+  await select(screen.getByLabelText('Select a language'), 'Spanish')
+  expect(screen.getByText('No content has been configured for this language.')).toBeInTheDocument()
+})
+
+test('selected language routes from url', async () => {
+  const siteContent = mockSiteContent()
+  const portalEnvContext = mockPortalEnvContext('sandbox')
+  renderWithRouter(
+    <SiteContentEditor siteContent={siteContent} previewApi={emptyApi} readOnly={false}
+      loadSiteContent={jest.fn()} createNewVersion={jest.fn()} switchToVersion={jest.fn()}
+      portalEnvContext={portalEnvContext}/>, ['/?lang=es'])
+  expect(screen.getByText('No content has been configured for this language.')).toBeInTheDocument()
 })
 
 test('does not render a language selector when there is only one language', async () => {
@@ -161,11 +182,10 @@ test('does not render a language selector when there is only one language', asyn
       supportedLanguages: []
     }
   }
-  const { RoutedComponent } = setupRouterTest(
+  renderWithRouter(
     <SiteContentEditor siteContent={siteContent} previewApi={emptyApi} readOnly={false}
       loadSiteContent={jest.fn()} createNewVersion={jest.fn()} switchToVersion={jest.fn()}
       portalEnvContext={mockContextOnlyEnglish}/>)
-  render(RoutedComponent)
 
   expect(screen.queryByLabelText('Select a language')).not.toBeInTheDocument()
 })


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Upgrades the language selector for the SiteContent editor to be url-param backed, and to not disable the whole page (which prevented switching back) if you switch to a language for which there is no LocalSiteContent

<img width="1238" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/100e1682-a6c3-46ff-a48f-909bc83f4748">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/siteContent?lang=es
2. confirm the spanish content is shown in the preview
3.  make sure ourhealth is populated, then run
`insert into portal_environment_language values (gen_random_uuid() ,now(), now(), 'es', 'Espanish', (select id from portal_environment where portal_id = (select id from portal where shortcode = 'ourhealth') and environment_name = 'sandbox'));`
to add a language
4. go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/siteContent
5. switch to spanish
6. confirm you see a "no content for this language message"
7. confirm you can switch back to English