### PR TITLE
[JN-1328] adding profile-not-overwriting capability

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -271,7 +271,7 @@ public class EnrolleeImportService {
                         participantUserService.findOne(participantUserInfo.getUsername(),
                                 studyEnv.getEnvironmentName()).orElseThrow(() -> new IllegalStateException("Participant User could not be found or for PPUser")),
                         ppUser,
-                        profileService.find(ppUser.getProfileId()).orElseThrow(IllegalStateException::new)
+                        profileService.loadWithMailingAddress(ppUser.getProfileId()).orElseThrow(IllegalStateException::new)
                 )).orElseGet(() ->
                         registrationService.register(portalShortcode, studyEnv.getEnvironmentName(), participantUserInfo.getUsername(), null, null)
                 );

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -36,14 +36,19 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.BeanWrapper;
+import org.springframework.beans.BeanWrapperImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.beans.FeatureDescriptor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.time.Instant;
 import java.util.*;
+import java.util.stream.Stream;
 
 @Service
 @Slf4j
@@ -299,17 +304,15 @@ public class EnrolleeImportService {
     protected Profile importProfile(Map<String, String> enrolleeMap, Profile registrationProfile,
                                     ExportOptions exportOptions, StudyEnvironment studyEnv, DataAuditInfo auditInfo) {
         ProfileFormatter profileFormatter = new ProfileFormatter(exportOptions);
-        Profile profile = profileFormatter.fromStringMap(studyEnv.getId(), enrolleeMap);
-        // we still don't want to send emails during the import process
-        profile.setDoNotEmail(true);
-        profile.setId(registrationProfile.getId());
-        profile.setMailingAddressId(registrationProfile.getMailingAddressId());
-        profile.getMailingAddress().setId(registrationProfile.getMailingAddressId());
-        // if there's no explicit contact email, default to the username
-        if (profile.getContactEmail() == null) {
-            profile.setContactEmail(registrationProfile.getContactEmail());
+        Profile importProfile = profileFormatter.fromStringMap(studyEnv.getId(), enrolleeMap);
+        // only copy non-null properties -- this avoids overwriting already set values (especially in the case of multi-study imports)
+        copyNonNullProperties(importProfile, registrationProfile, List.of("mailingAddress"));
+        if (importProfile.getMailingAddress() != null) {
+            copyNonNullProperties(importProfile.getMailingAddress(), registrationProfile.getMailingAddress(), List.of());
         }
-        return profileService.updateWithMailingAddress(profile, auditInfo);
+        // we still don't want to send emails during the import process
+        registrationProfile.setDoNotEmail(true);
+        return profileService.updateWithMailingAddress(registrationProfile, auditInfo);
     }
 
     protected List<SurveyResponse> importSurveyResponses(String portalShortcode,
@@ -355,5 +358,19 @@ public class EnrolleeImportService {
         // we're not worrying about dating the response yet
         return surveyResponseService.updateResponse(response, new ResponsibleEntity(DataAuditInfo.systemProcessName(getClass(), "importSurveyResponse")),
                 "Imported", ppUser, enrollee, relatedTask.getId(), portalId).getResponse();
+    }
+
+    public static void copyNonNullProperties(Object source, Object target, List<String> ignoreProperties) {
+        String[] ignorePropertiesArray = Stream.of(ignoreProperties, getNullPropertyNames(source)).flatMap(Collection::stream).toArray(String[]::new);
+        BeanUtils.copyProperties(source, target, ignorePropertiesArray);
+    }
+
+
+    public static List<String> getNullPropertyNames(Object source) {
+        final BeanWrapper wrappedSource = new BeanWrapperImpl(source);
+        return Stream.of(wrappedSource.getPropertyDescriptors())
+                .map(java.beans.FeatureDescriptor::getName)
+                .filter(propertyName -> wrappedSource.getPropertyValue(propertyName) == null)
+                .toList();
     }
 }

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/StudyEnvironmentFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/StudyEnvironmentFactory.java
@@ -70,6 +70,17 @@ public class StudyEnvironmentFactory {
         return studyEnvironmentService.create(studyEnv);
     }
 
+    public StudyEnvironmentBundle buildBundle(String testName, EnvironmentName envName, Portal portal, PortalEnvironment portalEnv) {
+        Study study = studyFactory.buildPersisted(portal.getId(), testName);
+        StudyEnvironment studyEnvironment = buildPersisted(envName, study.getId(), testName);
+        return StudyEnvironmentBundle.builder()
+                .study(study)
+                .studyEnv(studyEnvironment)
+                .portal(portal)
+                .portalEnv(portalEnv)
+                .build();
+    }
+
     public StudyEnvironmentBundle buildBundle(String testName, EnvironmentName envName) {
         Portal portal = portalFactory.buildPersisted(testName);
         Study study = studyFactory.buildPersisted(portal.getId(), testName);


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Avoids inadvertent profile overwrites when importing across multiple studies (or multiple surveys in the same study)

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  this would be a big hassle to test explicitly (it would involve exporting the demo participants, deleting the profile columns, and then reimporting and confirming the profiles weren't removed).
2. So it's probably best to just pay extra attention to the unit tests