### PR TITLE
[JN-1371] Public status page

### DIFF
--- a/ui-admin/src/App.tsx
+++ b/ui-admin/src/App.tsx
@@ -31,6 +31,7 @@ import AdminUserRouter from './user/AdminUserRouter'
 import LogEventViewer from './health/LogEventViewer'
 import { initializeMixpanel } from '@juniper/ui-core'
 import mixpanel from 'mixpanel-browser'
+import { StatusPage } from './status/StatusPage'
 
 /** auto-scroll-to-top on any navigation */
 const ScrollToTop = () => {
@@ -61,6 +62,7 @@ function App() {
                   <ScrollToTop/>
                   <Routes>
                     <Route path="/">
+                      <Route path="/system/status" element={<StatusPage/>}/>
                       <Route element={<ProtectedRoute>
                         <NavContextProvider><PageFrame config={config}/></NavContextProvider>
                       </ProtectedRoute>}>

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -1695,10 +1695,13 @@ export default {
     bearerToken = token
   },
 
-  getSystemStatus(): Promise<SystemStatus> {
-    const url = `http://localhost:8080/status`
-    return fetch(url, this.getGetInit())
-      .then(this.processJsonResponse)
+  async getSystemStatus(): Promise<SystemStatus> {
+    const url = `/status`
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: this.getInitHeaders()
+    })
+    return await this.processJsonResponse(response)
   }
 
 }

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -34,7 +34,7 @@ import {
   AdminUserParams,
   Role
 } from './adminUser'
-import { SystemStatus } from '../status/status'
+import { SystemStatus } from 'status/status'
 
 export type {
   Answer,

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -34,6 +34,7 @@ import {
   AdminUserParams,
   Role
 } from './adminUser'
+import { SystemStatus } from '../status/status'
 
 export type {
   Answer,
@@ -1682,6 +1683,15 @@ export default {
     return await this.processJsonResponse(response)
   },
 
+  async getSystemStatus(): Promise<SystemStatus> {
+    const url = `/status`
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: this.getInitHeaders()
+    })
+    return await this.processJsonResponse(response)
+  },
+
   getParticipantLink(portalEnvConfig: PortalEnvironmentConfig, uiHostname: string,
     portalShortcode: string, envName: string): string {
     if (portalEnvConfig?.participantHostname) {
@@ -1693,26 +1703,8 @@ export default {
 
   setBearerToken(token: string | null) {
     bearerToken = token
-  },
-
-  async getSystemStatus(): Promise<SystemStatus> {
-    const url = `/status`
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: this.getInitHeaders()
-    })
-    return await this.processJsonResponse(response)
   }
 
-}
-
-type SystemStatus = {
-  ok: boolean
-  systems: Record<string, SubsystemStatus>[]
-}
-
-type SubsystemStatus = {
-  ok: boolean
 }
 
 /** gets an image url for SiteMedia */

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -1693,8 +1693,23 @@ export default {
 
   setBearerToken(token: string | null) {
     bearerToken = token
+  },
+
+  getSystemStatus(): Promise<SystemStatus> {
+    const url = `http://localhost:8080/status`
+    return fetch(url, this.getGetInit())
+      .then(this.processJsonResponse)
   }
 
+}
+
+type SystemStatus = {
+  ok: boolean
+  systems: Record<string, SubsystemStatus>[]
+}
+
+type SubsystemStatus = {
+  ok: boolean
 }
 
 /** gets an image url for SiteMedia */

--- a/ui-admin/src/status/StatusPage.test.tsx
+++ b/ui-admin/src/status/StatusPage.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+import { StatusPage } from './StatusPage'
+import Api from 'api/api'
+import { asMockedFn } from '@juniper/ui-core'
+
+jest.mock('api/api')
+
+describe('StatusPage', () => {
+  it('renders operational status when system is up', async () => {
+    asMockedFn(Api.getSystemStatus).mockResolvedValue({ ok: true, systems: [] })
+    render(<StatusPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('operational')).toBeInTheDocument()
+    })
+  })
+
+  it('renders degraded status when system is down', async () => {
+    asMockedFn(Api.getSystemStatus).mockResolvedValue({ ok: false, systems: [] })
+    render(<StatusPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('degraded')).toBeInTheDocument()
+    })
+  })
+})

--- a/ui-admin/src/status/StatusPage.tsx
+++ b/ui-admin/src/status/StatusPage.tsx
@@ -46,13 +46,13 @@ const SystemStatus = ({ operational }: { operational: boolean }) => {
             <p className="card-text">
               {operational ? (
                 <>
-                  This system is
+                  Juniper is
                   <span className="fw-bold text-success mx-1">operational</span>
                   and all systems are functioning normally
                 </>
               ) : (
                 <>
-                  This system is currently experiencing
+                  Juniper is currently experiencing
                   <span className="fw-bold text-danger mx-1">degraded</span>
                   functionality. Users may experience issues with some or all functionality
                 </>

--- a/ui-admin/src/status/StatusPage.tsx
+++ b/ui-admin/src/status/StatusPage.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheckCircle, faExclamationCircle } from '@fortawesome/free-solid-svg-icons'
+import Api from '../api/api'
 
 export const StatusPage = () => {
   useEffect(() => {
-
+    const foo = Api.getSystemStatus()
+    console.log(foo)
   }, [])
 
 

--- a/ui-admin/src/status/StatusPage.tsx
+++ b/ui-admin/src/status/StatusPage.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect } from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faCheckCircle, faExclamationCircle } from '@fortawesome/free-solid-svg-icons'
+
+export const StatusPage = () => {
+  useEffect(() => {
+
+  }, [])
+
+
+  return <div className="d-flex flex-column align-items-center justify-content-center vh-100">
+    <h3 className="mb-3">Juniper Status</h3>
+    <SystemStatus title="Admin" operational={true}/>
+    <SystemStatus title="Participant" operational={false}/>
+    <div className="text-center">
+      <div className="text-muted">
+            Please contact <a href="mailto:support@juniper.terra.bio">
+          support@juniper.terra.bio
+        </a> for additional support.
+      </div>
+    </div>
+  </div>
+}
+
+
+const SystemStatus = ({ title, operational }: {
+    title: string,
+    operational: boolean
+}) => {
+  if (!operational) {
+    return <div className="card mb-3" style={{ maxWidth: '500px' }}>
+      <div className="row g-0 align-items-center">
+        <div className="col-md-4">
+          <FontAwesomeIcon icon={faExclamationCircle} className={'text-center fa-8x text-danger p-4'}/>
+        </div>
+        <div className="col-md-8">
+          <div className="card-body">
+            <h5 className="card-title">Juniper {title} System</h5>
+            <p className="card-text">
+              Participants may experience
+              <span className="fw-bold text-danger"> degraded </span>
+              functionality while accessing their studies
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  }
+
+
+  return <div className="card mb-3" style={{ maxWidth: '500px' }}>
+    <div className="row g-0 align-items-center">
+      <div className="col-md-4">
+        <FontAwesomeIcon icon={faCheckCircle} className={'text-center fa-8x text-success p-4'}/>
+      </div>
+      <div className="col-md-8">
+        <div className="card-body">
+          <h5 className="card-title">Juniper {title} System</h5>
+          <p className="card-text">
+            This system is
+            <span className="fw-bold text-success"> operational </span>
+            and all systems are functioning normally
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+}

--- a/ui-admin/src/status/StatusPage.tsx
+++ b/ui-admin/src/status/StatusPage.tsx
@@ -1,70 +1,66 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheckCircle, faExclamationCircle } from '@fortawesome/free-solid-svg-icons'
-import Api from '../api/api'
+import Api from 'api/api'
+import LoadingSpinner from 'util/LoadingSpinner'
 
 export const StatusPage = () => {
+  const [operational, setOperational] = useState<boolean>()
+
+  const loadSystemStatus = async () => {
+    const systemStatus = await Api.getSystemStatus()
+    setOperational(systemStatus.ok)
+  }
+
   useEffect(() => {
-    const foo = Api.getSystemStatus()
-    console.log(foo)
+    loadSystemStatus()
   }, [])
 
-
   return <div className="d-flex flex-column align-items-center justify-content-center vh-100">
-    <h3 className="mb-3">Juniper Status</h3>
-    <SystemStatus title="Admin" operational={true}/>
-    <SystemStatus title="Participant" operational={false}/>
+    {operational === undefined ?
+      <LoadingSpinner /> :
+      <SystemStatus operational={operational}/>
+    }
     <div className="text-center">
       <div className="text-muted">
-            Please contact <a href="mailto:support@juniper.terra.bio">
-          support@juniper.terra.bio
-        </a> for additional support.
+        Please contact <a href="mailto:support@juniper.terra.bio">support@juniper.terra.bio</a> for additional support.
       </div>
     </div>
   </div>
 }
 
 
-const SystemStatus = ({ title, operational }: {
-    title: string,
-    operational: boolean
-}) => {
-  if (!operational) {
-    return <div className="card mb-3" style={{ maxWidth: '500px' }}>
+const SystemStatus = ({ operational }: { operational: boolean }) => {
+  return (
+    <div className="card mb-3" style={{ maxWidth: '500px' }}>
       <div className="row g-0 align-items-center">
         <div className="col-md-4">
-          <FontAwesomeIcon icon={faExclamationCircle} className={'text-center fa-8x text-danger p-4'}/>
+          <FontAwesomeIcon
+            icon={operational ? faCheckCircle : faExclamationCircle}
+            className={`text-center fa-8x p-4 ${operational ? 'text-success' : 'text-danger'}`}
+          />
         </div>
         <div className="col-md-8">
           <div className="card-body">
-            <h5 className="card-title">Juniper {title} System</h5>
+            <h5 className="card-title">Juniper Status</h5>
             <p className="card-text">
-              Participants may experience
-              <span className="fw-bold text-danger"> degraded </span>
-              functionality while accessing their studies
+              {operational ? (
+                <>
+                  This system is
+                  <span className="fw-bold text-success mx-1">operational</span>
+                  and all systems are functioning normally
+                </>
+              ) : (
+                <>
+                  This system is currently experiencing
+                  <span className="fw-bold text-danger mx-1">degraded</span>
+                  functionality. Users may experience issues with some or all functionality
+                </>
+              )}
             </p>
           </div>
         </div>
       </div>
     </div>
-  }
-
-
-  return <div className="card mb-3" style={{ maxWidth: '500px' }}>
-    <div className="row g-0 align-items-center">
-      <div className="col-md-4">
-        <FontAwesomeIcon icon={faCheckCircle} className={'text-center fa-8x text-success p-4'}/>
-      </div>
-      <div className="col-md-8">
-        <div className="card-body">
-          <h5 className="card-title">Juniper {title} System</h5>
-          <p className="card-text">
-            This system is
-            <span className="fw-bold text-success"> operational </span>
-            and all systems are functioning normally
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
+  )
 }

--- a/ui-admin/src/status/StatusPage.tsx
+++ b/ui-admin/src/status/StatusPage.tsx
@@ -47,13 +47,13 @@ const SystemStatus = ({ operational }: { operational: boolean }) => {
               {operational ? (
                 <>
                   Juniper is
-                  <span className="fw-bold text-success mx-1">operational</span>
+                  <span className="fw-bold text-success"> operational </span>
                   and all systems are functioning normally
                 </>
               ) : (
                 <>
                   Juniper is currently experiencing
-                  <span className="fw-bold text-danger mx-1">degraded</span>
+                  <span className="fw-bold text-danger"> degraded </span>
                   functionality. Users may experience issues with some or all functionality
                 </>
               )}

--- a/ui-admin/src/status/status.ts
+++ b/ui-admin/src/status/status.ts
@@ -1,0 +1,8 @@
+export type SystemStatus = {
+    ok: boolean
+    systems: Record<string, SubsystemStatus>[]
+}
+
+type SubsystemStatus = {
+    ok: boolean
+}

--- a/ui-admin/vite.config.ts
+++ b/ui-admin/vite.config.ts
@@ -32,7 +32,8 @@ export default defineConfig({
     port: 3000,
     proxy: {
       '/api': 'http://localhost:8080',
-      '/config': 'http://localhost:8080'
+      '/config': 'http://localhost:8080',
+      '/status': 'http://localhost:8080'
     }
   },
   resolve: {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds a publicly accessible status page with two states:

<img width="595" alt="Screenshot 2024-10-11 at 3 41 31 PM" src="https://github.com/user-attachments/assets/dbf19111-cd9d-4577-8237-20707ccc4f61">

<img width="619" alt="Screenshot 2024-10-11 at 3 41 22 PM" src="https://github.com/user-attachments/assets/5abce733-7860-454c-bbf2-1c162d1fd3d2">

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Go to https://localhost:3000/system/status
Confirm that it is publicly visible and the current status is shown