### PR TITLE
[JN-1397] fix atcp key ordering problem

### DIFF
--- a/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
+++ b/pepper-import/src/main/java/bio/terra/pearl/pepper/ActivityImporter.java
@@ -479,8 +479,15 @@ public class ActivityImporter {
      */
     public static Map<String, String> getVariableTranslationsTxt(String templateText, Collection<TemplateVariable> templateVariables) {
         Map<String, String> textMap = new HashMap<>();
+
+        List<TemplateVariable> templateVariableCopy = new ArrayList<>(templateVariables);
+
+        // sort variable names by length to ensure that situations like, e.g., $diagnosis_center and $diagnosis_center_country
+        // are handled in the correct order
+        templateVariableCopy.sort(Comparator.comparingInt(var -> -1 * var.getName().length()));
+
         // for each variable, get the translations and replace the variable name with the translation text in the appropriate language
-        for (TemplateVariable var : templateVariables) {
+        for (TemplateVariable var : templateVariableCopy) {
             for (Translation translation : var.getTranslations()) {
                 String languageText = textMap.getOrDefault(translation.getLanguageCode(), StringUtils.trim(templateText));
                 languageText = languageText.replace("$" + var.getName(), translation.getText());


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

final quick fix before kiara does a deep dive into everything that should be changed.

in a couple spots, A-T surveys translated things weirdly because there were keys that were conflicting depending on the order of execution (e.g. `diagnosis_location` and `diagnosis_location_country`). this makes sure it tries the longest key first 

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- n/a, if you want, go check out the contacting physician A-T portal in demo. it's the most up to date, the countries should render as expected. (before it was like "Center for A-T, Center For A-T_country", whereas now it's "Center For A-T, United States", for example)