### PR TITLE
[JN-1140] Exposing survey rule functionality

### DIFF
--- a/ui-admin/src/study/surveys/FormOptionsModal.tsx
+++ b/ui-admin/src/study/surveys/FormOptionsModal.tsx
@@ -15,7 +15,6 @@ import {
 import InfoPopup from 'components/forms/InfoPopup'
 import { StudyEnvContextT } from '../StudyEnvironmentRouter'
 import {
-  userHasPermission,
   useUser
 } from 'user/UserProvider'
 import { LazySearchQueryBuilder } from 'search/LazySearchQueryBuilder'
@@ -113,16 +112,15 @@ export const FormOptions = ({ studyEnvContext, initialWorkingForm, updateWorking
                 })}
               /> Allow study staff to edit participant responses
             </label>}
-              Eligibility Rule
-            {userHasPermission(user, studyEnvContext.portal.id, 'prototype_tester')
-              && <div className="my-2">
-                <LazySearchQueryBuilder
-                  studyEnvContext={studyEnvContext}
-                  onSearchExpressionChange={exp => updateWorkingForm({
-                    ...workingForm, eligibilityRule: exp
-                  })}
-                  searchExpression={workingForm.eligibilityRule || ''}/>
-              </div>}
+            <h3 className="h6 mt-4">Eligibility Rule</h3>
+            <div className="mb-2">
+              <LazySearchQueryBuilder
+                studyEnvContext={studyEnvContext}
+                onSearchExpressionChange={exp => updateWorkingForm({
+                  ...workingForm, eligibilityRule: exp
+                })}
+                searchExpression={workingForm.eligibilityRule || ''}/>
+            </div>
           </div>
         </div>
     }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Now that Hearthive has surveys with rules going into prod, we should make rule visibility generally available.
![image](https://github.com/broadinstitute/juniper/assets/2800795/5eb63046-ad3f-45ec-9891-0eac15b1d4d1)

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. log into admin tool as "staff@ourhealth.org"
2. open a survey, and go to configuration menu
3. confirm rule editor appears