### PR TITLE
[JN-1122] Log exception message in processNotification

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
@@ -91,7 +91,8 @@ public class EnrolleeEmailService implements NotificationSender {
                     // email starts, so the notification update will fail. This is expected and not a problem.
                     log.info("notification update failed for populated withdrawn participant -- this is expected");
                 } else {
-                    log.error("failed to update notification: {}, portal: {}, trigger: {}", notification.getId(), contextInfo.portal().getShortcode(), config.getId());
+                    log.error("failed to update notification: {}, portal: {}, trigger: {}, error: {}",
+                            notification.getId(), contextInfo.portal().getShortcode(), config.getId(), e.getMessage());
                 }
             }
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds the exception message to the log message that we're seeing a bunch in the prod alerts channel.

I spent a little bit of time perusing prod logs but didn't find anything. I also didn't have any luck trying to reproduce the condition locally. What I really want to see is the error message- it's most likely coming from the database.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Add an exception to line 86
* Try sending an email
* Verify that the exception message is logged