### PR TITLE
[JN-1259] Capture return tracking number + UX cleanup

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
@@ -108,7 +108,7 @@ public class KitExtService {
 
     KitRequest kitRequest =
         kitRequestService.findByEnrolleeAndBarcode(
-            authContext.getEnrollee(), kitCollectionDto.kitBarcode());
+            authContext.getEnrollee(), kitCollectionDto.kitLabel());
 
     kitRequest.setReturnTrackingNumber(kitCollectionDto.returnTrackingNumber());
 

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
@@ -110,6 +110,8 @@ public class KitExtService {
         kitRequestService.findByEnrolleeAndBarcode(
             authContext.getEnrollee(), kitCollectionDto.kitBarcode());
 
+    kitRequest.setReturnTrackingNumber(kitCollectionDto.returnTrackingNumber());
+
     return kitRequestService.collectKit(
         authContext.getOperator(), kitRequest, KitRequestStatus.COLLECTED_BY_STAFF);
   }

--- a/core/src/main/java/bio/terra/pearl/core/dao/kit/KitRequestDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/kit/KitRequestDao.java
@@ -28,7 +28,7 @@ public class KitRequestDao extends BaseMutableJdbiDao<KitRequest> {
         return super.findAllByProperty("enrollee_id", enrolleeId);
     }
 
-    public Optional<KitRequest> findByEnrolleeAndBarcode(UUID enrolleeId, String kitLabel) {
+    public Optional<KitRequest> findByEnrolleeAndLabel(UUID enrolleeId, String kitLabel) {
         return findByTwoProperties("enrollee_id", enrolleeId, "kit_label", kitLabel);
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/dao/kit/KitRequestDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/kit/KitRequestDao.java
@@ -28,8 +28,8 @@ public class KitRequestDao extends BaseMutableJdbiDao<KitRequest> {
         return super.findAllByProperty("enrollee_id", enrolleeId);
     }
 
-    public Optional<KitRequest> findByEnrolleeAndBarcode(UUID enrolleeId, String barcode) {
-        return findByTwoProperties("enrollee_id", enrolleeId, "kit_barcode", barcode);
+    public Optional<KitRequest> findByEnrolleeAndBarcode(UUID enrolleeId, String kitLabel) {
+        return findByTwoProperties("enrollee_id", enrolleeId, "kit_label", kitLabel);
     }
 
     public Map<UUID, List<KitRequest>> findByEnrolleeIds(Collection<UUID> enrolleeIds) {

--- a/core/src/main/java/bio/terra/pearl/core/model/kit/KitRequest.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/kit/KitRequest.java
@@ -33,7 +33,7 @@ public class KitRequest extends BaseEntity {
     private Instant receivedAt;
     private String trackingNumber;
     private String returnTrackingNumber;
-    private String kitLabel;
+    private String kitLabel;  // the barcode 
     private String errorMessage;
     /**
      * JSON blob of the request state from DSM or another sample processor, kept to make sure we capture

--- a/core/src/main/java/bio/terra/pearl/core/model/kit/KitRequest.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/kit/KitRequest.java
@@ -33,7 +33,7 @@ public class KitRequest extends BaseEntity {
     private Instant receivedAt;
     private String trackingNumber;
     private String returnTrackingNumber;
-    private String kitBarcode;
+    private String kitLabel;
     private String errorMessage;
     /**
      * JSON blob of the request state from DSM or another sample processor, kept to make sure we capture

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestDto.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestDto.java
@@ -39,7 +39,7 @@ public class KitRequestDto {
   private Instant receivedAt;
   private String trackingNumber;
   private String returnTrackingNumber;
-  private String kitLabel;
+  private String kitLabel;   // the barcode from the kit label
   private boolean skipAddressValidation;
   private String errorMessage;
   /**

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestDto.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestDto.java
@@ -39,7 +39,7 @@ public class KitRequestDto {
   private Instant receivedAt;
   private String trackingNumber;
   private String returnTrackingNumber;
-  private String kitBarcode;
+  private String kitLabel;
   private boolean skipAddressValidation;
   private String errorMessage;
   /**
@@ -63,7 +63,7 @@ public class KitRequestDto {
     this.receivedAt = kitRequest.getReceivedAt();
     this.trackingNumber = kitRequest.getTrackingNumber();
     this.returnTrackingNumber = kitRequest.getReturnTrackingNumber();
-    this.kitBarcode = kitRequest.getKitBarcode();
+    this.kitLabel = kitRequest.getKitLabel();
     this.errorMessage = kitRequest.getErrorMessage();
     this.skipAddressValidation = kitRequest.isSkipAddressValidation();
     this.details = createRequestDetails(kitRequest, objectMapper);

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
@@ -105,7 +105,7 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
                 .enrolleeId(enrollee.getId())
                 .creatingAdminUserId(operator.getId())
                 .distributionMethod(DistributionMethod.IN_PERSON)
-                .kitBarcode(kitRequestCreationDto.kitBarcode)
+                .kitLabel(kitRequestCreationDto.kitLabel)
                 .skipAddressValidation(kitRequestCreationDto.skipAddressValidation)
                 .build();
         dao.createWithIdSpecified(inPersonKitRequest);
@@ -137,9 +137,9 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
         return new KitRequestDto(kitRequest, kitRequest.getKitType(), enrollee.getShortcode(), objectMapper);
     }
 
-    public record KitRequestCreationDto(String kitType, DistributionMethod distributionMethod, String kitBarcode, boolean skipAddressValidation) { }
+    public record KitRequestCreationDto(String kitType, DistributionMethod distributionMethod, String kitLabel, boolean skipAddressValidation) { }
 
-    public record KitCollectionDto(String kitBarcode, String returnTrackingNumber) {}
+    public record KitCollectionDto(String kitLabel, String returnTrackingNumber) {}
 
     /**
      * Collect the address fields sent to Pepper with a kit request. This is not the full DSM request, just the address

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
@@ -139,7 +139,7 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
 
     public record KitRequestCreationDto(String kitType, DistributionMethod distributionMethod, String kitBarcode, boolean skipAddressValidation) { }
 
-    public record KitCollectionDto(String kitBarcode) {}
+    public record KitCollectionDto(String kitBarcode, String returnTrackingNumber) {}
 
     /**
      * Collect the address fields sent to Pepper with a kit request. This is not the full DSM request, just the address

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
@@ -169,7 +169,7 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
     }
 
     public KitRequest findByEnrolleeAndBarcode(Enrollee enrollee, String barcode) {
-        return dao.findByEnrolleeAndBarcode(enrollee.getId(), barcode).orElseThrow(() ->
+        return dao.findByEnrolleeAndLabel(enrollee.getId(), barcode).orElseThrow(() ->
                 new NotFoundException("Kit request not found for enrollee %s and barcode %s"
                         .formatted(enrollee.getShortcode(), barcode)));
     }

--- a/core/src/main/resources/db/changelog/changesets/2024_08_28_in_person_kits.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_08_28_in_person_kits.yaml
@@ -10,7 +10,7 @@ databaseChangeLog:
         - addColumn:
             tableName: kit_request
             columns:
-              - column: { name: kit_barcode, type: text, constraints: { nullable: true } }
+              - column: { name: kit_label, type: text, constraints: { nullable: true } }
         - addColumn:
             tableName: kit_request
             columns:

--- a/ui-admin/package.json
+++ b/ui-admin/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
+    "@fortawesome/free-brands-svg-icons": "^6.5.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@juniper/ui-core": "*",
     "@tanstack/react-table": "^8.8.2",

--- a/ui-admin/package.json
+++ b/ui-admin/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
-    "@fortawesome/free-brands-svg-icons": "^6.5.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@juniper/ui-core": "*",
     "@tanstack/react-table": "^8.8.2",

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -927,7 +927,7 @@ export default {
     studyShortcode: string,
     envName: string,
     enrolleeShortcode: string,
-    kitOptions: { kitType: string, distributionMethod: string, skipAddressValidation: boolean, kitBarcode: string }
+    kitOptions: { kitType: string, distributionMethod: string, skipAddressValidation: boolean, kitLabel: string }
   ): Promise<string> {
     const url =
       `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/enrollees/${enrolleeShortcode}/requestKit`
@@ -944,7 +944,7 @@ export default {
     studyShortcode: string,
     envName: string,
     enrolleeShortcode: string,
-    kitOptions: { kitBarcode: string, returnTrackingNumber: string }
+    kitOptions: { kitLabel: string, returnTrackingNumber: string }
   ): Promise<string> {
     const url =
         `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/enrollees/${enrolleeShortcode}/collectKit`

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -944,7 +944,7 @@ export default {
     studyShortcode: string,
     envName: string,
     enrolleeShortcode: string,
-    kitOptions: { kitBarcode: string }
+    kitOptions: { kitBarcode: string, returnTrackingNumber: string }
   ): Promise<string> {
     const url =
         `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/enrollees/${enrolleeShortcode}/collectKit`

--- a/ui-admin/src/study/kits/KitList.tsx
+++ b/ui-admin/src/study/kits/KitList.tsx
@@ -23,13 +23,12 @@ import { enrolleeKitRequestPath } from 'study/participants/enrolleeView/Enrollee
 import KitStatusCell from 'study/participants/KitStatusCell'
 import { Button } from 'components/forms/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faExternalLinkAlt, faRefresh } from '@fortawesome/free-solid-svg-icons'
+import { faRefresh } from '@fortawesome/free-solid-svg-icons'
 import { successNotification } from 'util/notifications'
 import { Store } from 'react-notifications-component'
 import { useUser } from 'user/UserProvider'
 import { convertToHumanReadable, KitRequestDetails } from 'study/participants/KitRequests'
 import { useAdminUserContext } from 'providers/AdminUserProvider'
-import { faFedex } from '@fortawesome/free-brands-svg-icons'
 
 type KitStatusTabConfig = {
   statuses: string[],
@@ -85,7 +84,8 @@ const statusTabs: KitStatusTabConfig[] = [
     key: 'collected',
     additionalColumns: [
       'creatingAdminUserId',
-      'collectingAdminUserId', 'returnTrackingNumber'
+      'collectingAdminUserId',
+      'returnTrackingNumber'
     ]
   },
   {
@@ -243,7 +243,7 @@ function KitListView({ studyEnvContext, tab, kits, initialColumnVisibility }: {
     accessorKey: 'trackingNumber',
     enableColumnFilter: false
   }, {
-    header: 'Kit Origin',
+    header: 'Distribution Method',
     accessorKey: 'distributionMethod',
     enableColumnFilter: false,
     accessorFn: data => convertToHumanReadable(data.distributionMethod)
@@ -265,13 +265,7 @@ function KitListView({ studyEnvContext, tab, kits, initialColumnVisibility }: {
   }, {
     header: 'Return Tracking Number',
     accessorKey: 'returnTrackingNumber',
-    enableColumnFilter: false,
-    cell: data => data.getValue() ? <><FontAwesomeIcon icon={faFedex} className={'fa-xl me-1'}/>
-      <a href={`https://www.fedex.com/apps/fedextrack/?tracknumbers=${data.getValue()}`} target="_blank">
-        {/* todo: these might not always be fedex */}
-        {data.getValue()} <FontAwesomeIcon icon={faExternalLinkAlt}/>
-      </a>
-    </> : <span className={'text-muted'}>n/a</span>
+    enableColumnFilter: false
   }, {
     header: 'Returned',
     accessorKey: 'receivedAt',

--- a/ui-admin/src/study/kits/KitList.tsx
+++ b/ui-admin/src/study/kits/KitList.tsx
@@ -50,7 +50,7 @@ const defaultColumns: VisibilityState = {
   'returnTrackingNumber': false,
   'creatingAdminUserId': false,
   'collectingAdminUserId': false,
-  'kitBarcode': false,
+  'kitLabel': false,
   'receivedAt': false,
   'status': false,
   'distributionMethod': false
@@ -244,8 +244,8 @@ function KitListView({ studyEnvContext, tab, kits, initialColumnVisibility }: {
     accessorKey: 'trackingNumber',
     enableColumnFilter: false
   }, {
-    header: 'Kit Barcode',
-    accessorKey: 'kitBarcode',
+    header: 'Kit Label',
+    accessorKey: 'kitLabel',
     enableColumnFilter: false
   }, {
     header: 'Distribution Method',

--- a/ui-admin/src/study/kits/KitList.tsx
+++ b/ui-admin/src/study/kits/KitList.tsx
@@ -23,12 +23,13 @@ import { enrolleeKitRequestPath } from 'study/participants/enrolleeView/Enrollee
 import KitStatusCell from 'study/participants/KitStatusCell'
 import { Button } from 'components/forms/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faRefresh } from '@fortawesome/free-solid-svg-icons'
+import { faExternalLinkAlt, faRefresh } from '@fortawesome/free-solid-svg-icons'
 import { successNotification } from 'util/notifications'
 import { Store } from 'react-notifications-component'
 import { useUser } from 'user/UserProvider'
-import { KitRequestDetails } from 'study/participants/KitRequests'
+import { convertToHumanReadable, KitRequestDetails } from 'study/participants/KitRequests'
 import { useAdminUserContext } from 'providers/AdminUserProvider'
+import { faFedex } from '@fortawesome/free-brands-svg-icons'
 
 type KitStatusTabConfig = {
   statuses: string[],
@@ -84,7 +85,7 @@ const statusTabs: KitStatusTabConfig[] = [
     key: 'collected',
     additionalColumns: [
       'creatingAdminUserId',
-      'collectingAdminUserId'
+      'collectingAdminUserId', 'returnTrackingNumber'
     ]
   },
   {
@@ -244,7 +245,8 @@ function KitListView({ studyEnvContext, tab, kits, initialColumnVisibility }: {
   }, {
     header: 'Kit Origin',
     accessorKey: 'distributionMethod',
-    enableColumnFilter: false
+    enableColumnFilter: false,
+    accessorFn: data => convertToHumanReadable(data.distributionMethod)
   }, {
     header: 'Requested By',
     accessorKey: 'creatingAdminUserId',
@@ -263,7 +265,13 @@ function KitListView({ studyEnvContext, tab, kits, initialColumnVisibility }: {
   }, {
     header: 'Return Tracking Number',
     accessorKey: 'returnTrackingNumber',
-    enableColumnFilter: false
+    enableColumnFilter: false,
+    cell: data => data.getValue() ? <><FontAwesomeIcon icon={faFedex} className={'fa-xl me-1'}/>
+      <a href={`https://www.fedex.com/apps/fedextrack/?tracknumbers=${data.getValue()}`} target="_blank">
+        {/* todo: these might not always be fedex */}
+        {data.getValue()} <FontAwesomeIcon icon={faExternalLinkAlt}/>
+      </a>
+    </> : <span className={'text-muted'}>n/a</span>
   }, {
     header: 'Returned',
     accessorKey: 'receivedAt',

--- a/ui-admin/src/study/kits/KitList.tsx
+++ b/ui-admin/src/study/kits/KitList.tsx
@@ -50,6 +50,7 @@ const defaultColumns: VisibilityState = {
   'returnTrackingNumber': false,
   'creatingAdminUserId': false,
   'collectingAdminUserId': false,
+  'kitBarcode': false,
   'receivedAt': false,
   'status': false,
   'distributionMethod': false
@@ -241,6 +242,10 @@ function KitListView({ studyEnvContext, tab, kits, initialColumnVisibility }: {
   }, {
     header: 'Tracking Number',
     accessorKey: 'trackingNumber',
+    enableColumnFilter: false
+  }, {
+    header: 'Kit Barcode',
+    accessorKey: 'kitBarcode',
     enableColumnFilter: false
   }, {
     header: 'Distribution Method',

--- a/ui-admin/src/study/kits/KitList.tsx
+++ b/ui-admin/src/study/kits/KitList.tsx
@@ -27,7 +27,7 @@ import { faRefresh } from '@fortawesome/free-solid-svg-icons'
 import { successNotification } from 'util/notifications'
 import { Store } from 'react-notifications-component'
 import { useUser } from 'user/UserProvider'
-import { convertToHumanReadable, KitRequestDetails } from 'study/participants/KitRequests'
+import { prettifyString, KitRequestDetails } from 'study/participants/KitRequests'
 import { useAdminUserContext } from 'providers/AdminUserProvider'
 
 type KitStatusTabConfig = {
@@ -251,7 +251,7 @@ function KitListView({ studyEnvContext, tab, kits, initialColumnVisibility }: {
     header: 'Distribution Method',
     accessorKey: 'distributionMethod',
     enableColumnFilter: false,
-    accessorFn: data => convertToHumanReadable(data.distributionMethod)
+    accessorFn: data => prettifyString(data.distributionMethod)
   }, {
     header: 'Requested By',
     accessorKey: 'creatingAdminUserId',

--- a/ui-admin/src/study/kits/kitcollection/KitScanner.tsx
+++ b/ui-admin/src/study/kits/kitcollection/KitScanner.tsx
@@ -19,7 +19,7 @@ import {
   faSearch
 } from '@fortawesome/free-solid-svg-icons'
 import { Checkbox } from 'components/forms/Checkbox'
-import { successNotification } from 'util/notifications'
+import { failureNotification, successNotification } from 'util/notifications'
 import { Store } from 'react-notifications-component'
 
 const kitScanModeOptions = [
@@ -71,7 +71,10 @@ export const KitScanner = ({ studyEnvContext }: { studyEnvContext: StudyEnvConte
   }
 
   const collectKit = async () => {
-    if (!enrollee || !kitBarcode || !returnTrackingNumber) { return } //notify of an error here
+    if (!enrollee || !kitBarcode || !returnTrackingNumber) {
+      Store.addNotification(failureNotification('Please complete all steps before submitting'))
+      return
+    }
     doApiLoad(async () => {
       await Api.collectKit(
         studyEnvContext.portal.shortcode,

--- a/ui-admin/src/study/kits/kitcollection/KitScanner.tsx
+++ b/ui-admin/src/study/kits/kitcollection/KitScanner.tsx
@@ -242,7 +242,7 @@ export const KitScanner = ({ studyEnvContext }: { studyEnvContext: StudyEnvConte
       </Button>
       { showKitScanner &&
         <BarcodeScanner
-          expectedFormats={['upc_a']}
+          expectedFormats={['code_128']}
           onError={error => setKitCodeError(error)}
           onSuccess={result => {
             setKitBarcode(result.rawValue)
@@ -273,7 +273,7 @@ export const KitScanner = ({ studyEnvContext }: { studyEnvContext: StudyEnvConte
           </Button>
           { showKitScanner &&
           <BarcodeScanner
-            expectedFormats={['upc_a']}
+            expectedFormats={['code_128']}
             onError={error => setReturnTrackingNumberError(error)}
             onSuccess={result => {
               setReturnTrackingNumber(result.rawValue)

--- a/ui-admin/src/study/kits/kitcollection/KitScanner.tsx
+++ b/ui-admin/src/study/kits/kitcollection/KitScanner.tsx
@@ -35,7 +35,7 @@ export const KitScanner = ({ studyEnvContext }: { studyEnvContext: StudyEnvConte
   const [enrollee, setEnrollee] = useState<Enrollee>()
   const [enrolleeCodeError, setEnrolleeCodeError] = useState<string>()
   const [isEnrolleeIdentityConfirmed, setIsEnrolleeIdentityConfirmed] = useState(false)
-  const [kitBarcode, setKitBarcode] = useState<string>()
+  const [kitLabel, setKitLabel] = useState<string>()
   const [kitCodeError, setKitCodeError] = useState<string>()
   const [returnTrackingNumber, setReturnTrackingNumber] = useState<string>()
   const [returnTrackingNumberError, setReturnTrackingNumberError] = useState<string>()
@@ -46,7 +46,7 @@ export const KitScanner = ({ studyEnvContext }: { studyEnvContext: StudyEnvConte
   const { user } = useUser()
 
   const assignKit = async () => {
-    if (!enrollee || !kitBarcode) { return }
+    if (!enrollee || !kitLabel) { return }
     doApiLoad(async () => {
       await Api.createKitRequest(
         studyEnvContext.portal.shortcode,
@@ -56,7 +56,7 @@ export const KitScanner = ({ studyEnvContext }: { studyEnvContext: StudyEnvConte
         {
           kitType: 'SALIVA',
           distributionMethod: 'IN_PERSON',
-          kitBarcode,
+          kitLabel,
           skipAddressValidation: false
         }
       )
@@ -71,7 +71,7 @@ export const KitScanner = ({ studyEnvContext }: { studyEnvContext: StudyEnvConte
   }
 
   const collectKit = async () => {
-    if (!enrollee || !kitBarcode || !returnTrackingNumber) {
+    if (!enrollee || !kitLabel || !returnTrackingNumber) {
       Store.addNotification(failureNotification('Please complete all steps before submitting'))
       return
     }
@@ -82,7 +82,7 @@ export const KitScanner = ({ studyEnvContext }: { studyEnvContext: StudyEnvConte
         studyEnvContext.currentEnv.environmentName,
         enrollee.shortcode,
         {
-          kitBarcode,
+          kitLabel,
           returnTrackingNumber
         }
       )
@@ -159,7 +159,7 @@ export const KitScanner = ({ studyEnvContext }: { studyEnvContext: StudyEnvConte
           setSelectedScanMode(kitScanModeOptions.find(option => option.value === selectedOption?.value))
           setEnrollee(undefined)
           setIsEnrolleeIdentityConfirmed(false)
-          setKitBarcode(undefined)
+          setKitLabel(undefined)
         }}
       />
     </KitCollectionStepWrapper>
@@ -176,7 +176,7 @@ export const KitScanner = ({ studyEnvContext }: { studyEnvContext: StudyEnvConte
         setEnrollee(undefined)
         setShowEnrolleeCodeScanner(!showEnrolleeCodeScanner)
         setIsEnrolleeIdentityConfirmed(false)
-        setKitBarcode(undefined)
+        setKitLabel(undefined)
       }}>
         Click to scan enrollee code
       </Button>
@@ -235,28 +235,28 @@ export const KitScanner = ({ studyEnvContext }: { studyEnvContext: StudyEnvConte
 
     <KitCollectionStepWrapper
       title={'Step 4'}
-      status={kitBarcode ? 'COMPLETE' : 'INCOMPLETE'}
+      status={kitLabel ? 'COMPLETE' : 'INCOMPLETE'}
     >
-      <div className="mb-3">Click to open the camera and scan the kit barcode</div>
+      <div className="mb-3">Click to open the camera and scan the kit label</div>
       <Button className="mb-2" variant={'primary'} disabled={!isEnrolleeIdentityConfirmed}
         tooltip={!isEnrolleeIdentityConfirmed ? 'You must complete the prior steps first' : ''}
         onClick={() => setShowKitScanner(!showKitScanner)}>
-            Click to scan kit barcode
+            Click to scan kit label
       </Button>
       { showKitScanner &&
         <BarcodeScanner
           expectedFormats={['code_128']}
           onError={error => setKitCodeError(error)}
           onSuccess={result => {
-            setKitBarcode(result.rawValue)
+            setKitLabel(result.rawValue)
             setShowKitScanner(false)
           }}/>
       }
       <TextInput
         className="my-2"
         disabled={false}
-        value={kitBarcode}
-        onChange={e => setKitBarcode(e)}>
+        value={kitLabel}
+        onChange={e => setKitLabel(e)}>
       </TextInput>
       { kitCodeError &&
             <div className="text-danger">{kitCodeError}</div>
@@ -270,7 +270,7 @@ export const KitScanner = ({ studyEnvContext }: { studyEnvContext: StudyEnvConte
           <div className="mb-3">Place the kit in the provided return packaging, and
         click to open the camera and scan the kit return label</div>
           <Button className="mb-2" variant={'primary'} disabled={!isEnrolleeIdentityConfirmed}
-            tooltip={!kitBarcode ? 'You must complete the prior steps first' : ''}
+            tooltip={!kitLabel ? 'You must complete the prior steps first' : ''}
             onClick={() => setShowReturnTrackingNumberScanner(!showReturnTrackingNumberScanner)}>
         Click to scan kit return label
           </Button>
@@ -294,11 +294,11 @@ export const KitScanner = ({ studyEnvContext }: { studyEnvContext: StudyEnvConte
           }
         </KitCollectionStepWrapper> }
     <div className="d-flex justify-content-end">
-      <Button disabled={!(kitBarcode && enrollee && selectedScanMode)} variant={'primary'} //todo check return label
+      <Button disabled={!(kitLabel && enrollee && selectedScanMode)} variant={'primary'} //todo check return label
         onClick={async () => {
           setEnrollee(undefined)
           setIsEnrolleeIdentityConfirmed(false)
-          setKitBarcode(undefined)
+          setKitLabel(undefined)
           setEnrolleeCodeError(undefined)
           setEnrolleeShortcodeOverride(undefined)
           setSelectedScanMode(undefined)

--- a/ui-admin/src/study/kits/kitcollection/KitScanner.tsx
+++ b/ui-admin/src/study/kits/kitcollection/KitScanner.tsx
@@ -36,6 +36,7 @@ export const KitScanner = ({ studyEnvContext }: { studyEnvContext: StudyEnvConte
   const [isEnrolleeIdentityConfirmed, setIsEnrolleeIdentityConfirmed] = useState(false)
   const [kitBarcode, setKitBarcode] = useState<string | undefined>()
   const [kitCodeError, setKitCodeError] = useState<string>()
+  //todo implement kit return label scanning
 
   const [enableManualOverride, setEnableManualOverride] = useState(false)
   const [enrolleeShortcodeOverride, setEnrolleeShortcodeOverride] = useState<string>()
@@ -255,6 +256,37 @@ export const KitScanner = ({ studyEnvContext }: { studyEnvContext: StudyEnvConte
             <div className="text-danger">{kitCodeError}</div>
       }
     </KitCollectionStepWrapper>
+    { selectedScanMode?.value === 'COLLECT' &&
+        <KitCollectionStepWrapper
+          title={'Step 5'}
+          status={kitBarcode ? 'COMPLETE' : 'INCOMPLETE'}
+        >
+          <div className="mb-3">Place the kit in the provided return packaging, and
+        click to open the camera and scan the kit return label</div>
+          <Button className="mb-2" variant={'primary'} disabled={!isEnrolleeIdentityConfirmed}
+            tooltip={!isEnrolleeIdentityConfirmed ? 'You must complete the prior steps first' : ''}
+            onClick={() => setShowKitScanner(!showKitScanner)}>
+        Click to scan kit return label
+          </Button>
+          { showKitScanner &&
+          <BarcodeScanner
+            expectedFormats={['code_128']}
+            onError={error => setKitCodeError(error)}
+            onSuccess={result => {
+              setKitBarcode(result.rawValue)
+              setShowKitScanner(false)
+            }}/>
+          }
+          { enableManualOverride && <TextInput
+            className="my-2"
+            disabled={false}
+            value={kitBarcode}
+            onChange={e => setKitBarcode(e)}>
+          </TextInput> }
+          { kitCodeError &&
+          <div className="text-danger">{kitCodeError}</div>
+          }
+        </KitCollectionStepWrapper> }
     <div className="d-flex justify-content-end">
       <Button disabled={!(kitBarcode && enrollee && selectedScanMode)} variant={'primary'}
         onClick={async () => {

--- a/ui-admin/src/study/kits/kitcollection/KitScanner.tsx
+++ b/ui-admin/src/study/kits/kitcollection/KitScanner.tsx
@@ -45,6 +45,16 @@ export const KitScanner = ({ studyEnvContext }: { studyEnvContext: StudyEnvConte
 
   const { user } = useUser()
 
+  const isSubmitDisabled = () => {
+    if (!kitLabel || !enrollee || !selectedScanMode) {
+      return true
+    }
+    if (selectedScanMode.value === 'COLLECT' && !returnTrackingNumber) {
+      return true
+    }
+    return false
+  }
+
   const assignKit = async () => {
     if (!enrollee || !kitLabel) { return }
     doApiLoad(async () => {
@@ -294,7 +304,8 @@ export const KitScanner = ({ studyEnvContext }: { studyEnvContext: StudyEnvConte
           }
         </KitCollectionStepWrapper> }
     <div className="d-flex justify-content-end">
-      <Button disabled={!(kitLabel && enrollee && selectedScanMode)} variant={'primary'} //todo check return label
+      <Button disabled={isSubmitDisabled()}
+        variant={'primary'}
         onClick={async () => {
           setEnrollee(undefined)
           setIsEnrolleeIdentityConfirmed(false)
@@ -302,6 +313,8 @@ export const KitScanner = ({ studyEnvContext }: { studyEnvContext: StudyEnvConte
           setEnrolleeCodeError(undefined)
           setEnrolleeShortcodeOverride(undefined)
           setSelectedScanMode(undefined)
+          setReturnTrackingNumber(undefined)
+          setReturnTrackingNumberError(undefined)
           if (selectedScanMode?.value === 'ASSIGN') {
             await assignKit()
           } if (selectedScanMode?.value === 'COLLECT') {

--- a/ui-admin/src/study/participants/KitRequests.test.tsx
+++ b/ui-admin/src/study/participants/KitRequests.test.tsx
@@ -15,6 +15,6 @@ test('renders kit requests', async () => {
     expect(screen.getByText('Kit Requests')).toBeInTheDocument()
   })
   expect(screen.getByText('Test kit')).toBeInTheDocument()
-  expect(screen.getByText('CREATED')).toBeInTheDocument()
+  expect(screen.getByText('Created')).toBeInTheDocument()
   expect(screen.getByText('1234 Fake Street')).toBeInTheDocument()
 })

--- a/ui-admin/src/study/participants/KitRequests.tsx
+++ b/ui-admin/src/study/participants/KitRequests.tsx
@@ -31,7 +31,7 @@ function KitRequestAddress({ sentToAddressJson }: { sentToAddressJson: string })
   if (!sentToAddressJson) {
     return <div className="text-muted fst-italic">n/a<InfoPopup content={
       <div>
-        <div className="d=flex">Kits assigned to a participant in person will not have a shipping address</div>
+        <div className="d=flex">Kits distributed to a participant in person will not have a shipping address</div>
       </div>
     } placement='left'/></div>
   }
@@ -60,7 +60,8 @@ const columns: ColumnDef<KitRequest, string>[] = [{
   cell: ({ row }) => <KitRequestAddress sentToAddressJson={row.original.sentToAddress}/>
 }, {
   header: 'Distribution Method',
-  accessorKey: 'distributionMethod'
+  accessorKey: 'distributionMethod',
+  accessorFn: data => convertToHumanReadable(data.distributionMethod)
 }, {
   header: 'Details',
   accessorKey: 'details',
@@ -123,4 +124,9 @@ export default function KitRequests({ enrollee, studyEnvContext, onUpdate }:
       {renderEmptyMessage(enrollee.kitRequests, 'No kit requests')}
     </div>}
   </InfoCard>
+}
+
+export const convertToHumanReadable = (value: string) => {
+  //takes a string such as IN_PERSON and converts it to In Person
+  return value.split('_').map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()).join(' ')
 }

--- a/ui-admin/src/study/participants/KitRequests.tsx
+++ b/ui-admin/src/study/participants/KitRequests.tsx
@@ -61,7 +61,7 @@ const columns: ColumnDef<KitRequest, string>[] = [{
 }, {
   header: 'Distribution Method',
   accessorKey: 'distributionMethod',
-  accessorFn: data => convertToHumanReadable(data.distributionMethod)
+  accessorFn: data => prettifyString(data.distributionMethod)
 }, {
   header: 'Details',
   accessorKey: 'details',
@@ -81,12 +81,9 @@ export const KitRequestDetails = ({ kitRequest }: { kitRequest: KitRequest }) =>
 }
 
 /** Shows a list of all kit requests for an enrollee. */
-export default function KitRequests({ enrollee, studyEnvContext, onUpdate }:
-                                      {
-                                        enrollee: Enrollee,
-                                        studyEnvContext: StudyEnvContextT,
-                                        onUpdate: () => void
-                                      }) {
+export default function KitRequests({ enrollee, studyEnvContext, onUpdate }: {
+  enrollee: Enrollee, studyEnvContext: StudyEnvContextT, onUpdate: () => void
+}) {
   const { user } = useUser()
   const [showRequestKitModal, setShowRequestKitModal] = useState(false)
 
@@ -106,10 +103,10 @@ export default function KitRequests({ enrollee, studyEnvContext, onUpdate }:
       <div className="d-flex justify-content-between align-items-center w-100">
         <div className="fw-bold lead my-1">Kit Requests</div>
         {user?.superuser &&
-            <Button onClick={() => setShowRequestKitModal(true)}
-              variant="light" className="border m-1">
-              <FontAwesomeIcon icon={faPlus} className="fa-lg"/> Request a kit
-            </Button>
+          <Button onClick={() => setShowRequestKitModal(true)}
+            variant="light" className="border m-1">
+            <FontAwesomeIcon icon={faPlus} className="fa-lg"/> Request a kit
+          </Button>
         }
       </div>
     </InfoCardHeader>
@@ -126,7 +123,7 @@ export default function KitRequests({ enrollee, studyEnvContext, onUpdate }:
   </InfoCard>
 }
 
-export const convertToHumanReadable = (value: string) => {
-  //takes a string such as IN_PERSON and converts it to In Person
+export const prettifyString = (value: string) => {
+  //takes a string such as COLLECTED_BY_STAFF and converts it to Collected By Staff
   return value.split('_').map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()).join(' ')
 }

--- a/ui-admin/src/study/participants/KitRequests.tsx
+++ b/ui-admin/src/study/participants/KitRequests.tsx
@@ -25,6 +25,7 @@ import {
   InfoCard,
   InfoCardHeader
 } from 'components/InfoCard'
+import { startCase } from 'lodash'
 
 /** Component for rendering the address a kit was sent to based on JSON captured at the time of the kit request. */
 function KitRequestAddress({ sentToAddressJson }: { sentToAddressJson: string }) {
@@ -126,5 +127,5 @@ export default function KitRequests({ enrollee, studyEnvContext, onUpdate }: {
 export const prettifyString = (value: string) => {
   if (!value) { return '' }
   //takes a string such as COLLECTED_BY_STAFF and converts it to Collected By Staff
-  return value.split('_').map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()).join(' ')
+  return value.split('_').map(s => startCase(s.toLowerCase())).join(' ')
 }

--- a/ui-admin/src/study/participants/KitRequests.tsx
+++ b/ui-admin/src/study/participants/KitRequests.tsx
@@ -52,7 +52,7 @@ const columns: ColumnDef<KitRequest, string>[] = [{
   accessorKey: 'status',
   cell: ({ row }) => <KitStatusCell kitRequest={row.original} infoPlacement='right'/>
 }, {
-  header: 'Created',
+  header: 'Date Created',
   accessorKey: 'createdAt',
   accessorFn: data => instantToDefaultString(data.createdAt)
 }, {
@@ -124,6 +124,7 @@ export default function KitRequests({ enrollee, studyEnvContext, onUpdate }: {
 }
 
 export const prettifyString = (value: string) => {
+  if (!value) { return '' }
   //takes a string such as COLLECTED_BY_STAFF and converts it to Collected By Staff
   return value.split('_').map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()).join(' ')
 }

--- a/ui-admin/src/study/participants/KitStatusCell.tsx
+++ b/ui-admin/src/study/participants/KitStatusCell.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import InfoPopup from 'components/forms/InfoPopup'
 import { Placement } from 'react-bootstrap/types'
 import { KitRequest } from '@juniper/ui-core'
+import { convertToHumanReadable } from './KitRequests'
 
 /**
  * Component to render the currentStatus as reported by Pepper, including some help text to explain what the statuses
@@ -25,7 +26,7 @@ export default function KitStatusCell(
   const errorMessage = kitRequest.errorMessage ? `: ${kitRequest.errorMessage}` : ''
   const content = `${info}${errorMessage}`
   return <>
-    {kitRequest.status}
+    {convertToHumanReadable(kitRequest.status)}
     {info && <InfoPopup content={content} placement={infoPlacement}/>}
   </>
 }

--- a/ui-admin/src/study/participants/KitStatusCell.tsx
+++ b/ui-admin/src/study/participants/KitStatusCell.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import InfoPopup from 'components/forms/InfoPopup'
 import { Placement } from 'react-bootstrap/types'
 import { KitRequest } from '@juniper/ui-core'
-import { convertToHumanReadable } from './KitRequests'
+import { prettifyString } from './KitRequests'
 
 /**
  * Component to render the currentStatus as reported by Pepper, including some help text to explain what the statuses
@@ -26,7 +26,7 @@ export default function KitStatusCell(
   const errorMessage = kitRequest.errorMessage ? `: ${kitRequest.errorMessage}` : ''
   const content = `${info}${errorMessage}`
   return <>
-    {convertToHumanReadable(kitRequest.status)}
+    {prettifyString(kitRequest.status)}
     {info && <InfoPopup content={content} placement={infoPlacement}/>}
   </>
 }

--- a/ui-core/src/types/kits.ts
+++ b/ui-core/src/types/kits.ts
@@ -17,7 +17,7 @@ export type KitRequest = {
     receivedAt?: number,
     trackingNumber?: string,
     returnTrackingNumber?: string,
-    kitBarcode?: string,
+    kitLabel?: string,
     errorMessage?: string,
     details?: string,
     enrolleeShortcode?: string,

--- a/ui-participant/src/hub/HubPage.tsx
+++ b/ui-participant/src/hub/HubPage.tsx
@@ -102,9 +102,9 @@ export default function HubPage() {
 
 
         <div className="my-md-4 mx-auto" style={{ maxWidth: 768 }}>
-          <div className="w-100 mt-2 mb-0 d-flex mb-2">
-            {proxyRelations.length > 0 && <ParticipantSelector/>}
-          </div>
+          { proxyRelations.length > 0 && <div className="w-100 mt-2 mb-0 d-flex mb-2">
+            <ParticipantSelector/>
+          </div> }
           <main
             className="hub-dashboard py-4 px-2 px-md-5 shadow-sm"
             style={{ background: '#fff' }}

--- a/ui-participant/src/hub/kit/KitBanner.test.tsx
+++ b/ui-participant/src/hub/kit/KitBanner.test.tsx
@@ -35,7 +35,7 @@ describe('HubPageKits', () => {
 
     expect(screen.getByText('Sample collection kits')).toBeInTheDocument()
     expect(screen.getByText(sentDate)).toBeInTheDocument()
-    expect(screen.getByText('A sample kit has been provided to you')).toBeInTheDocument()
+    expect(screen.getByText('You have received a sample kit')).toBeInTheDocument()
   })
 
   it('renders a kit collected banner', () => {
@@ -49,6 +49,6 @@ describe('HubPageKits', () => {
 
     expect(screen.getByText('Sample collection kits')).toBeInTheDocument()
     expect(screen.getByText(sentDate)).toBeInTheDocument()
-    expect(screen.getByText('Your sample kit was collected by the study team')).toBeInTheDocument()
+    expect(screen.getByText('Your sample kit has been received')).toBeInTheDocument()
   })
 })

--- a/ui-participant/src/hub/kit/KitBanner.test.tsx
+++ b/ui-participant/src/hub/kit/KitBanner.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
-import { mockKitRequest } from 'test-utils/test-participant-factory'
+import { mockAssignedKitRequest, mockKitRequest } from 'test-utils/test-participant-factory'
 import KitBanner from './KitBanner'
 import { instantToDateString } from '../../util/timeUtils'
 import { setupRouterTest } from '@juniper/ui-core'
@@ -19,8 +19,36 @@ describe('HubPageKits', () => {
     // with two kits, one sent and one received, we should only see the sent kit
     expect(screen.getByText('Sample collection kits')).toBeInTheDocument()
     expect(screen.getByText(sentDate)).toBeInTheDocument()
-    expect(screen.getByText('Your saliva kit is on its way.')).toBeInTheDocument()
+    expect(screen.getByText('Your saliva kit is on its way.', { exact: false })).toBeInTheDocument()
     expect(screen.getByText('A sample kit was shipped')).toBeInTheDocument()
     expect(screen.queryByText('Your blood kit is on its way.')).not.toBeInTheDocument()
+  })
+
+  it('renders a kit provided banner', () => {
+    const mockKitRequest = mockAssignedKitRequest('CREATED', 'SALIVA')
+    const kitRequests = [mockKitRequest]
+
+    const sentDate = instantToDateString(mockKitRequest.createdAt)
+
+    const { RoutedComponent } = setupRouterTest(<KitBanner kitRequests={kitRequests}/>)
+    render(RoutedComponent)
+
+    expect(screen.getByText('Sample collection kits')).toBeInTheDocument()
+    expect(screen.getByText(sentDate)).toBeInTheDocument()
+    expect(screen.getByText('A sample kit has been provided to you')).toBeInTheDocument()
+  })
+
+  it('renders a kit collected banner', () => {
+    const mockKitRequest = mockAssignedKitRequest('COLLECTED_BY_STAFF', 'SALIVA')
+    const kitRequests = [mockKitRequest]
+
+    const sentDate = instantToDateString(mockKitRequest.createdAt)
+
+    const { RoutedComponent } = setupRouterTest(<KitBanner kitRequests={kitRequests}/>)
+    render(RoutedComponent)
+
+    expect(screen.getByText('Sample collection kits')).toBeInTheDocument()
+    expect(screen.getByText(sentDate)).toBeInTheDocument()
+    expect(screen.getByText('Your sample kit was collected by the study team')).toBeInTheDocument()
   })
 })

--- a/ui-participant/src/hub/kit/KitBanner.tsx
+++ b/ui-participant/src/hub/kit/KitBanner.tsx
@@ -77,9 +77,9 @@ const titleForStatus = (status: string) => {
     case 'SENT':
       return 'A sample kit was shipped'
     case 'CREATED':
-      return 'A sample kit has been provided to you'
+      return 'You have received a sample kit'
     case 'COLLECTED_BY_STAFF':
-      return 'Your sample kit was collected by the study team'
+      return 'Your sample kit has been received'
   }
 }
 
@@ -124,7 +124,7 @@ function KitStatus({ kitRequest }: {kitRequest: KitRequest}) {
   return <div className={kitEventClass} style={kitEventProps}>
     <div className="d-flex justify-content-between px-0">
       <div className={iconClass}>
-        <FontAwesomeIcon className="pt-1" icon={iconForStatus(kitRequest.status)} style={iconProps}/>
+        <FontAwesomeIcon className="pt-1 pe-2" icon={iconForStatus(kitRequest.status)} style={iconProps}/>
       </div>
       <div className={eventTextClass}>
         <div className="fw-bold">{titleForStatus(kitRequest.status)}</div>

--- a/ui-participant/src/hub/kit/KitBanner.tsx
+++ b/ui-participant/src/hub/kit/KitBanner.tsx
@@ -122,7 +122,7 @@ const descriptionForStatus = (kitRequest: KitRequest) => {
 
 function KitStatus({ kitRequest }: {kitRequest: KitRequest}) {
   return <div className={kitEventClass} style={kitEventProps}>
-    <div className="d-flex justify-content-between">
+    <div className="d-flex justify-content-between px-0">
       <div className={iconClass}>
         <FontAwesomeIcon className="pt-1" icon={iconForStatus(kitRequest.status)} style={iconProps}/>
       </div>

--- a/ui-participant/src/hub/kit/KitBanner.tsx
+++ b/ui-participant/src/hub/kit/KitBanner.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
-import { KitRequest } from '../../api/api'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faTruckFast } from '@fortawesome/free-solid-svg-icons'
+import { faCircleCheck, faHandHolding, faQuestion, faTruckFast } from '@fortawesome/free-solid-svg-icons'
+import { KitRequest } from '@juniper/ui-core'
+import { NavLink } from 'react-router-dom'
 import { instantToDateString } from '../../util/timeUtils'
 
 const kitEventProps = {
@@ -25,7 +26,7 @@ const iconProps = {
 const iconClass = 'col-xs-2 col-sm-1 col-md-1'
 const eventTextClass = 'col-xs-7 col-sm-8 col-md-8'
 const eventDateClass = 'col-xs-3 col-sm-3 col-md-3 text-end'
-const kitEventClass = 'row mb-3 pt-3'
+const kitEventClass = 'row pt-3'
 
 const renderHeader = () => {
   return <div className={kitEventClass} style={kitHeaderProps}>
@@ -47,26 +48,13 @@ export default function KitBanner({ kitRequests }: {kitRequests: KitRequest[]}) 
     return null
   }
 
-  const renderSentStatus = (kitRequest: KitRequest) => {
-    return <div className={kitEventClass} style={kitEventProps}>
-      <div className={iconClass}>
-        <FontAwesomeIcon className="h2" icon={faTruckFast} style={iconProps}/>
-      </div>
-      <div className={eventTextClass}>
-        <div className="fw-bold">A sample kit was shipped</div>
-        <span className="text-muted">Your {kitRequest.kitType.displayName.toLowerCase()} kit is on its way. </span>
-        <span className="text-muted">Once your receive your kit, please complete and send it back to us </span>
-        <span className="text-muted">with the prepaid envelope provided.</span>
-      </div>
-      <div className={eventDateClass}>
-        {kitRequest.sentAt && instantToDateString(kitRequest.sentAt)}
-      </div>
-    </div>
-  }
-
   // for now, only show un-returned kits
   const unreturnedKits = kitRequests.filter(kitRequest => kitRequest.status === 'SENT')
-  if (unreturnedKits.length === 0) {
+  const inPersonKits = kitRequests.filter(kitRequest => kitRequest.distributionMethod === 'IN_PERSON')
+
+  const kitsToDisplay = unreturnedKits.concat(inPersonKits)
+
+  if (kitsToDisplay.length === 0) {
     return null
   }
 
@@ -75,12 +63,79 @@ export default function KitBanner({ kitRequests }: {kitRequests: KitRequest[]}) 
       <h2 className="fs-6 text-uppercase mb-0">Sample collection kits</h2>
       {renderHeader()}
       <ul className="list-unstyled">
-        {unreturnedKits.map(kitRequest => {
+        {kitsToDisplay.map(kitRequest => {
           return <li className="container" key={kitRequest.id}>
-            {renderSentStatus(kitRequest)}
+            <KitStatus kitRequest={kitRequest}/>
           </li>
         })}
       </ul>
     </>
   )
+}
+
+const titleForStatus = (status: string) => {
+  switch (status) {
+    case 'SENT':
+      return 'A sample kit was shipped'
+    case 'CREATED':
+      return 'A sample kit has been provided to you'
+    case 'COLLECTED_BY_STAFF':
+      return 'Your sample kit was collected by the study team'
+    default:
+      return 'Unknown sample status'
+  }
+}
+
+const iconForStatus = (status: string) => {
+  switch (status) {
+    case 'SENT':
+      return faTruckFast
+    case 'CREATED':
+      return faHandHolding
+    case 'COLLECTED_BY_STAFF':
+      return faCircleCheck
+    default:
+      return faQuestion
+  }
+}
+
+const descriptionForStatus = (kitRequest: KitRequest) => {
+  switch (kitRequest.status) {
+    case 'SENT':
+      return <>Your {kitRequest.kitType.displayName.toLowerCase()} kit is on its way.
+            Once you receive your kit, please complete and send it back to us
+            with the prepaid envelope provided.</>
+    case 'CREATED':
+      return <>A member of the study team has provided you
+        with a {kitRequest.kitType.displayName.toLowerCase()} kit in-person.
+        Please complete the kit and return it to the study team. <NavLink to={'/hub/kits'}>
+          Click here</NavLink> for more information.
+      </>
+    case 'COLLECTED_BY_STAFF':
+      return <>A member of the study team has collected your
+        completed {kitRequest.kitType.displayName.toLowerCase()} kit. Thank you for
+        your participation.</>
+    default:
+      return 'Unknown'
+  }
+}
+
+function KitStatus({ kitRequest }: {kitRequest: KitRequest}) {
+  return <div className={kitEventClass} style={kitEventProps}>
+    <div className="d-flex justify-content-between">
+      <div className={iconClass}>
+        <FontAwesomeIcon className="pt-1" icon={iconForStatus(kitRequest.status)} style={iconProps}/>
+      </div>
+      <div className={eventTextClass}>
+        <div className="fw-bold">{titleForStatus(kitRequest.status)}</div>
+        <span className="text-muted">
+          {descriptionForStatus(kitRequest)}
+        </span>
+      </div>
+      <div className={eventDateClass}>
+        {kitRequest.distributionMethod === 'IN_PERSON' ?
+          instantToDateString(kitRequest.createdAt) : instantToDateString(kitRequest.sentAt)}
+      </div>
+    </div>
+  </div>
 }

--- a/ui-participant/src/hub/kit/KitBanner.tsx
+++ b/ui-participant/src/hub/kit/KitBanner.tsx
@@ -3,7 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCircleCheck, faHandHolding, faQuestion, faTruckFast } from '@fortawesome/free-solid-svg-icons'
 import { KitRequest } from '@juniper/ui-core'
 import { NavLink } from 'react-router-dom'
-import { instantToDateString } from '../../util/timeUtils'
+import { instantToDateString } from 'util/timeUtils'
 
 const kitEventProps = {
   padding: '1em 0em',
@@ -80,8 +80,6 @@ const titleForStatus = (status: string) => {
       return 'A sample kit has been provided to you'
     case 'COLLECTED_BY_STAFF':
       return 'Your sample kit was collected by the study team'
-    default:
-      return 'Unknown kit status'
   }
 }
 
@@ -101,21 +99,24 @@ const iconForStatus = (status: string) => {
 const descriptionForStatus = (kitRequest: KitRequest) => {
   switch (kitRequest.status) {
     case 'SENT':
-      return <>Your {kitRequest.kitType.displayName.toLowerCase()} kit is on its way.
-            Once you receive your kit, please complete and send it back to us
-            with the prepaid envelope provided.</>
+      return <>
+        Your {kitRequest.kitType.displayName.toLowerCase()} kit is on its way.
+        Once you receive your kit, please complete and send it back to us
+        with the prepaid envelope provided.
+      </>
     case 'CREATED':
-      return <>A member of the study team has provided you
+      return <>
+        A member of the study team has provided you
         with a {kitRequest.kitType.displayName.toLowerCase()} kit in-person.
         Please complete the kit and return it to the study team. <NavLink to={'/hub/kits'}>
-          Click here</NavLink> for more information.
+        Click here</NavLink> for more information.
       </>
     case 'COLLECTED_BY_STAFF':
-      return <>A member of the study team has collected your
-        completed {kitRequest.kitType.displayName.toLowerCase()} kit. Thank you for
-        your participation.</>
-    default:
-      return 'Unknown'
+      return <>
+        A member of the study team has collected your
+        completed {kitRequest.kitType.displayName.toLowerCase()} kit.
+        Thank you for your participation.
+      </>
   }
 }
 

--- a/ui-participant/src/hub/kit/KitBanner.tsx
+++ b/ui-participant/src/hub/kit/KitBanner.tsx
@@ -48,11 +48,10 @@ export default function KitBanner({ kitRequests }: {kitRequests: KitRequest[]}) 
     return null
   }
 
-  // for now, only show un-returned kits
-  const unreturnedKits = kitRequests.filter(kitRequest => kitRequest.status === 'SENT')
-  const inPersonKits = kitRequests.filter(kitRequest => kitRequest.distributionMethod === 'IN_PERSON')
-
-  const kitsToDisplay = unreturnedKits.concat(inPersonKits)
+  // for now, only show un-returned kits or kits distributed in person
+  const kitsToDisplay = kitRequests
+    .filter(kitRequest =>
+      kitRequest.status === 'SENT' || kitRequest.distributionMethod === 'IN_PERSON')
 
   if (kitsToDisplay.length === 0) {
     return null
@@ -82,7 +81,7 @@ const titleForStatus = (status: string) => {
     case 'COLLECTED_BY_STAFF':
       return 'Your sample kit was collected by the study team'
     default:
-      return 'Unknown sample status'
+      return 'Unknown kit status'
   }
 }
 

--- a/ui-participant/src/hub/kit/KitInstructions.test.tsx
+++ b/ui-participant/src/hub/kit/KitInstructions.test.tsx
@@ -57,7 +57,7 @@ describe('KitInstructions', () => {
     expect(screen.getByText('Sample Kit Instructions')).toBeInTheDocument()
     expect(screen.queryByText('Consent Required')).not.toBeInTheDocument()
     expect(screen.getByText('Your sample collection kit')).toBeInTheDocument()
-    expect(screen.getByDisplayValue('assigned-barcode')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('assigned-label')).toBeInTheDocument()
     expect(screen.queryByLabelText('assign-qr')).not.toBeInTheDocument()
   })
 

--- a/ui-participant/src/hub/kit/KitInstructions.test.tsx
+++ b/ui-participant/src/hub/kit/KitInstructions.test.tsx
@@ -31,7 +31,7 @@ describe('KitInstructions', () => {
 
     expect(screen.getByText('Sample Kit Instructions')).toBeInTheDocument()
     expect(screen.queryByText('Consent Required')).not.toBeInTheDocument()
-    expect(screen.getByText('Your kit information')).toBeInTheDocument()
+    expect(screen.getByText('Your sample collection kit')).toBeInTheDocument()
     expect(screen.getByLabelText('assign-qr')).toBeInTheDocument()
     expect(screen.queryByLabelText('return-qr')).not.toBeInTheDocument()
   })
@@ -56,7 +56,7 @@ describe('KitInstructions', () => {
 
     expect(screen.getByText('Sample Kit Instructions')).toBeInTheDocument()
     expect(screen.queryByText('Consent Required')).not.toBeInTheDocument()
-    expect(screen.getByText('Your kit information')).toBeInTheDocument()
+    expect(screen.getByText('Your sample collection kit')).toBeInTheDocument()
     expect(screen.getByDisplayValue('assigned-barcode')).toBeInTheDocument()
     expect(screen.queryByLabelText('assign-qr')).not.toBeInTheDocument()
   })
@@ -69,7 +69,7 @@ describe('KitInstructions', () => {
         ...mockEnrollee(),
         profileId: mockUseActiveUser().ppUser?.profileId || '',
         consented: true,
-        kitRequests: [mockAssignedKitRequest('COLLECTED', 'SALIVA')]
+        kitRequests: [mockAssignedKitRequest('COLLECTED_BY_STAFF', 'SALIVA')]
       }]
     })
 
@@ -81,7 +81,7 @@ describe('KitInstructions', () => {
 
     expect(screen.getByText('Sample Kit Instructions')).toBeInTheDocument()
     expect(screen.queryByText('Consent Required')).not.toBeInTheDocument()
-    expect(screen.getByText('Your kit information')).toBeInTheDocument()
+    expect(screen.getByText('Your sample collection kit')).toBeInTheDocument()
     expect(screen.queryByDisplayValue('assigned-barcode')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('assign-qr')).not.toBeInTheDocument()
     expect(screen.getByText('A member of the study team has received your sample collection kit.',

--- a/ui-participant/src/hub/kit/KitInstructions.tsx
+++ b/ui-participant/src/hub/kit/KitInstructions.tsx
@@ -62,14 +62,14 @@ const KitContent = ({ enrollee }: { enrollee: Enrollee }) => {
 
 const UnconsentedKitView = () => {
   return (
-    <div className="mb-3 rounded round-3 p-3 bg-white shadow-sm">
+    <div className="mb-3 rounded round-3 py-4 px-md-5 bg-white shadow-sm">
       <h2 className="d-flex align-items-center mb-3">
         <FontAwesomeIcon className="text-danger me-2" icon={faCircleExclamation}/> Consent Required
       </h2>
-      <div className="mb-3">
+      <div className="pb-3">
         Before completing a sample collection kit, you must read and sign the study consent form.
       </div>
-      <div className="d-flex justify-content-center">
+      <div className="py-3 text-center mb-4" style={{ background: 'var(--brand-color-shift-90)' }}>
         <Link to={'/hub'} className="btn rounded-pill ps-4 pe-4 fw-bold btn-primary">
           Start Consent
         </Link>

--- a/ui-participant/src/hub/kit/KitInstructions.tsx
+++ b/ui-participant/src/hub/kit/KitInstructions.tsx
@@ -12,7 +12,7 @@ export default function KitInstructions() {
   const activeEnrollee = enrollees.find(enrollee => enrollee.profileId === ppUser?.profileId)
 
   return <div
-    className="hub-dashboard-background flex-grow-1"
+    className="hub-dashboard-background flex-grow-1 px-2"
     style={{ background: 'var(--dashboard-background-color)' }}>
     <div className="row mx-0 justify-content-center">
       <div className="my-md-4 mx-auto px-0" style={{ maxWidth: 768 }}>

--- a/ui-participant/src/hub/kit/KitInstructions.tsx
+++ b/ui-participant/src/hub/kit/KitInstructions.tsx
@@ -47,7 +47,11 @@ const BaseKitInstructions = () => {
 }
 
 const KitContent = ({ enrollee }: { enrollee: Enrollee }) => {
-  const activeKit = enrollee.kitRequests.filter(kit => kit.distributionMethod === 'IN_PERSON')[0]
+  //in the event that there are multiple in-person kits for an enrollee, we want to display the most recent one.
+  //the assumption is that there will only ever be one, but in case study staff have to reissue a kit, we want to
+  //display the most recent one
+  const activeKit = enrollee.kitRequests.filter(kit => kit.distributionMethod === 'IN_PERSON')
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0]
 
   if (!enrollee.consented) { return <UnconsentedKitView/> }
   if (!activeKit) { return <NoActiveKitView enrollee={enrollee}/> }

--- a/ui-participant/src/hub/kit/KitInstructions.tsx
+++ b/ui-participant/src/hub/kit/KitInstructions.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import { useActiveUser } from 'providers/ActiveUserProvider'
-import { Enrollee, KitRequest, PortalEnvironment } from '@juniper/ui-core'
-import { usePortalEnv } from 'providers/PortalProvider'
+import { Enrollee, KitRequest } from '@juniper/ui-core'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faBox, faCircleExclamation, faRefresh } from '@fortawesome/free-solid-svg-icons'
 import QRCode from 'react-qr-code'
@@ -10,7 +9,6 @@ import QRCode from 'react-qr-code'
 //TODO: JN-1294, implement i18n for this entire component
 export default function KitInstructions() {
   const { ppUser, enrollees } = useActiveUser()
-  const { portalEnv } = usePortalEnv()
   const activeEnrollee = enrollees.find(enrollee => enrollee.profileId === ppUser?.profileId)
 
   return <div
@@ -20,11 +18,11 @@ export default function KitInstructions() {
       <div className="my-md-4 mx-auto" style={{ maxWidth: 768 }}>
         <div className="card-body">
           <div className="align-items-center">
-            <BaseKitInstructions portalEnv={portalEnv}/>
+            <BaseKitInstructions/>
             {activeEnrollee ?
               <KitContent enrollee={activeEnrollee}/> :
               <div className="text-danger">
-                No enrollee found. Please contact a member of the study team.
+                No enrollee found. Please contact a member of the study team for assistance.
               </div>
             }
           </div>
@@ -34,19 +32,16 @@ export default function KitInstructions() {
   </div>
 }
 
-const BaseKitInstructions = ({ portalEnv }: { portalEnv: PortalEnvironment }) => {
-  const studySupportEmail = portalEnv.portalEnvironmentConfig.emailSourceAddress
-
+const BaseKitInstructions = () => {
   return <div className="mb-3 rounded round-3 py-4 bg-white px-md-5 shadow-sm">
     <h1 className="pb-3">Sample Kit Instructions</h1>
     <div className="pb-3">
-      If you are receiving a sample collection kit in-person, you will have the option to
-      complete the collection kit now and return it immediately, or take it home and ship it
-      back using the provided return label.
+      If you are completing a sample collection kit in-person, please follow the instructions provided
+        by a member of the study team. Any additional information that you may need, such as your unique
+        participant identifier, will be provided below.
     </div>
     <div className="pb-3">
-      If you have any questions, please ask a member of the
-      study team or email <a href={`mailto:${studySupportEmail}`}>{studySupportEmail}</a>
+      If you have any questions, please ask a member of the study team.
     </div>
   </div>
 }
@@ -65,14 +60,14 @@ const UnconsentedKitView = () => {
   return (
     <div className="mb-3 rounded round-3 p-3 bg-white shadow-sm">
       <h2 className="d-flex align-items-center mb-3">
-        <FontAwesomeIcon className="text-danger me-1" icon={faCircleExclamation}/> Consent Required
+        <FontAwesomeIcon className="text-danger me-2" icon={faCircleExclamation}/> Consent Required
       </h2>
       <div className="mb-3">
-          Before completing a sample collection kit, you must read and sign the study consent form.
+        Before completing a sample collection kit, you must read and sign the study consent form.
       </div>
       <div className="d-flex justify-content-center">
         <Link to={'/hub'} className="btn rounded-pill ps-4 pe-4 fw-bold btn-primary">
-            Start Consent
+          Start Consent
         </Link>
       </div>
     </div>
@@ -83,7 +78,7 @@ const NoActiveKitView = ({ enrollee }: { enrollee: Enrollee }) => {
   return (
     <div className="mb-3 rounded round-3 py-4 px-md-5 bg-white shadow-sm">
       <h2 className="d-flex align-items-center mb-3">
-        <FontAwesomeIcon className="me-1" icon={faBox}/> Your sample collection kit
+        <FontAwesomeIcon className="me-2" icon={faBox}/> Sample collection kit
       </h2>
       <div>
           To receive a sample collection kit, a member of the study team will scan your unique participation code
@@ -111,7 +106,7 @@ const CollectedKitView = () => {
   return (
     <div className="mb-3 rounded round-3 py-4 bg-white px-md-5 shadow-sm">
       <h2 className="d-flex align-items-center mb-3">
-        <FontAwesomeIcon className="me-1" icon={faBox}/> Your sample collection kit
+        <FontAwesomeIcon className="me-2" icon={faBox}/> Sample collection kit
       </h2>
       <div className="mb-3">
           A member of the study team has received your sample collection kit.
@@ -123,7 +118,7 @@ const CollectedKitView = () => {
       </div>
       <div className="py-3 text-center mb-4" style={{ background: 'var(--brand-color-shift-90)' }}>
         <Link to={'/hub'} className="btn rounded-pill ps-4 pe-4 fw-bold btn-primary">
-                Return to Dashboard
+          Return to Dashboard
         </Link>
       </div>
     </div>
@@ -134,7 +129,7 @@ const DistributedKitView = ({ enrollee, activeKit }: { enrollee: Enrollee, activ
   return (
     <div className="mb-3 rounded round-3 py-4 bg-white px-md-5 shadow-sm px-md-5">
       <h2 className="d-flex align-items-center mb-3">
-        <FontAwesomeIcon className="me-1" icon={faBox}/> Your sample collection kit
+        <FontAwesomeIcon className="me-2" icon={faBox}/> Sample collection kit
       </h2>
       <div className="mb-3">
           A member of the team has provided you with a sample collection kit.
@@ -144,14 +139,14 @@ const DistributedKitView = ({ enrollee, activeKit }: { enrollee: Enrollee, activ
       </div>
       <label className="form-label fw-bold mb-0">Your kit identifier:</label>
       <input
-        className="mb-2 form-control"
+        className="mb-2 form-control bg-white"
         disabled={true}
         placeholder={'No kit provided'}
         value={activeKit.kitBarcode}>
       </input>
       <div className="mt-3">
-              After you have completed the sample collection kit, please return it to a member of the study team
-              and allow them to scan your participation code below.
+          After you have completed the sample collection kit, please return it to a member of the study team
+          and allow them to scan your participation code below.
       </div>
       <div className="d-flex flex-column align-items-center">
         <QRCode value={enrollee.shortcode} size={300}
@@ -159,7 +154,7 @@ const DistributedKitView = ({ enrollee, activeKit }: { enrollee: Enrollee, activ
       </div>
       <div className="py-3 text-center mb-4" style={{ background: 'var(--brand-color-shift-90)' }}>
         <Link to={'/hub'} className="btn rounded-pill ps-4 pe-4 fw-bold btn-primary">
-                  Return to Dashboard
+          Return to Dashboard
         </Link>
       </div>
     </div>

--- a/ui-participant/src/hub/kit/KitInstructions.tsx
+++ b/ui-participant/src/hub/kit/KitInstructions.tsx
@@ -146,7 +146,7 @@ const DistributedKitView = ({ enrollee, activeKit }: { enrollee: Enrollee, activ
         className="mb-2 form-control bg-white"
         disabled={true}
         placeholder={'No kit provided'}
-        value={activeKit.kitBarcode}>
+        value={activeKit.kitLabel}>
       </input>
       <div className="mt-3">
           After you have completed the sample collection kit, please return it to a member of the study team

--- a/ui-participant/src/hub/kit/KitInstructions.tsx
+++ b/ui-participant/src/hub/kit/KitInstructions.tsx
@@ -4,7 +4,7 @@ import { useActiveUser } from 'providers/ActiveUserProvider'
 import { Enrollee, KitRequest, PortalEnvironment } from '@juniper/ui-core'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faBox, faCircleExclamation, faHourglassStart, faRefresh } from '@fortawesome/free-solid-svg-icons'
+import { faBox, faCircleExclamation, faRefresh } from '@fortawesome/free-solid-svg-icons'
 import QRCode from 'react-qr-code'
 
 //TODO: JN-1294, implement i18n for this entire component
@@ -16,8 +16,8 @@ export default function KitInstructions() {
   return <div
     className="hub-dashboard-background flex-grow-1"
     style={{ background: 'var(--dashboard-background-color)' }}>
-    <div className="row mx-0 justify-content-center py-4">
-      <div className="col-12 col-sm-10 col-lg-6">
+    <div className="row mx-0 justify-content-center">
+      <div className="my-md-4 mx-auto" style={{ maxWidth: 768 }}>
         <div className="card-body">
           <div className="align-items-center">
             <BaseKitInstructions portalEnv={portalEnv}/>
@@ -37,8 +37,8 @@ export default function KitInstructions() {
 const BaseKitInstructions = ({ portalEnv }: { portalEnv: PortalEnvironment }) => {
   const studySupportEmail = portalEnv.portalEnvironmentConfig.emailSourceAddress
 
-  return <div className="mb-3 rounded round-3 border border-1 p-3 bg-white">
-    <h2 className="fw-bold pb-3">Sample Kit Instructions</h2>
+  return <div className="mb-3 rounded round-3 py-4 bg-white px-md-5 shadow-sm">
+    <h1 className="pb-3">Sample Kit Instructions</h1>
     <div className="pb-3">
       If you are receiving a sample collection kit in-person, you will have the option to
       complete the collection kit now and return it immediately, or take it home and ship it
@@ -56,14 +56,14 @@ const KitContent = ({ enrollee }: { enrollee: Enrollee }) => {
 
   if (!enrollee.consented) { return <UnconsentedKitView/> }
   if (!activeKit) { return <NoActiveKitView enrollee={enrollee}/> }
-  if (activeKit.status === 'COLLECTED') { return <CollectedKitView/> }
+  if (activeKit.status === 'COLLECTED_BY_STAFF') { return <CollectedKitView/> }
 
-  return <ReturnedKitView enrollee={enrollee} activeKit={activeKit}/>
+  return <DistributedKitView enrollee={enrollee} activeKit={activeKit}/>
 }
 
 const UnconsentedKitView = () => {
   return (
-    <div className="mb-3 rounded round-3 border border-1 p-3 bg-white">
+    <div className="mb-3 rounded round-3 p-3 bg-white shadow-sm">
       <h2 className="d-flex align-items-center mb-3">
         <FontAwesomeIcon className="text-danger me-1" icon={faCircleExclamation}/> Consent Required
       </h2>
@@ -81,23 +81,23 @@ const UnconsentedKitView = () => {
 
 const NoActiveKitView = ({ enrollee }: { enrollee: Enrollee }) => {
   return (
-    <div className="mb-3 rounded round-3 border border-1 p-3 bg-white">
+    <div className="mb-3 rounded round-3 py-4 px-md-5 bg-white shadow-sm">
       <h2 className="d-flex align-items-center mb-3">
-        <FontAwesomeIcon className="me-1" icon={faHourglassStart}/> Your kit information
+        <FontAwesomeIcon className="me-1" icon={faBox}/> Your sample collection kit
       </h2>
-      <div className="mb-3">
-          To receive a sample collection kit, a member of the study team will scan your unique QR code below to
-          associate a kit with your account.
+      <div>
+          To receive a sample collection kit, a member of the study team will scan your unique participation code
+          below to associate a sample kit with your account.
       </div>
       <div className="d-flex flex-column align-items-center">
-        <QRCode value={enrollee.shortcode} size={200}
-          className={'pb-3'} aria-label={'assign-qr'}/>
+        <QRCode value={enrollee.shortcode} size={300}
+          className={'m-5 p-4 border rounded-3 shadow-lg'} aria-label={'assign-qr'}/>
       </div>
       <div className="pb-3">
-          Once you have received a kit, please refresh this page to view the kit information and
-          view further instructions.
+          Once you have received a kit, please refresh this page to view your kit information and
+          receive further instructions.
       </div>
-      <div className="d-flex justify-content-center">
+      <div className="py-3 text-center mb-4" style={{ background: 'var(--brand-color-shift-90)' }}>
         <button className="btn rounded-pill ps-4 pe-4 fw-bold btn-primary"
           onClick={() => window.location.reload()}>
           <FontAwesomeIcon icon={faRefresh}/> Refresh
@@ -109,53 +109,58 @@ const NoActiveKitView = ({ enrollee }: { enrollee: Enrollee }) => {
 
 const CollectedKitView = () => {
   return (
-    <div className="mb-3 rounded round-3 border border-1 p-3 bg-white">
+    <div className="mb-3 rounded round-3 py-4 bg-white px-md-5 shadow-sm">
       <h2 className="d-flex align-items-center mb-3">
-        <FontAwesomeIcon className="me-1" icon={faBox}/> Your kit information
+        <FontAwesomeIcon className="me-1" icon={faBox}/> Your sample collection kit
       </h2>
       <div className="mb-3">
-          A member of the study team has received your sample collection kit. Thank you for your participation.
+          A member of the study team has received your sample collection kit.
           You will receive an email notification when your sample has been processed, and you will be able
-          to view your results on your study dashboard.
+          to view the status of the sample on your study dashboard.
       </div>
-      <div className="d-flex justify-content-center">
+      <div className="mb-3">
+          Thank you for your participation.
+      </div>
+      <div className="py-3 text-center mb-4" style={{ background: 'var(--brand-color-shift-90)' }}>
         <Link to={'/hub'} className="btn rounded-pill ps-4 pe-4 fw-bold btn-primary">
-            Return to Dashboard
+                Return to Dashboard
         </Link>
       </div>
     </div>
   )
 }
 
-const ReturnedKitView = ({ enrollee, activeKit }: { enrollee: Enrollee, activeKit: KitRequest }) => {
+const DistributedKitView = ({ enrollee, activeKit }: { enrollee: Enrollee, activeKit: KitRequest }) => {
   return (
-    <div className="mb-3 rounded round-3 border border-1 p-3 bg-white">
+    <div className="mb-3 rounded round-3 py-4 bg-white px-md-5 shadow-sm px-md-5">
       <h2 className="d-flex align-items-center mb-3">
-        <FontAwesomeIcon className="me-1" icon={faBox}/> Your kit information
+        <FontAwesomeIcon className="me-1" icon={faBox}/> Your sample collection kit
       </h2>
       <div className="mb-3">
           A member of the team has provided you with a sample collection kit.
           This sample kit is associated with your account. If you are assisting someone else with their
-          sample collection kit, please ensure that each participant completes their own sample collection kit.
+          sample collection kit, please ensure that each participant completes the sample collection
+          kit that was assigned to them.
       </div>
-      <label className="form-label fw-bold mb-0">Your unique kit identifier:</label>
+      <label className="form-label fw-bold mb-0">Your kit identifier:</label>
       <input
-        className="my-2 form-control"
+        className="mb-2 form-control"
         disabled={true}
         placeholder={'No kit provided'}
         value={activeKit.kitBarcode}>
       </input>
-      <div className="mb-3 mt-3">
-          After you have completed the sample collection kit, please return it to a member of the study team
-          and show them the QR code below.
+      <div className="mt-3">
+              After you have completed the sample collection kit, please return it to a member of the study team
+              and allow them to scan your participation code below.
       </div>
       <div className="d-flex flex-column align-items-center">
-        <QRCode value={enrollee.shortcode} size={200}
-          className={'pb-3'} aria-label={'return-qr'}/>
+        <QRCode value={enrollee.shortcode} size={300}
+          className={'m-5 p-4 border rounded-3 shadow-lg'} aria-label={'return-qr'}/>
       </div>
-      <div className="mb-3 mt-3">
-          If you wish to complete your sample kit at a later time, you may instead
-          choose to return it by shipping it back using the provided return label.
+      <div className="py-3 text-center mb-4" style={{ background: 'var(--brand-color-shift-90)' }}>
+        <Link to={'/hub'} className="btn rounded-pill ps-4 pe-4 fw-bold btn-primary">
+                  Return to Dashboard
+        </Link>
       </div>
     </div>
   )

--- a/ui-participant/src/hub/kit/KitInstructions.tsx
+++ b/ui-participant/src/hub/kit/KitInstructions.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import { useActiveUser } from 'providers/ActiveUserProvider'
 import { Enrollee, KitRequest } from '@juniper/ui-core'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faBox, faCircleExclamation, faRefresh } from '@fortawesome/free-solid-svg-icons'
+import { faCircleExclamation, faRefresh } from '@fortawesome/free-solid-svg-icons'
 import QRCode from 'react-qr-code'
 
 //TODO: JN-1294, implement i18n for this entire component
@@ -15,7 +15,7 @@ export default function KitInstructions() {
     className="hub-dashboard-background flex-grow-1"
     style={{ background: 'var(--dashboard-background-color)' }}>
     <div className="row mx-0 justify-content-center">
-      <div className="my-md-4 mx-auto" style={{ maxWidth: 768 }}>
+      <div className="my-md-4 mx-auto px-0" style={{ maxWidth: 768 }}>
         <div className="card-body">
           <div className="align-items-center">
             <BaseKitInstructions/>
@@ -78,7 +78,7 @@ const NoActiveKitView = ({ enrollee }: { enrollee: Enrollee }) => {
   return (
     <div className="mb-3 rounded round-3 py-4 px-md-5 bg-white shadow-sm">
       <h2 className="d-flex align-items-center mb-3">
-        <FontAwesomeIcon className="me-2" icon={faBox}/> Sample collection kit
+        Your sample collection kit
       </h2>
       <div>
           To receive a sample collection kit, a member of the study team will scan your unique participation code
@@ -106,7 +106,7 @@ const CollectedKitView = () => {
   return (
     <div className="mb-3 rounded round-3 py-4 bg-white px-md-5 shadow-sm">
       <h2 className="d-flex align-items-center mb-3">
-        <FontAwesomeIcon className="me-2" icon={faBox}/> Sample collection kit
+        Your sample collection kit
       </h2>
       <div className="mb-3">
           A member of the study team has received your sample collection kit.
@@ -129,7 +129,7 @@ const DistributedKitView = ({ enrollee, activeKit }: { enrollee: Enrollee, activ
   return (
     <div className="mb-3 rounded round-3 py-4 bg-white px-md-5 shadow-sm px-md-5">
       <h2 className="d-flex align-items-center mb-3">
-        <FontAwesomeIcon className="me-2" icon={faBox}/> Sample collection kit
+        Your sample collection kit
       </h2>
       <div className="mb-3">
           A member of the team has provided you with a sample collection kit.

--- a/ui-participant/src/test-utils/test-participant-factory.ts
+++ b/ui-participant/src/test-utils/test-participant-factory.ts
@@ -114,7 +114,7 @@ export const mockAssignedKitRequest = (kitStatus: string, kitType: string): KitR
   return {
     ...mockKitRequest(kitStatus, kitType),
     distributionMethod: 'IN_PERSON',
-    kitBarcode: 'assigned-barcode',
+    kitLabel: 'assigned-label',
     returnTrackingNumber: 'some-tracking'
   }
 }

--- a/ui-participant/src/test-utils/test-participant-factory.ts
+++ b/ui-participant/src/test-utils/test-participant-factory.ts
@@ -1,5 +1,4 @@
 import {
-  KitRequest,
   KitType,
   ParticipantTask,
   ParticipantTaskStatus,
@@ -9,7 +8,7 @@ import {
 import {
   defaultSurvey,
   Enrollee,
-  HubResponse,
+  HubResponse, KitRequest,
   ParticipantUser,
   Profile
 } from '@juniper/ui-core'
@@ -20,6 +19,7 @@ export const mockParticipantUser: () => ParticipantUser = () => {
   return {
     id: 'user1',
     username: 'mockUser1@mock.com',
+    shortcode: 'ACC_fakeShortcode',
     token: 'fakeToken',
     lastLogin: 0
   }
@@ -100,6 +100,8 @@ export const mockKitRequest = (kitStatus: string, kitType: string): KitRequest =
   return {
     id: 'kitRequest1',
     kitType: mockKitType(kitType),
+    distributionMethod: 'MAILED',
+    skipAddressValidation: false,
     createdAt: now,
     status: kitStatus,
     sentToAddress: '123 Main St',
@@ -112,7 +114,8 @@ export const mockAssignedKitRequest = (kitStatus: string, kitType: string): KitR
   return {
     ...mockKitRequest(kitStatus, kitType),
     distributionMethod: 'IN_PERSON',
-    kitBarcode: 'assigned-barcode'
+    kitBarcode: 'assigned-barcode',
+    returnTrackingNumber: 'some-tracking'
   }
 }
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Note that this PR is into the branch `mb-jn-1259-assign-kits-updated-ux`, which has already been reviewed. I was holding that PR from being merged until I got these changes in.

Final step is DSM integration which will come in a follow-up PR shortly.

* Adds new step to capture return tracking number when collecting a kit
* Tightens up the participant UX and gets it close to final form. At this point, I imagine only text/wording will change.

Desktop screenshots: 
![screencapture-sandbox-ourhealth-localhost-3001-hub-kits-2024-09-16-20_40_50](https://github.com/user-attachments/assets/42520a31-f2c7-4778-9385-7386ac155da8)

![screencapture-sandbox-ourhealth-localhost-3001-hub-kits-2024-09-16-20_45_12](https://github.com/user-attachments/assets/9c873c40-a5d8-45af-b800-b3ac69a59607)

![screencapture-sandbox-ourhealth-localhost-3001-hub-kits-2024-09-16-20_46_05](https://github.com/user-attachments/assets/6d12dd34-f8de-448b-a926-0ed4b523bf97)

Note: to reduce number of screenshots, all kit states are shown in this image:
![screencapture-sandbox-ourhealth-localhost-3001-hub-2024-09-17-17_14_54](https://github.com/user-attachments/assets/f453ab69-a291-48bf-a871-9b274a26d402)

MOBILE:

![screencapture-sandbox-ourhealth-localhost-3001-hub-2024-09-17-17_14_43](https://github.com/user-attachments/assets/71ed4146-f2a6-4187-8b29-5570a789d9d0)


![screencapture-sandbox-ourhealth-localhost-3001-hub-kits-2024-09-17-17_12_58](https://github.com/user-attachments/assets/a6b9e66b-2678-4715-9f30-35d83a920954)
![screencapture-sandbox-ourhealth-localhost-3001-hub-kits-2024-09-17-17_13_32](https://github.com/user-attachments/assets/c158b5d8-b53c-4bcb-84f7-18586718d36c)

![screencapture-sandbox-ourhealth-localhost-3001-hub-kits-2024-09-17-17_13_56](https://github.com/user-attachments/assets/07739e65-fea7-4f0d-ae73-fc51cd669a84)

New step in admin collection flow:
![screencapture-localhost-3000-ourhealth-studies-ourheart-env-sandbox-kits-scan-2024-09-16-20_52_16](https://github.com/user-attachments/assets/83ac1dba-61a7-44af-8483-de483ad8c2f3)



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

* Restart admin and participant APIs and repopulate demo
* Log into demo as newbie@test.com and go to https://sandbox.demo.localhost:3001/hub/kits
* Confirm that you see the "Consent Required" warning
* Complete the consent form and go back to the page
* In another tab as an admin, go to the scan kit page: https://localhost:3000/demo/studies/heartdemo/env/sandbox/kits/scan
* Select "Assign a new kit" in step 1
* Complete step 2 by scanning the newbie@test.com's QR code (or check the "enable manual override mode" at the top) and type in `HDNEWB` and hit the search button
* Confirm the user's information in step 3
* Scan some random barcode or enter one manually (any text will do) [see [this doc](https://docs.google.com/document/d/1Icc9gNjHMrw9qZJzkUM5v7zfSyuVnQR0ZhuEhF6X9cA/edit) for example barcodes at the bottom]
* Submit
* Refresh the participant's kit page and confirm that you see the barcode entered in step 4
* Repeat the same steps, but with step 1 set to "Collect a completed kit"
* Use manual override mode to enter in some random tracking number
* Refresh the participant's kit page and confirm that the text indicates that their kit has been collected
* Go to the kit list and confirm you see their kit in the "Collected" status tab
* Also confirm you see the assigned and collected kit on their profile page with the tracking number shown