### PR TITLE
[JN-1116] Add survey response editing permission

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/SurveyResponseController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/SurveyResponseController.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.api.admin.controller.forms;
 
 import bio.terra.pearl.api.admin.api.SurveyResponseApi;
 import bio.terra.pearl.api.admin.service.auth.AuthUtilService;
+import bio.terra.pearl.api.admin.service.auth.context.PortalStudyEnvAuthContext;
 import bio.terra.pearl.api.admin.service.forms.SurveyResponseExtService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
@@ -44,9 +45,17 @@ public class SurveyResponseController implements SurveyResponseApi {
     AdminUser user = authUtilService.requireAdminUser(request);
     EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
     SurveyResponse responseDto = objectMapper.convertValue(body, SurveyResponse.class);
+    PortalStudyEnvAuthContext authContext =
+        PortalStudyEnvAuthContext.of(user, portalShortcode, studyShortcode, environmentName);
     HubResponse hubResponse =
         surveyResponseExtService.updateResponse(
-            user, portalShortcode, environmentName, responseDto, enrolleeShortcode, taskId);
+            authContext,
+            user,
+            portalShortcode,
+            environmentName,
+            responseDto,
+            enrolleeShortcode,
+            taskId);
     return ResponseEntity.ok(hubResponse);
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/SurveyResponseController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/SurveyResponseController.java
@@ -49,13 +49,7 @@ public class SurveyResponseController implements SurveyResponseApi {
         PortalStudyEnvAuthContext.of(user, portalShortcode, studyShortcode, environmentName);
     HubResponse hubResponse =
         surveyResponseExtService.updateResponse(
-            authContext,
-            user,
-            portalShortcode,
-            environmentName,
-            responseDto,
-            enrolleeShortcode,
-            taskId);
+            authContext, user, responseDto, enrolleeShortcode, taskId);
     return ResponseEntity.ok(hubResponse);
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyResponseExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyResponseExtService.java
@@ -1,6 +1,8 @@
 package bio.terra.pearl.api.admin.service.forms;
 
 import bio.terra.pearl.api.admin.service.auth.AuthUtilService;
+import bio.terra.pearl.api.admin.service.auth.EnforcePortalStudyEnvPermission;
+import bio.terra.pearl.api.admin.service.auth.context.PortalStudyEnvAuthContext;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.audit.ResponsibleEntity;
@@ -29,14 +31,16 @@ public class SurveyResponseExtService {
     this.surveyResponseService = surveyResponseService;
   }
 
+  @EnforcePortalStudyEnvPermission(permission = "survey_response_edit")
   public HubResponse updateResponse(
+      PortalStudyEnvAuthContext authContext,
       AdminUser user,
       String portalShortcode,
       EnvironmentName envName,
       SurveyResponse responseDto,
       String enrolleeShortcode,
       UUID taskId) {
-    Portal portal = authUtilService.authUserToPortal(user, portalShortcode);
+    Portal portal = authContext.getPortal();
     Enrollee enrollee = authUtilService.authAdminUserToEnrollee(user, enrolleeShortcode);
     PortalParticipantUser ppUser = portalParticipantUserService.findForEnrollee(enrollee);
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyResponseExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyResponseExtService.java
@@ -3,7 +3,6 @@ package bio.terra.pearl.api.admin.service.forms;
 import bio.terra.pearl.api.admin.service.auth.AuthUtilService;
 import bio.terra.pearl.api.admin.service.auth.EnforcePortalStudyEnvPermission;
 import bio.terra.pearl.api.admin.service.auth.context.PortalStudyEnvAuthContext;
-import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.audit.ResponsibleEntity;
 import bio.terra.pearl.core.model.participant.Enrollee;
@@ -35,8 +34,6 @@ public class SurveyResponseExtService {
   public HubResponse updateResponse(
       PortalStudyEnvAuthContext authContext,
       AdminUser user,
-      String portalShortcode,
-      EnvironmentName envName,
       SurveyResponse responseDto,
       String enrolleeShortcode,
       UUID taskId) {

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/SurveyResponseExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/SurveyResponseExtServiceTests.java
@@ -1,0 +1,42 @@
+package bio.terra.pearl.api.admin.service.forms;
+
+import bio.terra.pearl.api.admin.BaseSpringBootTest;
+import bio.terra.pearl.api.admin.service.auth.AuthUtilService;
+import bio.terra.pearl.api.admin.service.auth.context.PortalStudyEnvAuthContext;
+import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.service.exception.NotFoundException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+public class SurveyResponseExtServiceTests extends BaseSpringBootTest {
+  private final PortalStudyEnvAuthContext emptyAuthContext =
+      PortalStudyEnvAuthContext.of(
+          new AdminUser(), "someportal", "somestudy", EnvironmentName.sandbox);
+
+  @Autowired private SurveyResponseExtService surveyResponseExtService;
+  @MockBean private AuthUtilService authUtilService;
+
+  @Test
+  public void updateSurveyResponseRequiresAuth() {
+    Assertions.assertThrows(
+        NotFoundException.class,
+        () ->
+            surveyResponseExtService.updateResponse(
+                emptyAuthContext,
+                new AdminUser(),
+                "someportal",
+                EnvironmentName.sandbox,
+                null,
+                "someenrollee",
+                null));
+    Mockito.verify(authUtilService)
+        .authUserToPortalWithPermission(
+            emptyAuthContext.getOperator(),
+            emptyAuthContext.getPortalShortcode(),
+            "survey_response_edit");
+  }
+}

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/SurveyResponseExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/SurveyResponseExtServiceTests.java
@@ -26,13 +26,7 @@ public class SurveyResponseExtServiceTests extends BaseSpringBootTest {
         NotFoundException.class,
         () ->
             surveyResponseExtService.updateResponse(
-                emptyAuthContext,
-                new AdminUser(),
-                "someportal",
-                EnvironmentName.sandbox,
-                null,
-                "someenrollee",
-                null));
+                emptyAuthContext, new AdminUser(), null, "someenrollee", null));
     Mockito.verify(authUtilService)
         .authUserToPortalWithPermission(
             emptyAuthContext.getOperator(),

--- a/populate/src/main/resources/seed/iam/permissions.json
+++ b/populate/src/main/resources/seed/iam/permissions.json
@@ -28,5 +28,10 @@
     "name": "tdr_export",
     "displayName": "TDR snapshot management",
     "description": "Allows user to export study data to Terra Data Repo"
+  },
+  {
+    "name": "survey_response_edit",
+    "displayName": "Survey response editing",
+    "description": "Allows user to edit participant survey responses"
   }
 ]

--- a/populate/src/main/resources/seed/iam/roles.json
+++ b/populate/src/main/resources/seed/iam/roles.json
@@ -3,7 +3,13 @@
     "name": "study_admin",
     "displayName": "Study admin",
     "description": "View and edit all aspects of a study",
-    "permissionNames": ["study_settings_edit", "survey_edit", "consent_form_edit", "site_content_edit"]
+    "permissionNames": [
+      "study_settings_edit",
+      "survey_edit",
+      "consent_form_edit",
+      "site_content_edit",
+      "survey_response_edit"
+    ]
   },
   {
     "name": "prototype_tester",

--- a/ui-admin/src/study/participants/survey/SurveyResponseView.test.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyResponseView.test.tsx
@@ -10,6 +10,12 @@ import { render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import userEvent from '@testing-library/user-event'
 import { RawEnrolleeSurveyView } from './SurveyResponseView'
+import { userHasPermission } from 'user/UserProvider'
+
+jest.mock('user/UserProvider', () => ({
+  ...jest.requireActual('user/UserProvider'),
+  userHasPermission: jest.fn()
+}))
 
 describe('RawEnrolleeSurveyView', () => {
   const mockResponseWithAnswer = {
@@ -45,6 +51,9 @@ describe('RawEnrolleeSurveyView', () => {
   })
 
   test('Editing mode shows the survey response editor', async () => {
+    (userHasPermission as jest.Mock).mockImplementation(() => {
+      return true
+    })
     const { RoutedComponent } = setupRouterTest(
       <RawEnrolleeSurveyView enrollee={mockEnrollee()}
         updateResponseMap={jest.fn()}

--- a/ui-admin/src/study/participants/survey/SurveyResponseView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyResponseView.tsx
@@ -97,17 +97,18 @@ export function RawEnrolleeSurveyView({
                 description="Read form responses"
               />
               <div className="dropdown-divider my-1"></div>
-              <DropdownButton
-                onClick={() => setIsEditing(true)}
-                icon={faPencil}
-                disabled={
-                  !configSurvey.survey.allowAdminEdit ||
-                    !userHasPermission(user, studyEnvContext.portal.id, 'survey_response_edit')
-                }
-                label="Editing"
-                description="Edit form responses directly"
-              />
-              <div className="dropdown-divider my-1"></div>
+              {userHasPermission(user, studyEnvContext.portal.id, 'survey_response_edit') &&
+                <>
+                  <DropdownButton
+                    onClick={() => setIsEditing(true)}
+                    icon={faPencil}
+                    disabled={!configSurvey.survey.allowAdminEdit}
+                    label="Editing"
+                    description="Edit form responses directly"
+                  />
+                  <div className="dropdown-divider my-1"></div>
+                </>
+              }
               <DropdownButton
                 onClick={() => {
                   setIsEditing(false)

--- a/ui-admin/src/study/participants/survey/SurveyResponseView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyResponseView.tsx
@@ -11,7 +11,7 @@ import DocumentTitle from 'util/DocumentTitle'
 import _uniq from 'lodash/uniq'
 import pluralize from 'pluralize'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
-import { useUser } from 'user/UserProvider'
+import { userHasPermission, useUser } from 'user/UserProvider'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   faCheck, faCircleCheck,
@@ -100,7 +100,10 @@ export function RawEnrolleeSurveyView({
               <DropdownButton
                 onClick={() => setIsEditing(true)}
                 icon={faPencil}
-                disabled={!configSurvey.survey.allowAdminEdit}
+                disabled={
+                  !configSurvey.survey.allowAdminEdit ||
+                    !userHasPermission(user, studyEnvContext.portal.id, 'survey_response_edit')
+                }
                 label="Editing"
                 description="Edit form responses directly"
               />


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Puts survey response editing behind an admin permission- currently given to all study admins, but we could eventually break it out into another role in the future.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Redeploy the admin API app to populate the new permission
* Log in as `staff@heartdemo.org` and confirm that you can still edit responses for users: https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants/HDINVI