### PR TITLE
[JN-1175] family audit table

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/family/FamilyController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/family/FamilyController.java
@@ -110,4 +110,24 @@ public class FamilyController implements FamilyApi {
 
     return ResponseEntity.ok(family);
   }
+
+  @Override
+  public ResponseEntity<Object> listChangeRecords(
+      String portalShortcode,
+      String studyShortcode,
+      String envName,
+      String familyShortcode,
+      String modelName) {
+    AdminUser operator = authUtilService.requireAdminUser(request);
+
+    return ResponseEntity.ok(
+        familyExtService.listChangeRecords(
+            PortalStudyEnvAuthContext.of(
+                operator,
+                portalShortcode,
+                studyShortcode,
+                EnvironmentName.valueOfCaseInsensitive(envName)),
+            familyShortcode,
+            modelName));
+  }
 }

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -639,16 +639,16 @@ paths:
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
-  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/enrollees/{enrolleeShortcode}:
+  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/enrollees/{enrolleeShortcodeOrId}:
     get:
-      summary: Finds an enrollee by shortcode
+      summary: Finds an enrollee by shortcode or id
       tags: [ enrollee ]
       operationId: find
       parameters:
         - { name: portalShortcode, in: path, required: true, schema: { type: string } }
         - { name: studyShortcode, in: path, required: true, schema: { type: string } }
         - { name: envName, in: path, required: true, schema: { type: string } }
-        - { name: enrolleeShortcode, in: path, required: true, schema: { type: string } }
+        - { name: enrolleeShortcodeOrId, in: path, required: true, schema: { type: string } }
       responses:
         '200':
           description: Enrollee object
@@ -950,7 +950,7 @@ paths:
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/families/{familyShortcode}/changeRecords:
     get:
       summary: List of data change records for a family
-      tags: [ enrollee ]
+      tags: [ family ]
       operationId: listChangeRecords
       parameters:
         - { name: portalShortcode, in: path, required: true, schema: { type: string } }

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -947,6 +947,23 @@ paths:
           description: Successful deletion
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/families/{familyShortcode}/changeRecords:
+    get:
+      summary: List of data change records for a family
+      tags: [ enrollee ]
+      operationId: listChangeRecords
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: studyShortcode, in: path, required: true, schema: { type: string } }
+        - { name: envName, in: path, required: true, schema: { type: string } }
+        - { name: familyShortcode, in: path, required: true, schema: { type: string } }
+        - { name: modelName, in: query, required: false, schema: { type: string } }
+      responses:
+        '200':
+          description: List of DataChangeRecords
+          content: { application/json: { schema: { type: object } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/triggers:
     get:
       summary: gets all the active triggered actions for the environment

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/family/FamilyExtServiceTest.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/family/FamilyExtServiceTest.java
@@ -40,7 +40,9 @@ class FamilyExtServiceTest extends BaseSpringBootTest {
             "find", AuthAnnotationSpec.withPortalStudyEnvPerm("participant_data_view"),
             "addEnrollee", AuthAnnotationSpec.withPortalStudyEnvPerm("participant_data_edit"),
             "removeEnrollee", AuthAnnotationSpec.withPortalStudyEnvPerm("participant_data_edit"),
-            "updateProband", AuthAnnotationSpec.withPortalStudyEnvPerm("participant_data_edit")));
+            "updateProband", AuthAnnotationSpec.withPortalStudyEnvPerm("participant_data_edit"),
+            "listChangeRecords",
+                AuthAnnotationSpec.withPortalStudyEnvPerm("participant_data_view")));
   }
 
   @Test

--- a/core/src/main/java/bio/terra/pearl/core/dao/workflow/DataChangeRecordDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/workflow/DataChangeRecordDao.java
@@ -76,4 +76,12 @@ public class DataChangeRecordDao extends BaseJdbiDao<DataChangeRecord> {
     public void deleteByEnrolleeId(UUID enrolleeId) {
         deleteByProperty("enrollee_id", enrolleeId);
     }
+
+    public List<DataChangeRecord> findByFamilyId(UUID familyId) {
+        return findAllByProperty("family_id", familyId);
+    }
+
+    public List<DataChangeRecord> findByFamilyIdAndModelName(UUID familyId, String model) {
+        return findAllByTwoProperties("family_id", familyId, "model_name", model);
+    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/audit/DataAuditInfo.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/audit/DataAuditInfo.java
@@ -31,6 +31,7 @@ public class DataAuditInfo {
     private UUID enrolleeId;
     private UUID portalParticipantUserId;
     private UUID surveyId;
+    private UUID familyId;
     private String justification; // if an admin changes a participant's data, a justification is needed
 
     // If one operation creates multiple DataChangeRecords, then

--- a/core/src/main/java/bio/terra/pearl/core/model/audit/DataChangeRecord.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/audit/DataChangeRecord.java
@@ -28,6 +28,7 @@ public class DataChangeRecord extends BaseEntity {
     private UUID portalParticipantUserId; // id of the impacted portal participant user
     private UUID operationId; // unique id to group operations
     private UUID surveyId; // survey id of the form source of the change
+    private UUID familyId; // family id related to this change
     private UUID modelId; // id of the object corresponding to the audit record
     private String modelName; // either a class (like Profile) or a stableId of a survey
     private String fieldName; // either a property of a class (like givenName) or a survey question stableId
@@ -43,6 +44,7 @@ public class DataChangeRecord extends BaseEntity {
                 .enrolleeId(auditInfo.getEnrolleeId())
                 .portalParticipantUserId(auditInfo.getPortalParticipantUserId())
                 .surveyId(auditInfo.getSurveyId())
+                .familyId(auditInfo.getFamilyId())
                 .justification(auditInfo.getJustification());
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeRelationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeRelationService.java
@@ -195,6 +195,7 @@ public class EnrolleeRelationService extends DataAuditedService<EnrolleeRelation
             throw new IllegalArgumentException("Family ID is required for family relationships");
         }
 
+        auditInfo.setFamilyId(relation.getFamilyId());
         auditInfo.setEnrolleeId(relation.getTargetEnrolleeId());
         // ensure that the enrollees are in the family
         familyEnrolleeService.getOrCreate(

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/FamilyService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/FamilyService.java
@@ -4,6 +4,7 @@ import bio.terra.pearl.core.dao.participant.EnrolleeRelationDao;
 import bio.terra.pearl.core.dao.participant.FamilyDao;
 import bio.terra.pearl.core.dao.participant.ProfileDao;
 import bio.terra.pearl.core.model.audit.DataAuditInfo;
+import bio.terra.pearl.core.model.audit.DataChangeRecord;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.Family;
 import bio.terra.pearl.core.model.participant.FamilyEnrollee;
@@ -129,7 +130,7 @@ public class FamilyService extends DataAuditedService<Family, FamilyDao> {
 
         // attach audit info to the enrollee (so it shows up in data audit table)
         auditInfo.setEnrolleeId(enrollee.getId());
-
+        auditInfo.setFamilyId(family.getId());
         familyEnrolleeService.create(
                 FamilyEnrollee.builder()
                         .familyId(family.getId())
@@ -158,6 +159,8 @@ public class FamilyService extends DataAuditedService<Family, FamilyDao> {
             throw new IllegalArgumentException("Cannot remove proband from family");
         }
 
+        auditInfo.setFamilyId(family.getId());
+        auditInfo.setEnrolleeId(enrollee.getId());
         // also cleans up any relationships the enrollee has within the family
         familyEnrolleeService.deleteFamilyEnrolleeAndAllRelationships(
                 enrollee.getId(),
@@ -177,6 +180,16 @@ public class FamilyService extends DataAuditedService<Family, FamilyDao> {
                 .orElseThrow(() -> new IllegalArgumentException("Enrollee not in family"));
 
         family.setProbandEnrolleeId(enrollee.getId());
+        auditInfo.setFamilyId(family.getId());
+        auditInfo.setEnrolleeId(enrollee.getId());
         return update(family, auditInfo);
+    }
+
+    public List<DataChangeRecord> findDataChangeRecordsByFamilyId(UUID familyId) {
+        return dataChangeRecordService.findByFamilyId(familyId);
+    }
+
+    public List<DataChangeRecord> findDataChangeRecordsByFamilyIdAndModelName(UUID familyId, String model) {
+        return dataChangeRecordService.findByFamilyIdAndModelName(familyId, model);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/DataChangeRecordService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/DataChangeRecordService.java
@@ -75,4 +75,12 @@ public class DataChangeRecordService extends ImmutableEntityService<DataChangeRe
     public void deleteByEnrolleeId(UUID enrolleeId) {
         dao.deleteByEnrolleeId(enrolleeId);
     }
+
+    public List<DataChangeRecord> findByFamilyId(UUID familyId) {
+        return dao.findByFamilyId(familyId);
+    }
+
+    public List<DataChangeRecord> findByFamilyIdAndModelName(UUID familyId, String model) {
+        return dao.findByFamilyIdAndModelName(familyId, model);
+    }
 }

--- a/core/src/main/resources/db/changelog/changesets/2024_07_03_family_change_records.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_07_03_family_change_records.yaml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: "family_change_records"
+      author: connorlbark
+      changes:
+        - addColumn:
+            tableName: data_change_record
+            columns:
+              - column:
+                  name: family_id
+                  type: uuid
+                  constraints:
+                    foreignKeyName: fk_family_enrollee_family_id,
+                    references: family(id)
+                    nullable: true

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -284,6 +284,9 @@ databaseChangeLog:
   - include:
       file: changesets/2024_06_28_primary_study.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2024_07_03_family_change_records.yaml
+      relativeToChangelogFile: true
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements
 # are atomic. When they are grouped in a changeset and one fails the changeset cannot be
 # rolled back or rerun making recovery more difficult

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -125,6 +125,7 @@ export type DataChangeRecord = {
   oldValue: string,
   newValue: string,
   responsibleUserId?: string,
+  enrolleeId?: string,
   responsibleAdminUserId?: string,
   justification?: string
 }
@@ -746,9 +747,9 @@ export default {
     return await this.processJsonResponse(response)
   },
 
-  async getEnrollee(portalShortcode: string, studyShortcode: string, envName: string, enrolleeShortcode: string):
+  async getEnrollee(portalShortcode: string, studyShortcode: string, envName: string, enrolleeShortcodeOrId: string):
     Promise<Enrollee> {
-    const url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/enrollees/${enrolleeShortcode}`
+    const url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/enrollees/${enrolleeShortcodeOrId}`
     const response = await fetch(url, this.getGetInit())
     return await this.processJsonResponse(response)
   },
@@ -1348,6 +1349,19 @@ export default {
       method: 'PATCH',
       headers: this.getInitHeaders()
     })
+    return await this.processJsonResponse(result)
+  },
+
+  async fetchFamilyChangeRecords(
+    portalShortcode: string, studyShortcode: string, environmentName: EnvironmentName,
+    familyShortcode: string, modelName?: string
+  ): Promise<DataChangeRecord[]> {
+    const params = queryString.stringify({ modelName })
+    const url = `${
+      baseStudyEnvUrl(portalShortcode, studyShortcode, environmentName)
+    }/families/${familyShortcode}/changeRecords?${params}`
+
+    const result = await fetch(url, this.getGetInit())
     return await this.processJsonResponse(result)
   },
 

--- a/ui-admin/src/study/families/FamilyAuditTable.tsx
+++ b/ui-admin/src/study/families/FamilyAuditTable.tsx
@@ -1,0 +1,175 @@
+import React, { useMemo } from 'react'
+import {
+  Enrollee,
+  Family,
+  instantToDefaultString
+} from '@juniper/ui-core'
+import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
+import Api, { DataChangeRecord } from 'api/api'
+import { useLoadingEffect } from 'api/api-utils'
+import LoadingSpinner from 'util/LoadingSpinner'
+import { useAdminUserContext } from 'providers/AdminUserProvider'
+import {
+  ColumnDef,
+  getCoreRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable
+} from '@tanstack/react-table'
+import { basicTableLayout } from 'util/tableUtils'
+import { EnrolleeLink } from 'study/participants/enrolleeView/EnrolleeLink'
+import { get } from 'lodash'
+import { renderDiff } from 'util/changeRecordUtils'
+
+type DataChangeRecordWithEnrollees = DataChangeRecord & {
+  enrollee?: Enrollee
+  targetEnrollee?: Enrollee
+}
+
+/**
+ * Renders a table of audit records for a family.
+ */
+export const FamilyAuditTable = ({
+  family, studyEnvContext
+} : {
+  family: Family, studyEnvContext: StudyEnvContextT
+}) => {
+  const { users } = useAdminUserContext()
+  const [sorting, setSorting] = React.useState<SortingState>([{ 'id': 'createdAt', 'desc': true }])
+  const [changeRecords, setChangeRecords] = React.useState<DataChangeRecordWithEnrollees[]>([])
+
+  const {
+    isLoading
+  } = useLoadingEffect(async () => {
+    const newChangeRecords = await Api.fetchFamilyChangeRecords(
+      studyEnvContext.portal.shortcode, studyEnvContext.study.shortcode, studyEnvContext.currentEnv.environmentName,
+      family.shortcode
+    )
+    const enrichedChangeRecords = await Promise.all(newChangeRecords.map(fetchEnrollees))
+
+    setChangeRecords(enrichedChangeRecords)
+  })
+
+  const getFamilyMemberOrFetch = async (enrolleeId: string): Promise<Enrollee> => {
+    const familyMember = family.members?.find(m => m.id === enrolleeId)
+    if (!familyMember) {
+      return await Api.getEnrollee(
+        studyEnvContext.portal.shortcode,
+        studyEnvContext.study.shortcode,
+        studyEnvContext.currentEnv.environmentName,
+        enrolleeId)
+    }
+
+    return Promise.resolve(familyMember)
+  }
+
+  const tryGetProperty = (obj: string, prop: string): string | undefined => {
+    const parsed = JSON.parse(obj)
+    return get(parsed, prop, undefined)
+  }
+
+  const fetchEnrollees = async (record: DataChangeRecord): Promise<DataChangeRecordWithEnrollees> => {
+    if (['FamilyEnrollee', 'EnrolleeRelation'].includes(record.modelName)) {
+      const oldValue = record.oldValue || '{}'
+      const newValue = record.newValue || '{}'
+
+      const enrolleeId = tryGetProperty(newValue, 'enrolleeId')
+        || tryGetProperty(oldValue, 'enrolleeId')
+      const targetEnrolleeId = tryGetProperty(newValue, 'targetEnrolleeId')
+        || tryGetProperty(oldValue, 'targetEnrolleeId')
+
+      // fetch the enrollee (only if they aren't in family); the assumption is that
+      // there shouldn't be too many of these, so it's not a big deal to fetch
+      // individually
+      const enrollee = enrolleeId ? await getFamilyMemberOrFetch(enrolleeId) : undefined
+      const targetEnrollee = targetEnrolleeId ? await getFamilyMemberOrFetch(targetEnrolleeId) : undefined
+
+      return {
+        ...record,
+        enrollee,
+        targetEnrollee
+      }
+    }
+
+    return record
+  }
+
+  const columns = useMemo<ColumnDef<DataChangeRecordWithEnrollees>[]>(() => {
+    return [
+      {
+        header: 'Time',
+        accessorKey: 'createdAt',
+        cell: info => instantToDefaultString(info.getValue() as number)
+      },
+      {
+        header: 'Model',
+        accessorKey: 'modelName'
+      },
+      {
+        header: 'Type',
+        cell: ({ row }) => {
+          const oldValue = row.original.oldValue
+          const newValue = row.original.newValue
+          if (oldValue && !newValue) {
+            return 'Deleted'
+          } else if (!oldValue && newValue) {
+            return 'Created'
+          } else {
+            return 'Updated'
+          }
+        }
+      },
+      {
+        header: 'Update',
+        cell: ({ row }) => {
+          return renderDiff(row.original)
+        }
+      },
+      {
+        header: 'Enrollee',
+        cell: ({ row }) => {
+          const enrollee = row.original.enrollee
+          return enrollee && <EnrolleeLink enrollee={enrollee} studyEnvContext={studyEnvContext}/>
+        }
+      },
+      {
+        header: 'Target Enrollee',
+        cell: ({ row }) => {
+          const enrollee = row.original.targetEnrollee
+          return enrollee && <EnrolleeLink enrollee={enrollee} studyEnvContext={studyEnvContext}/>
+        }
+      },
+      {
+        header: 'Justification',
+        accessorKey: 'justification'
+      },
+      {
+        header: 'Source',
+        cell: ({ row }) => (
+          row.original.responsibleUserId ? 'Participant' :
+            row.original.responsibleAdminUserId &&
+            `Admin (${(users.find(u => u.id === row.original.responsibleAdminUserId)?.username)})`
+        )
+      }
+    ]
+  }, [users])
+
+
+  const table = useReactTable({
+    data: changeRecords,
+    columns,
+    state: {
+      sorting
+    },
+    enableRowSelection: true,
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel()
+  })
+  if (isLoading) {
+    return <LoadingSpinner/>
+  }
+  return <div>
+    {basicTableLayout(table)}
+  </div>
+}

--- a/ui-admin/src/study/families/FamilyAuditTable.tsx
+++ b/ui-admin/src/study/families/FamilyAuditTable.tsx
@@ -69,12 +69,14 @@ export const FamilyAuditTable = ({
   }
 
   const fetchEnrollees = async (record: DataChangeRecord): Promise<DataChangeRecordWithEnrollees> => {
-    if (['FamilyEnrollee', 'EnrolleeRelation'].includes(record.modelName)) {
+    if (['FamilyEnrollee', 'EnrolleeRelation', 'Family'].includes(record.modelName)) {
       const oldValue = record.oldValue || '{}'
       const newValue = record.newValue || '{}'
 
       const enrolleeId = tryGetProperty(newValue, 'enrolleeId')
         || tryGetProperty(oldValue, 'enrolleeId')
+        || tryGetProperty(newValue, 'probandEnrolleeId')
+        || tryGetProperty(oldValue, 'probandEnrolleeId')
       const targetEnrolleeId = tryGetProperty(newValue, 'targetEnrolleeId')
         || tryGetProperty(oldValue, 'targetEnrolleeId')
 

--- a/ui-admin/src/study/families/FamilyView.tsx
+++ b/ui-admin/src/study/families/FamilyView.tsx
@@ -25,6 +25,7 @@ import { FamilyOverview } from './FamilyOverview'
 import { uniq } from 'lodash/fp'
 import { FamilyMembersAndRelations } from 'study/families/FamilyMembersAndRelations'
 import { useUser } from 'user/UserProvider'
+import { FamilyAuditTable } from 'study/families/FamilyAuditTable'
 
 
 export type SurveyWithResponsesT = {
@@ -77,6 +78,9 @@ export function LoadedFamilyView({ family, studyEnvContext, reloadFamily }:
                 <NavLink to="overview" className={getLinkCssClasses}>Overview<span
                   className='badge bg-primary fw-light ms-2'>BETA</span></NavLink>
               </li>}
+              <li style={navListItemStyle} className="ps-3">
+                <NavLink to="changeRecords" className={getLinkCssClasses}>Audit history</NavLink>
+              </li>
             </ul>
           </div>
           <div className="participantTabContent flex-grow-1 bg-white p-3 pt-0">
@@ -95,6 +99,10 @@ export function LoadedFamilyView({ family, studyEnvContext, reloadFamily }:
                   family={family}
                   studyEnvContext={studyEnvContext}/>}
                 />}
+                <Route path="changeRecords" element={<FamilyAuditTable
+                  family={family}
+                  studyEnvContext={studyEnvContext}
+                />}/>
                 <Route path="*" element={<div>unknown enrollee route</div>}/>
               </Routes>
             </ErrorBoundary>

--- a/ui-admin/src/study/participants/DataChangeRecords.tsx
+++ b/ui-admin/src/study/participants/DataChangeRecords.tsx
@@ -2,14 +2,21 @@ import React, { useState } from 'react'
 import Api, { DataChangeRecord } from 'api/api'
 import { StudyEnvContextT } from '../StudyEnvironmentRouter'
 import LoadingSpinner from 'util/LoadingSpinner'
-import { Enrollee, findDifferencesBetweenObjects, instantToDefaultString, ObjectDiff } from '@juniper/ui-core'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faArrowRight } from '@fortawesome/free-solid-svg-icons'
-import { ColumnDef, getCoreRowModel, getSortedRowModel, SortingState, useReactTable } from '@tanstack/react-table'
+import {
+  Enrollee,
+  instantToDefaultString
+} from '@juniper/ui-core'
+import {
+  ColumnDef,
+  getCoreRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable
+} from '@tanstack/react-table'
 import { basicTableLayout } from 'util/tableUtils'
 import { useLoadingEffect } from 'api/api-utils'
-import { isEmpty } from 'lodash'
 import { useAdminUserContext } from 'providers/AdminUserProvider'
+import { renderDiff } from 'util/changeRecordUtils'
 
 
 /** loads the list of notifications for a given enrollee and displays them in the UI */
@@ -34,44 +41,7 @@ export default function DataChangeRecords({ enrollee, studyEnvContext }:
     {
       header: 'Update',
       cell: ({ row }) => {
-        const diffs: ObjectDiff[] = []
-
-        try {
-          const newObject: {
-            [index: string]: object
-          } = !isEmpty(row.original.newValue) ? JSON.parse(row.original.newValue) : {}
-          const oldObject: {
-            [index: string]: object
-          } = !isEmpty(row.original.oldValue) ? JSON.parse(row.original.oldValue) : {}
-
-          if ((newObject && typeof newObject === 'object') && (oldObject && typeof oldObject === 'object')) {
-            diffs.push(...findDifferencesBetweenObjects(oldObject, newObject))
-          } else {
-            diffs.push({
-              fieldName: row.original.fieldName || row.original.modelName,
-              oldValue: row.original.oldValue,
-              newValue: row.original.newValue
-            })
-          }
-        } catch (e: unknown) {
-          diffs.push({
-            fieldName: row.original.fieldName || row.original.modelName,
-            oldValue: row.original.oldValue,
-            newValue: row.original.newValue
-          })
-        }
-
-        return (
-          <div>
-            {
-              diffs.map((diff, idx) => (
-                <div key={idx}>
-                  {diff.fieldName}: {diff.oldValue} <FontAwesomeIcon icon={faArrowRight}/> {diff.newValue}
-                </div>
-              ))
-            }
-          </div>
-        )
+        return renderDiff(row.original)
       }
     },
     {

--- a/ui-admin/src/util/changeRecordUtils.tsx
+++ b/ui-admin/src/util/changeRecordUtils.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { DataChangeRecord } from 'api/api'
+import {
+  findDifferencesBetweenObjects,
+  ObjectDiff
+} from '@juniper/ui-core'
+import { isEmpty } from 'lodash'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faArrowRight } from '@fortawesome/free-solid-svg-icons'
+
+/**
+ * Renders a detailed line-by-line diff between old/new values of a change record.
+ */
+export const renderDiff = (changeRecord: DataChangeRecord) => {
+  const diffs: ObjectDiff[] = []
+
+  try {
+    const newObject: {
+      [index: string]: object
+    } = !isEmpty(changeRecord.newValue) ? JSON.parse(changeRecord.newValue) : {}
+    const oldObject: {
+      [index: string]: object
+    } = !isEmpty(changeRecord.oldValue) ? JSON.parse(changeRecord.oldValue) : {}
+
+    if ((newObject && typeof newObject === 'object') && (oldObject && typeof oldObject === 'object')) {
+      diffs.push(...findDifferencesBetweenObjects(oldObject, newObject))
+    } else {
+      diffs.push({
+        fieldName: changeRecord.fieldName || changeRecord.modelName,
+        oldValue: changeRecord.oldValue,
+        newValue: changeRecord.newValue
+      })
+    }
+  } catch (e: unknown) {
+    diffs.push({
+      fieldName: changeRecord.fieldName || changeRecord.modelName,
+      oldValue: changeRecord.oldValue,
+      newValue: changeRecord.newValue
+    })
+  }
+
+  return (
+    <div>
+      {
+        diffs.map((diff, idx) => (
+          <div key={idx}>
+            {diff.fieldName}: {diff.oldValue} <FontAwesomeIcon icon={faArrowRight}/> {diff.newValue}
+          </div>
+        ))
+      }
+    </div>
+  )
+}


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Allows associating data change records with a family, and creates a view into changes related to the family.

Because these changes rely on the raw enrollee id, I created new columns `Enrollee` and `Target Enrollee` and hydrate them either with the members on the family or by fetching from the backend. This way it's easier to see who the change is related to.

That being said - it's not the greatest or most intuitive UI in the world. If you're not familiar with the internals of juniper, enrollee vs target enrollee might be confusing. But it feels like a poweruser thing that you would know what you're looking for when you go to this view, so I'm not sure it's worth spending lots of time refining it. IMO to make it better would require that the table was intelligent enough to have different views for each model (e.g., it shows a custom row for family enrollee creation, or deletion, or enrollee relation creation, etc.) which would be a very non-trivial amount of work.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Go to `https://localhost:3000/demo/studies/heartdemo/env/sandbox/families/F_SALKFM`
- Do a bunch of operations on the family - change proband, add member, remove member, add relation, remove relation, etc.
- Verify that they show up in the audit table with the relevant enrollees attached