### PR TITLE
[JN-1216] Consistent button sizing for Step Overview section

### DIFF
--- a/ui-core/src/participant/landing/sections/ParticipationDetailTemplate.tsx
+++ b/ui-core/src/participant/landing/sections/ParticipationDetailTemplate.tsx
@@ -104,7 +104,7 @@ function ParticipationDetailTemplate(props: ParticipationDetailTemplateProps) {
         { blurb && <p className={classNames('fs-4', actionButton ? 'mb-4' : 'mb-0')}>
           <InlineMarkdown>{blurb}</InlineMarkdown>
         </p> }
-        {actionButton && <ConfiguredButton config={actionButton} />}
+        {actionButton && <ConfiguredButton config={actionButton} className="btn-lg"/>}
       </div>
     </div>
   </div>

--- a/ui-core/src/participant/landing/sections/StepOverviewTemplate.tsx
+++ b/ui-core/src/participant/landing/sections/StepOverviewTemplate.tsx
@@ -106,7 +106,7 @@ function StepOverviewTemplate(props: StepOverviewTemplateProps) {
       <div className="d-grid gap-2 d-md-flex justify-content-center mt-4">
         {
           _.map(buttons, (button, i) => {
-            return <ConfiguredButton key={i} config={button} className="px-4 me-md-2" />
+            return <ConfiguredButton key={i} config={button} className="btn-lg px-4 me-md-2" />
           })
         }
       </div>


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

gVASC asked about this. All other buttons in the participant app use the `btn-lg` styling, but the buttons in the Step Overview and Participation Detail section types didn't. This makes them consistent.

ParticipationDetail template:
Before
<img width="1261" alt="Screenshot 2024-07-22 at 6 07 07 PM" src="https://github.com/user-attachments/assets/497c1ded-d1f1-436a-8470-c86eac697ffa">

After
<img width="1262" alt="Screenshot 2024-07-22 at 6 07 18 PM" src="https://github.com/user-attachments/assets/fa353a3b-93aa-46dc-b606-09bc32d50f82">

Step Overview template:

Before
<img width="1261" alt="Screenshot 2024-07-22 at 6 08 34 PM" src="https://github.com/user-attachments/assets/2e4c48f2-4e08-47e6-a0e8-0be5055befa3">

After
<img width="1259" alt="Screenshot 2024-07-22 at 6 08 46 PM" src="https://github.com/user-attachments/assets/5a9e3b1c-27dd-4f31-ab95-6fac6a8d6339">



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Confirm that the "Learn More About Participation" button is the same size as all other buttons: https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/siteContent