### PR TITLE
[JN-1365] fixing export options bug and code cleanup

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/export/integration/AirtableExporter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/integration/AirtableExporter.java
@@ -29,9 +29,9 @@ public class AirtableExporter extends ExternalExporter {
         this.config = config;
     }
 
-    protected void send(ExportIntegration integration, ByteArrayOutputStream baos,
+    protected void send(ExportIntegration integration, ByteArrayOutputStream outputStream,
                        Consumer<String> handleComplete, Consumer<Exception> handleError) {
-        var postRequest = buildAuthedPostRequest(buildPath(integration), baos);
+        var postRequest = buildAuthedPostRequest(buildPath(integration), outputStream);
         postRequest.retrieve()
                 .toBodilessEntity()
                 .subscribe(

--- a/core/src/main/java/bio/terra/pearl/core/service/export/integration/ExternalExporter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/integration/ExternalExporter.java
@@ -1,4 +1,4 @@
-package bio.terra.pearl.core.service.export.integration;
+    package bio.terra.pearl.core.service.export.integration;
 
 import bio.terra.pearl.core.model.export.ExportIntegration;
 import bio.terra.pearl.core.model.export.ExportIntegrationJob;
@@ -17,7 +17,7 @@ public abstract class ExternalExporter {
 
     private final EnrolleeExportService enrolleeExportService;
 
-    protected abstract void send(ExportIntegration integration, ByteArrayOutputStream baos, Consumer<String> handleComplete, Consumer<Exception> handleError);
+    protected abstract void send(ExportIntegration integration, ByteArrayOutputStream outputStream, Consumer<String> handleComplete, Consumer<Exception> handleError);
 
     public ExternalExporter(ExportIntegrationJobService exportIntegrationJobService, EnrolleeExportService enrolleeExportService) {
         this.exportIntegrationJobService = exportIntegrationJobService;
@@ -36,12 +36,12 @@ public abstract class ExternalExporter {
             job.setStatus(ExportIntegrationJob.Status.GENERATING);
             job = exportIntegrationJobService.update(job);
 
-            ByteArrayOutputStream baos = createExportStream(integration, parsedOpts);
+            ByteArrayOutputStream outputStream = createExportStream(integration, parsedOpts);
 
             job.setStatus(ExportIntegrationJob.Status.SENDING);
             final ExportIntegrationJob updatedJob = exportIntegrationJobService.update(job);
 
-            send(integration, baos,
+            send(integration, outputStream,
                     (String msg) -> handleComplete(updatedJob, integration, msg),
                     (Exception e) -> handleError(updatedJob, integration, e));
         } catch (Exception e) {

--- a/core/src/test/java/bio/terra/pearl/core/service/export/integration/ExportIntegrationServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/integration/ExportIntegrationServiceTests.java
@@ -100,9 +100,9 @@ public class ExportIntegrationServiceTests extends BaseSpringBootTest {
             super(exportIntegrationJobService, enrolleeExportService);
         }
         @Override
-        public void send(ExportIntegration integration, ByteArrayOutputStream baos, Consumer<String> handleComplete, Consumer<Exception> handleError) {
+        public void send(ExportIntegration integration, ByteArrayOutputStream outputStream, Consumer<String> handleComplete, Consumer<Exception> handleError) {
             // confirm the output stream can be stringified, otherwise do nothing
-            baos.toString();
+            outputStream.toString();
             handleComplete.accept("mock done");
         }
     }
@@ -112,7 +112,7 @@ public class ExportIntegrationServiceTests extends BaseSpringBootTest {
             super(exportIntegrationJobService, enrolleeExportService);
         }
         @Override
-        public void send(ExportIntegration integration, ByteArrayOutputStream baos, Consumer<String> handleComplete, Consumer<Exception> handleError) {
+        public void send(ExportIntegration integration, ByteArrayOutputStream outputStream, Consumer<String> handleComplete, Consumer<Exception> handleError) {
             handleError.accept(new RuntimeException("mock error"));
         }
     }

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -267,7 +267,7 @@ export type ExportOptions = {
   splitOptionsIntoColumns?: boolean,
   stableIdsForOptions?: boolean,
   onlyIncludeMostRecent?: boolean,
-  includeSubheaders?: boolean,
+  includeSubHeaders?: boolean,
   excludeModules?: string[],
   filterString?: string,
   rowLimit?: number

--- a/ui-admin/src/integration/AirtableIntegrationDashboard.tsx
+++ b/ui-admin/src/integration/AirtableIntegrationDashboard.tsx
@@ -4,7 +4,7 @@ import Api, { InternalConfig } from 'api/api'
 import LoadingSpinner from 'util/LoadingSpinner'
 
 
-/** shows basic config for address validation service */
+/** shows basic config for airtable */
 export default function AirtableIntegrationDashboard() {
   const [config, setConfig] = useState<InternalConfig>()
 

--- a/ui-admin/src/study/export/ExportDataModal.tsx
+++ b/ui-admin/src/study/export/ExportDataModal.tsx
@@ -33,7 +33,7 @@ const DEFAULT_EXPORT_OPTS: ExportOptions = {
   splitOptionsIntoColumns: false,
   stableIdsForOptions: false,
   fileFormat: 'TSV',
-  includeSubheaders: true,
+  includeSubHeaders: true,
   onlyIncludeMostRecent: true,
   filterString: undefined,
   excludeModules: []
@@ -170,12 +170,12 @@ export function ExportOptionsForm({ exportOptions, setExportOptions }:
           Include subheaders for columns
         </p>
         <label className="me-3">
-          <input type="radio" name="includeSubheaders" value="true" checked={exportOptions.includeSubheaders}
-            onChange={() => setExportOptions({ ...exportOptions, includeSubheaders: true })} className="me-1"/> Yes
+          <input type="radio" name="includeSubheaders" value="true" checked={exportOptions.includeSubHeaders}
+            onChange={() => setExportOptions({ ...exportOptions, includeSubHeaders: true })} className="me-1"/> Yes
         </label>
         <label>
-          <input type="radio" name="includeSubheaders" value="false" checked={!exportOptions.includeSubheaders}
-            onChange={() => setExportOptions({ ...exportOptions, includeSubheaders: false })} className="me-1"/> No
+          <input type="radio" name="includeSubheaders" value="false" checked={!exportOptions.includeSubHeaders}
+            onChange={() => setExportOptions({ ...exportOptions, includeSubHeaders: false })} className="me-1"/> No
         </label>
       </div>
       <div className="py-2">

--- a/ui-admin/src/study/export/integrations/ExportIntegrationJobList.tsx
+++ b/ui-admin/src/study/export/integrations/ExportIntegrationJobList.tsx
@@ -29,7 +29,7 @@ type ExportIntegrationJobMatched = ExportIntegrationJob & {
   adminUser?: AdminUser
 }
 
-/** show the mailing list in table */
+/** show the list of export integrations for the environment */
 export default function ExportIntegrationJobList({ studyEnvContext }:
   {studyEnvContext: StudyEnvContextT }) {
   const [integrations, setIntegrations] = useState<ExportIntegration[]>([])

--- a/ui-admin/src/study/export/integrations/ExportIntegrationList.tsx
+++ b/ui-admin/src/study/export/integrations/ExportIntegrationList.tsx
@@ -36,7 +36,7 @@ const DEFAULT_EXPORT_INTEGRATION: ExportIntegration = {
     splitOptionsIntoColumns: false,
     stableIdsForOptions: false,
     fileFormat: 'CSV',
-    includeSubheaders: false,
+    includeSubHeaders: false,
     onlyIncludeMostRecent: true,
     filterString: buildFilter({ includeProxiesAsRows: false, includeUnconsented: false }),
     excludeModules: ['surveys']


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Fixes a bug where includeSubHeaders wasn't being set due to casing issues.  Also incorporates some code cleanup suggestions from the prior PR (some cleanup is still pending a larger refactoring PR that's in-process)

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/export/integrations
2. select "create new"
3. confirm "include sub headers" is set to false
4. save
5. in the database, run `select * from export_options;` to confirm include_sub_headers is actually set to false for.