### PR TITLE
[JN-1275]  java 21

### DIFF
--- a/.github/actions/build-push-image/action.yaml
+++ b/.github/actions/build-push-image/action.yaml
@@ -27,7 +27,7 @@ runs:
     - name: Setup JDK
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'adopt'
         cache: 'gradle'
     - name: Construct Docker Image Name and Tag
@@ -42,10 +42,10 @@ runs:
         # this value will always be the same so specifying directly
         workload_identity_provider: projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider
         service_account: ${{ inputs.publish-service-account }}
-    
+
     - name: Setup gcloud
       uses: google-github-actions/setup-gcloud@v1
-    
+
     - name: Explicitly Auth Docker For GCR
       shell: bash
       run: gcloud auth configure-docker ${{ inputs.image-repo }} --quiet
@@ -56,13 +56,13 @@ runs:
         ./gradlew --build-cache ${{ inputs.gradle-build-args }} \
         --image=${{ steps.image-name.outputs.name }} \
         -Djib.console=plain
-    
+
     - name: Run Trivy Vulnerability Scan
       uses: broadinstitute/dsp-appsec-trivy-action@v1
       with:
         image: ${{ steps.image-name.outputs.name }}
-    
+
     - name: Push Image
       shell: bash
       run: docker push ${{ steps.image-name.outputs.name }}
-    
+

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'adopt'
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -43,10 +43,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of SonarQube analysis
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -15,10 +15,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
       - name: Scan via gradle
         run: >-

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'gradle'
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ DTOs, and populate services.  the PopulateCliApp can be used to populate specifi
 ## Local development
 
 ### Prerequisites
-* Java 17
+* Java 21
 * IntelliJ
 * Node v20+ (v20.10.0 tested)
 * Docker
@@ -56,7 +56,7 @@ In IntelliJ, File -> New -> Project from Existing Sources.  When importing the p
 
 * **Server:**
 
-   * Make sure IntelliJ is set to Java 17 in *two* places
+   * Make sure IntelliJ is set to Java 21 in *two* places
       * Project Structure > Project Settings > Project > SDK
       * Settings > Build, Execution, Deployment > Build Tools > Gradle > Gradle Projects > \[this project\] > Gradle JVM
          * Recommended setting for this is "Project SDK"

--- a/api-admin/build.gradle
+++ b/api-admin/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.freefair.lombok" version "6.5.1"
+    id "io.freefair.lombok" version "8.7.1"
     id 'bio.terra.java-spring-conventions'
     id 'de.undercouch.download'
     id 'com.google.cloud.tools.jib'
@@ -10,11 +10,11 @@ plugins {
 
 apply from: 'generators.gradle'
 apply from: 'publishing.gradle'
-
+sourceCompatibility = '21'
 
 dependencies {
 
-    implementation 'bio.terra:terra-common-lib:0.1.10-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:1.1.17-20240716.185355-1'
     implementation project(':core')
     implementation project(':populate')
     implementation 'org.apache.commons:commons-dbcp2'
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.yaml:snakeyaml:2.0'
     implementation 'com.auth0:java-jwt:4.2.2'
     implementation 'org.liquibase:liquibase-core:4.21.1'
+    implementation ('com.diffplug.spotless:spotless-plugin-gradle:6.25.0')
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 
     implementation 'net.javacrumbs.shedlock:shedlock-spring:5.2.0'
@@ -65,4 +66,11 @@ jibDockerBuild.dependsOn('copyWebApp')
 
 test {
     useJUnitPlatform ()
+}
+
+spotless {
+    java {
+        palantirJavaFormat("2.38.0")
+        removeUnusedImports()
+    }
 }

--- a/api-admin/build.gradle
+++ b/api-admin/build.gradle
@@ -4,7 +4,6 @@ plugins {
     id 'de.undercouch.download'
     id 'com.google.cloud.tools.jib'
     id 'com.srcclr.gradle'
-
     id 'com.gorylenko.gradle-git-properties' version '2.4.2'
 }
 
@@ -12,17 +11,22 @@ apply from: 'generators.gradle'
 apply from: 'publishing.gradle'
 sourceCompatibility = '21'
 
-dependencies {
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
 
-    implementation 'bio.terra:terra-common-lib:1.1.17-20240716.185355-1'
+dependencies {
+    implementation 'bio.terra:terra-common-lib:0.1.10-SNAPSHOT'
     implementation project(':core')
     implementation project(':populate')
     implementation 'org.apache.commons:commons-dbcp2'
     implementation 'org.apache.commons:commons-text:1.10.0'
     implementation 'commons-beanutils:commons-beanutils:1.9.4'
-    implementation 'org.springframework.boot:spring-boot-starter:3.2.5'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:3.2.5'
-    implementation 'org.springframework.boot:spring-boot-starter-web:3.2.5'
+    implementation 'org.springframework.boot:spring-boot-starter:3.3.2'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:3.3.2'
+    implementation 'org.springframework.boot:spring-boot-starter-web:3.3.2'
     implementation 'org.yaml:snakeyaml:2.0'
     implementation 'org.springframework.retry:spring-retry'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:3.1.0'
@@ -32,17 +36,17 @@ dependencies {
     implementation 'org.yaml:snakeyaml:2.0'
     implementation 'com.auth0:java-jwt:4.2.2'
     implementation 'org.liquibase:liquibase-core:4.21.1'
-    implementation ('com.diffplug.spotless:spotless-plugin-gradle:6.25.0')
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 
     implementation 'net.javacrumbs.shedlock:shedlock-spring:5.2.0'
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.2.0'
+
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5',
             // Uncomment the next line if you want to use RSASSA-PSS (PS256, PS384, PS512) algorithms:
             //'org.bouncycastle:bcprov-jdk15on:1.70',
             'io.jsonwebtoken:jjwt-jackson:0.11.5' // or 'io.jsonwebtoken:jjwt-gson:0.11.5' for gson
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation('org.springframework.boot:spring-boot-starter-test:3.1.2') {
+    testImplementation('org.springframework.boot:spring-boot-starter-test:3.3.2') {
         // Fixes warning about multiple occurrences of JSONObject on the classpath
         exclude group: 'com.vaadin.external.google', module: 'android-json'
     }
@@ -63,14 +67,6 @@ task copyWebApp(type: Copy) {
 copyWebApp.dependsOn(rootProject.bundleAdminUI)
 jibDockerBuild.dependsOn('copyWebApp')
 
-
 test {
     useJUnitPlatform ()
-}
-
-spotless {
-    java {
-        palantirJavaFormat("2.38.0")
-        removeUnusedImports()
-    }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/BaseStatusService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/BaseStatusService.java
@@ -20,12 +20,16 @@ import lombok.extern.slf4j.Slf4j;
 public class BaseStatusService {
   /** cached status */
   private final AtomicReference<SystemStatus> cachedStatus;
+
   /** configuration parameters */
   private final StatusCheckConfiguration configuration;
+
   /** set of status methods to check */
   private final ConcurrentHashMap<String, Supplier<SystemStatusSystems>> statusCheckMap;
+
   /** scheduler */
   private final ScheduledExecutorService scheduler;
+
   /** last time cache was updated */
   private final AtomicReference<Instant> lastStatusUpdate;
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledKitStatusService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ScheduledKitStatusService.java
@@ -14,6 +14,7 @@ public class ScheduledKitStatusService {
   public ScheduledKitStatusService(KitRequestService kitRequestService) {
     this.kitRequestService = kitRequestService;
   }
+
   /**
    * Update kit statuses from Pepper at 12:30am every day. We're _very_ generous with lockAtMostFor
    * because this only runs once per day.

--- a/api-participant/build.gradle
+++ b/api-participant/build.gradle
@@ -3,15 +3,16 @@ plugins {
     id 'de.undercouch.download'
     id 'com.google.cloud.tools.jib'
     id 'com.srcclr.gradle'
-    id "io.freefair.lombok" version "6.5.1"
+    id "io.freefair.lombok" version "8.7.1"
     id 'com.gorylenko.gradle-git-properties' version '2.4.2'
 }
 
 apply from: 'generators.gradle'
 apply from: 'publishing.gradle'
+sourceCompatibility = '21'
 
 dependencies {
-    implementation 'bio.terra:terra-common-lib:0.1.10-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:1.1.17-20240716.185355-1'
     implementation project(':core')
     implementation 'org.apache.commons:commons-dbcp2'
     implementation 'org.apache.commons:commons-text:1.10.0'
@@ -27,7 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'com.sendgrid:sendgrid-java:4.0.1'
     implementation 'org.liquibase:liquibase-core:4.21.1'
-
+    implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.25.0'
     implementation 'com.auth0:java-jwt:4.2.2'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
@@ -74,4 +75,11 @@ jibDockerBuild.dependsOn('createUnfingerprintedAssets')
 
 test {
     useJUnitPlatform ()
+}
+
+spotless {
+    java {
+        palantirJavaFormat("2.38.0")
+        removeUnusedImports()
+    }
 }

--- a/api-participant/build.gradle
+++ b/api-participant/build.gradle
@@ -10,16 +10,22 @@ plugins {
 apply from: 'generators.gradle'
 apply from: 'publishing.gradle'
 sourceCompatibility = '21'
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
 
 dependencies {
-    implementation 'bio.terra:terra-common-lib:1.1.17-20240716.185355-1'
+    implementation 'bio.terra:terra-common-lib:0.1.10-SNAPSHOT'
     implementation project(':core')
     implementation 'org.apache.commons:commons-dbcp2'
     implementation 'org.apache.commons:commons-text:1.10.0'
     implementation 'commons-beanutils:commons-beanutils:1.9.4'
-    implementation 'org.springframework.boot:spring-boot-starter:3.2.5'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:3.1.2'
-    implementation 'org.springframework.boot:spring-boot-starter-web:3.2.5'
+    implementation 'org.springframework.boot:spring-boot-starter:3.3.2'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:3.3.2'
+    implementation 'org.springframework.boot:spring-boot-starter-web:3.3.2'
     implementation 'org.yaml:snakeyaml:2.0'
     implementation 'org.springframework.retry:spring-retry'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:3.1.0'
@@ -28,7 +34,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'com.sendgrid:sendgrid-java:4.0.1'
     implementation 'org.liquibase:liquibase-core:4.21.1'
-    implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.25.0'
     implementation 'com.auth0:java-jwt:4.2.2'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
@@ -38,7 +43,7 @@ dependencies {
             'io.jsonwebtoken:jjwt-jackson:0.11.5' // or 'io.jsonwebtoken:jjwt-gson:0.11.5' for gson
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
-    testImplementation('org.springframework.boot:spring-boot-starter-test:3.1.2') {
+    testImplementation('org.springframework.boot:spring-boot-starter-test:3.3.2') {
         // Fixes warning about multiple occurrences of JSONObject on the classpath
         exclude group: 'com.vaadin.external.google', module: 'android-json'
     }
@@ -46,6 +51,7 @@ dependencies {
     testImplementation 'commons-io:commons-io:2.13.0'
     // See https://stackoverflow.com/questions/5644011/multi-project-test-dependencies-with-gradle/60138176#60138176
     testImplementation(testFixtures(project(":core")))
+    testImplementation 'io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:1.41.0'
 }
 
 task copyWebApp(type: Copy) {
@@ -75,11 +81,4 @@ jibDockerBuild.dependsOn('createUnfingerprintedAssets')
 
 test {
     useJUnitPlatform ()
-}
-
-spotless {
-    java {
-        palantirJavaFormat("2.38.0")
-        removeUnusedImports()
-    }
 }

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/service/BaseStatusService.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/service/BaseStatusService.java
@@ -20,12 +20,16 @@ import lombok.extern.slf4j.Slf4j;
 public class BaseStatusService {
   /** cached status */
   private final AtomicReference<SystemStatus> cachedStatus;
+
   /** configuration parameters */
   private final StatusCheckConfiguration configuration;
+
   /** set of status methods to check */
   private final ConcurrentHashMap<String, Supplier<SystemStatusSystems>> statusCheckMap;
+
   /** scheduler */
   private final ScheduledExecutorService scheduler;
+
   /** last time cache was updated */
   private final AtomicReference<Instant> lastStatusUpdate;
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.11.0'
+    implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.25.0'
     implementation 'com.felipefzdz.gradle.shellcheck:shellcheck:1.4.6'
     implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.3.0'
     implementation 'com.srcclr.gradle:com.srcclr.gradle.gradle.plugin:3.1.12'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation 'com.google.cloud.tools.jib:com.google.cloud.tools.jib.gradle.plugin:3.3.0'
     implementation 'com.srcclr.gradle:com.srcclr.gradle.gradle.plugin:3.1.12'
     implementation 'de.undercouch.download:de.undercouch.download.gradle.plugin:5.2.0'
-    implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.12'
+    implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.20'
     implementation 'io.spring.dependency-management:io.spring.dependency-management.gradle.plugin:1.0.15.RELEASE'
     implementation 'org.hidetake.swagger.generator:org.hidetake.swagger.generator.gradle.plugin:2.19.2'
     implementation 'org.sonarqube:org.sonarqube.gradle.plugin:4.2.1.3168'

--- a/buildSrc/src/main/groovy/bio.terra.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.java-common-conventions.gradle
@@ -1,3 +1,4 @@
+
 plugins {
     id 'idea'
     id 'jacoco'
@@ -86,8 +87,8 @@ compileJava {
 
 // Spotbugs configuration
 spotbugs {
-    reportLevel = 'high'
-    effort = 'max'
+    reportLevel = com.github.spotbugs.snom.Confidence.valueOf("HIGH")
+    effort = com.github.spotbugs.snom.Effort.MAX
 }
 spotbugsMain {
     reports {
@@ -105,3 +106,6 @@ jacocoTestReport {
         xml.required = true
     }
 }
+
+// See https://github.com/spotbugs/spotbugs-gradle-plugin/issues/1197
+ext['commons-lang3.version']='3.13.0'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.freefair.lombok" version "6.5.1"
+    id "io.freefair.lombok" version "8.7.1"
     id 'java'
     id 'org.liquibase.gradle' version '2.1.0'
     id "java-test-fixtures"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -22,14 +22,14 @@ dependencies {
     antlr "org.antlr:antlr4:4.13.1"
     compileOnly "org.antlr:antlr4-runtime:4.13.1"
 
-    implementation 'org.springframework.boot:spring-boot-starter:3.2.5'
+    implementation 'org.springframework.boot:spring-boot-starter:3.3.2'
     implementation group: 'org.postgresql', name: 'postgresql', version: '42.5.5'
     implementation group: 'org.jdbi', name: 'jdbi3-spring5', version: '3.34.0'
     implementation group: 'org.jdbi', name: 'jdbi3-sqlobject', version: '3.34.0'
     implementation group: 'org.jdbi', name: 'jdbi3-postgres', version: '3.34.0'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:3.2.5'
-    implementation 'org.springframework.boot:spring-boot-starter-webflux:3.2.5'
-    implementation 'org.springframework.boot:spring-boot-starter-validation:3.2.5'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:3.3.2'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux:3.3.2'
+    implementation 'org.springframework.boot:spring-boot-starter-validation:3.3.2'
     implementation 'org.springframework.retry:spring-retry:1.3.4'
     implementation 'org.apache.commons:commons-text:1.10.0'
     implementation 'commons-beanutils:commons-beanutils:1.9.4'
@@ -55,11 +55,11 @@ dependencies {
     liquibaseRuntime 'ch.qos.logback:logback-classic'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:3.1.2'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:3.3.2'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.11.0'
     testImplementation 'com.github.seregamorph:hamcrest-more-matchers:0.1'
 
-    testFixturesImplementation 'org.springframework.boot:spring-boot-starter-test:3.1.2'
+    testFixturesImplementation 'org.springframework.boot:spring-boot-starter-test:3.3.2'
     testFixturesImplementation 'org.apache.commons:commons-text:1.10.0'
     testFixturesImplementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 group = 'bio.terra.pearl.core'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'
+sourceCompatibility = '21'
 
 repositories {
     mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,3 @@
 org.gradle.parallel=true
+# Snoar thrashes if this is too low
+org.gradle.jvmargs=-Xmx2048M

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/pepper-import/build.gradle
+++ b/pepper-import/build.gradle
@@ -18,14 +18,14 @@ repositories {
 dependencies {
     implementation project(':core')
     implementation project(':populate')
-    implementation 'org.springframework.boot:spring-boot-starter:3.2.5'
+    implementation 'org.springframework.boot:spring-boot-starter:3.3.2'
     implementation group: 'org.jdbi', name: 'jdbi3-spring5', version: '3.34.0'
     implementation group: 'org.jdbi', name: 'jdbi3-sqlobject', version: '3.34.0'
     implementation group: 'org.jdbi', name: 'jdbi3-postgres', version: '3.34.0'
     implementation 'org.apache.commons:commons-text:1.10.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:3.2.5'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:3.2.5'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:3.3.2'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:3.3.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
     implementation 'org.yaml:snakeyaml:2.0'
     implementation 'com.typesafe:config:1.4.1'

--- a/pepper-import/build.gradle
+++ b/pepper-import/build.gradle
@@ -7,6 +7,12 @@ plugins {
 
 group = 'bio.terra.pearl.core'
 version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '21'
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
 
 repositories {
     mavenCentral()

--- a/pepper-import/build.gradle
+++ b/pepper-import/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "io.freefair.lombok" version "5.3.3.3"
+    id "io.freefair.lombok" version "8.7.1"
     id 'java'
     id 'jacoco'
     id 'org.springframework.boot'

--- a/populate/build.gradle
+++ b/populate/build.gradle
@@ -1,12 +1,12 @@
 plugins {
-    id "io.freefair.lombok" version "5.3.3.3"
+    id "io.freefair.lombok" version "8.7.1"
     id 'java'
     id 'jacoco'
 }
 
 group = 'bio.terra.pearl.core'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'
+sourceCompatibility = '21'
 
 repositories {
     mavenCentral()

--- a/populate/build.gradle
+++ b/populate/build.gradle
@@ -17,14 +17,14 @@ repositories {
 
 dependencies {
     implementation project(':core')
-    implementation 'org.springframework.boot:spring-boot-starter:3.2.5'
+    implementation 'org.springframework.boot:spring-boot-starter:3.3.2'
     implementation group: 'org.jdbi', name: 'jdbi3-spring5', version: '3.34.0'
     implementation group: 'org.jdbi', name: 'jdbi3-sqlobject', version: '3.34.0'
     implementation group: 'org.jdbi', name: 'jdbi3-postgres', version: '3.34.0'
     implementation 'org.apache.commons:commons-text:1.10.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:3.2.5'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:3.2.5'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:3.3.2'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:3.3.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
     implementation 'org.yaml:snakeyaml:2.0'
 

--- a/populate/src/main/java/bio/terra/pearl/populate/dto/participant/EnrolleePopDto.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/dto/participant/EnrolleePopDto.java
@@ -28,8 +28,10 @@ public class EnrolleePopDto extends Enrollee implements TimeShiftable {
      * useful for fine-grained control of tasks and status, the former more useful for quick and accurate synthetic
      * participant creation.
      * */
+    @Builder.Default
     private boolean simulateSubmissions = false;
     /** if true, the enrollee will be withdrawn via the withdrawEnrollee method in WithdrawnEnrolleeService after creation */
+    @Builder.Default
     private boolean withdrawn = false;
     private PreEnrollmentResponsePopDto preEnrollmentResponseDto;
     @Builder.Default


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Updates the build to Java 21, bringing along various dependencies  

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  install Java 21   ` brew install openjdk@21 `
2. set 21 as your version using jenv
3. update your IntelliJ project settings to use java 21 (see the REAME.md) for instructions
4. install latest gradle (8.9). `brew install gradle`
5. stop any existing gradle daemons. `./gradlew --stop`
6. confirm tests pass `./gradlew test`
7. confirm services deploy and run