### PR TITLE
[JN-1378] handle paneldynamic errors better

### DIFF
--- a/ui-admin/src/forms/formContentValidation.test.ts
+++ b/ui-admin/src/forms/formContentValidation.test.ts
@@ -160,6 +160,35 @@ describe('validateFormContent', () => {
     expect(errors[0]).toBe(`Duplicate element name: test`)
   })
 
+  it('validateElementNames returns an error if two elements have a duplicate name within paneldynamic', () => {
+    const formContent: FormContent = {
+      title: 'test',
+      pages: [
+        {
+          elements: [
+            {
+              name: 'test',
+              type: 'paneldynamic',
+              templateElements: [
+                {
+                  name: 'test',
+                  type: 'text',
+                  title: 'test title'
+                }
+              ],
+              title: 'test title'
+            }
+          ]
+        }
+      ]
+    } as FormContent
+
+    const elements = getAllElements(formContent)
+    const errors = validateElementNames(elements)
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toBe(`Duplicate element name: test`)
+  })
+
   it('validateElementTypes returns an error if an element is missing a type', () => {
     const formContent: FormContent = {
       title: 'test',

--- a/ui-admin/src/forms/formContentValidation.test.ts
+++ b/ui-admin/src/forms/formContentValidation.test.ts
@@ -189,6 +189,45 @@ describe('validateFormContent', () => {
     expect(errors[0]).toBe(`Duplicate element name: test`)
   })
 
+  it('validateElementNames searches deeply nested questions', () => {
+    const formContent: FormContent = {
+      title: 'test',
+      pages: [
+        {
+          elements: [
+            {
+              type: 'panel',
+              elements: [
+                {
+                  name: 'testpanel',
+                  type: 'paneldynamic',
+                  templateElements: [
+                    {
+                      name: 'test',
+                      type: 'text',
+                      title: 'test title'
+                    },
+                    {
+                      name: 'test',
+                      type: 'text',
+                      title: 'test title 2'
+                    }
+                  ]
+                }
+              ],
+              title: 'test title'
+            }
+          ]
+        }
+      ]
+    } as FormContent
+
+    const elements = getAllElements(formContent)
+    const errors = validateElementNames(elements)
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toBe(`Duplicate element name: test`)
+  })
+
   it('validateElementTypes returns an error if an element is missing a type', () => {
     const formContent: FormContent = {
       title: 'test',

--- a/ui-admin/src/forms/formContentValidation.ts
+++ b/ui-admin/src/forms/formContentValidation.ts
@@ -1,4 +1,9 @@
-import { FormContent, HtmlElement, Question, TemplatedQuestion } from '@juniper/ui-core'
+import {
+  FormContent,
+  HtmlElement,
+  Question,
+  TemplatedQuestion
+} from '@juniper/ui-core'
 
 /** Returns a validated FormContent object, or throws an error if invalid. */
 export const validateFormJson = (rawFormContent: unknown): FormContent => {
@@ -110,6 +115,14 @@ export const getAllElements = (formContent: FormContent): (Question | HtmlElemen
         throw new Error(`Error parsing form. Please ensure that all panels have an 'elements' property.`)
       } else {
         return element.elements
+      }
+    } else if ('type' in element && element.type === 'paneldynamic') {
+      if (!('templateElements' in element)) {
+        throw new Error(
+          `Error parsing form. Please ensure that all paneldynamic elements have a 'templateElements' property.`
+        )
+      } else {
+        return element.templateElements.concat(element) // paneldynamic is itself a question
       }
     } else {
       return element

--- a/ui-admin/src/forms/formContentValidation.ts
+++ b/ui-admin/src/forms/formContentValidation.ts
@@ -106,22 +106,22 @@ export const getAllElements = (formContent: FormContent): (Question | HtmlElemen
     if (!('elements' in page)) {
       throw new Error(`Error parsing form. Please ensure that all pages have an 'elements' property.`)
     }
-    return page.elements.flatMap(_getAllElements)
+    return page.elements.flatMap(getAllQuestions)
   }) || []
 }
 
-function _getAllElements(element: FormElement): (Question | HtmlElement)[] {
+function getAllQuestions(element: FormElement): (Question | HtmlElement)[] {
   if ('type' in element && element.type === 'panel') {
     if (!('elements' in element)) {
       throw new Error(`Error parsing form. Please ensure that all panels have an 'elements' property.`)
     }
-    return element.elements?.flatMap(_getAllElements) || []
+    return element.elements?.flatMap(getAllQuestions) || []
   } else if ('type' in element && element.type === 'paneldynamic') {
     if (!('templateElements' in element)) {
       throw new Error(
         `Error parsing form. Please ensure that all panel dynamic elements have a 'templateElements' property.`)
     }
-    return (element.templateElements?.flatMap(_getAllElements) || []).concat(element)
+    return (element.templateElements?.flatMap(getAllQuestions) || []).concat(element)
   }
   return [element]
 }

--- a/ui-core/src/types/forms.ts
+++ b/ui-core/src/types/forms.ts
@@ -154,6 +154,13 @@ export type FormPanel = BaseElement & {
   elements: (HtmlElement | Question)[]
 }
 
+export type FormPanelDynamic = BaseElement & {
+  name: string
+  title: string
+  type: 'paneldynamic'
+  templateElements: (HtmlElement | Question)[]
+}
+
 export type HtmlElement = {
   name: string
   type: 'html'
@@ -237,6 +244,7 @@ export type Question =
   | TemplatedQuestion
   | TextQuestion
   | HtmlQuestion
+  | FormPanelDynamic
 
 export type InteractiveQuestion = Exclude<Question, HtmlQuestion>
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Makes `getAllElements` more robust (recursive + searches through dynamic panels)

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Try out survey with content
```json
{
  "pages": [
    {
      "elements": [
        {
          "name": "testpanel",
          "type": "paneldynamic",
          "templateElements": [
            {
              "type": "text",
              "name": "test",
              "title": "test",
              "description": "",
              "isRequired": false,
              "inputType": "text"
            },
            {
              "type": "text",
              "name": "test",
              "title": "test",
              "description": "",
              "isRequired": false,
              "inputType": "text"
            }
          ]
        }
      ]
    }
  ]
}
```
- verify you get error that prevents you from saving content
- observe unit tests