### PR TITLE
[JN-1196] deleting language texts as part of survey deletion

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
@@ -532,12 +532,15 @@ public abstract class BaseJdbiDao<T extends BaseEntity> {
         );
     }
 
-    protected void deleteByParentUuid(String parentColumnName, UUID parentUUID, BaseJdbiDao parentDao) {
+    protected void deleteByTwoProperties(String columnName, Object columnValue, String column2Name, Object column2Value) {
         jdbi.withHandle(handle ->
-                handle.createUpdate("delete from " + tableName + " using  " + parentDao.tableName
-                        + " where " + tableName + ".id = " + parentDao.tableName + "." + parentColumnName
-                        + " and " + parentColumnName + " = :parentUUID;")
-                        .bind("parentUUID", parentUUID)
+                handle.createUpdate("""
+                            delete from %s 
+                            where %s = :propertyValue 
+                            AND %s = :property2value;
+                            """.formatted(tableName, columnName, column2Name))
+                        .bind("propertyValue", columnValue)
+                        .bind("property2value", column2Value)
                         .execute()
         );
     }

--- a/core/src/main/java/bio/terra/pearl/core/dao/i18n/LanguageTextDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/i18n/LanguageTextDao.java
@@ -25,6 +25,10 @@ public class LanguageTextDao extends BaseMutableJdbiDao<LanguageText> {
         return findByTwoProperties("key_name", keyName, "language", language);
     }
 
+    public void deleteByKeyNameAndPortal(String keyName, UUID portalId) {
+        deleteByTwoProperties("key_name", keyName, "portal_id", portalId);
+    }
+
     //returns all language texts that are either global or portal specific
     public List<LanguageText> findByPortalIdOrNullPortalId(UUID portalId, String language) {
         return jdbi.withHandle(

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyParseUtils.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyParseUtils.java
@@ -221,6 +221,15 @@ public class SurveyParseUtils {
         return questionStableIdNode != null ? questionStableIdNode.asText() : null;
     }
 
+    /** extracts LanguageTexts suitable for rendering the survey title in the participant UI from the survey content */
+    public static List<LanguageText> extractLanguageTexts(Survey survey) {
+        Map<String, String> parsedTitles = SurveyParseUtils.parseSurveyTitle(survey.getContent(), survey.getName());
+        return SurveyParseUtils.titlesToLanguageTexts(
+                SurveyParseUtils.formToLanguageTextKey(survey.getStableId(),survey.getVersion()),
+                survey.getPortalId(),
+                parsedTitles);
+    }
+
     //Returns a Map of languageCode -> title for the survey
     public static Map<String, String> parseSurveyTitle(String formContent, String formName) {
         if(formContent == null) {
@@ -277,16 +286,14 @@ public class SurveyParseUtils {
     }
 
     public static List<LanguageText> titlesToLanguageTexts(String keyName, UUID portalId, Map<String, String> titles) {
-        List<LanguageText> texts = new ArrayList<>();
-        for (Map.Entry<String, String> entry : titles.entrySet()) {
+        return titles.entrySet().stream().map(entry -> {
             LanguageText text = new LanguageText();
             text.setKeyName(keyName);
             text.setLanguage(entry.getKey());
             text.setText(entry.getValue());
             text.setPortalId(portalId);
-            texts.add(text);
-        }
-        return texts;
+            return text;
+        }).toList();
     }
 
     public static String formToLanguageTextKey(String stableId, Integer version) {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

We weren't cleaning up language texts created for the survey title as part of survey deletion.  this fixes that

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  redeploy ApiAdminApp
2. create a survey
3. delete the survey 
4. create another survey with the same stableId
5. confirm you can without errors