### PR TITLE
[JN-1293] Fix empty form bug in SplitFormDesigner

### DIFF
--- a/ui-admin/src/forms/designer/split/SplitFormDesigner.test.tsx
+++ b/ui-admin/src/forms/designer/split/SplitFormDesigner.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+
+import { SplitFormDesigner } from './SplitFormDesigner'
+import { screen, render, act } from '@testing-library/react'
+
+jest.spyOn(window, 'scrollTo').mockImplementation(() => { })
+
+describe('SplitFormDesigner', () => {
+  it('should render SplitFormDesigner for an empty form', () => {
+    render(
+      <SplitFormDesigner
+        content={{ 'title': 'Test empty form', 'pages': [{ 'elements': [] }] }}
+        onChange={() => jest.fn()}
+        currentLanguage={{ id: '0', languageCode: 'en', languageName: 'English' }}
+        supportedLanguages={[{ id: '0', languageCode: 'en', languageName: 'English' }]}
+      />)
+    expect(screen.getByLabelText('Insert a new question')).toBeInTheDocument()
+    expect(screen.getByLabelText('Insert a new panel')).toBeInTheDocument()
+    expect(screen.getByText('Previous page')).toBeInTheDocument()
+    expect(screen.getByText('Scroll to top')).toBeInTheDocument()
+    expect(screen.getByText('Next page')).toBeInTheDocument()
+  })
+
+  it('should handle page change', () => {
+    render(
+      <SplitFormDesigner
+        content={
+          {
+            'title': 'Test two page form',
+            'pages': [{
+              'elements': [
+                { 'type': 'text', 'name': 'q1', 'title': 'question1' }
+              ]
+            }, {
+              'elements': [
+                { 'type': 'text', 'name': 'q2', 'title': 'question2' }
+              ]
+            }]
+          }}
+        onChange={() => jest.fn()}
+        currentLanguage={{ id: '0', languageCode: 'en', languageName: 'English' }}
+        supportedLanguages={[{ id: '0', languageCode: 'en', languageName: 'English' }]}
+      />)
+
+    //Confirm initial page view is correct
+    expect(screen.getAllByText('question1')).toHaveLength(2)
+    expect(screen.queryAllByText('question2')).toHaveLength(0)
+
+    act(() => screen.getByText('Next page').click())
+
+    //Confirm next page view is correct
+    expect(screen.queryAllByText('question1')).toHaveLength(0)
+    expect(screen.getAllByText('question2')).toHaveLength(2)
+
+    act(() => screen.getByText('Previous page').click())
+
+    //Confirm returning to the original page view is correct
+    expect(screen.getAllByText('question1')).toHaveLength(2)
+    expect(screen.queryAllByText('question2')).toHaveLength(0)
+  })
+
+  it('should scroll to top', () => {
+    render(
+      <SplitFormDesigner
+        content={{ 'title': 'Foo', 'pages': [{ 'elements': [] }] }}
+        onChange={() => jest.fn()}
+        currentLanguage={{ id: '0', languageCode: 'en', languageName: 'English' }}
+        supportedLanguages={[{ id: '0', languageCode: 'en', languageName: 'English' }]}
+      />)
+    act(() => screen.getByText('Scroll to top').click())
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0)
+  })
+})

--- a/ui-admin/src/forms/designer/split/SplitFormDesigner.tsx
+++ b/ui-admin/src/forms/designer/split/SplitFormDesigner.tsx
@@ -35,8 +35,12 @@ export const SplitFormDesigner = ({ content, onChange, currentLanguage, supporte
   }
 
   return <div className="mt-3 container w-100">
+    <div className="d-flex">
+      {renderNewElementButton(content, onChange, -1, currentPageNo, 'question')}
+      {renderNewElementButton(content, onChange, -1, currentPageNo, 'panel')}
+    </div>
     <>
-      {currentPage.elements.map((element, elementIndex) => (
+      {currentPage && currentPage.elements && currentPage.elements.map((element, elementIndex) => (
         <div key={elementIndex} className="container">
           <SplitFormElementDesigner currentPageNo={currentPageNo}
             elementIndex={elementIndex} editedContent={content}
@@ -62,7 +66,7 @@ export const SplitFormDesigner = ({ content, onChange, currentLanguage, supporte
       <Button variant="light" className="border m-1"
         disabled={currentPageNo === content.pages.length - 1}
         onClick={() => handlePageChange('next')}>
-                Next page <FontAwesomeIcon icon={faArrowRight}/>
+        Next page <FontAwesomeIcon icon={faArrowRight}/>
       </Button>
     </div>
   </div>

--- a/ui-admin/src/forms/formContentValidation.ts
+++ b/ui-admin/src/forms/formContentValidation.ts
@@ -82,7 +82,7 @@ export const validateElementNames = (elements: (Question | HtmlElement)[]) => {
 
   //It's hard to reference individual elements that don't have names, so just return the count.
   if (invalidElements.length === 1) {
-    errorMessages.push(`1 element is missing a 'name' field.`)
+    errorMessages.push(`1 element is missing a 'name' (stable ID) field.`)
   } else if (invalidElements.length > 1) {
     errorMessages.push(`${invalidElements.length} elements are missing a 'name' field.`)
   }

--- a/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.test.tsx
@@ -144,7 +144,7 @@ describe('CreateSurveyModal', () => {
         autoUpdateTaskAssignments: true,
         blurb: 'Testing out the screener blurb...',
         assignToExistingEnrollees: true,
-        content: '{"pages":[]}',
+        content: '{"pages":[{"elements":[]}]}',
         createdAt: expect.anything(),
         lastUpdatedAt: expect.anything(),
         id: '',

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -15,7 +15,7 @@ import { faLightbulb, faUsersViewfinder } from '@fortawesome/free-solid-svg-icon
 import { FormOptions } from './FormOptionsModal'
 import { useUser } from '../../user/UserProvider'
 
-const QUESTIONNAIRE_TEMPLATE = '{"pages":[]}'
+const QUESTIONNAIRE_TEMPLATE = '{"pages":[{"elements":[]}]}'
 const randomSuffix = Math.random().toString(36).substring(2, 15)
 const HTML_TEMPLATE = `{"pages":[{"elements":[{"type":"html","name":"outreach_content_${randomSuffix}"}]}]}`
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Fixes a bug that prevented the split form designer from being used with an empty form.

Also adds Insert new question / Insert new panel buttons to the 0 index slot, allowing you to insert an initial question.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Create a new form
* Confirm that you can use the split view designer to add a first question