### PR TITLE
[JN-1400] After pre-enroll, redirect users directly to pending consents

### DIFF
--- a/e2e-tests/src/pages/ourhealth/study-dashboard.ts
+++ b/e2e-tests/src/pages/ourhealth/study-dashboard.ts
@@ -37,7 +37,7 @@ export default class StudyDashboard extends OurHealthPageBase {
   get activity() {
     const page = this.page
     const parent = this.locator
-    const states = ['Not Started', 'Locked', 'Completed']
+    const states = ['Not Started', 'Locked', 'Completed', 'Print OurHealth Consent']
 
     return new class {
       async status(name: string | RegExp): Promise<string> {

--- a/e2e-tests/src/tests/studies/ourhealth/new-registration-age18.test.ts
+++ b/e2e-tests/src/tests/studies/ourhealth/new-registration-age18.test.ts
@@ -41,26 +41,6 @@ test.describe('Home page', () => {
       await createAcct.clickByRole('button', 'Complete')
     })
 
-    const dashboard = await test.step('Landing on Dashboard for the first time', async (): Promise<StudyDashboard> => {
-      const dashboard = new StudyDashboard(page)
-      await dashboard.waitReady()
-
-      // activities are visible and match expected initial status
-      for (const name of Object.values(Activities)) {
-        const dashboardActivity = dashboard.activity
-        const isVisible = await dashboardActivity.isVisible(name)
-        expect(isVisible, `"${name}" activity is not visible in Dashboard`).toBe(true)
-        if (name === 'OurHealth Consent') {
-          expect(await dashboardActivity.status(name)).toStrictEqual('Not Started')
-        } else {
-          expect(await dashboardActivity.status(name)).toStrictEqual('Locked')
-        }
-      }
-
-      await dashboard.clickByRole('link', 'Start Consent')
-      return dashboard
-    })
-
     /* NOTE: text contents on each page ARE NOT verified */
     await test.step('Step 1: Start Consent', async () => {
       const consent = new StudyConsent(page)
@@ -81,6 +61,26 @@ test.describe('Home page', () => {
       await consent.drawSignature(data.QLabel.Signature)
 
       await consent.clickByRole('button', 'Complete')
+    })
+
+    const dashboard = await test.step('Landing on Dashboard for the first time', async (): Promise<StudyDashboard> => {
+      const dashboard = new StudyDashboard(page)
+      await dashboard.waitReady()
+
+      // activities are visible and match expected initial status
+      for (const name of Object.values(Activities)) {
+        const dashboardActivity = dashboard.activity
+        const isVisible = await dashboardActivity.isVisible(name)
+        expect(isVisible, `"${name}" activity is not visible in Dashboard`).toBe(true)
+        if (name === 'OurHealth Consent') {
+          expect(await dashboardActivity.status(name)).toStrictEqual('Print OurHealth Consent')
+        } else if (name === 'The Basics') {
+          expect(await dashboardActivity.status(name)).toStrictEqual('Not Started')
+        } else {
+          expect(await dashboardActivity.status(name)).toStrictEqual('Locked')
+        }
+      }
+      return dashboard
     })
 
     await test.step('Step 2: Start Surveys', async () => {

--- a/ui-participant/src/Navbar.test.tsx
+++ b/ui-participant/src/Navbar.test.tsx
@@ -5,7 +5,6 @@ import {
 import React from 'react'
 
 import {
-  HtmlPage,
   NavbarItemExternal,
   NavbarItemInternal,
   NavbarItemInternalAnchor,
@@ -52,10 +51,7 @@ describe('CustomNavLink', () => {
       itemType: 'INTERNAL',
       text: 'Internal link',
       itemOrder: 1,
-      internalPath: 'testPage',
-      htmlPage: {
-        path: 'testPage'
-      } as HtmlPage
+      internalPath: 'testPage'
     }
 
     const { RoutedComponent } = setupRouterTest(<CustomNavLink navLink={navbarItem} />)

--- a/ui-participant/src/hub/HubPage.tsx
+++ b/ui-participant/src/hub/HubPage.tsx
@@ -8,7 +8,6 @@ import Api, {
   Portal,
   Study
 } from 'api/api'
-import { isTaskActive } from './TaskLink'
 import { DocumentTitle } from 'util/DocumentTitle'
 
 import {
@@ -29,6 +28,7 @@ import { useActiveUser } from 'providers/ActiveUserProvider'
 import { useUser } from 'providers/UserProvider'
 import ParticipantSelector from '../participant/ParticipantSelector'
 import { Link } from 'react-router-dom'
+import { isTaskActive } from './task/taskUtils'
 
 
 /** renders the logged-in hub page */

--- a/ui-participant/src/hub/OutreachTasks.tsx
+++ b/ui-participant/src/hub/OutreachTasks.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react'
 import Api, { ParticipantTask, Study, SurveyResponse, TaskWithSurvey } from 'api/api'
-import { getTaskPath } from './TaskLink'
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 import SurveyModal from './SurveyModal'
 import { Enrollee, EnvironmentName, useI18n, useTaskIdParam } from '@juniper/ui-core'
 import { usePortalEnv } from '../providers/PortalProvider'
+import { getTaskPath } from './task/taskUtils'
 
 type OutreachParams = {
     enrolleeShortcode?: string,

--- a/ui-participant/src/hub/StudyResearchTasks.tsx
+++ b/ui-participant/src/hub/StudyResearchTasks.tsx
@@ -1,8 +1,9 @@
-import TaskLink, { getTaskPath, isTaskAccessible, isTaskActive } from './TaskLink'
 import { Link } from 'react-router-dom'
 import React from 'react'
 import { ParticipantTask } from 'api/api'
 import { Enrollee, useI18n } from '@juniper/ui-core'
+import { getNextTask, getTaskPath, isTaskAccessible, isTaskActive, taskComparator } from './task/taskUtils'
+import TaskLink from './TaskLink'
 
 
 const taskTypeMap: Record<string, string> = {
@@ -122,26 +123,4 @@ function TaskGrouping({ title, tasks, enrollee, studyShortcode }: {
       </ol>
     </>
   )
-}
-
-/** returns the next actionable task for the enrollee, or undefined if there is no remaining task */
-export function getNextTask(enrollee: Enrollee, sortedTasks: ParticipantTask[]) {
-  const nextTask = sortedTasks.find(task => isTaskAccessible(task, enrollee) && isTaskActive(task))
-  return nextTask
-}
-
-export const TASK_TYPE_ORDER = ['CONSENT', 'SURVEY']
-export const TASK_STATUS_ORDER = ['IN_PROGRESS', 'NEW', 'COMPLETE']
-
-/** Sorts tasks based on their types, then based on status, and then based on their internal ordering */
-export function taskComparator(taskA: ParticipantTask, taskB: ParticipantTask) {
-  const typeOrder = TASK_TYPE_ORDER.indexOf(taskA.taskType) - TASK_TYPE_ORDER.indexOf(taskB.taskType)
-  if (typeOrder != 0) {
-    return typeOrder
-  }
-  const statusOrder = TASK_STATUS_ORDER.indexOf(taskA.status) - TASK_STATUS_ORDER.indexOf(taskB.status)
-  if (statusOrder != 0) {
-    return statusOrder
-  }
-  return taskA.taskOrder - taskB.taskOrder
 }

--- a/ui-participant/src/hub/StudyResearchTasks.tsx
+++ b/ui-participant/src/hub/StudyResearchTasks.tsx
@@ -125,7 +125,7 @@ function TaskGrouping({ title, tasks, enrollee, studyShortcode }: {
 }
 
 /** returns the next actionable task for the enrollee, or undefined if there is no remaining task */
-function getNextTask(enrollee: Enrollee, sortedTasks: ParticipantTask[]) {
+export function getNextTask(enrollee: Enrollee, sortedTasks: ParticipantTask[]) {
   const nextTask = sortedTasks.find(task => isTaskAccessible(task, enrollee) && isTaskActive(task))
   return nextTask
 }
@@ -134,7 +134,7 @@ export const TASK_TYPE_ORDER = ['CONSENT', 'SURVEY']
 export const TASK_STATUS_ORDER = ['IN_PROGRESS', 'NEW', 'COMPLETE']
 
 /** Sorts tasks based on their types, then based on status, and then based on their internal ordering */
-function taskComparator(taskA: ParticipantTask, taskB: ParticipantTask) {
+export function taskComparator(taskA: ParticipantTask, taskB: ParticipantTask) {
   const typeOrder = TASK_TYPE_ORDER.indexOf(taskA.taskType) - TASK_TYPE_ORDER.indexOf(taskB.taskType)
   if (typeOrder != 0) {
     return typeOrder

--- a/ui-participant/src/hub/TaskLink.test.tsx
+++ b/ui-participant/src/hub/TaskLink.test.tsx
@@ -1,7 +1,7 @@
 import { ParticipantTask } from 'api/api'
 
-import { isTaskAccessible } from './TaskLink'
 import { Enrollee } from '@juniper/ui-core'
+import { isTaskAccessible } from './task/taskUtils'
 
 describe('isTaskAccessible', () => {
   it('returns true for completed tasks when another task blocks hub', () => {

--- a/ui-participant/src/hub/TaskLink.tsx
+++ b/ui-participant/src/hub/TaskLink.tsx
@@ -6,6 +6,7 @@ import { faCircle, faCircleXmark } from '@fortawesome/free-regular-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { hideVisually } from 'polished'
 import { Enrollee, useI18n } from '@juniper/ui-core'
+import { getTaskPath, isTaskAccessible } from './task/taskUtils'
 
 export type StatusDisplayInfo = {
   icon: React.ReactNode,
@@ -82,39 +83,4 @@ export default function TaskLink({ task, studyShortcode, enrollee }:
       </div>
     </div>
   )
-}
-
-/** returns a string for including in a <Link to={}> link to be navigated by the participant */
-export function getTaskPath(task: ParticipantTask, enrolleeShortcode: string,
-  studyShortcode: string, isPrint = false): string {
-  const url = `study/${studyShortcode}/enrollee/${enrolleeShortcode}/${task.taskType.toLowerCase()}`
-  +  `/${task.targetStableId}/${task.targetAssignedVersion}${isPrint ? '/print' : ''}?taskId=${task.id}`
-  return url
-}
-
-/** is the task actionable by the user? the rules are:
- * consent forms are always actionable.
- * nothing else is actionable until consent
- * required tasks must be done in-order
- * non-required tasks are not actionable until all required tasks are cleared */
-export function isTaskAccessible(task: ParticipantTask, enrollee: Enrollee) {
-  if (task.taskType === 'CONSENT' || task.status === 'COMPLETE') {
-    return true
-  }
-  const openConsents = enrollee.participantTasks
-    .filter(task => task.taskType === 'CONSENT' && task.status !== 'COMPLETE')
-  if (openConsents.length) {
-    return false
-  }
-  const openRequiredTasks = enrollee.participantTasks.filter(task => task.blocksHub && task.status !== 'COMPLETE')
-    .sort((a, b) => a.taskOrder - b.taskOrder)
-  if (openRequiredTasks.length) {
-    return task.id === openRequiredTasks[0].id
-  }
-  return true
-}
-
-/** is the task ready to be worked on (not done or rejected) */
-export function isTaskActive(task: ParticipantTask) {
-  return ['NEW', 'VIEWED', 'IN_PROGRESS'].includes(task.status)
 }

--- a/ui-participant/src/hub/task/taskUtils.test.tsx
+++ b/ui-participant/src/hub/task/taskUtils.test.tsx
@@ -1,0 +1,108 @@
+import { getNextConsentTask, taskComparator } from './taskUtils'
+import { mockEnrollee, mockHubResponse, mockParticipantTask } from 'test-utils/test-participant-factory'
+
+describe('taskComparator', () => {
+  it('should sort tasks by type', () => {
+    const taskA = mockParticipantTask('CONSENT', 'NEW')
+    const taskB = mockParticipantTask('SURVEY', 'NEW')
+    expect(taskComparator(taskA, taskB)).toBeLessThan(0)
+    expect(taskComparator(taskB, taskA)).toBeGreaterThan(0)
+  })
+
+  it('should sort tasks by status when types are the same', () => {
+    const taskA = mockParticipantTask('SURVEY', 'IN_PROGRESS')
+    const taskB = mockParticipantTask('SURVEY', 'NEW')
+    expect(taskComparator(taskA, taskB)).toBeLessThan(0)
+    expect(taskComparator(taskB, taskA)).toBeGreaterThan(0)
+  })
+
+  it('should sort tasks by task order when types and statuses are the same', () => {
+    const taskA = {
+      ...mockParticipantTask('SURVEY', 'NEW'),
+      taskOrder: 1
+    }
+    const taskB = {
+      ...mockParticipantTask('SURVEY', 'NEW'),
+      taskOrder: 2
+    }
+
+    expect(taskComparator(taskA, taskB)).toBeLessThan(0)
+    expect(taskComparator(taskB, taskA)).toBeGreaterThan(0)
+  })
+
+  it('should return 0 for tasks with the same type, status, and order', () => {
+    const taskA = mockParticipantTask('SURVEY', 'NEW')
+    const taskB = mockParticipantTask('SURVEY', 'NEW')
+    expect(taskComparator(taskA, taskB)).toBe(0)
+  })
+})
+
+describe('getNextConsentTask', () => {
+  it('should return the next actionable consent task', () => {
+    const hubResponse = {
+      ...mockHubResponse(),
+      enrollee: {
+        ...mockEnrollee(),
+        participantTasks: [
+          {
+            ...mockParticipantTask('SURVEY', 'NEW'),
+            id: 'survey1',
+            taskOrder: 3
+          },
+          {
+            ...mockParticipantTask('CONSENT', 'NEW'),
+            taskOrder: 1,
+            id: 'consent1'
+          },
+          {
+            ...mockParticipantTask('CONSENT', 'NEW'),
+            taskOrder: 2,
+            id: 'consent2'
+          }
+        ]
+      }
+    }
+    const nextTask = getNextConsentTask(hubResponse)
+    expect(nextTask?.id).toBe('consent1')
+  })
+
+  it('should return undefined if no consent tasks are available', () => {
+    const hubResponse = {
+      ...mockHubResponse(),
+      enrollee: {
+        ...mockEnrollee(),
+        participantTasks: [mockParticipantTask('SURVEY', 'NEW')]
+      }
+    }
+    const nextTask = getNextConsentTask(hubResponse)
+    expect(nextTask).toBeUndefined()
+  })
+
+  it('should return undefined if all consent tasks are completed', () => {
+    const hubResponse = {
+      ...mockHubResponse(),
+      enrollee: {
+        ...mockEnrollee(),
+        participantTasks: [
+          {
+            ...mockParticipantTask('SURVEY', 'COMPLETE'),
+            id: 'survey1',
+            taskOrder: 3
+          },
+          {
+            ...mockParticipantTask('CONSENT', 'COMPLETE'),
+            taskOrder: 1,
+            id: 'consent1'
+          },
+          {
+            ...mockParticipantTask('CONSENT', 'COMPLETE'),
+            taskOrder: 2
+
+          }
+        ]
+      }
+    }
+    const nextTask = getNextConsentTask(hubResponse)
+    expect(nextTask).toBeUndefined()
+  })
+})

--- a/ui-participant/src/hub/task/taskUtils.ts
+++ b/ui-participant/src/hub/task/taskUtils.ts
@@ -1,4 +1,4 @@
-import { Enrollee, ParticipantTask } from '@juniper/ui-core'
+import { Enrollee, HubResponse, ParticipantTask } from '@juniper/ui-core'
 
 /** returns the next actionable task for the enrollee, or undefined if there is no remaining task */
 export function getNextTask(enrollee: Enrollee, sortedTasks: ParticipantTask[]) {
@@ -61,4 +61,9 @@ export function getSortedActiveTasks(tasks: ParticipantTask[], taskType: string)
   return tasks
     .filter(task => task.taskType === taskType && isTaskActive(task))
     .sort(taskComparator)
+}
+
+export function getNextConsentTask(hubResponse: HubResponse) {
+  const sortedActiveConsentTasks = getSortedActiveTasks(hubResponse.enrollee.participantTasks, 'CONSENT')
+  return getNextTask(hubResponse.enrollee, sortedActiveConsentTasks)
 }

--- a/ui-participant/src/hub/task/taskUtils.ts
+++ b/ui-participant/src/hub/task/taskUtils.ts
@@ -1,0 +1,64 @@
+import { Enrollee, ParticipantTask } from '@juniper/ui-core'
+
+/** returns the next actionable task for the enrollee, or undefined if there is no remaining task */
+export function getNextTask(enrollee: Enrollee, sortedTasks: ParticipantTask[]) {
+  const nextTask = sortedTasks.find(task => isTaskAccessible(task, enrollee) && isTaskActive(task))
+  return nextTask
+}
+
+export const TASK_TYPE_ORDER = ['CONSENT', 'SURVEY']
+export const TASK_STATUS_ORDER = ['IN_PROGRESS', 'NEW', 'COMPLETE']
+
+/** Sorts tasks based on their types, then based on status, and then based on their internal ordering */
+export function taskComparator(taskA: ParticipantTask, taskB: ParticipantTask) {
+  const typeOrder = TASK_TYPE_ORDER.indexOf(taskA.taskType) - TASK_TYPE_ORDER.indexOf(taskB.taskType)
+  if (typeOrder != 0) {
+    return typeOrder
+  }
+  const statusOrder = TASK_STATUS_ORDER.indexOf(taskA.status) - TASK_STATUS_ORDER.indexOf(taskB.status)
+  if (statusOrder != 0) {
+    return statusOrder
+  }
+  return taskA.taskOrder - taskB.taskOrder
+}
+
+/** returns a string for including in a <Link to={}> link to be navigated by the participant */
+export function getTaskPath(task: ParticipantTask, enrolleeShortcode: string,
+  studyShortcode: string, isPrint = false): string {
+  const url = `study/${studyShortcode}/enrollee/${enrolleeShortcode}/${task.taskType.toLowerCase()}`
+        +  `/${task.targetStableId}/${task.targetAssignedVersion}${isPrint ? '/print' : ''}?taskId=${task.id}`
+  return url
+}
+
+/** is the task actionable by the user? the rules are:
+ * consent forms are always actionable.
+ * nothing else is actionable until consent
+ * required tasks must be done in-order
+ * non-required tasks are not actionable until all required tasks are cleared */
+export function isTaskAccessible(task: ParticipantTask, enrollee: Enrollee) {
+  if (task.taskType === 'CONSENT' || task.status === 'COMPLETE') {
+    return true
+  }
+  const openConsents = enrollee.participantTasks
+    .filter(task => task.taskType === 'CONSENT' && task.status !== 'COMPLETE')
+  if (openConsents.length) {
+    return false
+  }
+  const openRequiredTasks = enrollee.participantTasks.filter(task => task.blocksHub && task.status !== 'COMPLETE')
+    .sort((a, b) => a.taskOrder - b.taskOrder)
+  if (openRequiredTasks.length) {
+    return task.id === openRequiredTasks[0].id
+  }
+  return true
+}
+
+/** is the task ready to be worked on (not done or rejected) */
+export function isTaskActive(task: ParticipantTask) {
+  return ['NEW', 'VIEWED', 'IN_PROGRESS'].includes(task.status)
+}
+
+export function getSortedActiveTasks(tasks: ParticipantTask[], taskType: string): ParticipantTask[] {
+  return tasks
+    .filter(task => task.taskType === taskType && isTaskActive(task))
+    .sort(taskComparator)
+}

--- a/ui-participant/src/login/LoginUnauthed.tsx
+++ b/ui-participant/src/login/LoginUnauthed.tsx
@@ -5,7 +5,6 @@ import { findDefaultEnrollmentStudy } from './RedirectFromOAuth'
 import { enrollCurrentUserInStudy } from '../util/enrolleeUtils'
 import { useNavigate } from 'react-router-dom'
 import { usePortalEnv } from '../providers/PortalProvider'
-import { useI18n } from '@juniper/ui-core'
 
 /** component for showing a login dialog that hides other content on the page */
 export default function LoginUnauthed() {
@@ -14,7 +13,6 @@ export default function LoginUnauthed() {
   const { loginUser, refreshLoginState } = useUser()
   const navigate = useNavigate()
   const { portal } = usePortalEnv()
-  const { i18n } = useI18n()
 
   const defaultEnrollStudy = findDefaultEnrollmentStudy(null, portal.portalStudies)
 

--- a/ui-participant/src/login/LoginUnauthed.tsx
+++ b/ui-participant/src/login/LoginUnauthed.tsx
@@ -28,8 +28,7 @@ export default function LoginUnauthed() {
 
       // Enroll in the default study if not already enrolled in any study
       if (defaultEnrollStudy && !loginResult.enrollees.length) {
-        const hubUpdate = await enrollCurrentUserInStudy(defaultEnrollStudy.shortcode,
-          defaultEnrollStudy.name, null, refreshLoginState, i18n)
+        const hubUpdate = await enrollCurrentUserInStudy(defaultEnrollStudy.shortcode, null, refreshLoginState)
         navigate('/hub', { replace: true, state: hubUpdate })
       }
     } catch (e) {

--- a/ui-participant/src/login/RedirectFromOAuth.tsx
+++ b/ui-participant/src/login/RedirectFromOAuth.tsx
@@ -21,8 +21,7 @@ import {
   log,
   logError
 } from 'util/loggingUtils'
-import { HubUpdate } from '../hub/hubUpdates'
-import { getNextTask, getSortedActiveTasks, getTaskPath } from '../hub/task/taskUtils'
+import { handleNewStudyEnroll } from '../studies/enroll/StudyEnrollRouter'
 
 export const RedirectFromOAuth = () => {
   const auth = useAuth()
@@ -96,28 +95,7 @@ export const RedirectFromOAuth = () => {
               const hubResponse = await enrollCurrentUserInStudy(
                 defaultEnrollStudy.shortcode, preEnrollResponseId, refreshLoginState)
 
-              const sortedActiveConsentTasks = getSortedActiveTasks(hubResponse.enrollee.participantTasks, 'CONSENT')
-              const nextConsentTask = getNextTask(hubResponse.enrollee, sortedActiveConsentTasks)
-
-              if (nextConsentTask) {
-                //if there's a pending consent, navigate directly to the first one. note that we don't
-                //show the "Welcome to the study" banner in this case
-                const consentTaskPath = getTaskPath(
-                  nextConsentTask, hubResponse.enrollee.shortcode, defaultEnrollStudy.shortcode)
-                navigate(`../hub/${consentTaskPath}`, { replace: true })
-              } else {
-                const hubUpdate: HubUpdate = {
-                  message: {
-                    title: i18n('hubUpdateWelcomeToStudyTitle', {
-                      substitutions: { studyName: defaultEnrollStudy.name }
-                    }),
-                    detail: i18n('hubUpdateWelcomeToStudyDetail'),
-                    type: 'INFO'
-                  }
-                }
-
-                navigate('/hub', { replace: true, state: hubUpdate })
-              }
+              handleNewStudyEnroll(hubResponse, defaultEnrollStudy.shortcode, navigate, i18n, defaultEnrollStudy.name)
             } else {
               navigate('/hub', { replace: true })
             }

--- a/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
+++ b/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
@@ -152,10 +152,10 @@ function StudyEnrollOutletMatched(props: StudyEnrollOutletMatchedProps) {
         try {
           const hubUpdate = isProxyEnrollment
             ? await enrollProxyUserInStudy(
-              studyShortcode, studyName, preEnrollResponseId, ppUserId, refreshLoginState, i18n
+              studyShortcode, preEnrollResponseId, ppUserId, refreshLoginState
             )
             : await enrollCurrentUserInStudy(
-              studyShortcode, studyName, preEnrollResponseId, refreshLoginState, i18n
+              studyShortcode, preEnrollResponseId, refreshLoginState
             )
           navigate('/hub', { replace: true, state: hubUpdate })
         } catch (e) {

--- a/ui-participant/src/test-utils/test-participant-factory.ts
+++ b/ui-participant/src/test-utils/test-participant-factory.ts
@@ -8,7 +8,7 @@ import {
 import {
   defaultSurvey,
   Enrollee,
-  HubResponse, KitRequest,
+  HubResponse, KitRequest, KitRequestStatus,
   ParticipantUser,
   Profile
 } from '@juniper/ui-core'
@@ -104,7 +104,7 @@ export const mockSurvey = (stableId: string): Survey => {
 }
 
 /** mock a kit request */
-export const mockKitRequest = (kitStatus: string, kitType: string): KitRequest => {
+export const mockKitRequest = (kitStatus: KitRequestStatus, kitType: string): KitRequest => {
   const now = new Date().getTime() * 1000
   return {
     id: 'kitRequest1',
@@ -119,7 +119,7 @@ export const mockKitRequest = (kitStatus: string, kitType: string): KitRequest =
   }
 }
 
-export const mockAssignedKitRequest = (kitStatus: string, kitType: string): KitRequest => {
+export const mockAssignedKitRequest = (kitStatus: KitRequestStatus, kitType: string): KitRequest => {
   return {
     ...mockKitRequest(kitStatus, kitType),
     distributionMethod: 'IN_PERSON',
@@ -143,7 +143,13 @@ export const mockHubResponse = (): HubResponse => {
   return {
     enrollee: mockEnrollee(),
     tasks: [],
-    response: {},
+    response: {
+      resumeData: '',
+      enrolleeId: 'enrollee1',
+      surveyId: 'survey1',
+      complete: true,
+      answers: []
+    },
     profile: mockProfile()
   }
 }

--- a/ui-participant/src/util/enrolleeUtils.ts
+++ b/ui-participant/src/util/enrolleeUtils.ts
@@ -2,10 +2,8 @@ import Api, {
   PortalParticipantUser,
   Study
 } from 'api/api'
-import { HubUpdate } from 'hub/hubUpdates'
 import {
-  Enrollee,
-  I18nOptions,
+  Enrollee, HubResponse,
   useI18n
 } from '@juniper/ui-core'
 import { useUser } from '../providers/UserProvider'
@@ -22,24 +20,15 @@ export function userHasJoinedStudy(study: Study, enrollees: Enrollee[]) {
 /** enrolls the user and displays a welcome banner on the dashboard */
 export async function enrollCurrentUserInStudy(
   studyShortcode: string,
-  studyName: string,
   preEnrollResponseId: string | null,
-  refreshLogin: () => Promise<void>,
-  i18n: (key: string, options?: I18nOptions) => string
-) {
-  await Api.createEnrollee({
+  refreshLogin: () => Promise<void>
+): Promise<HubResponse> {
+  const hubResponse = await Api.createEnrollee({
     studyShortcode,
     preEnrollResponseId
   })
-  const hubUpdate: HubUpdate = {
-    message: {
-      title: i18n('hubUpdateWelcomeToStudyTitle', { substitutions: { studyName } }),
-      detail: i18n('hubUpdateWelcomeToStudyDetail'),
-      type: 'INFO'
-    }
-  }
   await refreshLogin()
-  return hubUpdate
+  return hubResponse
 }
 
 /**
@@ -48,26 +37,17 @@ export async function enrollCurrentUserInStudy(
  */
 export async function enrollProxyUserInStudy(
   studyShortcode: string,
-  studyName: string,
   preEnrollResponseId: string | null,
   governedPpUserId: string | null,
-  refreshLogin: () => Promise<void>,
-  i18n: (key: string, options?: I18nOptions) => string
-) {
-  await Api.createGovernedEnrollee({
+  refreshLogin: () => Promise<void>
+): Promise<HubResponse> {
+  const hubResponse = await Api.createGovernedEnrollee({
     studyShortcode,
     preEnrollResponseId,
     governedPpUserId
   })
-  const hubUpdate: HubUpdate = {
-    message: {
-      title: i18n('hubUpdateWelcomeToStudyTitle', { substitutions: { studyName } }),
-      detail: i18n('hubUpdateWelcomeToStudyDetail'),
-      type: 'INFO'
-    }
-  }
   await refreshLogin()
-  return hubUpdate
+  return hubResponse
 }
 
 /**


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Redirects users directly to any pending consents after they complete the pre-enroll for a study

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Try this two times: once with b2c enabled and the other with b2c disabled:

1. Fill out the pre-enroll and register for ourhealth
2. Confirm you're directed to the consent immediately