### PR TITLE
[JN-1225] fix address validation

### DIFF
--- a/ui-participant/src/components/ThemedSurveyAddressValidation.tsx
+++ b/ui-participant/src/components/ThemedSurveyAddressValidation.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { ReactQuestionFactory } from 'survey-react-ui'
 import { SurveyQuestionAddressValidation } from '@juniper/ui-core'
 import ThemedModal from './ThemedModal'
 import { ModalProps } from 'react-bootstrap'
@@ -9,8 +8,3 @@ export class ThemedSurveyQuestionAddressValidation extends SurveyQuestionAddress
     return ThemedModal
   }
 }
-
-// register themed address validation type
-ReactQuestionFactory.Instance.registerQuestion('addressvalidation', props => {
-  return React.createElement(ThemedSurveyQuestionAddressValidation, props)
-})

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -1,12 +1,25 @@
-import React, { useEffect, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import React, {
+  useEffect,
+  useState
+} from 'react'
+import {
+  useNavigate,
+  useParams
+} from 'react-router-dom'
 import 'survey-core/survey.i18n'
 
-import Api, { Portal, SurveyWithResponse } from 'api/api'
+import Api, {
+  Portal,
+  SurveyWithResponse
+} from 'api/api'
 
 import {
-  ApiProvider, Enrollee, EnvironmentName, PagedSurveyView,
-  useI18n, useTaskIdParam
+  ApiProvider,
+  Enrollee,
+  EnvironmentName,
+  PagedSurveyView,
+  useI18n,
+  useTaskIdParam
 } from '@juniper/ui-core'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { PageLoadingIndicator } from 'util/LoadingSpinner'
@@ -15,6 +28,14 @@ import { DocumentTitle } from 'util/DocumentTitle'
 import { useActiveUser } from 'providers/ActiveUserProvider'
 import { useUser } from 'providers/UserProvider'
 import { HubUpdate } from 'hub/hubUpdates'
+import { ThemedSurveyQuestionAddressValidation } from 'components/ThemedSurveyAddressValidation'
+import { ReactQuestionFactory } from 'survey-react-ui'
+
+// register themed address validation type
+ReactQuestionFactory.Instance.registerQuestion('addressvalidation', props => {
+  return React.createElement(ThemedSurveyQuestionAddressValidation, props)
+})
+
 
 /** handles loading the survey form and responses from the server */
 function SurveyView({ showHeaders = true }: { showHeaders?: boolean }) {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

In some code shuffle, the participant ui stopped importing and adding the themed address validation modal. This fixes that.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Fill out demo basics and ensure address validation works as expected. If using stub endpoint, just put in `415 IMPROVABLE St` to get the modal.