### PR TITLE
[JN-1313] Add participant user shortcodes

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/PopulateExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/PopulateExtService.java
@@ -9,6 +9,7 @@ import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.site.SiteContent;
 import bio.terra.pearl.core.model.survey.Survey;
+import bio.terra.pearl.core.service.participant.ParticipantUserService;
 import bio.terra.pearl.populate.service.*;
 import bio.terra.pearl.populate.service.contexts.FilePopulateContext;
 import bio.terra.pearl.populate.service.contexts.PortalPopulateContext;
@@ -33,6 +34,7 @@ public class PopulateExtService {
   private final PortalParticipantUserPopulator portalParticipantUserPopulator;
   private final AdminConfigPopulator adminConfigPopulator;
   private final PortalExtractService portalExtractService;
+  private final ParticipantUserService participantUserService;
 
   public PopulateExtService(
       BaseSeedPopulator baseSeedPopulator,
@@ -42,7 +44,8 @@ public class PopulateExtService {
       SiteContentPopulator siteContentPopulator,
       PortalParticipantUserPopulator portalParticipantUserPopulator,
       AdminConfigPopulator adminConfigPopulator,
-      PortalExtractService portalExtractService) {
+      PortalExtractService portalExtractService,
+      ParticipantUserService participantUserService) {
     this.baseSeedPopulator = baseSeedPopulator;
     this.enrolleePopulator = enrolleePopulator;
     this.surveyPopulator = surveyPopulator;
@@ -51,6 +54,7 @@ public class PopulateExtService {
     this.portalParticipantUserPopulator = portalParticipantUserPopulator;
     this.adminConfigPopulator = adminConfigPopulator;
     this.portalExtractService = portalExtractService;
+    this.participantUserService = participantUserService;
   }
 
   @SuperuserOnly
@@ -184,6 +188,9 @@ public class PopulateExtService {
   @SuperuserOnly
   public Object populateCommand(
       OperatorAuthContext authContext, String command, Object commandParams) {
+    if ("CREATE_PARTICIPANT_SHORTCODES".equals(command)) {
+      return participantUserService.createMissingShortcodes();
+    }
     if ("CONVERT_CONSENTS".equals(command)) {
       throw new IllegalArgumentException("that command is no longer supported");
     }

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/PopulateExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/PopulateExtServiceTests.java
@@ -27,7 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 public class PopulateExtServiceTests extends BaseSpringBootTest {
   private PopulateExtService emptyService =
-      new PopulateExtService(null, null, null, null, null, null, null, null);
+      new PopulateExtService(null, null, null, null, null, null, null, null, null);
 
   @Autowired private PopulateExtService populateExtService;
   @Autowired private StudyEnvironmentFactory studyEnvironmentFactory;

--- a/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
@@ -284,7 +284,15 @@ public abstract class BaseJdbiDao<T extends BaseEntity> {
     }
 
 
-    protected List<T> findAllByProperty(String columnName, Object columnValue) {
+    public List<T> findAllByProperty(String columnName, Object columnValue) {
+        if(columnValue == null) {
+            return jdbi.withHandle(handle ->
+                    handle.createQuery("select * from " + tableName + " where " + columnName + " is null;")
+                            .mapTo(clazz)
+                            .list()
+            );
+        }
+
         return jdbi.withHandle(handle ->
                 handle.createQuery("select * from " + tableName + " where " + columnName + " = :columnValue;")
                         .bind("columnValue", columnValue)

--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/ParticipantUserDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/ParticipantUserDao.java
@@ -3,6 +3,8 @@ package bio.terra.pearl.core.dao.participant;
 import bio.terra.pearl.core.dao.BaseMutableJdbiDao;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
+
+import java.util.List;
 import java.util.Optional;
 import org.jdbi.v3.core.Jdbi;
 import org.springframework.stereotype.Component;
@@ -18,6 +20,16 @@ public class ParticipantUserDao extends BaseMutableJdbiDao<ParticipantUser> {
 
    public Optional<ParticipantUser> findOne(String username, EnvironmentName environmentName) {
       return findByTwoProperties("username", username, "environment_name", environmentName);
+   }
+
+   public Optional<ParticipantUser> findOneByShortcode(String shortcode) {
+      return findByProperty("shortcode", shortcode);
+   }
+
+   public List<ParticipantUser> findAllWithMissingShortcode() {
+      return jdbi.withHandle(handle -> handle.createQuery("SELECT * FROM participant_user WHERE shortcode IS NULL")
+            .mapTo(ParticipantUser.class)
+            .list());
    }
 
    public Optional<ParticipantUser> findByToken(String token) {

--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/ParticipantUserDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/ParticipantUserDao.java
@@ -26,12 +26,6 @@ public class ParticipantUserDao extends BaseMutableJdbiDao<ParticipantUser> {
       return findByProperty("shortcode", shortcode);
    }
 
-   public List<ParticipantUser> findAllWithMissingShortcode() {
-      return jdbi.withHandle(handle -> handle.createQuery("SELECT * FROM participant_user WHERE shortcode IS NULL")
-            .mapTo(ParticipantUser.class)
-            .list());
-   }
-
    public Optional<ParticipantUser> findByToken(String token) {
       return findByProperty("token", token);
    }

--- a/core/src/main/java/bio/terra/pearl/core/model/participant/ParticipantUser.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/participant/ParticipantUser.java
@@ -17,6 +17,8 @@ import java.util.Set;
 public class ParticipantUser extends BaseEntity {
     private String username;
 
+    private String shortcode;
+
     private String token;
 
     private Instant lastLogin;

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ParticipantUserFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ParticipantUserFormatter.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 
 public class ParticipantUserFormatter extends BeanModuleFormatter<ParticipantUser> {
     public static final String PARTICIPANT_USER_MODULE_NAME = "account";
-    public static final List<String> INCLUDED_PROPERTIES = List.of("username", "createdAt");
+    public static final List<String> INCLUDED_PROPERTIES = List.of("username", "createdAt", "shortcode");
 
     public ParticipantUserFormatter(ExportOptions exportOptions) {
         itemFormatters = INCLUDED_PROPERTIES.stream().map(propName -> new PropertyItemFormatter<ParticipantUser>(propName, ParticipantUser.class))

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ParticipantUserFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ParticipantUserFormatter.java
@@ -1,6 +1,5 @@
 package bio.terra.pearl.core.service.export.formatters.module;
 
-import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.service.export.EnrolleeExportData;
 import bio.terra.pearl.core.service.export.ExportOptions;

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ParticipantUserFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ParticipantUserFormatter.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 
 public class ParticipantUserFormatter extends BeanModuleFormatter<ParticipantUser> {
     public static final String PARTICIPANT_USER_MODULE_NAME = "account";
-    public static final List<String> INCLUDED_PROPERTIES = List.of("username", "createdAt", "shortcode");
+    public static final List<String> INCLUDED_PROPERTIES = List.of("shortcode", "username", "createdAt");
 
     public ParticipantUserFormatter(ExportOptions exportOptions) {
         itemFormatters = INCLUDED_PROPERTIES.stream().map(propName -> new PropertyItemFormatter<ParticipantUser>(propName, ParticipantUser.class))

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/ParticipantUserService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/ParticipantUserService.java
@@ -67,7 +67,7 @@ public class ParticipantUserService extends CrudService<ParticipantUser, Partici
     // we expect to delete this after the backfill-migration has been run on existing participants
     // see JN-1318: https://broadworkbench.atlassian.net/browse/JN-1318
     public List<UUID> createMissingShortcodes() {
-        List<ParticipantUser> users = dao.findAllWithMissingShortcode();
+        List<ParticipantUser> users = dao.findAllByProperty("shortcode", null);
 
         users.forEach(participantUser -> {
             String shortcode = shortcodeService.generateShortcode("ACC", dao::findOneByShortcode);

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/ParticipantUserService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/ParticipantUserService.java
@@ -64,6 +64,8 @@ public class ParticipantUserService extends CrudService<ParticipantUser, Partici
     }
 
     // creates an "ACC"-prefixed shortcode for each participant user that's missing one
+    // we expect to delete this after the backfill-migration has been run on existing participants
+    // see JN-1318: https://broadworkbench.atlassian.net/browse/JN-1318
     public List<UUID> createMissingShortcodes() {
         List<ParticipantUser> users = dao.findAllWithMissingShortcode();
 

--- a/core/src/main/resources/db/changelog/changesets/2024_09_05_participant_shortcode.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_09_05_participant_shortcode.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: "participant_shortcode"
+      author: mbemis
+      changes:
+        - addColumn:
+            tableName: participant_user
+            columns:
+              - column: { name: shortcode, type: varchar(255) } #nullable for now to facilitate backfill migration

--- a/core/src/main/resources/db/changelog/changesets/2024_09_05_participant_shortcode.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_09_05_participant_shortcode.yaml
@@ -6,4 +6,4 @@ databaseChangeLog:
         - addColumn:
             tableName: participant_user
             columns:
-              - column: { name: shortcode, type: varchar(255) } #nullable for now to facilitate backfill migration
+              - column: { name: shortcode, type: text } #nullable for now to facilitate backfilling

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -308,6 +308,9 @@ databaseChangeLog:
   - include:
       file: changesets/2024_08_12_add_parent_to_question_def.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2024_09_05_participant_shortcode.yaml
+      relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/core/src/test/java/bio/terra/pearl/core/service/participant/ParticipantUserServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/participant/ParticipantUserServiceTests.java
@@ -1,9 +1,7 @@
 package bio.terra.pearl.core.service.participant;
 
 import bio.terra.pearl.core.BaseSpringBootTest;
-import bio.terra.pearl.core.factory.participant.MailingAddressFactory;
 import bio.terra.pearl.core.factory.participant.ParticipantUserFactory;
-import bio.terra.pearl.core.factory.participant.ProfileFactory;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -15,11 +13,7 @@ public class ParticipantUserServiceTests extends BaseSpringBootTest {
     @Autowired
     private ParticipantUserService participantUserService;
     @Autowired
-    private ProfileFactory profileFactory;
-    @Autowired
     private ParticipantUserFactory participantUserFactory;
-    @Autowired
-    private MailingAddressFactory mailingAddressFactory;
 
 
     @Test
@@ -28,6 +22,7 @@ public class ParticipantUserServiceTests extends BaseSpringBootTest {
         ParticipantUser user = participantUserFactory.builderWithDependencies(getTestName(info))
                 .build();
         ParticipantUser savedUser = participantUserService.create(user);
+        Assertions.assertNotNull(savedUser.getShortcode());
         Assertions.assertNotNull(savedUser.getId());
     }
 }

--- a/ui-core/src/types/user.ts
+++ b/ui-core/src/types/user.ts
@@ -20,6 +20,7 @@ export type ParticipantNote = {
 export type ParticipantUser = {
     id: string,
     username: string,
+    shortcode: string,
     token: string,
     lastLogin: number
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds participant user shortcodes to allow enrollees to be tied together across studies w/o using PII

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
* Check out `development` and repopulate OurHealth
* Restart AdminApiApp and ParticipantApiApp with this branch checked out 
* Log in as an admin and verify that account.shortcode is now visible, but it's blank for everyone: https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/export/dataBrowser
* Enroll a new user in OurHealth sandbox
* Confirm that new user has an account.shortcode generated for them, but everyone else is still blank: https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/export/dataBrowser
* Run the `CREATE_PARTICIPANT_SHORTCODES` command: https://localhost:3000/populate/runCommand and confirm you get back a bunch of UUIDs (one for each participant user that was migrated)
* Go back to data export preview and verify that account.shortcode is now populated for everyone: https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/export/dataBrowser