### PR TITLE
[JN-1304] Add new juniperdemoprod b2c tenant to cors origins

### DIFF
--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PortalController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PortalController.java
@@ -54,7 +54,8 @@ public class PortalController implements PortalApi {
   @Override
   @CrossOrigin(
       origins = {
-        "https://juniperdemodev.b2clogin.com", // Heart Demo (demo only)
+        "https://juniperdemodev.b2clogin.com", // Heart Demo (demo)
+        "https://juniperdemoprod.b2clogin.com", // Demo Portal (prod)
         "https://junipercmidemo.b2clogin.com", // CMI (demo only)
         "https://juniperrgpdemo.b2clogin.com", // RGP (demo only)
         "https://ourhealthdev.b2clogin.com", // OurHealth (demo)

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PublicApiController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/PublicApiController.java
@@ -104,7 +104,8 @@ public class PublicApiController implements PublicApi {
 
   @CrossOrigin(
       origins = {
-        "https://juniperdemodev.b2clogin.com", // Heart Demo (demo only)
+        "https://juniperdemodev.b2clogin.com", // Heart Demo (demo)
+        "https://juniperdemoprod.b2clogin.com", // Demo Portal (prod)
         "https://junipercmidemo.b2clogin.com", // CMI (demo only)
         "https://juniperrgpdemo.b2clogin.com", // RGP (demo only)
         "https://ourhealthdev.b2clogin.com", // OurHealth (demo)

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/SiteMediaController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/SiteMediaController.java
@@ -24,7 +24,8 @@ public class SiteMediaController implements SiteMediaApi {
   @Override
   @CrossOrigin(
       origins = {
-        "https://juniperdemodev.b2clogin.com", // Heart Demo (demo only)
+        "https://juniperdemodev.b2clogin.com", // Heart Demo (demo)
+        "https://juniperdemoprod.b2clogin.com", // Demo Portal (prod)
         "https://junipercmidemo.b2clogin.com", // CMI (demo only)
         "https://juniperrgpdemo.b2clogin.com", // RGP (demo only)
         "https://ourhealthdev.b2clogin.com", // OurHealth (prod)


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds juniperdemoprod to the accepted list of cors origins to allow for proper b2c branding

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Not a good way to test this locally, so just check that any of the existing demo tenants (ourhealth, hearthive, heart demo, cmi) still work properly