### PR TITLE
[JN-1319] fixing hidden dropdown

### DIFF
--- a/ui-admin/src/util/tableDragDropUtils.tsx
+++ b/ui-admin/src/util/tableDragDropUtils.tsx
@@ -44,8 +44,7 @@ const DraggableRow = function<T>({ row, idFunc }: { row: Row<T>, idFunc: (row: R
     transform: CSS.Transform.toString(transform), //let dnd-kit do its thing
     transition,
     opacity: isDragging ? 0.8 : 1,
-    zIndex: isDragging ? 1 : 0,
-    position: 'relative'
+    zIndex: isDragging ? 1 : 0
   }
   return (
     // connect row ref to dnd-kit, apply important styles


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

The drag-drop table had the effect of obscuring the dropdown menus -- they were hidden after clicking underneath the other table rows

BEFORE FIX:

![image](https://github.com/user-attachments/assets/99542781-9eb6-48ad-9091-210f70af2ac8)

AFTER FIX:

![image](https://github.com/user-attachments/assets/edf45e3b-c665-42f4-a55e-4a2afb5a8a60)


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  go tohttps://localhost:3000/demo/studies/heartdemo/env/sandbox/forms
2. confirm drag drop reorder and ellipsis menus work as expected