### PR TITLE
[JN-1260] Fix null enrollee on mailed kit requests

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
@@ -96,16 +96,13 @@ public class KitExtService {
                     () ->
                         new NotFoundException(
                             "Enrollee not found for enrolleeShortcode: " + enrolleeShortcode));
-        PortalEnrolleeAuthContext enrolleeAuthContext =
-            PortalEnrolleeAuthContext.of(
+        KitRequestDto createdKit =
+            kitRequestService.requestKit(
                 authContext.getOperator(),
-                authContext.getPortalShortcode(),
                 authContext.getStudyShortcode(),
-                authContext.getEnvironmentName(),
-                enrolleeShortcode);
-        enrolleeAuthContext.setEnrollee(enrollee);
-        KitRequestDto kitDto = requestKit(enrolleeAuthContext, kitRequestCreationDto);
-        response.addKitRequest(kitDto);
+                enrollee,
+                kitRequestCreationDto);
+        response.addKitRequest(createdKit);
       } catch (Exception e) {
         // add the enrollee shortcode to the message for disambiguation.  Once we refine the UX for
         // this, a structured response might be useful here

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
@@ -8,6 +8,7 @@ import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
+import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.kit.KitRequestDto;
 import bio.terra.pearl.core.service.kit.KitRequestService;
 import bio.terra.pearl.core.service.kit.pepper.PepperApiException;
@@ -91,7 +92,10 @@ public class KitExtService {
             enrolleeService
                 .findByShortcodeAndStudyEnvId(
                     enrolleeShortcode, authContext.getStudyEnvironment().getId())
-                .get();
+                .orElseThrow(
+                    () ->
+                        new NotFoundException(
+                            "Enrollee not found for enrolleeShortcode: " + enrolleeShortcode));
         PortalEnrolleeAuthContext enrolleeAuthContext =
             PortalEnrolleeAuthContext.of(
                 authContext.getOperator(),

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -929,7 +929,7 @@ export default {
     studyShortcode: string,
     envName: string,
     enrolleeShortcode: string,
-    kitOptions: { kitType: string, distributionMethod: string, skipAddressValidation: boolean, kitLabel: string }
+    kitOptions: { kitType: string, distributionMethod: string, skipAddressValidation: boolean, kitLabel?: string }
   ): Promise<string> {
     const url =
       `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/enrollees/${enrolleeShortcode}/requestKit`
@@ -963,7 +963,7 @@ export default {
     studyShortcode: string,
     envName: string,
     enrolleeShortcodes: string[],
-    kitOptions: { kitType: string, skipAddressValidation: boolean }
+    kitOptions: { kitType: string, distributionMethod: string, skipAddressValidation: boolean }
   ): Promise<KitRequestListResponse> {
     const url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/requestKits`
     const response = await fetch(url, {

--- a/ui-admin/src/study/kits/RequestKitsModal.tsx
+++ b/ui-admin/src/study/kits/RequestKitsModal.tsx
@@ -27,7 +27,7 @@ export default function RequestKitsModal({
   const handleSubmit = async () => {
     doApiLoad(async () => {
       const response = await Api.requestKits(portal.shortcode, study.shortcode, currentEnv.environmentName,
-        enrolleeShortcodes, { kitType, skipAddressValidation })
+        enrolleeShortcodes, { kitType, distributionMethod: 'MAILED', skipAddressValidation })
       if (response.exceptions.length) {
         const errorMessage = response.exceptions
           .map(exception => exception.message).join('; ')

--- a/ui-admin/src/study/participants/RequestKitModal.tsx
+++ b/ui-admin/src/study/participants/RequestKitModal.tsx
@@ -27,7 +27,7 @@ export default function RequestKitModal({
     setIsLoading(true)
     try {
       await Api.createKitRequest(portal.shortcode, study.shortcode,
-        currentEnv.environmentName, enrolleeShortcode, { kitType, skipAddressValidation })
+        currentEnv.environmentName, enrolleeShortcode, { kitType, distributionMethod: 'MAILED', skipAddressValidation })
       Store.addNotification(successNotification('Kit request created'))
       onSubmit()
     } catch (e) {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Fixes an issue where the enrollee would be null for bulk mailed kit requests. This ensures that it's properly added to the authcontext.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Restart admin API
Turn OFF development realm and mock DSM for OurHealth sandbox
Confirm you can send bulk kits: https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/kits/eligible
Confirm you can send individual kits: https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/participants/OHBASC/kitRequests