### PR TITLE
[JN-1317] fixing profile import

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -226,7 +226,8 @@ public class EnrolleeImportService {
 
         importSurveyResponses(portalShortcode, enrolleeMap, exportOptions, studyEnv, regResult.portalParticipantUser(), enrollee, auditInfo);
 
-        /** restore email */
+        /** restore email -- reload the profile since answermappings may have changed it */
+        profile = profileService.find(profile.getId()).orElseThrow();
         profile.setDoNotEmail(false);
         profileService.update(profile, auditInfo);
         return enrollee;

--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
@@ -14,8 +14,7 @@ import bio.terra.pearl.core.model.kit.KitType;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.model.participant.Profile;
-import bio.terra.pearl.core.model.survey.Answer;
-import bio.terra.pearl.core.model.survey.Survey;
+import bio.terra.pearl.core.model.survey.*;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
 import bio.terra.pearl.core.model.workflow.TaskStatus;
 import bio.terra.pearl.core.service.admin.AdminUserService;
@@ -419,6 +418,14 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
                 .stableId("importTest1")
                 .content(TWO_QUESTION_SURVEY_CONTENT)
                 .portalId(bundle.getPortal().getId())
+                        .answerMappings(List.of(
+                                AnswerMapping.builder()
+                                        .targetType(AnswerMappingTargetType.PROFILE)
+                                        .mapType(AnswerMappingMapType.STRING_TO_STRING)
+                                        .targetField("givenName")
+                                        .questionStableId("importFirstName")
+                                        .build()
+                        ))
                 .version(1)
         );
         surveyFactory.attachToEnv(survey, bundle.getStudyEnv().getId(), true);
@@ -447,6 +454,10 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
         Answer favColor = answers.stream().filter(answer -> answer.getQuestionStableId().equals("importFavColors"))
                 .findFirst().get();
         assertThat(favColor.getObjectValue(), equalTo("[\"red\", \"blue\"]"));
+
+        // confirm profile mapping got processed
+        Profile profile = profileService.find(enrollee.getProfileId()).orElseThrow();
+        assertThat(profile.getGivenName(), equalTo("Jeff"));
     }
 
     private void verifyParticipant(ImportItem importItem, UUID studyEnvId,

--- a/populate/src/main/resources/seed/portals/hearthive/import/test-profile-import.csv
+++ b/populate/src/main/resources/seed/portals/hearthive/import/test-profile-import.csv
@@ -1,0 +1,2 @@
+basics.complete,account.username,basics.firstname,basics.lastname,basics.birthdate,basics.addressline1,basics.addressline2,basics.city,basics.postcode,basics.state,basics.country
+2024-01-01,user1@foo.com,John,Doe,1990-01-01,123 Main St,,Anytown,12345,CA,US


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

We were inadvertently nuking some profile changes when we were toggling doNotEmail as part of the import process.  This fixes that

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy ApiAdminApp
2. run `./scripts/populate_portal.sh hearthive`
3. go to https://localhost:3000/hearthive/studies/hh_registry/env/sandbox/dataImports
4. select "new data import"
5. for the file, use `populate/src/main/resources/seed/portals/hearthive/import/test-profile-import.csv`
6. after import, click on the participant and confirm their first name was copied to their profile
