### PR TITLE
[JN-1163] AnswerMapping for marketing opt-in

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
@@ -8,6 +8,7 @@ import bio.terra.pearl.core.model.notification.Trigger;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.study.Study;
+import bio.terra.pearl.core.model.workflow.TaskType;
 import bio.terra.pearl.core.service.notification.NotificationContextInfo;
 import bio.terra.pearl.core.service.notification.NotificationSender;
 import bio.terra.pearl.core.service.notification.NotificationService;
@@ -151,6 +152,12 @@ public class EnrolleeEmailService implements NotificationSender {
                                    NotificationContextInfo contextInfo) {
         if (ruleData.getProfile() != null && ruleData.getProfile().isDoNotEmail()) {
             log.info("skipping email, enrollee {} is doNotEmail: triggerId: {}, portalEnv: {}",
+                    ruleData.getEnrollee().getShortcode(), config.getId(), config.getPortalEnvironmentId());
+            return false;
+        }
+        if (ruleData.getProfile() != null && ruleData.getProfile().isDoNotEmailSolicit() && config.getTaskType().equals(TaskType.OUTREACH)) {
+            System.out.println("SKIPPING!!!");
+            log.info("skipping email, enrollee {} is doNotEmailSolicit: triggerId: {}, portalEnv: {}",
                     ruleData.getEnrollee().getShortcode(), config.getId(), config.getPortalEnvironmentId());
             return false;
         }

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
@@ -156,7 +156,6 @@ public class EnrolleeEmailService implements NotificationSender {
             return false;
         }
         if (ruleData.getProfile() != null && ruleData.getProfile().isDoNotEmailSolicit() && config.getTaskType().equals(TaskType.OUTREACH)) {
-            System.out.println("SKIPPING!!!");
             log.info("skipping email, enrollee {} is doNotEmailSolicit: triggerId: {}, portalEnv: {}",
                     ruleData.getEnrollee().getShortcode(), config.getId(), config.getPortalEnvironmentId());
             return false;

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
@@ -148,16 +148,19 @@ public class EnrolleeEmailService implements NotificationSender {
     }
 
     public boolean shouldSendEmail(Trigger config,
-                                   EnrolleeContext ruleData,
+                                   EnrolleeContext enrolleeContext,
                                    NotificationContextInfo contextInfo) {
-        if (ruleData.getProfile() != null && ruleData.getProfile().isDoNotEmail()) {
+        if (enrolleeContext.getProfile() == null) {
+            return false;  // no address to send email to
+        }
+        if (enrolleeContext.getProfile().isDoNotEmail()) {
             log.info("skipping email, enrollee {} is doNotEmail: triggerId: {}, portalEnv: {}",
-                    ruleData.getEnrollee().getShortcode(), config.getId(), config.getPortalEnvironmentId());
+                    enrolleeContext.getEnrollee().getShortcode(), config.getId(), config.getPortalEnvironmentId());
             return false;
         }
-        if (ruleData.getProfile() != null && ruleData.getProfile().isDoNotEmailSolicit() && config.getTaskType().equals(TaskType.OUTREACH)) {
+        if (enrolleeContext.getProfile().isDoNotEmailSolicit() && config.getTaskType().equals(TaskType.OUTREACH)) {
             log.info("skipping email, enrollee {} is doNotEmailSolicit: triggerId: {}, portalEnv: {}",
-                    ruleData.getEnrollee().getShortcode(), config.getId(), config.getPortalEnvironmentId());
+                    enrolleeContext.getEnrollee().getShortcode(), config.getId(), config.getPortalEnvironmentId());
             return false;
         }
         if (config.getEmailTemplateId() == null) {

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
@@ -29,6 +29,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiFunction;
 
+import static java.lang.Boolean.parseBoolean;
+
 /**
  * Handles mapping ParsedSnapshots (typically received from the frontend) into objects.  This is done with stableIdMaps
  * which map question stableIds to the object properties they should be assigned to.
@@ -158,19 +160,8 @@ public class AnswerProcessingService {
             AnswerMappingMapType.STRING_TO_STRING, (Answer answer, AnswerMapping mapping) -> StringUtils.trim(answer.getStringValue()),
             AnswerMappingMapType.STRING_TO_LOCAL_DATE, (Answer answer, AnswerMapping mapping) ->
                     mapToDate(answer.getStringValue(), mapping),
-            AnswerMappingMapType.STRING_TO_BOOLEAN, (Answer answer, AnswerMapping mapping) -> mapToBoolean(answer.getStringValue(), mapping)
+            AnswerMappingMapType.STRING_TO_BOOLEAN, (Answer answer, AnswerMapping mapping) -> parseBoolean(answer.getStringValue())
     );
-
-    public static Boolean mapToBoolean(String booleanString, AnswerMapping mapping) {
-        try {
-            return Boolean.parseBoolean(booleanString);
-        } catch (Exception e) {
-            if (mapping.isErrorOnFail()) {
-                throw new IllegalArgumentException("Could not parse boolean " + booleanString);
-            }
-        }
-        return null;
-    }
 
     public static LocalDate mapToDate(String dateString, AnswerMapping mapping) {
         try {

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
@@ -157,7 +157,8 @@ public class AnswerProcessingService {
     public static final Map<AnswerMappingMapType, BiFunction<Answer, AnswerMapping, Object>> JSON_MAPPERS = Map.of(
             AnswerMappingMapType.STRING_TO_STRING, (Answer answer, AnswerMapping mapping) -> StringUtils.trim(answer.getStringValue()),
             AnswerMappingMapType.STRING_TO_LOCAL_DATE, (Answer answer, AnswerMapping mapping) ->
-                    mapToDate(answer.getStringValue(), mapping)
+                    mapToDate(answer.getStringValue(), mapping),
+            AnswerMappingMapType.STRING_TO_BOOLEAN, (Answer answer, AnswerMapping mapping) -> Boolean.parseBoolean(answer.getStringValue())
     );
 
     public static LocalDate mapToDate(String dateString, AnswerMapping mapping) {

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
@@ -158,8 +158,19 @@ public class AnswerProcessingService {
             AnswerMappingMapType.STRING_TO_STRING, (Answer answer, AnswerMapping mapping) -> StringUtils.trim(answer.getStringValue()),
             AnswerMappingMapType.STRING_TO_LOCAL_DATE, (Answer answer, AnswerMapping mapping) ->
                     mapToDate(answer.getStringValue(), mapping),
-            AnswerMappingMapType.STRING_TO_BOOLEAN, (Answer answer, AnswerMapping mapping) -> Boolean.parseBoolean(answer.getStringValue())
+            AnswerMappingMapType.STRING_TO_BOOLEAN, (Answer answer, AnswerMapping mapping) -> mapToBoolean(answer.getStringValue(), mapping)
     );
+
+    public static Boolean mapToBoolean(String booleanString, AnswerMapping mapping) {
+        try {
+            return Boolean.parseBoolean(booleanString);
+        } catch (Exception e) {
+            if (mapping.isErrorOnFail()) {
+                throw new IllegalArgumentException("Could not parse boolean " + booleanString);
+            }
+        }
+        return null;
+    }
 
     public static LocalDate mapToDate(String dateString, AnswerMapping mapping) {
         try {

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailServiceTests.java
@@ -180,7 +180,7 @@ public class EnrolleeEmailServiceTests extends BaseSpringBootTest {
                 enrolleeBundle.enrollee().getStudyEnvironmentId(), enrolleeBundle.portalParticipantUser().getPortalEnvironmentId());
 
         testSendProfile(enrolleeEmailService, enrolleeBundle, config);
-        testDoNotSendProfile(enrolleeEmailService, enrolleeBundle, config);
+        testDoNotSendSolicitProfile(enrolleeEmailService, enrolleeBundle, config);
     }
 
     private void testSendProfile(EnrolleeEmailService enrolleeEmailService, EnrolleeFactory.EnrolleeBundle enrolleeBundle, Trigger config) {
@@ -196,6 +196,15 @@ public class EnrolleeEmailServiceTests extends BaseSpringBootTest {
     private void testDoNotSendProfile(EnrolleeEmailService enrolleeEmailService, EnrolleeFactory.EnrolleeBundle enrolleeBundle, Trigger config) {
         Notification notification = notificationFactory.buildPersisted(enrolleeBundle, config);
         EnrolleeContext ruleData = new EnrolleeContext(enrolleeBundle.enrollee(), Profile.builder().doNotEmail(true).build(), null);
+        NotificationContextInfo contextInfo = new NotificationContextInfo(null, null, null, null, null);
+        enrolleeEmailService.processNotification(notification, config, ruleData, contextInfo);
+        Notification updatedNotification = notificationService.find(notification.getId()).get();
+        assertThat(updatedNotification.getDeliveryStatus(), equalTo(NotificationDeliveryStatus.SKIPPED));
+    }
+
+    private void testDoNotSendSolicitProfile(EnrolleeEmailService enrolleeEmailService, EnrolleeFactory.EnrolleeBundle enrolleeBundle, Trigger config) {
+        Notification notification = notificationFactory.buildPersisted(enrolleeBundle, config);
+        EnrolleeContext ruleData = new EnrolleeContext(enrolleeBundle.enrollee(), Profile.builder().doNotEmail(false).doNotEmailSolicit(true).build(), null);
         NotificationContextInfo contextInfo = new NotificationContextInfo(null, null, null, null, null);
         enrolleeEmailService.processNotification(notification, config, ruleData, contextInfo);
         Notification updatedNotification = notificationService.find(notification.getId()).get();

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailServiceTests.java
@@ -12,6 +12,7 @@ import bio.terra.pearl.core.model.participant.Profile;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.portal.PortalEnvironmentConfig;
+import bio.terra.pearl.core.model.workflow.TaskType;
 import bio.terra.pearl.core.service.notification.NotificationContextInfo;
 import bio.terra.pearl.core.service.notification.NotificationService;
 import bio.terra.pearl.core.service.rule.EnrolleeContext;
@@ -160,6 +161,22 @@ public class EnrolleeEmailServiceTests extends BaseSpringBootTest {
                 .emailTemplateId(emailTemplate.getId())
                 .deliveryType(NotificationDeliveryType.EMAIL)
                 .triggerType(TriggerType.EVENT),
+                enrolleeBundle.enrollee().getStudyEnvironmentId(), enrolleeBundle.portalParticipantUser().getPortalEnvironmentId());
+
+        testSendProfile(enrolleeEmailService, enrolleeBundle, config);
+        testDoNotSendProfile(enrolleeEmailService, enrolleeBundle, config);
+    }
+
+    @Test
+    @Transactional
+    public void testEmailSendOrSkipSolicit(TestInfo info) {
+        EnrolleeFactory.EnrolleeBundle enrolleeBundle = enrolleeFactory.buildWithPortalUser(getTestName(info));
+        EmailTemplate emailTemplate = emailTemplateFactory.buildPersisted(getTestName(info), enrolleeBundle.portalId());
+        Trigger config = triggerFactory.buildPersisted(Trigger.builder()
+                .emailTemplateId(emailTemplate.getId())
+                .deliveryType(NotificationDeliveryType.EMAIL)
+                .triggerType(TriggerType.EVENT)
+                .taskType(TaskType.OUTREACH),
                 enrolleeBundle.enrollee().getStudyEnvironmentId(), enrolleeBundle.portalParticipantUser().getPortalEnvironmentId());
 
         testSendProfile(enrolleeEmailService, enrolleeBundle, config);

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/AnswerProcessingServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/AnswerProcessingServiceTests.java
@@ -122,6 +122,18 @@ public class AnswerProcessingServiceTests extends BaseSpringBootTest {
     }
 
     @Test
+    public void mapStringToBoolean() {
+        AnswerMapping mapping = new AnswerMapping();
+        Object result = AnswerProcessingService.JSON_MAPPERS.get(AnswerMappingMapType.STRING_TO_BOOLEAN)
+                .apply(Answer.builder().stringValue("true").build(), mapping);
+        assertThat((Boolean) result, equalTo(true));
+
+        result = AnswerProcessingService.JSON_MAPPERS.get(AnswerMappingMapType.STRING_TO_BOOLEAN)
+                .apply(Answer.builder().stringValue("false").build(), mapping);
+        assertThat((Boolean) result, equalTo(false));
+    }
+
+    @Test
     public void mapToDateHandlesFormatString() {
         AnswerMapping mapping = AnswerMapping.builder().formatString("MM/dd/yyyy").build();
         LocalDate result = AnswerProcessingService.mapToDate("11/12/1987", mapping);

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
@@ -27,7 +27,6 @@
       "targetField": "givenName",
       "mapType": "STRING_TO_STRING"
     },
-
     {
       "questionStableId": "governed_family_name",
       "targetType": "PROFILE",

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
@@ -27,6 +27,7 @@
       "targetField": "givenName",
       "mapType": "STRING_TO_STRING"
     },
+
     {
       "questionStableId": "governed_family_name",
       "targetType": "PROFILE",
@@ -38,6 +39,12 @@
       "targetType": "PROFILE",
       "targetField": "mailingAddress.country",
       "mapType": "STRING_TO_STRING"
+    },
+    {
+      "questionStableId": "do_not_email_solicit",
+      "targetType": "PROFILE",
+      "targetField": "doNotEmailSolicit",
+      "mapType": "STRING_TO_BOOLEAN"
     }
   ],
   "jsonContent": {
@@ -244,6 +251,35 @@
                   "es": "No",
                   "dev": "DEV_No"
                 }
+              }
+            ]
+          },
+          {
+            "type": "radiogroup",
+            "name": "do_not_email_solicit",
+            "title": {
+              "en": "I would like to receive marketing communications to the email address that I provide during registration.",
+              "es": "Me gustaría recibir comunicaciones de marketing a la dirección de correo electrónico que proporcioné durante el registro.",
+              "dev": "I would like to receive marketing communications to the email address that I provide during registration."
+            },
+            "description": "",
+            "isRequired": true,
+            "choices": [
+              {
+                "text": {
+                  "en": "Yes",
+                  "es": "Sí",
+                  "dev": "DEV_Yes"
+                },
+                "value": "false"
+              },
+              {
+                "text": {
+                  "en": "No",
+                  "es": "No",
+                  "dev": "DEV_No"
+                },
+                "value": "true"
               }
             ]
           }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds a new question to the Heart Demo pre-enroll to allow the user to opt out of marketing/outreach emails.

Also adds the EnrolleeEmailService logic to actually skip the emails in this case.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

In the admin tool, select any Heart Demo participant and switch them "Do Not Solicit: On" (make sure that Notifications in general are On too)
Try sending them an Outreach reminder email
Observe in the logs: `2024-07-26T14:11:51.993-04:00 pL48xm4Z  INFO 83152 --- [nio-8080-exec-9] b.t.p.c.s.n.email.EnrolleeEmailService   : skipping email, enrollee YDJCNZ is doNotEmailSolicit: triggerId: 7e842b7a-1725-432d-99e6-f882335aa942, portalEnv: 042bafd6-bb36-4efb-8f55-c5d7203fcb56` 