### PR TITLE
[JN-1277] updating email send logic

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -314,6 +314,10 @@ public class EnrolleeImportService {
         profile.setId(registrationProfile.getId());
         profile.setMailingAddressId(registrationProfile.getMailingAddressId());
         profile.getMailingAddress().setId(registrationProfile.getMailingAddressId());
+        // if there's no explicit contact email, default to the username
+        if (profile.getContactEmail() == null) {
+            profile.setContactEmail(registrationProfile.getContactEmail());
+        }
         return profileService.updateWithMailingAddress(profile, auditInfo);
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
@@ -74,6 +74,7 @@ public class EnrolleeEmailService implements NotificationSender {
                         ruleData.getEnrollee().getShortcode(), ruleData.getProfile().getPreferredLanguage());
             }
         }
+        // now save/update the Notification object
         if (notification.getId() != null) {
             // the notification might have been saved, but in a transaction not-yet completed (if, for example,
             // study enrollment transaction is taking a long time). So retry the update if it fails
@@ -148,7 +149,7 @@ public class EnrolleeEmailService implements NotificationSender {
     public boolean shouldSendEmail(Trigger config,
                                    EnrolleeContext enrolleeContext,
                                    NotificationContextInfo contextInfo) {
-        if (enrolleeContext.getProfile() == null) {
+        if (enrolleeContext.getProfile() == null || enrolleeContext.getProfile().getContactEmail() == null) {
             return false;  // no address to send email to
         }
         if (enrolleeContext.getProfile().isDoNotEmail()) {

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
@@ -16,6 +16,7 @@ import bio.terra.pearl.core.service.study.StudyService;
 import bio.terra.pearl.core.shared.ApplicationRoutingPaths;
 import com.sendgrid.Mail;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.springframework.retry.backoff.FixedBackOffPolicy;
 import org.springframework.retry.support.RetryTemplate;
@@ -149,7 +150,7 @@ public class EnrolleeEmailService implements NotificationSender {
     public boolean shouldSendEmail(Trigger config,
                                    EnrolleeContext enrolleeContext,
                                    NotificationContextInfo contextInfo) {
-        if (enrolleeContext.getProfile() == null || enrolleeContext.getProfile().getContactEmail() == null) {
+        if (enrolleeContext.getProfile() == null || StringUtils.isBlank(enrolleeContext.getProfile().getContactEmail())) {
             return false;  // no address to send email to
         }
         if (enrolleeContext.getProfile().isDoNotEmail()) {

--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
@@ -127,6 +127,8 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
         userExpected.setUsername("userName1");
         Profile profileExpected = new Profile();
         profileExpected.setBirthDate(LocalDate.parse("1980-10-10"));
+        // confirm the account name gets copied over
+        profileExpected.setContactEmail(userExpected.getUsername());
         verifyParticipant(imports.get(0), studyEnvId, userExpected, enrolleeExpected, profileExpected);
 
         Enrollee enrolleeExpected2 = new Enrollee();
@@ -135,6 +137,7 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
         userExpected2.setCreatedAt(Instant.parse("2024-05-11T10:00:00Z"));
         userExpected2.setUsername("userName2");
         Profile profileExpected2 = new Profile();
+        profileExpected2.setContactEmail(userExpected2.getUsername());
         verifyParticipant(imports.get(1), studyEnvId, userExpected2, enrolleeExpected2, profileExpected2);
         verifySurveyQuestionAnswer(imports.get(0), "medical_history", "diagnosis", "sick");
     }

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailServiceTests.java
@@ -185,7 +185,7 @@ public class EnrolleeEmailServiceTests extends BaseSpringBootTest {
 
     private void testSendProfile(EnrolleeEmailService enrolleeEmailService, EnrolleeFactory.EnrolleeBundle enrolleeBundle, Trigger config) {
         Notification notification = notificationFactory.buildPersisted(enrolleeBundle, config);
-        EnrolleeContext ruleData = new EnrolleeContext(enrolleeBundle.enrollee(), Profile.builder().build(), null);
+        EnrolleeContext ruleData = new EnrolleeContext(enrolleeBundle.enrollee(), Profile.builder().contactEmail("someAddress").build(), null);
         NotificationContextInfo contextInfo = new NotificationContextInfo(null, null, null, null, null);
         enrolleeEmailService.processNotification(notification, config, ruleData, contextInfo);
         Notification updatedNotification = notificationService.find(notification.getId()).get();

--- a/ui-admin/src/study/participants/AdHocEmailModal.tsx
+++ b/ui-admin/src/study/participants/AdHocEmailModal.tsx
@@ -38,9 +38,9 @@ export default function AdHocEmailModal({ enrolleeShortcodes, onDismiss, studyEn
         customMessages: { adHocMessage, adHocSubject },
         triggerId: selectedConfig.id
       })
-      Store.addNotification(successNotification('email sent'))
+      Store.addNotification(successNotification('email processed'))
     } catch (e) {
-      Store.addNotification(failureNotification('email send failed'))
+      Store.addNotification(failureNotification('email processing failed'))
     }
     onDismiss()
   }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

This was motivated by a bunch of prod errors triggered by imports with null contactEmails.

1. Updates the importer to user the username as the email if none is specific
2. Sets the email service to skip sending emails if there's no email address provided
3. Sets the triggered reminder service to not retry skipped/failed emails at the same interval as "sent" emails -- retrying a failed/skipped email every 10 minutes just isn't likely to yield useful outcomes.

this also clarifies some language in the ad-hoc email sender that it's just reporting whether the operation was successful, not whether the email was sent.  Right now the ad-hoc sender isn't heavily used, but if it does become more used, we'll want to upgrade the UX to support a more useful sent/skipped/failed report.

Another thing that might be useful in the future is a dashboard of all notifications for a given study environment, so that one could quickly see if emails are succeeding, and if too many/not enough are being sent

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  in demo, update Jonas Salk participant profile to have an empty email address `https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants/HDSALK/profile`
2. On the participant list `https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants`, select HDSALK
3.  then go actions -> send email -> Consent reminder -> Send
5. go to Jonas Salk's timeline, `https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants/HDSALK/timeline` and confirm that the email is listed as "SKIPPED"
