### PR TITLE
[JN-1160] adding profile editing to form preview

### DIFF
--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/lostInterest.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/lostInterest.json
@@ -21,7 +21,7 @@
               {
                 "name": "lost_interest_header",
                 "type": "html",
-                "html": "<p>You indicated that you've lost interest in things</p>"
+                "html": "<p>You, {profile.givenName} {profile.familyName}, indicated that you've lost interest in things</p>"
               }
             ]
           },

--- a/ui-admin/src/components/forms/TextInput.tsx
+++ b/ui-admin/src/components/forms/TextInput.tsx
@@ -3,18 +3,23 @@ import React, { useId } from 'react'
 import InfoPopup from './InfoPopup'
 
 export type TextInputProps = Omit<JSX.IntrinsicElements['input'], 'onChange'> & {
-  infoContent?: React.ReactNode,
+  infoContent?: React.ReactNode
   description?: string
   required?: boolean
   label?: string
-  labelClassname?: string,
-  placeholder?: string,
+  labelClassname?: string
+  unboldLabel?: boolean // by default, form labels are 'fw-semibold', set this to not apply that style
+  placeholder?: string
   onChange?: (value: string) => void
 }
 
 /** A text input with label and description. */
 export const TextInput = (props: TextInputProps) => {
-  const { infoContent, description, required, label, labelClassname, placeholder, ...inputProps } = props
+  const {
+    infoContent, description,
+    required, label, labelClassname, unboldLabel,
+    placeholder, ...inputProps
+  } = props
   const { className, disabled, id, value, onChange } = inputProps
 
   const generatedId = useId()
@@ -24,7 +29,7 @@ export const TextInput = (props: TextInputProps) => {
   return (
     <>
       {label && <label
-        className={classNames('form-label', 'fw-semibold', labelClassname)}
+        className={classNames('form-label', unboldLabel ? '' :'fw-semibold', labelClassname)}
         htmlFor={inputId}
       >
         {label}

--- a/ui-admin/src/forms/FormPreview.tsx
+++ b/ui-admin/src/forms/FormPreview.tsx
@@ -3,6 +3,7 @@ import { Survey as SurveyJSComponent } from 'survey-react-ui'
 import 'survey-core/survey.i18n'
 
 import {
+  applyMarkdown,
   createAddressValidator,
   FormContent,
   PortalEnvironmentLanguage,
@@ -30,10 +31,15 @@ export const FormPreview = (props: FormPreviewProps) => {
   const { i18n } = useI18n()
 
   const [surveyModel] = useState(() => {
+    // note that this roughly mimics surveyUtils.newSurveyJSModel but with key differences, such
+    // as the pages not being url-routable
     const model = surveyJSModelFromFormContent(formContent)
     model.setVariable('portalEnvironmentName', 'sandbox')
+    model.setVariable('profile', { })
+    model.setVariable('proxyProfile', { })
     model.ignoreValidation = true
     model.locale = defaultLanguage.languageCode
+    model.onTextMarkdown.add(applyMarkdown)
     model.onServerValidateQuestions.add(createAddressValidator(addr => Api.validateAddress(addr), i18n))
     return model
   })
@@ -50,12 +56,16 @@ export const FormPreview = (props: FormPreviewProps) => {
           value={{
             ignoreValidation: surveyModel.ignoreValidation,
             showInvisibleElements: surveyModel.showInvisibleElements,
-            locale: surveyModel.locale
+            locale: surveyModel.locale,
+            profile: surveyModel.getVariable('profile'),
+            proxyProfile: surveyModel.getVariable('proxyProfile')
           }}
-          onChange={({ ignoreValidation, showInvisibleElements, locale }) => {
+          onChange={({ ignoreValidation, showInvisibleElements, locale, profile, proxyProfile }) => {
             surveyModel.ignoreValidation = ignoreValidation
             surveyModel.showInvisibleElements = showInvisibleElements
             surveyModel.locale = locale
+            surveyModel.setVariable('profile', profile)
+            surveyModel.setVariable('proxyProfile', proxyProfile)
             forceUpdate()
           }}
         />

--- a/ui-admin/src/forms/FormPreviewOptions.tsx
+++ b/ui-admin/src/forms/FormPreviewOptions.tsx
@@ -1,15 +1,17 @@
 import React, { useState } from 'react'
-import { PortalEnvironmentLanguage } from '@juniper/ui-core'
+import { PortalEnvironmentLanguage, Profile } from '@juniper/ui-core'
 import Select from 'react-select'
 import useReactSingleSelect from 'util/react-select-utils'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faGlobe } from '@fortawesome/free-solid-svg-icons'
 import { usePortalLanguage } from 'portal/languages/usePortalLanguage'
+import InfoPopup from '../components/forms/InfoPopup'
+import { TextInput } from '../components/forms/TextInput'
 
 type FormPreviewOptions = {
   ignoreValidation: boolean
   showInvisibleElements: boolean
   locale: string
+  profile?: Profile
+  proxyProfile?: Profile
 }
 
 type FormPreviewOptionsProps = {
@@ -37,6 +39,7 @@ export const FormPreviewOptions = (props: FormPreviewOptionsProps) => {
 
   return (
     <div>
+      <h3 className="h6">Preview options</h3>
       <div className="form-check">
         <label className="form-check-label" htmlFor="form-preview-ignore-validation">
           <input
@@ -50,12 +53,12 @@ export const FormPreviewOptions = (props: FormPreviewOptionsProps) => {
           />
           Ignore validation
         </label>
+        <InfoPopup content={<p className="form-text">
+          Ignore validation to preview all pages of a form without enforcing required fields.
+          Enable validation to simulate a participant&apos;s experience.
+        </p>}/>
       </div>
-      <p className="form-text">
-        Ignore validation to preview all pages of a form without enforcing required fields.
-        Enable validation to simulate a participant&apos;s experience.
-      </p>
-      <div className="form-check">
+      <div className="form-check mt-3">
         <label className="form-check-label" htmlFor="form-preview-show-invisible-elements">
           <input
             checked={value.showInvisibleElements}
@@ -68,13 +71,19 @@ export const FormPreviewOptions = (props: FormPreviewOptionsProps) => {
           />
           Show invisible questions
         </label>
+        <InfoPopup content={<p className="form-text">
+          Show all questions, regardless of their visibility. Use this to review questions that
+          would be hidden by survey branching logic.
+        </p>}/>
       </div>
-      <p className="form-text">
-        Show all questions, regardless of their visibility. Use this to review questions that
-        would be hidden by survey branching logic.
-      </p>
-      { languageOptions.length > 1 && <><div className="form-group">
-        <label htmlFor={selectLanguageInputId}><FontAwesomeIcon icon={faGlobe}/> Language Preview</label>
+      <div className="form-group mt-3">
+        <label htmlFor={selectLanguageInputId}>Language Preview</label>
+        <InfoPopup content={<p><p>
+          The language to use when rendering the form. If the language is not supported for this form, the default
+          language for the form will be used. </p>
+        <p>The values for this dropdown are taken from the supported languages
+          configurable in &quot;Site Settings&quot;.
+        </p></p>}/>
         <Select
           inputId={selectLanguageInputId}
           options={languageOptions}
@@ -84,10 +93,68 @@ export const FormPreviewOptions = (props: FormPreviewOptionsProps) => {
             onChange({ ...value, locale: language?.value.languageCode ?? 'default' })
           }}/>
       </div>
-      <p className="form-text">
-        The language to use when rendering the form. If the language is not supported for this form, the default
-          language for the form will be used.
-      </p></> }
+      <div className="mt-4">
+        <div data-testid="profileInfoFields">
+          <h4 className="h6">
+          Participant profile <InfoPopup content={<p>
+          Change the values below to test how your survey appears to different participants
+          due to branching logic or dynamic texts.  The participant profile is the profile of the
+          user taking the survey.
+            </p>}/>
+          </h4>
+          <TextInput onChange={text => onChange({
+            ...value,
+            profile: {
+              ...value.profile,
+              givenName: text
+            }
+          })}
+          label={'Given name'}
+          unboldLabel={true}
+          value={value.profile?.givenName ?? ''} />
+          <TextInput onChange={text => onChange({
+            ...value,
+            profile: {
+              ...value.profile,
+              familyName: text
+            }
+          })}
+          label={'Family name'}
+          unboldLabel={true}
+          value={value.profile?.familyName ?? ''} />
+        </div>
+        <div data-testid="proxyInfoFields">
+          <h4 className="h6 mt-3">
+            Proxy profile <InfoPopup content={<p>
+            Change the values below to test how your survey appears to different participants
+            due to branching logic or dynamic texts.  The proxy profile is the profile of the
+            person the user is taking the survey on behalf of.
+            </p>}/>
+          </h4>
+          <TextInput onChange={text => onChange({
+            ...value,
+            proxyProfile: {
+              ...value.proxyProfile,
+              givenName: text
+            }
+          })}
+          label={'Given name'}
+          data-testid="proxyGivenName"
+          unboldLabel={true}
+          value={value.proxyProfile?.givenName ?? ''} />
+          <TextInput onChange={text => onChange({
+            ...value,
+            proxyProfile: {
+              ...value.proxyProfile,
+              familyName: text
+            }
+          })}
+          label={'Family name'}
+          unboldLabel={true}
+          value={value.proxyProfile?.familyName ?? ''} />
+        </div>
+      </div>
+
     </div>
   )
 }

--- a/ui-admin/src/portal/languages/PortalEnvLanguageEditor.test.tsx
+++ b/ui-admin/src/portal/languages/PortalEnvLanguageEditor.test.tsx
@@ -25,7 +25,8 @@ test('removes items after confirmation dialog', async () => {
   await userEvent.click(getTableCell(screen.getByRole('table'), 'English', 'Actions').querySelector('button')!)
   expect(screen.getByText('Remove this language from the dropdown?')).toBeInTheDocument()
   await userEvent.click(screen.getByText('Yes'))
-  expect(setItemsSpy).toHaveBeenCalledWith([{ languageName: 'Español', languageCode: 'es', id: '1' }])
+  expect(setItemsSpy).toHaveBeenCalledTimes(1)
+  expect(setItemsSpy.mock.lastCall[0](initialLanguages)).toEqual([{ languageName: 'Español', languageCode: 'es', id: '1' }])
 })
 
 test('add items after confirmation click', async () => {
@@ -34,8 +35,11 @@ test('add items after confirmation click', async () => {
   await userEvent.click(screen.getByLabelText('Add New'))
   await select(screen.getByLabelText('Language name'), 'Deutsch')
   await userEvent.click(screen.getByLabelText('Accept'))
-  expect(setItemsSpy).toHaveBeenCalledWith([...initialLanguages,
-    { languageName: 'Deutsch', languageCode: 'de', id: '' }])
+  expect(setItemsSpy).toHaveBeenCalledTimes(1)
+  expect(setItemsSpy.mock.lastCall[0](initialLanguages)).toEqual([
+    ...initialLanguages,
+    { languageName: 'Deutsch', languageCode: 'de', id: '' }
+  ])
 })
 
 test('add items does not appear if readonly', async () => {

--- a/ui-admin/src/portal/languages/PortalEnvLanguageEditor.test.tsx
+++ b/ui-admin/src/portal/languages/PortalEnvLanguageEditor.test.tsx
@@ -26,7 +26,8 @@ test('removes items after confirmation dialog', async () => {
   expect(screen.getByText('Remove this language from the dropdown?')).toBeInTheDocument()
   await userEvent.click(screen.getByText('Yes'))
   expect(setItemsSpy).toHaveBeenCalledTimes(1)
-  expect(setItemsSpy.mock.lastCall[0](initialLanguages)).toEqual([{ languageName: 'Español', languageCode: 'es', id: '1' }])
+  expect(setItemsSpy.mock.lastCall[0](initialLanguages))
+    .toEqual([{ languageName: 'Español', languageCode: 'es', id: '1' }])
 })
 
 test('add items after confirmation click', async () => {

--- a/ui-admin/src/portal/languages/PortalEnvLanguageEditor.tsx
+++ b/ui-admin/src/portal/languages/PortalEnvLanguageEditor.tsx
@@ -11,7 +11,7 @@ import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table
 import { basicTableLayout } from 'util/tableUtils'
 import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan'
 import { Button } from 'components/forms/Button'
-import { TextInput } from '../../components/forms/TextInput'
+import { TextInput } from 'components/forms/TextInput'
 
 type EditablePortalEnvironmentLanguage = PortalEnvironmentLanguage & { isEditing: boolean }
 type PortalEnvironmentLanguageRow = PortalEnvironmentLanguage | EditablePortalEnvironmentLanguage
@@ -65,7 +65,7 @@ const LANGUAGE_OPTIONS: PortalEnvironmentLanguageOpt[] = [{
  */
 export default function PortalEnvLanguageEditor({ items, setItems, readonly } : {
     items: PortalEnvironmentLanguage[],
-    setItems: (items: PortalEnvironmentLanguage[]) => void,
+    setItems:  React.Dispatch<React.SetStateAction<PortalEnvironmentLanguage[]>>,
   readonly: boolean
   }
 ) {
@@ -77,16 +77,18 @@ export default function PortalEnvLanguageEditor({ items, setItems, readonly } : 
     if (!itemSelectedForDeletion) {
       return
     }
-
-    const filteredItems = items.filter(m => m.languageCode !== itemSelectedForDeletion.languageCode)
-    setItems(filteredItems)
+    setItems(items => {
+      const filteredItems = items.filter(m => m.languageCode !== itemSelectedForDeletion.languageCode)
+      return filteredItems
+    })
     setItemSelectedForDeletion(null)
   }
 
   const addNewItem = (item: PortalEnvironmentLanguage) => {
-    const newItems = [...items, item]
     setNewItem(makeEmptyNewItem())
-    setItems(newItems)
+    setItems(items => {
+      return [...items, item]
+    })
   }
 
   const columns: ColumnDef<PortalEnvironmentLanguage>[] = useMemo(() => {

--- a/ui-core/src/surveyUtils.tsx
+++ b/ui-core/src/surveyUtils.tsx
@@ -348,8 +348,7 @@ export function useSurveyJSModel(
   return { surveyModel, refreshSurvey, pageNumber, SurveyComponent, setSurveyModel }
 }
 
-// TODO: Add JSDoc
-// eslint-disable-next-line jsdoc/require-jsdoc
+/** apply markdown to the given surveyJS entity */
 export const applyMarkdown = (survey: object, options: { text: string, html: string }) => {
   const markdownText = micromark(options.text)
   // chop off <p> tags.


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

In order to test dynamic texts for A-T more easily, I added the ability to change the enrollee/proxy profile during form editing.  For now this is a simple sidebar, later we may need to make it into a full-fledged editor modal so that birthdate, sexAtBirth, and other profile fields can be customized to test logic.

<img width="1207" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/614059a9-f4b1-48b9-b678-8f5c2cd450b0">

to make room for this, I condensed the other preview options with liberal use of InfoPopups.

This also contains a bugfix for the language selector -- adding multiple languages would sometimes have timing bugs

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1. repopulate demo
2. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/forms/surveys/hd_hd_lost_interest
3. go to the `Preview` tab
4. fill in values for profile given name or profile family name.  Observe the question gets updated with the values
