### PR TITLE
[JN-1028] fix asset fingerprint smudging

### DIFF
--- a/api-admin/build.gradle
+++ b/api-admin/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 task copyWebApp(type: Copy) {
     from "$rootDir/ui-admin/dist"
     into "$rootDir/api-admin/build/resources/main/static"
+    duplicatesStrategy(DuplicatesStrategy.INCLUDE) // overwrite with the more recent version if the file already exists
 }
 
 // for now, only jib depends on copyWebApp, so that a npm rebuild/install will not be triggered for

--- a/api-participant/build.gradle
+++ b/api-participant/build.gradle
@@ -51,6 +51,8 @@ task copyWebApp(type: Copy) {
     dependsOn(rootProject.bundleParticipantUI)
     from "$rootDir/ui-participant/dist"
     into "$rootDir/api-participant/build/resources/main/static"
+    duplicatesStrategy(DuplicatesStrategy.INCLUDE) // overwrite with the more recent version if the file already exists
+
 }
 
 // creates copies of the fingerprinted js files without the asset fingerprint.
@@ -61,6 +63,7 @@ task createUnfingerprintedJs(type: Copy) {
     into "$rootDir/api-participant/build/resources/main/static/assets"
     rename("index-([^.]{8}).js", "index.js")
     rename('(.*)-([^.]{8}).js', '$1.chunk.js')
+    duplicatesStrategy(DuplicatesStrategy.INCLUDE) // overwrite with the more recent version if the file already exists
 }
 
 // creates copies of the fingerprinted CSS files without the asset fingerprint
@@ -70,6 +73,7 @@ task createUnfingerprintedCss(type: Copy) {
     from "$rootDir/api-participant/build/resources/main/static/assets"
     into "$rootDir/api-participant/build/resources/main/static/assets"
     rename("index-([^.]{8}).css", "index.css")
+    duplicatesStrategy(DuplicatesStrategy.INCLUDE) // overwrite with the more recent version if the file already exists
 }
 
 // See comment in PublicApiController.java for why we want unfingerprinted versions of assets.  We still keep the fingerprinted

--- a/api-participant/build.gradle
+++ b/api-participant/build.gradle
@@ -56,31 +56,14 @@ task copyWebApp(type: Copy) {
 }
 
 // creates copies of the fingerprinted js files without the asset fingerprint.
-task createUnfingerprintedJs(type: Copy) {
+task createUnfingerprintedAssets(type: Copy) {
     dependsOn('copyWebApp')
     dependsOn('processResources')
     from "$rootDir/api-participant/build/resources/main/static/assets"
     into "$rootDir/api-participant/build/resources/main/static/assets"
-    rename("index-([^.]{8}).js", "index.js")
-    rename('(.*)-([^.]{8}).js', '$1.chunk.js')
+    rename('(.+)-([a-zA-Z0-9-_]+)\\.js', '$1.js')
+    rename("index-([a-zA-Z0-9-_]+).css", "index.css")
     duplicatesStrategy(DuplicatesStrategy.INCLUDE) // overwrite with the more recent version if the file already exists
-}
-
-// creates copies of the fingerprinted CSS files without the asset fingerprint
-task createUnfingerprintedCss(type: Copy) {
-    dependsOn('copyWebApp')
-    dependsOn('processResources')
-    from "$rootDir/api-participant/build/resources/main/static/assets"
-    into "$rootDir/api-participant/build/resources/main/static/assets"
-    rename("index-([^.]{8}).css", "index.css")
-    duplicatesStrategy(DuplicatesStrategy.INCLUDE) // overwrite with the more recent version if the file already exists
-}
-
-// See comment in PublicApiController.java for why we want unfingerprinted versions of assets.  We still keep the fingerprinted
-// versions for reference to help in determining which version of a file the server *actually* has
-task createUnfingerprintedAssets() {
-    dependsOn('createUnfingerprintedJs')
-    dependsOn('createUnfingerprintedCss')
 }
 
 // for now, only jib depends on copyWebApp (via createUnfingerprintedAssets),

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PublicApiController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PublicApiController.java
@@ -187,19 +187,14 @@ public class PublicApiController implements PublicApi {
    * site not appearing as down during deploys. Eventually, we should upgrade our deployment/hosting
    * infrastructure to solve this problem in a more robust way
    */
-  @GetMapping(value = "/assets/index-{hash}.js")
-  public String getFingerprintedJs() {
-    return "forward:/assets/index.js";
-  }
-
   @GetMapping(value = "/assets/index-{hash}.css")
   public String getFingerprintedCss() {
     return "forward:/assets/index.css";
   }
 
-  @GetMapping(value = "/assets/{chunkId}-{hash}.js")
-  public String getFingerprintedJsChunks(@PathVariable("chunkId") String chunkId) {
-    return "forward:/assets/%s.js".formatted(chunkId);
+  @GetMapping(value = "/assets/{fileId}-{hash}.js")
+  public String getFingerprintedJs(@PathVariable("fileId") String fileId) {
+    return "forward:/assets/%s.js".formatted(fileId);
   }
 
   private Optional<PortalEnvironmentDescriptor> getPortalDescriptorForRequest(


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

There was a task ordering instability in the previous setup.  this consolidates the fingerprint smudge into a single copy to avoid the tasks stepping on each other.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. run `./gradlew api-participant:clean`
2. run `./gradlew api-participant:jibDockerBuild`
3. redeploy ApiAdminApp
4. in your browser, try to load http://sandbox.ourhealth.localhost:8081/assets/index-FAKEHASH.css -- confirm you get the css file