### PR TITLE
[JN-1119] adding support for i18n validations in ActivityImport

### DIFF
--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
@@ -161,12 +161,13 @@ public class ActivityImporter {
                     .name(pepperQuestionDef.getStableId())
                     .type(questionType)
                     .title(titleMap)
-                    .required(false)
+                    .isRequired(false)
                     //.isRequired() //revisit
                     .inputType(inputType)
                     .choices(choices)
                     .visibleIf(blockDef.getShownExpr())
                     .build();
+            ValidationConverter.applyValidation(pepperQuestionDef, surveyJSQuestion);
 
             JsonNode questionNode = objectMapper.valueToTree(surveyJSQuestion);
             questionNodes.add(questionNode);
@@ -220,7 +221,7 @@ public class ActivityImporter {
      * so we need to replace the variable name with the translation text in the appropriate language,
      * but preserve the markup
      */
-    private Map<String, String> getVariableTranslationsTxt(String templateText, Collection<TemplateVariable> templateVariables) {
+    public static Map<String, String> getVariableTranslationsTxt(String templateText, Collection<TemplateVariable> templateVariables) {
         Map<String, String> textMap = new HashMap<>();
         // for each variable, get the translations and replace the variable name with the translation text in the appropriate language
         for (TemplateVariable var : templateVariables) {

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ValidationConverter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ValidationConverter.java
@@ -1,0 +1,41 @@
+package bio.terra.pearl.pepper;
+
+import bio.terra.pearl.pepper.dto.SurveyJSQuestion;
+import bio.terra.pearl.pepper.dto.SurveyJsValidator;
+import org.broadinstitute.ddp.model.activity.definition.question.QuestionDef;
+import org.broadinstitute.ddp.model.activity.definition.validation.IntRangeRuleDef;
+import org.broadinstitute.ddp.model.activity.definition.validation.RuleDef;
+import org.broadinstitute.ddp.model.activity.types.RuleType;
+
+public class ValidationConverter {
+    public static SurveyJsValidator convert(RuleDef ruleDef) {
+        RuleType ruleType = ruleDef.getRuleType();
+        if (ruleType.equals(RuleType.INT_RANGE)) {
+            IntRangeRuleDef intRangeDef = (IntRangeRuleDef) ruleDef;
+            return SurveyJsValidator.builder()
+                    .type("numeric")
+                    .minValue(intRangeDef.getMin())
+                    .maxValue(intRangeDef.getMax())
+                    .text(ActivityImporter.getVariableTranslationsTxt(ruleDef.getHintTemplate().getTemplateText(),
+                            ruleDef.getHintTemplate().getVariables()))
+                    .build();
+        }
+        return null;
+    }
+
+    public static void applyValidation(QuestionDef questionDef, SurveyJSQuestion targetQuestion) {
+        for (RuleDef ruleDef : questionDef.getValidations()) {
+            SurveyJsValidator validator = convert(ruleDef);
+            if (validator != null) {
+                targetQuestion.getValidators().add(ValidationConverter.convert(ruleDef));
+            }
+            if (ruleDef.getRuleType().equals(RuleType.REQUIRED)) {
+                targetQuestion.setRequired(true);
+                targetQuestion.setRequiredText(
+                        ActivityImporter.getVariableTranslationsTxt(ruleDef.getHintTemplate().getTemplateText(),
+                                ruleDef.getHintTemplate().getVariables())
+                );
+            }
+        }
+    }
+}

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ValidationConverter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ValidationConverter.java
@@ -31,7 +31,7 @@ public class ValidationConverter {
             }
             if (ruleDef.getRuleType().equals(RuleType.REQUIRED)) {
                 targetQuestion.setRequired(true);
-                targetQuestion.setRequiredText(
+                targetQuestion.setRequiredErrorText(
                         ActivityImporter.getVariableTranslationsTxt(ruleDef.getHintTemplate().getTemplateText(),
                                 ruleDef.getHintTemplate().getVariables())
                 );

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJSQuestion.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJSQuestion.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -17,10 +18,12 @@ public class SurveyJSQuestion {
     public String type;
     public String inputType;
     public Map<String, String> title;
-    public boolean required;
-    //public boolean isRequired;
+    public boolean isRequired;
+    public Map<String, String> requiredText;
     public List<Choice> choices;
     public String visibleIf;
+    @Builder.Default
+    public List<SurveyJsValidator> validators = new ArrayList<>();
 
     @AllArgsConstructor
     @Data

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJSQuestion.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJSQuestion.java
@@ -19,7 +19,7 @@ public class SurveyJSQuestion {
     public String inputType;
     public Map<String, String> title;
     public boolean isRequired;
-    public Map<String, String> requiredText;
+    public Map<String, String> requiredErrorText;
     public List<Choice> choices;
     public String visibleIf;
     @Builder.Default

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJsValidator.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJsValidator.java
@@ -1,0 +1,20 @@
+package bio.terra.pearl.pepper.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@Setter
+@Builder
+public class SurveyJsValidator {
+    String type;
+    @Builder.Default
+    Map<String, String> text = new HashMap<>();
+    String regex;
+    Long minValue;
+    Long maxValue;
+}

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/basic.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/basic.json
@@ -198,7 +198,7 @@
               {
                 "type": "regex",
                 "text": "Enter a number between 1 and 300.",
-                "regex": "^([1-9][0-9]?|[1-2]\\d\\d|300)$"
+                  "regex": "^([1-9][0-9]?|[1-2]\\d\\d|300)$"
               }
             ],
             "inputType": "number"

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -13,6 +13,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { IconProp } from '@fortawesome/fontawesome-svg-core'
 import { faLightbulb, faUsersViewfinder } from '@fortawesome/free-solid-svg-icons'
 import { FormOptions } from './FormOptionsModal'
+import { useUser } from '../../user/UserProvider'
 
 const QUESTIONNAIRE_TEMPLATE = '{"pages":[]}'
 const randomSuffix = Math.random().toString(36).substring(2, 15)
@@ -22,7 +23,7 @@ const HTML_TEMPLATE = `{"pages":[{"elements":[{"type":"html","name":"outreach_co
 const CreateSurveyModal = ({ studyEnvContext, onDismiss, type }:
                                {studyEnvContext: StudyEnvContextT, onDismiss: () => void, type: SurveyType}) => {
   const [isLoading, setIsLoading] = useState(false)
-
+  const { user } = useUser()
   const portalContext = useContext(PortalContext) as PortalContextT
   const navigate = useNavigate()
   // Screeners and research surveys default to an empty form, but marketing
@@ -134,6 +135,23 @@ const CreateSurveyModal = ({ studyEnvContext, onDismiss, type }:
                 setForm({ ...form, blurb: event.target.value })}/>
           </div>
         </>}
+        { user?.superuser && <div>
+          Import JSON
+          <input type="text" onChange={e => {
+            const importForm: Survey & { jsonContent: string}  = JSON.parse(e.target.value)
+            setForm({
+              ...defaultSurvey,
+              surveyType: type,
+              id: '',
+              createdAt: Date.now(),
+              lastUpdatedAt: Date.now(),
+              stableId: importForm.stableId,
+              version: importForm.version ?? 1,
+              name: importForm.name,
+              content: JSON.stringify(importForm.jsonContent)
+            })
+          }}/>
+        </div>}
       </form>
     </Modal.Body>
     <Modal.Footer>


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

This adds some support for importing validation and required texts from Pepper.  We're assuming the logic will have to be hand-checked, but importing the translation text is a huge timesaver.

<img width="709" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/b3b2d724-c975-47f8-8eb3-dfc502d54c9f">

This also adds a superuser-only survey model import feature to the survey creation modal
<img width="595" alt="image" src="https://github.com/broadinstitute/juniper/assets/2800795/ba37bfdb-c68c-43c5-a357-571bd23ad916">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1. Run 'PepperImportCliApp'
2. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/forms
3. click "add" under Research Surveys
4. in the "Import JSON" text box, paste the contents of the `pepper-import/out/medical-history.conf` file that was generated from your run above
5. click create (you may have to wait a while -- the survey is biiiig)
6. go to form preview
7. uncheck the "ignore validations" checkbox
8. go through the survey, observe the first question is required, and the required error text is internationalized
