### PR TITLE
JN-1334 admin task duplicate bug

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
@@ -256,7 +256,7 @@ public class SurveyTaskDispatcher {
                                    List<ParticipantTask> allTasks) {
         return !allTasks.stream()
                 .filter(existingTask ->
-                        List.of(TaskType.SURVEY, TaskType.CONSENT, TaskType.OUTREACH).contains(existingTask.getTaskType()) &&
+                        existingTask.getTaskType().equals(task.getTaskType()) &&
                         existingTask.getTargetStableId().equals(task.getTargetStableId()) &&
                         !isRecurrenceWindowOpen(studySurvey, existingTask))
                 .toList().isEmpty();

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
@@ -82,23 +82,24 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
     }
 
     @Test
-    void testOutreachIsDuplicate() {
+    void testIsDuplicateForTaskTypes() {
         Survey survey = Survey.builder().recur(false).build();
         StudyEnvironmentSurvey studyEnvironmentSurvey = StudyEnvironmentSurvey.builder()
                 .survey(survey)
                 .build();
-        ParticipantTask outreachTask1 = ParticipantTask.builder()
-                .targetStableId("oh_outsideAdvert")
-                .taskType(TaskType.OUTREACH)
-                .build();
-        List<ParticipantTask> existingTasks = List.of(outreachTask1);
-        ParticipantTask outreachTask2 = ParticipantTask.builder()
-                .targetStableId("oh_outsideAdvert")
-                .taskType(TaskType.OUTREACH)
-                .build();
-        boolean isDuplicate = SurveyTaskDispatcher.isDuplicateTask(studyEnvironmentSurvey, outreachTask2,
-                existingTasks);
-        assertTrue(isDuplicate);
+        List.of(TaskType.SURVEY, TaskType.CONSENT, TaskType.OUTREACH, TaskType.ADMIN_FORM).stream().forEach(taskType -> {
+            ParticipantTask surveyTask1 = ParticipantTask.builder()
+                    .targetStableId("TASK_1")
+                    .taskType(taskType)
+                    .build();
+            ParticipantTask surveyTask2 = ParticipantTask.builder()
+                    .targetStableId("TASK_1")
+                    .taskType(taskType)
+                    .build();
+            boolean isDuplicate = SurveyTaskDispatcher.isDuplicateTask(studyEnvironmentSurvey, surveyTask2,
+                    List.of(surveyTask1));
+            assertTrue(isDuplicate);
+        });
     }
 
     @Test


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

We were excluding admin froms from duplicate fitlers.  so every time someone from Hearthive completes a survey, they were getting a new admin form task...  What's weird is that the UI and export still mostly work even for participants with 5+ duplicate admin forms, Rachel only noticed it because there was a discrepancy between the UI and export for one participant.  

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  redeploy ApiAdminApp
2. run `./scripts/populate/populate_portal.sh hearthive`
3. goto `https://localhost:3000/hearthive/studies/hh_registry/env/sandbox/participants/HHNEWB`
4. complete the admin form for them
5. go to `https://localhost:3000/hearthive/studies/hh_registry/env/sandbox/participants/HHNEWB/tasks`, confirm there is only one admin form task.