### PR TITLE
[JN-1353] fixing pop errors

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/config/InitialPopulate.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/config/InitialPopulate.java
@@ -1,7 +1,6 @@
 package bio.terra.pearl.api.admin.config;
 
 import bio.terra.pearl.core.service.admin.AdminUserService;
-import bio.terra.pearl.core.service.i18n.LanguageTextService;
 import bio.terra.pearl.populate.service.BaseSeedPopulator;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
@@ -14,7 +13,6 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class InitialPopulate {
   @Autowired private AdminUserService adminUserService;
-  @Autowired private LanguageTextService languageTextService;
   @Autowired private BaseSeedPopulator baseSeedPopulator;
 
   @EventListener(ApplicationReadyEvent.class)

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/config/InitialPopulate.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/config/InitialPopulate.java
@@ -19,17 +19,31 @@ public class InitialPopulate {
 
   @EventListener(ApplicationReadyEvent.class)
   public void populateSeedIfNeeded() throws IOException {
+    if (isJUnitTest()) {
+      log.info("Skipping seed populate for JUnit test");
+      return;
+    }
     if (adminUserService.count() == 0) {
       log.info("No admin users found, populating base");
       baseSeedPopulator.populate("seed");
     } else {
       log.info("Existing admin users found, skipping seed populate");
     }
+
     log.info("Repopulating core language texts");
     baseSeedPopulator.populateLanguageTexts();
     log.info("Repopulating roles and permissions");
     baseSeedPopulator.populateRolesAndPermissions();
     log.info("Repopulating kit types");
     baseSeedPopulator.populateKitTypes();
+  }
+
+  public static boolean isJUnitTest() {
+    for (StackTraceElement element : Thread.currentThread().getStackTrace()) {
+      if (element.getClassName().startsWith("org.junit.")) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/admin/AdminUserExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/admin/AdminUserExtServiceTests.java
@@ -65,6 +65,7 @@ public class AdminUserExtServiceTests extends BaseSpringBootTest {
   @Transactional
   public void testCreateNewAdminAndPortalUser(TestInfo info) {
     Portal portal = portalFactory.buildPersisted(getTestName(info));
+    roleFactory.buildPersistedCreatePermissions("study_admin", List.of("admin_user_edit"));
     AdminUserBundle operatorBundle =
         portalAdminUserFactory.buildPersistedWithRoles(
             getTestName(info), portal, List.of("study_admin"));
@@ -88,6 +89,7 @@ public class AdminUserExtServiceTests extends BaseSpringBootTest {
     /** add a user already in another portal to a new portal */
     Portal portal = portalFactory.buildPersisted(getTestName(info));
     Portal portal2 = portalFactory.buildPersisted(getTestName(info));
+    roleFactory.buildPersistedCreatePermissions("study_admin", List.of("admin_user_edit"));
     AdminUserBundle operatorBundle =
         portalAdminUserFactory.buildPersistedWithRoles(
             getTestName(info), portal, List.of("study_admin"));
@@ -113,6 +115,8 @@ public class AdminUserExtServiceTests extends BaseSpringBootTest {
   @Transactional
   public void testGetAttachesRolesAndPermissions(TestInfo info) {
     Portal portal = portalFactory.buildPersisted(getTestName(info));
+    roleFactory.buildPersistedCreatePermissions("study_admin", List.of("admin_user_edit"));
+    roleFactory.buildPersisted("prototype_tester");
     AdminUserBundle adminUserBundle =
         portalAdminUserFactory.buildPersistedWithPortals(getTestName(info), List.of(portal));
     portalAdminUserRoleService.setRoles(
@@ -139,6 +143,7 @@ public class AdminUserExtServiceTests extends BaseSpringBootTest {
   public void testSetRolesLimitedByOperator(TestInfo info) {
     Portal portal = portalFactory.buildPersisted(getTestName(info));
     Role role1 = roleFactory.buildPersisted(getTestName(info));
+    roleFactory.buildPersistedCreatePermissions("study_admin", List.of("admin_user_edit"));
 
     AdminUserBundle operatorBundle =
         portalAdminUserFactory.buildPersistedWithRoles(
@@ -181,6 +186,7 @@ public class AdminUserExtServiceTests extends BaseSpringBootTest {
   public void testSetRolesAllowsExistingOperator(TestInfo info) {
     Portal portal = portalFactory.buildPersisted(getTestName(info));
     Role role1 = roleFactory.buildPersisted(getTestName(info));
+    roleFactory.buildPersistedCreatePermissions("study_admin", List.of("admin_user_edit"));
 
     AdminUserBundle operatorBundle =
         portalAdminUserFactory.buildPersistedWithRoles(
@@ -188,12 +194,12 @@ public class AdminUserExtServiceTests extends BaseSpringBootTest {
 
     AdminUserBundle userBundle =
         portalAdminUserFactory.buildPersistedWithRoles(
-            getTestName(info), portal, List.of("publisher"));
+            getTestName(info), portal, List.of(role1.getName()));
 
     adminUserExtService.setPortalUserRoles(
         PortalAuthContext.of(operatorBundle.user(), portal.getShortcode()),
         userBundle.user().getId(),
-        List.of("study_admin", "publisher"));
+        List.of("study_admin", role1.getName()));
 
     assertThat(
         portalAdminUserFactory.userHasRole(

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/auth/EnforcePortalEnrolleePermissionTest.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/auth/EnforcePortalEnrolleePermissionTest.java
@@ -210,7 +210,9 @@ public class EnforcePortalEnrolleePermissionTest extends BaseSpringBootTest {
     AdminUser operator = operatorBundle.user();
     UUID portalAdminUserId = operatorBundle.portalAdminUsers().get(0).getId();
 
-    Role role = roleFactory.buildPersisted(getTestName(info), List.of("participant_data_view"));
+    Role role =
+        roleFactory.buildPersistedCreatePermissions(
+            getTestName(info), List.of("participant_data_view"));
     DataAuditInfo auditInfo = DataAuditInfo.builder().systemProcess(getTestName(info)).build();
     portalAdminUserRoleService.create(
         PortalAdminUserRole.builder()

--- a/core/src/main/java/bio/terra/pearl/core/model/admin/PortalAdminUserRole.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/admin/PortalAdminUserRole.java
@@ -17,5 +17,4 @@ public class PortalAdminUserRole extends BaseEntity {
     private UUID portalAdminUserId;
     private Role role;
     private UUID roleId;
-    private UUID studyId;
 }

--- a/core/src/main/resources/db/changelog/changesets/2024_02_09_permission_populate.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_02_09_permission_populate.yaml
@@ -1,4 +1,4 @@
-databaseChangeLog:
+databaseChangeLog:  # This script is DEPRECATED -- it has been replaced by RolePopulator.  This has been removed from the changelog
   - changeSet:
       id: "add_initial_permissions"
       author: dbush

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -213,9 +213,6 @@ databaseChangeLog:
       file: changesets/2024_02_23_rename_site_image.yaml
       relativeToChangelogFile: true
   - include:
-      file: changesets/2024_02_09_permission_populate.yaml
-      relativeToChangelogFile: true
-  - include:
       file: changesets/2024_03_05_portal_user_constraints.yaml
       relativeToChangelogFile: true
   - include:

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/admin/RoleFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/admin/RoleFactory.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.factory.admin;
 
 import bio.terra.pearl.core.model.admin.Role;
+import bio.terra.pearl.core.service.admin.PermissionService;
 import bio.terra.pearl.core.service.admin.RoleService;
 import java.util.List;
 
@@ -13,6 +14,10 @@ public class RoleFactory {
 
     @Autowired
     private RoleService roleService;
+    @Autowired
+    private PermissionFactory permissionFactory;
+    @Autowired
+    private PermissionService permissionService;
 
     private Role.RoleBuilder builder(String roleName) {
         return Role.builder().name(roleName).description(roleName + "_" + RandomStringUtils.randomAlphabetic(4));
@@ -24,6 +29,14 @@ public class RoleFactory {
     }
 
     public Role buildPersisted(String roleName, List<String> permissions) {
+        Role role = builder(roleName).build();
+        return roleService.create(role, permissions);
+    }
+
+    public Role buildPersistedCreatePermissions(String roleName, List<String> permissions) {
+        for (String permName : permissions) {
+            permissionFactory.buildPersisted(permName);
+        }
         Role role = builder(roleName).build();
         return roleService.create(role, permissions);
     }

--- a/populate/src/main/resources/seed/iam/roles.json
+++ b/populate/src/main/resources/seed/iam/roles.json
@@ -33,7 +33,7 @@
     "name": "prototype_tester",
     "displayName": "Prototype access",
     "description": "Use features being prototyped",
-    "permissionNames": ["team_roles_edit"]
+    "permissionNames": []
   },
   {
     "name": "power_user",

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateOurhealthTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateOurhealthTest.java
@@ -43,6 +43,7 @@ public class PopulateOurhealthTest extends BasePopulatePortalsTest {
     @Test
     @Transactional
     public void testPopulateOurHealth() throws Exception {
+        baseSeedPopulator.populateRolesAndPermissions();
         Portal portal = portalPopulator.populate(new FilePopulateContext("portals/ourhealth/portal.json"), true);
         Assertions.assertEquals("ourhealth", portal.getShortcode());
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

We were getting occasional role population errors in tests.  I suspect the cause is that this startup script was running any time the application was starting, but because it triggers on applicationReady, it might not be within the transactional wrapper of the test.  At least, that's the theory.  So we're disabling this method for unit tests.  

Ordinarily, detecting whether you're inside a test and behaving differently is a bad idea, but this seems like a good case for a limited exception to that rule

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  see if unit tests don't sporadically fail over the next 2 weeks 😄 