### PR TITLE
[JN-1259] moving lazy import for kits

### DIFF
--- a/ui-participant/src/hub/HubRouter.tsx
+++ b/ui-participant/src/hub/HubRouter.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { lazy } from 'react'
 import { Route, Routes } from 'react-router-dom'
 import Navbar from '../Navbar'
 import HubPage from './HubPage'
@@ -7,7 +7,7 @@ import SurveyView from './survey/SurveyView'
 import { ParticipantProfile } from 'participant/ParticipantProfile'
 import PrintSurveyView from './survey/PrintSurveyView'
 import ManageProfiles from '../participant/ManageProfiles'
-import { KitInstructions } from './kit/KitInstructions'
+const KitInstructions = lazy(() => import('./kit/KitInstructions'))
 
 /** Handles url pathing for hub routes (a.k.a participant is signed in) */
 export default function HubRouter() {

--- a/ui-participant/src/hub/kit/KitInstructions.test.tsx
+++ b/ui-participant/src/hub/kit/KitInstructions.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { act, render, screen } from '@testing-library/react'
-import { KitInstructions } from './KitInstructions'
+import KitInstructions from './KitInstructions'
 import { asMockedFn, setupRouterTest } from '@juniper/ui-core'
 import { useActiveUser } from 'providers/ActiveUserProvider'
 import { mockUseActiveUser } from 'test-utils/user-mocking-utils'

--- a/ui-participant/src/hub/kit/KitInstructions.tsx
+++ b/ui-participant/src/hub/kit/KitInstructions.tsx
@@ -3,11 +3,11 @@ import { Link } from 'react-router-dom'
 import { useActiveUser } from 'providers/ActiveUserProvider'
 import { KitCollectionStep, KitReturnType } from '@juniper/ui-core'
 import { usePortalEnv } from 'providers/PortalProvider'
-const QRCode = lazy(() => import('react-qr-code'))
+import QRCode from 'react-qr-code'
 
 //TODO: JN-1294, implement i18n for this entire component
 
-export function KitInstructions() {
+export default function KitInstructions() {
   const { ppUser, enrollees } = useActiveUser()
   const { portalEnv } = usePortalEnv()
   const activeEnrollee = enrollees.find(enrollee => enrollee.profileId === ppUser?.profileId)

--- a/ui-participant/src/hub/kit/KitInstructions.tsx
+++ b/ui-participant/src/hub/kit/KitInstructions.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, useState } from 'react'
+import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useActiveUser } from 'providers/ActiveUserProvider'
 import { KitCollectionStep, KitReturnType } from '@juniper/ui-core'


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Having the lazy import target a named file solves the multiple index problem.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. `./gradlew api-participant:clean`
2. `./gradlew api-participant:jibDockerBuild`
3.  go to `http://sandbox.demo.localhost:8081`
4. confirm page renders
5. go to `http://sandbox.demo.localhost:8081/hub/kitInstructions`
6. confirm kit instructions still appear               