### PR TITLE
[JN-1170] fixing default survey name logic

### DIFF
--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -69,9 +69,8 @@ function SurveyView({ showHeaders = true }: { showHeaders?: boolean }) {
           'hubUpdateFormSubmittedTitle',
           {
             substitutions: {
-              formName: i18n(`${form.stableId}:${form.version}`)
-            },
-            defaultValue: form.name
+              formName: i18n(`${form.stableId}:${form.version}`, { defaultValue: form.name })
+            }
           }),
         type: 'SUCCESS'
       }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

We weren't correctly defaulting the name for surveys without corresponding language texts.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. repopulate demo
2. in your database, delete the demo-specific language texts `delete from language_text where portal_id = (select id from portal where shortcode = 'demo');`
3. go to https://sandbox.demo.localhost:3001/, log in as jsalk@test.com
4. edit/complete a survey.  
5. Confirm a regular '<<survey name>> complete' message appears, and not a '{stableID:version} complete' message