### PR TITLE
[JN-1134] add env language

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/portal/PortalEnvironmentController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/portal/PortalEnvironmentController.java
@@ -7,9 +7,12 @@ import bio.terra.pearl.api.admin.service.portal.PortalPublishingExtService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
+import bio.terra.pearl.core.model.portal.PortalEnvironmentLanguage;
 import bio.terra.pearl.core.model.publishing.PortalEnvironmentChange;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
@@ -42,6 +45,17 @@ public class PortalEnvironmentController implements PortalEnvironmentApi {
     PortalEnvironment updatedEnv =
         portalExtService.updateEnvironment(portalShortcode, environmentName, portalEnv, user);
     return ResponseEntity.ok(updatedEnv);
+  }
+
+  @Override
+  public ResponseEntity<Object> setLanguages(String portalShortcode, String envName, Object body) {
+    AdminUser user = authUtilService.requireAdminUser(request);
+    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
+    List<PortalEnvironmentLanguage> updatedLanguages =
+        objectMapper.convertValue(body, new TypeReference<List<PortalEnvironmentLanguage>>() {});
+    updatedLanguages =
+        portalExtService.setLanguages(portalShortcode, environmentName, updatedLanguages, user);
+    return ResponseEntity.ok(updatedLanguages);
   }
 
   @Override

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/portal/PortalExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/portal/PortalExtService.java
@@ -6,10 +6,12 @@ import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.portal.PortalEnvironmentConfig;
+import bio.terra.pearl.core.model.portal.PortalEnvironmentLanguage;
 import bio.terra.pearl.core.service.admin.PortalAdminUserService;
 import bio.terra.pearl.core.service.exception.PermissionDeniedException;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentConfigService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
+import bio.terra.pearl.core.service.portal.PortalLanguageService;
 import bio.terra.pearl.core.service.portal.PortalService;
 import bio.terra.pearl.core.service.portal.exception.PortalConfigMissing;
 import bio.terra.pearl.core.service.portal.exception.PortalEnvironmentMissing;
@@ -24,6 +26,7 @@ public class PortalExtService {
   private PortalEnvironmentService portalEnvironmentService;
   private PortalEnvironmentConfigService portalEnvironmentConfigService;
   private PortalAdminUserService portalAdminUserService;
+  private PortalLanguageService portalLanguageService;
   private AuthUtilService authUtilService;
 
   public PortalExtService(
@@ -100,7 +103,11 @@ public class PortalExtService {
             .orElseThrow(PortalEnvironmentMissing::new);
     portalEnv.setSiteContentId(updatedEnv.getSiteContentId());
     portalEnv.setPreRegSurveyId(updatedEnv.getPreRegSurveyId());
-    return portalEnvironmentService.update(portalEnv);
+    portalEnv = portalEnvironmentService.update(portalEnv);
+    if (updatedEnv.getSupportedLanguages().size() > 0) {
+      List<PortalEnvironmentLanguage> updatedLangs = portalLanguageService.setPortalEnvLanguages(portalEnv.getId(), updatedEnv.getSupportedLanguages());
+      portalEnv.setSupportedLanguages(updatedLangs);
+    }
   }
 
   public void removeUserFromPortal(UUID adminUserId, String portalShortcode, AdminUser operator) {

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/siteContent/SiteContentExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/siteContent/SiteContentExtService.java
@@ -7,8 +7,8 @@ import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.portal.PortalEnvironmentLanguage;
 import bio.terra.pearl.core.model.site.SiteContent;
+import bio.terra.pearl.core.service.portal.PortalEnvironmentLanguageService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
-import bio.terra.pearl.core.service.portal.PortalLanguageService;
 import bio.terra.pearl.core.service.site.SiteContentService;
 import java.util.List;
 import java.util.Optional;
@@ -19,17 +19,17 @@ import org.springframework.stereotype.Service;
 public class SiteContentExtService {
   private final AuthUtilService authUtilService;
   private final SiteContentService siteContentService;
-  private final PortalLanguageService portalLanguageService;
+  private final PortalEnvironmentLanguageService portalEnvironmentLanguageService;
   private final PortalEnvironmentService portalEnvironmentService;
 
   public SiteContentExtService(
       AuthUtilService authUtilService,
       SiteContentService siteContentService,
-      PortalLanguageService portalLanguageService,
+      PortalEnvironmentLanguageService portalEnvironmentLanguageService,
       PortalEnvironmentService portalEnvironmentService) {
     this.authUtilService = authUtilService;
     this.siteContentService = siteContentService;
-    this.portalLanguageService = portalLanguageService;
+    this.portalEnvironmentLanguageService = portalEnvironmentLanguageService;
     this.portalEnvironmentService = portalEnvironmentService;
   }
 
@@ -60,7 +60,7 @@ public class SiteContentExtService {
   public Optional<SiteContent> loadSiteContent(UUID siteContentId, PortalEnvironment portalEnv) {
     Optional<SiteContent> siteContentOpt = siteContentService.find(siteContentId);
     List<PortalEnvironmentLanguage> languages =
-        portalLanguageService.findByPortalEnvId(portalEnv.getId());
+        portalEnvironmentLanguageService.findByPortalEnvId(portalEnv.getId());
     if (siteContentOpt.isPresent()
         && siteContentOpt.get().getPortalId().equals(portalEnv.getPortalId())) {
       for (PortalEnvironmentLanguage lang : languages) {

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -1210,6 +1210,23 @@ paths:
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/env/{envName}/portalLanguages:
+    post:
+      summary: Updates an environments list of supported languages.
+      tags: [ portalEnvironment ]
+      operationId: setLanguages
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: envName, in: path, required: true, schema: { type: string } }
+      requestBody:
+        required: true
+        content: { application/json: { schema: { type: object } } }
+      responses:
+        '200':
+          description: List of PortalLanguages
+          content: { application/json: { schema: { type: object } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/env/{envName}/dashboard/config/alerts:
     get:
       summary: Lists all participant dashboard alert configs for a portal environment

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/portal/PortalExtServiceTest.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/portal/PortalExtServiceTest.java
@@ -10,8 +10,10 @@ import bio.terra.pearl.core.model.portal.PortalEnvironmentConfig;
 import bio.terra.pearl.core.service.admin.PortalAdminUserService;
 import bio.terra.pearl.core.service.exception.PermissionDeniedException;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentConfigService;
+import bio.terra.pearl.core.service.portal.PortalEnvironmentLanguageService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
 import bio.terra.pearl.core.service.portal.PortalService;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
@@ -32,6 +34,7 @@ public class PortalExtServiceTest {
   @MockBean private PortalEnvironmentService mockPortalEnvironmentService;
   @MockBean private PortalEnvironmentConfigService portalEnvironmentConfigService;
   @MockBean private PortalAdminUserService portalAdminUserService;
+  @MockBean private PortalEnvironmentLanguageService portalEnvironmentLanguageService;
 
   @Test
   public void updateConfigHostnameRequiresSuperuser() {
@@ -66,5 +69,13 @@ public class PortalExtServiceTest {
     Assertions.assertThrows(
         PermissionDeniedException.class,
         () -> portalExtService.removeUserFromPortal(UUID.randomUUID(), "testPortal", operator));
+  }
+
+  @Test
+  public void updateLanguagesRequiresSandbox() {
+    AdminUser user = AdminUser.builder().superuser(true).build();
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> portalExtService.setLanguages("foo", EnvironmentName.irb, List.of(), user));
   }
 }

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/siteContent/SiteContentExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/siteContent/SiteContentExtServiceTests.java
@@ -12,7 +12,7 @@ import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.portal.PortalEnvironmentLanguage;
 import bio.terra.pearl.core.model.site.LocalizedSiteContent;
 import bio.terra.pearl.core.model.site.SiteContent;
-import bio.terra.pearl.core.service.portal.PortalLanguageService;
+import bio.terra.pearl.core.service.portal.PortalEnvironmentLanguageService;
 import bio.terra.pearl.core.service.site.SiteContentService;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -25,20 +25,20 @@ public class SiteContentExtServiceTests extends BaseSpringBootTest {
   @Autowired private PortalEnvironmentFactory portalEnvironmentFactory;
   @Autowired private SiteContentFactory siteContentFactory;
   @Autowired private SiteContentService siteContentService;
-  @Autowired private PortalLanguageService portalLanguageService;
+  @Autowired private PortalEnvironmentLanguageService portalEnvironmentLanguageService;
 
   @Test
   @Transactional
   public void testGetLoadAllLanguages(TestInfo testInfo) {
     PortalEnvironment portalEnv =
         portalEnvironmentFactory.buildPersisted(getTestName(testInfo), EnvironmentName.sandbox);
-    portalLanguageService.create(
+    portalEnvironmentLanguageService.create(
         PortalEnvironmentLanguage.builder()
             .languageCode("es")
             .languageName("Spanish")
             .portalEnvironmentId(portalEnv.getId())
             .build());
-    portalLanguageService.create(
+    portalEnvironmentLanguageService.create(
         PortalEnvironmentLanguage.builder()
             .languageCode("en")
             .languageName("English")

--- a/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalEnvironmentDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalEnvironmentDao.java
@@ -20,16 +20,16 @@ public class PortalEnvironmentDao extends BaseMutableJdbiDao<PortalEnvironment> 
     private PortalEnvironmentConfigDao portalEnvironmentConfigDao;
     private SiteContentDao siteContentDao;
     private SurveyDao surveyDao;
-    private PortalLanguageDao portalLanguageDao;
+    private PortalEnvironmentLanguageDao portalEnvironmentLanguageDao;
     public PortalEnvironmentDao(Jdbi jdbi,
                                 PortalEnvironmentConfigDao portalEnvironmentConfigDao,
                                 SiteContentDao siteContentDao, SurveyDao surveyDao,
-                                PortalLanguageDao portalLanguageDao) {
+                                PortalEnvironmentLanguageDao portalEnvironmentLanguageDao) {
         super(jdbi);
         this.portalEnvironmentConfigDao = portalEnvironmentConfigDao;
         this.siteContentDao = siteContentDao;
         this.surveyDao = surveyDao;
-        this.portalLanguageDao = portalLanguageDao;
+        this.portalEnvironmentLanguageDao = portalEnvironmentLanguageDao;
     }
 
     @Override
@@ -67,7 +67,7 @@ public class PortalEnvironmentDao extends BaseMutableJdbiDao<PortalEnvironment> 
             if (portalEnv.getPreRegSurveyId() != null) {
                 portalEnv.setPreRegSurvey(surveyDao.find(portalEnv.getPreRegSurveyId()).get());
             }
-            List<PortalEnvironmentLanguage> portalEnvLanguages = portalLanguageDao.findByPortalEnvId(portalEnv.getId());
+            List<PortalEnvironmentLanguage> portalEnvLanguages = portalEnvironmentLanguageDao.findByPortalEnvId(portalEnv.getId());
             portalEnv.getSupportedLanguages().addAll(portalEnvLanguages);
         });
         return portalEnvOpt;

--- a/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalEnvironmentLanguageDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalEnvironmentLanguageDao.java
@@ -9,14 +9,14 @@ import java.util.List;
 import java.util.UUID;
 
 @Component
-public class PortalLanguageDao extends BaseJdbiDao<PortalEnvironmentLanguage> {
+public class PortalEnvironmentLanguageDao extends BaseJdbiDao<PortalEnvironmentLanguage> {
 
     @Override
     public Class<PortalEnvironmentLanguage> getClazz() {
         return PortalEnvironmentLanguage.class;
     }
 
-    public PortalLanguageDao(Jdbi jdbi) {
+    public PortalEnvironmentLanguageDao(Jdbi jdbi) {
         super(jdbi);
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalLanguageDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalLanguageDao.java
@@ -23,4 +23,8 @@ public class PortalLanguageDao extends BaseJdbiDao<PortalEnvironmentLanguage> {
     public List<PortalEnvironmentLanguage> findByPortalEnvId(UUID portalId) {
         return findAllByProperty("portal_environment_id", portalId);
     }
+
+    public void deleteByPortalEnvId(UUID portalId) {
+        deleteByProperty("portal_environment_id", portalId);
+    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/publishing/ListChange.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/publishing/ListChange.java
@@ -2,4 +2,5 @@ package bio.terra.pearl.core.model.publishing;
 
 import java.util.List;
 
+/** record of a diff of lists of items.  T is the item type, CT is a representation of a diff for changed items */
 public record ListChange<T, CT>(List<T> addedItems, List<T> removedItems, List<CT> changedItems) { }

--- a/core/src/main/java/bio/terra/pearl/core/model/publishing/PortalEnvironmentChange.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/publishing/PortalEnvironmentChange.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.core.model.publishing;
 
 import bio.terra.pearl.core.model.notification.EmailTemplate;
 import bio.terra.pearl.core.model.notification.Trigger;
+import bio.terra.pearl.core.model.portal.PortalEnvironmentLanguage;
 import bio.terra.pearl.core.model.site.SiteContent;
 import bio.terra.pearl.core.model.survey.Survey;
 
@@ -16,5 +17,7 @@ public record PortalEnvironmentChange(VersionedEntityChange<SiteContent> siteCon
                                       VersionedEntityChange<Survey> preRegSurveyChanges,
                                       ListChange<Trigger, VersionedConfigChange<EmailTemplate>> triggerChanges,
                                       List<ParticipantDashboardAlertChange> participantDashboardAlertChanges,
-                                      List<StudyEnvironmentChange> studyEnvChanges)
+                                      List<StudyEnvironmentChange> studyEnvChanges,
+                                      /** for now, we don't represent changed languages, just add/remove */
+                                      ListChange<PortalEnvironmentLanguage, Object> languageChanges )
 {}

--- a/core/src/main/java/bio/terra/pearl/core/service/portal/PortalEnvironmentLanguageService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/portal/PortalEnvironmentLanguageService.java
@@ -1,19 +1,18 @@
 package bio.terra.pearl.core.service.portal;
 
-import bio.terra.pearl.core.dao.portal.PortalLanguageDao;
+import bio.terra.pearl.core.dao.portal.PortalEnvironmentLanguageDao;
 import bio.terra.pearl.core.model.portal.PortalEnvironmentLanguage;
 import bio.terra.pearl.core.service.ImmutableEntityService;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 @Service
-public class PortalLanguageService extends ImmutableEntityService<PortalEnvironmentLanguage, PortalLanguageDao> {
+public class PortalEnvironmentLanguageService extends ImmutableEntityService<PortalEnvironmentLanguage, PortalEnvironmentLanguageDao> {
 
-    public PortalLanguageService(PortalLanguageDao portalLanguageDao) {
-        super(portalLanguageDao);
+    public PortalEnvironmentLanguageService(PortalEnvironmentLanguageDao portalEnvironmentLanguageDao) {
+        super(portalEnvironmentLanguageDao);
     }
 
     public List<PortalEnvironmentLanguage> findByPortalEnvId(UUID portalId) {

--- a/core/src/main/java/bio/terra/pearl/core/service/portal/PortalEnvironmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/portal/PortalEnvironmentService.java
@@ -36,7 +36,7 @@ public class PortalEnvironmentService extends CrudService<PortalEnvironment, Por
     private SiteContentService siteContentService;
     private SurveyService surveyService;
     private PortalDashboardConfigService portalDashboardConfigService;
-    private PortalLanguageService portalLanguageService;
+    private PortalEnvironmentLanguageService portalEnvironmentLanguageService;
 
     public PortalEnvironmentService(PortalEnvironmentDao portalEnvironmentDao,
                                     PortalEnvironmentConfigService portalEnvironmentConfigService,
@@ -49,7 +49,7 @@ public class PortalEnvironmentService extends CrudService<PortalEnvironment, Por
                                     DataChangeRecordService dataChangeRecordService,
                                     PortalDashboardConfigService portalDashboardConfigService,
                                     SurveyService surveyService,
-                                    PortalLanguageService portalLanguageService) {
+                                    PortalEnvironmentLanguageService portalEnvironmentLanguageService) {
         super(portalEnvironmentDao);
         this.portalEnvironmentConfigService = portalEnvironmentConfigService;
         this.portalParticipantUserService = portalParticipantUserService;
@@ -61,7 +61,7 @@ public class PortalEnvironmentService extends CrudService<PortalEnvironment, Por
         this.siteContentService = siteContentService;
         this.surveyService = surveyService;
         this.portalDashboardConfigService = portalDashboardConfigService;
-        this.portalLanguageService = portalLanguageService;
+        this.portalEnvironmentLanguageService = portalEnvironmentLanguageService;
     }
 
     public List<PortalEnvironment> findByPortal(UUID portalId) {
@@ -97,7 +97,7 @@ public class PortalEnvironmentService extends CrudService<PortalEnvironment, Por
 
         newEnv.getSupportedLanguages().forEach(supportedLanguage -> {
             supportedLanguage.setPortalEnvironmentId(newEnv.getId());
-            portalLanguageService.create(supportedLanguage);
+            portalEnvironmentLanguageService.create(supportedLanguage);
         });
 
         return newEnv;

--- a/core/src/main/java/bio/terra/pearl/core/service/portal/PortalLanguageService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/portal/PortalLanguageService.java
@@ -5,6 +5,7 @@ import bio.terra.pearl.core.model.portal.PortalEnvironmentLanguage;
 import bio.terra.pearl.core.service.ImmutableEntityService;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -17,6 +18,15 @@ public class PortalLanguageService extends ImmutableEntityService<PortalEnvironm
 
     public List<PortalEnvironmentLanguage> findByPortalEnvId(UUID portalId) {
         return dao.findByPortalEnvId(portalId);
+    }
+
+    /** for now, just do a hard delete/recreate */
+    public List<PortalEnvironmentLanguage> setPortalEnvLanguages(UUID portalEnvId, List<PortalEnvironmentLanguage> languages) {
+        dao.deleteByPortalEnvId(portalEnvId);
+        return languages.stream().map(language -> {
+            language.setPortalEnvironmentId(portalEnvId);
+            return dao.create(language);
+        }).toList();
     }
 
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/publishing/PortalDiffService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/publishing/PortalDiffService.java
@@ -9,6 +9,7 @@ import bio.terra.pearl.core.model.dashboard.ParticipantDashboardAlert;
 import bio.terra.pearl.core.model.notification.EmailTemplate;
 import bio.terra.pearl.core.model.notification.Trigger;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
+import bio.terra.pearl.core.model.portal.PortalEnvironmentLanguage;
 import bio.terra.pearl.core.model.publishing.*;
 import bio.terra.pearl.core.model.site.SiteContent;
 import bio.terra.pearl.core.model.study.Study;
@@ -18,6 +19,7 @@ import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.service.notification.TriggerService;
 import bio.terra.pearl.core.service.portal.PortalDashboardConfigService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentConfigService;
+import bio.terra.pearl.core.service.portal.PortalEnvironmentLanguageService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
 import bio.terra.pearl.core.service.site.SiteContentService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
@@ -35,16 +37,17 @@ public class PortalDiffService {
     public static final List<String> CONFIG_IGNORE_PROPS = List.of("id", "createdAt", "lastUpdatedAt", "class",
             "studyEnvironmentId", "portalEnvironmentId", "emailTemplateId", "emailTemplate",
             "consentFormId", "consentForm", "surveyId", "survey", "versionedEntity", "trigger");
-    private PortalEnvironmentService portalEnvService;
-    private PortalEnvironmentConfigService portalEnvironmentConfigService;
-    private SiteContentService siteContentService;
-    private SurveyService surveyService;
-    private TriggerService triggerService;
-    private PortalDashboardConfigService portalDashboardConfigService;
-    private ObjectMapper objectMapper;
-    private PortalEnvironmentChangeRecordDao portalEnvironmentChangeRecordDao;
-    private StudyEnvironmentService studyEnvironmentService;
-    private StudyService studyService;
+    private final PortalEnvironmentService portalEnvService;
+    private final PortalEnvironmentConfigService portalEnvironmentConfigService;
+    private final SiteContentService siteContentService;
+    private final SurveyService surveyService;
+    private final TriggerService triggerService;
+    private final PortalDashboardConfigService portalDashboardConfigService;
+    private final ObjectMapper objectMapper;
+    private final PortalEnvironmentChangeRecordDao portalEnvironmentChangeRecordDao;
+    private final StudyEnvironmentService studyEnvironmentService;
+    private final StudyService studyService;
+    private final PortalEnvironmentLanguageService portalEnvironmentLanguageService;
 
     public PortalDiffService(PortalEnvironmentService portalEnvService,
                              PortalEnvironmentConfigService portalEnvironmentConfigService,
@@ -53,7 +56,8 @@ public class PortalDiffService {
                              PortalDashboardConfigService portalDashboardConfigService,
                              ObjectMapper objectMapper,
                              PortalEnvironmentChangeRecordDao portalEnvironmentChangeRecordDao,
-                             StudyEnvironmentService studyEnvironmentService, StudyService studyService) {
+                             StudyEnvironmentService studyEnvironmentService, StudyService studyService,
+                             PortalEnvironmentLanguageService portalEnvironmentLanguageService) {
         this.portalEnvService = portalEnvService;
         this.portalEnvironmentConfigService = portalEnvironmentConfigService;
         this.siteContentService = siteContentService;
@@ -64,6 +68,7 @@ public class PortalDiffService {
         this.portalEnvironmentChangeRecordDao = portalEnvironmentChangeRecordDao;
         this.studyEnvironmentService = studyEnvironmentService;
         this.studyService = studyService;
+        this.portalEnvironmentLanguageService = portalEnvironmentLanguageService;
     }
 
     public PortalEnvironmentChange diffPortalEnvs(String shortcode, EnvironmentName source, EnvironmentName dest) throws Exception {
@@ -91,14 +96,15 @@ public class PortalDiffService {
         List<ParticipantDashboardAlert> destAlerts = new ArrayList<>(destEnv.getParticipantDashboardAlerts());
         List<ParticipantDashboardAlert> sourceAlerts = new ArrayList<>(sourceEnv.getParticipantDashboardAlerts());
         List<ParticipantDashboardAlertChange> alertChangeLists = diffAlertLists(sourceAlerts, destAlerts);
-
+        ListChange<PortalEnvironmentLanguage, Object> languageChanges = diffLanguages(sourceEnv.getSupportedLanguages(), destEnv.getSupportedLanguages());
         return new PortalEnvironmentChange(
                 siteContentRecord,
                 envConfigChanges,
                 preRegRecord,
                 triggerChanges,
                 alertChangeLists,
-                studyEnvChanges
+                studyEnvChanges,
+                languageChanges
         );
     }
 
@@ -140,6 +146,7 @@ public class PortalDiffService {
         if (portalEnv.getPreRegSurveyId() != null) {
             portalEnv.setPreRegSurvey(surveyService.find(portalEnv.getPreRegSurveyId()).get());
         }
+        portalEnv.setSupportedLanguages(portalEnvironmentLanguageService.findByPortalEnvId(portalEnv.getId()));
         List<Trigger> triggers = triggerService.findByPortalEnvironmentId(portalEnv.getId());
         triggerService.attachTemplates(triggers);
         portalEnv.setTriggers(triggers);
@@ -221,6 +228,23 @@ public class PortalDiffService {
                 surveyChanges,
                 triggerChanges
         );
+    }
+
+    /** diffs the two lists -- any changes to a language will be considered an add/remove */
+    public ListChange<PortalEnvironmentLanguage, Object> diffLanguages(List<PortalEnvironmentLanguage> sourceLangs, List<PortalEnvironmentLanguage> destLangs) {
+        List<PortalEnvironmentLanguage> unmatchedDestLangs = new ArrayList<>(destLangs);
+        List<PortalEnvironmentLanguage> addedLangs = new ArrayList<>();
+        for (PortalEnvironmentLanguage sourceLang : sourceLangs) {
+            PortalEnvironmentLanguage matchedLang = unmatchedDestLangs.stream().filter(
+                    destLang -> destLang.getLanguageCode().equals(sourceLang.getLanguageCode()) && destLang.getLanguageName().equals(sourceLang.getLanguageName()))
+                    .findAny().orElse(null);
+            if (matchedLang == null) {
+                addedLangs.add(sourceLang);
+            } else {
+                unmatchedDestLangs.remove(matchedLang);
+            }
+        }
+        return new ListChange<>(addedLangs, unmatchedDestLangs, Collections.emptyList());
     }
 
     public StudyEnvironment loadStudyEnvForProcessing(String shortcode, EnvironmentName envName) {

--- a/core/src/main/java/bio/terra/pearl/core/service/publishing/PortalPublishingService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/publishing/PortalPublishingService.java
@@ -10,6 +10,7 @@ import bio.terra.pearl.core.model.notification.EmailTemplate;
 import bio.terra.pearl.core.model.notification.Trigger;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.portal.PortalEnvironmentConfig;
+import bio.terra.pearl.core.model.portal.PortalEnvironmentLanguage;
 import bio.terra.pearl.core.model.publishing.ConfigChange;
 import bio.terra.pearl.core.model.publishing.ListChange;
 import bio.terra.pearl.core.model.publishing.ParticipantDashboardAlertChange;
@@ -27,6 +28,7 @@ import bio.terra.pearl.core.service.notification.TriggerService;
 import bio.terra.pearl.core.service.notification.email.EmailTemplateService;
 import bio.terra.pearl.core.service.portal.PortalDashboardConfigService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentConfigService;
+import bio.terra.pearl.core.service.portal.PortalEnvironmentLanguageService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
 import bio.terra.pearl.core.service.site.SiteContentService;
 import bio.terra.pearl.core.service.survey.SurveyService;
@@ -44,17 +46,18 @@ import java.util.UUID;
  */
 @Service
 public class PortalPublishingService {
-    private PortalDiffService portalDiffService;
-    private PortalEnvironmentService portalEnvironmentService;
-    private PortalEnvironmentConfigService portalEnvironmentConfigService;
-    private PortalEnvironmentChangeRecordDao portalEnvironmentChangeRecordDao;
-    private PortalDashboardConfigService portalDashboardConfigService;
-    private TriggerService triggerService;
-    private SurveyService surveyService;
-    private EmailTemplateService emailTemplateService;
-    private SiteContentService siteContentService;
-    private StudyPublishingService studyPublishingService;
-    private ObjectMapper objectMapper;
+    private final PortalDiffService portalDiffService;
+    private final PortalEnvironmentService portalEnvironmentService;
+    private final PortalEnvironmentConfigService portalEnvironmentConfigService;
+    private final PortalEnvironmentChangeRecordDao portalEnvironmentChangeRecordDao;
+    private final PortalDashboardConfigService portalDashboardConfigService;
+    private final TriggerService triggerService;
+    private final SurveyService surveyService;
+    private final EmailTemplateService emailTemplateService;
+    private final SiteContentService siteContentService;
+    private final StudyPublishingService studyPublishingService;
+    private final PortalEnvironmentLanguageService portalEnvironmentLanguageService;
+    private final ObjectMapper objectMapper;
 
 
     public PortalPublishingService(PortalDiffService portalDiffService,
@@ -64,7 +67,8 @@ public class PortalPublishingService {
                                    PortalDashboardConfigService portalDashboardConfigService,
                                    TriggerService triggerService, SurveyService surveyService,
                                    EmailTemplateService emailTemplateService, SiteContentService siteContentService,
-                                   StudyPublishingService studyPublishingService, ObjectMapper objectMapper) {
+                                   StudyPublishingService studyPublishingService,
+                                   PortalEnvironmentLanguageService portalEnvironmentLanguageService, ObjectMapper objectMapper) {
         this.portalDiffService = portalDiffService;
         this.portalEnvironmentService = portalEnvironmentService;
         this.portalEnvironmentConfigService = portalEnvironmentConfigService;
@@ -75,6 +79,7 @@ public class PortalPublishingService {
         this.emailTemplateService = emailTemplateService;
         this.siteContentService = siteContentService;
         this.studyPublishingService = studyPublishingService;
+        this.portalEnvironmentLanguageService = portalEnvironmentLanguageService;
         this.objectMapper = objectMapper;
     }
 
@@ -98,6 +103,7 @@ public class PortalPublishingService {
         applyChangesToSiteContent(destEnv, envChanges.siteContentChange());
         applyChangesToTriggers(destEnv, envChanges.triggerChanges());
         applyChangesToParticipantDashboardAlerts(destEnv, envChanges.participantDashboardAlertChanges());
+        applyChangesToLanguages(destEnv, envChanges.languageChanges());
         for (StudyEnvironmentChange studyEnvChange : envChanges.studyEnvChanges()) {
             StudyEnvironment studyEnv = portalDiffService.loadStudyEnvForProcessing(studyEnvChange.studyShortcode(), destEnv.getEnvironmentName());
             studyPublishingService.applyChanges(studyEnv, studyEnvChange, destEnv.getId(), destEnv.getPortalId());
@@ -211,6 +217,17 @@ public class PortalPublishingService {
             }
         } catch (Exception e) {
             throw new RuntimeException("Error applying changes to alert: " + alert.getId(), e);
+        }
+    }
+
+    protected void applyChangesToLanguages(PortalEnvironment destEnv, ListChange<PortalEnvironmentLanguage, Object> languageChanges) {
+        for (PortalEnvironmentLanguage language : languageChanges.addedItems()) {
+            language.cleanForCopying();
+            language.setPortalEnvironmentId(destEnv.getId());
+            portalEnvironmentLanguageService.create(language);
+        }
+        for (PortalEnvironmentLanguage language : languageChanges.removedItems()) {
+            portalEnvironmentLanguageService.delete(language.getId(), CascadeProperty.EMPTY_SET);
         }
     }
 

--- a/core/src/test/java/bio/terra/pearl/core/service/portal/PortalEnvironmentLanguageServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/portal/PortalEnvironmentLanguageServiceTest.java
@@ -1,0 +1,45 @@
+package bio.terra.pearl.core.service.portal;
+
+import bio.terra.pearl.core.BaseSpringBootTest;
+import bio.terra.pearl.core.factory.portal.PortalEnvironmentFactory;
+import bio.terra.pearl.core.model.portal.PortalEnvironment;
+import bio.terra.pearl.core.model.portal.PortalEnvironmentLanguage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class PortalEnvironmentLanguageServiceTest extends BaseSpringBootTest {
+    @Autowired
+    private PortalEnvironmentLanguageService portalEnvironmentLanguageService;
+    @Autowired
+    private PortalEnvironmentFactory portalEnvironmentFactory;
+
+    @Test
+    @Transactional
+    public void testSetLanguages(TestInfo info) {
+        PortalEnvironment portalEnvironment = portalEnvironmentFactory.buildPersisted(getTestName(info));
+        List<PortalEnvironmentLanguage> languages = List.of(
+            PortalEnvironmentLanguage.builder().languageName("English").languageCode("en").build(),
+            PortalEnvironmentLanguage.builder().languageName("Espanish").languageCode("es").build()
+        );
+        List<PortalEnvironmentLanguage> savedLanguages = portalEnvironmentLanguageService.setPortalEnvLanguages(portalEnvironment.getId(), languages);
+        assertThat(savedLanguages, hasSize(2));
+        assertThat(portalEnvironmentLanguageService.findByPortalEnvId(portalEnvironment.getId()), hasSize(2));
+
+        // now confirm that a second call deletes previous languages and sets the new one
+        List<PortalEnvironmentLanguage> newLanguages = List.of(
+            PortalEnvironmentLanguage.builder().languageName("French").languageCode("fr").build()
+        );
+        savedLanguages = portalEnvironmentLanguageService.setPortalEnvLanguages(portalEnvironment.getId(), newLanguages);
+        assertThat(savedLanguages, hasSize(1));
+        assertThat(portalEnvironmentLanguageService.findByPortalEnvId(portalEnvironment.getId()), hasSize(1));
+        assertThat(portalEnvironmentLanguageService.findByPortalEnvId(portalEnvironment.getId()).get(0),
+                hasProperty("languageName", equalTo("French")));
+    }
+}

--- a/core/src/test/java/bio/terra/pearl/core/service/publishing/PortalDiffServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/publishing/PortalDiffServiceTests.java
@@ -144,7 +144,6 @@ public class PortalDiffServiceTests extends BaseSpringBootTest {
         assertThat(diffs.removedItems().get(0), samePropertyValuesAs(removedConfig));
     }
 
-
     @Test
     public void testDiffBothUninitialized() throws Exception {
         PortalEnvironment sourceEnv = PortalEnvironment.builder().portalEnvironmentConfig(

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/portal/PortalEnvironmentLanguageFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/portal/PortalEnvironmentLanguageFactory.java
@@ -1,0 +1,22 @@
+package bio.terra.pearl.core.factory.portal;
+
+import bio.terra.pearl.core.model.portal.PortalEnvironmentLanguage;
+import bio.terra.pearl.core.service.portal.PortalEnvironmentLanguageService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class PortalEnvironmentLanguageFactory {
+    @Autowired
+    private PortalEnvironmentLanguageService portalEnvironmentLanguageService;
+    public PortalEnvironmentLanguage addToEnvironment(UUID portalEnvironmentId, String languageName, String languageCode) {
+        PortalEnvironmentLanguage language = PortalEnvironmentLanguage.builder()
+                .languageName(languageName.valueOf(languageName))
+                .languageCode(languageCode)
+                .portalEnvironmentId(portalEnvironmentId)
+                .build();
+        return portalEnvironmentLanguageService.create(language);
+    }
+}

--- a/populate/src/main/java/bio/terra/pearl/populate/service/PortalPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/PortalPopulator.java
@@ -15,7 +15,7 @@ import bio.terra.pearl.core.service.CascadeProperty;
 import bio.terra.pearl.core.service.portal.MailingListContactService;
 import bio.terra.pearl.core.service.portal.PortalDashboardConfigService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
-import bio.terra.pearl.core.service.portal.PortalLanguageService;
+import bio.terra.pearl.core.service.portal.PortalEnvironmentLanguageService;
 import bio.terra.pearl.core.service.portal.PortalService;
 import bio.terra.pearl.core.service.study.PortalStudyService;
 import bio.terra.pearl.populate.dto.AdminUserPopDto;
@@ -51,7 +51,7 @@ public class PortalPopulator extends BasePopulator<Portal, PortalPopDto, FilePop
     private final AdminUserPopulator adminUserPopulator;
     private final EmailTemplatePopulator emailTemplatePopulator;
     private final PortalDashboardConfigService portalDashboardConfigService;
-    private final PortalLanguageService portalLanguageService;
+    private final PortalEnvironmentLanguageService portalEnvironmentLanguageService;
 
 
     public PortalPopulator(PortalService portalService,
@@ -65,7 +65,7 @@ public class PortalPopulator extends BasePopulator<Portal, PortalPopDto, FilePop
                            AdminUserPopulator adminUserPopulator,
                            MailingListContactService mailingListContactService,
                            EmailTemplatePopulator emailTemplatePopulator,
-                           PortalLanguageService portalLanguageService) {
+                           PortalEnvironmentLanguageService portalEnvironmentLanguageService) {
         this.siteContentPopulator = siteContentPopulator;
         this.portalParticipantUserPopulator = portalParticipantUserPopulator;
         this.portalEnvironmentService = portalEnvironmentService;
@@ -78,7 +78,7 @@ public class PortalPopulator extends BasePopulator<Portal, PortalPopDto, FilePop
         this.mailingListContactService = mailingListContactService;
         this.adminUserPopulator = adminUserPopulator;
         this.emailTemplatePopulator = emailTemplatePopulator;
-        this.portalLanguageService = portalLanguageService;
+        this.portalEnvironmentLanguageService = portalEnvironmentLanguageService;
     }
 
     private void populateStudy(String studyFileName, PortalPopulateContext context, Portal portal, boolean overwrite) {
@@ -123,7 +123,7 @@ public class PortalPopulator extends BasePopulator<Portal, PortalPopDto, FilePop
         }
         for (PortalEnvironmentLanguage language : portalEnvPopDto.getSupportedLanguages()) {
             language.setPortalEnvironmentId(savedEnv.getId());
-            portalLanguageService.create(language);
+            portalEnvironmentLanguageService.create(language);
         }
         // re-save the portal environment to update it with any attached siteContents or preRegSurveys
         portalEnvironmentService.update(savedEnv);

--- a/populate/src/main/java/bio/terra/pearl/populate/service/extract/PortalExtractService.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/extract/PortalExtractService.java
@@ -5,12 +5,11 @@ import bio.terra.pearl.core.model.notification.Trigger;
 import bio.terra.pearl.core.model.participant.PortalParticipantUser;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
-import bio.terra.pearl.core.model.portal.PortalEnvironmentLanguage;
 import bio.terra.pearl.core.model.study.PortalStudy;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentConfigService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
-import bio.terra.pearl.core.service.portal.PortalLanguageService;
+import bio.terra.pearl.core.service.portal.PortalEnvironmentLanguageService;
 import bio.terra.pearl.core.service.portal.PortalService;
 import bio.terra.pearl.core.service.portal.exception.PortalConfigMissing;
 import bio.terra.pearl.populate.dto.PortalEnvironmentPopDto;
@@ -37,7 +36,7 @@ public class PortalExtractService {
     private final MediaExtractor mediaExtractor;
     private final EmailTemplateExtractor emailTemplateExtractor;
     private final ParticipantDashboardAlertDao participantDashboardAlertDao;
-    private final PortalLanguageService portalLanguageService;
+    private final PortalEnvironmentLanguageService portalEnvironmentLanguageService;
 
     private final ObjectMapper objectMapper;
 
@@ -51,7 +50,7 @@ public class PortalExtractService {
                                 MediaExtractor mediaExtractor,
                                 EmailTemplateExtractor emailTemplateExtractor,
                                 ParticipantDashboardAlertDao participantDashboardAlertDao,
-                                PortalLanguageService portalLanguageService,
+                                PortalEnvironmentLanguageService portalEnvironmentLanguageService,
                                 @Qualifier("extractionObjectMapper") ObjectMapper objectMapper) {
         this.portalService = portalService;
         this.portalEnvironmentService = portalEnvironmentService;
@@ -62,7 +61,7 @@ public class PortalExtractService {
         this.mediaExtractor = mediaExtractor;
         this.emailTemplateExtractor = emailTemplateExtractor;
         this.participantDashboardAlertDao = participantDashboardAlertDao;
-        this.portalLanguageService = portalLanguageService;
+        this.portalEnvironmentLanguageService = portalEnvironmentLanguageService;
         this.objectMapper = objectMapper;
         this.objectMapper.addMixIn(Portal.class, PortalMixin.class);
     }
@@ -116,7 +115,7 @@ public class PortalExtractService {
             surveyPopDto.setPopulateFileName(context.getFileNameForEntity(portalEnv.getPreRegSurveyId()));
             envPopDto.setPreRegSurveyDto(surveyPopDto);
         }
-        envPopDto.setSupportedLanguages(portalLanguageService.findByPortalEnvId(portalEnv.getId()));
+        envPopDto.setSupportedLanguages(portalEnvironmentLanguageService.findByPortalEnvId(portalEnv.getId()));
         envPopDto.setParticipantDashboardAlerts(participantDashboardAlertDao.findByPortalEnvironmentId(portalEnv.getId()));
         return envPopDto;
     }

--- a/populate/src/test/java/bio/terra/pearl/populate/BasePopulatePortalsTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/BasePopulatePortalsTest.java
@@ -9,7 +9,7 @@ import bio.terra.pearl.core.service.notification.TriggerService;
 import bio.terra.pearl.core.service.notification.email.EmailTemplateService;
 import bio.terra.pearl.core.service.participant.*;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
-import bio.terra.pearl.core.service.portal.PortalLanguageService;
+import bio.terra.pearl.core.service.portal.PortalEnvironmentLanguageService;
 import bio.terra.pearl.core.service.portal.PortalService;
 import bio.terra.pearl.core.service.site.SiteContentService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
@@ -83,7 +83,7 @@ public abstract class BasePopulatePortalsTest extends BaseSpringBootTest {
     @Autowired
     protected StudyEnvironmentKitTypeService studyEnvironmentKitTypeService;
     @Autowired
-    protected PortalLanguageService portalLanguageService;
+    protected PortalEnvironmentLanguageService portalEnvironmentLanguageService;
     @Autowired
     protected BaseSeedPopulator baseSeedPopulator;
 }

--- a/populate/src/test/java/bio/terra/pearl/populate/extract/PortalExtractTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/extract/PortalExtractTest.java
@@ -49,7 +49,7 @@ public class PortalExtractTest extends BasePopulatePortalsTest {
         PortalEnvironment sandboxPortalEnv = portalEnvironmentService.findOne("demo", EnvironmentName.sandbox).orElseThrow();
         // confirm portal environment properties got copied
         assertThat(participantDashboardAlertDao.findByPortalEnvironmentId(sandboxPortalEnv.getId()), hasSize(1));
-        assertThat(portalLanguageService.findByPortalEnvId(sandboxPortalEnv.getId()), hasSize(3));
+        assertThat(portalEnvironmentLanguageService.findByPortalEnvId(sandboxPortalEnv.getId()), hasSize(3));
 
         // confirm all templates got repopulated
         assertThat(surveyService.findByPortalId(restoredPortal.getId()), hasSize(14));

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -252,6 +252,7 @@ export type PortalEnvironmentChange = {
   triggerChanges: ListChange<Trigger, VersionedConfigChange>
   participantDashboardAlertChanges: ParticipantDashboardAlertChange[]
   studyEnvChanges: StudyEnvironmentChange[]
+  languageChanges: ListChange<PortalEnvironmentLanguage, VersionedConfigChange>
 }
 
 export type StudyEnvironmentChange = {

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -13,7 +13,7 @@ import {
   ParticipantTaskType,
   Portal,
   PortalEnvironment,
-  PortalEnvironmentConfig,
+  PortalEnvironmentConfig, PortalEnvironmentLanguage,
   Profile,
   SiteContent,
   Study,
@@ -1260,6 +1260,16 @@ export default {
       method: 'PATCH',
       headers: this.getInitHeaders(),
       body: JSON.stringify(update)
+    })
+    return await this.processJsonResponse(response)
+  },
+
+  async setPortalEnvLanguages(portalShortcode: string, envName: string, languages: PortalEnvironmentLanguage[]) {
+    const url = `${basePortalEnvUrl(portalShortcode, envName)}/portalLanguages`
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: this.getInitHeaders(),
+      body: JSON.stringify(languages)
     })
     return await this.processJsonResponse(response)
   },

--- a/ui-admin/src/components/forms/InfoPopup.tsx
+++ b/ui-admin/src/components/forms/InfoPopup.tsx
@@ -32,6 +32,8 @@ export default function InfoPopup({
     <div className="p-2">{content}</div>
   </Popover>
   return <OverlayTrigger rootClose trigger={trigger} placement={placement} overlay={popoverContent}>
-    <button aria-label="info popup" className="btn btn-secondary p-0 mx-2" style={{ color: '#777' }}>{target}</button>
+    <button type="button" aria-label="info popup"
+      className="btn btn-secondary p-0 mx-2"
+      style={{ color: '#777' }}>{target}</button>
   </OverlayTrigger>
 }

--- a/ui-admin/src/forms/FormPreview.test.tsx
+++ b/ui-admin/src/forms/FormPreview.test.tsx
@@ -164,8 +164,8 @@ describe('FormPreview', () => {
             <FormPreview
               formContent={localizedFormContent as unknown as FormContent}
               supportedLanguages={[
-                { languageCode: 'en', languageName: 'English' },
-                { languageCode: 'es', languageName: 'Spanish' }
+                { languageCode: 'en', languageName: 'English', id: '1' },
+                { languageCode: 'es', languageName: 'Spanish', id: '2' }
               ]}
             />
           </MockI18nProvider>)
@@ -185,7 +185,7 @@ describe('FormPreview', () => {
           <MockI18nProvider>
             <FormPreview
               formContent={localizedFormContent as unknown as FormContent}
-              supportedLanguages={[{ languageCode: 'en', languageName: 'English' }]}
+              supportedLanguages={[{ languageCode: 'en', languageName: 'English', id: '1' }]}
             />
           </MockI18nProvider>)
 

--- a/ui-admin/src/forms/FormPreview.tsx
+++ b/ui-admin/src/forms/FormPreview.tsx
@@ -13,7 +13,7 @@ import {
 
 import { FormPreviewOptions } from './FormPreviewOptions'
 import Api from 'api/api'
-import { usePortalLanguage } from 'portal/usePortalLanguage'
+import { usePortalLanguage } from 'portal/languages/usePortalLanguage'
 
 type FormPreviewProps = {
   formContent: FormContent

--- a/ui-admin/src/forms/FormPreviewOptions.tsx
+++ b/ui-admin/src/forms/FormPreviewOptions.tsx
@@ -4,7 +4,7 @@ import Select from 'react-select'
 import useReactSingleSelect from 'util/react-select-utils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faGlobe } from '@fortawesome/free-solid-svg-icons'
-import { usePortalLanguage } from 'portal/usePortalLanguage'
+import { usePortalLanguage } from 'portal/languages/usePortalLanguage'
 
 type FormPreviewOptions = {
   ignoreValidation: boolean

--- a/ui-admin/src/portal/MailingListView.test.tsx
+++ b/ui-admin/src/portal/MailingListView.test.tsx
@@ -20,8 +20,6 @@ const contacts: MailingListContact[] = [{
 }]
 
 test('renders a mailing list', async () => {
-  // avoid cluttering the console with the info messages from the table creation
-  jest.spyOn(console, 'info').mockImplementation(jest.fn())
   jest.spyOn(Api, 'fetchMailingList').mockResolvedValue(contacts)
   const portalContext = mockPortalContext()
   const portalEnv = portalContext.portal.portalEnvironments[0]

--- a/ui-admin/src/portal/MailingListView.test.tsx
+++ b/ui-admin/src/portal/MailingListView.test.tsx
@@ -20,6 +20,8 @@ const contacts: MailingListContact[] = [{
 }]
 
 test('renders a mailing list', async () => {
+  // avoid cluttering the console with the info messages from the table creation
+  jest.spyOn(console, 'info').mockImplementation(jest.fn())
   jest.spyOn(Api, 'fetchMailingList').mockResolvedValue(contacts)
   const portalContext = mockPortalContext()
   const portalEnv = portalContext.portal.portalEnvironments[0]

--- a/ui-admin/src/portal/PortalEnvConfigView.tsx
+++ b/ui-admin/src/portal/PortalEnvConfigView.tsx
@@ -55,10 +55,7 @@ const PortalEnvConfigView = ({ portalContext, portalEnv }: PortalEnvConfigViewPr
   const saveLanguages = async (e: React.MouseEvent) => {
     e.preventDefault()
     doApiLoad(async () => {
-      await Api.updatePortalEnv(portal.shortcode, portalEnv.environmentName, {
-        ...portalEnv,
-        supportedLanguages: workingLanguages
-      })
+      await Api.setPortalEnvLanguages(portal.shortcode, portalEnv.environmentName, workingLanguages)
       Store.addNotification(successNotification('Portal languages saved'))
       reloadPortal(portal.shortcode)
     }, { setIsLoading })
@@ -74,6 +71,8 @@ const PortalEnvConfigView = ({ portalContext, portalEnv }: PortalEnvConfigViewPr
         setSelectedLanguage,
         selectedLanguage
       )
+
+  const editableLanguages = portalEnv.environmentName === 'sandbox'
 
   return <div>
     <form className="bg-white">
@@ -132,18 +131,19 @@ const PortalEnvConfigView = ({ portalContext, portalEnv }: PortalEnvConfigViewPr
     </form>
     <form className="mt-5">
       <div>
-        <label className="form-label">
+        <h4 className="h5">
           Supported languages <InfoPopup content={'This list determines which languages appear in the dropdown' +
           'of the participant view.  It is up to you to create the content for that language.'}/>
-        </label>
-        <PortalEnvLanguageEditor items={workingLanguages} setItems={setWorkingLanguages} />
+        </h4>
+        <PortalEnvLanguageEditor items={workingLanguages} setItems={setWorkingLanguages}
+          readonly={!editableLanguages} />
       </div>
-      <Button onClick={saveLanguages}
+      { editableLanguages && <Button onClick={saveLanguages}
         variant="primary" disabled={!user?.superuser || isLoading}
         tooltip={user?.superuser ? 'Save' : 'You do not have permission to edit these settings'}>
         {isLoading && <LoadingSpinner/>}
         {!isLoading && 'Save languages'}
-      </Button>
+      </Button> }
     </form>
   </div>
 }

--- a/ui-admin/src/portal/PortalEnvConfigView.tsx
+++ b/ui-admin/src/portal/PortalEnvConfigView.tsx
@@ -41,6 +41,7 @@ const PortalEnvConfigView = ({ portalContext, portalEnv }: PortalEnvConfigViewPr
   }
   useUpdateEffect(() => {
     setConfig(portalEnv.portalEnvironmentConfig)
+    setWorkingLanguages(_cloneDeep(portalEnv.supportedLanguages))
   }, [portalContext.portal.shortcode, portalEnv.environmentName])
   /** saves any changes to the server */
   const save = async (e: React.MouseEvent) => {
@@ -136,7 +137,7 @@ const PortalEnvConfigView = ({ portalContext, portalEnv }: PortalEnvConfigViewPr
           'of the participant view.  It is up to you to create the content for that language.'}/>
         </h4>
         <PortalEnvLanguageEditor items={workingLanguages} setItems={setWorkingLanguages}
-          readonly={!editableLanguages} />
+          readonly={!editableLanguages} key={`${portal.shortcode}-${portalEnv.environmentName}`}/>
       </div>
       { editableLanguages && <Button onClick={saveLanguages}
         variant="primary" disabled={!user?.superuser || isLoading}

--- a/ui-admin/src/portal/PortalEnvConfigView.tsx
+++ b/ui-admin/src/portal/PortalEnvConfigView.tsx
@@ -131,7 +131,7 @@ const PortalEnvConfigView = ({ portalContext, portalEnv }: PortalEnvConfigViewPr
       </Button>
     </form>
     <form className="mt-5">
-      <div>
+      <div className="col-md-6">
         <h4 className="h5">
           Supported languages <InfoPopup content={'This list determines which languages appear in the dropdown' +
           'of the participant view.  It is up to you to create the content for that language.'}/>

--- a/ui-admin/src/portal/languages/PortalEnvLanguageEditor.test.tsx
+++ b/ui-admin/src/portal/languages/PortalEnvLanguageEditor.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { screen } from '@testing-library/react'
+
+import { PortalEnvironmentLanguage, renderWithRouter } from '@juniper/ui-core'
+import PortalEnvLanguageEditor from './PortalEnvLanguageEditor'
+import { getTableCell } from '../../test-utils/table-testing-utils'
+import userEvent from '@testing-library/user-event'
+import { select } from 'react-select-event'
+
+
+const initialLanguages: PortalEnvironmentLanguage[] = [
+  { languageName: 'English', languageCode: 'en' },
+  { languageName: 'Español', languageCode: 'es' }
+]
+test('renders a list', async () => {
+  const setItemsSpy = jest.fn()
+  renderWithRouter(<PortalEnvLanguageEditor items={initialLanguages} setItems={setItemsSpy} readonly={true} />)
+  expect(screen.getByText('English')).toBeInTheDocument()
+  expect(screen.getByText('Español')).toBeInTheDocument()
+})
+
+test('removes items after confirmation dialog', async () => {
+  const setItemsSpy = jest.fn()
+  renderWithRouter(<PortalEnvLanguageEditor items={initialLanguages} setItems={setItemsSpy} readonly={false} />)
+  await userEvent.click(getTableCell(screen.getByRole('table'), 'English', 'Actions').querySelector('button')!)
+  expect(screen.getByText('Remove this language from the dropdown?')).toBeInTheDocument()
+  await userEvent.click(screen.getByText('Yes'))
+  expect(setItemsSpy).toHaveBeenCalledWith([{ languageName: 'Español', languageCode: 'es' }])
+})
+
+test('add items after confirmation click', async () => {
+  const setItemsSpy = jest.fn()
+  renderWithRouter(<PortalEnvLanguageEditor items={initialLanguages} setItems={setItemsSpy} readonly={false} />)
+  await userEvent.click(screen.getByLabelText('Add New'))
+  await select(screen.getByLabelText('Language name'), 'Deutsch')
+  await userEvent.click(screen.getByLabelText('Accept'))
+  expect(setItemsSpy).toHaveBeenCalledWith([...initialLanguages, { languageName: 'Deutsch', languageCode: 'de' }])
+})
+
+test('add items does not appear if readonly', async () => {
+  const setItemsSpy = jest.fn()
+  renderWithRouter(<PortalEnvLanguageEditor items={initialLanguages} setItems={setItemsSpy} readonly={true} />)
+  expect(screen.queryByLabelText('Add New')).not.toBeInTheDocument()
+})
+

--- a/ui-admin/src/portal/languages/PortalEnvLanguageEditor.test.tsx
+++ b/ui-admin/src/portal/languages/PortalEnvLanguageEditor.test.tsx
@@ -25,7 +25,7 @@ test('removes items after confirmation dialog', async () => {
   await userEvent.click(getTableCell(screen.getByRole('table'), 'English', 'Actions').querySelector('button')!)
   expect(screen.getByText('Remove this language from the dropdown?')).toBeInTheDocument()
   await userEvent.click(screen.getByText('Yes'))
-  expect(setItemsSpy).toHaveBeenCalledWith([{ languageName: 'Español', languageCode: 'es' }])
+  expect(setItemsSpy).toHaveBeenCalledWith([{ languageName: 'Español', languageCode: 'es', id: '1' }])
 })
 
 test('add items after confirmation click', async () => {
@@ -34,7 +34,7 @@ test('add items after confirmation click', async () => {
   await userEvent.click(screen.getByLabelText('Add New'))
   await select(screen.getByLabelText('Language name'), 'Deutsch')
   await userEvent.click(screen.getByLabelText('Accept'))
-  expect(setItemsSpy).toHaveBeenCalledWith([...initialLanguages, { languageName: 'Deutsch', languageCode: 'de' }])
+  expect(setItemsSpy).toHaveBeenCalledWith([...initialLanguages, { languageName: 'Deutsch', languageCode: 'de', id: '' }])
 })
 
 test('add items does not appear if readonly', async () => {

--- a/ui-admin/src/portal/languages/PortalEnvLanguageEditor.test.tsx
+++ b/ui-admin/src/portal/languages/PortalEnvLanguageEditor.test.tsx
@@ -9,8 +9,8 @@ import { select } from 'react-select-event'
 
 
 const initialLanguages: PortalEnvironmentLanguage[] = [
-  { languageName: 'English', languageCode: 'en' },
-  { languageName: 'Español', languageCode: 'es' }
+  { languageName: 'English', languageCode: 'en', id: '1' },
+  { languageName: 'Español', languageCode: 'es', id: '1' }
 ]
 test('renders a list', async () => {
   const setItemsSpy = jest.fn()

--- a/ui-admin/src/portal/languages/PortalEnvLanguageEditor.test.tsx
+++ b/ui-admin/src/portal/languages/PortalEnvLanguageEditor.test.tsx
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react'
 
 import { PortalEnvironmentLanguage, renderWithRouter } from '@juniper/ui-core'
 import PortalEnvLanguageEditor from './PortalEnvLanguageEditor'
-import { getTableCell } from '../../test-utils/table-testing-utils'
+import { getTableCell } from 'test-utils/table-testing-utils'
 import userEvent from '@testing-library/user-event'
 import { select } from 'react-select-event'
 
@@ -34,7 +34,8 @@ test('add items after confirmation click', async () => {
   await userEvent.click(screen.getByLabelText('Add New'))
   await select(screen.getByLabelText('Language name'), 'Deutsch')
   await userEvent.click(screen.getByLabelText('Accept'))
-  expect(setItemsSpy).toHaveBeenCalledWith([...initialLanguages, { languageName: 'Deutsch', languageCode: 'de', id: '' }])
+  expect(setItemsSpy).toHaveBeenCalledWith([...initialLanguages,
+    { languageName: 'Deutsch', languageCode: 'de', id: '' }])
 })
 
 test('add items does not appear if readonly', async () => {

--- a/ui-admin/src/portal/languages/PortalEnvLanguageEditor.tsx
+++ b/ui-admin/src/portal/languages/PortalEnvLanguageEditor.tsx
@@ -139,7 +139,7 @@ export default function PortalEnvLanguageEditor({ items, setItems, readonly } : 
             aria-label={'Language code'}
             onChange={e => setNewItem({
               ...row.original,
-              languageName: e.target.value,
+              languageCode: e.target.value,
               isEditing: true
             })}
             value={row.original.languageCode}

--- a/ui-admin/src/portal/languages/PortalEnvLanguageEditor.tsx
+++ b/ui-admin/src/portal/languages/PortalEnvLanguageEditor.tsx
@@ -20,6 +20,10 @@ const isEditable = (row: PortalEnvironmentLanguageRow): row is EditablePortalEnv
   return !isNil((row as EditablePortalEnvironmentLanguage).isEditing)
 }
 
+/**
+ * some example languages options taken from A-T -- we might want to expand these.
+ * But a creatable select is used so users can add their own.
+ */
 const LANGUAGE_OPTIONS: PortalEnvironmentLanguage[] = [{
   'languageName': 'English',
   'languageCode': 'en'
@@ -58,9 +62,10 @@ const LANGUAGE_OPTIONS: PortalEnvironmentLanguage[] = [{
 /**
  * Table which allows viewing, deleting, and creating new answer mappings.
  */
-export default function PortalEnvLanguageEditor({ items, setItems } : {
+export default function PortalEnvLanguageEditor({ items, setItems, readonly } : {
     items: PortalEnvironmentLanguage[],
-    setItems: (items: PortalEnvironmentLanguage[]) => void
+    setItems: (items: PortalEnvironmentLanguage[]) => void,
+  readonly: boolean
   }
 ) {
   const [itemSelectedForDeletion, setItemSelectedForDeletion] = useState<PortalEnvironmentLanguage | null>(null)
@@ -93,15 +98,15 @@ export default function PortalEnvLanguageEditor({ items, setItems } : {
   }
 
 
-  const columns: ColumnDef<PortalEnvironmentLanguage>[] = useMemo(() => ([
-    {
+  const columns: ColumnDef<PortalEnvironmentLanguage>[] = useMemo(() => {
+    const baseCols: ColumnDef<PortalEnvironmentLanguage>[] = [{
       header: 'Name',
       accessorKey: 'languageName',
       cell: ({ row }) => {
         const value = row.original.languageName
         if (isEditable(row.original)) {
           return row.original.isEditing && <Creatable
-            aria-label={'language name'}
+            aria-label={'Language name'}
             options={LANGUAGE_OPTIONS.map(name => {
               return {
                 value: name.languageName,
@@ -123,8 +128,7 @@ export default function PortalEnvLanguageEditor({ items, setItems } : {
         }
         return value
       }
-    },
-    {
+    }, {
       header: 'Code',
       accessorKey: 'languageCode',
       cell: ({ row }) => {
@@ -132,15 +136,19 @@ export default function PortalEnvLanguageEditor({ items, setItems } : {
         if (isEditable(row.original)) {
           return row.original.isEditing && <input
             type="text"
-            aria-label={'language code'}
-            onChange={e => setNewItem({ ...row.original, languageName: e.target.value, isEditing: true })}
+            aria-label={'Language code'}
+            onChange={e => setNewItem({
+              ...row.original,
+              languageName: e.target.value,
+              isEditing: true
+            })}
             value={row.original.languageCode}
           />
         }
         return value
       }
-    },
-    {
+    }]
+    return readonly ? baseCols : baseCols.concat({
       header: 'Actions',
       id: 'actions',
       cell: ({ row }) => {
@@ -179,8 +187,8 @@ export default function PortalEnvLanguageEditor({ items, setItems } : {
           <FontAwesomeIcon icon={faTrashCan} aria-label={'Delete'}/>
         </Button>
       }
-    }
-  ]), [items, newItem])
+    })
+  }, [items, newItem, readonly])
 
   const data = useMemo(
     () => (items as PortalEnvironmentLanguageRow[]).concat(newItem),
@@ -207,7 +215,7 @@ const DeleteItemModal = (
 ) => {
   return <Modal onHide={onCancel} show={true}>
     <ModalBody>
-      Remove this language from the dropdown?
+      <div>Remove this language from the dropdown?</div>
     </ModalBody>
     <ModalFooter>
       <button className='btn btn-danger' onClick={onConfirm}>

--- a/ui-admin/src/portal/languages/PortalEnvLanguageEditor.tsx
+++ b/ui-admin/src/portal/languages/PortalEnvLanguageEditor.tsx
@@ -3,7 +3,7 @@ import { faCheck, faPlus, faX } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Creatable from 'react-select/creatable'
 import {
-  PortalEnvironmentLanguage
+  PortalEnvironmentLanguage, PortalEnvironmentLanguageOpt
 } from '@juniper/ui-core'
 import { isEmpty, isNil } from 'lodash'
 import { Modal, ModalBody, ModalFooter } from 'react-bootstrap'
@@ -14,7 +14,7 @@ import { Button } from 'components/forms/Button'
 
 type EditablePortalEnvironmentLanguage = PortalEnvironmentLanguage & { isEditing: boolean }
 type PortalEnvironmentLanguageRow = PortalEnvironmentLanguage | EditablePortalEnvironmentLanguage
-const makeEmptyNewItem = () => ({ languageCode: '', languageName: '', isEditing: false })
+const makeEmptyNewItem = () => ({ languageCode: '', languageName: '', isEditing: false, id: '' })
 
 const isEditable = (row: PortalEnvironmentLanguageRow): row is EditablePortalEnvironmentLanguage => {
   return !isNil((row as EditablePortalEnvironmentLanguage).isEditing)
@@ -24,7 +24,7 @@ const isEditable = (row: PortalEnvironmentLanguageRow): row is EditablePortalEnv
  * some example languages options taken from A-T -- we might want to expand these.
  * But a creatable select is used so users can add their own.
  */
-const LANGUAGE_OPTIONS: PortalEnvironmentLanguage[] = [{
+const LANGUAGE_OPTIONS: PortalEnvironmentLanguageOpt[] = [{
   'languageName': 'English',
   'languageCode': 'en'
 }, {
@@ -172,7 +172,8 @@ export default function PortalEnvLanguageEditor({ items, setItems, readonly } : 
                 || isEmpty(row.original.languageCode)}
               onClick={() => updateItem({
                 languageCode: row.original.languageCode,
-                languageName: row.original.languageName
+                languageName: row.original.languageName,
+                id: ''
               })}>
               <FontAwesomeIcon icon={faCheck} aria-label={'Accept'}/>
             </Button>

--- a/ui-admin/src/portal/languages/PortalEnvLanguageEditor.tsx
+++ b/ui-admin/src/portal/languages/PortalEnvLanguageEditor.tsx
@@ -1,0 +1,218 @@
+import React, { useMemo, useState } from 'react'
+import { faCheck, faPlus, faX } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import Creatable from 'react-select/creatable'
+import {
+  PortalEnvironmentLanguage
+} from '@juniper/ui-core'
+import { isEmpty, isNil } from 'lodash'
+import { Modal, ModalBody, ModalFooter } from 'react-bootstrap'
+import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
+import { basicTableLayout } from 'util/tableUtils'
+import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan'
+import { Button } from 'components/forms/Button'
+
+type EditablePortalEnvironmentLanguage = PortalEnvironmentLanguage & { isEditing: boolean }
+type PortalEnvironmentLanguageRow = PortalEnvironmentLanguage | EditablePortalEnvironmentLanguage
+const makeEmptyNewItem = () => ({ languageCode: '', languageName: '', isEditing: false })
+
+const isEditable = (row: PortalEnvironmentLanguageRow): row is EditablePortalEnvironmentLanguage => {
+  return !isNil((row as EditablePortalEnvironmentLanguage).isEditing)
+}
+
+const LANGUAGE_OPTIONS: PortalEnvironmentLanguage[] = [{
+  'languageName': 'English',
+  'languageCode': 'en'
+}, {
+  'languageName': 'Español',
+  'languageCode': 'es'
+}, {
+  'languageName': 'Deutsch',
+  'languageCode': 'de'
+}, {
+  'languageName': 'हिंदी',
+  'languageCode': 'hi'
+}, {
+  'languageName': 'Pусский',
+  'languageCode': 'ru'
+}, {
+  'languageName': '日本語',
+  'languageCode': 'ja'
+}, {
+  'languageName': 'Italiano',
+  'languageCode': 'it'
+}, {
+  'languageName': 'Française',
+  'languageCode': 'fr'
+}, {
+  'languageName': 'Polski',
+  'languageCode': 'pl'
+}, {
+  'languageName': '中文',
+  'languageCode': 'zh'
+}, {
+  'languageName': 'Türk',
+  'languageCode': 'tr'
+}]
+
+/**
+ * Table which allows viewing, deleting, and creating new answer mappings.
+ */
+export default function PortalEnvLanguageEditor({ items, setItems } : {
+    items: PortalEnvironmentLanguage[],
+    setItems: (items: PortalEnvironmentLanguage[]) => void
+  }
+) {
+  const [itemSelectedForDeletion, setItemSelectedForDeletion] = useState<PortalEnvironmentLanguage | null>(null)
+  // state for new item
+  const [newItem, setNewItem] =
+    useState<EditablePortalEnvironmentLanguage>(makeEmptyNewItem())
+  const deleteItem = async () => {
+    if (!itemSelectedForDeletion) {
+      return
+    }
+
+    const filteredItems = items.filter(m => m.languageCode !== itemSelectedForDeletion.languageCode)
+    setItems(filteredItems)
+    setItemSelectedForDeletion(null)
+  }
+
+  const addNewItem = (item: PortalEnvironmentLanguage) => {
+    const newItems = [...items, item]
+    setNewItem(makeEmptyNewItem())
+    setItems(newItems)
+  }
+
+  const updateItem = (item: PortalEnvironmentLanguage) => {
+    if (item.languageCode === newItem.languageCode) {
+      addNewItem(item)
+      return
+    }
+    const newItems = items.map(m => m.languageCode === item.languageCode ? item : m)
+    setItems(newItems)
+  }
+
+
+  const columns: ColumnDef<PortalEnvironmentLanguage>[] = useMemo(() => ([
+    {
+      header: 'Name',
+      accessorKey: 'languageName',
+      cell: ({ row }) => {
+        const value = row.original.languageName
+        if (isEditable(row.original)) {
+          return row.original.isEditing && <Creatable
+            aria-label={'language name'}
+            options={LANGUAGE_OPTIONS.map(name => {
+              return {
+                value: name.languageName,
+                label: name.languageName
+              }
+            })}
+            value={row.original.languageName && {
+              value: row.original.languageName,
+              label: row.original.languageName
+            }}
+            onChange={e => e && setNewItem(
+              {
+                ...row.original,
+                languageName: e.value,
+                languageCode: LANGUAGE_OPTIONS.find(lang => lang.languageName === e.value)?.languageCode || '',
+                isEditing: true
+              })}
+          />
+        }
+        return value
+      }
+    },
+    {
+      header: 'Code',
+      accessorKey: 'languageCode',
+      cell: ({ row }) => {
+        const value = row.original.languageCode
+        if (isEditable(row.original)) {
+          return row.original.isEditing && <input
+            type="text"
+            aria-label={'language code'}
+            onChange={e => setNewItem({ ...row.original, languageName: e.target.value, isEditing: true })}
+            value={row.original.languageCode}
+          />
+        }
+        return value
+      }
+    },
+    {
+      header: 'Actions',
+      id: 'actions',
+      cell: ({ row }) => {
+        if (isEditable(row.original)) {
+          if (!row.original.isEditing) {
+            return <button
+              className='btn btn-primary border-0'
+              onClick={() => setNewItem({
+                ...makeEmptyNewItem(),
+                isEditing: true
+              })}>
+              <FontAwesomeIcon icon={faPlus} aria-label={'Add New'}/>
+            </button>
+          }
+
+          return <>
+            <Button
+              className='btn btn-success me-2'
+              disabled={
+                isEmpty(row.original.languageName)
+                || isEmpty(row.original.languageCode)}
+              onClick={() => updateItem(row.original)}>
+              <FontAwesomeIcon icon={faCheck} aria-label={'Accept'}/>
+            </Button>
+            <Button className='btn btn-danger' onClick={() => setNewItem(makeEmptyNewItem())}>
+              <FontAwesomeIcon icon={faX} aria-label={'Cancel'}/>
+            </Button>
+          </>
+        }
+        return <Button className='btn btn-outline-danger border-0' onClick={() => {
+          setItemSelectedForDeletion(row.original)
+        }}>
+          <FontAwesomeIcon icon={faTrashCan} aria-label={'Delete'}/>
+        </Button>
+      }
+    }
+  ]), [items, newItem])
+
+  const data = useMemo(
+    () => (items as PortalEnvironmentLanguageRow[]).concat(newItem),
+    [items, newItem])
+
+  const table = useReactTable<PortalEnvironmentLanguageRow>({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel()
+  })
+
+  return <div className='px-3 pt-1'>
+    {basicTableLayout(table, { tdClass: 'col-1 ' })}
+    {itemSelectedForDeletion && <DeleteItemModal
+      onConfirm={deleteItem}
+      onCancel={() => setItemSelectedForDeletion(null)}/>}
+    <div>
+    </div>
+  </div>
+}
+
+const DeleteItemModal = (
+  { onConfirm, onCancel } : { onConfirm: () => void, onCancel: () => void }
+) => {
+  return <Modal onHide={onCancel} show={true}>
+    <ModalBody>
+      Remove this language from the dropdown?
+    </ModalBody>
+    <ModalFooter>
+      <button className='btn btn-danger' onClick={onConfirm}>
+        Yes
+      </button>
+      <button className='btn btn-secondary' onClick={onCancel}>
+        No
+      </button>
+    </ModalFooter>
+  </Modal>
+}

--- a/ui-admin/src/portal/languages/PortalEnvLanguageEditor.tsx
+++ b/ui-admin/src/portal/languages/PortalEnvLanguageEditor.tsx
@@ -11,6 +11,7 @@ import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table
 import { basicTableLayout } from 'util/tableUtils'
 import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan'
 import { Button } from 'components/forms/Button'
+import { TextInput } from '../../components/forms/TextInput'
 
 type EditablePortalEnvironmentLanguage = PortalEnvironmentLanguage & { isEditing: boolean }
 type PortalEnvironmentLanguageRow = PortalEnvironmentLanguage | EditablePortalEnvironmentLanguage
@@ -134,12 +135,13 @@ export default function PortalEnvLanguageEditor({ items, setItems, readonly } : 
       cell: ({ row }) => {
         const value = row.original.languageCode
         if (isEditable(row.original)) {
-          return row.original.isEditing && <input
-            type="text"
+          return row.original.isEditing && <TextInput
+            size={2}
+            maxLength={2}
             aria-label={'Language code'}
-            onChange={e => setNewItem({
+            onChange={textVal => setNewItem({
               ...row.original,
-              languageCode: e.target.value,
+              languageCode: textVal,
               isEditing: true
             })}
             value={row.original.languageCode}
@@ -189,7 +191,7 @@ export default function PortalEnvLanguageEditor({ items, setItems, readonly } : 
         </Button>
       }
     })
-  }, [items, newItem, readonly])
+  }, [])
 
   const data = useMemo(
     () => (items as PortalEnvironmentLanguageRow[]).concat(newItem),

--- a/ui-admin/src/portal/languages/usePortalLanguage.ts
+++ b/ui-admin/src/portal/languages/usePortalLanguage.ts
@@ -22,7 +22,8 @@ export function usePortalLanguage() {
     return {
       defaultLanguage: {
         languageCode: 'en',
-        languageName: 'English'
+        languageName: 'English',
+        id: ''
       },
       supportedLanguages
     }

--- a/ui-admin/src/portal/languages/usePortalLanguage.ts
+++ b/ui-admin/src/portal/languages/usePortalLanguage.ts
@@ -1,5 +1,5 @@
-import { useStudyEnvParamsFromPath } from '../study/StudyEnvironmentRouter'
-import { PortalContext } from './PortalProvider'
+import { useStudyEnvParamsFromPath } from '../../study/StudyEnvironmentRouter'
+import { PortalContext } from '../PortalProvider'
 import { useContext } from 'react'
 
 /**

--- a/ui-admin/src/portal/publish/PortalEnvDiff.test.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiff.test.tsx
@@ -19,7 +19,7 @@ describe('PortalEnvDiff', () => {
       sourceEnvName="sourceEnv"
       changeSet={emptyChangeSet}/>)
     render(RoutedComponent)
-    expect(screen.queryAllByText('no changes')).toHaveLength(5)
+    expect(screen.queryAllByText('no changes')).toHaveLength(6)
     expect(screen.queryAllByRole('input')).toHaveLength(0)
   })
 
@@ -39,7 +39,7 @@ describe('PortalEnvDiff', () => {
       sourceEnvName="sourceEnv"
       changeSet={changeSet}/>)
     render(RoutedComponent)
-    expect(screen.queryAllByText('no changes')).toHaveLength(4)
+    expect(screen.queryAllByText('no changes')).toHaveLength(5)
     expect(screen.queryAllByRole('checkbox')).toHaveLength(1)
 
     // if we save without making any changes, the result should be an empty changeset
@@ -74,7 +74,7 @@ describe('PortalEnvDiff', () => {
       sourceEnvName="sourceEnv"
       changeSet={changeSet}/>)
     render(RoutedComponent)
-    expect(screen.queryAllByText('no changes')).toHaveLength(4)
+    expect(screen.queryAllByText('no changes')).toHaveLength(5)
     expect(screen.queryAllByRole('checkbox')).toHaveLength(1)
 
     // if we save without making any changes, the result should be an empty changeset
@@ -120,7 +120,7 @@ describe('PortalEnvDiff', () => {
       changeSet={changeSet}/>)
     render(RoutedComponent)
     const changeCheckboxes = screen.queryAllByRole('checkbox')
-    expect(screen.queryAllByText('no changes')).toHaveLength(4)
+    expect(screen.queryAllByText('no changes')).toHaveLength(5)
     expect(changeCheckboxes).toHaveLength(2)
 
     for (const checkbox of changeCheckboxes) {

--- a/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
@@ -6,7 +6,13 @@ import {
 } from 'api/api'
 import { Link } from 'react-router-dom'
 import StudyEnvDiff from './StudyEnvDiff'
-import { ConfigChangeListView, ConfigChanges, renderNotificationConfig, VersionChangeView } from './diffComponents'
+import {
+  ConfigChangeListView,
+  ConfigChanges,
+  renderNotificationConfig,
+  renderPortalLanguage,
+  VersionChangeView
+} from './diffComponents'
 import { faArrowRight } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import _cloneDeep from 'lodash/cloneDeep'
@@ -17,7 +23,8 @@ export const emptyChangeSet: PortalEnvironmentChange = {
   preRegSurveyChanges: { changed: false },
   triggerChanges: { addedItems: [], removedItems: [], changedItems: [] },
   participantDashboardAlertChanges: [],
-  studyEnvChanges: []
+  studyEnvChanges: [],
+  languageChanges: { addedItems: [], removedItems: [], changedItems: [] }
 }
 
 export const emptyStudyEnvChange: StudyEnvironmentChange = {
@@ -101,6 +108,8 @@ export default function PortalEnvDiffView(
     })
   }
 
+  // @ts-ignore
+  // @ts-ignore
   return <div className="container mt-3">
     <h1 className="h4">
       Difference: {sourceEnvName}
@@ -191,6 +200,17 @@ export default function PortalEnvDiffView(
             setSelectedChanges={triggerChanges =>
               setSelectedChanges({ ...selectedChanges, triggerChanges })}
             renderItemSummary={renderNotificationConfig}/>
+        </div>
+      </div>
+      <div className="my-2">
+        <h2 className="h6">
+          Portal languages</h2>
+        <div className="ms-4">
+          <ConfigChangeListView configChangeList={changeSet.languageChanges}
+            selectedChanges={selectedChanges.languageChanges}
+            setSelectedChanges={languageChanges =>
+              setSelectedChanges({ ...selectedChanges, languageChanges })}
+            renderItemSummary={renderPortalLanguage}/>
         </div>
       </div>
       <div>

--- a/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
@@ -108,8 +108,6 @@ export default function PortalEnvDiffView(
     })
   }
 
-  // @ts-ignore
-  // @ts-ignore
   return <div className="container mt-3">
     <h1 className="h4">
       Difference: {sourceEnvName}

--- a/ui-admin/src/portal/publish/diffComponents.tsx
+++ b/ui-admin/src/portal/publish/diffComponents.tsx
@@ -212,6 +212,7 @@ export const renderNotificationConfig = (change: Trigger) => {
   </span></span>
 }
 
+/** summarizes a portal language */
 export const renderPortalLanguage = (change: PortalEnvironmentLanguage) => {
   return <span>{change.languageName} ({change.languageCode})</span>
 }

--- a/ui-admin/src/portal/publish/diffComponents.tsx
+++ b/ui-admin/src/portal/publish/diffComponents.tsx
@@ -8,6 +8,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faArrowRight } from '@fortawesome/free-solid-svg-icons'
 import React from 'react'
 import { Trigger, StudyEnvironmentSurvey } from '@juniper/ui-core/build/types/study'
+import { PortalEnvironmentLanguage } from '@juniper/ui-core'
 
 /**
  * returns html for displaying the differences in versions.  this does not yet include support
@@ -101,7 +102,7 @@ export const versionDisplay = (stableId: string, version: number) => {
   return <span>{stableId} v{version}</span>
 }
 
-export type Configable = StudyEnvironmentSurvey | Trigger
+export type Configable = StudyEnvironmentSurvey | Trigger | PortalEnvironmentLanguage
 type ConfigChangeListViewProps<T extends Configable> = {
   configChangeList: ListChange<T, VersionedConfigChange>,
   selectedChanges: ListChange<T, VersionedConfigChange>,
@@ -209,6 +210,10 @@ export const renderNotificationConfig = (change: Trigger) => {
   return <span>{change.emailTemplate.name} - {change.triggerType}<span className="text-muted fst-italic ms-2">
     ({change.emailTemplate.stableId} v{change.emailTemplate.version})
   </span></span>
+}
+
+export const renderPortalLanguage = (change: PortalEnvironmentLanguage) => {
+  return <span>{change.languageName} ({change.languageCode})</span>
 }
 
 /** summarizes a change to a versioned entity (name + version) */

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -22,7 +22,7 @@ import { faExternalLink } from '@fortawesome/free-solid-svg-icons/faExternalLink
 import { useConfig } from 'providers/ConfigProvider'
 import Modal from 'react-bootstrap/Modal'
 import { useNonNullReactSingleSelect } from 'util/react-select-utils'
-import { usePortalLanguage } from '../usePortalLanguage'
+import { usePortalLanguage } from '../languages/usePortalLanguage'
 
 
 type NavbarOption = {label: string, value: string}

--- a/ui-admin/src/study/notifications/EmailTemplateEditor.test.tsx
+++ b/ui-admin/src/study/notifications/EmailTemplateEditor.test.tsx
@@ -3,7 +3,7 @@ import EmailTemplateEditor from './EmailTemplateEditor'
 import { screen, render } from '@testing-library/react'
 import { mockEmailTemplate } from 'test-utils/mocking-utils'
 import { asMockedFn } from '@juniper/ui-core'
-import { usePortalLanguage } from 'portal/usePortalLanguage'
+import { usePortalLanguage } from 'portal/languages/usePortalLanguage'
 
 jest.mock('portal/usePortalLanguage', () => ({
   usePortalLanguage: jest.fn()

--- a/ui-admin/src/study/notifications/EmailTemplateEditor.test.tsx
+++ b/ui-admin/src/study/notifications/EmailTemplateEditor.test.tsx
@@ -14,14 +14,17 @@ describe('EmailTemplateEditor', () => {
     asMockedFn(usePortalLanguage).mockReturnValue({
       defaultLanguage: {
         languageCode: 'en',
-        languageName: 'English'
+        languageName: 'English',
+        id: ''
       },
       supportedLanguages: [{
         languageCode: 'en',
-        languageName: 'English'
+        languageName: 'English',
+        id: ''
       }, {
         languageCode: 'es',
-        languageName: 'Español'
+        languageName: 'Español',
+        id: ''
       }]
     })
 
@@ -40,11 +43,13 @@ describe('EmailTemplateEditor', () => {
     asMockedFn(usePortalLanguage).mockReturnValue({
       defaultLanguage: {
         languageCode: 'en',
-        languageName: 'English'
+        languageName: 'English',
+        id: ''
       },
       supportedLanguages: [{
         languageCode: 'en',
-        languageName: 'English'
+        languageName: 'English',
+        id: ''
       }]
     })
 

--- a/ui-admin/src/study/notifications/EmailTemplateEditor.test.tsx
+++ b/ui-admin/src/study/notifications/EmailTemplateEditor.test.tsx
@@ -5,7 +5,7 @@ import { mockEmailTemplate } from 'test-utils/mocking-utils'
 import { asMockedFn } from '@juniper/ui-core'
 import { usePortalLanguage } from 'portal/languages/usePortalLanguage'
 
-jest.mock('portal/usePortalLanguage', () => ({
+jest.mock('portal/languages/usePortalLanguage', () => ({
   usePortalLanguage: jest.fn()
 }))
 

--- a/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
+++ b/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
@@ -3,7 +3,7 @@ import EmailEditor, { EditorRef, EmailEditorProps } from 'react-email-editor'
 import { EmailTemplate, PortalEnvironmentLanguage } from '@juniper/ui-core'
 import { Tab, Tabs } from 'react-bootstrap'
 import { getMediaBaseUrl } from 'api/api'
-import { usePortalLanguage } from 'portal/usePortalLanguage'
+import { usePortalLanguage } from 'portal/languages/usePortalLanguage'
 import useReactSingleSelect from 'util/react-select-utils'
 import Select from 'react-select'
 

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
@@ -97,7 +97,7 @@ describe('ItemDisplay', () => {
       question={question as unknown as Question}
       answerMap={answerMap}
       surveyVersion={1}
-      supportedLanguages={[{ languageCode: 'es', languageName: 'Spanish' }]}
+      supportedLanguages={[{ languageCode: 'es', languageName: 'Spanish', id: '' }]}
       showFullQuestions={true}/>)
 
     expect(screen.getByText('(testQ) (Answered in Spanish)')).toBeInTheDocument()
@@ -116,7 +116,7 @@ describe('ItemDisplay', () => {
       question={question as unknown as Question}
       answerMap={answerMap}
       surveyVersion={1}
-      supportedLanguages={[{ languageCode: 'en', languageName: 'English' }]}
+      supportedLanguages={[{ languageCode: 'en', languageName: 'English', id: '' }]}
       showFullQuestions={true}/>)
 
     expect(screen.getByText('(testQ)')).toBeInTheDocument()
@@ -136,7 +136,7 @@ describe('ItemDisplay', () => {
       question={question as unknown as Question}
       answerMap={answerMap}
       surveyVersion={1}
-      supportedLanguages={[{ languageCode: 'es', languageName: 'Spanish' }]}
+      supportedLanguages={[{ languageCode: 'es', languageName: 'Spanish', id: '' }]}
       showFullQuestions={true}/>)
 
     expect(screen.getByText('(testQ)')).toBeInTheDocument()

--- a/ui-admin/src/study/participants/survey/SurveyResponseEditor.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyResponseEditor.tsx
@@ -7,7 +7,7 @@ import { AutosaveStatus, Enrollee, PagedSurveyView, useTaskIdParam } from '@juni
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
 import { Store } from 'react-notifications-component'
 import { failureNotification, successNotification } from 'util/notifications'
-import { usePortalLanguage } from 'portal/usePortalLanguage'
+import { usePortalLanguage } from 'portal/languages/usePortalLanguage'
 
 /** allows editing of a survey response */
 export default function SurveyResponseEditor({

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -94,8 +94,8 @@ export const mockPortalEnvironment: (envName: string) => PortalEnvironment = (en
   },
   environmentName: envName,
   supportedLanguages: [
-    { languageCode: 'en', languageName: 'English' },
-    { languageCode: 'es', languageName: 'Spanish' }
+    { languageCode: 'en', languageName: 'English', id: '1' },
+    { languageCode: 'es', languageName: 'Spanish', id: '2' }
   ],
   createdAt: 0
 })

--- a/ui-core/src/types/portal.ts
+++ b/ui-core/src/types/portal.ts
@@ -10,9 +10,13 @@ export type Portal = {
   portalStudies: PortalStudy[]
 }
 
-export type PortalEnvironmentLanguage = {
+export type PortalEnvironmentLanguageOpt = {
   languageCode: string
   languageName: string
+}
+
+export type PortalEnvironmentLanguage = PortalEnvironmentLanguageOpt & {
+  id: string
 }
 
 export type PortalStudy = {

--- a/ui-participant/src/Navbar.tsx
+++ b/ui-participant/src/Navbar.tsx
@@ -7,7 +7,7 @@ import { Link, NavLink, useLocation, useNavigate, useSearchParams } from 'react-
 import { HashLink } from 'react-router-hash-link'
 
 import Api, { getEnvSpec, getImageUrl, NavbarItem, PortalStudy, Study } from 'api/api'
-import { MailingListModal, PortalEnvironmentLanguage, useI18n } from '@juniper/ui-core'
+import { MailingListModal, PortalEnvironmentLanguage, PortalEnvironmentLanguageOpt, useI18n } from '@juniper/ui-core'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { useUser } from 'providers/UserProvider'
 import { useConfig } from 'providers/ConfigProvider'
@@ -202,7 +202,7 @@ export const filterUnjoinableStudies = (portalStudies: PortalStudy[]): PortalStu
  *
  */
 export function LanguageDropdown({ languageOptions, selectedLanguage, changeLanguage, reloadPortal }: {
-  languageOptions: PortalEnvironmentLanguage[],
+  languageOptions: PortalEnvironmentLanguageOpt[],
   selectedLanguage: string,
   changeLanguage: (languageCode: string) => void,
   reloadPortal: () => void

--- a/ui-participant/src/Navbar.tsx
+++ b/ui-participant/src/Navbar.tsx
@@ -7,7 +7,7 @@ import { Link, NavLink, useLocation, useNavigate, useSearchParams } from 'react-
 import { HashLink } from 'react-router-hash-link'
 
 import Api, { getEnvSpec, getImageUrl, NavbarItem, PortalStudy, Study } from 'api/api'
-import { MailingListModal, PortalEnvironmentLanguage, PortalEnvironmentLanguageOpt, useI18n } from '@juniper/ui-core'
+import { MailingListModal, PortalEnvironmentLanguageOpt, useI18n } from '@juniper/ui-core'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { useUser } from 'providers/UserProvider'
 import { useConfig } from 'providers/ConfigProvider'

--- a/ui-participant/src/test-utils/test-portal-factory.tsx
+++ b/ui-participant/src/test-utils/test-portal-factory.tsx
@@ -57,7 +57,7 @@ export const mockPortalEnvironment = (): PortalEnvironment => {
     environmentName: 'sandbox',
     portalEnvironmentConfig: mockPortalEnvironmentConfig(),
     siteContent: mockSiteContent(),
-    supportedLanguages: [{ languageCode: 'en', languageName: 'English' }]
+    supportedLanguages: [{ languageCode: 'en', languageName: 'English', id: '1' }]
   }
 }
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

This enables editing of the PortalLanguages from the admin tool.  This copies a fair bit of logic from the AnswerMapping table editor, and moves in the direction of genericizing some of the functionality.  I think the next time we do an editable list will be when we should really focus on pulling out general purpose "editable list" hooks

![image](https://github.com/broadinstitute/juniper/assets/2800795/063f4a4b-7c67-4ae2-b149-25912b4626fe)

This also adds portal languages to the publishing flow

![image](https://github.com/broadinstitute/juniper/assets/2800795/643cc588-43ab-4586-bc79-46c3b4bda889)



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy apiAdminApp
2. repopulate demo
3. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/settings
4. add/remove languages
5. save languages
6. go to https://sandbox.ourhealth.localhost:3001/  -- confirm the updated list appears
7. go to https://localhost:3000/demo/studies/heartdemo/publishing
8. choose "copy" from sandbox to irb
9. select one or more of the language changes to copy
10. press "Copy Changes"
11. confirm IRB environment has updated language list