### PR TITLE
[JN-1203] fixing e2e tests

### DIFF
--- a/e2e-tests/src/data/demo-en.json
+++ b/e2e-tests/src/data/demo-en.json
@@ -8,6 +8,7 @@
     "FamilyName": "Family Name",
     "IsAdult": "I am 18 years old or older.",
     "LiveInUS": "I live in the United States.",
+    "marketing": "I would like to receive marketing communications to the email address that I provide during registration.",
     "UnderstandEnglish": "I am comfortable reading or speaking English.",
     "SouthAsianAncestry": "I identify as having South Asian ancestry from one or more of these countries: Bangladesh, Bhutan, India, the Maldives, Nepal, Pakistan, or Sri Lanka."
   },

--- a/e2e-tests/src/tests/studies/demo/new-proxy-registration.test.ts
+++ b/e2e-tests/src/tests/studies/demo/new-proxy-registration.test.ts
@@ -22,33 +22,35 @@ test.describe('Proxy', () => {
       const prequal = await goToDemoPreEnroll(page)
 
       await prequal.getQuestion(data.PreEnroll.ProxyQuestion).select(data.PreEnroll.ProxyAnswerYes)
-      expect(await prequal.progress()).toMatch('Answered 1/9 questions')
+      expect(await prequal.progress()).toMatch('Answered 1/10 questions')
 
       await prequal.getQuestion(data.PreEnroll.ProxyGivenName).fillIn('Jonas')
-      expect(await prequal.progress()).toMatch('Answered 2/9 questions')
+      expect(await prequal.progress()).toMatch('Answered 2/10 questions')
 
       await prequal.getQuestion(data.PreEnroll.ProxyFamilyName).fillIn('Salk')
-      expect(await prequal.progress()).toMatch('Answered 3/9 questions')
+      expect(await prequal.progress()).toMatch('Answered 3/10 questions')
 
       await prequal.getQuestion(data.PreEnroll.GivenName, { exact: true }).fillIn('Peter')
-      expect(await prequal.progress()).toMatch('Answered 4/9 questions')
+      expect(await prequal.progress()).toMatch('Answered 4/10 questions')
 
       await prequal.getQuestion(data.PreEnroll.FamilyName, { exact: true }).fillIn('Salk')
-      expect(await prequal.progress()).toMatch('Answered 5/9 questions')
+      expect(await prequal.progress()).toMatch('Answered 5/10 questions')
 
       await prequal.clickByRole('button', 'Next')
 
       await prequal.getQuestion(data.PreEnroll.SouthAsianAncestry).select('Yes')
-      expect(await prequal.progress()).toMatch('Answered 6/9 questions')
+      expect(await prequal.progress()).toMatch('Answered 6/10 questions')
 
       await prequal.getQuestion(data.PreEnroll.UnderstandEnglish).select('Yes')
-      expect(await prequal.progress()).toMatch('Answered 7/9 questions')
+      expect(await prequal.progress()).toMatch('Answered 7/10 questions')
 
       await prequal.getQuestion(data.PreEnroll.IsAdult).select('Yes')
-      expect(await prequal.progress()).toMatch('Answered 8/9 questions')
+      expect(await prequal.progress()).toMatch('Answered 8/10 questions')
 
       await prequal.getQuestion(data.PreEnroll.LiveInUS).select('Yes')
-      expect(await prequal.progress()).toMatch('Answered 9/9 questions')
+      expect(await prequal.progress()).toMatch('Answered 9/10 questions')
+
+      await prequal.getQuestion(data.PreEnroll.marketing).select('Yes')
 
       await prequal.submit()
     })

--- a/e2e-tests/src/tests/studies/ourhealth/mailing-list.test.ts
+++ b/e2e-tests/src/tests/studies/ourhealth/mailing-list.test.ts
@@ -22,7 +22,7 @@ test('shows mailing list dialog on direct link', async ({ page }) => {
   await adminLogin(page)
   await page.goto(`${process.env.ADMIN_URL}/demo/studies/heartdemo/env/sandbox/mailingList`)
   await expect(page.getByTestId('loading-spinner')).not.toBeVisible()
-  const tableBody = page.locator('table.table-striped').locator('tbody')
+  const tableBody = page.locator('table').locator('tbody')
   const firstRow = tableBody.locator('tr').nth(0)
   await expect(firstRow.locator('td').nth(1)).toHaveText(email)
   await expect(firstRow.locator('td').nth(2)).toHaveText(name)


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

I'd thought these tests were broken from the Vite migration, but it was actually just an accumulation of configuration/product changes.  Also, you need to run the participant UX with `VITE_UNAUTHED_LOGIN=true` instead of `REACT_APP_UNAUTHED_LOGIN`...

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. `cd e2e-tests`
2. `npx playwright test`