### PR TITLE
[JN-1346] Clear unsaved changes when switching env, add margins

### DIFF
--- a/ui-admin/src/study/StudyEnvironmentRouter.tsx
+++ b/ui-admin/src/study/StudyEnvironmentRouter.tsx
@@ -123,7 +123,7 @@ function StudyEnvironmentRouter({ study }: { study: Study }) {
             portalEnv={portalEnv}/>}/>
           <Route path="dataImports" element={<DataImportList studyEnvContext={studyEnvContext}/>}/>
           <Route path="dataImports/:dataImportId" element={<DataImportView studyEnvContext={studyEnvContext}/>}/>
-          <Route path="settings/*" element={<LoadedSettingsView
+          <Route path="settings/*" element={<LoadedSettingsView key={currentEnv.environmentName}
             studyEnvContext={studyEnvContext}
             portalContext={portalContext}/>}
           />

--- a/ui-admin/src/study/settings/SettingsView.tsx
+++ b/ui-admin/src/study/settings/SettingsView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import Api, {
   PortalEnvironment,
   PortalEnvironmentConfig,
@@ -75,7 +75,6 @@ export function LoadedSettingsView(
     }, { setIsLoading: setIsLoadingPortalConfig })
   }
 
-
   const updateStudyConfig = (field: keyof StudyEnvironmentConfig, val: unknown) => {
     setStudyConfig(old => {
       return { ...old, [field]: val }
@@ -92,6 +91,13 @@ export function LoadedSettingsView(
       portalContext.reloadPortal(portalContext.portal.shortcode)
     }, { setIsLoading: setIsLoadingStudyConfig })
   }
+
+  useEffect(() => {
+    setPortalConfig(portalEnv.portalEnvironmentConfig)
+    setHasPortalConfigChanged(false)
+    setStudyConfig(studyEnvContext.currentEnv.studyEnvironmentConfig)
+    setHasStudyConfigChanged(false)
+  }, [studyEnvContext.currentEnv.environmentName])
 
 
   if (isLoadingStudyConfig || isLoadingPortalConfig) {
@@ -114,13 +120,13 @@ export function LoadedSettingsView(
               <li style={navListItemStyle}>
                 <CollapsableMenu header={`Portal Settings`} headerClass="text-black" content={
                   <ul className="list-unstyled">
-                    <li>
+                    <li className={'mb-2'}>
                       <NavLink end to="." className={getLinkCssClasses}>General</NavLink>
                     </li>
-                    <li>
+                    <li className={'mb-2'}>
                       <NavLink to="website" className={getLinkCssClasses}>Website</NavLink>
                     </li>
-                    <li>
+                    <li className={'mb-2'}>
                       <NavLink to="languages" className={getLinkCssClasses}>Languages</NavLink>
                     </li>
                   </ul>
@@ -130,12 +136,12 @@ export function LoadedSettingsView(
                 <CollapsableMenu header={`${studyEnvContext.study.name} Study Settings`} headerClass="text-black"
                   content={
                     <ul className="list-unstyled">
-                      <li>
+                      <li className={'mb-2'}>
                         <NavLink to={`enrollment`} className={getLinkCssClasses}>Study
                           Enrollment</NavLink>
                       </li>
                       <RequireUserPermission superuser>
-                        <li>
+                        <li className={'mb-2'}>
                           <NavLink to={`kits`} className={getLinkCssClasses}>Kits</NavLink>
                         </li>
                       </RequireUserPermission>

--- a/ui-admin/src/study/settings/SettingsView.tsx
+++ b/ui-admin/src/study/settings/SettingsView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import Api, {
   PortalEnvironment,
   PortalEnvironmentConfig,
@@ -91,14 +91,6 @@ export function LoadedSettingsView(
       portalContext.reloadPortal(portalContext.portal.shortcode)
     }, { setIsLoading: setIsLoadingStudyConfig })
   }
-
-  useEffect(() => {
-    setPortalConfig(portalEnv.portalEnvironmentConfig)
-    setHasPortalConfigChanged(false)
-    setStudyConfig(studyEnvContext.currentEnv.studyEnvironmentConfig)
-    setHasStudyConfigChanged(false)
-  }, [studyEnvContext.currentEnv.environmentName])
-
 
   if (isLoadingStudyConfig || isLoadingPortalConfig) {
     return <LoadingSpinner/>


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

From team testing this week, tweaks some margins and clears unsaved state when switching environment

Before
<img width="639" alt="Screenshot 2024-09-18 at 10 31 47 PM" src="https://github.com/user-attachments/assets/17a072be-49ea-4d18-9172-0c75bc795898">

After
<img width="654" alt="Screenshot 2024-09-18 at 10 31 33 PM" src="https://github.com/user-attachments/assets/ebcd3c90-d390-4c9e-9473-c924d8b3e479">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Go to https://localhost:3000/demo/studies/heartdemo/env/live/settings
Confirm that editing settings and switching envs without saving clears the unsaved state