### PR TITLE
[JN-1173] change study ineligible text

### DIFF
--- a/populate/src/main/resources/seed/i18n/dev/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/dev/languageTexts.json
@@ -85,5 +85,16 @@
   {"keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle", "text": "DEV_This user is already enrolled in ${studyName}.", "language": "dev"},
   {"keyName": "cookieAlertTitle", "text": "DEV_Cookies", "language": "dev"},
   {"keyName": "cookieAlertDetail", "text": "DEV_This site uses internet tokens called &quot;cookies&quot; to enable the proper functioning and security of our website, and to improve your experience while you use it. All of the cookies we use are strictly necessary cookies. This type of cookie does not collect any personally identifiable information about you and does not track your browsing habits. To learn more, [read our Privacy Policy](/privacy).", "language": "dev"},
-  {"keyName": "joinStudy", "text": "DEV_Join Study", "language": "dev"}
+  {"keyName": "joinStudy", "text": "DEV_Join Study", "language": "dev"},
+  {"keyName": "ineligibleThankYou", "text": "DEV_Thank you for your interest in ${studyName}", "language": "dev" },
+  {"keyName": "ineligibleDescription", "text": "DEV_Unfortunately, you do not meet the eligibility criteria to participate in ${studyName} at this time.", "language": "dev"},
+  {"keyName": "ineligibleProvideYourEmail", "text": "DEV_Provide your email below and we’ll keep you up-to-date on developments. You can unsubscribe at any time.", "language": "dev"},
+  {"keyName": "ineligibleStayInformed", "text": "DEV_Stay informed", "language": "dev"},
+  {"keyName": "backToPortalHomepage", "text": "DEV_Back to ${portalName} homepage", "language": "dev"},
+  {"keyName": "joinMailingList", "text": "DEV_Join Mailing List", "language": "dev"},
+  {"keyName": "mailingFormStayUpdated", "text":  "DEV_Stay updated with news about the study", "language": "dev"},
+  {"keyName": "yourName", "text": "DEV_Your name", "language": "dev"},
+  {"keyName": "yourEmail", "text": "DEV_Your email", "language": "dev"},
+  {"keyName": "join", "text":  "DEV_Join", "language": "dev"},
+  {"keyName": "thanksForJoining", "text": "DEV_Thanks for joining!", "language": "dev"}
 ]

--- a/populate/src/main/resources/seed/i18n/en/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/en/languageTexts.json
@@ -85,5 +85,16 @@
   {"keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle", "text": "This user is already enrolled in ${studyName}.", "language": "en"},
   {"keyName": "cookieAlertTitle", "text": "Cookies", "language": "en"},
   {"keyName": "cookieAlertDetail", "text": "This site uses internet tokens called &quot;cookies&quot; to enable the proper functioning and security of our website, and to improve your experience while you use it. All of the cookies we use are strictly necessary cookies. This type of cookie does not collect any personally identifiable information about you and does not track your browsing habits. To learn more, [read our Privacy Policy](/privacy).", "language": "en"},
-  {"keyName": "joinStudy", "text": "Join Study", "language": "en"}
+  {"keyName": "joinStudy", "text": "Join Study", "language": "en"},
+  {"keyName": "ineligibleThankYou", "text": "Thank you for your interest in ${studyName}", "language": "en" },
+  {"keyName": "ineligibleDescription", "text": "Unfortunately, you do not meet the eligibility criteria to participate in ${studyName} at this time.", "language": "en"},
+  {"keyName": "ineligibleProvideYourEmail", "text": "Provide your email below and we’ll keep you up-to-date on developments. You can unsubscribe at any time.", "language":  "en"},
+  {"keyName": "ineligibleStayInformed", "text": "Stay informed", "language": "en"},
+  {"keyName": "backToPortalHomepage", "text": "Back to ${portalName} homepage", "language": "en"},
+  {"keyName": "joinMailingList", "text": "Join Mailing List", "language": "en"},
+  {"keyName": "mailingFormStayUpdated", "text":  "Stay updated with news about the study", "language": "en"},
+  {"keyName": "yourName", "text": "Your name", "language": "en"},
+  {"keyName": "yourEmail", "text": "Your email", "language": "en"},
+  {"keyName": "join", "text":  "Join", "language": "en"},
+  {"keyName": "thanksForJoining", "text": "Thanks for joining!", "language": "en"}
 ]

--- a/populate/src/main/resources/seed/i18n/es/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/es/languageTexts.json
@@ -85,5 +85,17 @@
   {"keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle", "text": "Este usuario ya está inscrito en ${studyName}.", "language": "es"},
   {"keyName": "cookieAlertTitle", "text": "Galletas", "language": "es"},
   {"keyName": "cookieAlertDetail", "text": "Este sitio utiliza tokens de Internet llamados &quot;cookies&quot; para permitir el correcto funcionamiento y seguridad de nuestro sitio web, y para mejorar su experiencia mientras lo utiliza. Todas las cookies que utilizamos son cookies estrictamente necesarias. Este tipo de cookie no recopila ninguna información de identificación personal sobre usted y no rastrea sus hábitos de navegación. Para obtener más información, [lea nuestra Política de privacidad](/privacy).", "language": "es"},
-  {"keyName": "joinStudy", "text": "Unirse al Estudio", "language": "es"}
+  {"keyName": "joinStudy", "text": "Unirse al Estudio", "language": "es"},
+  {"keyName": "ineligibleThankYou", "text": "Gracias por su interés en ${studyName}", "language": "es"},
+  {"keyName": "ineligibleDescription", "text": "Desafortunadamente, no cumple con los criterios de elegibilidad para participar en ${studyName} en este momento.", "language": "es"},
+  {"keyName": "ineligibleProvideYourEmail", "text": "Proporcione su correo electrónico a continuación y lo mantendremos actualizado sobre los desarrollos. Puede darse de baja en cualquier momento.", "language": "es"},
+  {"keyName": "ineligibleStayInformed", "text": "Mantente informado", "language": "es"},
+  {"keyName": "backToPortalHomepage", "text": "Volver a la página principal de ${portalName}", "language": "es"},
+  {"keyName": "joinMailingList", "text": "Unirse a la Lista de Correos", "language": "es"},
+  {"keyName": "mailingFormStayUpdated", "text": "Manténgase actualizado con las noticias sobre el estudio", "language": "es"},
+  {"keyName": "yourName", "text": "Tu nombre", "language": "es"},
+  {"keyName": "yourEmail", "text": "Tu correo electrónico", "language": "es"},
+  {"keyName": "join", "text": "Unirse", "language": "es"},
+  {"keyName": "thanksForJoining", "text": "¡Gracias por unirse!", "language": "es"}
+
 ]

--- a/ui-admin/src/portal/MailingListView.test.tsx
+++ b/ui-admin/src/portal/MailingListView.test.tsx
@@ -1,11 +1,18 @@
 import React from 'react'
-import { render, screen, waitFor } from '@testing-library/react'
+import {
+  render,
+  screen,
+  waitFor
+} from '@testing-library/react'
 
 import Api, { MailingListContact } from 'api/api'
 import { mockPortalContext } from 'test-utils/mocking-utils'
 import userEvent from '@testing-library/user-event'
 import MailingListView from './MailingListView'
-import { setupRouterTest } from '@juniper/ui-core'
+import {
+  MockI18nProvider,
+  setupRouterTest
+} from '@juniper/ui-core'
 
 const contacts: MailingListContact[] = [{
   id: 'id1',
@@ -26,7 +33,10 @@ test('renders a mailing list', async () => {
   const portalContext = mockPortalContext()
   const portalEnv = portalContext.portal.portalEnvironments[0]
   const { RoutedComponent } =
-        setupRouterTest(<MailingListView portalContext={portalContext} portalEnv={portalEnv}/>)
+    setupRouterTest(<MockI18nProvider>
+      <MailingListView portalContext={portalContext}
+        portalEnv={portalEnv}/>
+    </MockI18nProvider>)
   render(RoutedComponent)
   await waitFor(() => {
     expect(screen.getByText('person1')).toBeInTheDocument()
@@ -40,7 +50,9 @@ test('renders a download mailing list button', async () => {
   const portalContext = mockPortalContext()
   const portalEnv = portalContext.portal.portalEnvironments[0]
   const { RoutedComponent } =
-        setupRouterTest(<MailingListView portalContext={portalContext} portalEnv={portalEnv}/>)
+    setupRouterTest(<MockI18nProvider>
+      <MailingListView portalContext={portalContext} portalEnv={portalEnv}/>
+    </MockI18nProvider>)
   render(RoutedComponent)
   await waitFor(() => {
     expect(screen.getByText('person1')).toBeInTheDocument()
@@ -59,7 +71,9 @@ test('delete button shows confirmation', async () => {
   const portalContext = mockPortalContext()
   const portalEnv = portalContext.portal.portalEnvironments[0]
   const { RoutedComponent } =
-      setupRouterTest(<MailingListView portalContext={portalContext} portalEnv={portalEnv}/>)
+    setupRouterTest(<MockI18nProvider>
+      <MailingListView portalContext={portalContext} portalEnv={portalEnv}/>
+    </MockI18nProvider>)
   render(RoutedComponent)
   await waitFor(() => {
     expect(screen.getByText('person1')).toBeInTheDocument()
@@ -78,7 +92,9 @@ test('sorts by join date by default', async () => {
   const portalContext = mockPortalContext()
   const portalEnv = portalContext.portal.portalEnvironments[0]
   const { RoutedComponent } =
-      setupRouterTest(<MailingListView portalContext={portalContext} portalEnv={portalEnv}/>)
+    setupRouterTest(<MockI18nProvider>
+      <MailingListView portalContext={portalContext} portalEnv={portalEnv}/>
+    </MockI18nProvider>)
   render(RoutedComponent)
   await waitFor(() => {
     expect(screen.getByText('person1')).toBeInTheDocument()

--- a/ui-core/src/participant/landing/MailingListForm.tsx
+++ b/ui-core/src/participant/landing/MailingListForm.tsx
@@ -7,11 +7,13 @@ import { useApiContext } from '../../participant/ApiProvider'
 
 type MailingListFormProps = {
   onJoin?: () => void
+  title?: React.ReactNode
+  body?: React.ReactNode
 }
 
 /** shows a form for entering name and email to join the portal mailing list */
 export function MailingListForm(props: MailingListFormProps) {
-  const { onJoin } = props
+  const { onJoin, body, title } = props
 
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
@@ -36,8 +38,8 @@ export function MailingListForm(props: MailingListFormProps) {
       color: 'var(--brand-color)',
       backgroundColor: 'var(--brand-color-shift-90)'
     }}/>
-    <h2 className="h4">Join Mailing List</h2>
-    <p>Stay updated with news about the study</p>
+    <h2 className="h4">{title ? title : 'Join Mailing List'}</h2>
+    {body ? body : <p>Stay updated with news about the study</p>}
     {!joined && <form onSubmit={submit} style={{ maxWidth: 300 }}>
       <input className="form-control my-3" size={30} style={inputStyle} type="text" placeholder="Your name"
         value={name} onChange={e => setName(e.target.value)}/>

--- a/ui-core/src/participant/landing/MailingListForm.tsx
+++ b/ui-core/src/participant/landing/MailingListForm.tsx
@@ -3,7 +3,8 @@ import React, { useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEnvelope } from '@fortawesome/free-regular-svg-icons'
 import { faCheck } from '@fortawesome/free-solid-svg-icons'
-import { useApiContext } from '../../participant/ApiProvider'
+import { useApiContext } from '../ApiProvider'
+import { useI18n } from '../I18nProvider'
 
 type MailingListFormProps = {
   onJoin?: () => void
@@ -15,6 +16,7 @@ type MailingListFormProps = {
 export function MailingListForm(props: MailingListFormProps) {
   const { onJoin, body, title } = props
 
+  const { i18n } = useI18n()
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
   const [joined, setJoined] = useState(false)
@@ -38,14 +40,14 @@ export function MailingListForm(props: MailingListFormProps) {
       color: 'var(--brand-color)',
       backgroundColor: 'var(--brand-color-shift-90)'
     }}/>
-    <h2 className="h4">{title ? title : 'Join Mailing List'}</h2>
-    {body ? body : <p>Stay updated with news about the study</p>}
+    <h2 className="h4">{title ? title : i18n('joinMailingList')}</h2>
+    {body ? body : <p>{i18n('mailingFormStayUpdated')}</p>}
     {!joined && <form onSubmit={submit} style={{ maxWidth: 300 }}>
-      <input className="form-control my-3" size={30} style={inputStyle} type="text" placeholder="Your name"
+      <input className="form-control my-3" size={30} style={inputStyle} type="text" placeholder={i18n('yourName')}
         value={name} onChange={e => setName(e.target.value)}/>
-      <input className="form-control my-3" size={30} style={inputStyle} type="email" placeholder="Your email"
+      <input className="form-control my-3" size={30} style={inputStyle} type="email" placeholder={i18n('yourEmail')}
         value={email} onChange={e => setEmail(e.target.value)}/>
-      <button className="form-control btn-primary btn" disabled={!inputValid}>Join</button>
+      <button className="form-control btn-primary btn" disabled={!inputValid}>{i18n('join')}</button>
     </form>}
     {joined && <div className="text-center mt-2">
       <FontAwesomeIcon className="fa-lg p-2 rounded-circle" icon={faCheck} style={{
@@ -53,7 +55,7 @@ export function MailingListForm(props: MailingListFormProps) {
         backgroundColor: 'var(--brand-color-shift-90)'
       }}/>
       <p>
-        Thanks for joining!<br/>
+        {i18n('thanksForJoining')}<br/>
       </p>
 
     </div>}

--- a/ui-participant/src/Navbar.test.tsx
+++ b/ui-participant/src/Navbar.test.tsx
@@ -1,4 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import {
+  render,
+  screen
+} from '@testing-library/react'
 import React from 'react'
 
 import {
@@ -6,15 +9,28 @@ import {
   NavbarItemExternal,
   NavbarItemInternal,
   NavbarItemInternalAnchor,
-  NavbarItemMailingList, PortalStudy
+  NavbarItemMailingList,
+  PortalStudy
 } from 'api/api'
 
-import Navbar, { AccountOptionsDropdown, CustomNavLink, getMainJoinLink, LanguageDropdown } from './Navbar'
-import { asMockedFn, MockI18nProvider, setupRouterTest } from '@juniper/ui-core'
+import Navbar, {
+  AccountOptionsDropdown,
+  CustomNavLink,
+  getMainJoinLink,
+  LanguageDropdown
+} from './Navbar'
+import {
+  asMockedFn,
+  MockI18nProvider,
+  setupRouterTest
+} from '@juniper/ui-core'
 import { UserManager } from 'oidc-client-ts'
 import { useUser } from './providers/UserProvider'
 import { usePortalEnv } from './providers/PortalProvider'
-import { mockPortalEnvironmentConfig, mockUsePortalEnv } from './test-utils/test-portal-factory'
+import {
+  mockPortalEnvironmentConfig,
+  mockUsePortalEnv
+} from './test-utils/test-portal-factory'
 import { mockUseUser } from './test-utils/user-mocking-utils'
 
 jest.mock('oidc-client-ts')
@@ -97,7 +113,7 @@ describe('CustomNavLink', () => {
     }
 
     // Act
-    render(<CustomNavLink navLink={navbarItem} />)
+    render(<MockI18nProvider><CustomNavLink navLink={navbarItem}/></MockI18nProvider>)
 
     // Assert
     const link = screen.getByText('Mailing list link')

--- a/ui-participant/src/studies/enroll/StudyIneligible.tsx
+++ b/ui-participant/src/studies/enroll/StudyIneligible.tsx
@@ -2,7 +2,10 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 
 import { Portal } from 'api/api'
-import { MailingListForm } from '@juniper/ui-core'
+import {
+  MailingListForm,
+  useI18n
+} from '@juniper/ui-core'
 
 type StudyIneligibleProps = {
   portal: Portal
@@ -12,24 +15,28 @@ type StudyIneligibleProps = {
 /** Shows a page indicating the person is ineligible to register for the portal */
 export default function StudyIneligible(props: StudyIneligibleProps) {
   const { portal, studyName } = props
+
+  const { i18n } = useI18n()
   return (
     <div className="flex-grow-1" style={{ background: '#f2f2f2' }}>
       <div className="container col-md-6 mt-5">
-        <h1 className="h3 mb-3">Thank you for your interest in {studyName}</h1>
+        <h1 className="h3 mb-3">{i18n('ineligibleThankYou', { substitutions: { studyName } })}</h1>
         <p>
-          Unfortunately, you do not meet the eligibility criteria to participate in {studyName} at this time.
+          {i18n('ineligibleDescription', { substitutions: { studyName } })}
         </p>
         <div className="card mt-4">
           <div className="card-body py-5">
             <MailingListForm
-              title='Stay informed'
+              title={i18n('ineligibleStayInformed')}
               body={<p>
-                Provide your email below and we’ll keep you up-to-date on developments. You can unsubscribe at any time.
+                {i18n('ineligibleProvideYourEmail')}
               </p>}/>
           </div>
         </div>
         <p className="text-center mt-3">
-          <Link to="/">Back to {portal.name} homepage</Link>
+          <Link to="/">
+            {i18n('backToPortalHomepage', { substitutions: { portalName: portal.name } })}
+          </Link>
         </p>
       </div>
     </div>

--- a/ui-participant/src/studies/enroll/StudyIneligible.tsx
+++ b/ui-participant/src/studies/enroll/StudyIneligible.tsx
@@ -15,17 +15,17 @@ export default function StudyIneligible(props: StudyIneligibleProps) {
   return (
     <div className="flex-grow-1" style={{ background: '#f2f2f2' }}>
       <div className="container col-md-6 mt-5">
-        <h1 className="h3 mb-3">Sorry, you are not eligible to enroll right now</h1>
+        <h1 className="h3 mb-3">Thank you for your interest in {studyName}</h1>
         <p>
-          The {studyName} study can only accept participants who meet all of the conditions.
-        </p>
-        <p>
-          Over time, we may be able to expand the participation requirements of this project.
-          If you join our mailing list below, we can contact you with updates.
+          Unfortunately, you do not meet the eligibility criteria to participate in {studyName} at this time.
         </p>
         <div className="card mt-4">
           <div className="card-body py-5">
-            <MailingListForm/>
+            <MailingListForm
+              title='Stay informed'
+              body={<p>
+                Provide your email below and we’ll keep you up-to-date on developments. You can unsubscribe at any time.
+              </p>}/>
           </div>
         </div>
         <p className="text-center mt-3">


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

<img width="1919" alt="Screenshot 2024-07-10 at 11 00 39 AM" src="https://github.com/broadinstitute/juniper/assets/17440010/106673be-dfaa-48c2-82a1-616ad9620d76">
<img width="375" alt="image" src="https://github.com/broadinstitute/juniper/assets/17440010/57161b3c-cfe2-42eb-a1be-7e5a1efeda2a">

mailing list form doesn't change in other places:
<img width="1919" alt="Screenshot 2024-07-10 at 11 00 55 AM" src="https://github.com/broadinstitute/juniper/assets/17440010/a4b2e63e-e3d8-4898-bf18-a7079c9c0899">

now, with i18n!

<img width="1511" alt="Screenshot 2024-07-11 at 11 13 54 AM" src="https://github.com/broadinstitute/juniper/assets/17440010/38b7afb4-fef4-445c-8682-f2a0d5fc5ad2">
<img width="1511" alt="image" src="https://github.com/broadinstitute/juniper/assets/17440010/5d05c22f-a483-4cc9-97d0-201887d4a5be">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Go to any demo or ourhealth pre-enroll and get into an unqualified state
- Ensure that the text matches the text in the ticket
- Change to spanish, go back to unqualified and ensure correct text
- Ensure mailing list hasn't changed
- Ensure mailing list looks good in spanish, too