### PR TITLE
[JN-1295] Add study env config flag for enabling in-person kits

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/study/StudyEnvironmentConfig.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/study/StudyEnvironmentConfig.java
@@ -41,4 +41,11 @@ public class StudyEnvironmentConfig extends BaseEntity {
      */
     @Builder.Default
     private boolean useDevDsmRealm = true;
+
+    /**
+     * if true, the study staff will be able to scan in-person kits into the system,
+     * and participants will see information about in-person kits on their dashboard
+     */
+    @Builder.Default
+    private boolean enableInPersonKits = false;
 }

--- a/core/src/main/resources/db/changelog/changesets/2024_10_02_in_person_kits_env_config.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_10_02_in_person_kits_env_config.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: "in_person_kits_env_config"
+      author: mbemis
+      changes:
+        - addColumn:
+            tableName: study_environment_config
+            columns:
+              - column: { name: enable_in_person_kits, type: boolean, defaultValueBoolean: false, constraints: { nullable: false} }

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -329,6 +329,9 @@ databaseChangeLog:
   - include:
       file: changesets/2024_09_20_export_integration.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2024_10_02_in_person_kits_env_config.yaml
+      relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
@@ -38,7 +38,8 @@
         "enableFamilyLinkage": true,
         "passwordProtected": false,
         "password": "broad_institute",
-        "initialized": true
+        "initialized": true,
+        "enableInPersonKits": true
       },
       "preEnrollSurveyDto": {
         "populateFileName": "surveys/preEnroll.json"
@@ -179,7 +180,8 @@
         "enableFamilyLinkage": true,
         "passwordProtected": false,
         "password": "broad_institute",
-        "initialized": true
+        "initialized": true,
+        "enableInPersonKits": true
       },
       "preEnrollSurveyDto": {
         "populateFileName": "surveys/preEnroll.json"
@@ -228,7 +230,8 @@
         "enableFamilyLinkage": true,
         "passwordProtected": false,
         "password": "broad_institute",
-        "initialized": true
+        "initialized": true,
+        "enableInPersonKits": true
       },
       "preEnrollSurveyDto": {
         "populateFileName": "surveys/preEnroll.json"

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/study.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/study.json
@@ -28,7 +28,8 @@
         "acceptingEnrollment": true,
         "passwordProtected": false,
         "password": "broad_institute",
-        "initialized": true
+        "initialized": true,
+        "enableInPersonKits": true
       },
       "preEnrollSurveyDto": {
         "populateFileName": "surveys/preEnroll.json"
@@ -102,7 +103,8 @@
         "acceptingEnrollment": true,
         "passwordProtected": false,
         "password": "broad_institute",
-        "initialized": false
+        "initialized": false,
+        "enableInPersonKits": true
       }
     },
     {
@@ -113,7 +115,8 @@
         "password": "broad_institute",
         "initialized": false,
         "useDevDsmRealm": false,
-        "useStubDsm": false
+        "useStubDsm": false,
+        "enableInPersonKits": true
       }
     }
   ]

--- a/ui-admin/src/study/settings/SettingsView.test.tsx
+++ b/ui-admin/src/study/settings/SettingsView.test.tsx
@@ -133,18 +133,6 @@ describe('Study Settings', () => {
 
     expect(screen.getByText('Kit types')).toBeInTheDocument()
   })
-  test('Does not render kits for non-superusers', () => {
-    const { RoutedComponent } = setupRouterTest(<MockUserProvider user={mockAdminUser(false)}>
-      <LoadedSettingsView
-        studyEnvContext={mockStudyEnvContext()}
-        portalContext={mockPortalContext()}
-      />
-    </MockUserProvider>, ['/enrollment'])
-
-    render(RoutedComponent)
-
-    expect(screen.queryByText('Kits')).not.toBeInTheDocument()
-  })
   test('updates study settings', async () => {
     const mock = jest.spyOn(Api, 'updateStudyEnvironmentConfig')
 
@@ -186,7 +174,8 @@ describe('Study Settings', () => {
         'password': 'super_secret',
         'passwordProtected': false,
         'useDevDsmRealm': false,
-        'useStubDsm': false
+        'useStubDsm': false,
+        'enableInPersonKits': false
       }
     )
   })

--- a/ui-admin/src/study/settings/SettingsView.tsx
+++ b/ui-admin/src/study/settings/SettingsView.tsx
@@ -29,7 +29,6 @@ import { Store } from 'react-notifications-component'
 import { successNotification } from 'util/notifications'
 import LoadingSpinner from 'util/LoadingSpinner'
 import { useUser } from 'user/UserProvider'
-import { RequireUserPermission } from 'util/RequireUserPermission'
 
 
 /** shows a url-routable settings page for both the portal and the selected study */
@@ -132,11 +131,9 @@ export function LoadedSettingsView(
                         <NavLink to={`enrollment`} className={getLinkCssClasses}>Study
                           Enrollment</NavLink>
                       </li>
-                      <RequireUserPermission superuser>
-                        <li className={'mb-2'}>
-                          <NavLink to={`kits`} className={getLinkCssClasses}>Kits</NavLink>
-                        </li>
-                      </RequireUserPermission>
+                      <li className={'mb-2'}>
+                        <NavLink to={`kits`} className={getLinkCssClasses}>Kits</NavLink>
+                      </li>
                     </ul>}
                 />
               </li>
@@ -196,21 +193,20 @@ export function LoadedSettingsView(
                     />
                   </SettingsPage>}
                 />
-                {user?.superuser &&
-                    <Route path="kits" element={
-                      <SettingsPage
-                        title='Kit Settings'
-                        saveStudyConfig={saveStudyConfig}
-                        canSaveStudyConfig={hasStudyConfigChanged}
-                      >
-                        <KitSettings
-                          studyEnvContext={studyEnvContext}
-                          portalContext={portalContext}
-                          config={studyConfig}
-                          updateConfig={updateStudyConfig}
-                        />
-                      </SettingsPage>}
-                    />}
+                <Route path="kits" element={
+                  <SettingsPage
+                    title='Kit Settings'
+                    saveStudyConfig={saveStudyConfig}
+                    canSaveStudyConfig={hasStudyConfigChanged}
+                  >
+                    <KitSettings
+                      studyEnvContext={studyEnvContext}
+                      portalContext={portalContext}
+                      config={studyConfig}
+                      updateConfig={updateStudyConfig}
+                    />
+                  </SettingsPage>}
+                />
 
                 <Route index element={<div>unknown settings route</div>}/>
               </Routes>

--- a/ui-admin/src/study/settings/SettingsView.tsx
+++ b/ui-admin/src/study/settings/SettingsView.tsx
@@ -28,7 +28,6 @@ import { doApiLoad } from 'api/api-utils'
 import { Store } from 'react-notifications-component'
 import { successNotification } from 'util/notifications'
 import LoadingSpinner from 'util/LoadingSpinner'
-import { useUser } from 'user/UserProvider'
 
 
 /** shows a url-routable settings page for both the portal and the selected study */
@@ -41,8 +40,6 @@ export function LoadedSettingsView(
       studyEnvContext: StudyEnvContextT,
       portalContext: LoadedPortalContextT
     }) {
-  const { user } = useUser()
-
   const portal = portalContext.portal
   const portalEnv = portalContext.portal.portalEnvironments
     .find(env =>

--- a/ui-admin/src/study/settings/study/KitSettings.test.tsx
+++ b/ui-admin/src/study/settings/study/KitSettings.test.tsx
@@ -1,0 +1,44 @@
+import { setupRouterTest } from '@juniper/ui-core'
+import { mockAdminUser, MockUserProvider } from 'test-utils/user-mocking-utils'
+import { mockPortalContext, mockStudyEnvContext, mockStudyEnvironmentConfig } from 'test-utils/mocking-utils'
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { KitSettings } from './KitSettings'
+
+describe('Kit Settings', () => {
+  test('Does not render superuser-only kit options for non-superusers', () => {
+    const { RoutedComponent } = setupRouterTest(<MockUserProvider user={mockAdminUser(false)}>
+      <KitSettings
+        studyEnvContext={mockStudyEnvContext()}
+        portalContext={mockPortalContext()}
+        config={mockStudyEnvironmentConfig()}
+        updateConfig={() => {}}
+      />
+    </MockUserProvider>, [''])
+
+    render(RoutedComponent)
+
+    expect(screen.queryByText('Enable in-person kits')).toBeInTheDocument()
+    expect(screen.queryByText('Use kit request development realm')).not.toBeInTheDocument()
+    expect(screen.queryByText('Kit types')).not.toBeInTheDocument()
+    expect(screen.queryByText('Kit types')).not.toBeInTheDocument()
+  })
+
+  test('Renders superuser-only kit options for superusers', () => {
+    const { RoutedComponent } = setupRouterTest(<MockUserProvider user={mockAdminUser(true)}>
+      <KitSettings
+        studyEnvContext={mockStudyEnvContext()}
+        portalContext={mockPortalContext()}
+        config={mockStudyEnvironmentConfig()}
+        updateConfig={() => {}}
+      />
+    </MockUserProvider>, [''])
+
+    render(RoutedComponent)
+
+    expect(screen.queryByText('Enable in-person kits')).toBeInTheDocument()
+    expect(screen.queryByText('Use kit request development realm')).toBeInTheDocument()
+    expect(screen.queryByText('Kit types')).toBeInTheDocument()
+    expect(screen.queryByText('Kit types')).toBeInTheDocument()
+  })
+})

--- a/ui-admin/src/study/settings/study/KitSettings.test.tsx
+++ b/ui-admin/src/study/settings/study/KitSettings.test.tsx
@@ -20,7 +20,7 @@ describe('Kit Settings', () => {
 
     expect(screen.queryByText('Enable in-person kits')).toBeInTheDocument()
     expect(screen.queryByText('Use kit request development realm')).not.toBeInTheDocument()
-    expect(screen.queryByText('Kit types')).not.toBeInTheDocument()
+    expect(screen.queryByText('Use mock kit requests')).not.toBeInTheDocument()
     expect(screen.queryByText('Kit types')).not.toBeInTheDocument()
   })
 
@@ -38,7 +38,7 @@ describe('Kit Settings', () => {
 
     expect(screen.queryByText('Enable in-person kits')).toBeInTheDocument()
     expect(screen.queryByText('Use kit request development realm')).toBeInTheDocument()
-    expect(screen.queryByText('Kit types')).toBeInTheDocument()
+    expect(screen.queryByText('Use mock kit requests')).toBeInTheDocument()
     expect(screen.queryByText('Kit types')).toBeInTheDocument()
   })
 })

--- a/ui-admin/src/study/settings/study/KitSettings.tsx
+++ b/ui-admin/src/study/settings/study/KitSettings.tsx
@@ -71,53 +71,65 @@ export const KitSettings = (
 
   const isLoading = isLoadingKitTypes || isUpdatingKitTypes
 
-  return <RequireUserPermission superuser>
-    <InfoCard>
-      <InfoCardHeader>
-        <InfoCardTitle title={`Kit types`}/>
-      </InfoCardHeader>
-      <div className="p-2">
-        <div style={{ width: 300 }} className="mb-2">
-          <Select className="m-1" options={kitTypeOptions} isMulti={true} value={selectedKitTypes}
-            isClearable={false}
-            isDisabled={studyEnv.environmentName !== 'sandbox'}
-            onChange={selected => setSelectedKitTypes(selected as {
-                                  value: string,
-                                  label: string
-                                }[])}
-          />
+  return <>
+    <RequireUserPermission superuser>
+      <InfoCard>
+        <InfoCardHeader>
+          <InfoCardTitle title={`Kit types`}/>
+        </InfoCardHeader>
+        <div className="p-2">
+          <div style={{ width: 300 }} className="mb-2">
+            <Select className="m-1" options={kitTypeOptions} isMulti={true} value={selectedKitTypes}
+              isClearable={false}
+              isDisabled={studyEnv.environmentName !== 'sandbox'}
+              onChange={selected => setSelectedKitTypes(selected as {
+                    value: string,
+                    label: string
+                  }[])}
+            />
+          </div>
+          <Button onClick={saveKitTypes}
+            variant="primary"
+            disabled={isLoadingKitTypes || studyEnv.environmentName !== 'sandbox'}
+            className={'mb-2'}
+            tooltip={'Only possible in the sandbox environment'}>
+            {isLoading && <LoadingSpinner/>}
+            {!isLoading && 'Save kit types'}
+          </Button>
         </div>
-        <Button onClick={saveKitTypes}
-          variant="primary"
-          disabled={isLoadingKitTypes || studyEnv.environmentName !== 'sandbox'}
-          className={'mb-2'}
-          tooltip={'Only possible in the sandbox environment'}>
-          {isLoading && <LoadingSpinner/>}
-          {!isLoading && 'Save kit types'}
-        </Button>
+
+      </InfoCard>
+
+      <div>
+        <label className="form-label">
+        Use mock kit requests <InfoPopup content={
+          `If checked, kit requests will be mocked for this environment, `
+          + `and not sent to any external services.`
+          }/>
+          <input type="checkbox" checked={config.useStubDsm}
+            onChange={e => updateConfig('useStubDsm', e.target.checked)}/>
+        </label>
       </div>
-
-    </InfoCard>
-
-    <div>
-      <label className="form-label">
-                    use mock kit requests <InfoPopup content={
-              `If checked, kit requests will be mocked for this environment, `
-              + `and not sent to any external services.`
-        }/>
-        <input type="checkbox" checked={config.useStubDsm}
-          onChange={e => updateConfig('useStubDsm', e.target.checked)}/>
-      </label>
-    </div>
-    <div>
-      <label className="form-label">
-                use kit request development realm
-        <InfoPopup content={
-                `If checked, kit requests will be sent to DSM, but to a development realm so they can be reviewed, but 
+      <div>
+        <label className="form-label">
+        Use kit request development realm
+          <InfoPopup content={
+          `If checked, kit requests will be sent to DSM, but to a development realm so they can be reviewed, but 
                will not be shipped. To actually mail kits, this and the above field should be unchecked.`}/>
-        <input type="checkbox" checked={config.useDevDsmRealm}
-          onChange={e => updateConfig('useDevDsmRealm', e.target.checked)}/>
+          <input type="checkbox" checked={config.useDevDsmRealm}
+            onChange={e => updateConfig('useDevDsmRealm', e.target.checked)}/>
+        </label>
+      </div>
+    </RequireUserPermission>
+    <div>
+      <label className="form-label">
+        Enable in-person kits <InfoPopup content={
+          `If checked, in-person kit requests will be enabled for this study environment.
+          Participants will see information about completing in-person kits on the participant dashboard.`
+        }/>
+        <input type="checkbox" checked={config.enableInPersonKits}
+          onChange={e => updateConfig('enableInPersonKits', e.target.checked)}/>
       </label>
     </div>
-  </RequireUserPermission>
+  </>
 }

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -10,7 +10,7 @@ import Api, {
   PortalEnvironmentConfig,
   PortalStudy,
   SiteMediaMetadata,
-  StudyEnvironment,
+  StudyEnvironment, StudyEnvironmentConfig,
   SurveyResponse,
   Trigger
 } from 'api/api'
@@ -20,7 +20,7 @@ import {
   EmailTemplate,
   Enrollee,
   Family,
-  KitRequest,
+  KitRequest, KitRequestStatus,
   KitType,
   LocalizedEmailTemplate,
   ParticipantDashboardAlert,
@@ -178,6 +178,20 @@ export const mockSurveyVersionsList: () => Survey[] = () => ([
   }
 ])
 
+export const mockStudyEnvironmentConfig = (): StudyEnvironmentConfig => {
+  return {
+    initialized: true,
+    password: 'blah',
+    passwordProtected: false,
+    acceptingEnrollment: true,
+    enableFamilyLinkage: false,
+    acceptingProxyEnrollment: false,
+    useDevDsmRealm: false,
+    useStubDsm: false,
+    enableInPersonKits: false
+  }
+}
+
 /** returns a simple studyEnvContext object for use/extension in tests */
 export const mockStudyEnvContext: () => StudyEnvContextT = () => {
   const sandboxEnv: StudyEnvironment = {
@@ -185,16 +199,8 @@ export const mockStudyEnvContext: () => StudyEnvContextT = () => {
     id: 'studyEnvId',
     configuredSurveys: [mockConfiguredSurvey()],
     triggers: [],
-    studyEnvironmentConfig: {
-      initialized: true,
-      password: 'blah',
-      passwordProtected: false,
-      acceptingEnrollment: true,
-      enableFamilyLinkage: false,
-      acceptingProxyEnrollment: false,
-      useDevDsmRealm: false,
-      useStubDsm: false
-    }
+    studyEnvironmentConfig: mockStudyEnvironmentConfig(),
+    kitTypes: []
   }
   return {
     study: {
@@ -273,11 +279,12 @@ export const mockExternalKitRequest = (): PepperKit => {
 /** returns a mock kit request */
 export const mockKitRequest: (args?: {
   enrolleeShortcode?: string,
-  status?: string
+  status?: KitRequestStatus
 }) => KitRequest = ({ enrolleeShortcode, status } = {}) => ({
   id: 'kitRequestId',
   createdAt: 1704393045,
   kitType: mockKitType(),
+  distributionMethod: 'MAILED',
   status: status || 'CREATED',
   // This is intentionally a little different from the enrollee's current mailing address to show that sentToAddress
   // is a capture of the mailing address at the time the kit was sent.

--- a/ui-core/src/types/study.ts
+++ b/ui-core/src/types/study.ts
@@ -37,6 +37,7 @@ export type StudyEnvironmentConfig = {
   password: string
   useStubDsm: boolean
   useDevDsmRealm: boolean
+  enableInPersonKits: boolean
 }
 
 export type StudyEnvironmentSurvey = {

--- a/ui-participant/src/hub/kit/KitsPage.test.tsx
+++ b/ui-participant/src/hub/kit/KitsPage.test.tsx
@@ -4,10 +4,18 @@ import { asMockedFn, KitRequest, KitRequestStatus, setupRouterTest } from '@juni
 import KitsPage from './KitsPage'
 import { mockEnrollee, mockPortalParticipantUser, mockProfile } from 'test-utils/test-participant-factory'
 import { useActiveUser } from 'providers/ActiveUserProvider'
+import { usePortalEnv } from '../../providers/PortalProvider'
+import { mockUsePortalEnv } from '../../test-utils/test-portal-factory'
+
+jest.mock('providers/PortalProvider', () => ({ usePortalEnv: jest.fn() }))
 
 jest.mock('providers/ActiveUserProvider', () => ({
   useActiveUser: jest.fn()
 }))
+
+beforeEach(() => {
+  asMockedFn(usePortalEnv).mockReturnValue(mockUsePortalEnv())
+})
 
 const mockActiveUserWithKits = (kitRequests: KitRequest[]) => {
   return {

--- a/ui-participant/src/hub/kit/KitsPage.tsx
+++ b/ui-participant/src/hub/kit/KitsPage.tsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom'
 import { instantToDateString } from 'util/timeUtils'
 import { useActiveUser } from 'providers/ActiveUserProvider'
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core'
+import { usePortalEnv } from '../../providers/PortalProvider'
 
 export default function KitsPage() {
   const { enrollees, ppUser } = useActiveUser()
@@ -106,8 +107,11 @@ const EnrolleeKitRequests = ({ enrollee }: { enrollee: Enrollee }) => {
   const visibleKitRequests = enrolleeKitRequests.filter(kit =>
     kit.status !== 'DEACTIVATED' && kit.status !== 'ERRORED').sort((a, b) => b.createdAt - a.createdAt)
 
-  //TODO make this a studyenv setting
-  const isInPersonKitEnabled = true
+  const { portal, portalEnv } = usePortalEnv()
+  const currentStudyEnv = portal.portalStudies.find(pStudy =>
+    pStudy.study.studyEnvironments.find(studyEnv =>
+      studyEnv.environmentName === portalEnv.environmentName))?.study.studyEnvironments[0]
+  const isInPersonKitEnabled = currentStudyEnv?.studyEnvironmentConfig.enableInPersonKits
 
   return <div className="mb-3 rounded round-3 py-4 bg-white px-md-5 shadow-sm px-2">
     <h1 className="pb-3">Sample collection kits</h1>

--- a/ui-participant/src/hub/kit/KitsPage.tsx
+++ b/ui-participant/src/hub/kit/KitsPage.tsx
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom'
 import { instantToDateString } from 'util/timeUtils'
 import { useActiveUser } from 'providers/ActiveUserProvider'
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core'
-import { usePortalEnv } from '../../providers/PortalProvider'
+import { usePortalEnv } from 'providers/PortalProvider'
 
 export default function KitsPage() {
   const { enrollees, ppUser } = useActiveUser()

--- a/ui-participant/src/test-utils/test-portal-factory.tsx
+++ b/ui-participant/src/test-utils/test-portal-factory.tsx
@@ -34,6 +34,7 @@ export const mockStudyEnv = (): StudyEnvironment => {
   return {
     id: 'studyEnv1',
     environmentName: 'sandbox',
+    kitTypes: [],
     studyEnvironmentConfig: {
       acceptingEnrollment: true,
       enableFamilyLinkage: false,
@@ -42,7 +43,8 @@ export const mockStudyEnv = (): StudyEnvironment => {
       passwordProtected: false,
       password: 'password',
       useDevDsmRealm: true,
-      useStubDsm: true
+      useStubDsm: true,
+      enableInPersonKits: true
     },
     configuredSurveys: [],
     triggers: []
@@ -88,6 +90,7 @@ export const mockLocalSiteContent = (): LocalSiteContent => {
   return {
     language: 'en',
     navbarItems: [],
+    pages: [],
     landingPage: mockHtmlPage(),
     navLogoCleanFileName: 'navLogo.png',
     navLogoVersion: 1


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Allows study staff to toggle in-person kits per study environment. If it's disabled, participants won't see any information about completing in-person kits. They'll still see any in-person kits in their kit history.

Non super-users now have access to the Kits panel in Site Settings, but this is the only option they can toggle. Everything else is still superuser only.

![screencapture-sandbox-demo-localhost-3001-hub-kits-2024-10-02-19_38_16](https://github.com/user-attachments/assets/51205659-7f93-43f8-8030-0e747c879f8f)

<img width="1512" alt="Screenshot 2024-10-02 at 7 40 07 PM" src="https://github.com/user-attachments/assets/9a5d0b7b-5031-4c63-9881-3a068dc97391">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Repopulate ourhealth
Log into ourhealth
As jsalk@test.com, confirm that you see in-person kit information on your dashboard https://sandbox.ourhealth.localhost:3001/hub/kits
As a non-superuser, toggle the setting and confirm the dashboard hides this information
