### PR TITLE
[JN-1316] Wrap long answers in survey response view

### DIFF
--- a/ui-admin/src/study/participants/survey/AnswerEditHistory.tsx
+++ b/ui-admin/src/study/participants/survey/AnswerEditHistory.tsx
@@ -30,7 +30,9 @@ export const AnswerEditHistory = ({ question, answer, editHistory, supportedLang
       aria-expanded="false"
     >
       <div className="d-flex align-items-center">
-        <pre className="fw-bold my-0">{getDisplayValue(answer, question)}</pre>
+        <pre className="fw-bold my-0 text-break text-start" style={{ whiteSpace: 'pre-wrap' }}>
+          {getDisplayValue(answer, question)}
+        </pre>
         { editHistory.length > 0 ?
           <FontAwesomeIcon icon={faHistory} className="fa-sm ms-2 text-muted"/> :
           <FontAwesomeIcon icon={faChevronDown} className="fa-sm ms-2 text-muted"/>}


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Prevents long responses from stretching off the screen. We could also truncate them and allow the user to view the full answer with a click, but I think wrap does a good enough job and the UX is simpler

Before
![screencapture-localhost-3000-demo-studies-heartdemo-env-sandbox-participants-HDSALK-surveys-hd-hd-medList-2024-09-29-08_42_09](https://github.com/user-attachments/assets/23e05e27-3f2e-4551-9b2f-37a41a845446)

After
![screencapture-localhost-3000-demo-studies-heartdemo-env-sandbox-participants-HDSALK-surveys-hd-hd-medList-2024-09-29-08_41_48](https://github.com/user-attachments/assets/0498c55e-d217-44a0-9631-09604a08f114)



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Edit a participant response to be very very long
Make sure it wraps correctly when in 'Viewing' mode