### PR TITLE
[JN-1404] fix proxy profile being populated even when not proxy environment

### DIFF
--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -40,7 +40,7 @@ ReactQuestionFactory.Instance.registerQuestion('addressvalidation', props => {
 /** handles loading the survey form and responses from the server */
 function SurveyView({ showHeaders = true }: { showHeaders?: boolean }) {
   const { portal, portalEnv } = usePortalEnv()
-  const { enrollees } = useActiveUser()
+  const { enrollees, ppUser } = useActiveUser()
   const { user, updateEnrollee, updateProfile, enrollees: allEnrollees } = useUser()
   const [formAndResponses, setFormAndResponse] = useState<SurveyWithResponse | null>(null)
   const params = useParams()
@@ -48,9 +48,9 @@ function SurveyView({ showHeaders = true }: { showHeaders?: boolean }) {
   const stableId = params.stableId
   const version = parseInt(params.version ?? '')
 
-  const proxyProfile = allEnrollees
+  const proxyProfile = ppUser?.participantUserId != user?.id ? allEnrollees
     .find(enrollee => enrollee.participantUserId === user?.id && enrollee.profile)
-    ?.profile
+    ?.profile : undefined
 
   const { i18n, selectedLanguage } = useI18n()
   const taskId = useTaskIdParam() ?? ''


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

`{isGovernedUser}` is derived from `proxyProfile` existing, and we were always populating it. The other approach here would be to keep `proxyProfile` always populated and either derive `isGovernedUser` from if `profile.id != proxyProfile.id` or there's another `isGovernedUser` prop on the paged survey view.

As an aside, I think it would be worth doing a code cleanup to have a `SurveyJsVariables` type with all of these things in it, and maybe even a `generateSurveyJsVariables(e: Enrollee, ...)` method. If you guys like that idea, I can do that here.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- extract cmi portal from dev
- upload cmi portal
- create non-proxy adult user
- ensure that consent shows correct language ("I" not "my child")