### PR TITLE
[JN-1320] Participant list UX tweaks [member's choice]

### DIFF
--- a/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
@@ -200,7 +200,7 @@ test('allows the user to group by family', async () => {
   //Wait for results to be rendered
   await screen.findAllByText('JOSALK')
 
-  await userEvent.click(screen.getByLabelText('Family view'))
+  await userEvent.click(screen.getByLabelText('Switch to family view'))
 
   //Wait for results to be rendered
   expect(screen.getAllByText('F_MOCK')[0]).toBeInTheDocument()

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -2,12 +2,9 @@ import React, { useState } from 'react'
 import Api, { EnrolleeSearchExpressionResult } from 'api/api'
 import LoadingSpinner from 'util/LoadingSpinner'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
-
-
 import { useLoadingEffect } from 'api/api-utils'
 import { renderPageHeader } from 'util/pageUtils'
 import ParticipantSearch from './search/ParticipantSearch'
-
 import { useParticipantSearchState } from 'util/participantSearchUtils'
 import { concatSearchExpressions } from 'util/searchExpressionUtils'
 import ParticipantListTableGroupedByFamily from 'study/participants/participantList/ParticipantListTableGroupedByFamily'

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import Api, { EnrolleeSearchExpressionResult } from 'api/api'
 import LoadingSpinner from 'util/LoadingSpinner'
-import { StudyEnvContextT } from '../../StudyEnvironmentRouter'
+import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
 
 
 import { useLoadingEffect } from 'api/api-utils'
@@ -12,7 +12,7 @@ import { useParticipantSearchState } from 'util/participantSearchUtils'
 import { concatSearchExpressions } from 'util/searchExpressionUtils'
 import ParticipantListTableGroupedByFamily from 'study/participants/participantList/ParticipantListTableGroupedByFamily'
 import ParticipantListTable from 'study/participants/participantList/ParticipantListTable'
-import { Button } from '../../../components/forms/Button'
+import { Button } from 'components/forms/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faUserLarge, faUserLargeSlash } from '@fortawesome/free-solid-svg-icons'
 import { faUsers } from '@fortawesome/free-solid-svg-icons/faUsers'
@@ -24,8 +24,6 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
   const { portal, study, currentEnv } = studyEnvContext
   const [participantList, setParticipantList] = useState<EnrolleeSearchExpressionResult[]>([])
 
-
-  //gets the 'view' query param from the url
   const [searchParams, setSearchParams] = useSearchParams()
   const [view, setView] = useState<'participant' | 'family' | 'withdrawn'>(
       searchParams.get('view') as never || 'participant')

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -68,6 +68,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
       />
       <div className="btn-group border my-1">
         <Button id="grid" variant='light'
+          aria-label={'Switch to withdrawn view'}
           className={`btn btn-sm ${view === 'withdrawn' ? 'btn-dark' : 'btn-light'}`}
           tooltip={'Switch to withdrawn view'}
           onClick={() => {
@@ -77,6 +78,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
           <FontAwesomeIcon icon={faUserLargeSlash}/>
         </Button>
         <Button id="grid" variant='light'
+          aria-label={'Switch to participant view'}
           className={`btn btn-sm ${view === 'participant' ? 'btn-dark' : 'btn-light'}`}
           tooltip={'Switch to participant view'}
           onClick={() => {
@@ -86,6 +88,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
           <FontAwesomeIcon icon={faUserLarge}/>
         </Button>
         <Button id="list" variant='light'
+          aria-label={'Switch to family view'}
           className={`btn btn-sm ${view === 'family' ? 'btn-dark' : 'btn-light'}`}
           tooltip={'Switch to family view'}
           onClick={() => {

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -2,11 +2,8 @@ import React, { useState } from 'react'
 import Api, { EnrolleeSearchExpressionResult } from 'api/api'
 import LoadingSpinner from 'util/LoadingSpinner'
 import { StudyEnvContextT } from '../../StudyEnvironmentRouter'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import {
-  faPeopleGroup,
-  faPerson
-} from '@fortawesome/free-solid-svg-icons'
+
+
 import { useLoadingEffect } from 'api/api-utils'
 import { renderPageHeader } from 'util/pageUtils'
 import ParticipantSearch from './search/ParticipantSearch'
@@ -15,16 +12,23 @@ import { useParticipantSearchState } from 'util/participantSearchUtils'
 import { concatSearchExpressions } from 'util/searchExpressionUtils'
 import ParticipantListTableGroupedByFamily from 'study/participants/participantList/ParticipantListTableGroupedByFamily'
 import ParticipantListTable from 'study/participants/participantList/ParticipantListTable'
-import { Button } from 'components/forms/Button'
-import { useSingleSearchParam } from 'util/searchParamsUtils'
-import { Link } from 'react-router-dom'
+import { Button } from '../../../components/forms/Button'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faUserLarge, faUserLargeSlash } from '@fortawesome/free-solid-svg-icons'
+import { faUsers } from '@fortawesome/free-solid-svg-icons/faUsers'
+import WithdrawnEnrolleeList from './WithdrawnEnrolleeList'
+import { useSearchParams } from 'react-router-dom'
 
 /** Shows a list of (for now) enrollees */
 function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
   const { portal, study, currentEnv } = studyEnvContext
   const [participantList, setParticipantList] = useState<EnrolleeSearchExpressionResult[]>([])
-  const [groupByFamilyString, setGroupByFamily] = useSingleSearchParam('groupByFamily')
-  const groupByFamily = groupByFamilyString === 'true'
+
+
+  //gets the 'view' query param from the url
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [view, setView] = useState<'participant' | 'family' | 'withdrawn'>(
+      searchParams.get('view') as never || 'participant')
 
   const familyLinkageEnabled = studyEnvContext.currentEnv.studyEnvironmentConfig.enableFamilyLinkage
 
@@ -55,35 +59,57 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
 
   return <div className="ParticipantList container-fluid px-4 py-2">
     {renderPageHeader('Participant List')}
-    <div className="d-flex align-content-center align-items-center">
+    <div className="d-flex align-content-center align-items-center justify-content-between">
       <ParticipantSearch
         key={currentEnv.environmentName}
         studyEnvContext={studyEnvContext}
         searchState={searchState}
         updateSearchState={updateSearchState}
         setSearchState={setSearchState}
+        disabled={view === 'withdrawn'}
       />
-
-      {
-        familyLinkageEnabled && <div className="d-flex align-content-center p-2">
-          <Button
-            variant="light" className="border btn-sm"
-            aria-label={groupByFamily ? 'Participant view' : 'Family view'}
-            onClick={() => setGroupByFamily(groupByFamily ? 'false' : 'true')}>
-            {groupByFamily
-              ? <><FontAwesomeIcon size={'sm'} className={'p-0 m-0'} icon={faPerson}/> Participant view</>
-              : <><FontAwesomeIcon size={'sm'} className={'p-0 m-0'} icon={faPeopleGroup}/> Family view</>}
-          </Button>
-        </div>
-      }
-      <div><Link to={`withdrawn`}>Withdrawn</Link></div>
+      <div className="btn-group border my-1">
+        <Button id="grid" variant='light'
+          className={`btn btn-sm ${view === 'withdrawn' ? 'btn-dark' : 'btn-light'}`}
+          tooltip={'Switch to withdrawn view'}
+          onClick={() => {
+            setSearchParams({ view: 'withdrawn' })
+            setView('withdrawn')
+          }}>
+          <FontAwesomeIcon icon={faUserLargeSlash}/>
+        </Button>
+        <Button id="grid" variant='light'
+          className={`btn btn-sm ${view === 'participant' ? 'btn-dark' : 'btn-light'}`}
+          tooltip={'Switch to participant view'}
+          onClick={() => {
+            setSearchParams({ view: 'participant' })
+            setView('participant')
+          }}>
+          <FontAwesomeIcon icon={faUserLarge}/>
+        </Button>
+        <Button id="list" variant='light'
+          className={`btn btn-sm ${view === 'family' ? 'btn-dark' : 'btn-light'}`}
+          tooltip={'Switch to family view'}
+          onClick={() => {
+            setSearchParams({ view: 'family' })
+            setView('family')
+          }}>
+          <FontAwesomeIcon icon={faUsers}/>
+        </Button>
+      </div>
     </div>
 
 
     <LoadingSpinner isLoading={isLoading}>
-      {groupByFamily
-        ? <ParticipantListTableGroupedByFamily participantList={participantList} studyEnvContext={studyEnvContext}/>
-        : <ParticipantListTable participantList={participantList} studyEnvContext={studyEnvContext} reload={reload}/>}
+      {view === 'family' &&
+        <ParticipantListTableGroupedByFamily participantList={participantList} studyEnvContext={studyEnvContext}/>
+      }
+      {view === 'participant' &&
+        <ParticipantListTable participantList={participantList} studyEnvContext={studyEnvContext} reload={reload}/>
+      }
+      {view === 'withdrawn' &&
+        <WithdrawnEnrolleeList studyEnvContext={studyEnvContext}/>
+      }
     </LoadingSpinner>
   </div>
 }

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -87,7 +87,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
           }}>
           <FontAwesomeIcon icon={faUserLarge}/>
         </Button>
-        <Button id="list" variant='light'
+        { familyLinkageEnabled && <Button id="list" variant='light'
           aria-label={'Switch to family view'}
           className={`btn btn-sm ${view === 'family' ? 'btn-dark' : 'btn-light'}`}
           tooltip={'Switch to family view'}
@@ -96,7 +96,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
             setView('family')
           }}>
           <FontAwesomeIcon icon={faUsers}/>
-        </Button>
+        </Button> }
       </div>
     </div>
 

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -12,12 +12,9 @@ import { useParticipantSearchState } from 'util/participantSearchUtils'
 import { concatSearchExpressions } from 'util/searchExpressionUtils'
 import ParticipantListTableGroupedByFamily from 'study/participants/participantList/ParticipantListTableGroupedByFamily'
 import ParticipantListTable from 'study/participants/participantList/ParticipantListTable'
-import { Button } from 'components/forms/Button'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faUserLarge, faUserLargeSlash } from '@fortawesome/free-solid-svg-icons'
-import { faUsers } from '@fortawesome/free-solid-svg-icons/faUsers'
 import WithdrawnEnrolleeList from './WithdrawnEnrolleeList'
 import { useSearchParams } from 'react-router-dom'
+import { ParticipantListViewSwitcher } from './ParticipantListViewSwitcher'
 
 /** Shows a list of (for now) enrollees */
 function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) {
@@ -66,40 +63,13 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
         setSearchState={setSearchState}
         disabled={view === 'withdrawn'}
       />
-      <div className="btn-group border my-1">
-        <Button variant='light'
-          aria-label={'Switch to withdrawn view'}
-          className={`btn btn-sm ${view === 'withdrawn' ? 'btn-dark' : 'btn-light'}`}
-          tooltip={'Switch to withdrawn view'}
-          onClick={() => {
-            setSearchParams({ view: 'withdrawn' })
-            setView('withdrawn')
-          }}>
-          <FontAwesomeIcon icon={faUserLargeSlash}/>
-        </Button>
-        <Button variant='light'
-          aria-label={'Switch to participant view'}
-          className={`btn btn-sm ${view === 'participant' ? 'btn-dark' : 'btn-light'}`}
-          tooltip={'Switch to participant view'}
-          onClick={() => {
-            setSearchParams({ view: 'participant' })
-            setView('participant')
-          }}>
-          <FontAwesomeIcon icon={faUserLarge}/>
-        </Button>
-        { familyLinkageEnabled && <Button variant='light'
-          aria-label={'Switch to family view'}
-          className={`btn btn-sm ${view === 'family' ? 'btn-dark' : 'btn-light'}`}
-          tooltip={'Switch to family view'}
-          onClick={() => {
-            setSearchParams({ view: 'family' })
-            setView('family')
-          }}>
-          <FontAwesomeIcon icon={faUsers}/>
-        </Button> }
-      </div>
+      <ParticipantListViewSwitcher
+        view={view}
+        setView={setView}
+        setSearchParams={setSearchParams}
+        familyLinkageEnabled={familyLinkageEnabled}
+      />
     </div>
-
 
     <LoadingSpinner isLoading={isLoading}>
       {view === 'family' &&

--- a/ui-admin/src/study/participants/participantList/ParticipantList.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.tsx
@@ -67,7 +67,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
         disabled={view === 'withdrawn'}
       />
       <div className="btn-group border my-1">
-        <Button id="grid" variant='light'
+        <Button variant='light'
           aria-label={'Switch to withdrawn view'}
           className={`btn btn-sm ${view === 'withdrawn' ? 'btn-dark' : 'btn-light'}`}
           tooltip={'Switch to withdrawn view'}
@@ -77,7 +77,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
           }}>
           <FontAwesomeIcon icon={faUserLargeSlash}/>
         </Button>
-        <Button id="grid" variant='light'
+        <Button variant='light'
           aria-label={'Switch to participant view'}
           className={`btn btn-sm ${view === 'participant' ? 'btn-dark' : 'btn-light'}`}
           tooltip={'Switch to participant view'}
@@ -87,7 +87,7 @@ function ParticipantList({ studyEnvContext }: {studyEnvContext: StudyEnvContextT
           }}>
           <FontAwesomeIcon icon={faUserLarge}/>
         </Button>
-        { familyLinkageEnabled && <Button id="list" variant='light'
+        { familyLinkageEnabled && <Button variant='light'
           aria-label={'Switch to family view'}
           className={`btn btn-sm ${view === 'family' ? 'btn-dark' : 'btn-light'}`}
           tooltip={'Switch to family view'}

--- a/ui-admin/src/study/participants/participantList/ParticipantListTable.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantListTable.tsx
@@ -242,11 +242,14 @@ function ParticipantListTable({
         {showEmailModal && <AdHocEmailModal enrolleeShortcodes={enrolleesSelected}
           studyEnvContext={studyEnvContext}
           onDismiss={() => setShowEmailModal(false)}/>}
-        { showSyntheticModal &&
-          <CreateSyntheticEnrolleeModal studyEnvContext={studyEnvContext}
-            onDismiss={() => setShowSyntheticModal(false)}
-            onSubmit={() => { setShowSyntheticModal(false); reload() }}
-          />}
+        {showSyntheticModal &&
+            <CreateSyntheticEnrolleeModal studyEnvContext={studyEnvContext}
+              onDismiss={() => setShowSyntheticModal(false)}
+              onSubmit={() => {
+                setShowSyntheticModal(false)
+                reload()
+              }}
+            />}
       </div>
     </div>
     {basicTableLayout(table, { filterable: !disableColumnFiltering, tableClass })}

--- a/ui-admin/src/study/participants/participantList/ParticipantListTable.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantListTable.tsx
@@ -214,28 +214,33 @@ function ParticipantListTable({
         <RowVisibilityCount table={table}/>
       </div>}
       <div className="d-flex">
-        <EllipsisDropdownButton aria-label="Actions" text="Actions" className="ms-auto"/>
-        <div className="dropdown-menu">
-          <ul className="list-unstyled pt-3">
+        <EllipsisDropdownButton variant={'light'} aria-label="Actions" text="Actions" className="ms-auto border my-1"/>
+        <ul className="dropdown-menu">
+          <ul className="list-unstyled">
             <li>
               <Button onClick={() => setShowEmailModal(allowSendEmail)}
-                variant="light" className="bg-white border-0" disabled={!allowSendEmail}
+                variant="light"
+                className={'dropdown-item d-flex align-items-center'}
+                disabled={!allowSendEmail}
                 tooltip={allowSendEmail ? 'Send email' : 'Select at least one participant'}>
-                <FontAwesomeIcon icon={faEnvelope} className="fa-lg"/> Send email
+                <FontAwesomeIcon icon={faEnvelope} className="fa-lg me-2"/> Send email
               </Button>
             </li>
+            <div className="dropdown-divider my-1"></div>
             <li>
-              <DownloadControl table={table} buttonClass="bg-white border-0"
+              <DownloadControl table={table} buttonClass={'dropdown-item'}
                 fileName={`${portal.shortcode}-ParticipantList-${currentIsoDate()}`}/>
             </li>
-            {(currentEnv.environmentName != 'live') && <li>
-              <Button variant="light" className="bg-white border-0"
+            {(currentEnv.environmentName != 'live') && <><div className="dropdown-divider my-1"></div><li>
+              <Button variant="light" className={'dropdown-item d-flex align-items-center'}
+                tooltip={'Add a synthetic participant to this study environment'}
                 onClick={() => setShowSyntheticModal(!showSyntheticModal)}>
-                <FontAwesomeIcon icon={faPlus}/> Add synthetic participant
+                <FontAwesomeIcon icon={faPlus} className={'fa-lg me-2'}/> Add synthetic participant
               </Button>
-            </li>}
+            </li></>
+            }
           </ul>
-        </div>
+        </ul>
 
 
         <ColumnVisibilityControl table={table}/>

--- a/ui-admin/src/study/participants/participantList/ParticipantListViewSwitcher.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantListViewSwitcher.tsx
@@ -1,4 +1,4 @@
-import { Button } from '../../../components/forms/Button'
+import { Button } from 'components/forms/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faUserLarge, faUserLargeSlash } from '@fortawesome/free-solid-svg-icons'
 import { faUsers } from '@fortawesome/free-solid-svg-icons/faUsers'

--- a/ui-admin/src/study/participants/participantList/ParticipantListViewSwitcher.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantListViewSwitcher.tsx
@@ -1,0 +1,50 @@
+import { Button } from '../../../components/forms/Button'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faUserLarge, faUserLargeSlash } from '@fortawesome/free-solid-svg-icons'
+import { faUsers } from '@fortawesome/free-solid-svg-icons/faUsers'
+import React from 'react'
+
+type ParticipantListViewSwitcherProps = {
+    view: 'participant' | 'family' | 'withdrawn'
+    setView: (view: 'participant' | 'family' | 'withdrawn') => void
+    setSearchParams: (params: { view: string }) => void
+    familyLinkageEnabled: boolean
+}
+
+export const ParticipantListViewSwitcher = (props: ParticipantListViewSwitcherProps) => {
+  const { view, setView, setSearchParams, familyLinkageEnabled } = props
+  return (
+    <div className="btn-group border my-1">
+      <Button variant='light'
+        aria-label={'Switch to withdrawn view'}
+        className={`btn btn-sm ${view === 'withdrawn' ? 'btn-dark' : 'btn-light'}`}
+        tooltip={'Switch to withdrawn view'}
+        onClick={() => {
+          setSearchParams({ view: 'withdrawn' })
+          setView('withdrawn')
+        }}>
+        <FontAwesomeIcon icon={faUserLargeSlash}/>
+      </Button>
+      <Button variant='light'
+        aria-label={'Switch to participant view'}
+        className={`btn btn-sm ${view === 'participant' ? 'btn-dark' : 'btn-light'}`}
+        tooltip={'Switch to participant view'}
+        onClick={() => {
+          setSearchParams({ view: 'participant' })
+          setView('participant')
+        }}>
+        <FontAwesomeIcon icon={faUserLarge}/>
+      </Button>
+      { familyLinkageEnabled && <Button variant='light'
+        aria-label={'Switch to family view'}
+        className={`btn btn-sm ${view === 'family' ? 'btn-dark' : 'btn-light'}`}
+        tooltip={'Switch to family view'}
+        onClick={() => {
+          setSearchParams({ view: 'family' })
+          setView('family')
+        }}>
+        <FontAwesomeIcon icon={faUsers}/>
+      </Button> }
+    </div>
+  )
+}

--- a/ui-admin/src/study/participants/participantList/ParticipantListViewSwitcher.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantListViewSwitcher.tsx
@@ -4,9 +4,11 @@ import { faUserLarge, faUserLargeSlash } from '@fortawesome/free-solid-svg-icons
 import { faUsers } from '@fortawesome/free-solid-svg-icons/faUsers'
 import React from 'react'
 
+type ParticipantView = 'participant' | 'family' | 'withdrawn'
+
 type ParticipantListViewSwitcherProps = {
-    view: 'participant' | 'family' | 'withdrawn'
-    setView: (view: 'participant' | 'family' | 'withdrawn') => void
+    view: ParticipantView
+    setView: (view: ParticipantView) => void
     setSearchParams: (params: { view: string }) => void
     familyLinkageEnabled: boolean
 }

--- a/ui-admin/src/study/participants/participantList/WithdrawnEnrolleeList.tsx
+++ b/ui-admin/src/study/participants/participantList/WithdrawnEnrolleeList.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from 'react'
-import { paramsFromContext, StudyEnvContextT } from '../../StudyEnvironmentRouter'
-import { renderPageHeader } from '../../../util/pageUtils'
-import { useLoadingEffect } from '../../../api/api-utils'
-import Api, { WithdrawnEnrollee } from '../../../api/api'
-import { basicTableLayout, ColumnVisibilityControl } from '../../../util/tableUtils'
-import LoadingSpinner from '../../../util/LoadingSpinner'
+import { paramsFromContext, StudyEnvContextT } from 'study/StudyEnvironmentRouter'
+import { useLoadingEffect } from 'api/api-utils'
+import Api, { WithdrawnEnrollee } from 'api/api'
+import { basicTableLayout, ColumnVisibilityControl } from 'util/tableUtils'
+import LoadingSpinner from 'util/LoadingSpinner'
 import {
   ColumnDef,
   getCoreRowModel,
@@ -14,8 +13,8 @@ import {
   VisibilityState
 } from '@tanstack/react-table'
 import { instantToDefaultString } from '@juniper/ui-core'
-import { NavBreadcrumb } from '../../../navbar/AdminNavbar'
-import { DocsKey, ZendeskLink } from '../../../util/zendeskUtils'
+import { NavBreadcrumb } from 'navbar/AdminNavbar'
+import { DocsKey, ZendeskLink } from 'util/zendeskUtils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faInfoCircle } from '@fortawesome/free-solid-svg-icons'
 
@@ -78,7 +77,6 @@ export default function WithdrawnEnrolleeList({ studyEnvContext }: { studyEnvCon
     getSortedRowModel: getSortedRowModel()
   })
   return <div className="container-fluid px-4 py-2">
-    { renderPageHeader('Withdrawn enrollees') }
     <NavBreadcrumb value={'withdrawnList'}>Withdrawn</NavBreadcrumb>
     <FontAwesomeIcon icon={faInfoCircle}/> More information about the
     <ZendeskLink doc={DocsKey.WITHDRAWAL}> withdrawal process</ZendeskLink>.

--- a/ui-admin/src/study/participants/participantList/WithdrawnEnrolleeList.tsx
+++ b/ui-admin/src/study/participants/participantList/WithdrawnEnrolleeList.tsx
@@ -76,7 +76,7 @@ export default function WithdrawnEnrolleeList({ studyEnvContext }: { studyEnvCon
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel()
   })
-  return <div className="container-fluid px-4 py-2">
+  return <div className="container-fluid px-4 pt-4">
     <NavBreadcrumb value={'withdrawnList'}>Withdrawn</NavBreadcrumb>
     <FontAwesomeIcon icon={faInfoCircle}/> More information about the
     <ZendeskLink doc={DocsKey.WITHDRAWAL}> withdrawal process</ZendeskLink>.

--- a/ui-admin/src/study/participants/participantList/search/BasicSearch.tsx
+++ b/ui-admin/src/study/participants/participantList/search/BasicSearch.tsx
@@ -8,13 +8,15 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSearch } from '@fortawesome/free-solid-svg-icons'
 import { ParticipantSearchState } from 'util/participantSearchUtils'
 import { debounce } from 'lodash'
+import classNames from 'classnames'
 
 /**
  * renders and manages updates to a string search facet
  * */
-const BasicSearch = ({ searchState, setSearchState }: {
+const BasicSearch = ({ searchState, setSearchState, disabled = false }: {
   searchState: ParticipantSearchState,
-  setSearchState: (searchState: ParticipantSearchState) => void
+  setSearchState: (searchState: ParticipantSearchState) => void,
+  disabled?: boolean
 }) => {
   const [searchText, setSearchText] = useState(searchState.keywordSearch)
 
@@ -35,14 +37,17 @@ const BasicSearch = ({ searchState, setSearchState }: {
     e.preventDefault()
     setSearchState({ ...searchState, keywordSearch: searchText })
   }}
-  style={{ border: '1px solid #bbb', backgroundColor: '#fff', padding: '0.25em 0.75em 0em' }}>
-    <button type="submit" title="submit search" className="btn btn-secondary">
+  style={{ border: '1px solid #bbb', backgroundColor: disabled ? '#f7f7f7' : '#fff', padding: '0.25em 0.75em 0em' }}>
+    <button type="submit" title="submit search" className={classNames('btn', 'border-0',
+      disabled ? 'btn-light' : 'btn-secondary'
+    )} disabled={disabled}>
       <FontAwesomeIcon icon={faSearch}/>
     </button>
     <input
       type="text"
       value={searchText}
       size={40}
+      disabled={disabled}
       style={{ border: 'none', outline: 'none' }}
       placeholder={'Search by name, email, or shortcode'}
       onChange={e => {

--- a/ui-admin/src/study/participants/participantList/search/ParticipantSearch.tsx
+++ b/ui-admin/src/study/participants/participantList/search/ParticipantSearch.tsx
@@ -5,14 +5,17 @@ import BasicSearch from './BasicSearch'
 import SearchCriteriaView from './SearchCriteriaView'
 import { ParticipantSearchState } from 'util/participantSearchUtils'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faFilter } from '@fortawesome/free-solid-svg-icons'
 
 
 /** Participant search component for participant list page */
-function ParticipantSearch({ studyEnvContext, searchState, updateSearchState, setSearchState }: {
+function ParticipantSearch({ studyEnvContext, searchState, updateSearchState, setSearchState, disabled = false }: {
   studyEnvContext: StudyEnvContextT,
   searchState: ParticipantSearchState,
   updateSearchState: (field: keyof ParticipantSearchState, value: unknown) => void,
-  setSearchState: (searchState: ParticipantSearchState) => void
+  setSearchState: (searchState: ParticipantSearchState) => void,
+  disabled?: boolean
 }) {
   const [advancedSearch, setAdvancedSearch] = useState(false)
 
@@ -25,13 +28,14 @@ function ParticipantSearch({ studyEnvContext, searchState, updateSearchState, se
         setSearchState={setSearchState}/>}
       <div className="align-items-center">
         <BasicSearch
+          disabled={disabled}
           searchState={searchState}
           setSearchState={setSearchState}/>
       </div>
       <div className="ms-2">
-        <Button variant="light" className="border btn-sm"
+        <Button variant="light" className="border btn-sm" disabled={disabled}
           onClick={() => setAdvancedSearch(true)}>
-        Advanced Search
+          <FontAwesomeIcon icon={faFilter}/> Search Filters
         </Button>
       </div>
     </div>


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

The participant list was getting a bit crowded with controls. This adds a new button group that toggles between the withdrawn/participant/family views and maintains url-routability. Also renames "Advanced Search" to "Search Filters" and restyles the "Actions" dropdown

Before:
<img width="1262" alt="Screenshot 2024-09-09 at 2 53 35 PM" src="https://github.com/user-attachments/assets/fbe3dbe4-74a9-4b8b-815c-db596bb4951e">

After:


https://github.com/user-attachments/assets/ecf0e426-4ac9-4588-a7bd-169989d88490





#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants?view=family and try it out