### PR TITLE
[JN-1310] Fix participant profile page for non-US users

### DIFF
--- a/ui-participant/src/participant/EditParticipantProfileModals.tsx
+++ b/ui-participant/src/participant/EditParticipantProfileModals.tsx
@@ -14,7 +14,6 @@ import {
 import ThemedModal from '../components/ThemedModal'
 import Modal from 'react-bootstrap/Modal'
 import { isNil } from 'lodash'
-import { ApiErrorResponse } from '@juniper/ui-admin/src/api/api-utils'
 
 
 // skeleton for all profile edit modals
@@ -364,15 +363,7 @@ export function EditMailingAddressModal(props: EditModalProps) {
   const tryValidateAndSave = async () => {
     // only validate US addresses
     if (mailingAddress.country === 'US') {
-      try {
-        await validateAndSave()
-      } catch (e) {
-        await Api.log({
-          eventType: 'ERROR',
-          eventDetail: `Failed to validate address: ${(e as ApiErrorResponse).message}`,
-          eventName: 'failedToValidateAddress'
-        })
-      }
+      await validateAndSave()
     } else {
       // if not US, just save whatever they give us
       onSave(buildUpdatedProfile(mailingAddress))


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Addresses a hearthive prod error that was triggered by someone editing their non-US profile from their profile page.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Redeploy participant api
- Go to profile and attempt to put in `415 IMPROVABLE St` in the US
- Observe that it suggests a new address
- Change the addrress to non-US
- Observe that it saves no issues (no validation is ran)