### PR TITLE
[JN-1285] delete family functionality

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/family/FamilyController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/family/FamilyController.java
@@ -154,6 +154,27 @@ public class FamilyController implements FamilyApi {
   }
 
   @Override
+  public ResponseEntity<Object> delete(
+      String portalShortcode,
+      String studyShortcode,
+      String envName,
+      String familyShortcodeOrId,
+      String justification) {
+    AdminUser operator = authUtilService.requireAdminUser(request);
+
+    familyExtService.delete(
+        PortalStudyEnvAuthContext.of(
+            operator,
+            portalShortcode,
+            studyShortcode,
+            EnvironmentName.valueOfCaseInsensitive(envName)),
+        familyShortcodeOrId,
+        justification);
+
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
   public ResponseEntity<Object> listChangeRecords(
       String portalShortcode,
       String studyShortcode,

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -965,6 +965,22 @@ paths:
           content: *jsonContent
         '500':
           $ref: '#/components/responses/ServerError'
+    delete:
+      summary: Deletes a family
+      tags: [ family ]
+      operationId: delete
+      parameters:
+        - *portalShortcodeParam
+        - *studyShortcodeParam
+        - *envNameParam
+        - { name: familyShortcodeOrId, in: path, required: true, schema: { type: string } }
+        - { name: justification, in: query, required: true, schema: { type: string } }
+      responses:
+        '200':
+          description: New family object
+          content: { application/json: { schema: { type: object } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/families/{familyShortcode}/proband/{enrolleeShortcode}:
     patch:
       summary: Updates the family's proband

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/family/FamilyExtServiceTest.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/family/FamilyExtServiceTest.java
@@ -54,6 +54,8 @@ class FamilyExtServiceTest extends BaseSpringBootTest {
             "findAll",
             AuthAnnotationSpec.withPortalStudyEnvPerm("participant_data_view"),
             "create",
+            AuthAnnotationSpec.withPortalStudyEnvPerm("participant_data_edit"),
+            "delete",
             AuthAnnotationSpec.withPortalStudyEnvPerm("participant_data_edit")));
   }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/FamilyEnrolleeService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/FamilyEnrolleeService.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.core.service.participant;
 
 import bio.terra.pearl.core.dao.participant.FamilyEnrolleeDao;
 import bio.terra.pearl.core.model.audit.DataAuditInfo;
+import bio.terra.pearl.core.model.audit.DataChangeRecord;
 import bio.terra.pearl.core.model.participant.FamilyEnrollee;
 import bio.terra.pearl.core.service.DataAuditedService;
 import bio.terra.pearl.core.service.workflow.DataChangeRecordService;
@@ -86,5 +87,25 @@ public class FamilyEnrolleeService extends DataAuditedService<FamilyEnrollee, Fa
 
     public List<FamilyEnrollee> findByEnrolleeId(UUID id) {
         return dao.findByEnrolleeId(id);
+    }
+
+    @Override
+    protected DataChangeRecord makeCreationChangeRecord(FamilyEnrollee obj, DataAuditInfo auditInfo) {
+        DataChangeRecord dataChangeRecord = super.makeCreationChangeRecord(obj, auditInfo);
+
+        dataChangeRecord.setFamilyId(obj.getFamilyId());
+        dataChangeRecord.setEnrolleeId(obj.getEnrolleeId());
+
+        return dataChangeRecord;
+    }
+
+    @Override
+    protected DataChangeRecord makeDeletionChangeRecord(FamilyEnrollee obj, DataAuditInfo auditInfo) {
+        DataChangeRecord dataChangeRecord = super.makeDeletionChangeRecord(obj, auditInfo);
+
+        dataChangeRecord.setFamilyId(obj.getFamilyId());
+        dataChangeRecord.setEnrolleeId(obj.getEnrolleeId());
+
+        return dataChangeRecord;
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/FamilyService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/FamilyService.java
@@ -76,7 +76,10 @@ public class FamilyService extends DataAuditedService<Family, FamilyDao> {
     @Override
     @Transactional
     public void delete(UUID familyId, DataAuditInfo info) {
+        // before we delete family, let's remove all enrollees from it
         familyEnrolleeService.deleteByFamilyId(familyId, info);
+        // and then remove all relationships
+        enrolleeRelationService.deleteByFamilyId(familyId, info);
 
         super.delete(familyId, info);
     }

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -1408,6 +1408,22 @@ export default {
     return await this.processJsonResponse(result)
   },
 
+  async deleteFamily(
+    portalShortcode: string, studyShortcode: string, environmentName: EnvironmentName,
+    familyShortcode: string, justification: string
+  ): Promise<Response> {
+    const params = queryString.stringify({ justification })
+    const url = `${
+      baseStudyEnvUrl(portalShortcode, studyShortcode, environmentName)
+    }/families/${familyShortcode}?${params}`
+
+    const result = await fetch(url, {
+      method: 'DELETE',
+      headers: this.getInitHeaders()
+    })
+    return await this.processResponse(result)
+  },
+
   async fetchFamilyChangeRecords(
     portalShortcode: string, studyShortcode: string, environmentName: EnvironmentName,
     familyShortcode: string, modelName?: string

--- a/ui-admin/src/study/families/FamilyActions.tsx
+++ b/ui-admin/src/study/families/FamilyActions.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import { Family } from '@juniper/ui-core'
-import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
+import {
+  participantListPath,
+  StudyEnvContextT
+} from 'study/StudyEnvironmentRouter'
 import Api from 'api/api'
 import { Store } from 'react-notifications-component'
 import {
@@ -31,7 +34,11 @@ export const FamilyActions = (
         justification)
       setIsDeleting(false)
       Store.addNotification(successNotification('Family deleted.'))
-      navigate(`../../../participants?groupByFamily=true`)
+      navigate(`${participantListPath(
+        studyEnvContext.portal.shortcode,
+        studyEnvContext.study.shortcode,
+        studyEnvContext.currentEnv.environmentName
+      )}?groupByFamily=true`)
     } catch (e) {
       Store.addNotification(failureNotification('Could not delete family.'))
     }
@@ -40,7 +47,7 @@ export const FamilyActions = (
   return <div>
     <h4>Delete Family</h4>
     <p>
-      Note that participants will remain in the system.
+      Note: this only deletes the family relationships. Participants will still be able to participate in the study.
     </p>
     <button className="btn btn-danger" onClick={() => setIsDeleting(true)}>Delete Family</button>
     {isDeleting && <JustifyChangesModal

--- a/ui-admin/src/study/families/FamilyActions.tsx
+++ b/ui-admin/src/study/families/FamilyActions.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { Family } from '@juniper/ui-core'
+import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
+import Api from 'api/api'
+import { Store } from 'react-notifications-component'
+import {
+  failureNotification,
+  successNotification
+} from 'util/notifications'
+import JustifyChangesModal from 'study/participants/JustifyChangesModal'
+import { useNavigate } from 'react-router-dom'
+
+/**
+ * Renders editable page with all family members and relations.
+ */
+export const FamilyActions = (
+  { family, studyEnvContext }: {
+    family: Family, studyEnvContext: StudyEnvContextT
+  }
+) => {
+  const [isDeleting, setIsDeleting] = React.useState<boolean>(false)
+  const navigate = useNavigate()
+
+  const deleteFamily = async (justification: string) => {
+    try {
+      await Api.deleteFamily(
+        studyEnvContext.portal.shortcode,
+        studyEnvContext.study.shortcode,
+        studyEnvContext.currentEnv.environmentName,
+        family.shortcode,
+        justification)
+      setIsDeleting(false)
+      Store.addNotification(successNotification('Family deleted.'))
+      navigate(`../../../participants?groupByFamily=true`)
+    } catch (e) {
+      Store.addNotification(failureNotification('Could not delete family.'))
+    }
+  }
+
+  return <div>
+    <h4>Delete Family</h4>
+    <p>
+      Note that participants will remain in the system.
+    </p>
+    <button className="btn btn-danger" onClick={() => setIsDeleting(true)}>Delete Family</button>
+    {isDeleting && <JustifyChangesModal
+      saveWithJustification={deleteFamily}
+      onDismiss={() => setIsDeleting(false)}
+      bodyText={<p>Are you sure you want to delete {family.shortcode}?</p>}
+    />}
+  </div>
+}

--- a/ui-admin/src/study/families/FamilyView.tsx
+++ b/ui-admin/src/study/families/FamilyView.tsx
@@ -29,6 +29,7 @@ import { FamilyMembersAndRelations } from 'study/families/FamilyMembersAndRelati
 import { getFamilyNameString } from 'util/familyUtils'
 import { useUser } from 'user/UserProvider'
 import { FamilyAuditTable } from 'study/families/FamilyAuditTable'
+import { FamilyActions } from 'study/families/FamilyActions'
 
 
 export type SurveyWithResponsesT = {
@@ -84,6 +85,9 @@ export function LoadedFamilyView({ family, studyEnvContext, reloadFamily }:
               <li style={navListItemStyle} className="ps-3">
                 <NavLink to="changeRecords" className={getLinkCssClasses}>Audit history</NavLink>
               </li>
+              <li style={navListItemStyle} className="ps-3">
+                <NavLink end to="actions" className={getLinkCssClasses}>Advanced actions</NavLink>
+              </li>
             </ul>
           </div>
           <div className="participantTabContent flex-grow-1 bg-white p-3 pt-0">
@@ -103,6 +107,10 @@ export function LoadedFamilyView({ family, studyEnvContext, reloadFamily }:
                   studyEnvContext={studyEnvContext}/>}
                 />}
                 <Route path="changeRecords" element={<FamilyAuditTable
+                  family={family}
+                  studyEnvContext={studyEnvContext}
+                />}/>
+                <Route path="actions" element={<FamilyActions
                   family={family}
                   studyEnvContext={studyEnvContext}
                 />}/>


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Allows deleting a family.

<img width="1259" alt="image" src="https://github.com/user-attachments/assets/d43533bf-e9cb-44ab-8cf8-b6f0dc268d7a">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Populate demo
- Navigate to F_SALKFM (or create a new family)
- Delete the family from the advanced actions page
- Observe that it brings you to where you expect
- Go to one of the affected enrollees and look at their audit history to see the deletion record