### PR TITLE
[no ticket yet] Tweak timeline UX

### DIFF
--- a/ui-admin/src/components/InfoCard.tsx
+++ b/ui-admin/src/components/InfoCard.tsx
@@ -47,7 +47,7 @@ import { isEmpty } from 'lodash'
  * ```
  */
 export function InfoCard({ children }: { children: React.ReactNode }) {
-  return <div className="card w-75 border shadow-sm mb-3">
+  return <div className="card border shadow-sm mb-3">
     {children}
   </div>
 }

--- a/ui-admin/src/study/participants/KitRequests.tsx
+++ b/ui-admin/src/study/participants/KitRequests.tsx
@@ -82,7 +82,7 @@ export default function KitRequests({ enrollee, studyEnvContext, onUpdate }:
         <div className="fw-bold lead my-1">Kit Requests</div>
         {user?.superuser &&
             <Button onClick={() => setShowRequestKitModal(true)}
-              variant="light" className="border m-1">
+              variant="light" className="border">
               <FontAwesomeIcon icon={faPlus} className="fa-lg"/> Request a kit
             </Button>
         }

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeTimeline.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeTimeline.tsx
@@ -31,8 +31,8 @@ import {
   faEnvelopeOpen
 } from '@fortawesome/free-solid-svg-icons'
 import InfoPopup from 'components/forms/InfoPopup'
-import { InfoCard, InfoCardHeader } from '../../../components/InfoCard'
-import LoadingSpinner from '../../../util/LoadingSpinner'
+import { InfoCard, InfoCardHeader } from 'components/InfoCard'
+import LoadingSpinner from 'util/LoadingSpinner'
 import Select from 'react-select'
 
 

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeTimeline.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeTimeline.tsx
@@ -50,7 +50,6 @@ const EVENT_TYPES = [{
 }, {
   value: 'event',
   label: 'Events'
-
 }]
 
 /** loads the list of notifications and events for a given enrollee and displays them in the UI */

--- a/ui-admin/src/study/participants/enrolleeView/ParticipantNotesView.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/ParticipantNotesView.tsx
@@ -37,7 +37,7 @@ const ParticipantNotesView = ({ enrollee, notes, studyEnvContext, onUpdate }: Pa
       <div className="d-flex align-items-center justify-content-between w-100">
         <div className="fw-bold lead my-1">Notes</div>
         <Button onClick={() => setShowAdd(!showAdd)}
-          variant="light" className="border m-1">
+          variant="light" className="border">
           <FontAwesomeIcon icon={faPlus} className="fa-lg"/> Create new note
         </Button>
       </div>


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

The other day I just wanted to see which emails had gone out to a user. I guess I could have sorted by Delivery Type but there's just a ton of stuff going into the enrollee timeline so I think it could use some additional filters/controls.

This also turns the view into an InfoCard for consistent UX with other parts of the enrollee view, and changes their width to `w-100`.

Timeline Before
<img width="1512" alt="Screenshot 2024-07-22 at 8 20 34 PM" src="https://github.com/user-attachments/assets/e57f9d18-8bb0-4ec9-9e02-f42371313269">

Timeline After
<img width="1512" alt="Screenshot 2024-07-22 at 8 17 01 PM" src="https://github.com/user-attachments/assets/d70356b4-7eff-4230-8748-c969aef5c912">


Enrollee View Before:
<img width="1512" alt="Screenshot 2024-07-22 at 8 20 55 PM" src="https://github.com/user-attachments/assets/d794f1eb-a7b5-44d2-83c6-227ca3ae3782">

Enrollee View After:
<img width="1512" alt="Screenshot 2024-07-22 at 8 21 30 PM" src="https://github.com/user-attachments/assets/b800a83c-dd66-4472-88b5-1b83d2053f46">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

