### PR TITLE
[JN-1223] fixing asset regex

### DIFF
--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PublicApiController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PublicApiController.java
@@ -188,12 +188,12 @@ public class PublicApiController implements PublicApi {
    * site not appearing as down during deploys. Eventually, we should upgrade our deployment/hosting
    * infrastructure to solve this problem in a more robust way
    */
-  @GetMapping(value = "/assets/index-{hash}.css")
+  @GetMapping(value = "/assets/index-{hash:[a-zA-Z0-9-_]{8}}.css")
   public String getFingerprintedCss() {
     return "forward:/assets/index.css";
   }
 
-  @GetMapping(value = "/assets/{fileId}-{hash}.js")
+  @GetMapping(value = "/assets/{fileId}-{hash:[a-zA-Z0-9-_]{8}}.js")
   public String getFingerprintedJs(@PathVariable("fileId") String fileId) {
     return "forward:/assets/%s.js".formatted(fileId);
   }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

the `web-vitals` dependency wasn't getting served.  I thought it was because of a change in our dependency build, but nope, once again it's an asset-fingerprinting regex issue.  this updates the server-side regex to handle that (to match the asset-pipeline regex).

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. run `./gradlew api-participant:jibDockerBuild`
2. redeploy apiParticipantApp
3. go to http://sandbox.demo.localhost:8081/ 
4. confirm the `web-vitals-[[hash]].js` file loads successfully