### PR TITLE
[JN-1258] Clean up admin navbar on mobile

### DIFF
--- a/ui-admin/src/navbar/AdminNavbar.test.tsx
+++ b/ui-admin/src/navbar/AdminNavbar.test.tsx
@@ -29,5 +29,5 @@ test('renders the user menu', async () => {
   render(RoutedComponent)
   expect(screen.getByTitle('user menu')).toBeInTheDocument()
   userEvent.click(screen.getByTitle('user menu'))
-  expect(screen.getByText('testuser123')).toBeInTheDocument()
+  expect(screen.queryAllByText('testuser123')).toHaveLength(2)
 })

--- a/ui-admin/src/navbar/AdminNavbar.tsx
+++ b/ui-admin/src/navbar/AdminNavbar.tsx
@@ -18,45 +18,49 @@ function AdminNavbar() {
   }
   return <>
     <nav className="Navbar navbar navbar-expand-lg navbar-light">
-      <button className="navbar-toggler" type="button" data-bs-toggle="collapse"
+      <ul className="navbar-nav">
+        {breadCrumbs.map((crumb, index) => <li key={index}
+          className="ms-2 d-flex align-items-center">
+          {crumb} {(index < breadCrumbs.length - 1) &&
+            <FontAwesomeIcon icon={faChevronRight} className="fa-xs text-muted"/>}
+        </li>)}
+      </ul>
+      <button className="navbar-toggler mx-2" type="button" data-bs-toggle="collapse"
         data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false"
         aria-label="Toggle navigation">
         <span className="navbar-toggler-icon"></span>
       </button>
       <div className="collapse navbar-collapse z-1" id="navbarSupportedContent">
-        <ul className="navbar-nav ms-lg-3">
-          { breadCrumbs.map((crumb, index) => <li key={index}
-            className="ms-2 d-flex align-items-center" >
-            {crumb} {(index < breadCrumbs.length -1) &&
-              <FontAwesomeIcon icon={faChevronRight} className="fa-xs text-muted"/>}
-          </li>)}
-        </ul>
         <ul className="navbar-nav ms-auto" style={{
           position: 'sticky',
           right: 10
         }}>
           <li className="nav-item dropdown">
-            <a className="nav-link" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              <FontAwesomeIcon icon={faQuestionCircle} className="fa-2x nav-icon" title="help menu"/>
+            <a className="d-flex nav-link dropdown-toggle align-items-center"
+              href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <FontAwesomeIcon icon={faQuestionCircle} className="d-none d-lg-inline fa-2x nav-icon" title="help menu"/>
+              <span className="d-lg-none ms-2">Help</span>
             </a>
             <div className="dropdown-menu dropdown-menu-end p-3">
               <ul className="list-unstyled">
                 <li>
                   <Link className="dropdown-item" to="https://broad-juniper.zendesk.com" target="_blank">
-                      Help pages
+                    Help pages
                   </Link>
                 </li>
                 <li className="pt-2">
                   <a className="dropdown-item" onClick={() => setShowContactModal(!showContactModal)}>
-                      Contact support
+                    Contact support
                   </a>
                 </li>
               </ul>
             </div>
           </li>
           {currentUser.user && <li className="nav-item dropdown">
-            <a className="nav-link" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              <FontAwesomeIcon icon={faUserCircle} className="fa-2x nav-icon" title="user menu"/>
+            <a className="d-flex nav-link dropdown-toggle align-items-center"
+              href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              <FontAwesomeIcon icon={faUserCircle} className="d-none d-lg-inline fa-2x nav-icon" title="user menu"/>
+              <span className="d-lg-none ms-2">{currentUser.user.username}</span>
             </a>
             <div className="dropdown-menu dropdown-menu-end p-3">
               <h3 className="h6">{currentUser.user.username}</h3>

--- a/ui-admin/src/navbar/AdminSidebar.tsx
+++ b/ui-admin/src/navbar/AdminSidebar.tsx
@@ -22,9 +22,9 @@ export const sidebarNavLinkClasses = 'text-white p-1 rounded w-100 d-block sideb
 
 /** renders the left navbar of admin tool */
 const AdminSidebar = ({ config }: { config: Config }) => {
-  const HIDE_SIDEBAR_KEY = 'adminSidebar.hide'
+  const SHOW_SIDEBAR_KEY = 'adminSidebar.show'
 
-  const [open, setOpen] = useState(!(localStorage.getItem(HIDE_SIDEBAR_KEY) === 'true'))
+  const [open, setOpen] = useState((localStorage.getItem(SHOW_SIDEBAR_KEY) || 'true') === 'true')
   const { user } = useUser()
   const params = useParams()
 
@@ -46,48 +46,40 @@ const AdminSidebar = ({ config }: { config: Config }) => {
 
   return <div style={{ backgroundColor: color, minHeight: '100vh', minWidth: open ? '250px' : '50px' }}
     className="p-2 pt-3">
-
-    {!open && <Button variant="secondary" className="m-1 text-light" tooltipPlacement={'right'}
-      onClick={() => {
-        setOpen(!open)
-        localStorage.setItem(HIDE_SIDEBAR_KEY, (!open).toString())
-      }}
-      tooltip={open ? 'Hide sidebar' : 'Show sidebar'}>
-      <FontAwesomeIcon icon={faArrowRightFromBracket}
-        className={classNames(open ? 'fa-rotate-180' : '')}/>
-    </Button> }
-    {open && <>
+    <>
       <div className="d-flex justify-content-between align-items-center">
-        <Link to="/" className="text-white fs-4 px-2 rounded-1 sidebar-nav-link flex-grow-1">Juniper</Link>
+        { open && <Link to="/" className="text-white fs-4 px-2 rounded-1 sidebar-nav-link flex-grow-1">Juniper</Link> }
         <Button variant="secondary" className="m-1 text-light" tooltipPlacement={'right'}
           onClick={() => {
             setOpen(!open)
-            localStorage.setItem(HIDE_SIDEBAR_KEY, (!open).toString())
+            localStorage.setItem(SHOW_SIDEBAR_KEY, (!open).toString())
           }}
           tooltip={open ? 'Hide sidebar' : 'Show sidebar'}>
           <FontAwesomeIcon icon={faArrowRightFromBracket}
             className={classNames(open ? 'fa-rotate-180' : '')}/>
         </Button>
       </div>
-      { currentStudy && <StudySidebar study={currentStudy} portalList={portalList}
-        portalShortcode={portalShortcode!}/> }
+      { open && <>
+        { currentStudy && <StudySidebar study={currentStudy} portalList={portalList}
+          portalShortcode={portalShortcode!}/> }
 
-      {user?.superuser && <CollapsableMenu header={'Superuser functions'} content={
-        <ul className="list-unstyled">
-          <li className="mb-2">
-            <NavLink to="/users" className={sidebarNavLinkClasses}>All users</NavLink>
-          </li>
-          <li className="mb-2">
-            <NavLink to="/populate" className={sidebarNavLinkClasses}>Populate</NavLink>
-          </li>
-          <li className="mb-2">
-            <NavLink to="/integrations" className={sidebarNavLinkClasses}>Integrations</NavLink>
-          </li>
-          <li className="mb-2">
-            <NavLink to="/logEvents" className={sidebarNavLinkClasses}>Log Events</NavLink>
-          </li>
-        </ul>}/>}
-    </>}
+        {user?.superuser && <CollapsableMenu header={'Superuser functions'} content={
+          <ul className="list-unstyled">
+            <li className="mb-2">
+              <NavLink to="/users" className={sidebarNavLinkClasses}>All users</NavLink>
+            </li>
+            <li className="mb-2">
+              <NavLink to="/populate" className={sidebarNavLinkClasses}>Populate</NavLink>
+            </li>
+            <li className="mb-2">
+              <NavLink to="/integrations" className={sidebarNavLinkClasses}>Integrations</NavLink>
+            </li>
+            <li className="mb-2">
+              <NavLink to="/logEvents" className={sidebarNavLinkClasses}>Log Events</NavLink>
+            </li>
+          </ul>}/>}
+      </>}
+    </>
   </div>
 }
 

--- a/ui-admin/src/navbar/AdminSidebar.tsx
+++ b/ui-admin/src/navbar/AdminSidebar.tsx
@@ -2,13 +2,15 @@ import React, { useState } from 'react'
 import { useUser } from '../user/UserProvider'
 import { Link, NavLink, useParams } from 'react-router-dom'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faArrowLeft, faArrowRight } from '@fortawesome/free-solid-svg-icons'
+import { faArrowRightFromBracket } from '@fortawesome/free-solid-svg-icons'
 import { Study } from '@juniper/ui-core'
 import { studyShortcodeFromPath } from '../study/StudyRouter'
 import { useNavContext } from './NavContextProvider'
 import { StudySidebar } from './StudySidebar'
 import CollapsableMenu from './CollapsableMenu'
 import { Config } from '../api/api'
+import { Button } from '../components/forms/Button'
+import classNames from 'classnames'
 
 const ZONE_COLORS: { [index: string]: string } = {
   'dev': 'rgb(70 143 124)', // dark green
@@ -20,7 +22,9 @@ export const sidebarNavLinkClasses = 'text-white p-1 rounded w-100 d-block sideb
 
 /** renders the left navbar of admin tool */
 const AdminSidebar = ({ config }: { config: Config }) => {
-  const [open, setOpen] = useState(true)
+  const HIDE_SIDEBAR_KEY = 'adminSidebar.hide'
+
+  const [open, setOpen] = useState(!(localStorage.getItem(HIDE_SIDEBAR_KEY) === 'true'))
   const { user } = useUser()
   const params = useParams()
 
@@ -43,15 +47,27 @@ const AdminSidebar = ({ config }: { config: Config }) => {
   return <div style={{ backgroundColor: color, minHeight: '100vh', minWidth: open ? '250px' : '50px' }}
     className="p-2 pt-3">
 
-    {!open &&  <button onClick={() => setOpen(!open)} title="toggle sidebar" className="btn btn-link text-white">
-      <FontAwesomeIcon icon={faArrowRight}/>
-    </button>}
+    {!open && <Button variant="secondary" className="m-1 text-light" tooltipPlacement={'right'}
+      onClick={() => {
+        setOpen(!open)
+        localStorage.setItem(HIDE_SIDEBAR_KEY, (!open).toString())
+      }}
+      tooltip={open ? 'Hide sidebar' : 'Show sidebar'}>
+      <FontAwesomeIcon icon={faArrowRightFromBracket}
+        className={classNames(open ? 'fa-rotate-180' : '')}/>
+    </Button> }
     {open && <>
       <div className="d-flex justify-content-between align-items-center">
         <Link to="/" className="text-white fs-4 px-2 rounded-1 sidebar-nav-link flex-grow-1">Juniper</Link>
-        <button onClick={() => setOpen(!open)} title="toggle sidebar" className="btn btn-link text-white">
-          <FontAwesomeIcon icon={faArrowLeft}/>
-        </button>
+        <Button variant="secondary" className="m-1 text-light" tooltipPlacement={'right'}
+          onClick={() => {
+            setOpen(!open)
+            localStorage.setItem(HIDE_SIDEBAR_KEY, (!open).toString())
+          }}
+          tooltip={open ? 'Hide sidebar' : 'Show sidebar'}>
+          <FontAwesomeIcon icon={faArrowRightFromBracket}
+            className={classNames(open ? 'fa-rotate-180' : '')}/>
+        </Button>
       </div>
       { currentStudy && <StudySidebar study={currentStudy} portalList={portalList}
         portalShortcode={portalShortcode!}/> }

--- a/ui-admin/src/study/kits/kitcollection/KitScanner.tsx
+++ b/ui-admin/src/study/kits/kitcollection/KitScanner.tsx
@@ -287,14 +287,14 @@ export const KitScanner = ({ studyEnvContext }: { studyEnvContext: StudyEnvConte
             checked={enableManualReturnLabelOverride} onChange={e => {
               setEnableManualReturnLabelOverride(e)
             }}/>
-          { showKitScanner &&
-          <BarcodeScanner
-            expectedFormats={['code_128']}
-            onError={error => setReturnTrackingNumberError(error)}
-            onSuccess={result => {
-              setReturnTrackingNumber(result.rawValue)
-              setShowReturnTrackingNumberScanner(false)
-            }}/>
+          { showReturnTrackingNumberScanner &&
+            <BarcodeScanner
+              expectedFormats={['code_128']}
+              onError={error => setReturnTrackingNumberError(error)}
+              onSuccess={result => {
+                setReturnTrackingNumber(result.rawValue)
+                setShowReturnTrackingNumberScanner(false)
+              }}/>
           }
           <TextInput
             className="my-2"


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

To improve the kit scanning experience, this cleans up the navbar on the admin tool when viewing on a mobile device.

Also adds a local storage entry to remember when the sidebar was hidden, which is particularly important on mobile because the app is essentially unusable unless the sidebar is collapsed.

Mobile before (navbar hidden/expanded):
<img width="296" alt="Screenshot 2024-09-28 at 3 04 20 PM" src="https://github.com/user-attachments/assets/f43061de-a8f5-4459-aed5-193231a728d9"><img width="295" alt="Screenshot 2024-09-28 at 3 04 33 PM" src="https://github.com/user-attachments/assets/e62e8db9-be89-42ca-b548-0c539846e615">


Mobile after (navbar hidden/expanded):
<img width="297" alt="Screenshot 2024-09-28 at 4 03 09 PM" src="https://github.com/user-attachments/assets/70c16c4c-b017-462a-abc1-ae15b3efdfe5"><img width="297" alt="Screenshot 2024-09-28 at 4 03 20 PM" src="https://github.com/user-attachments/assets/86fbc973-daa3-40fc-b837-d59abb1c6f7f">


Desktop after:
<img width="1512" alt="Screenshot 2024-09-28 at 4 04 56 PM" src="https://github.com/user-attachments/assets/f820590a-6130-4fe0-b323-ebeed7308995">




#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Confirm the new navbar and sidebar functionality still works and there aren't any regressions
Confirm that the new styling looks good on mobile