### PR TITLE
[JN-1199] fixing double-survey publishing

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConfiguredSurveyController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConfiguredSurveyController.java
@@ -79,11 +79,7 @@ public class ConfiguredSurveyController implements ConfiguredSurveyApi {
 
   @Override
   public ResponseEntity<Object> replace(
-      String portalShortcode,
-      String studyShortcode,
-      String envName,
-      UUID studyEnvSurveyId,
-      Object body) {
+      String portalShortcode, String studyShortcode, String envName, Object body) {
     AdminUser operator = authUtilService.requireAdminUser(request);
     EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
     StudyEnvironmentSurvey newStudyEnvSurvey =
@@ -92,7 +88,6 @@ public class ConfiguredSurveyController implements ConfiguredSurveyApi {
         surveyExtService.replace(
             PortalStudyEnvAuthContext.of(
                 operator, portalShortcode, studyShortcode, environmentName),
-            studyEnvSurveyId,
             newStudyEnvSurvey);
     return ResponseEntity.ok(newStudyEnvSurvey);
   }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
@@ -194,9 +194,8 @@ public class SurveyExtService {
   /**
    * deactivates any existing active studyEnvironmentSurvey for the given stableId, and adds a new
    * config as specified in the update object. Note that the portalEnvironmentId and
-   * studyEnvironmentId will be set from the portalShortcode and studyShortcode params.
-   *
-   * <p>If studyEnvironmentSurveyId is null, this will deactivate the existing active config
+   * studyEnvironmentId will be set from the portalShortcode and studyShortcode params, and the order will be
+   * pulled from the prior active version.
    */
   @SandboxOnly
   @EnforcePortalStudyEnvPermission(permission = "survey_edit")

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
@@ -194,8 +194,8 @@ public class SurveyExtService {
   /**
    * deactivates any existing active studyEnvironmentSurvey for the given stableId, and adds a new
    * config as specified in the update object. Note that the portalEnvironmentId and
-   * studyEnvironmentId will be set from the portalShortcode and studyShortcode params, and the order will be
-   * pulled from the prior active version.
+   * studyEnvironmentId will be set from the portalShortcode and studyShortcode params, and the
+   * order will be pulled from the prior active version.
    */
   @SandboxOnly
   @EnforcePortalStudyEnvPermission(permission = "survey_edit")

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -261,6 +261,24 @@ paths:
           content: *jsonContent
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/configuredSurveys/replace:
+    post:
+      summary: Sets a configured survey on the environment, deactivating any existing configured surveys with the same stableId.
+      tags: [ configuredSurvey ]
+      operationId: replace
+      parameters:
+        - *portalShortcodeParam
+        - *studyShortcodeParam
+        - *envNameParam
+      requestBody:
+        required: true
+        content: *jsonContent
+      responses:
+        '200':
+          description: saved new configuredSurvey object
+          content: *jsonContent
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/configuredSurveys/{configSurveyId}:
     delete:
       summary: Removes a configured survey from a study environment
@@ -291,25 +309,6 @@ paths:
       responses:
         '200':
           description: saved configuredSurvey object
-          content: *jsonContent
-        '500':
-          $ref: '#/components/responses/ServerError'
-  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/configuredSurveys/{configSurveyId}/replace:
-    post:
-      summary: Replaces a configured survey with a different one, deactivates the old one
-      tags: [ configuredSurvey ]
-      operationId: replace
-      parameters:
-        - *portalShortcodeParam
-        - *studyShortcodeParam
-        - *envNameParam
-        - { name: configSurveyId, in: path, required: true, schema: { type: string, format: uuid } }
-      requestBody:
-        required: true
-        content: *jsonContent
-      responses:
-        '200':
-          description: saved new configuredSurvey object
           content: *jsonContent
         '500':
           $ref: '#/components/responses/ServerError'

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/SurveyExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/SurveyExtServiceTests.java
@@ -110,7 +110,6 @@ public class SurveyExtServiceTests extends BaseSpringBootTest {
             bundle.getPortal().getShortcode(),
             bundle.getStudy().getShortcode(),
             bundle.getStudyEnv().getEnvironmentName()),
-        studyEnvSurvey1.getId(),
         StudyEnvironmentSurvey.builder()
             .surveyId(survey2.getId())
             .studyEnvironmentId(bundle.getStudyEnv().getId())
@@ -122,7 +121,7 @@ public class SurveyExtServiceTests extends BaseSpringBootTest {
     List<StudyEnvironmentSurvey> studyEnvSurveys =
         studyEnvironmentSurveyService.findAllByStudyEnvId(bundle.getStudyEnv().getId(), null);
     StudyEnvironmentSurvey activeEnvSurvey =
-        studyEnvSurveys.stream().filter(ses -> ses.isActive()).findFirst().orElseThrow();
+        studyEnvSurveys.stream().filter(StudyEnvironmentSurvey::isActive).findFirst().orElseThrow();
     assertThat(activeEnvSurvey.getSurveyId(), equalTo(survey2.getId()));
 
     StudyEnvironmentSurvey inactiveEnvSurvey =

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -105,7 +105,8 @@ public class SurveyResponseService extends ImmutableEntityService<SurveyResponse
             }
         }
         StudyEnvironmentSurvey configSurvey = studyEnvironmentSurveyService
-                .findActiveBySurvey(studyEnvId, stableId).get();
+                .findActiveBySurvey(studyEnvId, stableId)
+                .stream().findFirst().orElseThrow(() -> new NotFoundException("no active survey found"));
         configSurvey.setSurvey(form);
         return new SurveyWithResponse(
                 configSurvey, lastResponse

--- a/core/src/test/java/bio/terra/pearl/core/dao/metrics/MetricsDaoTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/metrics/MetricsDaoTest.java
@@ -93,7 +93,7 @@ public class MetricsDaoTest extends BaseSpringBootTest {
 
     Survey optionalSurvey = surveyFactory.buildPersisted(getTestName(info));
     StudyEnvironmentSurvey optStudyEnvSurvey = StudyEnvironmentSurvey.builder()
-        .survey(optionalSurvey).surveyId(survey.getId()).studyEnvironmentId(studyEnv.getId()).build();
+        .survey(optionalSurvey).surveyId(optionalSurvey.getId()).studyEnvironmentId(studyEnv.getId()).build();
     studyEnvironmentSurveyService.create(optStudyEnvSurvey);
 
     Enrollee enrollee1 = enrolleeFactory.buildPersisted(getTestName(info), studyEnv);

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/StudyEnvironmentSurveyServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/StudyEnvironmentSurveyServiceTests.java
@@ -1,0 +1,54 @@
+package bio.terra.pearl.core.service.survey;
+
+import bio.terra.pearl.core.BaseSpringBootTest;
+import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
+import bio.terra.pearl.core.factory.survey.SurveyFactory;
+import bio.terra.pearl.core.model.study.StudyEnvironment;
+import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
+import bio.terra.pearl.core.model.survey.Survey;
+import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+public class StudyEnvironmentSurveyServiceTests extends BaseSpringBootTest {
+    @Autowired
+    private StudyEnvironmentSurveyService studyEnvironmentSurveyService;
+    @Autowired
+    private StudyEnvironmentFactory studyEnvironmentFactory;
+    @Autowired
+    private SurveyFactory surveyFactory;
+    @Autowired
+    private SurveyService surveyService;
+
+    @Test
+    @Transactional
+    public void testUniqueActiveLogic(TestInfo testInfo) {
+        StudyEnvironment studyEnv = studyEnvironmentFactory.buildPersisted(getTestName(testInfo));
+        Survey survey = surveyFactory.buildPersisted(getTestName(testInfo));
+
+        surveyFactory.attachToEnv(survey, studyEnv.getId(), true);
+
+        // try to attach a different version of the survey to the same environment
+        Survey newSurvey = surveyService.createNewVersion(survey.getPortalId(), survey);
+
+        final StudyEnvironmentSurvey studyEnvSurvey = StudyEnvironmentSurvey.builder()
+                .studyEnvironmentId(studyEnv.getId())
+                .surveyId(newSurvey.getId())
+                .active(true)
+                .surveyOrder(1)
+                .build();
+        Assertions.assertThrows(IllegalArgumentException.class, () -> studyEnvironmentSurveyService.create(studyEnvSurvey));
+
+        // confirm that the new survey can be added as inactive
+        studyEnvSurvey.setActive(false);
+        final StudyEnvironmentSurvey savedStudyEnvSurvey = studyEnvironmentSurveyService.create(studyEnvSurvey);
+
+        // but now we can't update it to active
+        savedStudyEnvSurvey.setActive(true);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> studyEnvironmentSurveyService.update(savedStudyEnvSurvey));
+    }
+
+}

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -527,6 +527,12 @@ export default {
     return await this.processJsonResponse(response)
   },
 
+  async getStudyEnvSurveys(portalShortcode: string, stableId: string, version: number): Promise<Survey> {
+    const url = `${API_ROOT}/portals/v1/${portalShortcode}/surveys/${stableId}/${version}/studyEnvSurveys`
+    const response = await fetch(url, this.getGetInit())
+    return await this.processJsonResponse(response)
+  },
+
   async createNewSurvey(portalShortcode: string, survey: Survey): Promise<Survey> {
     const url = `${API_ROOT}/portals/v1/${portalShortcode}/surveys`
 
@@ -558,10 +564,10 @@ export default {
     return await this.processJsonResponse(response)
   },
 
-  async replaceConfiguredSurvey(portalShortcode: string, studyShortcode: string, environmentName: string, oldId: string,
-    configuredSurvey: StudyEnvironmentSurvey): Promise<StudyEnvironmentSurvey> {
+  async replaceConfiguredSurvey(portalShortcode: string, studyShortcode: string, environmentName: string,
+    configuredSurvey: { surveyId: string, studyEnvironmentId: string }): Promise<StudyEnvironmentSurvey> {
     const url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, environmentName)}`
-      + `/configuredSurveys/${oldId}/replace`
+      + `/configuredSurveys/replace`
     const response = await fetch(url, {
       method: 'POST',
       headers: this.getInitHeaders(),

--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -32,7 +32,6 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
     portal,
     initialContent,
     initialAnswerMappings,
-    visibleVersionPreviews,
     supportedLanguages,
     currentLanguage,
     readOnly,
@@ -143,18 +142,6 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
             <FormPreview formContent={editedContent} currentLanguage={currentLanguage} />
           </ErrorBoundary>
         </Tab>
-        { visibleVersionPreviews.map(form =>
-          <Tab
-            key={`preview${form.version}`}
-            eventKey={`preview${form.version}`}
-            title={`Version ${form.version}`}
-          >
-            <FormPreview
-              formContent={JSON.parse(form.content) as FormContent}
-              currentLanguage={currentLanguage}
-            />
-          </Tab>
-        )}
       </Tabs>
     </div>
   )

--- a/ui-admin/src/study/surveys/FormHistoryModal.test.tsx
+++ b/ui-admin/src/study/surveys/FormHistoryModal.test.tsx
@@ -20,11 +20,11 @@ describe('VersionSelector', () => {
 
     await waitFor(() => expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument())
     await select(screen.getByLabelText('Other versions'), ['1'])
-    const openPreviewButton = screen.getByText('View')
+    const openPreviewButton = screen.getByText('View/Edit version 1')
     const switchVersionButton = screen.getByText('Switch sandbox to version 1')
     expect(openPreviewButton).toBeEnabled()
     expect(switchVersionButton).toBeEnabled()
     expect(openPreviewButton)
-      .toHaveAttribute('href', '/portalCode/studies/fakeStudy/env/sandbox/forms/surveys/survey1/1?readOnly=true')
+      .toHaveAttribute('href', '/portalCode/studies/fakeStudy/env/sandbox/forms/surveys/survey1/1')
   })
 })

--- a/ui-admin/src/study/surveys/FormHistoryModal.test.tsx
+++ b/ui-admin/src/study/surveys/FormHistoryModal.test.tsx
@@ -1,37 +1,30 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
-import { mockStudyEnvContext, mockSurvey, mockSurveyVersionsList } from 'test-utils/mocking-utils'
+import { mockStudyEnvContext, mockSurveyVersionsList } from 'test-utils/mocking-utils'
 import { select } from 'react-select-event'
 import FormHistoryModal from './FormHistoryModal'
-
-jest.mock('api/api', () => ({
-  getSurveyVersions: () => {
-    return Promise.resolve(mockSurveyVersionsList())
-  },
-  getSurvey: () => {
-    return Promise.resolve(mockSurvey())
-  }
-}))
+import Api from 'api/api'
 
 describe('VersionSelector', () => {
   test('renders a list of form versions that can be selected', async () => {
+    const surveyList = mockSurveyVersionsList()
+    jest.spyOn(Api, 'getSurveyVersions').mockResolvedValue(surveyList)
+
     const studyEnvContext = mockStudyEnvContext()
     render(<FormHistoryModal
       studyEnvContext={studyEnvContext}
-      workingForm={mockSurvey()}
+      workingForm={surveyList[1]}
       onDismiss={jest.fn()}
-      visibleVersionPreviews={[]}
-      setVisibleVersionPreviews={jest.fn()}
+      replaceSurvey={jest.fn()}
     />)
 
     await waitFor(() => expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument())
     await select(screen.getByLabelText('Other versions'), ['1'])
-    const openPreviewButton = screen.getByText('View preview')
-    const openEditorLink = screen.getByText('Open read-only editor')
-
+    const openPreviewButton = screen.getByText('View')
+    const switchVersionButton = screen.getByText('Switch sandbox to version 1')
     expect(openPreviewButton).toBeEnabled()
-    expect(openEditorLink).toBeEnabled()
-    expect(openEditorLink)
+    expect(switchVersionButton).toBeEnabled()
+    expect(openPreviewButton)
       .toHaveAttribute('href', '/portalCode/studies/fakeStudy/env/sandbox/forms/surveys/survey1/1?readOnly=true')
   })
 })

--- a/ui-admin/src/study/surveys/FormHistoryModal.tsx
+++ b/ui-admin/src/study/surveys/FormHistoryModal.tsx
@@ -67,20 +67,20 @@ export default function FormHistoryModal({
       </LoadingSpinner>
     </Modal.Body>
     <Modal.Footer className="d-flex justify-content-center">
-      {selectedVersion && <div className="d-flex justify-content-between w-100">
+      {selectedVersion && <div className="d-flex flex-column w-100">
         <a href={`${studyEnvFormsPath(studyEnvContext.portal.shortcode, studyEnvContext.study.shortcode,
           studyEnvContext.currentEnv.environmentName
-        )}/surveys/${stableId}/${selectedVersion.version}?readOnly=true`}
-        className="btn btn-secondary outline"
+        )}/surveys/${stableId}/${selectedVersion.version}`}
+        className="btn btn-primary"
         aria-disabled={!selectedVersion}
         style={{ pointerEvents: selectedVersion ? undefined : 'none' }}
         onClick={onDismiss}
         target="_blank"
         >
-            View <FontAwesomeIcon icon={faArrowRightFromBracket}/>
+            View/Edit version {selectedVersion.version} <FontAwesomeIcon icon={faArrowRightFromBracket}/>
         </a>
         {studyEnvContext.currentEnv.environmentName === 'sandbox' &&
-            <Button type="button" variant="secondary" onClick={doVersionSwitch} outline={true}>
+            <Button type="button" variant="link" onClick={doVersionSwitch} outline={true}>
               Switch sandbox to version { selectedVersion.version } <FontAwesomeIcon icon={faRotate}/>
             </Button>}
       </div>

--- a/ui-admin/src/study/surveys/FormHistoryModal.tsx
+++ b/ui-admin/src/study/surveys/FormHistoryModal.tsx
@@ -1,95 +1,90 @@
-import React, { useId, useState } from 'react'
+import React, { useState } from 'react'
 import Modal from 'react-bootstrap/Modal'
-import InfoPopup from 'components/forms/InfoPopup'
 import LoadingSpinner from 'util/LoadingSpinner'
 import Select from 'react-select'
-import { instantToDefaultString, VersionedForm } from '@juniper/ui-core'
+import { instantToDefaultString, Survey, VersionedForm } from '@juniper/ui-core'
 import { StudyEnvContextT, studyEnvFormsPath } from '../StudyEnvironmentRouter'
 import { useLoadingEffect } from 'api/api-utils'
 import Api from 'api/api'
 import { Button } from 'components/forms/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faArrowRightFromBracket } from '@fortawesome/free-solid-svg-icons'
+import { faArrowRightFromBracket, faRotate } from '@fortawesome/free-solid-svg-icons'
+import useReactSingleSelect from '../../util/react-select-utils'
 
 /**
  * Shows past versions of a form and controls for slecting them
  */
 export default function FormHistoryModal({
-  studyEnvContext, workingForm, visibleVersionPreviews, setVisibleVersionPreviews, isConsentForm = false, onDismiss
+  studyEnvContext, workingForm, onDismiss, replaceSurvey
 }:
   {studyEnvContext: StudyEnvContextT, workingForm: VersionedForm,
-    visibleVersionPreviews: VersionedForm[],
-    setVisibleVersionPreviews: (versions: VersionedForm[]) => void,
-    isConsentForm?: boolean, onDismiss: () => void}) {
-  const [versionList, setVersionList] = useState<VersionedForm[]>([])
-  const [selectedVersion, setSelectedVersion] = useState<number>()
+    replaceSurvey: (survey: Survey) => void, onDismiss: () => void}) {
+  const [versionList, setVersionList] = useState<Survey[]>([])
+  const [selectedVersion, setSelectedVersion] = useState<Survey>()
   const stableId = workingForm.stableId
-  const selectId = useId()
 
   const { isLoading } = useLoadingEffect(async () => {
     const result = await Api.getSurveyVersions(studyEnvContext.portal.shortcode, stableId)
-    setVersionList(result.sort((a, b) => b.version - a.version))
+    setVersionList(
+      result.sort((a, b) => b.version - a.version)
+        .filter(s => s.version !== workingForm.version)
+    )
   }, [stableId])
 
-  async function loadVersion(version: number) {
-    const result =  await Api.getSurvey(studyEnvContext.portal.shortcode, stableId, version)
-    setVisibleVersionPreviews([...visibleVersionPreviews, result])
+  const doVersionSwitch = async () => {
+    if (selectedVersion) {
+      await replaceSurvey(selectedVersion)
+      onDismiss()
+    }
   }
 
-  const versionOpts = versionList.map(formVersion => ({
+  const {  onChange, options, selectedOption, selectInputId } = useReactSingleSelect(versionList, formVersion => ({
     label: <span>
             Version <strong>{ formVersion.version }</strong>
       <span className="text-muted fst-italic ms-2">
                 ({instantToDefaultString(formVersion.createdAt)})
       </span>
     </span>,
-    value: formVersion.version
-  })).filter(opt => visibleVersionPreviews.every(previewedVersion => previewedVersion.version !== opt.value))
-
-  const selectedOpt = versionOpts.find(opt => opt.value === selectedVersion)
+    value: formVersion
+  }), setSelectedVersion, selectedVersion)
 
   return <Modal show={true}
     onHide={() => {
       onDismiss()
     }}>
     <Modal.Header closeButton>
-      <Modal.Title>{workingForm.name} - history</Modal.Title>
+      <Modal.Title>
+        <h2 className="h4">Version history</h2>
+        <span className="fs-5">{workingForm.name}</span>
+      </Modal.Title>
     </Modal.Header>
     <Modal.Body>
       <LoadingSpinner isLoading={isLoading}>
         <div className="d-flex align-items-baseline">
-          <label htmlFor={selectId} className="mt-3 d-block">Other versions</label>
-          <InfoPopup content={<span>Viewing as a preview will open a new tab in the current editor.
-        Opening in read-only mode will allow you to view the full editor in an entirely new browser tab.</span>}/>
+          <label htmlFor={selectInputId} className="mt-3 d-block">Other versions</label>
         </div>
-        <Select inputId={selectId} options={versionOpts} value={selectedOpt} onChange={opt =>
-          setSelectedVersion(opt?.value)}/>
+        <Select inputId={selectInputId} options={options} value={selectedOption} onChange={onChange}/>
       </LoadingSpinner>
     </Modal.Body>
-    <Modal.Footer>
-      <Button
-        variant="secondary"
-        disabled={!selectedVersion}
-        onClick={() => {
-          if (selectedVersion) {
-            loadVersion(selectedVersion)
-          }
-          onDismiss()
-        }}
-      >
-        View preview
-      </Button>
-      <a href={`${studyEnvFormsPath(studyEnvContext.portal.shortcode, studyEnvContext.study.shortcode,
-        studyEnvContext.currentEnv.environmentName
-      )}/${isConsentForm ? 'consentForms' : 'surveys'}/${stableId}/${selectedVersion}?readOnly=true`}
-      className="btn btn-secondary"
-      aria-disabled={!selectedVersion}
-      style={{ pointerEvents: selectedVersion ? undefined : 'none' }}
-      onClick={onDismiss}
-      target="_blank"
-      >
-        Open read-only editor <FontAwesomeIcon icon={faArrowRightFromBracket}/>
-      </a>
+    <Modal.Footer className="d-flex justify-content-center">
+      {selectedVersion && <div className="d-flex justify-content-between w-100">
+        <a href={`${studyEnvFormsPath(studyEnvContext.portal.shortcode, studyEnvContext.study.shortcode,
+          studyEnvContext.currentEnv.environmentName
+        )}/surveys/${stableId}/${selectedVersion.version}?readOnly=true`}
+        className="btn btn-secondary outline"
+        aria-disabled={!selectedVersion}
+        style={{ pointerEvents: selectedVersion ? undefined : 'none' }}
+        onClick={onDismiss}
+        target="_blank"
+        >
+            View <FontAwesomeIcon icon={faArrowRightFromBracket}/>
+        </a>
+        {studyEnvContext.currentEnv.environmentName === 'sandbox' &&
+            <Button type="button" variant="secondary" onClick={doVersionSwitch} outline={true}>
+              Switch sandbox to version { selectedVersion.version } <FontAwesomeIcon icon={faRotate}/>
+            </Button>}
+      </div>
+      }
     </Modal.Footer>
   </Modal>
 }

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -27,6 +27,7 @@ type SurveyEditorViewProps = {
   readOnly?: boolean
   onCancel: () => void
   onSave: (update: SaveableFormProps) => Promise<void>
+  replaceSurvey: (updatedSurvey: Survey) => void
 }
 
 /** renders a survey for editing/viewing */
@@ -36,6 +37,7 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
     studyEnvContext: { portal, currentEnv },
     currentForm,
     readOnly = false,
+    replaceSurvey,
     onCancel,
     onSave
   } = props
@@ -52,7 +54,6 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
   const [showDiscardDraftModal, setShowDiscardDraftModal] = useState(false)
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false)
   const [showVersionSelector, setShowVersionSelector] = useState(false)
-  const [visibleVersionPreviews, setVisibleVersionPreviews] = useState<VersionedForm[]>([])
   const [showErrors, setShowErrors] = useState(false)
 
   const [draft, setDraft] = useState<FormDraft | undefined>(
@@ -231,10 +232,9 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
           </ul>
         </div>
         { showVersionSelector && <FormHistoryModal
-          studyEnvContext={studyEnvContext} visibleVersionPreviews={visibleVersionPreviews}
-          setVisibleVersionPreviews={setVisibleVersionPreviews}
+          studyEnvContext={studyEnvContext}
           workingForm={{ ...currentForm, ...draft }}
-          isConsentForm={!isSurvey}
+          replaceSurvey={replaceSurvey}
           onDismiss={() => setShowVersionSelector(false)}
         />}
         { showAdvancedOptions && <FormOptionsModal
@@ -251,7 +251,6 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
           portal={portal}
           initialContent={draft?.content || currentForm.content} //favor loading the draft, if we find one
           initialAnswerMappings={draft?.answerMappings || currentForm.answerMappings || []}
-          visibleVersionPreviews={visibleVersionPreviews}
           supportedLanguages={portalEnv?.supportedLanguages || []}
           currentLanguage={currentLanguage}
           readOnly={readOnly}

--- a/ui-admin/src/study/surveys/SurveyView.tsx
+++ b/ui-admin/src/study/surveys/SurveyView.tsx
@@ -44,11 +44,18 @@ function RawSurveyView({ studyEnvContext, survey, readOnly = false }:
         portal.shortcode,
         { ...currentSurvey, ...saveableProps }
       )
-      const configuredSurvey = currentEnv.configuredSurveys
-        .find(s => s.survey.stableId === updatedSurvey.stableId) as StudyEnvironmentSurvey
-      const updatedConfig = { ...configuredSurvey, surveyId: updatedSurvey.id, survey: updatedSurvey }
+      replaceSurvey(updatedSurvey)
+    })
+  }
+
+  async function replaceSurvey(updatedSurvey: Survey) {
+    doApiLoad(async () => {
+      const updatedConfig = {
+        studyEnvironmentId: currentEnv.id,
+        surveyId: updatedSurvey.id
+      }
       const updatedConfiguredSurvey = await Api.replaceConfiguredSurvey(portal.shortcode,
-        study.shortcode, currentEnv.environmentName, configuredSurvey.id, updatedConfig)
+        study.shortcode, currentEnv.environmentName, updatedConfig)
       Store.addNotification(successNotification(
         `Updated ${currentEnv.environmentName} to version ${updatedSurvey.version}`
       ))
@@ -72,6 +79,7 @@ function RawSurveyView({ studyEnvContext, survey, readOnly = false }:
       readOnly={readOnly}
       onCancel={() => navigate(studyEnvFormsPath(portal.shortcode, study.shortcode, currentEnv.environmentName))}
       onSave={createNewVersion}
+      replaceSurvey={replaceSurvey}
     />
   )
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

The critical part of this is the logic preventing multiple active versions of the same survey to be saved.  This will fix one of the bugs OurHealth had last week where two staff members saved the same survey at the same time.  Fun fact, this save lgoic revealed a random typo in a test written last year.

This also updates the UX for the survey history to make it easier to switch/edit past versions.  It now mimics the (more recent and less complex) flow of the Website editor.

<img width="594" alt="image" src="https://github.com/user-attachments/assets/56bc29ab-cca3-40c6-ac8e-8940f3af1aff">

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy ApiAdminApp
2. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/forms/surveys/hd_hd_socialHealth
3. in the ... dropdown, select "version history"
4. play around with editing/switching versions, confirm UX behaves as expected
