### PR TITLE
[JN-1169] fix permission check on findWithSurveyNoContent

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
@@ -71,7 +71,7 @@ public class SurveyExtService {
     return surveysInPortal;
   }
 
-  @EnforcePortalStudyEnvPermission(permission = AuthUtilService.BASE_PERMISSON)
+  @EnforcePortalStudyPermission(permission = AuthUtilService.BASE_PERMISSON)
   public List<StudyEnvironmentSurvey> findWithSurveyNoContent(
       PortalStudyAuthContext authContext,
       String stableId,

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/SurveyExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/SurveyExtServiceTests.java
@@ -51,7 +51,7 @@ public class SurveyExtServiceTests extends BaseSpringBootTest {
             "listVersions",
             AuthAnnotationSpec.withPortalPerm("BASE"),
             "findWithSurveyNoContent",
-            AuthAnnotationSpec.withPortalStudyEnvPerm("BASE"),
+            AuthAnnotationSpec.withPortalStudyPerm("BASE"),
             "create",
             AuthAnnotationSpec.withPortalPerm("survey_edit"),
             "delete",


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Fixes a mismatched permission check that was causing the configured surveys to not load for studies.

Error was:

```
Exception: org.apache.commons.lang3.NotImplementedException: EnforcePermission annotation must be used on a method whose first argument is a PortalStudyEnvAuthContext

Request: GET /api/portals/v1/cmi/studies/cmi_template/configuredSurveys/findWithNoContent 500
org.apache.commons.lang3.NotImplementedException: EnforcePermission annotation must be used on a method whose first argument is a PortalStudyEnvAuthContext
```

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Restart admin API
Confirm that you can load the list of configured surveys: https://localhost:3000/demo/studies/heartdemo/env/sandbox/forms