### PR TITLE
[JN-1182] fixing annotations to enable constructing

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/publishing/StudyEnvironmentChange.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/publishing/StudyEnvironmentChange.java
@@ -4,7 +4,9 @@ import bio.terra.pearl.core.model.notification.EmailTemplate;
 import bio.terra.pearl.core.model.notification.Trigger;
 import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
 import bio.terra.pearl.core.model.survey.Survey;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
@@ -12,7 +14,7 @@ import java.util.List;
 
 @Getter
 @Setter
-@SuperBuilder
+@Builder
 public class StudyEnvironmentChange {
     String studyShortcode;
     List<ConfigChange> configChanges;

--- a/core/src/main/java/bio/terra/pearl/core/model/publishing/StudyEnvironmentChange.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/publishing/StudyEnvironmentChange.java
@@ -6,9 +6,7 @@ import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
 import bio.terra.pearl.core.model.survey.Survey;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

SuperBuilder doesn't yield a default constructor in the same way that Builder does, so serialization broke

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  go to https://localhost:3000/demo/studies/heartdemo/publishing
2. attempt to publish some changes from sandbox -> irb
3. confirm it works