### PR TITLE
[JN-1207] Add Not Found page for unmatched participant routes

### DIFF
--- a/populate/src/main/resources/seed/i18n/dev/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/dev/languageTexts.json
@@ -96,5 +96,10 @@
   {"keyName": "yourName", "text": "DEV_Your name", "language": "dev"},
   {"keyName": "yourEmail", "text": "DEV_Your email", "language": "dev"},
   {"keyName": "join", "text":  "DEV_Join", "language": "dev"},
-  {"keyName": "thanksForJoining", "text": "DEV_Thanks for joining!", "language": "dev"}
+  {"keyName": "thanksForJoining", "text": "DEV_Thanks for joining!", "language": "dev"},
+  {"keyName": "pageNotFoundTitle", "text": "DEV_Page not found", "language": "dev"},
+  {"keyName": "pageNotFoundMessage", "text": "DEV_If you believe this is an error, please contact ${studyContactEmail}", "language": "dev"},
+  {"keyName": "pageNotFoundReturnHome", "text": "DEV_Return to the home page", "language": "dev"},
+  {"keyName": "authErrorPageTitle", "text": "DEV_Something went wrong", "language": "dev"},
+  {"keyName": "authErrorPageMessage", "text": "DEV_There was an issue with our authentication service. Please try again. If the problem persists, please contact ${studyContactEmail}.", "language": "dev"}
 ]

--- a/populate/src/main/resources/seed/i18n/en/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/en/languageTexts.json
@@ -96,5 +96,10 @@
   {"keyName": "yourName", "text": "Your name", "language": "en"},
   {"keyName": "yourEmail", "text": "Your email", "language": "en"},
   {"keyName": "join", "text":  "Join", "language": "en"},
-  {"keyName": "thanksForJoining", "text": "Thanks for joining!", "language": "en"}
+  {"keyName": "thanksForJoining", "text": "Thanks for joining!", "language": "en"},
+  {"keyName": "pageNotFoundTitle", "text": "Page not found", "language": "en"},
+  {"keyName": "pageNotFoundMessage", "text": "If you believe this is an error, please contact ${studyContactEmail}", "language": "en"},
+  {"keyName": "pageNotFoundReturnHome", "text": "Return to the home page", "language": "en"},
+  {"keyName": "authErrorPageTitle", "text": "Something went wrong", "language": "en"},
+  {"keyName": "authErrorPageMessage", "text": "There was an issue with our authentication service. Please try again. If the problem persists, please contact ${studyContactEmail}.", "language": "en"}
 ]

--- a/populate/src/main/resources/seed/i18n/es/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/es/languageTexts.json
@@ -96,6 +96,10 @@
   {"keyName": "yourName", "text": "Tu nombre", "language": "es"},
   {"keyName": "yourEmail", "text": "Tu correo electrónico", "language": "es"},
   {"keyName": "join", "text": "Unirse", "language": "es"},
-  {"keyName": "thanksForJoining", "text": "¡Gracias por unirse!", "language": "es"}
-
+  {"keyName": "thanksForJoining", "text": "¡Gracias por unirse!", "language": "es"},
+  {"keyName": "pageNotFoundTitle", "text": "Página no encontrada", "language": "es"},
+  {"keyName": "pageNotFoundMessage", "text": "Si cree que se trata de un error, comuníquese con ${studyContactEmail}", "language": "es"},
+  {"keyName": "pageNotFoundReturnHome", "text": "Regresar a la página de inicio", "language": "es"},
+  {"keyName": "authErrorPageTitle", "text": "Algo salió mal", "language": "es"},
+  {"keyName": "authErrorPageMessage", "text": "Hubo un problema con nuestro servicio de autenticación. Inténtalo de nuevo. Si el problema persiste, por favor contacte ${studyContactEmail}", "language": "es"}
 ]

--- a/ui-participant/src/App.tsx
+++ b/ui-participant/src/App.tsx
@@ -27,6 +27,7 @@ import InvitationPage from './landing/registration/InvitationPage'
 import AuthError from './login/AuthError'
 import ActiveUserProvider from './providers/ActiveUserProvider'
 import { CookieAlert } from './CookieAlert'
+import PageNotFound from './PageNotFound'
 
 const PrivacyPolicyPage = lazy(() => import('terms/PrivacyPolicyPage'))
 const InvestigatorTermsOfUsePage = lazy(() => import('terms/InvestigatorTermsOfUsePage'))
@@ -140,7 +141,7 @@ function App() {
                               <Route path="/privacy" element={<PrivacyPolicyPage/>}/>
                               <Route path="/terms/investigator" element={<InvestigatorTermsOfUsePage/>}/>
                               <Route path="/terms/participant" element={<ParticipantTermsOfUsePage/>}/>
-                              <Route path="*" element={<div>unmatched route</div>}/>
+                              <Route path="*" element={<PageNotFound/>}/>
                             </Routes>
                           </Suspense>
                           {!cookiesAcknowledged && <CookieAlert onDismiss={() => setCookiesAcknowledged()} />}

--- a/ui-participant/src/PageNotFound.tsx
+++ b/ui-participant/src/PageNotFound.tsx
@@ -24,9 +24,7 @@ export default function PageNotFound() {
         <div className="fs-2 fw-light d-flex justify-content-center text-center">
           <div>
             <span>
-              The page you requested was not found.
-
-              If the problem persists, please
+              If you believe this is an error, please
               contact <a href={`mailto:${supportEmail}`}>{supportEmail}</a>.
             </span>
             <div className="d-flex justify-content-center mt-3">

--- a/ui-participant/src/PageNotFound.tsx
+++ b/ui-participant/src/PageNotFound.tsx
@@ -4,7 +4,7 @@ import { faCircleExclamation } from '@fortawesome/free-solid-svg-icons'
 import { usePortalEnv } from './providers/PortalProvider'
 import Navbar from './Navbar'
 import { Link } from 'react-router-dom'
-import {useI18n} from "@juniper/ui-core";
+import { useI18n } from '@juniper/ui-core'
 
 /**
  * Displays when there is an unmatched participant route.

--- a/ui-participant/src/PageNotFound.tsx
+++ b/ui-participant/src/PageNotFound.tsx
@@ -4,13 +4,16 @@ import { faCircleExclamation } from '@fortawesome/free-solid-svg-icons'
 import { usePortalEnv } from './providers/PortalProvider'
 import Navbar from './Navbar'
 import { Link } from 'react-router-dom'
+import {useI18n} from "@juniper/ui-core";
 
 /**
  * Displays when there is an unmatched participant route.
  */
 export default function PageNotFound() {
   const portalEnv = usePortalEnv()
-  const supportEmail = portalEnv.portalEnv.portalEnvironmentConfig.emailSourceAddress
+  const studyContactEmail = portalEnv.portalEnv.portalEnvironmentConfig.emailSourceAddress || ''
+  const { i18n } = useI18n()
+
   return (
     <div className="container-fluid bg-white min-vh-100 d-flex flex-column p-0">
       <Navbar aria-label="Primary"/>
@@ -18,18 +21,20 @@ export default function PageNotFound() {
         <div className="fs-1 fw-bold d-flex justify-content-center">
           <div>
             <FontAwesomeIcon className="me-2" icon={faCircleExclamation}/>
-            <span>Page not found</span>
+            <span>{i18n('pageNotFoundTitle')}</span>
           </div>
         </div>
         <div className="fs-2 fw-light d-flex justify-content-center text-center">
           <div>
             <span>
-              If you believe this is an error, please
-              contact <a href={`mailto:${supportEmail}`}>{supportEmail}</a>.
+              {i18n('pageNotFoundMessage', {
+                substitutions: {
+                  studyContactEmail
+              }})}
             </span>
             <div className="d-flex justify-content-center mt-3">
               <Link className="btn btn-outline-primary" to={'/'}>
-                Return to the home page
+                {i18n('pageNotFoundReturnHome')}
               </Link>
             </div>
           </div>

--- a/ui-participant/src/PageNotFound.tsx
+++ b/ui-participant/src/PageNotFound.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faCircleExclamation } from '@fortawesome/free-solid-svg-icons'
+import { usePortalEnv } from './providers/PortalProvider'
+import Navbar from './Navbar'
+import { Link } from 'react-router-dom'
+
+/**
+ * Displays when there is an unmatched participant route.
+ */
+export default function PageNotFound() {
+  const portalEnv = usePortalEnv()
+  const supportEmail = portalEnv.portalEnv.portalEnvironmentConfig.emailSourceAddress
+  return (
+    <div className="container-fluid bg-white min-vh-100 d-flex flex-column p-0">
+      <Navbar aria-label="Primary"/>
+      <main className="flex-grow-1 p-2 d-flex flex-column justify-content-center">
+        <div className="fs-1 fw-bold d-flex justify-content-center">
+          <div>
+            <FontAwesomeIcon className="me-2" icon={faCircleExclamation}/>
+            <span>Page not found</span>
+          </div>
+        </div>
+        <div className="fs-2 fw-light d-flex justify-content-center text-center">
+          <div>
+            <span>
+              The page you have requested was not found.
+
+              If the problem persists, please
+              contact <a href={`mailto:${supportEmail}`}>{supportEmail}</a>.
+            </span>
+            <div className="d-flex justify-content-center mt-3">
+              <Link className="btn btn-outline-primary" to={'/'}>
+                Return to the home page
+              </Link>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/ui-participant/src/PageNotFound.tsx
+++ b/ui-participant/src/PageNotFound.tsx
@@ -24,7 +24,7 @@ export default function PageNotFound() {
         <div className="fs-2 fw-light d-flex justify-content-center text-center">
           <div>
             <span>
-              The page you have requested was not found.
+              The page you requested was not found.
 
               If the problem persists, please
               contact <a href={`mailto:${supportEmail}`}>{supportEmail}</a>.

--- a/ui-participant/src/PageNotFound.tsx
+++ b/ui-participant/src/PageNotFound.tsx
@@ -30,7 +30,8 @@ export default function PageNotFound() {
               {i18n('pageNotFoundMessage', {
                 substitutions: {
                   studyContactEmail
-              }})}
+                }
+              })}
             </span>
             <div className="d-flex justify-content-center mt-3">
               <Link className="btn btn-outline-primary" to={'/'}>

--- a/ui-participant/src/login/AuthError.tsx
+++ b/ui-participant/src/login/AuthError.tsx
@@ -31,7 +31,8 @@ export default function AuthError() {
               {i18n('authErrorPageMessage', {
                 substitutions: {
                   studyContactEmail: supportEmail
-                }})}
+                }
+              })}
             </span>
           </div>
         </div>

--- a/ui-participant/src/login/AuthError.tsx
+++ b/ui-participant/src/login/AuthError.tsx
@@ -3,7 +3,7 @@ import Navbar from '../Navbar'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircleExclamation } from '@fortawesome/free-solid-svg-icons'
 import { usePortalEnv } from '../providers/PortalProvider'
-import {useI18n} from "@juniper/ui-core";
+import { useI18n } from '@juniper/ui-core'
 
 /**
  * Displays when there is an error from b2c.

--- a/ui-participant/src/login/AuthError.tsx
+++ b/ui-participant/src/login/AuthError.tsx
@@ -3,13 +3,16 @@ import Navbar from '../Navbar'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircleExclamation } from '@fortawesome/free-solid-svg-icons'
 import { usePortalEnv } from '../providers/PortalProvider'
+import {useI18n} from "@juniper/ui-core";
 
 /**
  * Displays when there is an error from b2c.
  */
 export default function AuthError() {
   const portalEnv = usePortalEnv()
-  const supportEmail = portalEnv.portalEnv.portalEnvironmentConfig.emailSourceAddress
+  const supportEmail = portalEnv.portalEnv.portalEnvironmentConfig.emailSourceAddress || '2'
+  const { i18n } = useI18n()
+
   return (
     <div className="container-fluid bg-white min-vh-100 d-flex flex-column p-0">
       <Navbar aria-label="Primary"/>
@@ -17,14 +20,18 @@ export default function AuthError() {
         <div className="fs-1 fw-bold d-flex justify-content-center">
           <div>
             <FontAwesomeIcon className="me-2" icon={faCircleExclamation}/>
-            <span>Something went wrong</span>
+            <span>
+              {i18n('authErrorPageTitle')}
+            </span>
           </div>
         </div>
         <div className="fs-2 fw-light d-flex justify-content-center text-center">
           <div>
             <span>
-              There was an issue with our authentication service. Please try again. If the problem persists, please
-              contact <a href={`mailto:${supportEmail}`}>{supportEmail}</a>.
+              {i18n('authErrorPageMessage', {
+                substitutions: {
+                  studyContactEmail: supportEmail
+                }})}
             </span>
           </div>
         </div>


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Mobile:
![Screenshot 2024-07-23 at 8 43 57 PM](https://github.com/user-attachments/assets/81cd9968-4da8-4233-9537-41b34b9941b6)

Desktop:
![Screenshot 2024-07-23 at 8 43 31 PM](https://github.com/user-attachments/assets/7c3f627d-1014-4e03-a4cb-335f6e806ff1)


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Go to https://sandbox.demo.localhost:3001/foo and confirm that you see the new page