### PR TITLE
[JN-1352] survey auto assign fix

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/survey/Survey.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/Survey.java
@@ -51,7 +51,7 @@ public class Survey extends BaseEntity implements Versioned, PortalAttached {
     @Builder.Default
     private boolean prepopulate = false; // whether to bring forward answers from prior completions (if recur is true)
     @Builder.Default
-    private boolean assignToAllNewEnrollees = true; // whether to assign the survey to all new enrollees by default
+    private boolean autoAssign = true; // whether to assign the survey to enrollees automatically once they meet the eligibility criteria
     @Builder.Default
     private boolean assignToExistingEnrollees = false; // whether to assign the survey automatically to existing enrollees
     @Builder.Default

--- a/core/src/main/resources/db/changelog/changesets/2024_09_18_survey_assign_rename.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_09_18_survey_assign_rename.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: "survey_assign_rename"
+      author: dbush
+      changes:
+        - addColumn:
+            tableName: survey
+            columns:
+              - column: { name: auto_assign, type: boolean, defaultValueBoolean: true, constraints: { nullable: false } }
+        - sql:
+            sql: |
+              update survey set 
+                auto_assign = assign_to_all_new_enrollees;

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -320,6 +320,9 @@ databaseChangeLog:
   - include:
       file: changesets/2024_09_10_participant_shortcode_non_nullable.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2024_09_18_survey_assign_rename.yaml
+      relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyServiceTests.java
@@ -68,7 +68,7 @@ public class SurveyServiceTests extends BaseSpringBootTest {
     public void testFindNoContent(TestInfo info) {
         Survey survey = surveyFactory.builderWithDependencies(getTestName(info)).build();
         survey.setSurveyType(SurveyType.OUTREACH);
-        survey.setAssignToAllNewEnrollees(true);
+        survey.setAutoAssign(true);
         UUID portalId = surveyService.create(survey).getPortalId();
 
         Survey fetchedSurvey = surveyService.findByStableId(survey.getStableId(), portalId).get(0);

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
@@ -11,9 +11,11 @@ import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.audit.ResponsibleEntity;
 import bio.terra.pearl.core.model.participant.Profile;
+import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
+import bio.terra.pearl.core.model.workflow.TaskStatus;
 import bio.terra.pearl.core.model.workflow.TaskType;
 import bio.terra.pearl.core.service.workflow.ParticipantTaskAssignDto;
 import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
@@ -97,6 +99,36 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
         boolean isDuplicate = SurveyTaskDispatcher.isDuplicateTask(studyEnvironmentSurvey, outreachTask2,
                 existingTasks);
         assertTrue(isDuplicate);
+    }
+
+    @Test
+    @Transactional
+    public void testAutoAssign(TestInfo testInfo) {
+        StudyEnvironmentFactory.StudyEnvironmentBundle sandboxBundle = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.sandbox);
+        Survey survey = surveyFactory.buildPersisted(surveyFactory.builderWithDependencies(getTestName(testInfo))
+                .stableId("main")
+                .content("{\"pages\":[{\"elements\":[{\"type\":\"text\",\"name\":\"diagnosis\",\"title\":\"What is your diagnosis?\"}]}]}")
+                        .portalId(sandboxBundle.getPortal().getId())
+                .autoAssign(true));
+        surveyFactory.attachToEnv(survey, sandboxBundle.getStudyEnv().getId(), true);
+        Survey followUpSurvey = surveyFactory.buildPersisted(surveyFactory.builderWithDependencies(getTestName(testInfo))
+                .stableId("followUp")
+                .portalId(sandboxBundle.getPortal().getId())
+                .autoAssign(false));
+        surveyFactory.attachToEnv(followUpSurvey, sandboxBundle.getStudyEnv().getId(), true);
+
+        EnrolleeFactory.EnrolleeBundle sandbox1 = enrolleeFactory.enroll(getTestName(testInfo), sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), sandboxBundle.getPortalEnv().getEnvironmentName());
+
+        // confirm only the main survey is assigned automatically
+        List<ParticipantTask> participantTasks = participantTaskService.findByEnrolleeId(sandbox1.enrollee().getId());
+        assertThat(participantTasks, hasSize(1));
+        assertThat(participantTasks.get(0).getTargetStableId(), equalTo("main"));
+
+        // confirm that even after a survey submit event with a completion, the followup task is still not assigned
+        surveyResponseFactory.submitStringAnswer(participantTasks.get(0), "diagnosis", "sick", true, sandbox1, sandboxBundle.getPortal());
+        participantTasks = participantTaskService.findByEnrolleeId(sandbox1.enrollee().getId());
+        assertThat(participantTasks, hasSize(1));
+        assertThat(participantTasks.get(0).getStatus(), equalTo(TaskStatus.COMPLETE));
     }
 
     @Test

--- a/ui-admin/src/study/surveys/FormOptionsModal.tsx
+++ b/ui-admin/src/study/surveys/FormOptionsModal.tsx
@@ -79,18 +79,22 @@ export const FormOptions = ({ studyEnvContext, initialWorkingForm, updateWorking
               /> Required
             </label>
             <label className="form-label d-block">
-              <input type="checkbox" checked={workingForm.assignToAllNewEnrollees}
+              <input type="checkbox" checked={workingForm.autoAssign}
                 onChange={e => updateWorkingForm({
-                  ...workingForm, assignToAllNewEnrollees: e.target.checked
+                  ...workingForm, autoAssign: e.target.checked
                 })}
-              /> Auto-assign to new participants
+              /> Auto-assign to participants based on eligibility <InfoPopup placement="right" content={<div>
+              if unchecked, the survey must be manually assigned by staff
+              </div>}/>
             </label>
             <label className="form-label d-block">
               <input type="checkbox" checked={workingForm.assignToExistingEnrollees}
                 onChange={e => updateWorkingForm({
                   ...workingForm, assignToExistingEnrollees: e.target.checked
                 })}
-              /> Auto-assign to existing participants
+              /> Auto-assign to existing participants <InfoPopup placement="right" content={<div>
+              If there are already-enrolled participants when this survey is first published, they will be assigned it
+              </div>}/>
             </label>
             <label className="form-label d-block">
               <input type="checkbox" checked={workingForm.autoUpdateTaskAssignments}

--- a/ui-admin/src/study/surveys/FormOptionsModal.tsx
+++ b/ui-admin/src/study/surveys/FormOptionsModal.tsx
@@ -92,7 +92,7 @@ export const FormOptions = ({ studyEnvContext, initialWorkingForm, updateWorking
                 onChange={e => updateWorkingForm({
                   ...workingForm, assignToExistingEnrollees: e.target.checked
                 })}
-              /> Auto-assign to existing participants <InfoPopup placement="right" content={<div>
+              /> Auto-assign to existing participants based on eligibility <InfoPopup placement="right" content={<div>
               If there are already-enrolled participants when this survey is first published, they will be assigned it
               </div>}/>
             </label>

--- a/ui-admin/src/study/surveys/SurveyView.tsx
+++ b/ui-admin/src/study/surveys/SurveyView.tsx
@@ -21,7 +21,7 @@ export type SaveableFormProps = {
   content: string
   answerMappings?: AnswerMapping[]
   required?: boolean
-  assignToAllNewEnrollees?: boolean
+  autoAssign?: boolean
   assignToExistingEnrollees?: boolean
   rule?: string
   allowAdminEdit?: boolean

--- a/ui-core/src/types/forms.ts
+++ b/ui-core/src/types/forms.ts
@@ -35,7 +35,7 @@ export type Survey = VersionedForm & {
   blurb?: string
   required: boolean
   rule?: string
-  assignToAllNewEnrollees: boolean
+  autoAssign: boolean
   assignToExistingEnrollees: boolean
   autoUpdateTaskAssignments: boolean
   recur: boolean
@@ -49,7 +49,7 @@ export type Survey = VersionedForm & {
 
 export const defaultSurvey = {
   required: false,
-  assignToAllNewEnrollees: true,
+  autoAssign: true,
   assignToExistingEnrollees: false,
   autoUpdateTaskAssignments: false,
   recur: false,


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

autoAssignToNewParticipants wasn't behaving as one would expect.  This clarifies the behavior and adds some test cases

![image](https://github.com/user-attachments/assets/56e31c16-e43b-4384-91b7-e879b83a0705)


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy apiAdminApp
2. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/forms/surveys/hd_hd_famHx
3. in the configuration options, set auto assign to false
4. save
5. in the participant list, go to actions -> add synthetic participant
6. add a consented participant
7. go to the details page for that participant, and click on the family history survey
8. confirm you see a message "this task has not been assigned to this participant"
