### PR TITLE
[JN-1114] Answer edit history

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeController.java
@@ -46,10 +46,14 @@ public class EnrolleeController implements EnrolleeApi {
 
   @Override
   public ResponseEntity<Object> listChangeRecords(
-      String portalShortcode, String studyShortcode, String envName, String enrolleeShortcode) {
+      String portalShortcode,
+      String studyShortcode,
+      String envName,
+      String enrolleeShortcode,
+      String modelName) {
     AdminUser adminUser = authUtilService.requireAdminUser(request);
     List<DataChangeRecord> records =
-        enrolleeExtService.findDataChangeRecords(adminUser, enrolleeShortcode);
+        enrolleeExtService.findDataChangeRecords(adminUser, enrolleeShortcode, modelName);
     return ResponseEntity.ok(records);
   }
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeExtService.java
@@ -62,8 +62,11 @@ public class EnrolleeExtService {
   }
 
   public List<DataChangeRecord> findDataChangeRecords(
-      AdminUser operator, String enrolleeShortcode) {
+      AdminUser operator, String enrolleeShortcode, String modelName) {
     Enrollee enrollee = authUtilService.authAdminUserToEnrollee(operator, enrolleeShortcode);
+    if (modelName != null) {
+      return dataChangeRecordService.findAllRecordsForEnrolleeAndModelName(enrollee, modelName);
+    }
     return dataChangeRecordService.findAllRecordsForEnrollee(enrollee);
   }
 

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -720,7 +720,7 @@ paths:
           $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/enrollees/{enrolleeShortcode}/changeRecords:
     get:
-      summary: List the notifications sent/pending for an enrollee
+      summary: List of data change records for an enrollee
       tags: [ enrollee ]
       operationId: listChangeRecords
       parameters:
@@ -728,6 +728,7 @@ paths:
         - { name: studyShortcode, in: path, required: true, schema: { type: string } }
         - { name: envName, in: path, required: true, schema: { type: string } }
         - { name: enrolleeShortcode, in: path, required: true, schema: { type: string } }
+        - { name: modelName, in: query, required: false, schema: { type: string } }
       responses:
         '200':
           description: List of DataChangeRecords

--- a/core/src/main/java/bio/terra/pearl/core/dao/workflow/DataChangeRecordDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/workflow/DataChangeRecordDao.java
@@ -37,6 +37,21 @@ public class DataChangeRecordDao extends BaseJdbiDao<DataChangeRecord> {
         );
     }
 
+    public List<DataChangeRecord> findAllRecordsForEnrolleeAndModelName(UUID enrolleeId, UUID portalParticipantUserId, String modelName) {
+        return jdbi.withHandle(handle ->
+                handle
+                        .createQuery("SELECT * FROM data_change_record" +
+                                "    WHERE enrollee_id = :enrolleeId" +
+                                "    AND model_name = :modelName" +
+                                "    OR portal_participant_user_id = :portalParticipantUserId;")
+                        .bind("enrolleeId", enrolleeId)
+                        .bind("modelName", modelName)
+                        .bind("portalParticipantUserId", portalParticipantUserId)
+                        .mapTo(clazz)
+                        .list()
+        );
+    }
+
 
     public List<DataChangeRecord> findByModelId(UUID modelId) {
         return findAllByProperty("model_id", modelId);

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/Answer.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/Answer.java
@@ -3,6 +3,8 @@ package bio.terra.pearl.core.model.survey;
 import bio.terra.pearl.core.model.BaseEntity;
 import java.util.Objects;
 import java.util.UUID;
+
+import bio.terra.pearl.core.model.audit.ResponsibleEntity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -34,6 +36,11 @@ public class Answer extends BaseEntity {
     // store all numbers as doubles to match Javascript/JSON.
     private Double numberValue;
     private Boolean booleanValue;
+
+    public void setCreatingEntity(ResponsibleEntity responsibleEntity) {
+        this.creatingParticipantUserId = responsibleEntity.getParticipantUser() != null ? responsibleEntity.getParticipantUser().getId() : null;
+        this.creatingAdminUserId = responsibleEntity.getAdminUser() != null ? responsibleEntity.getAdminUser().getId() : null;
+    }
 
     public void setValueAndType(Object value) {
         answerType = AnswerType.forValue(value);

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -302,7 +302,12 @@ public class SurveyResponseService extends ImmutableEntityService<SurveyResponse
 
     private Answer createAnswer(Answer answer, SurveyResponse response,
                                 Survey survey, PortalParticipantUser ppUser, ResponsibleEntity operator) {
-        answer.setCreatingEntity(operator);
+        if(operator.getParticipantUser() != null || operator.getAdminUser() != null) {
+            answer.setCreatingEntity(operator);
+        } else {
+            //Answers created by a system process (i.e. enrollee import) should be associated with the participant user
+            answer.setCreatingParticipantUserId(ppUser.getParticipantUserId());
+        }
         answer.setSurveyResponseId(response.getId());
         answer.setSurveyStableId(survey.getStableId());
         if (answer.getSurveyVersion() == 0) {

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -302,7 +302,7 @@ public class SurveyResponseService extends ImmutableEntityService<SurveyResponse
 
     private Answer createAnswer(Answer answer, SurveyResponse response,
                                 Survey survey, PortalParticipantUser ppUser, ResponsibleEntity operator) {
-        if (answer.getCreatingAdminUserId() != null) {
+        if (response.getCreatingAdminUserId() != null) {
             answer.setCreatingAdminUserId(operator.getAdminUser().getId());
         } else {
             // If an admin wasn't specified, we'll default to attributing this to the participant user.

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -303,7 +303,7 @@ public class SurveyResponseService extends ImmutableEntityService<SurveyResponse
     private Answer createAnswer(Answer answer, SurveyResponse response,
                                 Survey survey, PortalParticipantUser ppUser, ResponsibleEntity operator) {
         if (response.getCreatingAdminUserId() != null) {
-            answer.setCreatingAdminUserId(operator.getAdminUser().getId());
+            answer.setCreatingAdminUserId(response.getCreatingAdminUserId());
         } else {
             // If an admin wasn't specified, we'll default to attributing this to the participant user.
             // It's also possible that a system process (such as import) could have created the response,

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -302,14 +302,7 @@ public class SurveyResponseService extends ImmutableEntityService<SurveyResponse
 
     private Answer createAnswer(Answer answer, SurveyResponse response,
                                 Survey survey, PortalParticipantUser ppUser, ResponsibleEntity operator) {
-        if (response.getCreatingAdminUserId() != null) {
-            answer.setCreatingAdminUserId(response.getCreatingAdminUserId());
-        } else {
-            // If an admin wasn't specified, we'll default to attributing this to the participant user.
-            // It's also possible that a system process (such as import) could have created the response,
-            // but we still want to tie it to the participant user in that case.
-            answer.setCreatingParticipantUserId(ppUser.getParticipantUserId());
-        }
+        answer.setCreatingEntity(operator);
         answer.setSurveyResponseId(response.getId());
         answer.setSurveyStableId(survey.getStableId());
         if (answer.getSurveyVersion() == 0) {

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/DataChangeRecordService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/DataChangeRecordService.java
@@ -38,6 +38,15 @@ public class DataChangeRecordService extends ImmutableEntityService<DataChangeRe
         return dao.findAllRecordsForEnrollee(enrollee.getId(), ppUser.getId());
     }
 
+    // There can be records which exist for an enrollee which, for one reason or another,
+    // are tied only to the PortalParticipantUser. This grabs all of them
+    // to ensure that we are missing nothing for a given enrollee.
+    public List<DataChangeRecord> findAllRecordsForEnrolleeAndModelName(Enrollee enrollee, String modelName) {
+        PortalParticipantUser ppUser = portalParticipantUserService
+                .findForEnrollee(enrollee);
+        return dao.findAllRecordsForEnrolleeAndModelName(enrollee.getId(), ppUser.getId(), modelName);
+    }
+
     public List<DataChangeRecord> findByEnrollee(UUID enrolleeId) {
         return dao.findByEnrolleeId(enrolleeId);
     }

--- a/core/src/test/java/bio/terra/pearl/core/dao/survey/AnswerDaoTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/survey/AnswerDaoTests.java
@@ -38,8 +38,7 @@ public class AnswerDaoTests extends BaseSpringBootTest {
         .build();
     Answer savedAnswer = answerDao.create(stringAnswer);
     DaoTestUtils.assertGeneratedProperties(savedAnswer);
-    assertThat(savedAnswer, samePropertyValuesAs(stringAnswer, "id", "createdAt", "lastUpdatedAt",
-        "valueAndType"));
+    assertThat(savedAnswer, samePropertyValuesAs(stringAnswer, "id", "createdAt", "lastUpdatedAt"));
   }
 
   @Test

--- a/core/src/test/java/bio/terra/pearl/core/dao/survey/AnswerDaoTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/survey/AnswerDaoTests.java
@@ -38,7 +38,7 @@ public class AnswerDaoTests extends BaseSpringBootTest {
         .build();
     Answer savedAnswer = answerDao.create(stringAnswer);
     DaoTestUtils.assertGeneratedProperties(savedAnswer);
-    assertThat(savedAnswer, samePropertyValuesAs(stringAnswer, "id", "createdAt", "lastUpdatedAt"));
+    assertThat(savedAnswer, samePropertyValuesAs(stringAnswer, "id", "createdAt", "lastUpdatedAt", "valueAndType", "creatingEntity"));
   }
 
   @Test

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -776,9 +776,10 @@ export default {
   },
 
   async fetchEnrolleeChangeRecords(portalShortcode: string, studyShortcode: string, envName: string,
-    enrolleeShortcode: string): Promise<DataChangeRecord[]> {
-    const url =
-      `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/enrollees/${enrolleeShortcode}/changeRecords`
+    enrolleeShortcode: string, modelName?: string): Promise<DataChangeRecord[]> {
+    const params = queryString.stringify({ modelName })
+    const url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)
+    }/enrollees/${enrolleeShortcode}/changeRecords?${params}`
     const response = await fetch(url, this.getGetInit())
     return await this.processJsonResponse(response)
   },

--- a/ui-admin/src/study/participants/survey/AnswerEditHistory.tsx
+++ b/ui-admin/src/study/participants/survey/AnswerEditHistory.tsx
@@ -7,6 +7,7 @@ import { faArrowRight, faHistory, faPencil } from '@fortawesome/free-solid-svg-i
 import { AdminUser } from '../../../api/adminUser'
 import React from 'react'
 import { getDisplayValue } from './SurveyFullDataView'
+import { sortBy } from 'lodash'
 
 /**
  * Renders a dropdown with the edit history for a question response
@@ -61,8 +62,7 @@ const renderChangeRecordSimple = (changeRecord: DataChangeRecord) => {
 const renderOriginalAnswer = (
   question: Question | CalculatedValue, answer: Answer, changeRecords: DataChangeRecord[], users: AdminUser[]
 ) => {
-  const originalChangeRecord = changeRecords.sort((a, b) => a.createdAt > b.createdAt ? 1 :
-    a.createdAt < b.createdAt ? -1 : 0)[0]
+  const originalChangeRecord = sortBy(changeRecords, 'createdAt')[0]
   return <div className="dropdown-item d-flex align-items-center" style={{ pointerEvents: 'none' }}>
     <FontAwesomeIcon icon={faPencil} className="me-2"/>
     <div>

--- a/ui-admin/src/study/participants/survey/AnswerEditHistory.tsx
+++ b/ui-admin/src/study/participants/survey/AnswerEditHistory.tsx
@@ -1,0 +1,80 @@
+import { CalculatedValue, Question } from 'survey-core'
+import { Answer, instantToDefaultString } from '@juniper/ui-core'
+import { DataChangeRecord } from '../../../api/api'
+import { useAdminUserContext } from '../../../providers/AdminUserProvider'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faArrowRight, faHistory, faPencil } from '@fortawesome/free-solid-svg-icons'
+import { AdminUser } from '../../../api/adminUser'
+import React from 'react'
+import { getDisplayValue } from './SurveyFullDataView'
+
+/**
+ * Renders a dropdown with the edit history for a question response
+ */
+export const AnswerEditHistory = ({ question, answer, editHistory }: {
+    question: Question | CalculatedValue, answer: Answer, editHistory: DataChangeRecord[]
+}) => {
+  const { users } = useAdminUserContext()
+
+  return <>
+    <div
+      data-bs-toggle='dropdown'
+      role='button'
+      className="btn btn-light dropdown-toggle fst-italic ms-2 rounded-3 p-1 border-1"
+      id="viewHistory"
+      aria-label="View history"
+      aria-haspopup="true"
+      aria-expanded="false"
+    ><FontAwesomeIcon icon={faHistory} className="fa-sm"/> View history</div>
+    <div className="dropdown-menu" aria-labelledby="viewHistory">
+      {editHistory.map((changeRecord, index) =>
+        <div key={index} className="dropdown-item d-flex align-items-center" style={{ pointerEvents: 'none' }}>
+          <FontAwesomeIcon icon={faPencil} className="me-2"/>
+          <div>
+            {renderChangeRecordSimple(changeRecord)}
+            <div className="text-muted" style={{ fontSize: '0.75em' }}>
+                            Edited on {instantToDefaultString(changeRecord.createdAt)} by <span className='fw-semibold'>
+                {users.find(user =>
+                  user.id === changeRecord.responsibleAdminUserId)?.username ?? 'Participant'}
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+      {renderOriginalAnswer(question, answer, editHistory, users)}
+    </div>
+  </>
+}
+
+const renderChangeRecordSimple = (changeRecord: DataChangeRecord) => {
+  return <div className="d-flex align-items-center">
+    <div className="bg-danger-subtle fw-medium">{changeRecord.oldValue}</div>
+    <FontAwesomeIcon icon={faArrowRight} className="mx-1"/>
+    <div className="bg-success-subtle fw-medium">{changeRecord.newValue}</div>
+  </div>
+}
+
+/*
+ * Displays the original answer value and the entity responsible for answering it. If changes have
+ * been made to the answer, we backtrack through the change records to find the original answer.
+ */
+const renderOriginalAnswer = (
+  question: Question | CalculatedValue, answer: Answer, changeRecords: DataChangeRecord[], users: AdminUser[]
+) => {
+  const originalChangeRecord = changeRecords.sort((a, b) => a.createdAt > b.createdAt ? 1 :
+    a.createdAt < b.createdAt ? -1 : 0)[0]
+  return <div className="dropdown-item d-flex align-items-center" style={{ pointerEvents: 'none' }}>
+    <FontAwesomeIcon icon={faPencil} className="me-2"/>
+    <div>
+      <span className='fw-medium'>
+        {originalChangeRecord ? originalChangeRecord.oldValue : getDisplayValue(answer, question)}
+      </span>
+      <div className="text-muted" style={{ fontSize: '0.75em' }}>
+                Answered on {instantToDefaultString(answer.createdAt)} by <span className='fw-semibold'>
+          {users.find(user =>
+            user.id === answer.creatingAdminUserId)?.username ?? 'Participant'}
+        </span>
+      </div>
+    </div>
+  </div>
+}

--- a/ui-admin/src/study/participants/survey/AnswerEditHistory.tsx
+++ b/ui-admin/src/study/participants/survey/AnswerEditHistory.tsx
@@ -3,7 +3,7 @@ import { Answer, instantToDefaultString } from '@juniper/ui-core'
 import { DataChangeRecord } from 'api/api'
 import { useAdminUserContext } from 'providers/AdminUserProvider'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faArrowRight, faCircleInfo, faHistory, faPencil } from '@fortawesome/free-solid-svg-icons'
+import { faArrowRight, faChevronDown, faHistory, faPencil } from '@fortawesome/free-solid-svg-icons'
 import { AdminUser } from 'api/adminUser'
 import React from 'react'
 import { getDisplayValue } from './SurveyFullDataView'
@@ -30,8 +30,8 @@ export const AnswerEditHistory = ({ question, answer, editHistory }: {
       <div className="d-flex align-items-center">
         <pre className="fw-bold my-0">{getDisplayValue(answer, question)}</pre>
         { editHistory.length > 0 ?
-          <FontAwesomeIcon icon={faHistory} className="fa-sm ms-2"/> :
-          <FontAwesomeIcon icon={faCircleInfo} className="fa-sm ms-2"/>}
+          <FontAwesomeIcon icon={faHistory} className="fa-sm ms-2 text-muted"/> :
+          <FontAwesomeIcon icon={faChevronDown} className="fa-sm ms-2 text-muted"/>}
       </div>
     </div>
     <div className="dropdown-menu" aria-labelledby="viewHistory">

--- a/ui-admin/src/study/participants/survey/AnswerEditHistory.tsx
+++ b/ui-admin/src/study/participants/survey/AnswerEditHistory.tsx
@@ -1,10 +1,10 @@
 import { CalculatedValue, Question } from 'survey-core'
 import { Answer, instantToDefaultString } from '@juniper/ui-core'
-import { DataChangeRecord } from '../../../api/api'
-import { useAdminUserContext } from '../../../providers/AdminUserProvider'
+import { DataChangeRecord } from 'api/api'
+import { useAdminUserContext } from 'providers/AdminUserProvider'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faArrowRight, faHistory, faPencil } from '@fortawesome/free-solid-svg-icons'
-import { AdminUser } from '../../../api/adminUser'
+import { faArrowRight, faCircleInfo, faHistory, faPencil } from '@fortawesome/free-solid-svg-icons'
+import { AdminUser } from 'api/adminUser'
 import React from 'react'
 import { getDisplayValue } from './SurveyFullDataView'
 import { sortBy } from 'lodash'
@@ -21,12 +21,19 @@ export const AnswerEditHistory = ({ question, answer, editHistory }: {
     <div
       data-bs-toggle='dropdown'
       role='button'
-      className="btn btn-light dropdown-toggle fst-italic ms-2 rounded-3 p-1 border-1"
+      className="btn btn-light p-0"
       id="viewHistory"
       aria-label="View history"
       aria-haspopup="true"
       aria-expanded="false"
-    ><FontAwesomeIcon icon={faHistory} className="fa-sm"/> View history</div>
+    >
+      <div className="d-flex align-items-center">
+        <pre className="fw-bold my-0">{getDisplayValue(answer, question)}</pre>
+        { editHistory.length > 0 ?
+          <FontAwesomeIcon icon={faHistory} className="ms-2"/> :
+          <FontAwesomeIcon icon={faCircleInfo} className="ms-2"/>}
+      </div>
+    </div>
     <div className="dropdown-menu" aria-labelledby="viewHistory">
       {editHistory.map((changeRecord, index) =>
         <div key={index} className="dropdown-item d-flex align-items-center" style={{ pointerEvents: 'none' }}>

--- a/ui-admin/src/study/participants/survey/AnswerEditHistory.tsx
+++ b/ui-admin/src/study/participants/survey/AnswerEditHistory.tsx
@@ -30,8 +30,8 @@ export const AnswerEditHistory = ({ question, answer, editHistory }: {
       <div className="d-flex align-items-center">
         <pre className="fw-bold my-0">{getDisplayValue(answer, question)}</pre>
         { editHistory.length > 0 ?
-          <FontAwesomeIcon icon={faHistory} className="ms-2"/> :
-          <FontAwesomeIcon icon={faCircleInfo} className="ms-2"/>}
+          <FontAwesomeIcon icon={faHistory} className="fa-sm ms-2"/> :
+          <FontAwesomeIcon icon={faCircleInfo} className="fa-sm ms-2"/>}
       </div>
     </div>
     <div className="dropdown-menu" aria-labelledby="viewHistory">

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
@@ -1,10 +1,11 @@
 import { render, screen } from '@testing-library/react'
 import React from 'react'
 
-import { getDisplayValue, ItemDisplay, ResponseEditHistory } from './SurveyFullDataView'
+import { getDisplayValue, ItemDisplay } from './SurveyFullDataView'
 import { Question } from 'survey-core'
 import { Answer } from '@juniper/ui-core/build/types/forms'
 import { DataChangeRecord } from 'api/api'
+import { AnswerEditHistory } from './AnswerEditHistory'
 
 
 describe('getDisplayValue', () => {
@@ -219,7 +220,7 @@ describe('ItemDisplay', () => {
 
     const answerMap: Record<string, Answer> = {}
     answerMap[answer.questionStableId] = answer
-    render(<ResponseEditHistory
+    render(<AnswerEditHistory
       question={question} answer={answer} editHistory={[firstChangeRecord, secondChangeRecord]}/>)
 
     expect(screen.getByText('Answered on', { exact: false })).toBeInTheDocument()

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen } from '@testing-library/react'
 import React from 'react'
 
-import { getDisplayValue, ItemDisplay } from './SurveyFullDataView'
+import { getDisplayValue, ItemDisplay, ResponseEditHistory } from './SurveyFullDataView'
 import { Question } from 'survey-core'
 import { Answer } from '@juniper/ui-core/build/types/forms'
+import { DataChangeRecord } from 'api/api'
 
 
 describe('getDisplayValue', () => {
@@ -140,5 +141,89 @@ describe('ItemDisplay', () => {
       showFullQuestions={true}/>)
 
     expect(screen.getByText('(testQ)')).toBeInTheDocument()
+  })
+
+  it('renders an edit history button if the question has been edited', async () => {
+    const question = { name: 'testQ', text: 'test question', isVisible: true, getType: () => 'text' }
+    const answer: Answer = {
+      stringValue: 'test123',
+      questionStableId: 'testQ',
+      surveyVersion: 1,
+      viewedLanguage: 'es',
+      lastUpdatedAt: 1234
+    } as Answer
+
+    const changeRecord: DataChangeRecord = {
+      id: 'test_id',
+      createdAt: 1234,
+      modelName: 'test_survey',
+      fieldName: 'testQ',
+      oldValue: 'test123',
+      newValue: 'test456',
+      responsibleUserId: 'test_user'
+    }
+
+    const answerMap: Record<string, Answer> = {}
+    answerMap[answer.questionStableId] = answer
+    render(<ItemDisplay
+      question={question as unknown as Question}
+      answerMap={answerMap}
+      surveyVersion={2}
+      editHistory={[changeRecord]}
+      supportedLanguages={[{ languageCode: 'es', languageName: 'Spanish', id: '' }]}
+      showFullQuestions={true}/>)
+
+    expect(screen.getByText('View history')).toBeInTheDocument()
+
+    const viewHistoryButton = screen.getByText('View history')
+    viewHistoryButton.click()
+    expect(screen.getByText('test456')).toBeInTheDocument()
+  })
+
+  it('renders the full edit history for a question', async () => {
+    const question = {
+      name: 'testQ',
+      text: 'test question',
+      isVisible: true,
+      getType: () => 'text'
+    } as unknown as Question
+
+    const answer: Answer = {
+      stringValue: 'test123',
+      questionStableId: 'testQ',
+      surveyVersion: 1,
+      viewedLanguage: 'es',
+      lastUpdatedAt: 1577854800,
+      createdAt: 1577854800
+    } as Answer
+
+    const firstChangeRecord: DataChangeRecord = {
+      id: 'test_id',
+      createdAt: 1577858400,
+      modelName: 'test_survey',
+      fieldName: 'testQ',
+      oldValue: 'test123',
+      newValue: 'test456',
+      responsibleUserId: 'test_user'
+    }
+
+    const secondChangeRecord: DataChangeRecord = {
+      id: 'test_id',
+      createdAt: 1577862000,
+      modelName: 'test_survey',
+      fieldName: 'testQ',
+      oldValue: 'test456',
+      newValue: 'test789',
+      responsibleUserId: 'test_user'
+    }
+
+    const answerMap: Record<string, Answer> = {}
+    answerMap[answer.questionStableId] = answer
+    render(<ResponseEditHistory
+      question={question} answer={answer} editHistory={[firstChangeRecord, secondChangeRecord]}/>)
+
+    expect(screen.getByText('Answered on 1/1/2020, 12:00:00 AM by', { exact: false })).toBeInTheDocument()
+    expect(screen.getByText('Edited on 1/1/2020, 1:00:00 AM by', { exact: false })).toBeInTheDocument()
+    expect(screen.getByText('Edited on 1/1/2020, 2:00:00 AM by', { exact: false })).toBeInTheDocument()
   })
 })

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
@@ -222,8 +222,7 @@ describe('ItemDisplay', () => {
     render(<ResponseEditHistory
       question={question} answer={answer} editHistory={[firstChangeRecord, secondChangeRecord]}/>)
 
-    expect(screen.getByText('Answered on 1/1/2020, 12:00:00 AM by', { exact: false })).toBeInTheDocument()
-    expect(screen.getByText('Edited on 1/1/2020, 1:00:00 AM by', { exact: false })).toBeInTheDocument()
-    expect(screen.getByText('Edited on 1/1/2020, 2:00:00 AM by', { exact: false })).toBeInTheDocument()
+    expect(screen.getByText('Answered on', { exact: false })).toBeInTheDocument()
+    expect(screen.getAllByText('Edited on', { exact: false })).toHaveLength(2)
   })
 })

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
@@ -174,9 +174,9 @@ describe('ItemDisplay', () => {
       supportedLanguages={[{ languageCode: 'es', languageName: 'Spanish', id: '' }]}
       showFullQuestions={true}/>)
 
-    expect(screen.getByText('View history')).toBeInTheDocument()
+    expect(screen.getByLabelText('View history')).toBeInTheDocument()
 
-    const viewHistoryButton = screen.getByText('View history')
+    const viewHistoryButton = screen.getByLabelText('View history')
     viewHistoryButton.click()
     expect(screen.getByText('test456')).toBeInTheDocument()
   })

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -114,7 +114,9 @@ export const ItemDisplay = ({
 }: ItemDisplayProps) => {
   const answer = answerMap[question.name]
   const answerLanguage = supportedLanguages.find(lang => lang.languageCode === answer?.viewedLanguage)
-  const editHistoryForQuestion= editHistory.filter(changeRecord => changeRecord.fieldName === question.name).reverse()
+  const editHistoryForQuestion = editHistory
+    .filter(changeRecord => changeRecord.fieldName === question.name)
+    .sort((a, b) => b.createdAt - a.createdAt)
   const displayValue = getDisplayValue(answer, question)
   let stableIdText = question.name
   if (answer && answer.surveyVersion !== surveyVersion) {
@@ -131,7 +133,7 @@ export const ItemDisplay = ({
         <span className="ms-2 fst-italic text-muted">
         ({stableIdText}) {answerLanguage && ` (Answered in ${answerLanguage.languageName})`}
         </span>
-        { answer && <ResponseEditHistory question={question} answer={answer}editHistory={editHistoryForQuestion}/> }
+        { answer && <ResponseEditHistory question={question} answer={answer} editHistory={editHistoryForQuestion}/> }
       </div>
     </dt>
     <dl>

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -14,7 +14,7 @@ import PrintFormModal from './PrintFormModal'
 import { Route, Routes } from 'react-router-dom'
 import { renderTruncatedText } from 'util/pageUtils'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
-import { doApiLoad } from '../../../api/api-utils'
+import { doApiLoad } from 'api/api-utils'
 import { AnswerEditHistory } from './AnswerEditHistory'
 
 type SurveyFullDataViewProps = {

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -184,8 +184,8 @@ const getBeforeAndAfterAnswer = (changeRecord: DataChangeRecord) => {
 }
 
 /*
- * Displays the answer value and the entity responsible for answering it. If changes have been made to the answer,
- * we backtrack through the change records to find the original answer.
+ * Displays the original answer value and the entity responsible for answering it. If changes have
+ * been made to the answer, we backtrack through the change records to find the original answer.
  */
 const getOriginalAnswer = (
   question: Question | CalculatedValue, answer: Answer, changeRecords: DataChangeRecord[], users: AdminUser[]

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -16,8 +16,8 @@ import { renderTruncatedText } from 'util/pageUtils'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faArrowRight, faHistory, faPencil } from '@fortawesome/free-solid-svg-icons'
-import { useAdminUserContext } from '../../../providers/AdminUserProvider'
-import { AdminUser } from '../../../api/adminUser'
+import { useAdminUserContext } from 'providers/AdminUserProvider'
+import { AdminUser } from 'api/adminUser'
 
 type SurveyFullDataViewProps = {
   responseId?: string,
@@ -157,7 +157,7 @@ const ResponseEditHistory = ({ question, answer, editHistory }: {
     ><FontAwesomeIcon icon={faHistory} className="fa-sm"/> View history</div>
     <div className="dropdown-menu" aria-labelledby="viewHistory">
       {editHistory.map((changeRecord, index) =>
-        <div key={index} className="dropdown-item d-flex align-items-center disabled">
+        <div key={index} className="dropdown-item d-flex align-items-center" style={{ pointerEvents: 'none' }}>
           <FontAwesomeIcon icon={faPencil} className="me-2"/>
           <div>
             {beforeAndAfter(changeRecord)}
@@ -178,9 +178,9 @@ const ResponseEditHistory = ({ question, answer, editHistory }: {
 
 const beforeAndAfter = (changeRecord: DataChangeRecord) => {
   return <div className="d-flex align-items-center">
-    <div className="bg-danger-subtle fw-semibold">{changeRecord.oldValue}</div>
+    <div className="bg-danger-subtle fw-medium">{changeRecord.oldValue}</div>
     <FontAwesomeIcon icon={faArrowRight} className="mx-1"/>
-    <div className="bg-success-subtle fw-semibold">{changeRecord.newValue}</div>
+    <div className="bg-success-subtle fw-medium">{changeRecord.newValue}</div>
   </div>
 }
 
@@ -189,12 +189,11 @@ const firstValue = (
 ) => {
   const changeRecord = changeRecords.sort((a, b) => a.createdAt > b.createdAt ? 1 :
     a.createdAt < b.createdAt ? -1 : 0)[0]
-  console.log(answer)
   if (!changeRecord) {
-    return <div className="dropdown-item d-flex align-items-center disabled">
+    return <div className="dropdown-item d-flex align-items-center" style={{ pointerEvents: 'none' }}>
       <FontAwesomeIcon icon={faPencil} className="me-2"/>
       <div>
-        <span className='fw-semibold'>{getDisplayValue(answer, question)}</span>
+        <span className='fw-medium'>{getDisplayValue(answer, question)}</span>
         <div className="text-muted" style={{ fontSize: '0.75em' }}>
           Answered on {instantToDefaultString(answer.createdAt)} by <span className='fw-semibold'>
             {users.find(user =>
@@ -206,14 +205,14 @@ const firstValue = (
   }
 
 
-  return <div className="dropdown-item d-flex align-items-center disabled">
+  return <div className="dropdown-item d-flex align-items-center" style={{ pointerEvents: 'none' }}>
     <FontAwesomeIcon icon={faPencil} className="me-2"/>
     <div>
-      <span className='fw-semibold'>{changeRecord.oldValue}</span>
+      <span className='fw-medium'>{changeRecord.oldValue}</span>
       <div className="text-muted" style={{ fontSize: '0.75em' }}>
         Answered on {instantToDefaultString(answer.createdAt)} by <span className='fw-semibold'>
           {users.find(user =>
-            user.id === changeRecord.responsibleAdminUserId)?.username ?? 'Participant'}
+            user.id === answer.creatingAdminUserId)?.username ?? 'Participant'}
         </span>
       </div>
     </div>

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -160,7 +160,7 @@ const ResponseEditHistory = ({ question, answer, editHistory }: {
         <div key={index} className="dropdown-item d-flex align-items-center" style={{ pointerEvents: 'none' }}>
           <FontAwesomeIcon icon={faPencil} className="me-2"/>
           <div>
-            {beforeAndAfter(changeRecord)}
+            {getBeforeAndAfterAnswer(changeRecord)}
             <div className="text-muted" style={{ fontSize: '0.75em' }}>
                 Edited on {instantToDefaultString(changeRecord.createdAt)} by <span className='fw-semibold'>
                 {users.find(user =>
@@ -170,13 +170,12 @@ const ResponseEditHistory = ({ question, answer, editHistory }: {
           </div>
         </div>
       )}
-      {firstValue(question, answer, editHistory, users)}
-      {/*{findOriginalValueFromChangeRecords(answer, editHistoryForQuestion, users, question)}*/}
+      {getOriginalAnswer(question, answer, editHistory, users)}
     </div>
   </>
 }
 
-const beforeAndAfter = (changeRecord: DataChangeRecord) => {
+const getBeforeAndAfterAnswer = (changeRecord: DataChangeRecord) => {
   return <div className="d-flex align-items-center">
     <div className="bg-danger-subtle fw-medium">{changeRecord.oldValue}</div>
     <FontAwesomeIcon icon={faArrowRight} className="mx-1"/>
@@ -184,33 +183,23 @@ const beforeAndAfter = (changeRecord: DataChangeRecord) => {
   </div>
 }
 
-const firstValue = (
+/*
+ * Displays the answer value and the entity responsible for answering it. If changes have been made to the answer,
+ * we backtrack through the change records to find the original answer.
+ */
+const getOriginalAnswer = (
   question: Question | CalculatedValue, answer: Answer, changeRecords: DataChangeRecord[], users: AdminUser[]
 ) => {
-  const changeRecord = changeRecords.sort((a, b) => a.createdAt > b.createdAt ? 1 :
+  const originalChangeRecord = changeRecords.sort((a, b) => a.createdAt > b.createdAt ? 1 :
     a.createdAt < b.createdAt ? -1 : 0)[0]
-  if (!changeRecord) {
-    return <div className="dropdown-item d-flex align-items-center" style={{ pointerEvents: 'none' }}>
-      <FontAwesomeIcon icon={faPencil} className="me-2"/>
-      <div>
-        <span className='fw-medium'>{getDisplayValue(answer, question)}</span>
-        <div className="text-muted" style={{ fontSize: '0.75em' }}>
-          Answered on {instantToDefaultString(answer.createdAt)} by <span className='fw-semibold'>
-            {users.find(user =>
-              user.id === answer.creatingAdminUserId)?.username ?? 'Participant'}
-          </span>
-        </div>
-      </div>
-    </div>
-  }
-
-
   return <div className="dropdown-item d-flex align-items-center" style={{ pointerEvents: 'none' }}>
     <FontAwesomeIcon icon={faPencil} className="me-2"/>
     <div>
-      <span className='fw-medium'>{changeRecord.oldValue}</span>
+      <span className='fw-medium'>
+        {originalChangeRecord ? originalChangeRecord.oldValue : getDisplayValue(answer, question)}
+      </span>
       <div className="text-muted" style={{ fontSize: '0.75em' }}>
-        Answered on {instantToDefaultString(answer.createdAt)} by <span className='fw-semibold'>
+          Answered on {instantToDefaultString(answer.createdAt)} by <span className='fw-semibold'>
           {users.find(user =>
             user.id === answer.creatingAdminUserId)?.username ?? 'Participant'}
         </span>

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -135,11 +135,12 @@ export const ItemDisplay = ({
         <span className="ms-2 fst-italic text-muted">
         ({stableIdText}) {answerLanguage && ` (Answered in ${answerLanguage.languageName})`}
         </span>
-        { answer && <AnswerEditHistory question={question} answer={answer} editHistory={editHistoryForQuestion}/> }
       </div>
     </dt>
     <dl>
-      <pre className="fw-bold">{displayValue}</pre>
+      { answer ?
+        <AnswerEditHistory question={question} answer={answer} editHistory={editHistoryForQuestion}/> :
+        <pre className="fw-bold">{displayValue}</pre>}
     </dl>
   </>
 }

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { CalculatedValue, Question, SurveyModel } from 'survey-core'
 
 import {
-  createAddressValidator, Enrollee, instantToDefaultString,
+  createAddressValidator, Enrollee,
   makeSurveyJsData,
   PortalEnvironment,
   PortalEnvironmentLanguage,
@@ -14,11 +14,8 @@ import PrintFormModal from './PrintFormModal'
 import { Route, Routes } from 'react-router-dom'
 import { renderTruncatedText } from 'util/pageUtils'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faArrowRight, faHistory, faPencil } from '@fortawesome/free-solid-svg-icons'
-import { useAdminUserContext } from 'providers/AdminUserProvider'
-import { AdminUser } from 'api/adminUser'
 import { doApiLoad } from '../../../api/api-utils'
+import { AnswerEditHistory } from './AnswerEditHistory'
 
 type SurveyFullDataViewProps = {
   responseId?: string,
@@ -138,84 +135,13 @@ export const ItemDisplay = ({
         <span className="ms-2 fst-italic text-muted">
         ({stableIdText}) {answerLanguage && ` (Answered in ${answerLanguage.languageName})`}
         </span>
-        { answer && <ResponseEditHistory question={question} answer={answer} editHistory={editHistoryForQuestion}/> }
+        { answer && <AnswerEditHistory question={question} answer={answer} editHistory={editHistoryForQuestion}/> }
       </div>
     </dt>
     <dl>
       <pre className="fw-bold">{displayValue}</pre>
     </dl>
   </>
-}
-
-/**
- * Renders a dropdown with the edit history for a question response
- */
-export const ResponseEditHistory = ({ question, answer, editHistory }: {
-  question: Question | CalculatedValue, answer: Answer, editHistory: DataChangeRecord[]
-}) => {
-  const { users } = useAdminUserContext()
-
-  return <>
-    <div
-      data-bs-toggle='dropdown'
-      role='button'
-      className="btn btn-light dropdown-toggle fst-italic ms-2 rounded-3 p-1 border-1"
-      id="viewHistory"
-      aria-label="View history"
-      aria-haspopup="true"
-      aria-expanded="false"
-    ><FontAwesomeIcon icon={faHistory} className="fa-sm"/> View history</div>
-    <div className="dropdown-menu" aria-labelledby="viewHistory">
-      {editHistory.map((changeRecord, index) =>
-        <div key={index} className="dropdown-item d-flex align-items-center" style={{ pointerEvents: 'none' }}>
-          <FontAwesomeIcon icon={faPencil} className="me-2"/>
-          <div>
-            {getBeforeAndAfterAnswer(changeRecord)}
-            <div className="text-muted" style={{ fontSize: '0.75em' }}>
-                Edited on {instantToDefaultString(changeRecord.createdAt)} by <span className='fw-semibold'>
-                {users.find(user =>
-                  user.id === changeRecord.responsibleAdminUserId)?.username ?? 'Participant'}
-              </span>
-            </div>
-          </div>
-        </div>
-      )}
-      {getOriginalAnswer(question, answer, editHistory, users)}
-    </div>
-  </>
-}
-
-const getBeforeAndAfterAnswer = (changeRecord: DataChangeRecord) => {
-  return <div className="d-flex align-items-center">
-    <div className="bg-danger-subtle fw-medium">{changeRecord.oldValue}</div>
-    <FontAwesomeIcon icon={faArrowRight} className="mx-1"/>
-    <div className="bg-success-subtle fw-medium">{changeRecord.newValue}</div>
-  </div>
-}
-
-/*
- * Displays the original answer value and the entity responsible for answering it. If changes have
- * been made to the answer, we backtrack through the change records to find the original answer.
- */
-const getOriginalAnswer = (
-  question: Question | CalculatedValue, answer: Answer, changeRecords: DataChangeRecord[], users: AdminUser[]
-) => {
-  const originalChangeRecord = changeRecords.sort((a, b) => a.createdAt > b.createdAt ? 1 :
-    a.createdAt < b.createdAt ? -1 : 0)[0]
-  return <div className="dropdown-item d-flex align-items-center" style={{ pointerEvents: 'none' }}>
-    <FontAwesomeIcon icon={faPencil} className="me-2"/>
-    <div>
-      <span className='fw-medium'>
-        {originalChangeRecord ? originalChangeRecord.oldValue : getDisplayValue(answer, question)}
-      </span>
-      <div className="text-muted" style={{ fontSize: '0.75em' }}>
-          Answered on {instantToDefaultString(answer.createdAt)} by <span className='fw-semibold'>
-          {users.find(user =>
-            user.id === answer.creatingAdminUserId)?.username ?? 'Participant'}
-        </span>
-      </div>
-    </div>
-  </div>
 }
 
 /** renders the value of the answer, either as plaintext, a matched choice, or an image for signatures */

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -18,6 +18,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faArrowRight, faHistory, faPencil } from '@fortawesome/free-solid-svg-icons'
 import { useAdminUserContext } from 'providers/AdminUserProvider'
 import { AdminUser } from 'api/adminUser'
+import { doApiLoad } from '../../../api/api-utils'
 
 type SurveyFullDataViewProps = {
   responseId?: string,
@@ -54,9 +55,13 @@ export default function SurveyFullDataView({
 
   useEffect(() => {
     if (responseId && enrollee) {
-      Api.fetchEnrolleeChangeRecords(
-        studyEnvContext.portal.shortcode, studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName,
-        enrollee.shortcode, survey.stableId).then(changeRecords => {
+      doApiLoad(async () => {
+        const changeRecords = await Api.fetchEnrolleeChangeRecords(
+          studyEnvContext.portal.shortcode,
+          studyEnvContext.study.shortcode,
+          studyEnvContext.currentEnv.environmentName,
+          enrollee.shortcode,
+          survey.stableId)
         setChangeRecords(changeRecords)
       })
     }

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -142,7 +142,10 @@ export const ItemDisplay = ({
   </>
 }
 
-const ResponseEditHistory = ({ question, answer, editHistory }: {
+/**
+ * Renders a dropdown with the edit history for a question response
+ */
+export const ResponseEditHistory = ({ question, answer, editHistory }: {
   question: Question | CalculatedValue, answer: Answer, editHistory: DataChangeRecord[]
 }) => {
   const { users } = useAdminUserContext()

--- a/ui-admin/src/study/participants/survey/SurveyResponseView.test.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyResponseView.test.tsx
@@ -11,11 +11,14 @@ import React from 'react'
 import userEvent from '@testing-library/user-event'
 import { RawEnrolleeSurveyView } from './SurveyResponseView'
 import { userHasPermission } from 'user/UserProvider'
+import Api from 'api/api'
 
 jest.mock('user/UserProvider', () => ({
   ...jest.requireActual('user/UserProvider'),
   userHasPermission: jest.fn()
 }))
+
+jest.spyOn(Api, 'fetchEnrolleeChangeRecords').mockResolvedValue([])
 
 describe('RawEnrolleeSurveyView', () => {
   const mockResponseWithAnswer = {

--- a/ui-admin/src/study/participants/survey/SurveyResponseView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyResponseView.tsx
@@ -134,9 +134,12 @@ export function RawEnrolleeSurveyView({
       </div>
       <hr/>
       {(!isEditing && !response?.answers.length) && <div>No response for enrollee {enrollee.shortcode}</div>}
-      {(!isEditing && response?.answers.length) && <SurveyFullDataView answers={response?.answers || []}
+      {(!isEditing && response?.answers.length) && <SurveyFullDataView
+        responseId={response.id}
+        enrollee={enrollee}
+        answers={response?.answers || []}
         survey={configSurvey.survey}
-        userId={enrollee.participantUserId}
+        // userId={enrollee.participantUserId}
         studyEnvContext={studyEnvContext}/>}
       {isEditing && user && <SurveyResponseEditor studyEnvContext={studyEnvContext}
         updateResponseMap={updateResponseMap}

--- a/ui-admin/src/study/participants/survey/SurveyResponseView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyResponseView.tsx
@@ -139,7 +139,6 @@ export function RawEnrolleeSurveyView({
         enrollee={enrollee}
         answers={response?.answers || []}
         survey={configSurvey.survey}
-        // userId={enrollee.participantUserId}
         studyEnvContext={studyEnvContext}/>}
       {isEditing && user && <SurveyResponseEditor studyEnvContext={studyEnvContext}
         updateResponseMap={updateResponseMap}

--- a/ui-core/src/types/forms.ts
+++ b/ui-core/src/types/forms.ts
@@ -70,6 +70,10 @@ export type Answer = {
   surveyStableId?: string
   surveyVersion?: number
   viewedLanguage?: string
+  creatingParticipantUserId?: string
+  creatingAdminUserId?: string
+  createdAt?: number
+  lastUpdatedAt?: number
 }
 
 export type FormResponse = {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds a "View history" button to the survey response view. While most of this information is also displayed in the audit history table, it can be hard to piece together what's happening and you also can't view who originally answered the question.

This is intended to address https://github.com/broadinstitute/juniper/pull/955#discussion_r1651513466

<img width="764" alt="Screenshot 2024-07-01 at 2 48 06 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/2950f485-f579-4047-954f-1799bc1915a7">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Restart participant api, admin api, and admin UI
Repopulate demo
Make some answer edits as an admin or participant
Confirm that they show up in the response history view

_For a pre-populated test:_
View the basics survey response for Jonas Salk: https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants/HDSALK
You should see the edit history for their street address pre-populated:
<img width="547" alt="Screenshot 2024-07-01 at 2 48 23 PM" src="https://github.com/broadinstitute/juniper/assets/7257391/3dbca5c5-3fe1-4caf-9bc0-11ce2decb1f0">

