### PR TITLE
[JN-1135] adding SandboxOnly annotation

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/StudyEnvironmentController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/StudyEnvironmentController.java
@@ -3,6 +3,7 @@ package bio.terra.pearl.api.admin.controller;
 import bio.terra.pearl.api.admin.api.StudyEnvironmentApi;
 import bio.terra.pearl.api.admin.model.StudyEnvironmentDto;
 import bio.terra.pearl.api.admin.service.auth.AuthUtilService;
+import bio.terra.pearl.api.admin.service.auth.context.PortalStudyEnvAuthContext;
 import bio.terra.pearl.api.admin.service.study.StudyEnvironmentExtService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
@@ -42,7 +43,9 @@ public class StudyEnvironmentController implements StudyEnvironmentApi {
     StudyEnvironment envUpdate = objectMapper.convertValue(body, StudyEnvironment.class);
     StudyEnvironment savedEnv =
         studyEnvExtService.update(
-            adminUser, portalShortcode, studyShortcode, environmentName, envUpdate);
+            PortalStudyEnvAuthContext.of(
+                adminUser, portalShortcode, studyShortcode, environmentName),
+            envUpdate);
     return ResponseEntity.ok(objectMapper.convertValue(savedEnv, StudyEnvironmentDto.class));
   }
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/datarepo/DataRepoExportController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/datarepo/DataRepoExportController.java
@@ -4,7 +4,7 @@ import bio.terra.pearl.api.admin.api.DatarepoApi;
 import bio.terra.pearl.api.admin.model.CreateDataset;
 import bio.terra.pearl.api.admin.service.DataRepoExportExtService;
 import bio.terra.pearl.api.admin.service.auth.AuthUtilService;
-import bio.terra.pearl.api.admin.service.auth.PortalStudyEnvAuthContext;
+import bio.terra.pearl.api.admin.service.auth.context.PortalStudyEnvAuthContext;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.datarepo.DataRepoJob;

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/DataRepoExportExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/DataRepoExportExtService.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.api.admin.service;
 
 import bio.terra.pearl.api.admin.model.CreateDataset;
 import bio.terra.pearl.api.admin.service.auth.*;
+import bio.terra.pearl.api.admin.service.auth.context.PortalStudyEnvAuthContext;
 import bio.terra.pearl.core.model.datarepo.DataRepoJob;
 import bio.terra.pearl.core.model.datarepo.Dataset;
 import bio.terra.pearl.core.service.datarepo.DataRepoExportService;

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/BaseEnforcePortalPermissionAspect.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/BaseEnforcePortalPermissionAspect.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.api.admin.service.auth;
 
+import bio.terra.pearl.api.admin.service.auth.context.PortalAuthContext;
 import bio.terra.pearl.core.model.portal.Portal;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/BaseEnforcePortalStudyEnvPermissionAspect.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/BaseEnforcePortalStudyEnvPermissionAspect.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.api.admin.service.auth;
 
+import bio.terra.pearl.api.admin.service.auth.context.PortalStudyEnvAuthContext;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.study.PortalStudy;
 import bio.terra.pearl.core.model.study.StudyEnvironment;

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/BaseEnforcePortalStudyPermissionAspect.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/BaseEnforcePortalStudyPermissionAspect.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.api.admin.service.auth;
 
+import bio.terra.pearl.api.admin.service.auth.context.PortalStudyAuthContext;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.study.PortalStudy;
 import lombok.extern.slf4j.Slf4j;

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/SandboxOnly.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/SandboxOnly.java
@@ -1,0 +1,12 @@
+package bio.terra.pearl.api.admin.service.auth;
+
+import java.lang.annotation.*;
+
+/**
+ * annotation to mark a method as only available in the sandbox environment. The method's first
+ * argument must implement the EnvironmentAwareAuthContext interface
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Inherited
+public @interface SandboxOnly {}

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/SandboxOnlyAspect.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/SandboxOnlyAspect.java
@@ -1,0 +1,25 @@
+package bio.terra.pearl.api.admin.service.auth;
+
+import bio.terra.pearl.api.admin.service.auth.context.EnvironmentAwareAuthContext;
+import bio.terra.pearl.core.model.EnvironmentName;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+@Component
+@Aspect
+@Slf4j
+public class SandboxOnlyAspect {
+  @Before(value = "@annotation(SandboxOnly)")
+  public void enforceSandboxOnly(JoinPoint joinPoint) {
+    EnvironmentAwareAuthContext authContext =
+        BaseEnforcePermissionAspect.extractAuthContext(
+            joinPoint, EnvironmentAwareAuthContext.class, "SandboxOnly");
+    if (authContext.getEnvironmentName() != EnvironmentName.sandbox) {
+      throw new UnsupportedOperationException(
+          "This operation is only allowed in the sandbox environment");
+    }
+  }
+}

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/context/EnvironmentAwareAuthContext.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/context/EnvironmentAwareAuthContext.java
@@ -1,0 +1,7 @@
+package bio.terra.pearl.api.admin.service.auth.context;
+
+import bio.terra.pearl.core.model.EnvironmentName;
+
+public interface EnvironmentAwareAuthContext {
+  public EnvironmentName getEnvironmentName();
+}

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/context/PortalAuthContext.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/context/PortalAuthContext.java
@@ -1,4 +1,4 @@
-package bio.terra.pearl.api.admin.service.auth;
+package bio.terra.pearl.api.admin.service.auth.context;
 
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.portal.Portal;

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/context/PortalEnvAuthContext.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/context/PortalEnvAuthContext.java
@@ -1,0 +1,25 @@
+package bio.terra.pearl.api.admin.service.auth.context;
+
+import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.model.study.PortalStudy;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Getter
+@Setter
+public class PortalEnvAuthContext extends PortalAuthContext implements EnvironmentAwareAuthContext {
+  private PortalStudy portalStudy;
+  private EnvironmentName environmentName;
+
+  public static PortalEnvAuthContext of(
+      AdminUser operator, String portalShortcode, EnvironmentName environmentName) {
+    return PortalEnvAuthContext.builder()
+        .operator(operator)
+        .portalShortcode(portalShortcode)
+        .environmentName(environmentName)
+        .build();
+  }
+}

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/context/PortalStudyAuthContext.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/context/PortalStudyAuthContext.java
@@ -1,4 +1,4 @@
-package bio.terra.pearl.api.admin.service.auth;
+package bio.terra.pearl.api.admin.service.auth.context;
 
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.study.PortalStudy;

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/context/PortalStudyEnvAuthContext.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/context/PortalStudyEnvAuthContext.java
@@ -1,4 +1,4 @@
-package bio.terra.pearl.api.admin.service.auth;
+package bio.terra.pearl.api.admin.service.auth.context;
 
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
@@ -10,7 +10,8 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @Getter
 @Setter
-public class PortalStudyEnvAuthContext extends PortalStudyAuthContext {
+public class PortalStudyEnvAuthContext extends PortalStudyAuthContext
+    implements EnvironmentAwareAuthContext {
   EnvironmentName environmentName;
   StudyEnvironment studyEnvironment;
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/study/StudyEnvironmentExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/study/StudyEnvironmentExtService.java
@@ -1,6 +1,9 @@
 package bio.terra.pearl.api.admin.service.study;
 
 import bio.terra.pearl.api.admin.service.auth.AuthUtilService;
+import bio.terra.pearl.api.admin.service.auth.EnforcePortalStudyEnvPermission;
+import bio.terra.pearl.api.admin.service.auth.SandboxOnly;
+import bio.terra.pearl.api.admin.service.auth.context.PortalStudyEnvAuthContext;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.kit.KitType;
@@ -40,13 +43,10 @@ public class StudyEnvironmentExtService {
   }
 
   /** currently only supports changing the pre-enroll survey id */
-  public StudyEnvironment update(
-      AdminUser operator,
-      String portalShortcode,
-      String studyShortcode,
-      EnvironmentName envName,
-      StudyEnvironment update) {
-    StudyEnvironment studyEnv = authToStudyEnv(operator, portalShortcode, studyShortcode, envName);
+  @SandboxOnly
+  @EnforcePortalStudyEnvPermission(permission = "survey_edit")
+  public StudyEnvironment update(PortalStudyEnvAuthContext authContext, StudyEnvironment update) {
+    StudyEnvironment studyEnv = authContext.getStudyEnvironment();
     studyEnv.setPreEnrollSurveyId(update.getPreEnrollSurveyId());
     return studyEnvService.update(studyEnv);
   }

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/DataRepoExportExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/DataRepoExportExtServiceTests.java
@@ -3,7 +3,7 @@ package bio.terra.pearl.api.admin.service;
 import bio.terra.pearl.api.admin.BaseSpringBootTest;
 import bio.terra.pearl.api.admin.model.CreateDataset;
 import bio.terra.pearl.api.admin.service.auth.AuthUtilService;
-import bio.terra.pearl.api.admin.service.auth.PortalStudyEnvAuthContext;
+import bio.terra.pearl.api.admin.service.auth.context.PortalStudyEnvAuthContext;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.service.exception.NotFoundException;

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/auth/SandboxOnlyAnnotationTestBean.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/auth/SandboxOnlyAnnotationTestBean.java
@@ -1,0 +1,15 @@
+package bio.terra.pearl.api.admin.service.auth;
+
+import bio.terra.pearl.api.admin.service.auth.context.EnvironmentAwareAuthContext;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SandboxOnlyAnnotationTestBean {
+  @SandboxOnly
+  public void sandboxOnlyMethod(EnvironmentAwareAuthContext authContext) {}
+
+  public void allEnvMethod(EnvironmentAwareAuthContext authContext) {}
+
+  @SandboxOnly
+  public void sandboxOnlyMethodNoAuthContext(String foo) {}
+}

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/auth/SandboxOnlyTest.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/auth/SandboxOnlyTest.java
@@ -1,0 +1,46 @@
+package bio.terra.pearl.api.admin.service.auth;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import bio.terra.pearl.api.admin.BaseSpringBootTest;
+import bio.terra.pearl.api.admin.service.auth.context.PortalEnvAuthContext;
+import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.admin.AdminUser;
+import org.apache.commons.lang3.NotImplementedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class SandboxOnlyTest extends BaseSpringBootTest {
+  @Autowired private SandboxOnlyAnnotationTestBean sandboxOnlyAnnotationTestBean;
+
+  @Test
+  public void testSandboxOnlyMethodAllowsSandbox() {
+    sandboxOnlyAnnotationTestBean.sandboxOnlyMethod(
+        PortalEnvAuthContext.of(new AdminUser(), "foo", EnvironmentName.sandbox));
+    assertThat(true, equalTo(true));
+  }
+
+  @Test
+  public void testSandboxOnlyMethodDisallowsOther() {
+    Assertions.assertThrows(
+        UnsupportedOperationException.class,
+        () ->
+            sandboxOnlyAnnotationTestBean.sandboxOnlyMethod(
+                PortalEnvAuthContext.of(new AdminUser(), "foo", EnvironmentName.irb)));
+  }
+
+  @Test
+  public void testSandboxOnlyMethodErrorsOnNull() {
+    Assertions.assertThrows(
+        NotImplementedException.class, () -> sandboxOnlyAnnotationTestBean.sandboxOnlyMethod(null));
+  }
+
+  @Test
+  public void testSandboxOnlyNoAuthContextErrors() {
+    Assertions.assertThrows(
+        NotImplementedException.class,
+        () -> sandboxOnlyAnnotationTestBean.sandboxOnlyMethodNoAuthContext("someArg"));
+  }
+}


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds an `@SandboxOnly` annotation for methods that should be prevented from running in non-sandbox environments. (which forces users to use the publishing workflow for some changes).


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  I don't think there's a way to test this via the UI (at least not until we add this to other methods), so just take a look at the unit tests and confirm they make sense