### PR TITLE
[JN-1233] JSON parse error handling

### DIFF
--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
@@ -82,6 +82,17 @@ describe('getDisplayValue', () => {
     expect(screen.getByRole('img')).toHaveAttribute('src', 'data:image/png;base64, test123')
     expect(screen.queryByText('data:image/png;base64, test123')).not.toBeInTheDocument()
   })
+
+  it('renders a malformed object value as an error', async () => {
+    const question = {
+      name: 'testQ', text: 'test question',
+      isVisible: true,
+      getType: () => 'text'
+    }
+    const answer: Answer = { objectValue: '{dfaf }}', questionStableId: 'testQ' } as Answer
+    render(<span>{getDisplayValue(answer, question as unknown as Question)}</span>)
+    expect(screen.getByText('[[ parse error ]]')).toBeInTheDocument()
+  })
 })
 
 describe('ItemDisplay', () => {

--- a/ui-admin/src/study/participants/survey/SurveyResponseEditor.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyResponseEditor.tsx
@@ -1,9 +1,9 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Survey, SurveyResponse } from 'api/api'
 import DocumentTitle from 'util/DocumentTitle'
 
 import _cloneDeep from 'lodash/cloneDeep'
-import { AutosaveStatus, Enrollee, PagedSurveyView, useTaskIdParam } from '@juniper/ui-core'
+import { AutosaveStatus, Enrollee, PagedSurveyView, useTaskIdParam, makeSurveyJsData } from '@juniper/ui-core'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
 import { Store } from 'react-notifications-component'
 import { failureNotification, successNotification } from 'util/notifications'
@@ -29,6 +29,13 @@ export default function SurveyResponseEditor({
     envName: studyEnvContext.currentEnv.environmentName,
     portalShortcode: studyEnvContext.portal.shortcode
   }
+
+  useEffect(() => {
+    // do an initial test parse to identify errors
+    makeSurveyJsData(undefined, workingResponse.answers, undefined, (msg: React.ReactNode) => {
+      Store.addNotification(failureNotification(msg))
+    })
+  }, [])
 
   return <div>
     <DocumentTitle title={`${enrollee.shortcode} - ${survey.name}`}/>

--- a/ui-core/src/surveyUtils.tsx
+++ b/ui-core/src/surveyUtils.tsx
@@ -83,13 +83,24 @@ export const surveyJSModelFromForm = (form: VersionedForm): SurveyModel => {
 
 /** convert a list of answers and resumeData into the resume data format surveyJs expects */
 export function makeSurveyJsData(resumeData: string | undefined,
-  answers: Answer[] | undefined, userId: string | undefined):
+  answers: Answer[] | undefined, userId: string | undefined, alertFn?: (msg: React.ReactNode) => void):
   SurveyJsResumeData {
   answers = answers ?? []
   const answerHash = answers.reduce(
     (hash: Record<string, SurveyJsValueType>, answer: Answer) => {
       if (answer.objectValue) {
-        hash[answer.questionStableId] = JSON.parse(answer.objectValue)
+        try {
+          hash[answer.questionStableId] = JSON.parse(answer.objectValue)
+        } catch (e) {
+          if (alertFn) {
+            alertFn(<div className="text-danger">
+              Parse error <br/>
+              question {answer.questionStableId}<br/>
+              value: {answer.objectValue} <br/>
+              Saving this survey may overwrite this value.
+            </div>)
+          }
+        }
       } else {
         hash[answer.questionStableId] = answer.stringValue ?? answer.numberValue ?? null
       }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Previously, imports with malformed JSON in survey answers caused the enrollee view page to break. 
<img width="712" alt="image" src="https://github.com/user-attachments/assets/b4b070de-f74b-49b6-b323-1bbc8f37e3f1">

<img width="660" alt="image" src="https://github.com/user-attachments/assets/2c7affcf-2709-407d-ac24-4527bccc958a">

 This adds handling so they are reported and fixable via the editor.  If you go to the editor, the error will be alerted, and the answer for that question will be blank
<img width="1177" alt="image" src="https://github.com/user-attachments/assets/1497a4c0-9895-4516-935a-fe0fc4990fdf">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  from https://drive.google.com/drive/u/1/folders/1hc8s1HomQik0TDC2pYI_LBE-GDNIltYW, import that portal config zip.
2.  Go to https://localhost:3000/hearthive/studies/hh_registry/env/sandbox/dataImports
3.  do a new data import, using the HHsurvey_test.csv file from that same google folder
4. go to `https://localhost:3000/hearthive/studies/hh_registry/env/sandbox/participants/OOTWXL`
5. click the baseline survey, 
6. confirm you can find the "parse error" indication (near the bottom of the survey)
