### PR TITLE
[JN-1229] Use justify-content-center for HeroWithImage website section

### DIFF
--- a/ui-core/src/participant/landing/sections/HeroWithImageTemplate.tsx
+++ b/ui-core/src/participant/landing/sections/HeroWithImageTemplate.tsx
@@ -128,7 +128,7 @@ function HeroWithImageTemplate(props: HeroWithImageTemplateProps) {
           className={classNames(
             'col-12', `col-lg-${12 - imageCols}`,
             'py-3 p-sm-3 p-lg-5',
-            'd-flex flex-column flex-grow-1 justify-content-around'
+            'd-flex flex-column flex-grow-1 justify-content-center'
           )}
         >
           {!!title && (


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

I extracted portals for all of our customers and clicked through the pages comparing the before and after. IMO, everything looked good to me.

This was a request coming from OurHealth, but gVASC also asked for this in the past too.

Example:

Before
![Screenshot 2024-07-29 at 11 38 13 AM](https://github.com/user-attachments/assets/a1aa97a7-4b4d-48e3-834a-8a7a35dd3635)

After
![Screenshot 2024-07-29 at 11 38 20 AM](https://github.com/user-attachments/assets/666563bd-569f-4b82-b74a-493ee50e2e3c)

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Extract customer portals
Import them locally and make sure that things look good with HeroWithImageTemplate sections.