### PR TITLE
[JN-1218] Quick protection against log event viewer OOM

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/logging/LoggingController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/logging/LoggingController.java
@@ -29,7 +29,7 @@ public class LoggingController implements LoggingApi {
   }
 
   @Override
-  public ResponseEntity<Object> get(String days, Integer limit, String eventTypes) {
+  public ResponseEntity<Object> get(String days, String eventTypes, Integer limit) {
     AdminUser operator = authUtilService.requireAdminUser(request);
     OperatorAuthContext authContext = OperatorAuthContext.of(operator);
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/logging/LoggingController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/logging/LoggingController.java
@@ -29,12 +29,13 @@ public class LoggingController implements LoggingApi {
   }
 
   @Override
-  public ResponseEntity<Object> get(String days, String eventTypes) {
+  public ResponseEntity<Object> get(String days, Integer limit, String eventTypes) {
     AdminUser operator = authUtilService.requireAdminUser(request);
     OperatorAuthContext authContext = OperatorAuthContext.of(operator);
 
     List<LogEventType> logEventTypes =
         Arrays.stream(eventTypes.split(",")).map(LogEventType::valueOf).toList();
-    return ResponseEntity.ok(loggingExtService.listLogEvents(authContext, days, logEventTypes));
+    return ResponseEntity.ok(
+        loggingExtService.listLogEvents(authContext, days, logEventTypes, limit));
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/logging/LoggingExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/logging/LoggingExtService.java
@@ -18,11 +18,11 @@ public class LoggingExtService {
 
   @SuperuserOnly
   public List<LogEvent> listLogEvents(
-      OperatorAuthContext authContext, String days, List<LogEventType> eventTypes) {
+      OperatorAuthContext authContext, String days, List<LogEventType> eventTypes, Integer limit) {
     if (eventTypes.isEmpty()) {
       return List.of();
     }
 
-    return loggingService.listLogEvents(days, eventTypes);
+    return loggingService.listLogEvents(days, eventTypes, limit);
   }
 }

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -1908,6 +1908,7 @@ paths:
       parameters:
         - { name: eventTypes, in: query, required: false, schema: { type: string } }
         - { name: days, in: query, required: true, schema: { type: string } }
+        - { name: limit, in: query, required: true, schema: { type: integer } }
       responses:
         '200':
           description: logs

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -1908,7 +1908,7 @@ paths:
       parameters:
         - { name: eventTypes, in: query, required: false, schema: { type: string } }
         - { name: days, in: query, required: true, schema: { type: string } }
-        - { name: limit, in: query, required: true, schema: { type: integer } }
+        - { name: limit, in: query, required: false, schema: { type: integer, default: 1000 } }
       responses:
         '200':
           description: logs

--- a/core/src/main/java/bio/terra/pearl/core/dao/log/LogEventDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/log/LogEventDao.java
@@ -37,7 +37,7 @@ public class LogEventDao {
     );
   }
 
-  public List<LogEvent> listLogEvents(String days, List<LogEventType> eventTypes, Integer limit) {
+  public List<LogEvent> listLogEvents(String days, List<LogEventType> eventTypes, int limit) {
     return jdbi.withHandle(handle ->
         handle.createQuery("SELECT * FROM log_event WHERE event_type IN (<eventTypes>) AND created_at > now() - (:days || ' day')::interval limit :limit")
             .bindList("eventTypes", eventTypes)

--- a/core/src/main/java/bio/terra/pearl/core/dao/log/LogEventDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/log/LogEventDao.java
@@ -37,11 +37,12 @@ public class LogEventDao {
     );
   }
 
-  public List<LogEvent> listLogEvents(String days, List<LogEventType> eventTypes) {
+  public List<LogEvent> listLogEvents(String days, List<LogEventType> eventTypes, Integer limit) {
     return jdbi.withHandle(handle ->
-        handle.createQuery("SELECT * FROM log_event WHERE event_type IN (<eventTypes>) AND created_at > now() - (:days || ' day')::interval")
+        handle.createQuery("SELECT * FROM log_event WHERE event_type IN (<eventTypes>) AND created_at > now() - (:days || ' day')::interval limit :limit")
             .bindList("eventTypes", eventTypes)
             .bind("days", days)
+            .bind("limit", limit)
             .mapTo(LogEvent.class)
             .list()
     );

--- a/core/src/main/java/bio/terra/pearl/core/service/LoggingService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/LoggingService.java
@@ -32,8 +32,8 @@ public class LoggingService {
     objectMapper.setFilterProvider(filters);
   }
 
-  public List<LogEvent> listLogEvents(String days, List<LogEventType> eventTypes) {
-    return logEventDao.listLogEvents(days, eventTypes);
+  public List<LogEvent> listLogEvents(String days, List<LogEventType> eventTypes, Integer limit) {
+    return logEventDao.listLogEvents(days, eventTypes, limit);
   }
 
   /** creates a log event and sends the non-sensitive fields to container logs */

--- a/core/src/main/java/bio/terra/pearl/core/service/LoggingService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/LoggingService.java
@@ -18,8 +18,8 @@ import java.util.List;
 @Service
 @Slf4j
 public class LoggingService {
-  private LogEventDao logEventDao;
-  private ObjectMapper filteredEventMapper;
+  private final LogEventDao logEventDao;
+  private final ObjectMapper filteredEventMapper;
 
   public LoggingService(LogEventDao logEventDao, ObjectMapper objectMapper) {
     this.logEventDao = logEventDao;

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -1514,8 +1514,8 @@ export default {
     return await this.processJsonResponse(response)
   },
 
-  async loadLogEvents(eventTypes: string[], days: string) {
-    const params = queryString.stringify({ eventTypes: eventTypes.join(','), days })
+  async loadLogEvents(eventTypes: string[], days: string, limit: number = 1000) {
+    const params = queryString.stringify({ eventTypes: eventTypes.join(','), days, limit })
     const url = `${API_ROOT}/logEvents?${params}`
     const response = await fetch(url, this.getGetInit())
     return await this.processJsonResponse(response)

--- a/ui-admin/src/health/LogEventViewer.tsx
+++ b/ui-admin/src/health/LogEventViewer.tsx
@@ -127,7 +127,7 @@ export default function LogEventViewer() {
       {renderPageHeader('Log Events')}
       <span className="text-muted fst-italic">
         <FontAwesomeIcon icon={faInfoCircle} className="me-2"/>
-        This table is limited to 1000 log events. If you need to view more, query the database directly.
+        This table is limited to 1000 log events. If you need to view more, contact support.
       </span>
       <div className="mt-4">
         {isLoading && <LoadingSpinner/>}

--- a/ui-admin/src/health/LogEventViewer.tsx
+++ b/ui-admin/src/health/LogEventViewer.tsx
@@ -17,7 +17,7 @@ import { renderPageHeader } from 'util/pageUtils'
 import Modal from 'react-bootstrap/Modal'
 import { Button } from 'components/forms/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faUpRightAndDownLeftFromCenter } from '@fortawesome/free-solid-svg-icons'
+import { faInfoCircle, faUpRightAndDownLeftFromCenter } from '@fortawesome/free-solid-svg-icons'
 import Select from 'react-select'
 import pluralize from 'pluralize'
 
@@ -125,6 +125,10 @@ export default function LogEventViewer() {
   return (
     <div className="px-4 py-2">
       {renderPageHeader('Log Events')}
+      <span className="text-muted fst-italic">
+        <FontAwesomeIcon icon={faInfoCircle} className="me-2"/>
+        This table is limited to 1000 log events. If you need to view more, query the database directly.
+      </span>
       <div className="mt-4">
         {isLoading && <LoadingSpinner/>}
       </div>


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Caps the UI at requesting a max of 1000 log events.

<img width="1265" alt="Screenshot 2024-08-01 at 10 59 18 AM" src="https://github.com/user-attachments/assets/bfbffbd8-c942-4972-af62-94c5afa17c4e">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Restart admin API
Confirm sure you can still load up to 1,000 events in the UI