### PR TITLE
[JN-1166] Adding primary study concept

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/portal/PortalEnvironmentConfig.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/portal/PortalEnvironmentConfig.java
@@ -30,4 +30,5 @@ public class PortalEnvironmentConfig extends BaseEntity {
     private String emailSourceAddress; // what goes in the 'from' field of emails to participants from this portal
     @Builder.Default
     private String defaultLanguage = "en";
+    private String primaryStudy; // study shortcode of a study that all initial participants are enrolled in
 }

--- a/core/src/main/resources/db/changelog/changesets/2024_06_28_primary_study.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_06_28_primary_study.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: "add_primary_study"
+      author: dbush
+      changes:
+        - addColumn:
+            tableName: portal_environment_config
+            columns:
+              - column:
+                  name: primary_study
+                  type: text

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -281,6 +281,9 @@ databaseChangeLog:
   - include:
       file: changesets/2024_06_12_family_linkage_modified.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2024_06_28_primary_study.yaml
+      relativeToChangelogFile: true
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements
 # are atomic. When they are grouped in a changeset and one fails the changeset cannot be
 # rolled back or rerun making recovery more difficult

--- a/ui-admin/src/portal/PortalEnvConfigView.tsx
+++ b/ui-admin/src/portal/PortalEnvConfigView.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import Api, { PortalEnvironment } from 'api/api'
+import Api, { PortalEnvironment, PortalStudy } from 'api/api'
 import { useUser } from 'user/UserProvider'
 import { successNotification } from 'util/notifications'
 import { Store } from 'react-notifications-component'
@@ -73,6 +73,21 @@ const PortalEnvConfigView = ({ portalContext, portalEnv }: PortalEnvConfigViewPr
         selectedLanguage
       )
 
+  const {
+    onChange: primaryStudyOnChange, options: primaryStudyOptions,
+    selectedOption: selectedPrimaryStudyOption, selectInputId: selectPrimaryStudyInputId
+  } =
+    useReactSingleSelect(
+      portal.portalStudies,
+      (portalStudy: PortalStudy) =>
+        ({ label: portalStudy.study.name, value: portalStudy }),
+      (opt: PortalStudy | undefined) => setConfig({
+        ...config,
+        primaryStudy: opt?.study.shortcode
+      }),
+      portal.portalStudies.find(ps => ps.study.shortcode === config.primaryStudy)
+    )
+
   const editableLanguages = portalEnv.environmentName === 'sandbox'
 
   return <div>
@@ -123,6 +138,15 @@ const PortalEnvConfigView = ({ portalContext, portalEnv }: PortalEnvConfigViewPr
             }}/>
         </label>
       </div>
+      { portal.portalStudies.length > 1 && <div className="mb-3">
+
+        <label className="form-label" htmlFor={selectPrimaryStudyInputId}>
+          Primary study</label> <InfoPopup content={'The study that portal registrants will be taken to by default'}/>
+        <Select options={primaryStudyOptions} className="col-md-3"
+          value={selectedPrimaryStudyOption} inputId={selectPrimaryStudyInputId}
+          isDisabled={portalEnv.environmentName !== 'sandbox'} aria-label={'Select a study'}
+          onChange={primaryStudyOnChange}/>
+      </div> }
       <Button onClick={save}
         variant="primary" disabled={!user?.superuser || isLoading}
         tooltip={user?.superuser ? 'Save' : 'You do not have permission to edit these settings'}>

--- a/ui-admin/src/portal/siteContent/designer/components/ImageSelector.tsx
+++ b/ui-admin/src/portal/siteContent/designer/components/ImageSelector.tsx
@@ -10,14 +10,14 @@ import { ImageConfig } from '@juniper/ui-core'
  */
 export const ImageSelector = ({ portalEnvContext, imageList, image, onChange }: {
     portalEnvContext: PortalEnvContext,
-    imageList: SiteMediaMetadata[], image: ImageConfig, onChange: (image: SiteMediaMetadata) => void
+    imageList: SiteMediaMetadata[], image?: ImageConfig, onChange: (image: SiteMediaMetadata) => void
 }) => {
-  const initial = imageList.find(media => media.cleanFileName === image.cleanFileName)
+  const initial = imageList.find(media => media.cleanFileName === image?.cleanFileName)
   const [, setSelectedImage] = useState<SiteMediaMetadata | undefined>(initial)
 
   const imageOptionLabel = (image: SiteMediaMetadata, portalShortcode: string) => <div>
     {image.cleanFileName} <img style={{ maxHeight: '1.5em' }} alt={image.cleanFileName}
-      src={getMediaUrl(portalShortcode, image!.cleanFileName, image!.version)}/>
+      src={getMediaUrl(portalShortcode, image.cleanFileName, image!.version)}/>
   </div>
 
   const {

--- a/ui-admin/src/study/StudySettings.tsx
+++ b/ui-admin/src/study/StudySettings.tsx
@@ -34,8 +34,10 @@ export default function StudySettings({ studyEnvContext, portalContext }:
 
   return <div className="container-fluid px-4 py-2">
     { renderPageHeader('Site Settings') }
-    <StudyEnvConfigView studyEnvContext={studyEnvContext} portalContext={portalContext}/>
-    <PortalEnvConfigView portalEnv={portalEnv} portalContext={portalContext}/>
+    <StudyEnvConfigView studyEnvContext={studyEnvContext} portalContext={portalContext}
+      key={studyEnvContext.currentEnvPath}/>
+    <PortalEnvConfigView portalEnv={portalEnv} portalContext={portalContext}
+      key={portalEnv.environmentName}/>
   </div>
 }
 

--- a/ui-admin/src/util/react-select-utils.ts
+++ b/ui-admin/src/util/react-select-utils.ts
@@ -13,7 +13,7 @@ import { Dispatch, SetStateAction, useId } from 'react'
  * */
 export default function useReactSingleSelect<T>(items: T[],
   labelFunction: (i: T) => {label: React.ReactNode, value: T},
-  setSelectedItem: Dispatch<SetStateAction<T | undefined>>, selectedItem?: T) {
+  setSelectedItem: Dispatch<SetStateAction<T | undefined>> | ((x: T | undefined) => void), selectedItem?: T) {
   const options = items.map(labelFunction)
   const selectedValue = selectedItem ? labelFunction(selectedItem).value : undefined
   const selectedOption = options.find(opt => opt.value === selectedValue)

--- a/ui-core/src/types/portal.ts
+++ b/ui-core/src/types/portal.ts
@@ -39,8 +39,9 @@ export type PortalEnvironmentConfig = {
   password: string
   passwordProtected: boolean
   participantHostname?: string
-  emailSourceAddress?: string,
+  emailSourceAddress?: string
   defaultLanguage: string
+  primaryStudy?: string
 }
 
 export {}

--- a/ui-participant/src/Navbar.test.tsx
+++ b/ui-participant/src/Navbar.test.tsx
@@ -14,7 +14,7 @@ import { asMockedFn, MockI18nProvider, setupRouterTest } from '@juniper/ui-core'
 import { UserManager } from 'oidc-client-ts'
 import { useUser } from './providers/UserProvider'
 import { usePortalEnv } from './providers/PortalProvider'
-import { mockUsePortalEnv } from './test-utils/test-portal-factory'
+import { mockPortalEnvironmentConfig, mockUsePortalEnv } from './test-utils/test-portal-factory'
 import { mockUseUser } from './test-utils/user-mocking-utils'
 
 jest.mock('oidc-client-ts')
@@ -120,7 +120,7 @@ describe('joinPath', () => {
         }]
       }
     }] as PortalStudy[]
-    const joinPath = getMainJoinLink(portalStudies)
+    const joinPath = getMainJoinLink(portalStudies, mockPortalEnvironmentConfig())
     expect(joinPath).toBe('/studies/foo/join')
   })
 
@@ -146,7 +146,7 @@ describe('joinPath', () => {
         }]
       }
     }] as PortalStudy[]
-    const joinPath = getMainJoinLink(portalStudies)
+    const joinPath = getMainJoinLink(portalStudies, mockPortalEnvironmentConfig())
     expect(joinPath).toBe('/join')
   })
 
@@ -172,8 +172,36 @@ describe('joinPath', () => {
         }]
       }
     }] as PortalStudy[]
-    const joinPath = getMainJoinLink(portalStudies)
+    const joinPath = getMainJoinLink(portalStudies, mockPortalEnvironmentConfig())
     expect(joinPath).toBe('/studies/foo/join')
+  })
+
+  it('joins the primary study if there are multiple', () => {
+    const portalStudies = [{
+      study: {
+        shortcode: 'foo',
+        name: 'Foo',
+        studyEnvironments: [{
+          studyEnvironmentConfig: {
+            acceptingEnrollment: true
+          }
+        }]
+      }
+    }, {
+      study: {
+        shortcode: 'bar',
+        name: 'Bar',
+        studyEnvironments: [{
+          studyEnvironmentConfig: {
+            acceptingEnrollment: true
+          }
+        }]
+      }
+    }] as PortalStudy[]
+    const joinPath = getMainJoinLink(portalStudies, {
+      ...mockPortalEnvironmentConfig(), primaryStudy: 'bar'
+    })
+    expect(joinPath).toBe('/studies/bar/join')
   })
 })
 

--- a/ui-participant/src/Navbar.tsx
+++ b/ui-participant/src/Navbar.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useId, useRef } from 'react'
 import { Link, NavLink, useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import { HashLink } from 'react-router-hash-link'
 
-import Api, { getEnvSpec, getImageUrl, NavbarItem, PortalStudy, Study } from 'api/api'
+import Api, { getEnvSpec, getImageUrl, NavbarItem, PortalEnvironmentConfig, PortalStudy } from 'api/api'
 import { MailingListModal, PortalEnvironmentLanguageOpt, useI18n } from '@juniper/ui-core'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { useUser } from 'providers/UserProvider'
@@ -107,7 +107,7 @@ export default function Navbar(props: NavbarProps) {
                     'd-flex justify-content-center',
                     'mb-3 mb-lg-0 ms-lg-3'
                   )}
-                  to={getMainJoinLink(portal.portalStudies)}
+                  to={getMainJoinLink(portal.portalStudies, portalEnv.portalEnvironmentConfig)}
                 >
                   {i18n('navbarJoin')}
                 </NavLink>
@@ -173,9 +173,9 @@ export function CustomNavLink({ navLink }: { navLink: NavbarItem }) {
 /**
  * Returns the join link for a specific study
  */
-export const getJoinLink = (study: Study, opts?: { isProxyEnrollment?: boolean, ppUserId?: string }) => {
+export const getJoinLink = (studyShortcode: string, opts?: { isProxyEnrollment?: boolean, ppUserId?: string }) => {
   const { isProxyEnrollment, ppUserId } = opts || {}
-  const joinPath = `/studies/${study.shortcode}/join`
+  const joinPath = `/studies/${studyShortcode}/join`
   if (isProxyEnrollment || ppUserId) {
     return `${joinPath}?${isProxyEnrollment ? 'isProxyEnrollment=true' : ''}${ppUserId ? `&ppUserId=${ppUserId}` : ''}`
   }
@@ -183,11 +183,15 @@ export const getJoinLink = (study: Study, opts?: { isProxyEnrollment?: boolean, 
 }
 
 /** the default join link -- will be rendered in the top right corner */
-export const getMainJoinLink = (portalStudies: PortalStudy[]) => {
+export const getMainJoinLink = (portalStudies: PortalStudy[], portalEnvConfig: PortalEnvironmentConfig) => {
+  // if there's a primary study, link to it
+  if (portalEnvConfig.primaryStudy) {
+    return getJoinLink(portalEnvConfig.primaryStudy)
+  }
   const joinable = filterUnjoinableStudies(portalStudies)
   /** if there's only one joinable study, link directly to it */
   const joinPath = joinable.length === 1
-    ? getJoinLink(joinable[0].study)
+    ? getJoinLink(joinable[0].study.shortcode)
     : '/join'
   return joinPath
 }

--- a/ui-participant/src/hub/HubPage.tsx
+++ b/ui-participant/src/hub/HubPage.tsx
@@ -138,7 +138,7 @@ const StudySection = (props: StudySectionProps) => {
           {/* if the user is not a subject, prompt them to enroll */}
           <Link
             className="btn rounded-pill ps-4 pe-4 fw-bold btn-primary"
-            to={`${getJoinLink(matchedStudy, { ppUserId: ppUser?.id })}`}
+            to={`${getJoinLink(matchedStudy.shortcode, { ppUserId: ppUser?.id })}`}
           >
             {i18n('joinStudy')}
           </Link>


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

For multi-study portals, we need to designate a ‘primary study’ for various UX reasons – notably the “Register” button on the top right.

This also contains a simple null-safing fix to the new stiecontent editor that Matt and I think is related to video media configs.  We'll have a separate ticket to handle a proper UX treatment of videos

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy ApiAdminApp and ApiParticipantApp
2. Extract the hearthive portal from production
3. populate the hearthive portal locally
4. Go to https://localhost:3000/hearthive/studies/hh_registry/env/sandbox/settings
5. set "HeartHive" as the primary study and save
6. go to https://sandbox.hearthive.localhost:3001/
7. confirm the navbar "REgister" is to https://sandbox.hearthive.localhost:3001/studies/hh_registry/join
