### PR TITLE
[JN-1140] switching to advanced view no longer submits form

### DIFF
--- a/ui-admin/src/search/SearchQueryBuilder.tsx
+++ b/ui-admin/src/search/SearchQueryBuilder.tsx
@@ -292,10 +292,17 @@ const CustomFieldSelector = (props: FieldSelectorProps) => {
   const options = props.options.map(option => {
     return { label: option.label, value: option.label }
   })
-
   return <div className="w-100">
     <Select
       options={options}
+      styles={{
+        control: styles => ({ ...styles }),
+        option: styles => ({ ...styles }),
+        menu: styles => ({
+          ...styles,
+          width: '650px'
+        })
+      }}
       value={{ label: props.value || '', value: props.value || '' }}
       onChange={newVal => {
         if (newVal?.label != props.value) {

--- a/ui-admin/src/search/SearchQueryBuilder.tsx
+++ b/ui-admin/src/search/SearchQueryBuilder.tsx
@@ -39,6 +39,7 @@ import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Creatable from 'react-select/creatable'
 import pluralize from 'pluralize'
+import { Button } from '../components/forms/Button'
 
 /**
  * Frontend for building an enrollee search expression; can either
@@ -94,11 +95,11 @@ export const SearchQueryBuilder = ({
         search expression
         </ZendeskLink> that filters to enrollees that meet a specific criteria.
       </div>
-      <button
-        className="btn btn-link"
+      <Button
+        variant="link"
         onClick={() => setAdvancedMode(!advancedMode)}>
         {advancedMode ? '(switch to basic view)' : '(switch to advanced view)'}
-      </button>
+      </Button>
     </div>
     {parseSearchExpError && <div className="alert alert-danger mb-2">
       {parseSearchExpError.message}


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

<img width="489" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/ccf3a3b1-a537-4848-b8af-b032e865ecb4">

this also expands the answer choice options to be bigger.  this just hardocdes 650px which seemed to fit most of the demo stableIds

<img width="796" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/501b8499-9377-492e-8748-00c26fb8662a">



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. make sure demo is populated
2. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/forms/surveys/hd_hd_cardioHx
3. open the configuration
4. switch between rule advanced/basic view, confirm things work