### PR TITLE
[JN-1360] fix proxy profile mappings

### DIFF
--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/service/SurveyResponseExtService.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/service/SurveyResponseExtService.java
@@ -64,18 +64,17 @@ public class SurveyResponseExtService {
       UUID taskId) {
     Enrollee enrollee =
         authUtilService.authParticipantUserToEnrollee(user.getId(), enrolleeShortcode);
-    PortalWithPortalUser portalWithPortalUser =
-        authUtilService.authParticipantToPortal(
-            enrollee.getParticipantUserId(), portalShortcode, envName);
+    PortalWithPortalUser portalWithOperatorUser =
+        authUtilService.authParticipantToPortal(user.getId(), portalShortcode, envName);
     HubResponse result =
         surveyResponseService.updateResponse(
             response,
             new ResponsibleEntity(user),
             null,
-            portalWithPortalUser.ppUser(),
+            portalWithOperatorUser.ppUser(),
             enrollee,
             taskId,
-            portalWithPortalUser.portal().getId());
+            portalWithOperatorUser.portal().getId());
     return result;
   }
 }

--- a/api-participant/src/test/java/bio/terra/pearl/api/participant/service/SurveyResponseExtServiceTest.java
+++ b/api-participant/src/test/java/bio/terra/pearl/api/participant/service/SurveyResponseExtServiceTest.java
@@ -1,0 +1,107 @@
+package bio.terra.pearl.api.participant.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.pearl.api.participant.BaseSpringBootTest;
+import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
+import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
+import bio.terra.pearl.core.factory.survey.SurveyFactory;
+import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.participant.ParticipantUser;
+import bio.terra.pearl.core.model.participant.PortalParticipantUser;
+import bio.terra.pearl.core.model.participant.Profile;
+import bio.terra.pearl.core.model.survey.*;
+import bio.terra.pearl.core.model.workflow.ParticipantTask;
+import bio.terra.pearl.core.service.participant.ParticipantUserService;
+import bio.terra.pearl.core.service.participant.PortalParticipantUserService;
+import bio.terra.pearl.core.service.participant.ProfileService;
+import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+class SurveyResponseExtServiceTest extends BaseSpringBootTest {
+
+  @Autowired SurveyResponseExtService surveyResponseExtService;
+  @Autowired StudyEnvironmentFactory studyEnvironmentFactory;
+  @Autowired SurveyFactory surveyFactory;
+  @Autowired EnrolleeFactory enrolleeFactory;
+  @Autowired ParticipantUserService participantUserService;
+  @Autowired ParticipantTaskService participantTaskService;
+  @Autowired PortalParticipantUserService portalParticipantUserService;
+  @Autowired ProfileService profileService;
+
+  @Test
+  @Transactional
+  public void testProxyProfileMapping(TestInfo info) {
+
+    StudyEnvironmentFactory.StudyEnvironmentBundle studyEnvironmentBundle =
+        studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.sandbox);
+
+    List<AnswerMapping> answerMappings =
+        List.of(
+            AnswerMapping.builder()
+                .questionStableId("proxyGivenName")
+                .targetType(AnswerMappingTargetType.PROXY_PROFILE)
+                .mapType(AnswerMappingMapType.STRING_TO_STRING)
+                .targetField("givenName")
+                .build());
+
+    Survey survey =
+        surveyFactory.buildPersisted(
+            surveyFactory
+                .builder(getTestName(info))
+                .answerMappings(answerMappings)
+                .portalId(studyEnvironmentBundle.getPortal().getId())
+                .content(
+                    "{\"pages\":[{\"elements\":[{\"type\":\"text\",\"name\":\"proxyGivenName\",\"title\":\"What is your name?\"}]}]}"));
+
+    surveyFactory.attachToEnv(survey, studyEnvironmentBundle.getStudyEnv().getId(), true);
+
+    EnrolleeFactory.EnrolleeAndProxy enrolleeAndProxy =
+        enrolleeFactory.buildProxyAndGovernedEnrollee(
+            getTestName(info),
+            studyEnvironmentBundle.getPortalEnv(),
+            studyEnvironmentBundle.getStudyEnv());
+
+    SurveyResponse response =
+        SurveyResponse.builder()
+            .surveyId(survey.getId())
+            .enrolleeId(enrolleeAndProxy.governedEnrollee().getId())
+            .answers(
+                List.of(
+                    Answer.builder()
+                        .surveyVersion(survey.getVersion())
+                        .surveyStableId(survey.getStableId())
+                        .questionStableId("proxyGivenName")
+                        .stringValue("John")
+                        .build()))
+            .build();
+
+    ParticipantUser proxyUser =
+        participantUserService.find(enrolleeAndProxy.proxy().getParticipantUserId()).get();
+
+    PortalParticipantUser governedPpUser =
+        portalParticipantUserService.findForEnrollee(enrolleeAndProxy.governedEnrollee());
+    ParticipantTask task =
+        participantTaskService
+            .findTaskForActivity(
+                governedPpUser.getId(),
+                studyEnvironmentBundle.getStudyEnv().getId(),
+                survey.getStableId())
+            .get();
+
+    surveyResponseExtService.updateResponse(
+        proxyUser,
+        studyEnvironmentBundle.getPortal().getShortcode(),
+        EnvironmentName.sandbox,
+        response,
+        enrolleeAndProxy.governedEnrollee().getShortcode(),
+        task.getId());
+
+    Profile proxyProfile = profileService.find(enrolleeAndProxy.proxy().getProfileId()).get();
+    assertEquals("John", proxyProfile.getGivenName());
+  }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyParseUtils.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyParseUtils.java
@@ -174,6 +174,8 @@ public class SurveyParseUtils {
                 } else {
                     if (textNode.has("en")) {
                         text = textNode.get("en").asText();
+                    } else if (textNode.has("default")) {
+                        text = textNode.get("default").asText();
                     } else {
                         text = textNode.get("value").asText();
                     }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Code shuffles broke the underlying logic for proxy profile mappings. This is definitely my fault because the code was really unclear that the `ppUser` was supposed to be the `operator` ppuser. There definitely could be clearer code here. For now, this is just a fix + test to get it working again.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Extract CMI template portal from dev
- Create a proxy user
- Fill out the consent & make sure the proxy's name gets populated in their profile