### PR TITLE
[JN-1146] case-insensitive keyword search

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/search/expressions/EnrolleeTermComparisonFacet.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/expressions/EnrolleeTermComparisonFacet.java
@@ -69,8 +69,9 @@ public class EnrolleeTermComparisonFacet implements EnrolleeSearchExpression {
         Condition whereCondition;
         if (this.operator.equals(SearchOperators.CONTAINS)) {
             // If the operator is CONTAINS, we need to wrap the right term in % to make it a valid SQL LIKE clause
+            // contains is case insensitive
             whereCondition = condition(
-                    this.leftTermExtractor.termClause() + " LIKE concat('%', " + rightTermExtractor.termClause() + ", '%')",
+                    this.leftTermExtractor.termClause() + " ILIKE concat('%', " + rightTermExtractor.termClause() + ", '%')",
                     boundObjects.toArray()
             );
         } else {

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/SearchValue.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/SearchValue.java
@@ -143,7 +143,7 @@ public class SearchValue {
             return false;
         }
 
-        return this.stringValue.contains(rightSearchValue.stringValue);
+        return this.stringValue.toLowerCase().contains(rightSearchValue.stringValue.toLowerCase());
     }
 
     public enum SearchValueType {

--- a/core/src/test/java/bio/terra/pearl/core/service/search/expressions/EnrolleeSearchExpressionTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/search/expressions/EnrolleeSearchExpressionTest.java
@@ -406,6 +406,18 @@ class EnrolleeSearchExpressionTest extends BaseSpringBootTest {
                                         .build())
                                 .build()));
 
+        // case insensitive
+        assertTrue(enrolleeSearchExpressionParser
+                .parseRule("{profile.name} contains 'jonas'")
+                .evaluate(
+                        EnrolleeSearchContext
+                                .builder()
+                                .profile(Profile.builder()
+                                        .givenName("Jonas")
+                                        .familyName("Salk")
+                                        .build())
+                                .build()));
+
         assertTrue(enrolleeSearchExpressionParser
                 .parseRule("{profile.name} contains 'nas Sa'")
                 .evaluate(

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -165,6 +165,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
   return <div className="ParticipantList container-fluid px-4 py-2">
     { renderPageHeader('Participant List') }
     <ParticipantSearch
+      key={currentEnv.environmentName}
       studyEnvContext={studyEnvContext}
       searchState={searchState}
       updateSearchState={updateSearchState}


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Changes "contains" to be a case-insensitive operation, which restores keyword search to be case-insensitive.  This also fixes a bug where typing in a keyword in the sandbox environment would sometimes reset the environment to 'live'

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants
2. type `sa` in the search, confirm HDSALK appears in the results