### PR TITLE
[JN-1251] moving language report

### DIFF
--- a/ui-admin/src/study/participants/survey/AnswerEditHistory.tsx
+++ b/ui-admin/src/study/participants/survey/AnswerEditHistory.tsx
@@ -1,5 +1,5 @@
 import { CalculatedValue, Question } from 'survey-core'
-import { Answer, instantToDefaultString } from '@juniper/ui-core'
+import { Answer, instantToDefaultString, PortalEnvironmentLanguage } from '@juniper/ui-core'
 import { DataChangeRecord } from 'api/api'
 import { useAdminUserContext } from 'providers/AdminUserProvider'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -12,10 +12,12 @@ import { sortBy } from 'lodash'
 /**
  * Renders a dropdown with the edit history for a question response
  */
-export const AnswerEditHistory = ({ question, answer, editHistory }: {
-    question: Question | CalculatedValue, answer: Answer, editHistory: DataChangeRecord[]
+export const AnswerEditHistory = ({ question, answer, editHistory, supportedLanguages }: {
+    question: Question | CalculatedValue, answer: Answer,
+  editHistory: DataChangeRecord[], supportedLanguages: PortalEnvironmentLanguage[]
 }) => {
   const { users } = useAdminUserContext()
+  const answerLanguage = supportedLanguages?.find(lang => lang.languageCode === answer?.viewedLanguage)
 
   return <>
     <div
@@ -35,6 +37,9 @@ export const AnswerEditHistory = ({ question, answer, editHistory }: {
       </div>
     </div>
     <div className="dropdown-menu" aria-labelledby="viewHistory">
+      {answerLanguage && <span className="ms-2 text-muted fst-italic float-end me-3" style={{ fontSize: '0.75em' }}>
+          answered in {answerLanguage.languageName}
+      </span>}
       {editHistory.map((changeRecord, index) =>
         <div key={index} className="dropdown-item d-flex align-items-center" style={{ pointerEvents: 'none' }}>
           <FontAwesomeIcon icon={faPencil} className="me-2"/>

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
@@ -6,6 +6,7 @@ import { Question } from 'survey-core'
 import { Answer } from '@juniper/ui-core'
 import { DataChangeRecord } from 'api/api'
 import { AnswerEditHistory } from './AnswerEditHistory'
+import { userEvent } from '@testing-library/user-event'
 
 
 describe('getDisplayValue', () => {
@@ -112,8 +113,9 @@ describe('ItemDisplay', () => {
       surveyVersion={1}
       supportedLanguages={[{ languageCode: 'es', languageName: 'Spanish', id: '' }]}
       showFullQuestions={true}/>)
+    userEvent.click(screen.getAllByText('test123')[0])
 
-    expect(screen.getByText('(testQ) (Answered in Spanish)')).toBeInTheDocument()
+    expect(screen.getByText('answered in Spanish')).toBeInTheDocument()
   })
 
   it('renders correctly if a viewedLanguage is not specified', async () => {

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -112,7 +112,6 @@ export const ItemDisplay = ({
   question, answerMap, surveyVersion, showFullQuestions, supportedLanguages, editHistory = []
 }: ItemDisplayProps) => {
   const answer = answerMap[question.name]
-  const answerLanguage = supportedLanguages.find(lang => lang.languageCode === answer?.viewedLanguage)
   const editHistoryForQuestion = editHistory
     .filter(changeRecord => changeRecord.fieldName === question.name)
     .sort((a, b) => b.createdAt - a.createdAt)
@@ -130,13 +129,14 @@ export const ItemDisplay = ({
       <div className="d-flex align-items-center">
         {renderQuestionText(answer, question, showFullQuestions)}
         <span className="ms-2 fst-italic text-muted">
-        ({stableIdText}) {answerLanguage && ` (Answered in ${answerLanguage.languageName})`}
+        ({stableIdText})
         </span>
       </div>
     </dt>
     <dl>
       { answer ?
-        <AnswerEditHistory question={question} answer={answer} editHistory={editHistoryForQuestion}/> :
+        <AnswerEditHistory question={question} answer={answer} supportedLanguages={supportedLanguages}
+          editHistory={editHistoryForQuestion}/> :
         <pre className="fw-bold">{displayValue}</pre>}
     </dl>
   </>


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Moves "answered in" text from the main display into the detail popup.  We assume admins for the most part won't care, and so this declutters the interface

<img width="544" alt="image" src="https://github.com/user-attachments/assets/d90f614f-021b-4a0c-ac52-0198ad7878eb">

This reveals a gap in our audit history, because we're updating answers, we only store the language of the most recent answer.  We might want to think about a more exhaustive history

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  view Jonas Salk's basic survey in demo `https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants/HDSALK/surveys/hd_hd_basicInfo?taskId=0a9df8b1-98bf-42ef-98b7-3c0c13fcc4f3`
2. Click the answers, and confirm the language pops up.