### PR TITLE
[JN-981] option to include unconsented on export

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/export/ExportController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/export/ExportController.java
@@ -7,10 +7,13 @@ import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.service.export.ExportFileFormat;
 import bio.terra.pearl.core.service.export.ExportOptions;
+import bio.terra.pearl.core.service.search.EnrolleeSearchExpression;
+import bio.terra.pearl.core.service.search.EnrolleeSearchExpressionParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.ByteArrayOutputStream;
+import java.util.Objects;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +21,7 @@ import org.springframework.stereotype.Controller;
 
 @Controller
 public class ExportController implements ExportApi {
+  private final EnrolleeSearchExpressionParser enrolleeSearchExpressionParser;
   private AuthUtilService authUtilService;
   private HttpServletRequest request;
   private EnrolleeExportExtService enrolleeExportExtService;
@@ -29,12 +33,14 @@ public class ExportController implements ExportApi {
       HttpServletRequest request,
       EnrolleeExportExtService enrolleeExportExtService,
       ObjectMapper objectMapper,
-      HttpServletResponse response) {
+      HttpServletResponse response,
+      EnrolleeSearchExpressionParser enrolleeSearchExpressionParser) {
     this.authUtilService = authUtilService;
     this.request = request;
     this.enrolleeExportExtService = enrolleeExportExtService;
     this.objectMapper = objectMapper;
     this.response = response;
+    this.enrolleeSearchExpressionParser = enrolleeSearchExpressionParser;
   }
 
   /** just gets the export as a row TSV string, with no accompanying data dictionary */
@@ -46,11 +52,16 @@ public class ExportController implements ExportApi {
       Boolean splitOptionsIntoColumns,
       Boolean stableIdsForOptions,
       Boolean includeOnlyMostRecent,
-      Boolean includeProxiesAsRows,
+      String searchExpression,
       String fileFormat,
       Integer limit) {
     EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
     AdminUser user = authUtilService.requireAdminUser(request);
+
+    EnrolleeSearchExpression filter =
+        Objects.nonNull(searchExpression) && !searchExpression.isEmpty()
+            ? enrolleeSearchExpressionParser.parseRule(searchExpression)
+            : null;
 
     ExportOptions exportOptions =
         ExportOptions.builder()
@@ -58,7 +69,7 @@ public class ExportController implements ExportApi {
                 splitOptionsIntoColumns != null ? splitOptionsIntoColumns : false)
             .stableIdsForOptions(stableIdsForOptions != null ? stableIdsForOptions : false)
             .onlyIncludeMostRecent(includeOnlyMostRecent != null ? includeOnlyMostRecent : false)
-            .includeProxiesAsRows(includeProxiesAsRows != null ? includeProxiesAsRows : false)
+            .filter(filter)
             .fileFormat(
                 fileFormat != null ? ExportFileFormat.valueOf(fileFormat) : ExportFileFormat.TSV)
             .limit(limit)
@@ -79,8 +90,14 @@ public class ExportController implements ExportApi {
       Boolean splitOptionsIntoColumns,
       Boolean stableIdsForOptions,
       Boolean includeOnlyMostRecent,
-      Boolean includeProxiesAsRows,
+      String searchExpression,
       String fileFormat) {
+
+    EnrolleeSearchExpression filter =
+        Objects.nonNull(searchExpression) && !searchExpression.isEmpty()
+            ? enrolleeSearchExpressionParser.parseRule(searchExpression)
+            : null;
+
     EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
     AdminUser user = authUtilService.requireAdminUser(request);
     ExportOptions exportOptions =
@@ -89,7 +106,7 @@ public class ExportController implements ExportApi {
                 splitOptionsIntoColumns != null ? splitOptionsIntoColumns : false)
             .stableIdsForOptions(stableIdsForOptions != null ? stableIdsForOptions : false)
             .onlyIncludeMostRecent(includeOnlyMostRecent != null ? includeOnlyMostRecent : false)
-            .includeProxiesAsRows(includeProxiesAsRows != null ? includeProxiesAsRows : false)
+            .filter(filter)
             .fileFormat(
                 fileFormat != null ? ExportFileFormat.valueOf(fileFormat) : ExportFileFormat.TSV)
             .limit(null)

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -970,7 +970,7 @@ paths:
         - { name: splitOptionsIntoColumns, in: query, required: false, schema: { type: boolean, default: false } }
         - { name: stableIdsForOptions, in: query, required: false, schema: { type: boolean, default: false } }
         - { name: onlyIncludeMostRecent, in: query, required: false, schema: { type: boolean, default: true } }
-        - { name: includeProxiesAsRows, in: query, required: false, schema: { type: boolean, default: true } }
+        - { name: filter, in: query, required: false, schema: { type: string, default: '' } }
         - { name: fileFormat, in: query, required: false, schema: { type: string, default: "TSV" } }
         - { name: limit, in: query, required: false, schema: { type: integer } }
       responses:
@@ -991,7 +991,7 @@ paths:
         - { name: splitOptionsIntoColumns, in: query, required: false, schema: { type: boolean, default: false } }
         - { name: stableIdsForOptions, in: query, required: false, schema: { type: boolean, default: false } }
         - { name: onlyIncludeMostRecent, in: query, required: false, schema: { type: boolean, default: true } }
-        - { name: includeProxiesAsRows, in: query, required: false, schema: { type: boolean, default: true } }
+        - { name: filter, in: query, required: false, schema: { type: string, default: '' } }
         - { name: fileFormat, in: query, required: false, schema: { type: string, default: "TSV" } }
       responses:
         '200':

--- a/core/src/main/java/bio/terra/pearl/core/dao/search/EnrolleeSearchExpressionDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/search/EnrolleeSearchExpressionDao.java
@@ -1,5 +1,7 @@
 package bio.terra.pearl.core.dao.search;
 
+import bio.terra.pearl.core.dao.participant.EnrolleeDao;
+import bio.terra.pearl.core.dao.participant.ProfileDao;
 import bio.terra.pearl.core.model.address.MailingAddress;
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.participant.Enrollee;
@@ -8,6 +10,8 @@ import bio.terra.pearl.core.model.search.EnrolleeSearchExpressionResult;
 import bio.terra.pearl.core.model.survey.Answer;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
 import bio.terra.pearl.core.service.search.EnrolleeSearchExpression;
+import bio.terra.pearl.core.service.search.EnrolleeSearchOptions;
+import bio.terra.pearl.core.service.search.expressions.DefaultSearchExpression;
 import bio.terra.pearl.core.service.search.sql.EnrolleeSearchQueryBuilder;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
@@ -31,18 +35,33 @@ import java.util.function.Consumer;
 @Component
 public class EnrolleeSearchExpressionDao {
     private final Jdbi jdbi;
+    private final EnrolleeDao enrolleeDao;
+    private final ProfileDao profileDao;
 
-    public EnrolleeSearchExpressionDao(Jdbi jdbi) {
+    public EnrolleeSearchExpressionDao(Jdbi jdbi, EnrolleeDao enrolleeDao, ProfileDao profileDao) {
         this.jdbi = jdbi;
+        this.enrolleeDao = enrolleeDao;
+        this.profileDao = profileDao;
     }
 
     public List<EnrolleeSearchExpressionResult> executeSearch(EnrolleeSearchExpression expression, UUID studyEnvId) {
-        return executeSearch(expression.generateQueryBuilder(studyEnvId));
+        if (expression == null) {
+            expression = new DefaultSearchExpression(enrolleeDao, profileDao);
+        }
+        return executeSearch(expression.generateQueryBuilder(studyEnvId), EnrolleeSearchOptions.builder().build());
     }
 
-    private List<EnrolleeSearchExpressionResult> executeSearch(EnrolleeSearchQueryBuilder search) {
+    public List<EnrolleeSearchExpressionResult> executeSearch(EnrolleeSearchExpression expression, UUID studyEnvId, EnrolleeSearchOptions opts) {
+        if (expression == null) {
+            expression = new DefaultSearchExpression(enrolleeDao, profileDao);
+        }
+        return executeSearch(expression.generateQueryBuilder(studyEnvId), opts);
+    }
+
+    public List<EnrolleeSearchExpressionResult> executeSearch(EnrolleeSearchQueryBuilder search, EnrolleeSearchOptions opts) {
         return jdbi.withHandle(handle -> {
-            org.jooq.Query jooqQuery = search.toQuery(DSL.using(SQLDialect.POSTGRES));
+            org.jooq.Query jooqQuery = search.toQuery(DSL.using(SQLDialect.POSTGRES), opts);
+
             Query query = jdbiFromJooq(jooqQuery, handle);
             return query
                     .registerRowMapper(EnrolleeSearchExpressionResult.class, new EnrolleeSearchResultMapper())

--- a/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoExportService.java
@@ -11,12 +11,7 @@ import bio.terra.pearl.core.dao.study.StudyDao;
 import bio.terra.pearl.core.dao.study.StudyEnvironmentDao;
 import bio.terra.pearl.core.dao.survey.AnswerDao;
 import bio.terra.pearl.core.model.admin.AdminUser;
-import bio.terra.pearl.core.model.datarepo.DataRepoJob;
-import bio.terra.pearl.core.model.datarepo.Dataset;
-import bio.terra.pearl.core.model.datarepo.DatasetStatus;
-import bio.terra.pearl.core.model.datarepo.JobType;
-import bio.terra.pearl.core.model.datarepo.TdrColumn;
-import bio.terra.pearl.core.model.datarepo.TdrTable;
+import bio.terra.pearl.core.model.datarepo.*;
 import bio.terra.pearl.core.model.study.PortalStudy;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.service.azure.AzureBlobStorageClient;
@@ -36,13 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.io.ByteArrayOutputStream;
 import java.time.Instant;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 @Service
 @Slf4j
@@ -239,7 +228,7 @@ public class DataRepoExportService {
             List<Map<String, String>> enrolleeMaps = enrolleeExportService.generateExportMaps(
                     studyEnvironmentId,
                     moduleFormatters,
-                    false,
+                    null,
                     exportOptions.getLimit());
 
             TsvExporter tsvExporter = new TsvExporter(moduleFormatters, enrolleeMaps);

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
@@ -89,7 +89,11 @@ public class EnrolleeExportService {
         if (limit != null && !results.isEmpty()) {
             results = results.subList(0, Math.min(results.size(), limit));
         }
-        return generateExportMaps(results.stream().map(EnrolleeSearchExpressionResult::getEnrollee).toList(), moduleFormatters);
+        return generateExportMaps(
+                results.stream()
+                        .map(EnrolleeSearchExpressionResult::getEnrollee)
+                        .toList(),
+                moduleFormatters);
     }
 
     public List<Map<String, String>> generateExportMaps(List<Enrollee> enrollees,

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
@@ -1,25 +1,21 @@
 package bio.terra.pearl.core.service.export;
 
-import bio.terra.pearl.core.dao.kit.KitTypeDao;
+import bio.terra.pearl.core.dao.search.EnrolleeSearchExpressionDao;
 import bio.terra.pearl.core.dao.survey.AnswerDao;
 import bio.terra.pearl.core.dao.survey.SurveyQuestionDefinitionDao;
 import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.search.EnrolleeSearchExpressionResult;
 import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.model.survey.SurveyQuestionDefinition;
 import bio.terra.pearl.core.model.survey.SurveyType;
-import bio.terra.pearl.core.service.export.formatters.module.EnrolleeFormatter;
-import bio.terra.pearl.core.service.export.formatters.module.EnrolleeRelationFormatter;
-import bio.terra.pearl.core.service.export.formatters.module.KitRequestFormatter;
-import bio.terra.pearl.core.service.export.formatters.module.ModuleFormatter;
-import bio.terra.pearl.core.service.export.formatters.module.ParticipantUserFormatter;
-import bio.terra.pearl.core.service.export.formatters.module.ProfileFormatter;
-import bio.terra.pearl.core.service.export.formatters.module.SurveyFormatter;
+import bio.terra.pearl.core.service.export.formatters.module.*;
 import bio.terra.pearl.core.service.kit.KitRequestService;
 import bio.terra.pearl.core.service.participant.EnrolleeRelationService;
-import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.participant.ParticipantUserService;
 import bio.terra.pearl.core.service.participant.ProfileService;
+import bio.terra.pearl.core.service.search.EnrolleeSearchExpression;
+import bio.terra.pearl.core.service.search.EnrolleeSearchOptions;
 import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
 import bio.terra.pearl.core.service.survey.SurveyResponseService;
 import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
@@ -28,12 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 import static java.util.stream.Collectors.groupingBy;
 
@@ -46,35 +37,34 @@ public class EnrolleeExportService {
     private final StudyEnvironmentSurveyService studyEnvironmentSurveyService;
     private final SurveyResponseService surveyResponseService;
     private final ParticipantTaskService participantTaskService;
-    private final EnrolleeService enrolleeService;
     private final KitRequestService kitRequestService;
     private final ParticipantUserService participantUserService;
-    private final KitTypeDao kitTypeDao;
     private final ObjectMapper objectMapper;
     private final EnrolleeRelationService enrolleeRelationService;
+    private final EnrolleeSearchExpressionDao enrolleeSearchExpressionDao;
 
     public EnrolleeExportService(ProfileService profileService,
                                  AnswerDao answerDao,
                                  SurveyQuestionDefinitionDao surveyQuestionDefinitionDao,
-                                 StudyEnvironmentSurveyService studyEnvironmentSurveyService, SurveyResponseService surveyResponseService,
+                                 StudyEnvironmentSurveyService studyEnvironmentSurveyService,
+                                 SurveyResponseService surveyResponseService,
                                  ParticipantTaskService participantTaskService,
-                                 EnrolleeService enrolleeService, KitRequestService kitRequestService,
+                                 KitRequestService kitRequestService,
                                  ParticipantUserService participantUserService,
-                                 KitTypeDao kitTypeDao,
                                  EnrolleeRelationService enrolleeRelationService,
-                                 ObjectMapper objectMapper) {
+                                 ObjectMapper objectMapper,
+                                 EnrolleeSearchExpressionDao enrolleeSearchExpressionDao) {
         this.profileService = profileService;
         this.answerDao = answerDao;
         this.surveyQuestionDefinitionDao = surveyQuestionDefinitionDao;
         this.studyEnvironmentSurveyService = studyEnvironmentSurveyService;
         this.surveyResponseService = surveyResponseService;
         this.participantTaskService = participantTaskService;
-        this.enrolleeService = enrolleeService;
         this.kitRequestService = kitRequestService;
         this.participantUserService = participantUserService;
-        this.kitTypeDao = kitTypeDao;
         this.enrolleeRelationService = enrolleeRelationService;
         this.objectMapper = objectMapper;
+        this.enrolleeSearchExpressionDao = enrolleeSearchExpressionDao;
     }
 
     /**
@@ -83,18 +73,23 @@ public class EnrolleeExportService {
      * */
     public void export(ExportOptions exportOptions, UUID studyEnvironmentId, OutputStream os) {
         List<ModuleFormatter> moduleFormatters = generateModuleInfos(exportOptions, studyEnvironmentId);
-        List<Map<String, String>> enrolleeMaps = generateExportMaps(studyEnvironmentId, moduleFormatters, exportOptions.isIncludeProxiesAsRows(), exportOptions.getLimit());
+        List<Map<String, String>> enrolleeMaps = generateExportMaps(studyEnvironmentId, moduleFormatters, exportOptions.getFilter(), exportOptions.getLimit());
         BaseExporter exporter = getExporter(exportOptions.getFileFormat(), moduleFormatters, enrolleeMaps);
         exporter.export(os);
     }
 
-    public List<Map<String, String>> generateExportMaps(UUID studyEnvironmentId, List<ModuleFormatter> moduleFormatters, boolean includeProxiesAsRows, Integer limit) {
+    public List<Map<String, String>> generateExportMaps(UUID studyEnvironmentId, List<ModuleFormatter> moduleFormatters, EnrolleeSearchExpression filter, Integer limit) {
 
-        List<Enrollee> enrollees = enrolleeService.findByStudyEnvironment(studyEnvironmentId, includeProxiesAsRows ? null : true, "created_at", "DESC");
-        if (limit != null && enrollees.size() > 0) {
-            enrollees = enrollees.subList(0, Math.min(enrollees.size(), limit));
+        List<EnrolleeSearchExpressionResult> results =
+                enrolleeSearchExpressionDao.executeSearch(
+                        filter,
+                        studyEnvironmentId,
+                        EnrolleeSearchOptions.builder().sortField("enrollee.created_at").sortAscending(false).build());
+
+        if (limit != null && !results.isEmpty()) {
+            results = results.subList(0, Math.min(results.size(), limit));
         }
-        return generateExportMaps(enrollees, moduleFormatters);
+        return generateExportMaps(results.stream().map(EnrolleeSearchExpressionResult::getEnrollee).toList(), moduleFormatters);
     }
 
     public List<Map<String, String>> generateExportMaps(List<Enrollee> enrollees,

--- a/core/src/main/java/bio/terra/pearl/core/service/export/ExportOptions.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/ExportOptions.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.core.service.export;
 
+import bio.terra.pearl.core.service.search.EnrolleeSearchExpression;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
@@ -10,7 +11,7 @@ public final class ExportOptions {
     private final boolean splitOptionsIntoColumns;
     private final boolean stableIdsForOptions;
     private final boolean onlyIncludeMostRecent;
-    private final boolean includeProxiesAsRows;
+    private final EnrolleeSearchExpression filter;
     private final ExportFileFormat fileFormat;
     private final Integer limit;
 
@@ -18,7 +19,7 @@ public final class ExportOptions {
         this.splitOptionsIntoColumns = false;
         this.stableIdsForOptions = false;
         this.onlyIncludeMostRecent = true;
-        this.includeProxiesAsRows = false;
+        this.filter = null;
         this.fileFormat = ExportFileFormat.TSV;
         this.limit = null;
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/search/EnrolleeSearchExpression.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/EnrolleeSearchExpression.java
@@ -25,6 +25,10 @@ public interface EnrolleeSearchExpression {
     EnrolleeSearchQueryBuilder generateQueryBuilder(UUID studyEnvId);
 
     default Query generateQuery(UUID studyEnvId) {
-        return this.generateQueryBuilder(studyEnvId).toQuery(DSL.using(SQLDialect.POSTGRES));
+        return this.generateQuery(studyEnvId, EnrolleeSearchOptions.builder().build());
+    }
+
+    default Query generateQuery(UUID studyEnvId, EnrolleeSearchOptions opts) {
+        return this.generateQueryBuilder(studyEnvId).toQuery(DSL.using(SQLDialect.POSTGRES), opts);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/search/EnrolleeSearchOptions.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/EnrolleeSearchOptions.java
@@ -1,0 +1,14 @@
+package bio.terra.pearl.core.service.search;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Getter
+@Setter
+public class EnrolleeSearchOptions {
+    // be careful; potential sql injection, only use trusted values
+    private String sortField;
+    private boolean sortAscending;
+}

--- a/populate/src/test/java/bio/terra/pearl/populate/BasePopulatePortalsTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/BasePopulatePortalsTest.java
@@ -8,9 +8,10 @@ import bio.terra.pearl.core.service.kit.StudyEnvironmentKitTypeService;
 import bio.terra.pearl.core.service.notification.TriggerService;
 import bio.terra.pearl.core.service.notification.email.EmailTemplateService;
 import bio.terra.pearl.core.service.participant.*;
-import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentLanguageService;
+import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
 import bio.terra.pearl.core.service.portal.PortalService;
+import bio.terra.pearl.core.service.search.EnrolleeSearchExpressionParser;
 import bio.terra.pearl.core.service.site.SiteContentService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import bio.terra.pearl.core.service.study.StudyService;
@@ -86,4 +87,6 @@ public abstract class BasePopulatePortalsTest extends BaseSpringBootTest {
     protected PortalEnvironmentLanguageService portalEnvironmentLanguageService;
     @Autowired
     protected BaseSeedPopulator baseSeedPopulator;
+    @Autowired
+    protected EnrolleeSearchExpressionParser enrolleeSearchExpressionParser;
 }

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
@@ -2,11 +2,7 @@ package bio.terra.pearl.populate;
 
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.notification.EmailTemplate;
-import bio.terra.pearl.core.model.participant.Enrollee;
-import bio.terra.pearl.core.model.participant.ParticipantUser;
-import bio.terra.pearl.core.model.participant.PortalParticipantUser;
-import bio.terra.pearl.core.model.participant.Profile;
-import bio.terra.pearl.core.model.participant.RelationshipType;
+import bio.terra.pearl.core.model.participant.*;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.site.SiteContent;
@@ -32,12 +28,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.*;
 
 /** confirm demo portal populates as expected */
 public class PopulateDemoTest extends BasePopulatePortalsTest {
@@ -174,10 +165,11 @@ public class PopulateDemoTest extends BasePopulatePortalsTest {
                 .builder()
                 .onlyIncludeMostRecent(true)
                 .fileFormat(ExportFileFormat.TSV)
+                .filter(enrolleeSearchExpressionParser.parseRule("{enrollee.subject} = true"))
                 .limit(null)
                 .build();
         List<ModuleFormatter> moduleInfos = enrolleeExportService.generateModuleInfos(options, sandboxEnvironmentId);
-        List<Map<String, String>> exportData = enrolleeExportService.generateExportMaps(sandboxEnvironmentId, moduleInfos, false, options.getLimit());
+        List<Map<String, String>> exportData = enrolleeExportService.generateExportMaps(sandboxEnvironmentId, moduleInfos, options.getFilter(), options.getLimit());
 
         assertThat(exportData, hasSize(10));
         Map<String, String> oldVersionMap = exportData.stream().filter(map -> "HDVERS".equals(map.get("enrollee.shortcode")))

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateOurhealthTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateOurhealthTest.java
@@ -26,14 +26,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 public class PopulateOurhealthTest extends BasePopulatePortalsTest {
 
@@ -125,7 +121,7 @@ public class PopulateOurhealthTest extends BasePopulatePortalsTest {
                 .limit(null)
                 .build();
         List<ModuleFormatter> moduleInfos = enrolleeExportService.generateModuleInfos(options, sandboxEnvironmentId);
-        List<Map<String, String>> exportData = enrolleeExportService.generateExportMaps(sandboxEnvironmentId, moduleInfos, false, options.getLimit());
+        List<Map<String, String>> exportData = enrolleeExportService.generateExportMaps(sandboxEnvironmentId, moduleInfos, null, options.getLimit());
 
         assertThat(exportData, hasSize(6));
         Map<String, String> jsalkMap = exportData.stream().filter(map -> "OHSALK".equals(map.get("enrollee.shortcode")))

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -279,7 +279,7 @@ export type ExportOptions = {
   splitOptionsIntoColumns?: boolean,
   stableIdsForOptions?: boolean,
   onlyIncludeMostRecent?: boolean,
-  includeProxiesAsRows?: boolean,
+  filter?: string,
   limit?: number
 }
 

--- a/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
@@ -1,4 +1,7 @@
-import React, { useMemo, useState } from 'react'
+import React, {
+  useMemo,
+  useState
+} from 'react'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
 import Api, { ExportData } from 'api/api'
 import LoadingSpinner from 'util/LoadingSpinner'
@@ -17,9 +20,13 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faDownload } from '@fortawesome/free-solid-svg-icons'
 import { useLoadingEffect } from 'api/api-utils'
 import { Button } from 'components/forms/Button'
-import { renderPageHeader, renderTruncatedText } from 'util/pageUtils'
+import {
+  renderPageHeader,
+  renderTruncatedText
+} from 'util/pageUtils'
 import { failureNotification } from '../../../util/notifications'
 import { Store } from 'react-notifications-component'
+import { buildFilter } from 'util/exportUtils'
 
 // TODO: Add JSDoc
 // eslint-disable-next-line jsdoc/require-jsdoc
@@ -75,7 +82,7 @@ const ExportDataBrowser = ({ studyEnvContext }: {studyEnvContext: StudyEnvContex
       studyEnvContext.portal.shortcode,
       studyEnvContext.study.shortcode,
       studyEnvContext.currentEnv.environmentName, {
-        fileFormat: 'JSON', limit: 10, includeProxiesAsRows: false
+        fileFormat: 'JSON', limit: 10, filter: buildFilter()
       })
     const result = await response.json()
     if (!response.ok) {

--- a/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataBrowser.tsx
@@ -24,7 +24,7 @@ import {
   renderPageHeader,
   renderTruncatedText
 } from 'util/pageUtils'
-import { failureNotification } from '../../../util/notifications'
+import { failureNotification } from 'util/notifications'
 import { Store } from 'react-notifications-component'
 import { buildFilter } from 'util/exportUtils'
 

--- a/ui-admin/src/study/participants/export/ExportDataControl.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataControl.tsx
@@ -7,6 +7,7 @@ import { currentIsoDate } from '@juniper/ui-core'
 import { Link } from 'react-router-dom'
 import { saveBlobAsDownload } from 'util/downloadUtils'
 import { doApiLoad } from 'api/api-utils'
+import { buildFilter } from 'util/exportUtils'
 
 const FILE_FORMATS = [{
   label: 'Tab-delimted (.tsv)',
@@ -25,6 +26,7 @@ const ExportDataControl = ({ studyEnvContext, show, setShow }: {studyEnvContext:
   const [onlyIncludeMostRecent, setOnlyIncludeMostRecent] = useState(true)
   const [fileFormat, setFileFormat] = useState(FILE_FORMATS[0])
   const [includeProxiesAsRows, setIncludeProxiesAsRows] = useState(false)
+  const [includeUnconsented, setIncludeUnconsented] = useState(false)
 
   const [isLoading, setIsLoading] = useState(false)
 
@@ -33,7 +35,7 @@ const ExportDataControl = ({ studyEnvContext, show, setShow }: {studyEnvContext:
       onlyIncludeMostRecent,
       splitOptionsIntoColumns: !humanReadable,
       stableIdsForOptions: !humanReadable,
-      includeProxiesAsRows,
+      filter: buildFilter({ includeProxiesAsRows, includeUnconsented }),
       fileFormat: fileFormat.value
     }
   }
@@ -99,6 +101,11 @@ const ExportDataControl = ({ studyEnvContext, show, setShow }: {studyEnvContext:
             <input type="radio" name="onlyIncludeMostRecent" value="false" checked={!onlyIncludeMostRecent}
               onChange={includeRecentChanged} className="me-1" disabled={true}/>
             Include all completions
+          </label>
+          <label>
+            <input type="checkbox" name="includeUnconsented" checked={includeUnconsented}
+              onChange={() => setIncludeUnconsented(!includeUnconsented)} className="me-1"/>
+            Include enrollees who have not consented
           </label>
         </div>
         <div className="py-2">

--- a/ui-admin/src/study/participants/export/ExportDataControl.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataControl.tsx
@@ -102,22 +102,23 @@ const ExportDataControl = ({ studyEnvContext, show, setShow }: {studyEnvContext:
               onChange={includeRecentChanged} className="me-1" disabled={true}/>
             Include all completions
           </label>
+        </div>
+        <div className="py-2">
+          <p className="fw-bold mb-1">
+            Filter Options
+          </p>
           <label>
             <input type="checkbox" name="includeUnconsented" checked={includeUnconsented}
               onChange={() => setIncludeUnconsented(!includeUnconsented)} className="me-1"/>
             Include enrollees who have not consented
           </label>
-        </div>
-        <div className="py-2">
-          <p className="fw-bold mb-1">
-            Proxy Options
-          </p>
           <label>
             <input type="checkbox" name="includeProxiesAsRows" checked={includeProxiesAsRows}
               onChange={() => setIncludeProxiesAsRows(!includeProxiesAsRows)} className="me-1"/>
             Include proxies as rows
           </label>
         </div>
+
         <div className="py-2">
           <span className="fw-bold">File format</span><br/>
           {FILE_FORMATS.map(format => <label className="me-3" key={format.value}>

--- a/ui-admin/src/util/exportUtils.test.tsx
+++ b/ui-admin/src/util/exportUtils.test.tsx
@@ -1,0 +1,16 @@
+import { buildFilter } from 'util/exportUtils'
+
+describe('buildFilter', () => {
+  it('has expected default filter', () => {
+    expect(buildFilter()).toBe('{enrollee.subject} = true and {enrollee.consented} = true')
+  })
+  it('includesProxiesAsRows', () => {
+    expect(buildFilter({ includeProxiesAsRows: true })).toBe('{enrollee.consented} = true')
+  })
+  it('includesUnconsented', () => {
+    expect(buildFilter({ includeUnconsented: true })).toBe('{enrollee.subject} = true')
+  })
+  it('includesProxiesAsRows and includesUnconsented', () => {
+    expect(buildFilter({ includeProxiesAsRows: true, includeUnconsented: true })).toBe('')
+  })
+})

--- a/ui-admin/src/util/exportUtils.tsx
+++ b/ui-admin/src/util/exportUtils.tsx
@@ -6,7 +6,7 @@ export type ExportFilterOptions = {
 }
 
 /**
- *
+ * Builds a filter string for the export API. Defaults to only include consented subjects.
  */
 export const buildFilter = (
   opts: ExportFilterOptions = {

--- a/ui-admin/src/util/exportUtils.tsx
+++ b/ui-admin/src/util/exportUtils.tsx
@@ -1,8 +1,8 @@
 import { concatSearchExpressions } from 'util/searchExpressionUtils'
 
 export type ExportFilterOptions = {
-  includeProxiesAsRows: boolean,
-  includeUnconsented: boolean
+  includeProxiesAsRows?: boolean,
+  includeUnconsented?: boolean
 }
 
 /**

--- a/ui-admin/src/util/exportUtils.tsx
+++ b/ui-admin/src/util/exportUtils.tsx
@@ -1,0 +1,24 @@
+import { concatSearchExpressions } from 'util/searchExpressionUtils'
+
+export type ExportFilterOptions = {
+  includeProxiesAsRows: boolean,
+  includeUnconsented: boolean
+}
+
+/**
+ *
+ */
+export const buildFilter = (
+  opts: ExportFilterOptions = {
+    includeProxiesAsRows: false,
+    includeUnconsented: false
+  }): string => {
+  const facets: string[] = []
+  if (!opts.includeProxiesAsRows) {
+    facets.push('{enrollee.subject} = true')
+  }
+  if (!opts.includeUnconsented) {
+    facets.push('{enrollee.consented} = true')
+  }
+  return concatSearchExpressions(facets)
+}


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

I couldn't find a ticket that seemed like a good one for me to pick up in the sprint so I decided to go ahead with this one.

Replaces the underlying export dao methods with an enrollee search expression search (as specified in ticket) and replaces `includeProxiesAsRows`/`includeUnconsented` (and all similar future columns) with a simple `filter` search expression. The frontend then creates this expression, so the backend itself does not have any knowledge of the filtering options.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

on demo sandbox:
- Ensure no regressions on data export
- Ensure data export is properly sorted by created by date
- Export with and without unconsented; ensure HDINVI only shows up in one that includes unconsented
- Export with proxies; ensure HDPROX only shows up as own row in proxy-as-row export.