### PR TITLE
[JN-1126] auto-trimming answer mappings

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
@@ -15,6 +15,7 @@ import bio.terra.pearl.core.service.participant.ProfileService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.beanutils.PropertyUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -157,7 +158,7 @@ public class AnswerProcessingService {
     }
 
     public static final Map<AnswerMappingMapType, BiFunction<Answer, AnswerMapping, Object>> JSON_MAPPERS = Map.of(
-            AnswerMappingMapType.STRING_TO_STRING, (Answer answer, AnswerMapping mapping) -> answer.getStringValue(),
+            AnswerMappingMapType.STRING_TO_STRING, (Answer answer, AnswerMapping mapping) -> StringUtils.trim(answer.getStringValue()),
             AnswerMappingMapType.STRING_TO_LOCAL_DATE, (Answer answer, AnswerMapping mapping) ->
                     mapToDate(answer.getStringValue(), mapping)
     );

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/AnswerProcessingServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/AnswerProcessingServiceTests.java
@@ -109,6 +109,14 @@ public class AnswerProcessingServiceTests extends BaseSpringBootTest {
     }
 
     @Test
+    public void mapStringToStringTrims() {
+        AnswerMapping mapping = new AnswerMapping();
+        Object result = AnswerProcessingService.JSON_MAPPERS.get(AnswerMappingMapType.STRING_TO_STRING)
+                .apply(Answer.builder().stringValue("  foo  ").build(), mapping);
+        assertThat((String) result, equalTo("foo"));
+    }
+
+    @Test
     public void mapToDateHandlesFormatString() {
         AnswerMapping mapping = AnswerMapping.builder().formatString("MM/dd/yyyy").build();
         LocalDate result = AnswerProcessingService.mapToDate("11/12/1987", mapping);
@@ -153,7 +161,7 @@ public class AnswerProcessingServiceTests extends BaseSpringBootTest {
 
         List<Answer> answers = AnswerFactory.fromMap(Map.of(
                 "testSurvey_q1", "myFirstName",
-                "testSurvey_q2", "addressPart1",
+                "testSurvey_q2", "addressPart1 ",
                 "testSurvey_q3", "11/12/1987"
         ));
         List<AnswerMapping> mappings = List.of(


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

auto-trim whitespace for STRING_TO_STRING map types.  I think that makes sense as the default, if we ever need something different, we can add a STRING_TO_STRING_RAW or similar.


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  redeploy apiParticipantApp
2. go to sandbox.ourhealth.localhost:3001
3. log in as "consented@test.com"
4. fill in your name on the basics survey, but with leading/trailing whitespace
5. run `select given_name, family_name from profile;` in the database, and confirm the whitespace got trimmed