### PR TITLE
[JN-1028] fixing fingerprints

### DIFF
--- a/api-participant/build.gradle
+++ b/api-participant/build.gradle
@@ -61,8 +61,8 @@ task createUnfingerprintedAssets(type: Copy) {
     dependsOn('processResources')
     from "$rootDir/api-participant/build/resources/main/static/assets"
     into "$rootDir/api-participant/build/resources/main/static/assets"
-    rename('(.+)-([a-zA-Z0-9-_]+)\\.js', '$1.js')
-    rename("index-([a-zA-Z0-9-_]+).css", "index.css")
+    rename('(.+)-([a-zA-Z0-9-_]{8})\\.js', '$1.js')
+    rename("index-([a-zA-Z0-9-_]{8}).css", "index.css")
     duplicatesStrategy(DuplicatesStrategy.INCLUDE) // overwrite with the more recent version if the file already exists
 }
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

The latest build of development generated a fingerprint with a leading `-` which threw off the regex. 

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  run `./gradlew api-participant:clean`
2. `./gradlew api-participant:jibDockerBuild`
3. redeploy apiParticipantApp
4. go to `http://sandbox.demo.localhost:8081/` -- confirm it loads