### PR TITLE
[JN-1209] opening data import feature to non-superusers

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/dataimport/DataImportController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/dataimport/DataImportController.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.api.admin.controller.dataimport;
 
 import bio.terra.pearl.api.admin.api.DataImportApi;
 import bio.terra.pearl.api.admin.service.auth.AuthUtilService;
+import bio.terra.pearl.api.admin.service.auth.context.PortalStudyEnvAuthContext;
 import bio.terra.pearl.api.admin.service.enrollee.EnrolleeImportExtService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
@@ -30,51 +31,25 @@ public class DataImportController implements DataImportApi {
   }
 
   @Override
-  public ResponseEntity<Void> delete(
-      String portalShortcode, String studyShortcode, String envName, UUID importId) {
-    AdminUser operator = authUtilService.requireAdminUser(request);
-    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
-    enrolleeImportExtService.delete(
-        portalShortcode, studyShortcode, environmentName, importId, operator);
-    return ResponseEntity.noContent().build();
-  }
-
-  @Override
-  public ResponseEntity<Void> deleteItem(
-      String portalShortcode,
-      String studyShortcode,
-      String envName,
-      UUID importId,
-      UUID importItemId) {
-    AdminUser operator = authUtilService.requireAdminUser(request);
-    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
-    enrolleeImportExtService.deleteImportItem(
-        portalShortcode, studyShortcode, environmentName, importId, importItemId, operator);
-    return ResponseEntity.noContent().build();
-  }
-
-  @Override
   public ResponseEntity<Object> getAll(
       String portalShortcode, String studyShortcode, String envName) {
     AdminUser operator = authUtilService.requireAdminUser(request);
+    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
     return ResponseEntity.ok(
         enrolleeImportExtService.list(
-            portalShortcode,
-            studyShortcode,
-            EnvironmentName.valueOfCaseInsensitive(envName),
-            operator));
+            PortalStudyEnvAuthContext.of(
+                operator, portalShortcode, studyShortcode, environmentName)));
   }
 
   @Override
   public ResponseEntity<Object> get(
       String portalShortcode, String studyShortcode, String envName, UUID importId) {
     AdminUser operator = authUtilService.requireAdminUser(request);
+    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
     return ResponseEntity.ok(
         enrolleeImportExtService.get(
-            portalShortcode,
-            studyShortcode,
-            EnvironmentName.valueOfCaseInsensitive(envName),
-            operator,
+            PortalStudyEnvAuthContext.of(
+                operator, portalShortcode, studyShortcode, environmentName),
             importId));
   }
 
@@ -90,14 +65,39 @@ public class DataImportController implements DataImportApi {
     try {
       return ResponseEntity.ok(
           enrolleeImportExtService.importData(
-              portalShortcode,
-              studyShortcode,
-              environmentName,
+              PortalStudyEnvAuthContext.of(
+                  operator, portalShortcode, studyShortcode, environmentName),
               importFile.getInputStream(),
-              operator,
               fileFormat));
     } catch (IOException e) {
       throw new IllegalArgumentException("could not read import data");
     }
+  }
+
+  @Override
+  public ResponseEntity<Void> delete(
+      String portalShortcode, String studyShortcode, String envName, UUID importId) {
+    AdminUser operator = authUtilService.requireAdminUser(request);
+    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
+    enrolleeImportExtService.delete(
+        PortalStudyEnvAuthContext.of(operator, portalShortcode, studyShortcode, environmentName),
+        importId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<Void> deleteItem(
+      String portalShortcode,
+      String studyShortcode,
+      String envName,
+      UUID importId,
+      UUID importItemId) {
+    AdminUser operator = authUtilService.requireAdminUser(request);
+    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
+    enrolleeImportExtService.deleteImportItem(
+        PortalStudyEnvAuthContext.of(operator, portalShortcode, studyShortcode, environmentName),
+        importId,
+        importItemId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeImportExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeImportExtService.java
@@ -1,14 +1,11 @@
 package bio.terra.pearl.api.admin.service.enrollee;
 
 import bio.terra.pearl.api.admin.service.auth.AuthUtilService;
-import bio.terra.pearl.core.model.EnvironmentName;
-import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.api.admin.service.auth.EnforcePortalStudyEnvPermission;
+import bio.terra.pearl.api.admin.service.auth.context.PortalStudyEnvAuthContext;
 import bio.terra.pearl.core.model.dataimport.Import;
-import bio.terra.pearl.core.model.dataimport.ImportItem;
 import bio.terra.pearl.core.model.dataimport.ImportItemStatus;
 import bio.terra.pearl.core.model.dataimport.ImportStatus;
-import bio.terra.pearl.core.model.study.PortalStudy;
-import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.service.dataimport.ImportFileFormat;
 import bio.terra.pearl.core.service.dataimport.ImportItemService;
 import bio.terra.pearl.core.service.dataimport.ImportService;
@@ -45,97 +42,57 @@ public class EnrolleeImportExtService {
     this.studyEnvironmentService = studyEnvironmentService;
   }
 
-  public List<Import> list(
-      String portalShortcode, String studyShortcode, EnvironmentName envName, AdminUser operator) {
-    authUtilService.authUserToStudy(operator, portalShortcode, studyShortcode);
-    StudyEnvironment studyEnv =
-        studyEnvironmentService
-            .findByStudy(studyShortcode, envName)
-            .orElseThrow(() -> new NotFoundException("Study environment not found"));
-    return importService.findByStudyEnvWithItems(studyEnv.getId());
+  @EnforcePortalStudyEnvPermission(permission = "participant_data_view")
+  public List<Import> list(PortalStudyEnvAuthContext authContext) {
+    return importService.findByStudyEnvWithItems(authContext.getStudyEnvironment().getId());
   }
 
-  public Import get(
-      String portalShortcode,
-      String studyShortcode,
-      EnvironmentName envName,
-      AdminUser operator,
-      UUID id) {
-    authUtilService.authUserToStudy(operator, portalShortcode, studyShortcode);
-    StudyEnvironment studyEnv =
-        studyEnvironmentService
-            .findByStudy(studyShortcode, envName)
-            .orElseThrow(() -> new NotFoundException("Study environment not found"));
+  @EnforcePortalStudyEnvPermission(permission = "participant_data_view")
+  public Import get(PortalStudyEnvAuthContext authContext, UUID id) {
     Import dataImport =
         importService.find(id).orElseThrow(() -> new NotFoundException("Import not found"));
-    if (!dataImport.getStudyEnvironmentId().equals(studyEnv.getId())) {
-      throw new PermissionDeniedException(
-          "Import Id does not belong to the given study environment");
-    }
+    assertImportInStudyEnv(authContext, dataImport);
     importItemService.attachImportItems(dataImport);
     return dataImport;
   }
 
+  @EnforcePortalStudyEnvPermission(permission = "participant_data_edit")
   public Import importData(
-      String portalShortcode,
-      String studyShortcode,
-      EnvironmentName environmentName,
-      InputStream tsvData,
-      AdminUser operator,
-      ImportFileFormat fileFormat) {
-    authUtilService.authUserToPortal(operator, portalShortcode);
-    PortalStudy portalStudy =
-        authUtilService.authUserToStudy(operator, portalShortcode, studyShortcode);
-    StudyEnvironment studyEnv =
-        studyEnvironmentService.verifyStudy(studyShortcode, environmentName);
+      PortalStudyEnvAuthContext authContext, InputStream tsvData, ImportFileFormat fileFormat) {
     return enrolleImportService.importEnrollees(
-        portalShortcode, studyShortcode, studyEnv, tsvData, operator.getId(), fileFormat);
+        authContext.getPortalShortcode(),
+        authContext.getStudyShortcode(),
+        authContext.getStudyEnvironment(),
+        tsvData,
+        authContext.getOperator().getId(),
+        fileFormat);
   }
 
   @Transactional
-  public void delete(
-      String portalShortcode,
-      String studyShortcode,
-      EnvironmentName environmentName,
-      UUID id,
-      AdminUser operator) {
-    authUtilService.authUserToPortal(operator, portalShortcode);
-    PortalStudy portalStudy =
-        authUtilService.authUserToStudy(operator, portalShortcode, studyShortcode);
-    StudyEnvironment studyEnv =
-        studyEnvironmentService.verifyStudy(studyShortcode, environmentName);
+  @EnforcePortalStudyEnvPermission(permission = "participant_data_edit")
+  public void delete(PortalStudyEnvAuthContext authContext, UUID id) {
     Import dataImport =
         importService.find(id).orElseThrow(() -> new NotFoundException("Import not found"));
-    if (!dataImport.getStudyEnvironmentId().equals(studyEnv.getId())) {
-      throw new PermissionDeniedException(
-          "Import Id does not belong to the given study environment");
-    }
+    assertImportInStudyEnv(authContext, dataImport);
     importService.deleteEnrolleesByImportId(id);
     importService.updateStatus(id, ImportStatus.DELETED);
   }
 
   @Transactional
-  public void deleteImportItem(
-      String portalShortcode,
-      String studyShortcode,
-      EnvironmentName environmentName,
-      UUID importId,
-      UUID id,
-      AdminUser operator) {
-    authUtilService.authUserToPortal(operator, portalShortcode);
-    PortalStudy portalStudy =
-        authUtilService.authUserToStudy(operator, portalShortcode, studyShortcode);
-    StudyEnvironment studyEnv =
-        studyEnvironmentService.verifyStudy(studyShortcode, environmentName);
+  @EnforcePortalStudyEnvPermission(permission = "participant_data_edit")
+  public void deleteImportItem(PortalStudyEnvAuthContext authContext, UUID importId, UUID id) {
     Import dataImport =
         importService.find(importId).orElseThrow(() -> new NotFoundException("Import not found"));
-    if (!dataImport.getStudyEnvironmentId().equals(studyEnv.getId())) {
+    assertImportInStudyEnv(authContext, dataImport);
+    importItemService.find(id).orElseThrow(() -> new NotFoundException("ImportItem not found"));
+    importItemService.deleteEnrolleeByItemId(id);
+    importItemService.updateStatus(id, ImportItemStatus.DELETED);
+  }
+
+  private void assertImportInStudyEnv(PortalStudyEnvAuthContext authContext, Import dataImport) {
+    if (!dataImport.getStudyEnvironmentId().equals(authContext.getStudyEnvironment().getId())) {
       throw new PermissionDeniedException(
           "Import Id does not belong to the given study environment");
     }
-    ImportItem importItem =
-        importItemService.find(id).orElseThrow(() -> new NotFoundException("ImportItem not found"));
-    importItemService.deleteEnrolleeById(id);
-    importItemService.updateStatus(id, ImportItemStatus.DELETED);
   }
 }

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/dataimport/EnrolleeImportExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/dataimport/EnrolleeImportExtServiceTests.java
@@ -1,0 +1,30 @@
+package bio.terra.pearl.api.admin.service.dataimport;
+
+import bio.terra.pearl.api.admin.AuthAnnotationSpec;
+import bio.terra.pearl.api.admin.AuthTestUtils;
+import bio.terra.pearl.api.admin.BaseSpringBootTest;
+import bio.terra.pearl.api.admin.service.enrollee.EnrolleeImportExtService;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class EnrolleeImportExtServiceTests extends BaseSpringBootTest {
+  @Autowired private EnrolleeImportExtService enrolleeImportExtService;
+
+  @Test
+  public void testAuthentication() {
+    AuthTestUtils.assertAllMethodsAnnotated(
+        enrolleeImportExtService,
+        Map.of(
+            "get",
+            AuthAnnotationSpec.withPortalStudyEnvPerm("participant_data_view"),
+            "list",
+            AuthAnnotationSpec.withPortalStudyEnvPerm("participant_data_view"),
+            "delete",
+            AuthAnnotationSpec.withPortalStudyEnvPerm("participant_data_edit"),
+            "deleteImportItem",
+            AuthAnnotationSpec.withPortalStudyEnvPerm("participant_data_edit"),
+            "importData",
+            AuthAnnotationSpec.withPortalStudyEnvPerm("participant_data_edit")));
+  }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/dataimport/ImportItemService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/dataimport/ImportItemService.java
@@ -48,7 +48,7 @@ public class ImportItemService extends CrudService<ImportItem, ImportItemDao> {
     }
 
     @Transactional
-    public void deleteEnrolleeById(UUID id) {
+    public void deleteEnrolleeByItemId(UUID id) {
         ImportItem importItem = dao.find(id).orElseThrow(() -> new NotFoundException("Import not found "));
         if (importItem.getCreatedEnrolleeId() != null) {
             enrolleeService.delete(importItem.getCreatedEnrolleeId(), Set.of(EnrolleeService.AllowedCascades.PARTICIPANT_USER));

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -309,6 +309,8 @@ public class EnrolleeImportService {
                                     ExportOptions exportOptions, StudyEnvironment studyEnv, DataAuditInfo auditInfo) {
         ProfileFormatter profileFormatter = new ProfileFormatter(exportOptions);
         Profile profile = profileFormatter.fromStringMap(studyEnv.getId(), enrolleeMap);
+        // we still don't want to send emails during the import process
+        profile.setDoNotEmail(true);
         profile.setId(registrationProfile.getId());
         profile.setMailingAddressId(registrationProfile.getMailingAddressId());
         profile.getMailingAddress().setId(registrationProfile.getMailingAddressId());

--- a/populate/src/main/resources/seed/iam/roles.json
+++ b/populate/src/main/resources/seed/iam/roles.json
@@ -8,7 +8,8 @@
       "survey_edit",
       "consent_form_edit",
       "site_content_edit",
-      "participant_data_edit"
+      "participant_data_edit",
+      "participant_data_view"
     ]
   },
   {

--- a/ui-admin/src/navbar/StudySidebar.tsx
+++ b/ui-admin/src/navbar/StudySidebar.tsx
@@ -16,7 +16,7 @@ import {
   studyEnvSiteSettingsPath
 } from '../study/StudyEnvironmentRouter'
 import CollapsableMenu from './CollapsableMenu'
-import { isSuperuser, userHasPermission, useUser } from 'user/UserProvider'
+import { userHasPermission, useUser } from 'user/UserProvider'
 import { studyPublishingPath, studyUsersPath } from '../study/StudyRouter'
 import { sidebarNavLinkClasses } from './AdminSidebar'
 
@@ -56,10 +56,10 @@ export const StudySidebar = ({ study, portalList, portalShortcode }:
           <NavLink to={studyEnvMailingListPath(portalShortcode, study.shortcode, 'live')}
             className={sidebarNavLinkClasses} style={navStyleFunc}>Mailing List</NavLink>
         </li>
-        {isSuperuser() && <li className="mb-2">
+        <li className="mb-2">
           <NavLink to={studyEnvImportPath(portalShortcode, study.shortcode, 'sandbox')}
             className={sidebarNavLinkClasses} style={navStyleFunc}>Import Participants</NavLink>
-        </li>}
+        </li>
       </ul>}/>
       <CollapsableMenu header={'Analytics & Data'} content={<ul className="list-unstyled">
         <li className="mb-2">


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

HeartHive now needs this feature, so I'm removing the superuser-only gate.
<img width="316" alt="image" src="https://github.com/user-attachments/assets/14ee09ea-6352-46e9-b3a5-13cc9ba056d5">

This also fixes a bug where we were inadvertently re-enabling emails midway through the import process during profile import.  

this also fixes an oversight where study staff did not have participant_data_view permission 😄 

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. log in as staff@heartdemo.org (remember that you now need to set `VITE_UNAUTHED_LOGIN=true` in your ui-admin start command)
2. do a data export from `https://localhost:3000/demo/studies/heartdemo/env/sandbox/export/dataBrowser`
3. confirm you see "Import participants" in the left nav
4. click it, and then switch to the irb environment.
5. Use "add new" to import the file you just exported
6. confirm no permission errors occur