### PR TITLE
[JN-1315] Fix "No matching state found in storage" for double login

### DIFF
--- a/ui-participant/src/login/RedirectFromOAuth.tsx
+++ b/ui-participant/src/login/RedirectFromOAuth.tsx
@@ -14,7 +14,7 @@ import {
 import { enrollCurrentUserInStudy } from 'util/enrolleeUtils'
 import { PageLoadingIndicator } from 'util/LoadingSpinner'
 import { filterUnjoinableStudies } from 'Navbar'
-import { logError } from 'util/loggingUtils'
+import { log, logError } from 'util/loggingUtils'
 import { useI18n } from '@juniper/ui-core'
 
 export const RedirectFromOAuth = () => {
@@ -38,6 +38,18 @@ export const RedirectFromOAuth = () => {
       // do nothing and wait until a render after AuthProvider is done.
       // Also, we'll be manipulating state, so we may get rendered more than once before we navigate away, so make sure
       // we only process the return from OAuth once (when the user is still "anonymous")
+
+      if (auth.error && user) {
+        // This case can happen if the user is already logged in and tries to log in again with a consumed oauth state.
+        // The user already has a valid session, so we'll log that this happened but navigate to the hub without hassle.
+        // Note: this logs as INFO because we want to know that this happened, but it's a non-fatal error.
+        log({
+          eventType: 'INFO', eventName: 'oauth-error',
+          stackTrace: auth.error.stack, eventDetail: auth.error.message
+        })
+        navigate('/hub', { replace: true })
+        return
+      }
 
       if (auth.error) {
         logError({ message: auth.error.message || 'error' }, auth.error.stack || 'stack', 'oauth-error')


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

When a user initiates the login flow, our oauth library adds a `state` value to local storage. This value must match the `state` query parameter on the b2c login page. Once the login is complete, the value is removed from local storage.

If the user hits the back button, they'll return to the login page with the same `state` query param as their original login, but the value doesn't exist in local storage anymore, so when the login flow completes, the "No matching state found in storage" error is thrown.

Now, we'll honor the pre-existing login session, which was already the case, but we just won't redirect them to the error page and log as `ERROR`

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

On demo, or locally running `development` branch, confirm the original issue:

Log in as an existing participant using b2c
Hit the back button from the dashboard
Log in again
Confirm you get the no matching state found in storage error

Confirm the fix:

While running this branch, repeat the above steps and confirm that you're redirected to the hub (since you're already logged in), and confirm that we logged the error as INFO: https://localhost:3000/logEvents