### PR TITLE
[JN-1227] Add new RGP demo tenant

### DIFF
--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PortalController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PortalController.java
@@ -54,8 +54,9 @@ public class PortalController implements PortalApi {
   @Override
   @CrossOrigin(
       origins = {
-        "https://juniperdemodev.b2clogin.com", // Heart (demo only)
+        "https://juniperdemodev.b2clogin.com", // Heart Demo (demo only)
         "https://junipercmidemo.b2clogin.com", // CMI (demo only)
+        "https://juniperrgpdemo.b2clogin.com", // RGP (demo only)
         "https://ourhealthdev.b2clogin.com", // OurHealth (demo)
         "https://ourhealthstudy.b2clogin.com", // OurHealth (prod)
         "https://hearthivedev.b2clogin.com", // HeartHive (demo)

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PublicApiController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PublicApiController.java
@@ -104,8 +104,9 @@ public class PublicApiController implements PublicApi {
 
   @CrossOrigin(
       origins = {
-        "https://juniperdemodev.b2clogin.com", // Heart (demo only)
+        "https://juniperdemodev.b2clogin.com", // Heart Demo (demo only)
         "https://junipercmidemo.b2clogin.com", // CMI (demo only)
+        "https://juniperrgpdemo.b2clogin.com", // RGP (demo only)
         "https://ourhealthdev.b2clogin.com", // OurHealth (demo)
         "https://ourhealthstudy.b2clogin.com", // OurHealth (prod)
         "https://hearthivedev.b2clogin.com", // HeartHive (demo)

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/SiteMediaController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/SiteMediaController.java
@@ -24,8 +24,9 @@ public class SiteMediaController implements SiteMediaApi {
   @Override
   @CrossOrigin(
       origins = {
-        "https://juniperdemodev.b2clogin.com", // Heart (demo only)
+        "https://juniperdemodev.b2clogin.com", // Heart Demo (demo only)
         "https://junipercmidemo.b2clogin.com", // CMI (demo only)
+        "https://juniperrgpdemo.b2clogin.com", // RGP (demo only)
         "https://ourhealthdev.b2clogin.com", // OurHealth (prod)
         "https://ourhealthstudy.b2clogin.com", // OurHealth (demo)
         "https://hearthivedev.b2clogin.com", // HeartHive (prod)

--- a/api-participant/src/main/resources/b2c-config.yml
+++ b/api-participant/src/main/resources/b2c-config.yml
@@ -24,3 +24,8 @@ b2c:
     clientId: 0cdfdafd-75fb-4e36-b6a2-c00e79c86bb0
     policyName: B2C_1A_ddp_participant_signup_signin_cmi-dev
     changePasswordPolicyName: B2C_1A_ddp_participant_change_password_cmi-dev
+  rgp:
+    tenantName: juniperrgpdemo
+    clientId: 42445bb9-7ab2-48e9-b7a7-c5f84258e87b
+    policyName: B2C_1A_ddp_participant_signup_signin_rgp-dev
+    changePasswordPolicyName: B2C_1A_ddp_participant_change_password_rgp-dev


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds a new RGP demo b2c tenant.

Also see: 

https://github.com/broadinstitute/terraform-ap-deployments/pull/1653
https://github.com/broadinstitute/terra-helmfile/pull/5746

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Restart participant API
Extract RGP portal from demo
Import it locally
Restart participant UI with b2c enabled
Confirm you can log in/register using the new b2c tenant
