### PR TITLE
[JN-1375] Fix enrollee lookup + prevent COLLECTED_BY_STAFF status from being reset

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeController.java
@@ -40,7 +40,13 @@ public class EnrolleeController implements EnrolleeApi {
   public ResponseEntity<Object> find(
       String portalShortcode, String studyShortcode, String envName, String enrolleeShortcodeOrId) {
     AdminUser adminUser = authUtilService.requireAdminUser(request);
-    Enrollee enrollee = enrolleeExtService.findWithAdminLoad(adminUser, enrolleeShortcodeOrId);
+    Enrollee enrollee =
+        enrolleeExtService.findWithAdminLoad(
+            adminUser,
+            portalShortcode,
+            studyShortcode,
+            EnvironmentName.valueOf(envName),
+            enrolleeShortcodeOrId);
     return ResponseEntity.ok(enrollee);
   }
 

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeExtServiceTests.java
@@ -38,24 +38,40 @@ public class EnrolleeExtServiceTests extends BaseSpringBootTest {
         enrolleeFactory.buildWithPortalUser(
             getTestName(info), bundle.getPortalEnv(), bundle.getStudyEnv());
 
+    String portalShortcode = bundle.getPortal().getShortcode();
+    String studyShortcode = bundle.getStudy().getShortcode();
+    EnvironmentName envName = bundle.getStudyEnv().getEnvironmentName();
+
     Enrollee loadedEnrollee =
-        enrolleeExtService.findWithAdminLoad(operator, enrollee1.enrollee().getShortcode());
+        enrolleeExtService.findWithAdminLoad(
+            operator,
+            portalShortcode,
+            studyShortcode,
+            envName,
+            enrollee1.enrollee().getShortcode());
     assertThat(loadedEnrollee.getId(), equalTo(enrollee1.enrollee().getId()));
 
     loadedEnrollee =
-        enrolleeExtService.findWithAdminLoad(operator, enrollee1.enrollee().getId().toString());
+        enrolleeExtService.findWithAdminLoad(
+            operator,
+            portalShortcode,
+            studyShortcode,
+            envName,
+            enrollee1.enrollee().getId().toString());
     assertThat(loadedEnrollee.getId(), equalTo(enrollee1.enrollee().getId()));
 
     Assertions.assertThrows(
         NotFoundException.class,
         () -> {
-          enrolleeExtService.findWithAdminLoad(operator, UUID.randomUUID().toString());
+          enrolleeExtService.findWithAdminLoad(
+              operator, portalShortcode, studyShortcode, envName, UUID.randomUUID().toString());
         });
 
     Assertions.assertThrows(
         NotFoundException.class,
         () -> {
-          enrolleeExtService.findWithAdminLoad(operator, "BADCODE");
+          enrolleeExtService.findWithAdminLoad(
+              operator, portalShortcode, studyShortcode, envName, "BADCODE");
         });
   }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
@@ -393,6 +393,14 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
             kitRequest.setExternalKit(objectMapper.writeValueAsString(pepperKit));
             kitRequest.setExternalKitFetchedAt(pepperStatusFetchedAt);
             KitRequestStatus status = PepperKitStatus.mapToKitRequestStatus(pepperKit.getCurrentStatus());
+
+            // This is a special case for in-person kits that have been collected by staff. DSM considers these
+            // kits to be "sent", but we need to provide some extra granularity for study staff, so they know which
+            // kits have been collecting and which are still waiting to be collected.
+            if(status == KitRequestStatus.SENT && kitRequest.getDistributionMethod() == DistributionMethod.IN_PERSON) {
+                status = KitRequestStatus.COLLECTED_BY_STAFF;
+            }
+
             kitRequest.setStatus(status);
             setKitDates(kitRequest, pepperKit);
             // for now just copy these over on each update, since there is currently no reason to make it conditional


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Previously, enrollee lookups took in portal/study/env as parameters, but never checked against them to make sure that the enrollee actually existed in the given study environment (or portal, for that matter...). Now we'll throw an error if the enrollee doesn't exist in the specified study env.

Also fixes an issue where kit requests with status COLLECTED_BY_STAFF would be set back to SENT status when we fetch latest statuses from DSM. COLLECTED_BY_STAFF is a status that's unique to Juniper, so we have to have a little bit of special logic.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Go to the kit scanning tool (live environment) https://localhost:3000/demo/studies/heartdemo/env/live/kits/scan
Try loading an enrollee shortcode that exists in sandbox but isn't in live (i.e. HDSALK)
Confirm you get an error
Try switching to sandbox and loading HDSALK
Confirm it loads

For kit status fix:

Ensure OurHealth sandbox is using live dsm and NOT mock DSM
Assign a new kit to OHSALK and then collect it
Go to the kit status page: https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/kits/requested/collected
Click "Refresh"
Confirm that the in person kit remains in "COLLECTED_BY_STAFF" status