### PR TITLE
[JN-1314] fixing notification list links

### DIFF
--- a/ui-admin/src/study/notifications/TriggerNotifications.test.tsx
+++ b/ui-admin/src/study/notifications/TriggerNotifications.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { screen, waitFor } from '@testing-library/react'
+
+import {
+  mockStudyEnvContext,
+  mockNotification,
+  renderInPortalRouter, mockTrigger
+} from 'test-utils/mocking-utils'
+
+import Api from 'api/api'
+import TriggerNotifications from './TriggerNotifications'
+
+test('renders trigger notification list', async () => {
+  const studyEnvContext = mockStudyEnvContext()
+  const trigger = mockTrigger()
+  studyEnvContext.currentEnv.triggers.push(trigger)
+  const notifications = [
+    {
+      ...mockNotification(),
+      sentTo: 'someone@test.com'
+    }
+  ]
+  jest.spyOn(Api, 'fetchTriggerNotifications')
+    .mockImplementation(() => Promise.resolve(notifications))
+
+  renderInPortalRouter(studyEnvContext.portal, <TriggerNotifications studyEnvContext={studyEnvContext} />)
+  await waitFor(() => expect(screen.getByText('someone@test.com')).toBeInTheDocument())
+})

--- a/ui-admin/src/study/notifications/TriggerNotifications.tsx
+++ b/ui-admin/src/study/notifications/TriggerNotifications.tsx
@@ -17,9 +17,8 @@ export default function TriggerNotifications({ studyEnvContext }:
   const [tableData, setTableData] = useState<Notification[]>([])
   const [sorting, setSorting] = React.useState<SortingState>([{ 'id': 'createdAt', 'desc': true }])
 
-  const configId = useParams().configId as string
+  const triggerId = useParams().triggerId as string
 
-  const config = currentEnv.triggers.find(config => config.id === configId)
 
   const columns: ColumnDef<Notification>[] = [
     {
@@ -70,15 +69,14 @@ export default function TriggerNotifications({ studyEnvContext }:
     }
   ]
 
-
   const { isLoading } = useLoadingEffect(async () => {
     const notifications = await Api.fetchTriggerNotifications(
       portal.shortcode,
       study.shortcode,
       currentEnv.environmentName,
-      configId)
+      triggerId)
     setTableData(notifications)
-  }, [configId])
+  }, [triggerId])
 
 
   const table = useReactTable({
@@ -92,14 +90,7 @@ export default function TriggerNotifications({ studyEnvContext }:
     getSortedRowModel: getSortedRowModel()
   })
 
-  if (!config) {
-    return <div>Trigger config not found</div>
-  }
-
   return <div className={'w-100'}>
-    <div className='float-end'>
-      <NavLink to={`../configs/${configId}`}>Go Back</NavLink>
-    </div>
     <h5>Notifications</h5>
     {/* eslint-disable-next-line react/jsx-no-undef */}
     <LoadingSpinner isLoading={isLoading}>


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

The page showing notifications sent for a given trigger was broken (it got broken during the config -> trigger rename).  This also cleans up some of the logic and adds a test.  Not too much effort here since this will likely get redesigned as part of the trigger UX overhaul in-progress

![image](https://github.com/user-attachments/assets/0d263487-f338-4402-88e5-4f0769487f89)


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to `https://localhost:3000/demo/studies/heartdemo/env/sandbox/notificationContent`
2. click "consent form submission"
3. click "view sent emails"
4. confirm the list of notifications appears
