### PR TITLE
[JN-1281] Switch email update retry to exponential backoff

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
@@ -19,7 +19,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.springframework.retry.backoff.ExponentialBackOffPolicy;
-import org.springframework.retry.backoff.FixedBackOffPolicy;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
@@ -80,8 +80,9 @@ public class EnrolleeEmailService implements NotificationSender {
             // the notification might have been saved, but in a transaction not-yet completed (if, for example,
             // study enrollment transaction is taking a long time). So retry the update if it fails
             RetryTemplate retryTemplate = RetryTemplate.defaultInstance();
+            // exponential backoff with a max interval of 32 seconds, so we'll make retry attempts after 4, 8, 16, and 32 seconds
             ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
-            backOffPolicy.setInitialInterval(2000);
+            backOffPolicy.setInitialInterval(4000);
             backOffPolicy.setMaxInterval(32000);
             retryTemplate.setBackOffPolicy(backOffPolicy);
             try {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

This updates our existing query retry logic to an exponential backoff that occurs after 4, 8, 16, and 32 seconds. Previously it was a fixed backoff that would retry every 2 seconds, a maximum of 3 times

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Confirm that emails are still sent