### PR TITLE
[JN-1211]  update asset fingerprint smudging to Vite patterns

### DIFF
--- a/api-participant/build.gradle
+++ b/api-participant/build.gradle
@@ -57,19 +57,19 @@ task copyWebApp(type: Copy) {
 task createUnfingerprintedJs(type: Copy) {
     dependsOn('copyWebApp')
     dependsOn('processResources')
-    from "$rootDir/api-participant/build/resources/main/static/assets/js"
-    into "$rootDir/api-participant/build/resources/main/static/assets/js"
-    rename("index.([a-zA-Z0-9]{8}).js", "index.js")
-    rename('(.*).([a-zA-Z0-9]{8}).chunk.js', '$1.chunk.js')
+    from "$rootDir/api-participant/build/resources/main/static/assets"
+    into "$rootDir/api-participant/build/resources/main/static/assets"
+    rename("index-([^.]{8}).js", "index.js")
+    rename('(.*)-([^.]{8}).js', '$1.chunk.js')
 }
 
 // creates copies of the fingerprinted CSS files without the asset fingerprint
 task createUnfingerprintedCss(type: Copy) {
     dependsOn('copyWebApp')
     dependsOn('processResources')
-    from "$rootDir/api-participant/build/resources/main/static/static/css"
-    into "$rootDir/api-participant/build/resources/main/static/static/css"
-    rename("index.([a-zA-Z0-9]{8}).css", "index.css")
+    from "$rootDir/api-participant/build/resources/main/static/assets"
+    into "$rootDir/api-participant/build/resources/main/static/assets"
+    rename("index-([^.]{8}).css", "index.css")
 }
 
 // See comment in PublicApiController.java for why we want unfingerprinted versions of assets.  We still keep the fingerprinted

--- a/api-participant/build.gradle
+++ b/api-participant/build.gradle
@@ -57,10 +57,10 @@ task copyWebApp(type: Copy) {
 task createUnfingerprintedJs(type: Copy) {
     dependsOn('copyWebApp')
     dependsOn('processResources')
-    from "$rootDir/api-participant/build/resources/main/static/static/js"
-    into "$rootDir/api-participant/build/resources/main/static/static/js"
-    rename("main.([0-9a-f]{8}).js", "main.js")
-    rename('(.*).([0-9a-f]{8}).chunk.js', '$1.chunk.js')
+    from "$rootDir/api-participant/build/resources/main/static/assets/js"
+    into "$rootDir/api-participant/build/resources/main/static/assets/js"
+    rename("index.([a-zA-Z0-9]{8}).js", "index.js")
+    rename('(.*).([a-zA-Z0-9]{8}).chunk.js', '$1.chunk.js')
 }
 
 // creates copies of the fingerprinted CSS files without the asset fingerprint
@@ -69,7 +69,7 @@ task createUnfingerprintedCss(type: Copy) {
     dependsOn('processResources')
     from "$rootDir/api-participant/build/resources/main/static/static/css"
     into "$rootDir/api-participant/build/resources/main/static/static/css"
-    rename("main.*.css", "main.css")
+    rename("index.([a-zA-Z0-9]{8}).css", "index.css")
 }
 
 // See comment in PublicApiController.java for why we want unfingerprinted versions of assets.  We still keep the fingerprinted

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PublicApiController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PublicApiController.java
@@ -187,19 +187,19 @@ public class PublicApiController implements PublicApi {
    * site not appearing as down during deploys. Eventually, we should upgrade our deployment/hosting
    * infrastructure to solve this problem in a more robust way
    */
-  @GetMapping(value = "/static/js/main.{hash}.js")
+  @GetMapping(value = "/assets/index.{hash}.js")
   public String getFingerprintedJs() {
-    return "forward:/static/js/main.js";
+    return "forward:/assets/index.js";
   }
 
-  @GetMapping(value = "/static/css/main.{hash}.css")
+  @GetMapping(value = "/assets/index.{hash}.css")
   public String getFingerprintedCss() {
-    return "forward:/static/css/main.css";
+    return "forward:/assets/index.css";
   }
 
-  @GetMapping(value = "/static/js/{chunkId}.{hash}.chunk.js")
+  @GetMapping(value = "/assets/{chunkId}.{hash}.chunk.js")
   public String getFingerprintedJsChunks(@PathVariable("chunkId") String chunkId) {
-    return "forward:/static/js/%s.chunk.js".formatted(chunkId);
+    return "forward:/assets/%s.chunk.js".formatted(chunkId);
   }
 
   private Optional<PortalEnvironmentDescriptor> getPortalDescriptorForRequest(

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PublicApiController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PublicApiController.java
@@ -187,19 +187,19 @@ public class PublicApiController implements PublicApi {
    * site not appearing as down during deploys. Eventually, we should upgrade our deployment/hosting
    * infrastructure to solve this problem in a more robust way
    */
-  @GetMapping(value = "/assets/index.{hash}.js")
+  @GetMapping(value = "/assets/index-{hash}.js")
   public String getFingerprintedJs() {
     return "forward:/assets/index.js";
   }
 
-  @GetMapping(value = "/assets/index.{hash}.css")
+  @GetMapping(value = "/assets/index-{hash}.css")
   public String getFingerprintedCss() {
     return "forward:/assets/index.css";
   }
 
-  @GetMapping(value = "/assets/{chunkId}.{hash}.chunk.js")
+  @GetMapping(value = "/assets/{chunkId}-{hash}.js")
   public String getFingerprintedJsChunks(@PathVariable("chunkId") String chunkId) {
-    return "forward:/assets/%s.chunk.js".formatted(chunkId);
+    return "forward:/assets/%s.js".formatted(chunkId);
   }
 
   private Optional<PortalEnvironmentDescriptor> getPortalDescriptorForRequest(

--- a/api-participant/src/test/java/bio/terra/pearl/api/participant/api/PublicApiControllerTest.java
+++ b/api-participant/src/test/java/bio/terra/pearl/api/participant/api/PublicApiControllerTest.java
@@ -88,22 +88,22 @@ class PublicApiControllerTest {
   @Test
   void testHandlesMismatchedJSFingerprint() throws Exception {
     this.mockMvc
-        .perform(get("/static/js/main.12345678.js"))
-        .andExpect(forwardedUrl("/static/js/main.js"));
+        .perform(get("/assets/index-12345678.js"))
+        .andExpect(forwardedUrl("/assets/index.js"));
   }
 
   @Test
   void testHandlesMismatchedCSSFingerprint() throws Exception {
     this.mockMvc
-        .perform(get("/static/css/main.12345678.css"))
-        .andExpect(forwardedUrl("/static/css/main.css"));
+        .perform(get("/assets/index-12345678.css"))
+        .andExpect(forwardedUrl("/assets/index.css"));
   }
 
   @Test
   void testHandlesMismatchedJsChunkFingerprint() throws Exception {
     this.mockMvc
-        .perform(get("/static/js/111.12345678.chunk.js"))
-        .andExpect(forwardedUrl("/static/js/111.chunk.js"));
+        .perform(get("/assets/someChunk-12345678.js"))
+        .andExpect(forwardedUrl("/assets/someChunk.js"));
   }
 
   @Test


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

this updates our fingerprint smudging logic (which tells the server to ignore asset fingerprints and just serve the JS it has to avoid outages during rolling reloads), to the asset patterns that Vite compiles to.  the good news is that Vite chunks keep their names, so, e.g. `InvestigatorTermsOfUsePage.chunk.js` instead of `954.chunk.js` so that will make debugging chunk failed to fetch errors easier.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. run `./gradlew api-participant:clean`
2. run `./gradlew api-participant:jibDockerBuild`   
3. confirm in `api-participant/build/resources/main/static/assets` you have a plain index.js and index.css file, in addition to the hashed file names

<img width="377" alt="image" src="https://github.com/user-attachments/assets/fcf0e386-7e02-4578-805e-bf8a77481d63">
