### PR TITLE
[JN-1189] Consistent markdown support

### DIFF
--- a/ui-core/src/participant/landing/sections/HtmlSectionView.test.tsx
+++ b/ui-core/src/participant/landing/sections/HtmlSectionView.test.tsx
@@ -35,18 +35,6 @@ describe('HTMLSectionView', () => {
       expect(console.warn).toHaveBeenCalled()
     })
 
-    it('renders titles as markdown', () => {
-      const section: HtmlSection = {
-        id: 'sectionWithMarkdown',
-        sectionType: 'HERO_WITH_IMAGE',
-        sectionConfig: '{"title": "**Title**"}'
-      }
-
-      const { container } = render(<HtmlSectionView section={section} />)
-      expect(container).toHaveTextContent('Title')
-      expect(container).not.toHaveTextContent('**Title**')
-    })
-
     it.each([
       'FAQ',
       'HERO_CENTERED',

--- a/ui-core/src/participant/landing/sections/HtmlSectionView.test.tsx
+++ b/ui-core/src/participant/landing/sections/HtmlSectionView.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import { HtmlSectionView } from './HtmlSectionView'
-import { HtmlSection } from 'src/types/landingPageConfig'
+import { HtmlSection, SectionType } from 'src/types/landingPageConfig'
 
 
 describe('HTMLSectionView', () => {
@@ -33,6 +33,54 @@ describe('HTMLSectionView', () => {
       const { container } = render(<HtmlSectionView section={section} />)
       expect(container).toBeEmptyDOMElement()
       expect(console.warn).toHaveBeenCalled()
+    })
+
+    it('renders titles as markdown', () => {
+      const section: HtmlSection = {
+        id: 'sectionWithMarkdown',
+        sectionType: 'HERO_WITH_IMAGE',
+        sectionConfig: '{"title": "**Title**"}'
+      }
+
+      const { container } = render(<HtmlSectionView section={section} />)
+      expect(container).toHaveTextContent('Title')
+      expect(container).not.toHaveTextContent('**Title**')
+    })
+
+    it.each([
+      'FAQ',
+      'HERO_CENTERED',
+      'HERO_WITH_IMAGE',
+      'PARTICIPATION_DETAIL',
+      'PHOTO_BLURB_GRID',
+      'STEP_OVERVIEW'
+    ])('renders titles as markdown for %s', sectionType => {
+      const section: HtmlSection = {
+        id: `sectionWithMarkdown-${sectionType}`,
+        sectionType: sectionType as SectionType,
+        sectionConfig: '{"title": "**Title**", "questions": []}'
+      }
+
+      const { container } = render(<HtmlSectionView section={section} />)
+      expect(container).toHaveTextContent('Title')
+      expect(container).not.toHaveTextContent('**Title**')
+    })
+
+    it.each([
+      'FAQ',
+      'HERO_CENTERED',
+      'HERO_WITH_IMAGE',
+      'PARTICIPATION_DETAIL'
+    ])('renders blurbs as markdown for %s', sectionType => {
+      const section: HtmlSection = {
+        id: `sectionWithMarkdown-${sectionType}`,
+        sectionType: sectionType as SectionType,
+        sectionConfig: '{"blurb": "**Blurb**", "questions": []}'
+      }
+
+      const { container } = render(<HtmlSectionView section={section} />)
+      expect(container).toHaveTextContent('Blurb')
+      expect(container).not.toHaveTextContent('**Blurb**')
     })
   })
 })

--- a/ui-core/src/participant/landing/sections/ParticipationDetailTemplate.tsx
+++ b/ui-core/src/participant/landing/sections/ParticipationDetailTemplate.tsx
@@ -14,7 +14,7 @@ import ConfiguredMedia, { MediaConfig, mediaConfigProps, validateMediaConfig } f
 import { TemplateComponentProps } from './templateUtils'
 import { useApiContext } from '../../../participant/ApiProvider'
 import { blurbProp, titleProp } from './SectionProp'
-import { InlineMarkdown, Markdown } from '../../../participant/landing/Markdown'
+import { InlineMarkdown } from '../../../participant/landing/Markdown'
 
 type ParticipationDetailTemplateConfig = {
   actionButton?: ButtonConfig, // button
@@ -102,7 +102,7 @@ function ParticipationDetailTemplate(props: ParticipationDetailTemplateProps) {
         </h2>
         <p><FontAwesomeIcon icon={faClock}/> {timeIndication}</p>
         { blurb && <p className={classNames('fs-4', actionButton ? 'mb-4' : 'mb-0')}>
-          <Markdown>{blurb}</Markdown>
+          <InlineMarkdown>{blurb}</InlineMarkdown>
         </p> }
         {actionButton && <ConfiguredButton config={actionButton} />}
       </div>

--- a/ui-core/src/participant/landing/sections/ParticipationDetailTemplate.tsx
+++ b/ui-core/src/participant/landing/sections/ParticipationDetailTemplate.tsx
@@ -14,6 +14,7 @@ import ConfiguredMedia, { MediaConfig, mediaConfigProps, validateMediaConfig } f
 import { TemplateComponentProps } from './templateUtils'
 import { useApiContext } from '../../../participant/ApiProvider'
 import { blurbProp, titleProp } from './SectionProp'
+import { InlineMarkdown, Markdown } from '../../../participant/landing/Markdown'
 
 type ParticipationDetailTemplateConfig = {
   actionButton?: ButtonConfig, // button
@@ -97,11 +98,11 @@ function ParticipationDetailTemplate(props: ParticipationDetailTemplateProps) {
       <div className={classNames({ 'col-md-8': hasImage })}>
         <h2>
           <div className="h4">{stepNumberText}</div>
-          {title}
+          <InlineMarkdown>{title || ''}</InlineMarkdown>
         </h2>
         <p><FontAwesomeIcon icon={faClock}/> {timeIndication}</p>
         <p className={classNames('fs-4', actionButton ? 'mb-4' : 'mb-0')}>
-          {blurb}
+          <Markdown>{blurb || ''}</Markdown>
         </p>
         {actionButton && <ConfiguredButton config={actionButton} />}
       </div>

--- a/ui-core/src/participant/landing/sections/ParticipationDetailTemplate.tsx
+++ b/ui-core/src/participant/landing/sections/ParticipationDetailTemplate.tsx
@@ -98,12 +98,12 @@ function ParticipationDetailTemplate(props: ParticipationDetailTemplateProps) {
       <div className={classNames({ 'col-md-8': hasImage })}>
         <h2>
           <div className="h4">{stepNumberText}</div>
-          <InlineMarkdown>{title || ''}</InlineMarkdown>
+          {title && <InlineMarkdown>{title}</InlineMarkdown>}
         </h2>
         <p><FontAwesomeIcon icon={faClock}/> {timeIndication}</p>
-        <p className={classNames('fs-4', actionButton ? 'mb-4' : 'mb-0')}>
-          <Markdown>{blurb || ''}</Markdown>
-        </p>
+        { blurb && <p className={classNames('fs-4', actionButton ? 'mb-4' : 'mb-0')}>
+          <Markdown>{blurb}</Markdown>
+        </p> }
         {actionButton && <ConfiguredButton config={actionButton} />}
       </div>
     </div>

--- a/ui-core/src/participant/landing/sections/PhotoBlurbGrid.tsx
+++ b/ui-core/src/participant/landing/sections/PhotoBlurbGrid.tsx
@@ -8,7 +8,7 @@ import { requireOptionalArray, requireOptionalString, requirePlainObject, requir
   from '../../util/validationUtils'
 
 import ConfiguredMedia, { MediaConfig, mediaConfigProps, validateMediaConfig } from '../ConfiguredMedia'
-import { Markdown } from '../Markdown'
+import { InlineMarkdown, Markdown } from '../Markdown'
 
 import { TemplateComponentProps } from './templateUtils'
 import { useApiContext } from '../../../participant/ApiProvider'
@@ -94,7 +94,7 @@ function PhotoBlurbGrid(props: PhotoBlurbGridProps) {
   return <div id={anchorRef} style={getSectionStyle(config, getImageUrl)}>
     {!!title && (
       <h2 className="fs-1 fw-normal lh-sm text-center mb-4">
-        {title}
+        <InlineMarkdown>{title}</InlineMarkdown>
       </h2>
     )}
     {(subGrids ?? []).map((subGrid, index) => {

--- a/ui-core/src/participant/landing/sections/StepOverviewTemplate.tsx
+++ b/ui-core/src/participant/landing/sections/StepOverviewTemplate.tsx
@@ -9,7 +9,7 @@ import { requireOptionalArray, requireOptionalBoolean, requireOptionalString, re
 
 import ConfiguredButton, { ButtonConfig, buttonConfigProps, validateButtonConfig } from '../ConfiguredButton'
 import ConfiguredMedia, { MediaConfig, mediaConfigProps, validateMediaConfig } from '../ConfiguredMedia'
-import { InlineMarkdown, Markdown } from '../Markdown'
+import { InlineMarkdown } from '../Markdown'
 
 import { TemplateComponentProps } from './templateUtils'
 import { useApiContext } from '../../../participant/ApiProvider'
@@ -95,7 +95,7 @@ function StepOverviewTemplate(props: StepOverviewTemplateProps) {
               { showStepNumbers && <p className="text-uppercase fs-5 fw-semibold mb-0">Step {i + 1}</p> }
               <p className="text-uppercase fs-6">{duration}</p>
               <p className="fs-4 mb-0">
-                <Markdown>{blurb}</Markdown>
+                <InlineMarkdown>{blurb}</InlineMarkdown>
               </p>
             </div>
           </div>

--- a/ui-core/src/participant/landing/sections/StepOverviewTemplate.tsx
+++ b/ui-core/src/participant/landing/sections/StepOverviewTemplate.tsx
@@ -9,7 +9,7 @@ import { requireOptionalArray, requireOptionalBoolean, requireOptionalString, re
 
 import ConfiguredButton, { ButtonConfig, buttonConfigProps, validateButtonConfig } from '../ConfiguredButton'
 import ConfiguredMedia, { MediaConfig, mediaConfigProps, validateMediaConfig } from '../ConfiguredMedia'
-import { InlineMarkdown } from '../Markdown'
+import { InlineMarkdown, Markdown } from '../Markdown'
 
 import { TemplateComponentProps } from './templateUtils'
 import { useApiContext } from '../../../participant/ApiProvider'
@@ -95,7 +95,7 @@ function StepOverviewTemplate(props: StepOverviewTemplateProps) {
               { showStepNumbers && <p className="text-uppercase fs-5 fw-semibold mb-0">Step {i + 1}</p> }
               <p className="text-uppercase fs-6">{duration}</p>
               <p className="fs-4 mb-0">
-                {blurb}
+                <Markdown>{blurb}</Markdown>
               </p>
             </div>
           </div>


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

I did a quick comb through the app to find other areas where Markdown isn't supported because I'm 100% sure that gVASC/Pattern will find these and ask us to fix them.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Rebuild UI core
Try using markdown in the updated section fields