### PR TITLE
[JN-1288] Confirm sensitive changes when publishing

### DIFF
--- a/ui-admin/src/portal/publish/PortalEnvDiff.test.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiff.test.tsx
@@ -25,9 +25,15 @@ describe('PortalEnvDiff', () => {
     const { portal } = mockPortalContext()
     const changeSet: PortalEnvironmentChange = {
       ...emptyChangeSet,
-      configChanges: [
-        { propertyName: 'password', oldValue: 'secret', newValue: 'moreSecret' }
-      ]
+      languageChanges: {
+        addedItems: [{
+          languageCode: 'es',
+          languageName: 'Spanish',
+          id: 'es'
+        }],
+        removedItems: [],
+        changedItems: []
+      }
     }
     const spyApplyChanges = jest.fn(() => 1)
     renderInPortalRouter(portal, <PortalEnvDiffView
@@ -45,9 +51,39 @@ describe('PortalEnvDiff', () => {
     expect(spyApplyChanges).toHaveBeenCalledWith(emptyChangeSet)
 
     // if we save after clicking the password field, we should save with a config change
+    await userEvent.click(screen.getByText('Spanish (es)'))
+    await userEvent.click(screen.getByText(`Publish changes to ${portal.portalEnvironments[0].environmentName}`))
+
+    expect(spyApplyChanges).toHaveBeenCalledTimes(2)
+    expect(spyApplyChanges).toHaveBeenCalledWith(changeSet)
+  })
+
+  it('prompts for confirmation when pubhlishing sensitive config changes', async () => {
+    const { portal } = mockPortalContext()
+    const changeSet: PortalEnvironmentChange = {
+      ...emptyChangeSet,
+      configChanges: [
+        { propertyName: 'password', oldValue: 'secret', newValue: 'moreSecret' }
+      ]
+    }
+    const spyApplyChanges = jest.fn(() => 1)
+    renderInPortalRouter(portal, <PortalEnvDiffView
+      portal={portal}
+      destEnvName={portal.portalEnvironments[0].environmentName}
+      applyChanges={spyApplyChanges}
+      sourceEnvName="sourceEnv"
+      changeSet={changeSet}/>, { ...defaultRenderOpts, permissions: ['publish'] })
+    expect(screen.queryAllByText('no changes')).toHaveLength(5)
+    expect(screen.queryAllByRole('checkbox')).toHaveLength(1)
+
+    // if we save after clicking the password field, we should save with a config change
     await userEvent.click(screen.getByText('password:'))
     await userEvent.click(screen.getByText(`Publish changes to ${portal.portalEnvironments[0].environmentName}`))
-    expect(spyApplyChanges).toHaveBeenCalledTimes(2)
+
+    await screen.getByText('Confirm Publish')
+    await userEvent.click(screen.getByText('Publish'))
+
+    expect(spyApplyChanges).toHaveBeenCalledTimes(1)
     expect(spyApplyChanges).toHaveBeenCalledWith(changeSet)
   })
 

--- a/ui-admin/src/portal/publish/PortalEnvDiff.test.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiff.test.tsx
@@ -58,7 +58,7 @@ describe('PortalEnvDiff', () => {
     expect(spyApplyChanges).toHaveBeenCalledWith(changeSet)
   })
 
-  it('prompts for confirmation when pubhlishing sensitive config changes', async () => {
+  it('prompts for confirmation when publishing sensitive config changes', async () => {
     const { portal } = mockPortalContext()
     const changeSet: PortalEnvironmentChange = {
       ...emptyChangeSet,

--- a/ui-admin/src/portal/publish/PortalEnvDiff.test.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiff.test.tsx
@@ -50,7 +50,7 @@ describe('PortalEnvDiff', () => {
     expect(spyApplyChanges).toHaveBeenCalledTimes(1)
     expect(spyApplyChanges).toHaveBeenCalledWith(emptyChangeSet)
 
-    // if we save after clicking the password field, we should save with a config change
+    // if we save after clicking on a language field, we should save with a language change
     await userEvent.click(screen.getByText('Spanish (es)'))
     await userEvent.click(screen.getByText(`Publish changes to ${portal.portalEnvironments[0].environmentName}`))
 
@@ -76,7 +76,7 @@ describe('PortalEnvDiff', () => {
     expect(screen.queryAllByText('no changes')).toHaveLength(5)
     expect(screen.queryAllByRole('checkbox')).toHaveLength(1)
 
-    // if we save after clicking the password field, we should save with a config change
+    // if we save after clicking the password field, we should be prompted for confirmation
     await userEvent.click(screen.getByText('password:'))
     await userEvent.click(screen.getByText(`Publish changes to ${portal.portalEnvironments[0].environmentName}`))
 

--- a/ui-admin/src/portal/publish/PortalEnvDiff.test.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiff.test.tsx
@@ -81,6 +81,10 @@ describe('PortalEnvDiff', () => {
     await userEvent.click(screen.getByText(`Publish changes to ${portal.portalEnvironments[0].environmentName}`))
 
     await screen.getByText('Confirm Publish')
+
+    // at this time, changes should not have been published
+    expect(spyApplyChanges).toHaveBeenCalledTimes(0)
+
     await userEvent.click(screen.getByText('Publish'))
 
     expect(spyApplyChanges).toHaveBeenCalledTimes(1)

--- a/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
@@ -20,7 +20,7 @@ import { userHasPermission, useUser } from 'user/UserProvider'
 import { Button } from 'components/forms/Button'
 import { isEmpty } from 'lodash'
 import Modal from 'react-bootstrap/Modal'
-import LoadingSpinner from '../../util/LoadingSpinner'
+import LoadingSpinner from 'util/LoadingSpinner'
 
 export const emptyChangeSet: PortalEnvironmentChange = {
   siteContentChange: { changed: false },
@@ -306,12 +306,10 @@ const ConfirmConfigChangesModal = ({ portal, selectedChanges, applyChanges, onDi
   </Modal>
 }
 
-type ConfigChangeListProps = {
+const SensitiveConfigChangeList = ({ configChanges, title }: {
   configChanges: ConfigChange[],
   title: string
-}
-
-const SensitiveConfigChangeList = ({ configChanges, title }: ConfigChangeListProps) => {
+}) => {
   return configChanges.length > 0 ? (
     <>
       <label className="d-flex h4 mt-1">{title}</label>

--- a/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
@@ -235,8 +235,9 @@ export default function PortalEnvDiffView(
     <div className="d-flex justify-content-center mt-2 pb-5">
       { userHasPermission(user, portal.id, 'publish') && <>
         <Button variant="primary" onClick={() => {
+          // check for portal env and study env config changes. if empty, immediately apply changes
           if (isEmpty(selectedChanges.configChanges) &&
-              isEmpty(selectedChanges.studyEnvChanges.filter(studyChange => !isEmpty(studyChange.configChanges)))) {
+              selectedChanges.studyEnvChanges.every(studyChange => isEmpty(studyChange.configChanges))) {
             applyChanges(selectedChanges)
           } else {
             setShowConfirmModal(true)

--- a/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
@@ -10,7 +10,7 @@ import {
   ConfigChangeListView,
   ConfigChanges,
   renderNotificationConfig,
-  renderPortalLanguage,
+  renderPortalLanguage, valuePresent,
   VersionChangeView
 } from './diffComponents'
 import { faArrowRight } from '@fortawesome/free-solid-svg-icons'
@@ -282,15 +282,17 @@ const ConfirmConfigChangesModal = ({ portal, selectedChanges, applyChanges, onDi
 
       <SensitiveConfigChangeList configChanges={selectedChanges.configChanges} title="Portal Configuration"/>
 
-      {selectedChanges.studyEnvChanges.map(studyChanges => {
-        const studyName = portal.portalStudies.find(portalStudy =>
-          portalStudy.study.shortcode === studyChanges.studyShortcode)?.study.name || studyChanges.studyShortcode
+      <div className="mt-2">
+        {selectedChanges.studyEnvChanges.map(studyChanges => {
+          const studyName = portal.portalStudies.find(portalStudy =>
+            portalStudy.study.shortcode === studyChanges.studyShortcode)?.study.name || studyChanges.studyShortcode
 
-        return <SensitiveConfigChangeList
-          key={studyChanges.studyShortcode}
-          configChanges={studyChanges.configChanges}
-          title={`${studyName} Study Configuration`}/>
-      })}
+          return <SensitiveConfigChangeList
+            key={studyChanges.studyShortcode}
+            configChanges={studyChanges.configChanges}
+            title={`${studyName} Study Configuration`}/>
+        })}
+      </div>
 
       <div className="mt-3">Are you sure that you want to proceed?</div>
     </Modal.Body>
@@ -311,6 +313,7 @@ const SensitiveConfigChangeList = ({ configChanges, title }: {
   configChanges: ConfigChange[],
   title: string
 }) => {
+  const noVal = <span className="text-muted fst-italic">none</span>
   return configChanges.length > 0 ? (
     <>
       <label className="d-flex h4 mt-1">{title}</label>
@@ -318,9 +321,9 @@ const SensitiveConfigChangeList = ({ configChanges, title }: {
         <div className="d-flex" key={configChange.propertyName}>
           <div className="fw-semibold">{configChange.propertyName}:</div>
           <div className="ms-2">
-            {configChange.oldValue.toString()}
+            {valuePresent(configChange.oldValue) ? configChange.oldValue.toString() : noVal}
             <FontAwesomeIcon icon={faArrowRight} className="mx-2 fa-sm"/>
-            {configChange.newValue.toString()}
+            {valuePresent(configChange.newValue) ? configChange.newValue.toString() : noVal}
           </div>
         </div>
       ))}

--- a/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
+++ b/ui-admin/src/portal/publish/PortalEnvDiffView.tsx
@@ -18,6 +18,9 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import _cloneDeep from 'lodash/cloneDeep'
 import { userHasPermission, useUser } from 'user/UserProvider'
 import { Button } from 'components/forms/Button'
+import { isEmpty } from 'lodash'
+import Modal from 'react-bootstrap/Modal'
+import LoadingSpinner from '../../util/LoadingSpinner'
 
 export const emptyChangeSet: PortalEnvironmentChange = {
   siteContentChange: { changed: false },
@@ -99,6 +102,7 @@ type EnvironmentDiffProps = {
 export default function PortalEnvDiffView(
   { changeSet, destEnvName, applyChanges, sourceEnvName, portal }: EnvironmentDiffProps) {
   const [selectedChanges, setSelectedChanges] = useState<PortalEnvironmentChange>(getDefaultPortalEnvChanges(changeSet))
+  const [showConfirmModal, setShowConfirmModal] = useState(false)
   const { user } = useUser()
   const updateSelectedStudyEnvChanges = (update: StudyEnvironmentChange) => {
     const matchedIndex = selectedChanges.studyEnvChanges
@@ -230,7 +234,14 @@ export default function PortalEnvDiffView(
     </div>
     <div className="d-flex justify-content-center mt-2 pb-5">
       { userHasPermission(user, portal.id, 'publish') && <>
-        <Button variant="primary" onClick={() => applyChanges(selectedChanges)}>
+        <Button variant="primary" onClick={() => {
+          if (isEmpty(selectedChanges.configChanges) &&
+              isEmpty(selectedChanges.studyEnvChanges.filter(studyChange => !isEmpty(studyChange.configChanges)))) {
+            applyChanges(selectedChanges)
+          } else {
+            setShowConfirmModal(true)
+          }
+        }}>
           Publish changes to {destEnvName}
         </Button>
         {
@@ -244,7 +255,77 @@ export default function PortalEnvDiffView(
            To publish selected changes, you must have the &quot;publish&quot; permission, or contact support
          </div>
       }
+      { showConfirmModal &&
+        <ConfirmConfigChangesModal portal={portal} selectedChanges={selectedChanges} applyChanges={applyChanges}
+          onDismiss={() => setShowConfirmModal(false)}/>
+      }
     </div>
   </div>
+}
+
+const ConfirmConfigChangesModal = ({ portal, selectedChanges, applyChanges, onDismiss }: {
+  portal: Portal
+  selectedChanges: PortalEnvironmentChange,
+  applyChanges: (changeSet: PortalEnvironmentChange) => void,
+  onDismiss: () => void
+}) => {
+  return <Modal className="modal-lg" show={true} onHide={onDismiss}>
+    <Modal.Header closeButton>
+      <Modal.Title>Confirm Publish</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>
+      <div className="mb-2">
+        Some of the changes that you are about to publish may significantly impact study operations.
+        Please review the following items and confirm that you want to proceed:
+      </div>
+
+      <SensitiveConfigChangeList configChanges={selectedChanges.configChanges} title="Portal Configuration"/>
+
+      {selectedChanges.studyEnvChanges.map(studyChanges => {
+        const studyName = portal.portalStudies.find(portalStudy =>
+          portalStudy.study.shortcode === studyChanges.studyShortcode)?.study.name || studyChanges.studyShortcode
+
+        return <SensitiveConfigChangeList
+          key={studyChanges.studyShortcode}
+          configChanges={studyChanges.configChanges}
+          title={`${studyName} Study Configuration`}/>
+      })}
+
+      <div className="mt-3">Are you sure that you want to proceed?</div>
+    </Modal.Body>
+    <Modal.Footer>
+      <LoadingSpinner isLoading={false}>
+        <button className="btn btn-primary" onClick={() => {
+          applyChanges(selectedChanges)
+        }}>Publish</button>
+        <button className="btn btn-secondary" onClick={() => {
+          onDismiss()
+        }}>Cancel</button>
+      </LoadingSpinner>
+    </Modal.Footer>
+  </Modal>
+}
+
+type ConfigChangeListProps = {
+  configChanges: ConfigChange[],
+  title: string
+}
+
+const SensitiveConfigChangeList = ({ configChanges, title }: ConfigChangeListProps) => {
+  return configChanges.length > 0 ? (
+    <>
+      <label className="d-flex h4 mt-1">{title}</label>
+      {configChanges.map(configChange => (
+        <div className="d-flex" key={configChange.propertyName}>
+          <div className="fw-semibold">{configChange.propertyName}:</div>
+          <div className="ms-2">
+            {configChange.oldValue.toString()}
+            <FontAwesomeIcon icon={faArrowRight} className="mx-2 fa-sm"/>
+            {configChange.newValue.toString()}
+          </div>
+        </div>
+      ))}
+    </>
+  ) : null
 }
 

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.test.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.test.tsx
@@ -10,6 +10,11 @@ import { Store } from 'react-notifications-component'
 
 jest.spyOn(Store, 'addNotification').mockImplementation(() => '')
 
+jest.mock('api/api', () => ({
+  ...jest.requireActual('api/api'),
+  getPortalMedia: jest.fn().mockResolvedValue([])
+}))
+
 test('readOnly disables insert new section button', async () => {
   const mockPage = mockHtmlPage()
   const { RoutedComponent } = setupRouterTest(

--- a/ui-admin/src/search/SearchQueryBuilder.test.tsx
+++ b/ui-admin/src/search/SearchQueryBuilder.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '@testing-library/react'
 import { SearchQueryBuilder } from './SearchQueryBuilder'
 import { userEvent } from '@testing-library/user-event'
-import Api, { SearchValueTypeDefinition } from 'api/api'
+import { SearchValueTypeDefinition } from 'api/api'
 
 const mailingAddressCountryFacet: { [index: string]: SearchValueTypeDefinition } = {
   'profile.mailingAddress.country': {
@@ -21,10 +21,14 @@ const mailingAddressCountryFacet: { [index: string]: SearchValueTypeDefinition }
   }
 }
 
+jest.mock('../api/api', () => ({
+  ...jest.requireActual('../api/api'),
+  getExpressionSearchFacets: jest.fn().mockResolvedValue(mailingAddressCountryFacet),
+  executeSearchExpression: jest.fn().mockResolvedValue([])
+}))
+
 describe('SearchQueryBuilder', () => {
   it('should render with basic options', async () => {
-    jest.spyOn(Api, 'getExpressionSearchFacets').mockResolvedValue(mailingAddressCountryFacet)
-
     const onSearchExpressionChange = jest.fn()
     const { RoutedComponent } = setupRouterTest(
       <SearchQueryBuilder
@@ -57,9 +61,6 @@ describe('SearchQueryBuilder', () => {
   })
 
   it('should render advanced', async () => {
-    jest.clearAllMocks()
-    jest.spyOn(Api, 'getExpressionSearchFacets').mockResolvedValue(mailingAddressCountryFacet)
-
     const onSearchExpressionChange = jest.fn()
     renderWithRouter(<SearchQueryBuilder
       studyEnvContext={mockStudyEnvContext()}
@@ -82,8 +83,6 @@ describe('SearchQueryBuilder', () => {
   })
 
   it('should render with a saved search', async () => {
-    jest.spyOn(Api, 'getExpressionSearchFacets').mockResolvedValue(mailingAddressCountryFacet)
-
     const onSearchExpressionChange = jest.fn()
     const { RoutedComponent } = setupRouterTest(
       <SearchQueryBuilder
@@ -100,8 +99,6 @@ describe('SearchQueryBuilder', () => {
   })
 
   it('should render advanced editor if error in search expression', async () => {
-    jest.spyOn(Api, 'getExpressionSearchFacets').mockResolvedValue(mailingAddressCountryFacet)
-
     const onSearchExpressionChange = jest.fn()
     const { RoutedComponent } = setupRouterTest(
       <SearchQueryBuilder
@@ -121,8 +118,6 @@ describe('SearchQueryBuilder', () => {
   })
 
   it('should render advanced editor if functions used', async () => {
-    jest.spyOn(Api, 'getExpressionSearchFacets').mockResolvedValue(mailingAddressCountryFacet)
-
     const onSearchExpressionChange = jest.fn()
     const { RoutedComponent } = setupRouterTest(
       <SearchQueryBuilder
@@ -142,9 +137,6 @@ describe('SearchQueryBuilder', () => {
   })
 
   it('should disable basic editor if error introduced in advanced editor', async () => {
-    jest.spyOn(Api, 'getExpressionSearchFacets').mockResolvedValue(mailingAddressCountryFacet)
-    jest.spyOn(Api, 'executeSearchExpression').mockResolvedValue([])
-
     const { RoutedComponent } = setupRouterTest(
       <TestFullQueryBuilderState/>)
     render(RoutedComponent)
@@ -172,9 +164,6 @@ describe('SearchQueryBuilder', () => {
   })
 
   it('should disable basic editor if function introduced in advanced editor', async () => {
-    jest.spyOn(Api, 'getExpressionSearchFacets').mockResolvedValue(mailingAddressCountryFacet)
-    jest.spyOn(Api, 'executeSearchExpression').mockResolvedValue([])
-
     const { RoutedComponent } = setupRouterTest(
       <TestFullQueryBuilderState/>)
     render(RoutedComponent)
@@ -201,9 +190,6 @@ describe('SearchQueryBuilder', () => {
   })
 
   it('should disable basic editor if not introduced in advanced editor', async () => {
-    jest.spyOn(Api, 'getExpressionSearchFacets').mockResolvedValue(mailingAddressCountryFacet)
-    jest.spyOn(Api, 'executeSearchExpression').mockResolvedValue([])
-
     const { RoutedComponent } = setupRouterTest(
       <TestFullQueryBuilderState/>)
     render(RoutedComponent)

--- a/ui-admin/src/study/StudyContent.test.tsx
+++ b/ui-admin/src/study/StudyContent.test.tsx
@@ -5,6 +5,7 @@ import StudyContent from './StudyContent'
 import { mockConfiguredSurvey, mockStudyEnvContext, mockSurvey } from 'test-utils/mocking-utils'
 import Api from 'api/api'
 import { setupRouterTest } from '@juniper/ui-core'
+import { userEvent } from '@testing-library/user-event'
 
 test('renders surveys in-order', async () => {
   const studyEnvContext = mockStudyEnvContext()
@@ -39,7 +40,7 @@ test('renders a Create Survey modal', async () => {
   render(RoutedComponent)
   await waitFor(() => expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument())
   const addSurveyButton = screen.getByTestId('addResearchSurvey')
-  fireEvent.click(addSurveyButton)
+  await userEvent.click(addSurveyButton)
   expect(screen.getByText('Create new research form')).toBeInTheDocument()
   expect(screen.getByText('Name')).toBeInTheDocument()
   expect(screen.getByText('Stable ID')).toBeInTheDocument()

--- a/ui-admin/src/study/StudySettings.test.tsx
+++ b/ui-admin/src/study/StudySettings.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 
 import { StudyEnvConfigView } from './StudySettings'
 import { mockPortalContext, mockStudyEnvContext } from 'test-utils/mocking-utils'
@@ -17,10 +17,14 @@ test('renders a study env. config', async () => {
   const portalContext = mockPortalContext()
   const studyEnvContext = mockStudyEnvContext()
   const expectedConfig = studyEnvContext.currentEnv.studyEnvironmentConfig
-  render(
-    <MockSuperuserProvider>
-      <StudyEnvConfigView portalContext={portalContext} studyEnvContext={studyEnvContext}/>
-    </MockSuperuserProvider>)
+
+  await act(async () => {
+    render(
+      <MockSuperuserProvider>
+        <StudyEnvConfigView portalContext={portalContext} studyEnvContext={studyEnvContext}/>
+      </MockSuperuserProvider>
+    )
+  })
 
   expect(screen.getByLabelText('password')).toHaveValue(expectedConfig.password)
   expect((screen.getByLabelText('password protected') as HTMLInputElement).checked)

--- a/ui-admin/src/study/notifications/TriggerView.tsx
+++ b/ui-admin/src/study/notifications/TriggerView.tsx
@@ -66,9 +66,7 @@ export default function TriggerView({ studyEnvContext, portalContext, onDelete }
   const triggerId = useParams().triggerId
   const [trigger, setTrigger] = useState<Trigger>()
   const [workingTrigger, setWorkingTrigger] = useState<Trigger>()
-  console.log(workingTrigger)
   const hasTemplate = !!workingTrigger?.emailTemplate
-  console.log(hasTemplate)
 
   const { isLoading, setIsLoading } = useLoadingEffect(async () => {
     if (!triggerId) { return }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds an extra check during publish to prompt the user to double-check portal/study config changes. This should help us avoid accidental password protections, etc

Some unrelated changes: this PR also fixes a bunch of low hanging fruit re: unit test log spam

![Screenshot 2024-08-28 at 3 28 01 PM](https://github.com/user-attachments/assets/b6ef3c35-9207-4eeb-b447-e2938d0dfaa0)


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*


Modify some study configs for sandbox (password, acceptingEnrollment, etc)
Try and publish them, you should see an extra confirmation modal
