### PR TITLE
[JN-1095] Fix admin task migration

### DIFF
--- a/core/src/main/resources/db/changelog/changesets/2024_06_19_admin_tasks_to_participant_tasks.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_06_19_admin_tasks_to_participant_tasks.yaml
@@ -22,4 +22,4 @@ databaseChangeLog:
               FROM admin_task at
               JOIN participant_note pn ON at.participant_note_id = pn.id
               JOIN enrollee e ON pn.enrollee_id = e.id
-              JOIN portal_participant_user ppu ON e.participant_user_id = ppu.participant_user_id;
+              JOIN portal_participant_user ppu ON e.profile_id = ppu.profile_id;


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Fixes an incorrect join condition in the original admin_task migration

Generally you don't want to change liquibase migrations _after_ they've already been run, but since this is just the demo database, I'm proposing:

1. Deleting the migration record for this changeset: `delete from databasechangelog where id='admin_tasks_to_participant_tasks';`
2. Deleting the product of the original migration `delete from participant_task where task_type='ADMIN_NOTE';`
3. Redeploying this and letting the revised migration run

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Checkout code prior to migration `git checkout 129d412caa9ebf563ff1460f1a2d234b45f6fd03`
* Restart AdminApi
* Populate demo and ourhealth: `./scripts/populate_portal.sh demo ourhealth`
* Confirm in the database that you see 5 admin tasks: `select * from admin_task;`
* Checkout `development` with the broken migration
* Restart AdminApi
* Confirm in the database that you see 10 participant tasks for ADMIN_NOTE (there should have only been 5): `select * from participant_task where task_type='ADMIN_NOTE';`
* Run the steps described above to purge the liquibase migration
* Checkout this branch 
* Restart AdminApi
* Confirm that you only see 5 ADMIN_NOTE tasks, as expected: `select * from participant_task where task_type='ADMIN_NOTE';`
