### PR TITLE
[JN-1132]  fix i18n save of SiteContents

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/siteContent/SiteContentController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/siteContent/SiteContentController.java
@@ -3,6 +3,7 @@ package bio.terra.pearl.api.admin.controller.siteContent;
 import bio.terra.pearl.api.admin.api.SiteContentApi;
 import bio.terra.pearl.api.admin.service.auth.AuthUtilService;
 import bio.terra.pearl.api.admin.service.siteContent.SiteContentExtService;
+import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.site.SiteContent;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -31,28 +32,36 @@ public class SiteContentController implements SiteContentApi {
   }
 
   @Override
-  public ResponseEntity<Object> get(
-      String portalShortcode, String stableId, Integer version, String language) {
-    AdminUser adminUser = authUtilService.requireAdminUser(request);
+  public ResponseEntity<Object> get(String portalShortcode, String stableId, Integer version) {
+    AdminUser operator = authUtilService.requireAdminUser(request);
     Optional<SiteContent> siteContent =
-        siteContentExtService.get(portalShortcode, stableId, version, language, adminUser);
+        siteContentExtService.get(portalShortcode, stableId, version, operator);
+    return ResponseEntity.of(siteContent.map(content -> content));
+  }
+
+  @Override
+  public ResponseEntity<Object> getCurrent(String portalShortcode, String envName) {
+    AdminUser operator = authUtilService.requireAdminUser(request);
+    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
+    Optional<SiteContent> siteContent =
+        siteContentExtService.getCurrent(portalShortcode, environmentName, operator);
     return ResponseEntity.of(siteContent.map(content -> content));
   }
 
   @Override
   public ResponseEntity<Object> create(String portalShortcode, String stableId, Object body) {
-    AdminUser adminUser = authUtilService.requireAdminUser(request);
+    AdminUser operator = authUtilService.requireAdminUser(request);
     SiteContent siteContent = objectMapper.convertValue(body, SiteContent.class);
     SiteContent savedContent =
-        siteContentExtService.create(portalShortcode, stableId, siteContent, adminUser);
+        siteContentExtService.create(portalShortcode, stableId, siteContent, operator);
     return ResponseEntity.ok(savedContent);
   }
 
   @Override
   public ResponseEntity<Object> versionList(String portalShortcode, String stableId) {
-    AdminUser adminUser = authUtilService.requireAdminUser(request);
+    AdminUser operator = authUtilService.requireAdminUser(request);
     List<SiteContent> contents =
-        siteContentExtService.versionList(portalShortcode, stableId, adminUser);
+        siteContentExtService.versionList(portalShortcode, stableId, operator);
     return ResponseEntity.ok(contents);
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/siteContent/SiteContentExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/siteContent/SiteContentExtService.java
@@ -1,32 +1,71 @@
 package bio.terra.pearl.api.admin.service.siteContent;
 
 import bio.terra.pearl.api.admin.service.auth.AuthUtilService;
+import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.portal.Portal;
+import bio.terra.pearl.core.model.portal.PortalEnvironment;
+import bio.terra.pearl.core.model.portal.PortalEnvironmentLanguage;
 import bio.terra.pearl.core.model.site.SiteContent;
+import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
+import bio.terra.pearl.core.service.portal.PortalLanguageService;
 import bio.terra.pearl.core.service.site.SiteContentService;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.springframework.stereotype.Service;
 
 @Service
 public class SiteContentExtService {
-  private AuthUtilService authUtilService;
-  private SiteContentService siteContentService;
+  private final AuthUtilService authUtilService;
+  private final SiteContentService siteContentService;
+  private final PortalLanguageService portalLanguageService;
+  private final PortalEnvironmentService portalEnvironmentService;
 
   public SiteContentExtService(
-      AuthUtilService authUtilService, SiteContentService siteContentService) {
+      AuthUtilService authUtilService,
+      SiteContentService siteContentService,
+      PortalLanguageService portalLanguageService,
+      PortalEnvironmentService portalEnvironmentService) {
     this.authUtilService = authUtilService;
     this.siteContentService = siteContentService;
+    this.portalLanguageService = portalLanguageService;
+    this.portalEnvironmentService = portalEnvironmentService;
   }
 
   public Optional<SiteContent> get(
-      String portalShortcode, String stableId, Integer version, String language, AdminUser user) {
+      String portalShortcode, String stableId, Integer version, AdminUser user) {
     Portal portal = authUtilService.authUserToPortal(user, portalShortcode);
+    PortalEnvironment portalEnv =
+        portalEnvironmentService
+            .findOne(portal.getShortcode(), EnvironmentName.sandbox)
+            .orElseThrow();
+
     Optional<SiteContent> siteContentOpt =
         siteContentService.findByStableId(stableId, version, portal.getId());
-    if (siteContentOpt.isPresent() && siteContentOpt.get().getPortalId().equals(portal.getId())) {
-      siteContentService.attachChildContent(siteContentOpt.get(), language);
+    if (siteContentOpt.isEmpty()) {
+      return Optional.empty();
+    }
+    return loadSiteContent(siteContentOpt.get().getId(), portalEnv);
+  }
+
+  public Optional<SiteContent> getCurrent(
+      String portalShortcode, EnvironmentName environmentName, AdminUser operator) {
+    Portal portal = authUtilService.authUserToPortal(operator, portalShortcode);
+    PortalEnvironment portalEnv =
+        portalEnvironmentService.findOne(portal.getShortcode(), environmentName).orElseThrow();
+    return loadSiteContent(portalEnv.getSiteContentId(), portalEnv);
+  }
+
+  public Optional<SiteContent> loadSiteContent(UUID siteContentId, PortalEnvironment portalEnv) {
+    Optional<SiteContent> siteContentOpt = siteContentService.find(siteContentId);
+    List<PortalEnvironmentLanguage> languages =
+        portalLanguageService.findByPortalEnvId(portalEnv.getId());
+    if (siteContentOpt.isPresent()
+        && siteContentOpt.get().getPortalId().equals(portalEnv.getPortalId())) {
+      for (PortalEnvironmentLanguage lang : languages) {
+        siteContentService.attachChildContent(siteContentOpt.get(), lang.getLanguageCode());
+      }
       return siteContentOpt;
     }
     return Optional.empty();

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -405,7 +405,20 @@ paths:
         - { name: portalShortcode, in: path, required: true, schema: { type: string } }
         - { name: stableId, in: path, required: true, schema: { type: string } }
         - { name: version, in: path, required: true, schema: { type: integer } }
-        - { name: language, in: query, required: false, schema: { type: string } }
+      responses:
+        '200':
+          description: SiteContent object with all dependent relations attached
+          content: { application/json: { schema: { schema: { type: object } } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/env/{envName}/siteContent:
+    get:
+      summary: Returns the site content with for the given portal environment, along with all child content in the specified language (english is default)
+      tags: [ siteContent ]
+      operationId: getCurrent
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: envName, in: path, required: true, schema: { type: string } }
       responses:
         '200':
           description: SiteContent object with all dependent relations attached

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/siteContent/SiteContentExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/siteContent/SiteContentExtServiceTests.java
@@ -1,0 +1,75 @@
+package bio.terra.pearl.api.admin.service.siteContent;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+
+import bio.terra.pearl.api.admin.BaseSpringBootTest;
+import bio.terra.pearl.core.factory.portal.PortalEnvironmentFactory;
+import bio.terra.pearl.core.factory.site.SiteContentFactory;
+import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.portal.PortalEnvironment;
+import bio.terra.pearl.core.model.portal.PortalEnvironmentLanguage;
+import bio.terra.pearl.core.model.site.LocalizedSiteContent;
+import bio.terra.pearl.core.model.site.SiteContent;
+import bio.terra.pearl.core.service.portal.PortalLanguageService;
+import bio.terra.pearl.core.service.site.SiteContentService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+public class SiteContentExtServiceTests extends BaseSpringBootTest {
+  @Autowired private SiteContentExtService siteContentExtService;
+  @Autowired private PortalEnvironmentFactory portalEnvironmentFactory;
+  @Autowired private SiteContentFactory siteContentFactory;
+  @Autowired private SiteContentService siteContentService;
+  @Autowired private PortalLanguageService portalLanguageService;
+
+  @Test
+  @Transactional
+  public void testGetLoadAllLanguages(TestInfo testInfo) {
+    PortalEnvironment portalEnv =
+        portalEnvironmentFactory.buildPersisted(getTestName(testInfo), EnvironmentName.sandbox);
+    portalLanguageService.create(
+        PortalEnvironmentLanguage.builder()
+            .languageCode("es")
+            .languageName("Spanish")
+            .portalEnvironmentId(portalEnv.getId())
+            .build());
+    portalLanguageService.create(
+        PortalEnvironmentLanguage.builder()
+            .languageCode("en")
+            .languageName("English")
+            .portalEnvironmentId(portalEnv.getId())
+            .build());
+
+    SiteContent siteContent =
+        SiteContent.builder()
+            .portalId(portalEnv.getPortalId())
+            .stableId(getTestName(testInfo))
+            .version(1)
+            .localizedSiteContents(
+                List.of(
+                    LocalizedSiteContent.builder()
+                        .language("es")
+                        .navLogoCleanFileName("spanish-logo.png")
+                        .build(),
+                    LocalizedSiteContent.builder()
+                        .language("en")
+                        .navLogoCleanFileName("english-logo.png")
+                        .build()))
+            .build();
+    siteContent = siteContentService.create(siteContent);
+
+    SiteContent loadedSiteContent =
+        siteContentExtService.loadSiteContent(siteContent.getId(), portalEnv).orElseThrow();
+    assertThat(loadedSiteContent.getLocalizedSiteContents(), hasSize(2));
+    assertThat(
+        loadedSiteContent.getLocalizedSiteContents().stream()
+            .map(LocalizedSiteContent::getNavLogoCleanFileName)
+            .toList(),
+        containsInAnyOrder("spanish-logo.png", "english-logo.png"));
+  }
+}

--- a/populate/src/main/java/bio/terra/pearl/populate/dto/RoleDto.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/dto/RoleDto.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.populate.dto;
 
 import bio.terra.pearl.core.model.admin.Role;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -11,5 +12,6 @@ import java.util.List;
 
 @Getter @Setter @SuperBuilder @NoArgsConstructor
 public class RoleDto extends Role {
+    @Builder.Default
     private List<String> permissionNames = new ArrayList<>();
 }

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -703,11 +703,18 @@ export default {
     return await this.processJsonResponse(response)
   },
 
-  async getSiteContent(portalShortcode: string, stableId: string, version: number, language?: string) {
+  async getSiteContent(portalShortcode: string, stableId: string, version: number) {
     const baseUrl = `${basePortalUrl(portalShortcode)}/siteContents/${stableId}/${version}`
-    const response = await fetch(language ? `${baseUrl}?language=${language}` : baseUrl, this.getGetInit())
+    const response = await fetch(baseUrl, this.getGetInit())
     return await this.processJsonResponse(response)
   },
+
+  async getCurrentSiteContent(portalShortcode: string, environmentName: string) {
+    const baseUrl = `${basePortalEnvUrl(portalShortcode, environmentName)}/siteContent`
+    const response =await fetch(baseUrl, this.getGetInit())
+    return await this.processJsonResponse(response)
+  },
+
 
   async assignParticipantTasksToEnrollees(studyEnvParams: StudyEnvParams,
     assignDto: ParticipantTaskAssignDto): Promise<ParticipantTask[]> {

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.test.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.test.tsx
@@ -141,14 +141,35 @@ test('delete page button is disabled when Landing page is selected', async () =>
 test('renders a language selector when there are multiple languages', async () => {
   const siteContent = mockSiteContent()
   const portalEnvContext = mockPortalEnvContext('sandbox')
-  const { RoutedComponent } = setupRouterTest(
+  renderWithRouter(
     <SiteContentEditor siteContent={siteContent} previewApi={emptyApi} readOnly={false}
       loadSiteContent={jest.fn()} createNewVersion={jest.fn()} switchToVersion={jest.fn()}
       portalEnvContext={portalEnvContext}/>)
-  render(RoutedComponent)
 
   const languageSelector = screen.getByLabelText('Select a language')
   expect(languageSelector).toBeInTheDocument()
+})
+
+test('shows no content if nothing for a selected language', async () => {
+  const siteContent = mockSiteContent()
+  const portalEnvContext = mockPortalEnvContext('sandbox')
+  renderWithRouter(
+    <SiteContentEditor siteContent={siteContent} previewApi={emptyApi} readOnly={false}
+      loadSiteContent={jest.fn()} createNewVersion={jest.fn()} switchToVersion={jest.fn()}
+      portalEnvContext={portalEnvContext}/>)
+  expect(screen.queryByText('No content has been configured for this language.')).not.toBeInTheDocument()
+  await select(screen.getByLabelText('Select a language'), 'Spanish')
+  expect(screen.getByText('No content has been configured for this language.')).toBeInTheDocument()
+})
+
+test('selected language routes from url', async () => {
+  const siteContent = mockSiteContent()
+  const portalEnvContext = mockPortalEnvContext('sandbox')
+  renderWithRouter(
+    <SiteContentEditor siteContent={siteContent} previewApi={emptyApi} readOnly={false}
+      loadSiteContent={jest.fn()} createNewVersion={jest.fn()} switchToVersion={jest.fn()}
+      portalEnvContext={portalEnvContext}/>, ['/?lang=es'])
+  expect(screen.getByText('No content has been configured for this language.')).toBeInTheDocument()
 })
 
 test('does not render a language selector when there is only one language', async () => {
@@ -161,11 +182,10 @@ test('does not render a language selector when there is only one language', asyn
       supportedLanguages: []
     }
   }
-  const { RoutedComponent } = setupRouterTest(
+  renderWithRouter(
     <SiteContentEditor siteContent={siteContent} previewApi={emptyApi} readOnly={false}
       loadSiteContent={jest.fn()} createNewVersion={jest.fn()} switchToVersion={jest.fn()}
       portalEnvContext={mockContextOnlyEnglish}/>)
-  render(RoutedComponent)
 
   expect(screen.queryByLabelText('Select a language')).not.toBeInTheDocument()
 })

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -42,10 +42,9 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
     siteContent, previewApi, portalEnvContext, loadSiteContent, switchToVersion, createNewVersion, readOnly
   } = props
   const { portalEnv } = portalEnvContext
-  const initialContent = siteContent
   const [activeTab, setActiveTab] = useState<string | null>('designer')
   const [selectedNavOpt, setSelectedNavOpt] = useState<NavbarOption>(landingPageOption)
-  const [workingContent, setWorkingContent] = useState<SiteContent>(initialContent)
+  const [workingContent, setWorkingContent] = useState<SiteContent>(siteContent)
   const [showVersionSelector, setShowVersionSelector] = useState(false)
   const [showAddPageModal, setShowAddPageModal] = useState(false)
   const [showBrandingModal, setShowBrandingModal] = useState(false)
@@ -185,7 +184,7 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
   }
 
   const participantViewClick = () => {
-    if (hasInvalidSection || (initialContent !== workingContent)) {
+    if (hasInvalidSection || (siteContent !== workingContent)) {
       setShowUnsavedPreviewModal(true)
     } else {
       showParticipantView()
@@ -232,10 +231,10 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
         {
           isEditable && <div className="d-flex flex-grow-1">
             <Button className="ms-auto me-md-2" variant="primary"
-              disabled={readOnly || hasInvalidSection || (initialContent === workingContent)}
+              disabled={readOnly || hasInvalidSection || (siteContent === workingContent)}
               tooltipPlacement={'left'}
               tooltip={(() => {
-                if (initialContent === workingContent) {
+                if (siteContent === workingContent) {
                   return 'Site is unchanged. Make changes to save.'
                 }
                 if (hasInvalidSection) {
@@ -269,7 +268,6 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
               onChange={e => {
                 if (e?.value) {
                   languageOnChange(e)
-                  loadSiteContent(workingContent.stableId, workingContent.version, e?.value.languageCode)
                 }
               }}/>
           </div> }

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -22,6 +22,7 @@ import { faExternalLink } from '@fortawesome/free-solid-svg-icons/faExternalLink
 import { useConfig } from 'providers/ConfigProvider'
 import Modal from 'react-bootstrap/Modal'
 import { useNonNullReactSingleSelect } from 'util/react-select-utils'
+import { usePortalLanguage } from '../usePortalLanguage'
 
 type NavbarOption = {label: string, value: string}
 const landingPageOption = { label: 'Landing page', value: 'Landing page' }
@@ -55,7 +56,8 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
 
   const zoneConfig = useConfig()
   const [searchParams, setSearchParams] = useSearchParams()
-  const selectedLanguageCode = searchParams.get('lang') ?? workingContent.localizedSiteContents[0]?.language
+  const { defaultLanguage } = usePortalLanguage()
+  const selectedLanguageCode = searchParams.get('lang') ?? defaultLanguage.languageCode
   const selectedLanguage = portalEnvContext.portalEnv.supportedLanguages.find(portalLang =>
     portalLang.languageCode === selectedLanguageCode)
   const localContent = workingContent.localizedSiteContents.find(lsc => lsc.language === selectedLanguage?.languageCode)

--- a/ui-admin/src/portal/siteContent/SiteContentLoader.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentLoader.tsx
@@ -7,14 +7,12 @@ import { failureNotification, successNotification } from 'util/notifications'
 import LoadingSpinner from 'util/LoadingSpinner'
 import SiteContentEditor from './SiteContentEditor'
 import { previewApi } from 'util/apiContextUtils'
-import { usePortalLanguage } from '../usePortalLanguage'
 
 /** logic for loading, changing, and saving SiteContent objects */
 const SiteContentLoader = ({ portalEnvContext }: {portalEnvContext: PortalEnvContext}) => {
   const { portal, portalEnv } = portalEnvContext
   const portalShortcode = portal.shortcode
   const [isLoading, setIsLoading] = useState(true)
-  const { defaultLanguage } = usePortalLanguage()
   const [siteContent, setSiteContent] = useState(portalEnv.siteContent)
 
   if (!siteContent) {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Previously, we only fetched one language at a time for display in the admin tool.  This caused all sorts of fun loading and saving issues.  This changes the loading behavior to fetch all languages on initial load, which makes the save a simpler operation.

Also, the SiteContentEditor no longer relies on the portalEnvContext having a siteContent loaded on it -- instead a new `getCurrent` siteContent endpoint is added so that the component can just say "get me the siteContent for this environment"

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1. repopulate demo
2. redeploy ApiAdminApp
3. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/siteContent
4. make changes to the english content
5. make changes to the spanish content
6. go back to english view, confirm your changes still appear
7. save
8. confirm english and spanish changes all still appear
9. use the history menu to go back to a prior version
10. confirm the prior version renders correctly
