### PR TITLE
[JN-1305] Run e2e tests on PRs and notify of failure on merge

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - development
+  pull_request:
+    branches:
+      - development
 
 jobs:
   test:
@@ -54,3 +57,15 @@ jobs:
         path: |
           e2e-tests/playwright-report/**
           e2e-tests/test-results/**
+    - name: Notify slack on failure
+      uses: broadinstitute/action-slack@v3.8.0
+      if: failure() # && github.ref == 'refs/heads/development' #only notify on merges to development
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      with:
+        channel: '#juniper-dev-notifications'
+        status: failure
+        author_name: End-to-end failed on merge to development
+        fields: job
+        text: "End-to-end tests failed :sadpanda:"
+        username: 'Juniper Build Notifications'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -59,7 +59,7 @@ jobs:
           e2e-tests/test-results/**
     - name: Notify slack on failure
       uses: broadinstitute/action-slack@v3.8.0
-      if: failure() # && github.ref == 'refs/heads/development' #only notify on merges to development
+      if: failure() && github.ref == 'refs/heads/development'
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       with:
@@ -68,4 +68,4 @@ jobs:
         author_name: End-to-end failed on merge to development
         fields: job
         text: "End-to-end tests failed :sadpanda:"
-        username: 'Juniper Build Notifications'
+        username: 'Pearl Build Notifications'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -68,4 +68,4 @@ jobs:
         author_name: End-to-end failed on merge to development
         fields: job
         text: "End-to-end tests failed :sadpanda:"
-        username: 'Pearl Build Notifications'
+        username: 'Juniper Build Notifications'

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -87,7 +87,7 @@ jobs:
           author_name: Java CI build failed on merge to development
           fields: job
           text: "Java CI build failed :sadpanda:"
-          username: 'Pearl Build Notifications'
+          username: 'Juniper Build Notifications'
 
   # Need to uncomment these in follow up PR, The new Trivy and Tag workflows need to exist on the development branch
   # before the following steps will work

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -57,7 +57,7 @@ jobs:
           author_name: Publish docker Image
           fields: job
           text: "Publish failed :sadpanda:, image ${{ steps.build-publish.outputs.published-image }} failed to publish"
-          username: 'Pearl Build Notifications'
+          username: 'Juniper Build Notifications'
     
   publish-participant-image:
     needs: get-version-tag
@@ -92,7 +92,7 @@ jobs:
           author_name: Publish docker Image
           fields: job
           text: "Publish failed :sadpanda:, image ${{ steps.build-publish.outputs.published-image }} failed to publish"
-          username: 'Pearl Build Notifications'
+          username: 'Juniper Build Notifications'
   
   report-to-sherlock:
     # Report new version of application to DSP DevOps Tooling
@@ -133,6 +133,6 @@ jobs:
           author_name: Auto Deploy to Dev
           fields: job
           text: Deploy to dev of ${{ needs.get-version-tag.outputs.tag }} resulted in ${{ needs.set-version-in-dev.result }}
-          username: 'Pearl Build Notifications'
+          username: 'Juniper Build Notifications'
 
 

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -45,7 +45,7 @@ jobs:
           author_name: SonarCloud Java scan failed on merge to development
           fields: job
           text: "SonarCloud Java scan failed :sadpanda:"
-          username: 'Pearl Build Notifications'
+          username: 'Juniper Build Notifications'
 
 
   sonar-typescript:
@@ -87,4 +87,4 @@ jobs:
           author_name: SonarCloud TypeScript scan failed on merge to development
           fields: job
           text: "SonarCloud TypeScript scan failed :sadpanda:"
-          username: 'Pearl Build Notifications'
+          username: 'Juniper Build Notifications'

--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -36,4 +36,4 @@ jobs:
           author_name: UI CI build failed on merge to development
           fields: job
           text: "UI CI build failed :sadpanda:"
-          username: 'Pearl Build Notifications'
+          username: 'Juniper Build Notifications'

--- a/e2e-tests/src/data/demo-en.json
+++ b/e2e-tests/src/data/demo-en.json
@@ -14,6 +14,9 @@
   },
  "Consent": {
    "FullName": "Full legal name",
-   "Signature": "Signature of Subject"
+   "Signature": "Signature of Subject",
+   "VoluntaryParticipation": "I understand that my participation is voluntary and I am free to withdraw at any time",
+   "PermissionToUseDNA": "I give permission for my saliva samples to be used to obtain DNA for use in this study",
+   "AgreeToContact": "I agree to be contacted by the research team to be invited to participate in future medical and health-related studies"
  }
 }

--- a/e2e-tests/src/tests/studies/demo/new-proxy-registration.test.ts
+++ b/e2e-tests/src/tests/studies/demo/new-proxy-registration.test.ts
@@ -91,9 +91,9 @@ test.describe('Proxy', () => {
       progress = await consent.progress()
       expect(progress).toStrictEqual('Page 2 of 3')
       await consent.agree()
-      await consent.fillIn(data.Consent.VoluntaryParticipation, 'JS', page.locator('body'))
-      await consent.fillIn(data.Consent.PermissionToUseDNA, 'JS', page.locator('body'))
-      await consent.fillIn(data.Consent.AgreeToContact, 'JS', page.locator('body'))
+      await consent.getQuestion(data.Consent.VoluntaryParticipation).fillIn('JS')
+      await consent.getQuestion(data.Consent.PermissionToUseDNA).fillIn('JS')
+      await consent.getQuestion(data.Consent.AgreeToContact).fillIn('JS')
       await consent.clickByRole('button', 'Next')
 
 

--- a/e2e-tests/src/tests/studies/demo/new-proxy-registration.test.ts
+++ b/e2e-tests/src/tests/studies/demo/new-proxy-registration.test.ts
@@ -91,6 +91,9 @@ test.describe('Proxy', () => {
       progress = await consent.progress()
       expect(progress).toStrictEqual('Page 2 of 3')
       await consent.agree()
+      await consent.fillIn(data.Consent.VoluntaryParticipation, 'JS', page.locator('body'))
+      await consent.fillIn(data.Consent.PermissionToUseDNA, 'JS', page.locator('body'))
+      await consent.fillIn(data.Consent.AgreeToContact, 'JS', page.locator('body'))
       await consent.clickByRole('button', 'Next')
 
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

* Adds e2e tests to our PR checklist
* Notifies #juniper-dev-notifications when e2e tests fail on merge to `development`
* Updates an existing proxy e2e test to work with the updated consent form

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Run e2e tests locally to confirm new changes pass
Observe that e2e tests ran and passed on this PR