### PR TITLE
[JN-1224] AT pre-enroll/registration flow

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/SiteMediaController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/SiteMediaController.java
@@ -40,6 +40,7 @@ public class SiteMediaController implements SiteMediaApi {
   @Override
   public ResponseEntity<Resource> get(
       String portalShortcode, String envName, String cleanFileName, String version) {
+    cleanFileName = cleanFileName.toLowerCase();
     if (version.equalsIgnoreCase("latest")) {
       Optional<SiteMedia> siteMediaOpt =
           siteMediaExtService.findLatest(portalShortcode, cleanFileName);

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/SiteMediaController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/SiteMediaController.java
@@ -31,7 +31,9 @@ public class SiteMediaController implements SiteMediaApi {
         "https://hearthivedev.b2clogin.com", // HeartHive (prod)
         "https://hearthive.b2clogin.com", // HeartHive (demo)
         "https://gvascdev.b2clogin.com", // gVASC (demo)
-        "https://gvascprod.b2clogin.com" // gVASC (prod)
+        "https://gvascprod.b2clogin.com", // gVASC (prod)
+        "https://localhost:3000",
+        "https://sandbox.atcp.localhost:3001"
       },
       maxAge = 3600,
       methods = {RequestMethod.GET, RequestMethod.OPTIONS})

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/SiteMediaController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/SiteMediaController.java
@@ -32,7 +32,9 @@ public class SiteMediaController implements SiteMediaApi {
         "https://hearthivedev.b2clogin.com", // HeartHive (prod)
         "https://hearthive.b2clogin.com", // HeartHive (demo)
         "https://gvascdev.b2clogin.com", // gVASC (demo)
-        "https://gvascprod.b2clogin.com" // gVASC (prod)
+        "https://gvascprod.b2clogin.com", // gVASC (prod)
+        "https://localhost:3000",
+        "https://sandbox.atcp.localhost:3001"
       },
       maxAge = 3600,
       methods = {RequestMethod.GET, RequestMethod.OPTIONS})

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/SiteMediaController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/SiteMediaController.java
@@ -32,9 +32,7 @@ public class SiteMediaController implements SiteMediaApi {
         "https://hearthivedev.b2clogin.com", // HeartHive (prod)
         "https://hearthive.b2clogin.com", // HeartHive (demo)
         "https://gvascdev.b2clogin.com", // gVASC (demo)
-        "https://gvascprod.b2clogin.com", // gVASC (prod)
-        "https://localhost:3000",
-        "https://sandbox.atcp.localhost:3001"
+        "https://gvascprod.b2clogin.com" // gVASC (prod)
       },
       maxAge = 3600,
       methods = {RequestMethod.GET, RequestMethod.OPTIONS})

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/SiteMediaController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/SiteMediaController.java
@@ -45,7 +45,7 @@ public class SiteMediaController implements SiteMediaApi {
       String portalShortcode, String envName, String cleanFileName, Integer version) {
     Optional<SiteMedia> siteMediaOpt;
 
-    siteMediaOpt = siteMediaService.findOne(portalShortcode, cleanFileName, version);
+    siteMediaOpt = siteMediaService.findOne(portalShortcode, cleanFileName.toLowerCase(), version);
     return convertToResourceResponse(siteMediaOpt);
   }
 

--- a/api-participant/src/main/resources/b2c-config.yml
+++ b/api-participant/src/main/resources/b2c-config.yml
@@ -24,3 +24,8 @@ b2c:
     clientId: 0cdfdafd-75fb-4e36-b6a2-c00e79c86bb0
     policyName: B2C_1A_ddp_participant_signup_signin_cmi-dev
     changePasswordPolicyName: B2C_1A_ddp_participant_change_password_cmi-dev
+  atcp:
+    tenantName: none
+    clientId: none
+    policyName: none
+    changePasswordPolicyName: none

--- a/core/src/main/java/bio/terra/pearl/core/service/search/EnrolleeSearchExpressionParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/EnrolleeSearchExpressionParser.java
@@ -142,6 +142,8 @@ public class EnrolleeSearchExpressionParser {
             return new UserInputTerm(new SearchValue(Double.parseDouble(ctx.NUMBER().getText())));
         } else if (ctx.VARIABLE() != null) {
             return parseVariableTerm(ctx.VARIABLE().getText());
+        } else if (ctx.NULL() != null) {
+            return new UserInputTerm(new SearchValue());
         } else {
             throw new IllegalArgumentException("Unknown term type");
         }

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/SearchValue.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/SearchValue.java
@@ -107,8 +107,18 @@ public class SearchValue {
 
     public boolean greaterThan(SearchValue right) {
         return switch (this.searchValueType) {
-            case NUMBER -> this.numberValue > right.numberValue;
-            case INSTANT -> this.instantValue.isAfter(right.instantValue);
+            case NUMBER -> {
+                if (right.numberValue == null) {
+                    yield false;
+                }
+                yield this.numberValue > right.numberValue;
+            }
+            case INSTANT -> {
+                if (right.instantValue == null) {
+                    yield false;
+                }
+                yield this.instantValue.isAfter(right.instantValue);
+            }
             default -> false;
         };
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/SearchValue.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/SearchValue.java
@@ -87,6 +87,11 @@ public class SearchValue {
             // flip the comparison if the right side is an array so that we hit the array comparison logic
             return right.equals(this);
         }
+
+        if (this.searchValueType != right.searchValueType && !this.searchValueType.equals(SearchValueType.ARRAY)) {
+            return false;
+        }
+
         return switch (this.searchValueType) {
             case STRING -> this.stringValue.equals(right.stringValue);
             case NUMBER -> this.numberValue.equals(right.numberValue);
@@ -106,24 +111,20 @@ public class SearchValue {
     }
 
     public boolean greaterThan(SearchValue right) {
+        if (this.searchValueType != right.searchValueType) {
+            return false;
+        }
         return switch (this.searchValueType) {
-            case NUMBER -> {
-                if (right.numberValue == null) {
-                    yield false;
-                }
-                yield this.numberValue > right.numberValue;
-            }
-            case INSTANT -> {
-                if (right.instantValue == null) {
-                    yield false;
-                }
-                yield this.instantValue.isAfter(right.instantValue);
-            }
+            case NUMBER -> this.numberValue > right.numberValue;
+            case INSTANT -> this.instantValue.isAfter(right.instantValue);
             default -> false;
         };
     }
 
     public boolean greaterThanOrEqualTo(SearchValue right) {
+        if (this.searchValueType != right.searchValueType) {
+            return false;
+        }
         return switch (this.searchValueType) {
             case NUMBER -> this.numberValue >= right.numberValue;
             case INSTANT -> this.instantValue.isAfter(right.instantValue) || this.instantValue.equals(right.instantValue);

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
@@ -50,11 +50,7 @@ public class AnswerProcessingService {
             return;
         }
         processProfileAnswerMappings(enrollee, answers, mappings, operator, auditInfo);
-        // if the ppUser is not the same as the enrollee, we're in a proxy environment,
-        // so we should check proxy profile mappings. otherwise, ignore them.
-        if (!ppUser.getProfileId().equals(enrollee.getProfileId())) {
-            processProxyProfileAnswerMappings(enrollee, answers, mappings, ppUser, auditInfo);
-        }
+        processProxyProfileAnswerMappings(enrollee, answers, mappings, ppUser, auditInfo);
     }
 
     /**
@@ -91,6 +87,12 @@ public class AnswerProcessingService {
             List<AnswerMapping> mappings,
             PortalParticipantUser operator,
             DataAuditInfo auditInfo) {
+
+        // if the ppUser is the same as the enrollee, we're not in a proxy environment
+        if (operator.getProfileId().equals(enrollee.getProfileId())) {
+            return;
+        }
+
         List<AnswerMapping> proxyProfileMappings = mappings.stream().filter(mapping ->
                 mapping.getTargetType().equals(AnswerMappingTargetType.PROXY_PROFILE)).toList();
         if (proxyProfileMappings.isEmpty() || !hasTargetedChanges(proxyProfileMappings, answers, AnswerMappingTargetType.PROXY_PROFILE)) {

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
@@ -1,6 +1,5 @@
 package bio.terra.pearl.core.service.survey;
 
-import bio.terra.pearl.core.dao.workflow.DataChangeRecordDao;
 import bio.terra.pearl.core.model.audit.DataAuditInfo;
 import bio.terra.pearl.core.model.audit.DataChangeRecord;
 import bio.terra.pearl.core.model.audit.ResponsibleEntity;
@@ -13,7 +12,6 @@ import bio.terra.pearl.core.model.survey.AnswerMappingMapType;
 import bio.terra.pearl.core.model.survey.AnswerMappingTargetType;
 import bio.terra.pearl.core.model.workflow.ObjectWithChangeLog;
 import bio.terra.pearl.core.service.participant.ProfileService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -22,11 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.BiFunction;
 
 /**
@@ -56,7 +50,11 @@ public class AnswerProcessingService {
             return;
         }
         processProfileAnswerMappings(enrollee, answers, mappings, operator, auditInfo);
-        processProxyProfileAnswerMappings(enrollee, answers, mappings, ppUser, auditInfo);
+        // if the ppUser is not the same as the enrollee, we're in a proxy environment,
+        // so we should check proxy profile mappings. otherwise, ignore them.
+        if (!ppUser.getProfileId().equals(enrollee.getProfileId())) {
+            processProxyProfileAnswerMappings(enrollee, answers, mappings, ppUser, auditInfo);
+        }
     }
 
     /**

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyParseUtils.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyParseUtils.java
@@ -201,7 +201,12 @@ public class SurveyParseUtils {
      * in the answerField of the node
      * */
     protected static <T> T convertQuestionAnswerToClass(JsonNode node, String answerField, Class<T> returnClass, ObjectMapper objectMapper) throws JsonProcessingException {
-        String objectValueString = node.get(answerField).asText();
+        String objectValueString;
+        if (Objects.nonNull(answerField)) {
+            objectValueString = node.get(answerField).asText();
+        } else {
+            objectValueString = getAnswerValue(node);
+        }
         // Direct conversion for String
         if (returnClass == String.class) {
             return returnClass.cast(objectValueString);
@@ -214,6 +219,16 @@ public class SurveyParseUtils {
         } catch (Exception e) {
             throw new IllegalArgumentException("The provided returnClass does not have a String constructor that we can use.", e);
         }
+    }
+
+    private static String getAnswerValue(JsonNode node) {
+        for (String value : List.of("stringValue", "booleanValue", "objectValue", "numberValue")) {
+            JsonNode valueNode = node.get(value);
+            if (valueNode != null) {
+                return valueNode.asText();
+            }
+        }
+        throw new IllegalArgumentException("Could not find a value in the answer node");
     }
 
     protected static String getQuestionStableId(JsonNode node) {

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyParseUtils.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyParseUtils.java
@@ -176,6 +176,7 @@ public class SurveyParseUtils {
      * @param returnClass the class to return the answer as
      *                    The method assumes the returnClass is a valid class that can be used to convert the answer to
      * @param objectMapper the object mapper to use to convert the answer to the returnClass
+     * @param answerField the field to get the answer from in the question node. If null, it will attempt to get the answer from the first non-null field.
      * @param <T> the class to return the answer as
      * @return the answer to the question with the stableId questionStableId as the class returnClass
      * */
@@ -222,8 +223,8 @@ public class SurveyParseUtils {
     }
 
     private static String getAnswerValue(JsonNode node) {
-        for (String value : List.of("stringValue", "booleanValue", "objectValue", "numberValue")) {
-            JsonNode valueNode = node.get(value);
+        for (String valueField : List.of("stringValue", "booleanValue", "objectValue", "numberValue")) {
+            JsonNode valueNode = node.get(valueField);
             if (valueNode != null) {
                 return valueNode.asText();
             }

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
@@ -253,7 +253,7 @@ public class EnrollmentService {
             return false;
         }
         String questionStableId = answerMappingForProxyOpt.get().getQuestionStableId();
-        Boolean proxyAnswer = SurveyParseUtils.getAnswerByStableId(preEnrollResponse.getFullData(), questionStableId, Boolean.class, objectMapper, "stringValue");
+        Boolean proxyAnswer = SurveyParseUtils.getAnswerByStableId(preEnrollResponse.getFullData(), questionStableId, Boolean.class, objectMapper, null);
         if (proxyAnswer == null) {
             return false;
         }

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
@@ -423,7 +423,6 @@ public class ActivityImporter {
                     textQuestionDef.getPlaceholderTemplate().getVariables());
         }
 
-
         return txtMap;
     }
 
@@ -438,7 +437,8 @@ public class ActivityImporter {
         for (TemplateVariable var : templateVariables) {
             for (Translation translation : var.getTranslations()) {
                 String languageText = textMap.getOrDefault(translation.getLanguageCode(), StringUtils.trim(templateText));
-                textMap.put(translation.getLanguageCode(), languageText.replace( "$" + var.getName(), translation.getText()));
+                languageText = languageText.replace("$" + var.getName(), translation.getText());
+                textMap.put(translation.getLanguageCode(), languageText);
             }
         }
         return textMap;
@@ -507,10 +507,6 @@ public class ActivityImporter {
         if (StringUtils.isEmpty(pepperExpr)) {
             return null;
         }
-        // example:
-        // user.studies[\"atcp\"].forms[\"REGISTRATION\"].questions[\"REGISTRATION_COUNTRY\"].answers.hasOption (\"AF\")
-        // should become:
-        // {REGISTRATION_COUNTRY} contains 'AF'
 
         Pattern questionPattern = Pattern.compile("user\\.studies\\[\"(.*?)\"\\]\\.forms\\[\"(.*?)\"\\]\\.questions\\[\"(.*?)\"\\]\\.(.*?)\\((.*?)\\)");
         // study e.g.: !user.studies["atcp"].isGovernedParticipant()
@@ -564,15 +560,23 @@ public class ActivityImporter {
 
     /** maps pepper replacement vars to Juniper vars, and html markup to markdown.
      * After testing some more surveys, we might want to upgrade this to use a html->markdown parsing library */
-    Map<String, String> JUNIPER_PEPPER_STRING_MAP = Map.of(
-            "\\$ddp.participantFirstName\\(\\)", "{profile.givenName}",
-            "\\<p.*?\\>", "",
-            "\\</p\\>", "\\\\n",
-            "\\<span.*?\\>", "",
-            "\\</span\\>", "",
-            "\\<em.*?\\>", "**",
-            "\\</em\\>", "**",
-            " +", " "
+    static Map<String, String> JUNIPER_PEPPER_STRING_MAP = Map.ofEntries(
+            Map.entry("\\$ddp.participantFirstName\\(\\)", "{profile.givenName}"),
+            Map.entry("\\<p.*?\\>", ""),
+            Map.entry("\\</p\\>", "\\\\n"),
+            Map.entry("\\<span.*?\\>", ""),
+            Map.entry("\\</span\\>", ""),
+            Map.entry("\\<b.*?\\>", "**"),
+            Map.entry("\\</b\\>", "**"),
+            Map.entry("<b.*?>", "**"),
+            Map.entry("</b>", "**"),
+            Map.entry("\\<i.*?\\>", "_"),
+            Map.entry("\\</i\\>", "_"),
+            Map.entry("<i.*?>", "_"),
+            Map.entry("</i>", "_"),
+            Map.entry("\\<em.*?\\>", "**"),
+            Map.entry("\\</em\\>", "**"),
+            Map.entry(" +", " ")
     );
 
 }

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
@@ -204,6 +204,8 @@ public class ActivityImporter {
         }
 
         Map<String, String> titleMap = getQuestionTxt(pepperQuestionDef);
+        boolean titleIsEmpty = titleMap.isEmpty() || titleMap.values().stream().allMatch(StringUtils::isEmpty);
+
         String questionType = getQuestionType(pepperQuestionDef);
         String inputType = null;
 
@@ -286,6 +288,7 @@ public class ActivityImporter {
         SurveyJSQuestion surveyJSQuestion = SurveyJSQuestion.builder()
                 .name(pepperQuestionDef.getStableId())
                 .type(questionType)
+                .titleLocation(titleIsEmpty ? "hidden" : null)
                 .title(titleMap)
                 .placeholder(placeholder)
                 .labelTrue(labelTrue)
@@ -565,6 +568,8 @@ public class ActivityImporter {
             "\\$ddp.participantFirstName\\(\\)", "{profile.givenName}",
             "\\<p.*?\\>", "",
             "\\</p\\>", "\\\\n",
+            "\\<span.*?\\>", "",
+            "\\</span\\>", "",
             "\\<em.*?\\>", "**",
             "\\</em\\>", "**",
             " +", " "

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
@@ -570,12 +570,12 @@ public class ActivityImporter {
             Map.entry("\\</b\\>", "**"),
             Map.entry("<b.*?>", "**"),
             Map.entry("</b>", "**"),
-            Map.entry("\\<i.*?\\>", "_"),
-            Map.entry("\\</i\\>", "_"),
-            Map.entry("<i.*?>", "_"),
-            Map.entry("</i>", "_"),
-            Map.entry("\\<em.*?\\>", "**"),
-            Map.entry("\\</em\\>", "**"),
+            Map.entry("\\<i.*?\\>", "*"),
+            Map.entry("\\</i\\>", "*"),
+            Map.entry("<i.*?>", "*"),
+            Map.entry("</i>", "*"),
+            Map.entry("\\<em.*?\\>", "*"),
+            Map.entry("\\</em\\>", "*"),
             Map.entry(" +", " ")
     );
 

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ValidationConverter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ValidationConverter.java
@@ -40,7 +40,7 @@ public class ValidationConverter {
                     }
                 }
 
-                targetQuestion.setRequired(true);
+                targetQuestion.setIsRequired(true);
                 targetQuestion.setRequiredErrorText(
                         ActivityImporter.getVariableTranslationsTxt(ruleDef.getHintTemplate().getTemplateText(),
                                 ruleDef.getHintTemplate().getVariables())

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJSPanel.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJSPanel.java
@@ -1,0 +1,31 @@
+package bio.terra.pearl.pepper.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SurveyJSPanel {
+    @Builder.Default
+    String type = "panel";
+
+    String name;
+    Map<String,String> title;
+
+    List<JsonNode> elements;
+
+    List<JsonNode> templateElements;
+
+    Map<String, String> templateTitle;
+    Map<String, String> panelAddText;
+
+    String visibleIf;
+}

--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJSQuestion.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/dto/SurveyJSQuestion.java
@@ -19,6 +19,7 @@ public class SurveyJSQuestion {
     public String inputType;
     public Map<String, String> placeholder;
     public Map<String, String> title;
+    public String titleLocation;
     public Map<String, String> labelTrue;
     public Map<String, String> labelFalse;
     public String valueTrue;
@@ -29,7 +30,7 @@ public class SurveyJSQuestion {
     public Map<String, String> maxErrorText;
     public String minValueExpression;
     public String maxValueExpression;
-    public boolean isRequired;
+    public Boolean isRequired;
     public Map<String, String> requiredErrorText;
     public List<Choice> choices;
     public String visibleIf;

--- a/populate/.gitignore
+++ b/populate/.gitignore
@@ -1,3 +1,3 @@
-src/resources/seed/atcp
-src/resources/seed/atcp/*
-src/resources/seed/atcp/**/*
+src/main/resources/seed/atcp
+src/main/resources/seed/atcp/*
+src/main/resources/seed/atcp/**/*

--- a/populate/.gitignore
+++ b/populate/.gitignore
@@ -1,3 +1,1 @@
-src/main/resources/seed/atcp
-src/main/resources/seed/atcp/*
-src/main/resources/seed/atcp/**/*
+src/main/resources/seed/portals/atcp/

--- a/populate/.gitignore
+++ b/populate/.gitignore
@@ -1,2 +1,3 @@
-resources/seed/atcp
-resources/seed/atcp/*
+src/resources/seed/atcp
+src/resources/seed/atcp/*
+src/resources/seed/atcp/**/*

--- a/populate/.gitignore
+++ b/populate/.gitignore
@@ -1,0 +1,2 @@
+resources/seed/atcp
+resources/seed/atcp/*

--- a/ui-admin/src/forms/FormPreview.tsx
+++ b/ui-admin/src/forms/FormPreview.tsx
@@ -36,6 +36,7 @@ export const FormPreview = (props: FormPreviewProps) => {
     model.setVariable('portalEnvironmentName', 'sandbox')
     model.setVariable('profile', { })
     model.setVariable('proxyProfile', { })
+    model.setVariable('isGovernedUser', false)
     model.ignoreValidation = true
     model.locale = currentLanguage.languageCode
     model.onTextMarkdown.add(applyMarkdown)
@@ -60,13 +61,15 @@ export const FormPreview = (props: FormPreviewProps) => {
             showInvisibleElements: surveyModel.showInvisibleElements,
             locale: surveyModel.locale,
             profile: surveyModel.getVariable('profile'),
-            proxyProfile: surveyModel.getVariable('proxyProfile')
+            proxyProfile: surveyModel.getVariable('proxyProfile'),
+            isGovernedUser: surveyModel.getVariable('isGovernedUser')
           }}
-          onChange={({ ignoreValidation, showInvisibleElements, profile, proxyProfile }) => {
+          onChange={({ ignoreValidation, showInvisibleElements, profile, proxyProfile, isGovernedUser }) => {
             surveyModel.ignoreValidation = ignoreValidation
             surveyModel.showInvisibleElements = showInvisibleElements
             surveyModel.setVariable('profile', profile)
             surveyModel.setVariable('proxyProfile', proxyProfile)
+            surveyModel.setVariable('isGovernedUser', isGovernedUser)
             forceUpdate()
           }}
         />

--- a/ui-admin/src/forms/FormPreviewOptions.tsx
+++ b/ui-admin/src/forms/FormPreviewOptions.tsx
@@ -105,7 +105,7 @@ export const FormPreviewOptions = (props: FormPreviewOptionsProps) => {
           </label>
         </div>
       </div>
-      <div data-testid="proxyInfoFields">
+      <div>
         <div data-testid="proxyInfoFields">
           <h4 className="h6 mt-3">
             Proxy profile <InfoPopup content={<p>

--- a/ui-admin/src/forms/FormPreviewOptions.tsx
+++ b/ui-admin/src/forms/FormPreviewOptions.tsx
@@ -9,6 +9,7 @@ type FormPreviewOptions = {
   locale: string
   profile?: Profile
   proxyProfile?: Profile
+  isGovernedUser: boolean
 }
 
 type FormPreviewOptionsProps = {
@@ -62,10 +63,10 @@ export const FormPreviewOptions = (props: FormPreviewOptionsProps) => {
       <div className="mt-4">
         <div data-testid="profileInfoFields">
           <h4 className="h6">
-          Participant profile <InfoPopup content={<p>
-          Change the values below to test how your survey appears to different participants
-          due to branching logic or dynamic texts.  The participant profile is the profile of the
-          user taking the survey.
+            Participant profile <InfoPopup content={<p>
+            Change the values below to test how your survey appears to different participants
+            due to branching logic or dynamic texts. The participant profile is the profile of the
+            user taking the survey.
             </p>}/>
           </h4>
           <TextInput onChange={text => onChange({
@@ -77,7 +78,7 @@ export const FormPreviewOptions = (props: FormPreviewOptionsProps) => {
           })}
           label={'Given name'}
           unboldLabel={true}
-          value={value.profile?.givenName ?? ''} />
+          value={value.profile?.givenName ?? ''}/>
           <TextInput onChange={text => onChange({
             ...value,
             profile: {
@@ -87,13 +88,29 @@ export const FormPreviewOptions = (props: FormPreviewOptionsProps) => {
           })}
           label={'Family name'}
           unboldLabel={true}
-          value={value.profile?.familyName ?? ''} />
+          value={value.profile?.familyName ?? ''}/>
         </div>
+        <div className="form-check mt-2">
+          <label className="form-check-label" htmlFor="form-is-governed-user">
+            <input
+              checked={value.isGovernedUser}
+              className="form-check-input"
+              id="form-is-governed-user"
+              type="checkbox"
+              onChange={e => {
+                onChange({ ...value, isGovernedUser: e.target.checked })
+              }}
+            />
+            Is governed user
+          </label>
+        </div>
+      </div>
+      <div data-testid="proxyInfoFields">
         <div data-testid="proxyInfoFields">
           <h4 className="h6 mt-3">
             Proxy profile <InfoPopup content={<p>
             Change the values below to test how your survey appears to different participants
-            due to branching logic or dynamic texts.  The proxy profile is the profile of the
+            due to branching logic or dynamic texts. The proxy profile is the profile of the
             person the user is taking the survey on behalf of.
             </p>}/>
           </h4>

--- a/ui-admin/src/study/surveys/AnswerMappingEditor.tsx
+++ b/ui-admin/src/study/surveys/AnswerMappingEditor.tsx
@@ -1,5 +1,13 @@
-import React, { useEffect, useMemo, useState } from 'react'
-import { faCheck, faPlus, faX } from '@fortawesome/free-solid-svg-icons'
+import React, {
+  useEffect,
+  useMemo,
+  useState
+} from 'react'
+import {
+  faCheck,
+  faPlus,
+  faX
+} from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Select from 'react-select'
 import Creatable from 'react-select/creatable'
@@ -10,10 +18,23 @@ import {
   FormContent,
   getFormElements
 } from '@juniper/ui-core'
-import { isEmpty, isNil } from 'lodash'
-import { Modal, ModalBody, ModalFooter, ModalHeader, ModalTitle } from 'react-bootstrap'
+import {
+  isEmpty,
+  isNil
+} from 'lodash'
+import {
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle
+} from 'react-bootstrap'
 import { OnChangeAnswerMappings } from '../../forms/formEditorTypes'
-import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
+import {
+  ColumnDef,
+  getCoreRowModel,
+  useReactTable
+} from '@tanstack/react-table'
 import { basicTableLayout } from '../../util/tableUtils'
 import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan'
 
@@ -102,7 +123,10 @@ export default function AnswerMappingEditor(
   const [newAnswerMapping, setNewAnswerMapping] = useState<EditableAnswerMapping>({ isEditing: false })
 
   const elements = getFormElements(formContent)
-  const names = elements.filter(e => 'name' in e).map(e => 'name' in e ? e.name : '')
+  const names = elements
+    .filter(e => 'name' in e)
+    .map(e => 'name' in e ? e.name : '')
+    .concat(formContent.calculatedValues?.map(cv => cv.name) || [])
 
   useEffect(() => {
     // automatically set map type

--- a/ui-admin/src/study/surveys/PreEnrollView.tsx
+++ b/ui-admin/src/study/surveys/PreEnrollView.tsx
@@ -2,14 +2,21 @@ import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Store } from 'react-notifications-component'
 
-import {  StudyParams } from 'study/StudyRouter'
-import { StudyEnvContextT, studyEnvFormsPath } from 'study/StudyEnvironmentRouter'
+import { StudyParams } from 'study/StudyRouter'
+import {
+  StudyEnvContextT,
+  studyEnvFormsPath
+} from 'study/StudyEnvironmentRouter'
 import Api, { Survey } from 'api/api'
 
 import { successNotification } from 'util/notifications'
 import SurveyEditorView from './SurveyEditorView'
 import LoadingSpinner from 'util/LoadingSpinner'
-import { useLoadedSurvey, useSurveyParams } from './SurveyView'
+import {
+  SaveableFormProps,
+  useLoadedSurvey,
+  useSurveyParams
+} from './SurveyView'
 import { doApiLoad } from '../../api/api-utils'
 
 
@@ -27,10 +34,10 @@ function RawPreEnrollView({ studyEnvContext, survey, readOnly = false }:
   const [currentSurvey, setCurrentSurvey] = useState(survey)
 
   /** saves as a new version and updates the study environment accordingly */
-  async function createNewVersion({ content: updatedContent }: { content: string }): Promise<void> {
-    survey.content = updatedContent
+  async function createNewVersion(changes: SaveableFormProps): Promise<void> {
+    const newSurvey = { ...currentSurvey, ...changes }
     doApiLoad(async () => {
-      const updatedSurvey = await Api.createNewSurveyVersion(portal.shortcode, currentSurvey)
+      const updatedSurvey = await Api.createNewSurveyVersion(portal.shortcode, newSurvey)
       Store.addNotification(successNotification(`Survey saved successfully`))
       setCurrentSurvey(updatedSurvey)
       const updatedEnv = { ...currentEnv, preEnrollSurveyId: updatedSurvey.id }

--- a/ui-admin/src/study/surveys/PreRegView.tsx
+++ b/ui-admin/src/study/surveys/PreRegView.tsx
@@ -2,16 +2,26 @@ import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Store } from 'react-notifications-component'
 
-import { StudyEnvContextT, studyEnvSiteContentPath } from 'study/StudyEnvironmentRouter'
+import {
+  StudyEnvContextT,
+  studyEnvSiteContentPath
+} from 'study/StudyEnvironmentRouter'
 import Api, { Survey } from 'api/api'
 
 import { successNotification } from 'util/notifications'
 import SurveyEditorView from './SurveyEditorView'
 import LoadingSpinner from 'util/LoadingSpinner'
-import { useLoadedSurvey, useSurveyParams } from './SurveyView'
+import {
+  SaveableFormProps,
+  useLoadedSurvey,
+  useSurveyParams
+} from './SurveyView'
 import { doApiLoad } from 'api/api-utils'
 import { PortalEnvContext } from 'portal/PortalRouter'
-import { DocsKey, ZendeskLink } from 'util/zendeskUtils'
+import {
+  DocsKey,
+  ZendeskLink
+} from 'util/zendeskUtils'
 import InfoPopup from 'components/forms/InfoPopup'
 
 /** Preregistration editor.  This shares a LOT in common with SurveyView and PreEnrollView,
@@ -25,10 +35,10 @@ function RawPreRegView({ studyEnvContext, portalEnvContext, survey, readOnly = f
   const [currentSurvey, setCurrentSurvey] = useState(survey)
 
   /** saves as a new version and updates the study environment accordingly */
-  async function createNewVersion({ content: updatedContent }: { content: string }): Promise<void> {
-    survey.content = updatedContent
+  async function createNewVersion(changes: SaveableFormProps): Promise<void> {
+    const newSurvey = { ...currentSurvey, ...changes }
     doApiLoad(async () => {
-      const updatedSurvey = await Api.createNewSurveyVersion(portal.shortcode, currentSurvey)
+      const updatedSurvey = await Api.createNewSurveyVersion(portal.shortcode, newSurvey)
       Store.addNotification(successNotification(`Survey saved successfully`))
       setCurrentSurvey(updatedSurvey)
       const updatedEnv = { ...portalEnv, preRegSurveyId: updatedSurvey.id }

--- a/ui-core/src/surveyUtils.tsx
+++ b/ui-core/src/surveyUtils.tsx
@@ -1,11 +1,25 @@
 import './surveyjs'
 
-import { cloneDeep, get, set } from 'lodash'
+import {
+  cloneDeep,
+  get,
+  isNil,
+  set
+} from 'lodash'
 import { SurveyModel } from 'survey-core'
 
-import { Answer, FormContent, FormElement, Survey, VersionedForm } from './types/forms'
+import {
+  Answer,
+  FormContent,
+  FormElement,
+  Survey,
+  VersionedForm
+} from './types/forms'
 import { useSearchParams } from 'react-router-dom'
-import React, { useEffect, useState } from 'react'
+import React, {
+  useEffect,
+  useState
+} from 'react'
 import _union from 'lodash/union'
 import _keys from 'lodash/keys'
 import _isEqual from 'lodash/isEqual'
@@ -320,6 +334,7 @@ export function useSurveyJSModel(
     newSurveyModel.currentPageNo = pageNumber
     newSurveyModel.setVariable('profile', profile)
     newSurveyModel.setVariable('proxyProfile', proxyProfile)
+    newSurveyModel.setVariable('isGovernedUser', !isNil(proxyProfile))
     newSurveyModel.setVariable('portalEnvironmentName', envName)
     Object.keys(extraVariables).forEach(key => {
       newSurveyModel.setVariable(key, extraVariables[key])

--- a/ui-core/src/types/forms.ts
+++ b/ui-core/src/types/forms.ts
@@ -118,6 +118,13 @@ export type FormContent = {
   title: I18nSurveyElement
   pages: FormContentPage[]
   questionTemplates?: Question[]
+  calculatedValues?: CalculatedValue[]
+}
+
+export type CalculatedValue = {
+  name: string,
+  expression: string,
+  includeIntoResult: boolean
 }
 
 type BaseElement = {

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -1,33 +1,48 @@
-import React, { useEffect, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import React, {
+  useEffect,
+  useState
+} from 'react'
+import {
+  useNavigate,
+  useParams
+} from 'react-router-dom'
 import 'survey-core/survey.i18n'
 
-import Api, { Portal, SurveyWithResponse } from 'api/api'
+import Api, {
+  Portal,
+  SurveyWithResponse
+} from 'api/api'
 
 import {
-  ApiProvider, Enrollee, EnvironmentName, PagedSurveyView,
-  useI18n, useTaskIdParam
+  ApiProvider,
+  Enrollee,
+  EnvironmentName,
+  PagedSurveyView,
+  useI18n,
+  useTaskIdParam
 } from '@juniper/ui-core'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { PageLoadingIndicator } from 'util/LoadingSpinner'
 import { withErrorBoundary } from 'util/ErrorBoundary'
 import { DocumentTitle } from 'util/DocumentTitle'
-import { useActiveUser } from 'providers/ActiveUserProvider'
 import { useUser } from 'providers/UserProvider'
 import { HubUpdate } from 'hub/hubUpdates'
+import { useActiveUser } from 'providers/ActiveUserProvider'
 
 /** handles loading the survey form and responses from the server */
 function SurveyView({ showHeaders = true }: { showHeaders?: boolean }) {
   const { portal, portalEnv } = usePortalEnv()
   const { enrollees } = useActiveUser()
-  const { user, updateEnrollee, updateProfile } = useUser()
+  const { user, updateEnrollee, updateProfile, enrollees: allEnrollees } = useUser()
   const [formAndResponses, setFormAndResponse] = useState<SurveyWithResponse | null>(null)
   const params = useParams()
   const studyShortcode = params.studyShortcode
   const stableId = params.stableId
   const version = parseInt(params.version ?? '')
 
-  const proxyProfile = enrollees.find(enrollee => enrollee.participantUserId === user?.id && enrollee.profile)?.profile
+  const proxyProfile = allEnrollees
+    .find(enrollee => enrollee.participantUserId === user?.id && enrollee.profile)
+    ?.profile
 
   const { i18n, selectedLanguage } = useI18n()
   const taskId = useTaskIdParam() ?? ''

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -36,7 +36,6 @@ ReactQuestionFactory.Instance.registerQuestion('addressvalidation', props => {
   return React.createElement(ThemedSurveyQuestionAddressValidation, props)
 })
 
-]
 /** handles loading the survey form and responses from the server */
 function SurveyView({ showHeaders = true }: { showHeaders?: boolean }) {
   const { portal, portalEnv } = usePortalEnv()

--- a/ui-participant/src/participant/ParticipantProfile.tsx
+++ b/ui-participant/src/participant/ParticipantProfile.tsx
@@ -1,7 +1,18 @@
-import React, { useEffect, useState } from 'react'
+import React, {
+  useEffect,
+  useState
+} from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faChevronLeft, faPencil } from '@fortawesome/free-solid-svg-icons'
-import { dateToDefaultString, MailingAddress, Profile, useI18n } from '@juniper/ui-core'
+import {
+  faChevronLeft,
+  faPencil
+} from '@fortawesome/free-solid-svg-icons'
+import {
+  dateToDefaultString,
+  MailingAddress,
+  Profile,
+  useI18n
+} from '@juniper/ui-core'
 import Api from 'api/api'
 import { isEmpty } from 'lodash'
 import {
@@ -13,7 +24,10 @@ import {
   EditPhoneNumber
 } from './EditParticipantProfileModals'
 import { useActiveUser } from '../providers/ActiveUserProvider'
-import { Link, useParams } from 'react-router-dom'
+import {
+  Link,
+  useParams
+} from 'react-router-dom'
 import { useUser } from '../providers/UserProvider'
 
 /**
@@ -209,7 +223,8 @@ const ReadOnlyAddress = ({ address }: { address: MailingAddress | undefined }) =
     {address.street1 && <ProfileTextRow text={address.street1}/>}
     {address.street2 && <ProfileTextRow text={address.street2}/>}
     {(address.city || address.postalCode || address.state) &&
-        <ProfileTextRow text={`${address.city} ${address.state} ${address.postalCode}`.split(/\s+/).join(' ')}/>}
+        <ProfileTextRow
+          text={`${address.city || ''} ${address.state || ''} ${address.postalCode || ''}`.split(/\s+/).join(' ')}/>}
     {address.country && <ProfileTextRow text={address.country}/>}
   </>
 }

--- a/ui-participant/vite.config.ts
+++ b/ui-participant/vite.config.ts
@@ -1,4 +1,7 @@
-import { PluginOption, defineConfig } from 'vite'
+import {
+  defineConfig,
+  PluginOption
+} from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import viteTsconfigPaths from 'vite-tsconfig-paths'
 import * as path from 'path'


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Bunch of random changes for things I ran into:
- Get on site media controller automatically lowercases file input
   - (this is becuase the files get automatically lowercased on creation, so e.g. US_states.json becomes us_states.json. This is fine - but surveyjs doesn't have a `lower` function... so I either have to implement a lower function and apply it to the country code or lower case the input to site media - which is fine because everything is lowercased anyway)
- better null handling to search expressions
- `{isGovernedUser}` variable available in surveys, with the ability to set it on the admin form preview
- proxyProfile and profile as surveyjs vars were broken, so I fixed those
- Answer mappings weren't saved for prereg/pre-enroll on edit in admin tool, which is now fixed. Also, now calculated values are options for answer mappings.
- Supports different pepper survey types and general cleanup of AT import/export.
- Fixed issue where if you signed up for a country without states (e.g. `Guam`) then the participant profile should show undefined for stateProvince

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

You can test all of these out by importing this [this portal](https://drive.google.com/file/d/1qTFDp5xi0UXFeMMg9LucxP6Sn0gi_gIW/view?usp=drive_link) (which is in a new portal extracts folder) and playing around with it. You shouldn't use PepperImportCliApp, because these surveys have manual edits made to them.
- Testing site media stuff: fill out pre-enroll and try out different countries
- create proxy user and observe correct behavior
- observe that assents/consents are applied in the correct situations (consent < 7, assent 7 to 18, >=18 consent)
- observe that answer mappings are created appropriately 
- `{isGovernedUser}` and profile fixes can be tested by going to the `blood type` survey as a proxy and seeing that it correctly says your governed user's name.
   - go back as a normal/non-proxy user and the text should be different