### PR TITLE
[JN-1339] adding export options for AirTable

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/export/ExportController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/export/ExportController.java
@@ -139,7 +139,7 @@ public class ExportController implements ExportApi {
                 fileFormat != null ? ExportFileFormat.valueOf(fileFormat) : ExportFileFormat.TSV)
             .limit(limit)
             .includeSubHeaders(includeSubHeaders)
-            .excludeModules(excludeModules)
+            .excludeModules(excludeModules != null ? excludeModules : List.of())
             .build();
     return exportOptions;
   }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/export/ExportController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/export/ExportController.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.ByteArrayOutputStream;
+import java.util.List;
 import java.util.Objects;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
@@ -53,6 +54,8 @@ public class ExportController implements ExportApi {
       Boolean splitOptionsIntoColumns,
       Boolean stableIdsForOptions,
       Boolean includeOnlyMostRecent,
+      Boolean includeSubheaders,
+      List<String> excludeModules,
       String searchExpression,
       String fileFormat,
       Integer limit) {
@@ -66,7 +69,9 @@ public class ExportController implements ExportApi {
             limit,
             splitOptionsIntoColumns,
             stableIdsForOptions,
-            includeOnlyMostRecent);
+            includeOnlyMostRecent,
+            includeSubheaders,
+            excludeModules);
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     enrolleeExportExtService.export(
@@ -97,7 +102,9 @@ public class ExportController implements ExportApi {
             null,
             splitOptionsIntoColumns,
             stableIdsForOptions,
-            includeOnlyMostRecent);
+            includeOnlyMostRecent,
+            true,
+            List.of());
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     enrolleeExportExtService.exportDictionary(
@@ -113,7 +120,9 @@ public class ExportController implements ExportApi {
       Integer limit,
       Boolean splitOptionsIntoColumns,
       Boolean stableIdsForOptions,
-      Boolean includeOnlyMostRecent) {
+      Boolean includeOnlyMostRecent,
+      Boolean includeSubHeaders,
+      List<String> excludeModules) {
     EnrolleeSearchExpression filter =
         Objects.nonNull(searchExpression) && !searchExpression.isEmpty()
             ? enrolleeSearchExpressionParser.parseRule(searchExpression)
@@ -129,6 +138,8 @@ public class ExportController implements ExportApi {
             .fileFormat(
                 fileFormat != null ? ExportFileFormat.valueOf(fileFormat) : ExportFileFormat.TSV)
             .limit(limit)
+            .includeSubHeaders(includeSubHeaders)
+            .excludeModules(excludeModules)
             .build();
     return exportOptions;
   }

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -1149,6 +1149,8 @@ paths:
         - { name: splitOptionsIntoColumns, in: query, required: false, schema: { type: boolean, default: false } }
         - { name: stableIdsForOptions, in: query, required: false, schema: { type: boolean, default: false } }
         - { name: onlyIncludeMostRecent, in: query, required: false, schema: { type: boolean, default: true } }
+        - { name: includeSubheaders, in: query, required: false, schema: { type: boolean, default: true } }
+        - { name: excludeModules, in: query, required: false, schema: { type: array, items: { type: string } } }
         - { name: filter, in: query, required: false, schema: { type: string, default: '' } }
         - { name: fileFormat, in: query, required: false, schema: { type: string, default: "TSV" } }
         - { name: limit, in: query, required: false, schema: { type: integer } }

--- a/core/src/main/java/bio/terra/pearl/core/service/admin/RolePermissionService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/admin/RolePermissionService.java
@@ -4,6 +4,7 @@ import bio.terra.pearl.core.dao.admin.RolePermissionDao;
 import bio.terra.pearl.core.model.admin.RolePermission;
 import bio.terra.pearl.core.service.ImmutableEntityService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
@@ -19,6 +20,7 @@ public class RolePermissionService extends ImmutableEntityService<RolePermission
         return dao.findAllByRoleIds(roleIds);
     }
 
+    @Transactional
     public void deleteByRoleId(UUID roleId) {
         dao.deleteByRoleId(roleId);
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/admin/RoleService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/admin/RoleService.java
@@ -55,6 +55,7 @@ public class RoleService extends CrudService<Role, RoleDao> {
         return savedRole;
     }
 
+    @Transactional
     public Role update(Role role) {
         rolePermissionService.deleteByRoleId(role.getId());
 

--- a/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoExportService.java
@@ -227,7 +227,7 @@ public class DataRepoExportService {
             List<ModuleFormatter> moduleFormatters = enrolleeExportService.generateModuleInfos(exportOptions, studyEnvironmentId, List.of());
             List<Map<String, String>> enrolleeMaps = enrolleeExportService.generateExportMaps(List.of(), moduleFormatters);
 
-            TsvExporter tsvExporter = new TsvExporter(moduleFormatters, enrolleeMaps);
+            TsvExporter tsvExporter = new TsvExporter(moduleFormatters, enrolleeMaps, ExportFileFormat.TSV);
 
             tsvExporter.applyToEveryColumn((moduleExportInfo, itemExportInfo, choice, isOtherDescription, moduleRepeatNum) -> tdrColumns.add(new TdrColumn(
                     DataRepoExportUtils.juniperToDataRepoColumnName(moduleExportInfo.getColumnKey(itemExportInfo, choice, isOtherDescription, moduleRepeatNum)),

--- a/core/src/main/java/bio/terra/pearl/core/service/export/BaseExporter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/BaseExporter.java
@@ -29,7 +29,11 @@ public abstract class BaseExporter {
         this.columnEmptyValueMap = makeEmptyValueMap();
     }
 
-    public abstract void export(OutputStream os);
+    public void export(OutputStream os) {
+        export(os, true);
+    };
+
+    public abstract void export(OutputStream os, boolean includeSubHeaders);
 
     protected List<String> getColumnKeys() {
         List<String> columnKeys = new ArrayList<>();

--- a/core/src/main/java/bio/terra/pearl/core/service/export/ExportOptions.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/ExportOptions.java
@@ -1,8 +1,12 @@
 package bio.terra.pearl.core.service.export;
 
 import bio.terra.pearl.core.service.search.EnrolleeSearchExpression;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 @SuperBuilder
@@ -14,6 +18,9 @@ public final class ExportOptions {
     private final EnrolleeSearchExpression filter;
     private final ExportFileFormat fileFormat;
     private final Integer limit;
+    private final boolean includeSubHeaders;
+    @Builder.Default
+    private List<String> excludeModules = new ArrayList<>();
 
     public ExportOptions() {
         this.splitOptionsIntoColumns = false;
@@ -22,5 +29,7 @@ public final class ExportOptions {
         this.filter = null;
         this.fileFormat = ExportFileFormat.TSV;
         this.limit = null;
+        this.includeSubHeaders = false;
+        this.excludeModules = new ArrayList<>();
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/JsonExporter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/JsonExporter.java
@@ -19,7 +19,8 @@ public class JsonExporter extends BaseExporter {
         this.objectMapper = objectMapper;
     }
 
-    public void export(OutputStream os) {
+    /** the 'includeSubheaders' parameter is ignored for JSON export -- subheaders are always available in the returned JSON object */
+    public void export(OutputStream os, boolean includeSubHeaders) {
         PrintWriter printWriter = new PrintWriter(os);
         List<String> columnKeys = getColumnKeys();
         List<String> headerRowValues = getHeaderRow();

--- a/core/src/main/java/bio/terra/pearl/core/service/export/TsvExporter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/TsvExporter.java
@@ -12,8 +12,18 @@ import java.util.List;
 import java.util.Map;
 
 public class TsvExporter extends BaseExporter {
-    public TsvExporter(List<ModuleFormatter> moduleExportInfos, List<Map<String, String>> enrolleeMaps) {
+    private final ExportFileFormat fileFormat;
+
+    public TsvExporter(List<ModuleFormatter> moduleExportInfos, List<Map<String, String>> enrolleeMaps, ExportFileFormat fileFormat) {
         super(moduleExportInfos, enrolleeMaps);
+        if (!List.of(ExportFileFormat.CSV, ExportFileFormat.TSV).contains(fileFormat)) {
+            throw new IllegalArgumentException("Invalid file format for TsvExporter: " + fileFormat);
+        }
+        this.fileFormat = fileFormat;
+    }
+
+    public TsvExporter(List<ModuleFormatter> moduleExportInfos, List<Map<String, String>> enrolleeMaps) {
+        this(moduleExportInfos, enrolleeMaps, ExportFileFormat.TSV);
     }
 
     /**
@@ -21,16 +31,20 @@ public class TsvExporter extends BaseExporter {
      * can be supported
      */
     @Override
-    public void export(OutputStream os) {
+    public void export(OutputStream os, boolean includeSubHeaders) {
         try {
-            CSVPrinter writer = CSVFormat.TDF.builder().setRecordSeparator('\n').build().print(new OutputStreamWriter(os));
+            CSVFormat format = fileFormat.equals(ExportFileFormat.TSV) ? CSVFormat.TDF : CSVFormat.DEFAULT;
+            CSVPrinter writer = format.builder().setRecordSeparator('\n').build().print(new OutputStreamWriter(os));
 
             List<String> columnKeys = getColumnKeys();
             List<String> headerRowValues = getHeaderRow();
-            List<String> subHeaderRowValues = getSubHeaderRow();
 
             writer.printRecord(headerRowValues);
-            writer.printRecord(subHeaderRowValues);
+            if (includeSubHeaders) {
+                List<String> subHeaderRowValues = getSubHeaderRow();
+                writer.printRecord(subHeaderRowValues);
+            }
+
             for (Map<String, String> enrolleeMap : enrolleeMaps) {
                 List<String> rowValues = getRowValues(enrolleeMap, columnKeys);
                 writer.printRecord(rowValues);
@@ -42,5 +56,5 @@ public class TsvExporter extends BaseExporter {
             throw new IOInternalException("Error writing TSV file", e);
         }
     }
-    
+
 }

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
@@ -41,6 +41,7 @@ public class PopulateDemoTest extends BasePopulatePortalsTest {
     @Test
     @Transactional
     public void testPopulateDemo() throws Exception {
+        baseSeedPopulator.populateRolesAndPermissions();
         Portal portal = portalPopulator.populate(new FilePopulateContext("portals/demo/portal.json"), true);
         Assertions.assertEquals("demo", portal.getShortcode());
         PortalEnvironment sandbox = portalEnvironmentService.findOne("demo", EnvironmentName.sandbox).get();

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
@@ -41,7 +41,6 @@ public class PopulateDemoTest extends BasePopulatePortalsTest {
     @Test
     @Transactional
     public void testPopulateDemo() throws Exception {
-        baseSeedPopulator.populateRolesAndPermissions();
         Portal portal = portalPopulator.populate(new FilePopulateContext("portals/demo/portal.json"), true);
         Assertions.assertEquals("demo", portal.getShortcode());
         PortalEnvironment sandbox = portalEnvironmentService.findOne("demo", EnvironmentName.sandbox).get();

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -266,6 +266,8 @@ export type ExportOptions = {
   splitOptionsIntoColumns?: boolean,
   stableIdsForOptions?: boolean,
   onlyIncludeMostRecent?: boolean,
+  includeSubheaders?: boolean,
+  excludeModules?: string[],
   filter?: string,
   limit?: number
 }
@@ -1058,11 +1060,7 @@ export default {
     Promise<Response> {
     const exportOptionsParams = exportOptions as Record<string, unknown>
     let url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/export/data?`
-    const searchParams = new URLSearchParams()
-    for (const prop in exportOptionsParams) {
-      searchParams.set(prop, (exportOptionsParams[prop] as string | boolean).toString())
-    }
-    url += searchParams.toString()
+    url += queryString.stringify(exportOptionsParams)
     return fetch(url, this.getGetInit())
   },
 

--- a/ui-admin/src/study/participants/export/ExportDataControl.test.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataControl.test.tsx
@@ -11,7 +11,7 @@ test('renders the file types', async () => {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     <ExportDataControl studyEnvContext={mockStudyEnvContext()} show={true} setShow={() => {}}/>)
   render(RoutedComponent)
-  expect(screen.getByText('Tab-delimted (.tsv)')).toBeInTheDocument()
+  expect(screen.getByText('Tab-delimited (.tsv)')).toBeInTheDocument()
   expect(screen.getByText('Excel (.xlsx)')).toBeInTheDocument()
 })
 

--- a/ui-admin/src/study/participants/export/ExportDataControl.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataControl.tsx
@@ -19,7 +19,7 @@ const FILE_FORMATS = [{
   value: 'TSV',
   fileSuffix: 'tsv'
 }, {
-  label: 'Comma-delimted (.tsv)',
+  label: 'Comma-delimited (.csv)',
   value: 'CSV',
   fileSuffix: 'csv'
 }, {

--- a/ui-admin/src/study/participants/export/ExportDataControl.tsx
+++ b/ui-admin/src/study/participants/export/ExportDataControl.tsx
@@ -8,16 +8,27 @@ import { Link } from 'react-router-dom'
 import { saveBlobAsDownload } from 'util/downloadUtils'
 import { doApiLoad } from 'api/api-utils'
 import { buildFilter } from 'util/exportUtils'
+import { Button } from '../../../components/forms/Button'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons'
+import Select from 'react-select'
+import { useReactMultiSelect } from '../../../util/react-select-utils'
 
 const FILE_FORMATS = [{
-  label: 'Tab-delimted (.tsv)',
+  label: 'Tab-delimited (.tsv)',
   value: 'TSV',
   fileSuffix: 'tsv'
+}, {
+  label: 'Comma-delimted (.tsv)',
+  value: 'CSV',
+  fileSuffix: 'csv'
 }, {
   label: 'Excel (.xlsx)',
   value: 'EXCEL',
   fileSuffix: 'xlsx'
 }]
+
+const MODULE_EXCLUDE_OPTIONS: Record<string, string> = { surveys: 'Surveys' }
 
 /** form for configuring and downloading enrollee data */
 const ExportDataControl = ({ studyEnvContext, show, setShow }: {studyEnvContext: StudyEnvContextT, show: boolean,
@@ -27,14 +38,25 @@ const ExportDataControl = ({ studyEnvContext, show, setShow }: {studyEnvContext:
   const [fileFormat, setFileFormat] = useState(FILE_FORMATS[0])
   const [includeProxiesAsRows, setIncludeProxiesAsRows] = useState(false)
   const [includeUnconsented, setIncludeUnconsented] = useState(false)
-
+  const [includeSubheaders, setIncludeSubheaders] = useState(true)
+  const [showAdvancedOptions, setShowAdvancedOptions] = useState(false)
+  const [excludeModules, setExcludeModules] = useState<string[]>([])
   const [isLoading, setIsLoading] = useState(false)
+
+  const { selectInputId, selectedOptions, options, onChange } = useReactMultiSelect<string>(
+    Object.keys(MODULE_EXCLUDE_OPTIONS),
+    key => ({ label: MODULE_EXCLUDE_OPTIONS[key], value: key }),
+    setExcludeModules,
+    excludeModules
+  )
 
   const optionsFromState = (): ExportOptions => {
     return {
       onlyIncludeMostRecent,
       splitOptionsIntoColumns: !humanReadable,
       stableIdsForOptions: !humanReadable,
+      includeSubheaders,
+      excludeModules,
       filter: buildFilter({ includeProxiesAsRows, includeUnconsented }),
       fileFormat: fileFormat.value
     }
@@ -67,6 +89,10 @@ const ExportDataControl = ({ studyEnvContext, show, setShow }: {studyEnvContext:
     setOnlyIncludeMostRecent(e.target.value === 'true')
   }
 
+  const inlcudeSubheadersChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setIncludeSubheaders(e.target.value === 'true')
+  }
+
   return <Modal show={show} onHide={() => setShow(false)}>
     <Modal.Header closeButton>
       <Modal.Title>
@@ -79,56 +105,83 @@ const ExportDataControl = ({ studyEnvContext, show, setShow }: {studyEnvContext:
           <p className="fw-bold mb-1">
             Data format
           </p>
-          <label className="me-3">
+          <label className="form-control border-0">
             <input type="radio" name="humanReadable" value="true" checked={humanReadable}
               onChange={humanReadableChanged} className="me-1"/> Human-readable
           </label>
-          <label>
+          <label className="form-control border-0">
             <input type="radio" name="humanReadable" value="false" checked={!humanReadable}
               onChange={humanReadableChanged} className="me-1"/> Analysis-friendly
           </label>
         </div>
         <div className="py-2">
-          <p className="fw-bold mb-1">
-            Completions included of a survey (for recurring surveys)
-          </p>
-          <label className="me-3">
-            <input type="radio" name="onlyIncludeMostRecent" value="true" checked={onlyIncludeMostRecent}
-              onChange={includeRecentChanged} className="me-1" disabled={true}/>
-            Only include most recent
-          </label>
-          <label>
-            <input type="radio" name="onlyIncludeMostRecent" value="false" checked={!onlyIncludeMostRecent}
-              onChange={includeRecentChanged} className="me-1" disabled={true}/>
-            Include all completions
-          </label>
-        </div>
-        <div className="py-2">
-          <p className="fw-bold mb-1">
-            Filter Options
-          </p>
-          <label>
-            <input type="checkbox" name="includeUnconsented" checked={includeUnconsented}
-              onChange={() => setIncludeUnconsented(!includeUnconsented)} className="me-1"/>
-            Include enrollees who have not consented
-          </label>
-          <label>
-            <input type="checkbox" name="includeProxiesAsRows" checked={includeProxiesAsRows}
-              onChange={() => setIncludeProxiesAsRows(!includeProxiesAsRows)} className="me-1"/>
-            Include proxies as rows
-          </label>
-        </div>
-
-        <div className="py-2">
           <span className="fw-bold">File format</span><br/>
-          {FILE_FORMATS.map(format => <label className="me-3" key={format.value}>
+          {FILE_FORMATS.map(format => <label className="form-control border-0" key={format.value}>
             <input type="radio" name="fileFormat" value="TSV" checked={fileFormat.value === format.value}
               onChange={() => setFileFormat(format)}
               className="me-1"/>
             {format.label}
           </label>)}
         </div>
+        <div className="py-2">
+          <Button variant="secondary" onClick={() => setShowAdvancedOptions(!showAdvancedOptions)}>
+            <FontAwesomeIcon icon={showAdvancedOptions ? faChevronDown : faChevronUp}/> Advanced Options
+          </Button>
+        </div>
+        { showAdvancedOptions && <div className="px-3">
+          <div className="py-2">
+            <p className="fw-bold mb-1">
+              Completions included of a survey (for recurring surveys)
+            </p>
+            <label className="form-control border-0">
+              <input type="radio" name="onlyIncludeMostRecent" value="true" checked={onlyIncludeMostRecent}
+                onChange={includeRecentChanged} className="me-1" disabled={true}/>
+              Only include most recent
+            </label>
+            <label className="form-control border-0">
+              <input type="radio" name="onlyIncludeMostRecent" value="false" checked={!onlyIncludeMostRecent}
+                onChange={includeRecentChanged} className="me-1" disabled={true}/>
+              Include all completions
+            </label>
+          </div>
+          <div className="py-2">
+            <p className="fw-bold mb-1">
+              Include subheaders for columns
+            </p>
+            <label className="me-3">
+              <input type="radio" name="includeSubheaders" value="true" checked={includeSubheaders}
+                onChange={inlcudeSubheadersChanged} className="me-1"/> Yes
+            </label>
+            <label>
+              <input type="radio" name="includeSubheaders" value="false" checked={!includeSubheaders}
+                onChange={inlcudeSubheadersChanged} className="me-1"/> No
+            </label>
+          </div>
+          <div className="py-2">
+            <p className="fw-bold mb-1">
+              Filter Options
+            </p>
+            <label className="form-control border-0">
+              <input type="checkbox" name="includeUnconsented" checked={includeUnconsented}
+                onChange={() => setIncludeUnconsented(!includeUnconsented)} className="me-1"/>
+              Include enrollees who have not consented
+            </label>
+            <label className="form-control border-0">
+              <input type="checkbox" name="includeProxiesAsRows" checked={includeProxiesAsRows}
+                onChange={() => setIncludeProxiesAsRows(!includeProxiesAsRows)} className="me-1"/>
+              Include proxies as rows
+            </label>
+            <label className="form-control border-0" htmlFor={selectInputId}>
+              Exclude data from the following modules:
+            </label>
+            <Select options={options}
+              isMulti={true} value={selectedOptions}
+              inputId={selectInputId}
+              onChange={onChange}/>
+          </div>
+        </div> }
         <hr/>
+
         <div>
           For more information about download formats,
           see the <Link to="https://broad-juniper.zendesk.com/hc/en-us/articles/18259824756123" target="_blank">

--- a/ui-admin/src/util/react-select-utils.ts
+++ b/ui-admin/src/util/react-select-utils.ts
@@ -69,7 +69,7 @@ export function useReactMultiSelect<T>(items: T[],
 
   const onChange: ((opts: MultiValue<{ label: ReactNode, value: T } | undefined>) => void)
     = (opts: MultiValue<{label: ReactNode, value: T} | undefined>) =>
-    setSelectedItems(opts.map(opt => opt ? opt.value : undefined)
-      .filter(opt => !!opt) as T[])
+      setSelectedItems(opts.map(opt => opt ? opt.value : undefined)
+        .filter(opt => !!opt) as T[])
   return { onChange, options, selectedOptions, selectInputId }
 }

--- a/ui-admin/src/util/react-select-utils.ts
+++ b/ui-admin/src/util/react-select-utils.ts
@@ -1,4 +1,5 @@
-import { Dispatch, SetStateAction, useId } from 'react'
+import { Dispatch, ReactNode, SetStateAction, useId } from 'react'
+import { MultiValue } from 'react-select'
 
 /**
  * helper function for setting up an accessible react-select component, returns the currently selected item, and a
@@ -44,4 +45,31 @@ export function useNonNullReactSingleSelect<T>(items: T[],
 
   const onChange = (opt: {label: React.ReactNode, value: T} | null) => setSelectedItem(opt?.value ?? selectedItem)
   return { onChange, options, selectedOption, selectInputId }
+}
+
+/**
+ * helper function for setting up an accessible react-select component, returns the currently selected item, and a
+ * set of params to pass into the select component
+ *
+ * onChange: pass to the onChange of the <Select>
+ * options: pass to the options of the <Select>
+ * selectedItem: current value, use in your component logic
+ * selectedOption: pass to the "value" of the <Select>
+ * selectInputId: pass ot the of the <Select>
+ *
+ * */
+export function useReactMultiSelect<T>(items: T[],
+  labelFunction: (i: T) => {label: React.ReactNode, value: T},
+  setSelectedItems: Dispatch<SetStateAction<T[]>> | ((x: T[]) => void), selectedItems?: T[]) {
+  const options = items.map(labelFunction)
+  const selectedValues = selectedItems ?? []
+  const selectedOptions = selectedValues.map(
+    value => options.find(opt => opt.value === value))
+  const selectInputId = useId()
+
+  const onChange: ((opts: MultiValue<{ label: ReactNode, value: T } | undefined>) => void)
+    = (opts: MultiValue<{label: ReactNode, value: T} | undefined>) =>
+    setSelectedItems(opts.map(opt => opt ? opt.value : undefined)
+      .filter(opt => !!opt) as T[])
+  return { onChange, options, selectedOptions, selectInputId }
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

AirTable doesn't support TSV, multiple header rows, or more than 500 columns.  So this adds export options to enable exports compatible.  Adding them to the UX will make it easier for manual testing. 

<img width="536" alt="image" src="https://github.com/user-attachments/assets/1f3dad16-375b-4933-8bfd-046f74831386">

<img width="522" alt="image" src="https://github.com/user-attachments/assets/df562959-07e7-422c-9488-63ecc4b0cb84">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy apiAdminApp
2. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/export/dataBrowser
3. try out the new export options UX.