### PR TITLE
[JN-1219] Fix overlapped dropdowns on admin navbar

### DIFF
--- a/ui-admin/src/navbar/AdminNavbar.tsx
+++ b/ui-admin/src/navbar/AdminNavbar.tsx
@@ -23,7 +23,7 @@ function AdminNavbar() {
         aria-label="Toggle navigation">
         <span className="navbar-toggler-icon"></span>
       </button>
-      <div className="collapse navbar-collapse" id="navbarSupportedContent">
+      <div className="collapse navbar-collapse z-1" id="navbarSupportedContent">
         <ul className="navbar-nav ms-lg-3">
           { breadCrumbs.map((crumb, index) => <li key={index}
             className="ms-2 d-flex align-items-center" >


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Before:
<img width="293" alt="Screenshot 2024-07-22 at 7 42 01 PM" src="https://github.com/user-attachments/assets/9ec5d7e3-41aa-4b74-8e78-f119bb928736"><img width="274" alt="Screenshot 2024-07-22 at 7 41 56 PM" src="https://github.com/user-attachments/assets/b0e020f2-9f4b-4adf-a9d3-f5d3816605ac">

After:
<img width="307" alt="Screenshot 2024-07-22 at 7 41 46 PM" src="https://github.com/user-attachments/assets/9b932ebe-1de6-4ce4-84b8-845277599a99"><img width="282" alt="Screenshot 2024-07-22 at 7 41 42 PM" src="https://github.com/user-attachments/assets/14f9850b-8061-420b-96bd-c14c94f6badf">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Log into the admin ui and make sure that the navbar dropdowns are displayed on top of everything else 