### PR TITLE
[JN-1298] adding permissions to export

### DIFF
--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/EnrolleeExportExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/EnrolleeExportExtServiceTests.java
@@ -1,0 +1,23 @@
+package bio.terra.pearl.api.admin.service;
+
+import bio.terra.pearl.api.admin.AuthAnnotationSpec;
+import bio.terra.pearl.api.admin.AuthTestUtils;
+import bio.terra.pearl.api.admin.BaseSpringBootTest;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class EnrolleeExportExtServiceTests extends BaseSpringBootTest {
+  @Autowired private EnrolleeExportExtService enrolleeExportExtService;
+
+  @Test
+  public void testAuthentication() {
+    AuthTestUtils.assertAllMethodsAnnotated(
+        enrolleeExportExtService,
+        Map.of(
+            "export",
+            AuthAnnotationSpec.withPortalStudyEnvPerm("participant_data_view"),
+            "exportDictionary",
+            AuthAnnotationSpec.withPortalStudyEnvPerm("BASE")));
+  }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/export/DictionaryExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/DictionaryExportService.java
@@ -19,7 +19,7 @@ public class DictionaryExportService {
 
     public void exportDictionary(ExportOptions exportOptions, UUID portalId,
                                  UUID studyEnvironmentId,
-                                 OutputStream os) throws Exception {
+                                 OutputStream os) {
         List<ModuleFormatter> moduleFormatters = enrolleeExportService.generateModuleInfos(exportOptions, studyEnvironmentId, List.of());
         // for now, we only support Excel
         DataDictionaryExcelExporter exporter = new DataDictionaryExcelExporter(moduleFormatters, objectMapper);


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Updates the EnrolleeExportExtService with permission annotations, and does a smidge of refactor.  No functional changes

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  redeploy apiAdminApp
2. confirm export at `https://localhost:3000/demo/studies/heartdemo/env/sandbox/export/dataBrowser` still works