### PR TITLE
[JN-1321] fix github action upload to gcp permissions

### DIFF
--- a/.github/workflows/juniper-eng-infra-upload-image.yml
+++ b/.github/workflows/juniper-eng-infra-upload-image.yml
@@ -3,6 +3,8 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - cb-github-action-fix-permissions
 env:
   SERVICE_NAME: ${{ github.event.repository.name }}
   GOOGLE_PROJECT: broad-juniper-eng-infra
@@ -13,7 +15,7 @@ jobs:
   get-version-tag:
     runs-on: ubuntu-latest
     outputs:
-      tag: ${{ steps.tag.outputs.tag }}
+      tag: perm-test # ${{ steps.tag.outputs.tag }}
     steps:
       - name: Checkout Current Code
         uses: actions/checkout@v3


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

