### PR TITLE
[JN-1335] Open split survey editor for all

### DIFF
--- a/ui-admin/src/forms/FormContentEditor.test.tsx
+++ b/ui-admin/src/forms/FormContentEditor.test.tsx
@@ -1,8 +1,17 @@
-import { render } from '@testing-library/react'
+import {
+  render,
+  screen, waitFor
+} from '@testing-library/react'
 import React from 'react'
 
 import { FormContentEditor } from './FormContentEditor'
 import { mockPortal } from 'test-utils/mocking-utils'
+import { userHasPermission } from '../user/UserProvider'
+
+jest.mock('user/UserProvider', () => ({
+  ...jest.requireActual('user/UserProvider'),
+  userHasPermission: jest.fn()
+}))
 
 //This is valid JSON, but invalid survey JSON
 const formContent: string = JSON.stringify({
@@ -14,6 +23,9 @@ const formContent: string = JSON.stringify({
 
 describe('FormContentEditor', () => {
   it('should trap FormDesigner errors in an ErrorBoundary', () => {
+    (userHasPermission as jest.Mock).mockImplementation(() => {
+      return true
+    })
     // avoid cluttering the console with the error message from the expected error
     jest.spyOn(console, 'error').mockImplementation(jest.fn())
     const { container } = render(<FormContentEditor
@@ -26,8 +38,12 @@ describe('FormContentEditor', () => {
       onAnswerMappingChange={jest.fn()}
     />)
 
+    screen.getByText('Designer').click()
+
     // Our custom ErrorBoundary text
-    expect(container).toHaveTextContent('Something went wrong')
+    waitFor(() => {
+      expect(container).toHaveTextContent('Something went wrong')
+    })
     // JSON Editor and Preview tabs should still be visible
     expect(container).toHaveTextContent('JSON Editor')
     expect(container).toHaveTextContent('Preview')

--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -25,10 +25,6 @@ import { isEmpty } from 'lodash'
 import useStateCallback from 'util/useStateCallback'
 import AnswerMappingEditor from 'study/surveys/AnswerMappingEditor'
 import { SplitFormDesigner } from './designer/split/SplitFormDesigner'
-import {
-  userHasPermission,
-  useUser
-} from 'user/UserProvider'
 import { SplitCalculatedValueDesigner } from 'forms/designer/SplitCalculatedValueDesigner'
 
 type FormContentEditorProps = {
@@ -45,7 +41,6 @@ type FormContentEditorProps = {
 
 export const FormContentEditor = (props: FormContentEditorProps) => {
   const {
-    portal,
     initialContent,
     initialAnswerMappings,
     supportedLanguages,
@@ -57,7 +52,6 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
 
   const [activeTab, setActiveTab] = useState<string | null>('designer')
   const [tabsEnabled, setTabsEnabled] = useState(true)
-  const { user } = useUser()
 
   const [editedContent, setEditedContent] = useStateCallback(() => JSON.parse(initialContent) as FormContent)
 
@@ -94,7 +88,7 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
             />
           </ErrorBoundary>
         </Tab>
-        {userHasPermission(user, portal.id, 'prototype_tester') && <Tab
+        <Tab
           disabled={activeTab !== 'split' && !tabsEnabled}
           eventKey="split"
           title={<>Split Designer<span className='badge bg-primary fw-light ms-2'>BETA</span></>}
@@ -116,7 +110,7 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
               }}
             />
           </ErrorBoundary>
-        </Tab> }
+        </Tab>
         <Tab
           disabled={activeTab !== 'json' && !tabsEnabled}
           eventKey="json"

--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -26,6 +26,7 @@ import useStateCallback from 'util/useStateCallback'
 import AnswerMappingEditor from 'study/surveys/AnswerMappingEditor'
 import { SplitFormDesigner } from './designer/split/SplitFormDesigner'
 import { SplitCalculatedValueDesigner } from 'forms/designer/SplitCalculatedValueDesigner'
+import { userHasPermission, useUser } from 'user/UserProvider'
 
 type FormContentEditorProps = {
   portal: Portal
@@ -41,6 +42,7 @@ type FormContentEditorProps = {
 
 export const FormContentEditor = (props: FormContentEditorProps) => {
   const {
+    portal,
     initialContent,
     initialAnswerMappings,
     supportedLanguages,
@@ -50,8 +52,9 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
     onAnswerMappingChange
   } = props
 
-  const [activeTab, setActiveTab] = useState<string | null>('designer')
+  const [activeTab, setActiveTab] = useState<string | null>('split')
   const [tabsEnabled, setTabsEnabled] = useState(true)
+  const { user } = useUser()
 
   const [editedContent, setEditedContent] = useStateCallback(() => JSON.parse(initialContent) as FormContent)
 
@@ -64,7 +67,7 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
         unmountOnExit
         onSelect={setActiveTab}
       >
-        <Tab
+        {userHasPermission(user, portal.id, 'prototype_tester') &&< Tab
           disabled={activeTab !== 'designer' && !tabsEnabled}
           eventKey="designer"
           title="Designer"
@@ -87,7 +90,7 @@ export const FormContentEditor = (props: FormContentEditorProps) => {
               }}
             />
           </ErrorBoundary>
-        </Tab>
+        </Tab> }
         <Tab
           disabled={activeTab !== 'split' && !tabsEnabled}
           eventKey="split"

--- a/ui-admin/src/study/surveys/SurveyEditorView.test.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.test.tsx
@@ -10,6 +10,12 @@ import {
 import { userEvent } from '@testing-library/user-event'
 import { select } from 'react-select-event'
 import clearAllMocks = jest.clearAllMocks
+import { userHasPermission } from 'user/UserProvider'
+
+jest.mock('user/UserProvider', () => ({
+  ...jest.requireActual('user/UserProvider'),
+  userHasPermission: jest.fn()
+}))
 
 describe('SurveyEditorView', () => {
   const mockForm = ():Survey => ({
@@ -114,6 +120,9 @@ describe('SurveyEditorView', () => {
 
   test('toggles languages', async () => {
     const portal = mockTwoLanguagePortal()
+    ;(userHasPermission as jest.Mock).mockImplementation(() => {
+      return true
+    })
     renderInPortalRouter(portal,
       <SurveyEditorView
         studyEnvContext={mockStudyEnvContext()}
@@ -129,6 +138,8 @@ describe('SurveyEditorView', () => {
         onCancel={jest.fn()}
         onSave={jest.fn()}
       />)
+    await userEvent.click(screen.getByText('Designer'))
+
     await userEvent.click(screen.getByText('testQ'))
     expect(screen.getByText('English question')).toBeInTheDocument()
     expect(screen.queryByText('Español pregunta')).not.toBeInTheDocument()


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Opens up the split survey editor for all users.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Log in as a non-superuser and make sure you can access the split designer