### PR TITLE
[JN-1119] support composite questions + get translated title

### DIFF
--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
@@ -17,10 +17,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.content.I18nContentRenderer;
 import org.broadinstitute.ddp.model.activity.definition.*;
 import org.broadinstitute.ddp.model.activity.definition.i18n.Translation;
-import org.broadinstitute.ddp.model.activity.definition.question.PicklistOptionDef;
-import org.broadinstitute.ddp.model.activity.definition.question.PicklistQuestionDef;
-import org.broadinstitute.ddp.model.activity.definition.question.QuestionDef;
-import org.broadinstitute.ddp.model.activity.definition.question.TextQuestionDef;
+import org.broadinstitute.ddp.model.activity.definition.question.*;
 import org.broadinstitute.ddp.model.activity.definition.template.TemplateVariable;
 import org.broadinstitute.ddp.model.activity.types.BlockType;
 import org.broadinstitute.ddp.model.activity.types.PicklistRenderMode;
@@ -82,7 +79,7 @@ public class ActivityImporter {
         SurveyPopDto survey = SurveyPopDto.builder()
                 .stableId(activityDef.getActivityCode())
                 .version(1)
-                .name(activityDef.getTag())
+                .name(activityDef.getTag()) // TODO: grab from "translatedNames"
                 .build();
 
         ObjectNode root = objectMapper.createObjectNode();
@@ -135,44 +132,93 @@ public class ActivityImporter {
     private List<JsonNode> convertBlockQuestions(Map<String, Map<String, Object>> allLangMap, FormBlockDef blockDef) {
         List<JsonNode> questionNodes = new ArrayList<>();
         for (QuestionDef pepperQuestionDef : blockDef.getQuestions().toList()) {
-            Map<String, String> titleMap = getQuestionTxt(pepperQuestionDef);
-            String questionType = getQuestionType(pepperQuestionDef);
-            String inputType = null;
-            if (pepperQuestionDef.getQuestionType().name().equalsIgnoreCase("DATE")) {
-                inputType = "DATE";
-            }
-            if (pepperQuestionDef.getQuestionType().name().equalsIgnoreCase("NUMERIC")) {
-                inputType = "NUMBER";
-            }
-            //todo handle COMPOSITE questions
-            List<SurveyJSQuestion.Choice> choices = null;
-            if (pepperQuestionDef.getQuestionType().name().equalsIgnoreCase("PICKLIST")) {
-                choices = getPicklistChoices((PicklistQuestionDef) pepperQuestionDef, allLangMap);
-            }
 
-            //expression  revisit and try this
-            //parse the pepper expression for stableID and value/option and generate Juniper expression
-            //EX: user.studies[\"atcp\"].forms[\"REGISTRATION\"].questions[\"REGISTRATION_COUNTRY\"].answers.hasOption (\"AF\")
-            //parse value after questions[] and hasOption and generate
-            //"visibleIf": "{REGISTRATION_COUNTRY} contains 'AF'"
-            //works only for picklist/choices though
-
-            SurveyJSQuestion surveyJSQuestion = SurveyJSQuestion.builder()
-                    .name(pepperQuestionDef.getStableId())
-                    .type(questionType)
-                    .title(titleMap)
-                    .isRequired(false)
-                    //.isRequired() //revisit
-                    .inputType(inputType)
-                    .choices(choices)
-                    .visibleIf(blockDef.getShownExpr())
-                    .build();
-            ValidationConverter.applyValidation(pepperQuestionDef, surveyJSQuestion);
-
-            JsonNode questionNode = objectMapper.valueToTree(surveyJSQuestion);
-            questionNodes.add(questionNode);
+            questionNodes.add(convertQuestionToSurveyJsFormat(blockDef, allLangMap, pepperQuestionDef));
         }
         return questionNodes;
+    }
+
+    private JsonNode convertQuestionToSurveyJsFormat(FormBlockDef blockDef, Map<String, Map<String, Object>> allLangMap, QuestionDef pepperQuestionDef) {
+        Map<String, String> titleMap = getQuestionTxt(pepperQuestionDef);
+        String questionType = getQuestionType(pepperQuestionDef);
+        String inputType = null;
+        if (pepperQuestionDef.getQuestionType().name().equalsIgnoreCase("DATE")) {
+            inputType = "DATE";
+        }
+        if (pepperQuestionDef.getQuestionType().name().equalsIgnoreCase("NUMERIC")) {
+            inputType = "NUMBER";
+        }
+
+        if (pepperQuestionDef.getQuestionType().name().equalsIgnoreCase("COMPOSITE")) {
+            // composite questions are not questions in surveyjs, they need to
+            // be formatted differently
+
+            return convertCompositeQuestion(blockDef, allLangMap, (CompositeQuestionDef) pepperQuestionDef);
+        }
+
+        List<SurveyJSQuestion.Choice> choices = null;
+        if (pepperQuestionDef.getQuestionType().name().equalsIgnoreCase("PICKLIST")) {
+            choices = getPicklistChoices((PicklistQuestionDef) pepperQuestionDef, allLangMap);
+        }
+
+        //expression  revisit and try this
+        //parse the pepper expression for stableID and value/option and generate Juniper expression
+        //EX: user.studies[\"atcp\"].forms[\"REGISTRATION\"].questions[\"REGISTRATION_COUNTRY\"].answers.hasOption (\"AF\")
+        //parse value after questions[] and hasOption and generate
+        //"visibleIf": "{REGISTRATION_COUNTRY} contains 'AF'"
+        //works only for picklist/choices though
+
+        SurveyJSQuestion surveyJSQuestion = SurveyJSQuestion.builder()
+                .name(pepperQuestionDef.getStableId())
+                .type(questionType)
+                .title(titleMap)
+                .isRequired(false)
+                //.isRequired() //revisit
+                .inputType(inputType)
+                .choices(choices)
+                .visibleIf(blockDef.getShownExpr())
+                .build();
+        ValidationConverter.applyValidation(pepperQuestionDef, surveyJSQuestion);
+
+        return objectMapper.valueToTree(surveyJSQuestion);
+    }
+
+    private JsonNode convertCompositeQuestion(FormBlockDef blockDef, Map<String, Map<String, Object>> allLangMap, CompositeQuestionDef pepperQuestionDef) {
+
+        // steps:
+        // get all questions, convert to surveyJSQuestions and
+        // put them to field: templateElements
+
+        // title -> title
+        // type: paneldynamic
+        // addButtonTemplate -> panelAddText
+
+        Map<String, String> addButtonTemplate = null;
+        if (Objects.nonNull(pepperQuestionDef.getAddButtonTemplate())) {
+            addButtonTemplate = getVariableTranslationsTxt(pepperQuestionDef.getAddButtonTemplate().getTemplateText(),
+                    pepperQuestionDef.getAddButtonTemplate().getVariables());
+        }
+        // additionalItemTemplate -> templateTitle
+        Map<String, String> additionalItemTemplate = null;
+        if (Objects.nonNull(pepperQuestionDef.getAdditionalItemTemplate())) {
+            additionalItemTemplate = getVariableTranslationsTxt(pepperQuestionDef.getAdditionalItemTemplate().getTemplateText(),
+                    pepperQuestionDef.getAdditionalItemTemplate().getVariables());
+        }
+        // children -> templateElements
+        List<JsonNode> subQuestions = pepperQuestionDef.getChildren().stream()
+                .map(child -> convertQuestionToSurveyJsFormat(blockDef, allLangMap, child))
+                .collect(Collectors.toList());
+
+
+        Map<String, Object> compositeQuestionMap = new HashMap<>();
+        compositeQuestionMap.put("name", pepperQuestionDef.getStableId());
+        compositeQuestionMap.put("type", "paneldynamic");
+        compositeQuestionMap.put("title", getQuestionTxt(pepperQuestionDef));
+        compositeQuestionMap.put("templateElements", subQuestions);
+        compositeQuestionMap.put("panelAddText", addButtonTemplate);
+        compositeQuestionMap.put("templateTitle", additionalItemTemplate);
+        compositeQuestionMap.put("visibleIf", blockDef.getShownExpr());
+        return objectMapper.valueToTree(compositeQuestionMap);
     }
 
     private String getQuestionType(QuestionDef pepperQuestionDef) {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Supports composite questions from pepper.

<img width="680" alt="image" src="https://github.com/user-attachments/assets/f5bd145e-6942-4390-8cd9-6c8033af255e">

Also, adds translations for the title of the survey

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Run pepperimportcli
- Go to out/medical-history.conf
- Copy that file into the superuser import JSON functionality when you create a survey
- Verify the survey title shows up (and is translated in the JSON) and that the language keys were created as expected
- Ensure that you see multiple paneldynamic questions show up
- Go to the `medication` or `surgery` ones and verify that there are no missing translations relative to the pepper question definition