### PR TITLE
[JN-1436] adding field includes to data export

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/export/ExportIntegrationController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/export/ExportIntegrationController.java
@@ -86,6 +86,23 @@ public class ExportIntegrationController implements ExportIntegrationApi {
   }
 
   @Override
+  public ResponseEntity<Object> save(
+      String portalShortcode, String studyShortcode, String envName, UUID id, Object body) {
+    AdminUser adminUser = authUtilService.requireAdminUser(request);
+    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
+    ExportIntegration integration = objectMapper.convertValue(body, ExportIntegration.class);
+    if (!id.equals(integration.getId())) {
+      throw new IllegalArgumentException("ID in URL does not match ID in body");
+    }
+    integration =
+        exportIntegrationExtService.save(
+            PortalStudyEnvAuthContext.of(
+                adminUser, portalShortcode, studyShortcode, environmentName),
+            integration);
+    return ResponseEntity.ok(integration);
+  }
+
+  @Override
   public ResponseEntity<Object> findJobsByStudy(
       String portalShortcode, String studyShortcode, String envName) {
     AdminUser operator = authUtilService.requireAdminUser(request);

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/export/ExportIntegrationExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/export/ExportIntegrationExtService.java
@@ -65,6 +65,20 @@ public class ExportIntegrationExtService {
     return exportIntegrationService.create(exportIntegration);
   }
 
+  @EnforcePortalStudyEnvPermission(permission = "export_integration")
+  public ExportIntegration save(
+      PortalStudyEnvAuthContext authContext, ExportIntegration exportIntegration) {
+    ExportIntegration loadedIntegration =
+        exportIntegrationService
+            .find(exportIntegration.getId())
+            .orElseThrow(() -> new NotFoundException("Export Integration not found"));
+    if (!loadedIntegration.getStudyEnvironmentId().equals(authContext.getStudyEnvironment().getId())
+        || !loadedIntegration.getExportOptionsId().equals(exportIntegration.getExportOptionsId())) {
+      throw new NotFoundException("Export Integration not found");
+    }
+    return exportIntegrationService.update(exportIntegration);
+  }
+
   @EnforcePortalStudyEnvPermission(permission = "BASE")
   public List<ExportIntegrationJob> listJobs(PortalStudyEnvAuthContext authContext) {
     return exportIntegrationJobService.findByStudyEnvironment(

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -1158,7 +1158,7 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/export/data:
-    get:
+    post:
       summary: Gets the export data in the specified format
       tags: [ export ]
       operationId: exportData
@@ -1166,14 +1166,9 @@ paths:
         - *portalShortcodeParam
         - *studyShortcodeParam
         - *envNameParam
-        - { name: splitOptionsIntoColumns, in: query, required: false, schema: { type: boolean, default: false } }
-        - { name: stableIdsForOptions, in: query, required: false, schema: { type: boolean, default: false } }
-        - { name: onlyIncludeMostRecent, in: query, required: false, schema: { type: boolean, default: true } }
-        - { name: includeSubheaders, in: query, required: false, schema: { type: boolean, default: true } }
-        - { name: excludeModules, in: query, required: false, schema: { type: array, items: { type: string } } }
-        - { name: filter, in: query, required: false, schema: { type: string, default: '' } }
-        - { name: fileFormat, in: query, required: false, schema: { type: string, default: "TSV" } }
-        - { name: rowLimit, in: query, required: false, schema: { type: integer } }
+      requestBody:
+        required: true
+        content: *jsonContent
       responses:
         '200':
           description: export data
@@ -1181,7 +1176,7 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/export/dictionary:
-    get:
+    post:
       summary: Gets the export data dictionary
       tags: [ export ]
       operationId: exportDictionary
@@ -1189,11 +1184,9 @@ paths:
         - *portalShortcodeParam
         - *studyShortcodeParam
         - *envNameParam
-        - { name: splitOptionsIntoColumns, in: query, required: false, schema: { type: boolean, default: false } }
-        - { name: stableIdsForOptions, in: query, required: false, schema: { type: boolean, default: false } }
-        - { name: onlyIncludeMostRecent, in: query, required: false, schema: { type: boolean, default: true } }
-        - { name: filter, in: query, required: false, schema: { type: string, default: '' } }
-        - { name: fileFormat, in: query, required: false, schema: { type: string, default: "TSV" } }
+      requestBody:
+        required: true
+        content: *jsonContent
       responses:
         '200':
           description: export data

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -1241,6 +1241,24 @@ paths:
           content: *jsonContent
         '500':
           $ref: '#/components/responses/ServerError'
+    patch:
+      summary: saves an exportIntegration
+      tags: [ exportIntegration ]
+      operationId: save
+      parameters:
+        - *portalShortcodeParam
+        - *studyShortcodeParam
+        - *envNameParam
+        - { name: id, in: path, required: true, schema: { type: string, format: uuid } }
+      requestBody:
+        required: true
+        content: *jsonContent
+      responses:
+        '200':
+          description: The exportIntegration
+          content: *jsonContent
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/exportIntegrations/{id}/run:
     post:
       summary: runs the exportIntegration by id

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/export/ExportIntegrationExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/export/ExportIntegrationExtServiceTests.java
@@ -24,6 +24,8 @@ public class ExportIntegrationExtServiceTests extends BaseSpringBootTest {
             AuthAnnotationSpec.withPortalStudyEnvPerm("participant_data_view"),
             "create",
             AuthAnnotationSpec.withPortalStudyEnvPerm("export_integration"),
+            "save",
+            AuthAnnotationSpec.withPortalStudyEnvPerm("export_integration"),
             "listJobs",
             AuthAnnotationSpec.withPortalStudyEnvPerm("BASE")));
   }

--- a/core/src/main/java/bio/terra/pearl/core/dao/export/ExportOptionsDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/export/ExportOptionsDao.java
@@ -17,11 +17,4 @@ public class ExportOptionsDao extends BaseMutableJdbiDao<ExportOptions> {
     protected Class<ExportOptions> getClazz() {
         return ExportOptions.class;
     }
-
-    @Override
-    protected List<String> generateGetFields(Class<ExportOptions> clazz) {
-        List<String> getFields = super.generateGetFields(clazz);
-        getFields.add("excludeModules");
-        return getFields;
-    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyDao.java
@@ -82,11 +82,4 @@ public class SurveyDao extends BaseVersionedJdbiDao<Survey> {
     protected Class<Survey> getClazz() {
         return Survey.class;
     }
-
-    @Override
-    protected List<String> generateGetFields(Class<Survey> clazz) {
-        List<String> getFields = super.generateGetFields(clazz);
-        getFields.add("referencedQuestions");
-        return getFields;
-    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/export/ExportOptions.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/export/ExportOptions.java
@@ -30,4 +30,6 @@ public class ExportOptions extends BaseEntity {
     private boolean includeSubHeaders = true;
     @Builder.Default
     private List<String> excludeModules = new ArrayList<>();
+    @Builder.Default
+    private List<String> includeFields = new ArrayList<>();
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/participant/Enrollee.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/participant/Enrollee.java
@@ -34,6 +34,8 @@ public class Enrollee extends BaseEntity {
     @Builder.Default
     private boolean subject = true; // whether this Enrollee is a primary subject of the study (as opposed to just a proxy or family member)
     private boolean consented;
+    @Builder.Default
+    private EnrolleeSourceType source = EnrolleeSourceType.PORTAL_SITE;
 
     @Builder.Default
     private List<FamilyEnrollee> familyEnrollees = new ArrayList<>();

--- a/core/src/main/java/bio/terra/pearl/core/model/participant/EnrolleeSourceType.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/participant/EnrolleeSourceType.java
@@ -1,0 +1,6 @@
+package bio.terra.pearl.core.model.participant;
+
+public enum EnrolleeSourceType {
+    IMPORT, // the enrollee data was imported from an external source
+    PORTAL_SITE // default, they came in through standard signup flow
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportData.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportData.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.service.export;
 
 import bio.terra.pearl.core.model.participant.*;
+import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.model.survey.Answer;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
@@ -14,6 +15,7 @@ import java.util.List;
 
 @Getter @Setter @Builder @AllArgsConstructor
 public class EnrolleeExportData {
+    private Study study;
     private Enrollee enrollee;
     private ParticipantUser participantUser;
     private Profile profile;

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
@@ -7,6 +7,7 @@ import bio.terra.pearl.core.model.export.ExportOptions;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.EnrolleeRelation;
 import bio.terra.pearl.core.model.search.EnrolleeSearchExpressionResult;
+import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.study.StudyEnvironmentConfig;
 import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
@@ -24,6 +25,7 @@ import bio.terra.pearl.core.service.search.EnrolleeSearchOptions;
 import bio.terra.pearl.core.service.study.StudyEnvironmentConfigService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
+import bio.terra.pearl.core.service.study.StudyService;
 import bio.terra.pearl.core.service.survey.SurveyResponseService;
 import bio.terra.pearl.core.service.survey.SurveyService;
 import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
@@ -55,6 +57,7 @@ public class EnrolleeExportService {
     private final FamilyService familyService;
     private final EnrolleeSearchExpressionDao enrolleeSearchExpressionDao;
     private final StudyEnvironmentConfigService studyEnvironmentConfigService;
+    private final StudyService studyService;
 
     public EnrolleeExportService(ProfileService profileService,
                                  AnswerDao answerDao,
@@ -67,7 +70,9 @@ public class EnrolleeExportService {
                                  EnrolleeRelationService enrolleeRelationService,
                                  ObjectMapper objectMapper,
                                  FamilyService familyService,
-                                 EnrolleeSearchExpressionDao enrolleeSearchExpressionDao, StudyEnvironmentConfigService studyEnvironmentConfigService) {
+                                 EnrolleeSearchExpressionDao enrolleeSearchExpressionDao,
+                                 StudyEnvironmentConfigService studyEnvironmentConfigService,
+                                 StudyService studyService) {
         this.profileService = profileService;
         this.answerDao = answerDao;
         this.surveyQuestionDefinitionDao = surveyQuestionDefinitionDao;
@@ -83,6 +88,7 @@ public class EnrolleeExportService {
         this.familyService = familyService;
         this.enrolleeSearchExpressionDao = enrolleeSearchExpressionDao;
         this.studyEnvironmentConfigService = studyEnvironmentConfigService;
+        this.studyService = studyService;
     }
 
     /**
@@ -100,7 +106,9 @@ public class EnrolleeExportService {
     }
 
     public List<EnrolleeExportData> loadEnrolleeExportData(UUID studyEnvironmentId, ExportOptionsWithExpression exportOptions) {
+        Study study = studyService.findByStudyEnvironmentId(studyEnvironmentId).orElseThrow();
         return loadEnrolleesForExport(
+                study,
                 studyEnvironmentConfigService.findByStudyEnvironmentId(studyEnvironmentId),
                 loadEnrollees(studyEnvironmentId, exportOptions.getFilterExpression(), exportOptions.getRowLimit()));
     }
@@ -148,6 +156,7 @@ public class EnrolleeExportService {
     public List<ModuleFormatter> generateModuleInfos(ExportOptions exportOptions, UUID studyEnvironmentId, List<EnrolleeExportData> enrolleeExportData) {
         List<ModuleFormatter> allSimpleFormatters = List.of(
                 new EnrolleeFormatter(exportOptions),
+                new StudyFormatter(exportOptions),
                 new ParticipantUserFormatter(exportOptions),
                 new ProfileFormatter(exportOptions),
                 new KitRequestFormatter(exportOptions),
@@ -214,19 +223,20 @@ public class EnrolleeExportService {
         return moduleFormatters;
     }
 
-    protected List<EnrolleeExportData> loadEnrolleesForExport(StudyEnvironmentConfig config,
+    protected List<EnrolleeExportData> loadEnrolleesForExport(Study study,
+                                                              StudyEnvironmentConfig config,
                                                               List<Enrollee> enrollees) {
-
         // for now, load each enrollee individually.  Later we'll want more sophisticated batching strategies
         return enrollees
                 .stream()
-                .map(enrollee -> loadEnrolleeData(config, enrollee))
+                .map(enrollee -> loadEnrolleeData(study, config, enrollee))
                 .toList();
     }
 
-    protected EnrolleeExportData loadEnrolleeData(StudyEnvironmentConfig config,
+    protected EnrolleeExportData loadEnrolleeData(Study study, StudyEnvironmentConfig config,
                                                   Enrollee enrollee) {
         return new EnrolleeExportData(
+                study,
                 enrollee,
                 participantUserService.find(enrollee.getParticipantUserId()).orElseThrow(),
                 profileService.loadWithMailingAddress(enrollee.getProfileId()).get(),

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
@@ -150,9 +150,9 @@ public class EnrolleeExportService {
                 new EnrolleeFormatter(exportOptions),
                 new ParticipantUserFormatter(exportOptions),
                 new ProfileFormatter(exportOptions),
-                new KitRequestFormatter(),
-                new EnrolleeRelationFormatter(),
-                new FamilyFormatter());
+                new KitRequestFormatter(exportOptions),
+                new EnrolleeRelationFormatter(exportOptions),
+                new FamilyFormatter(exportOptions));
 
         List<ModuleFormatter> moduleFormatters = allSimpleFormatters.stream().filter(
                 moduleFormatter -> !exportOptions.getExcludeModules().contains(moduleFormatter.getModuleName())

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -231,7 +231,7 @@ public class EnrolleeImportService {
 
         importSurveyResponses(portalShortcode, enrolleeMap, exportOptions, studyEnv, regResult.portalParticipantUser(), enrollee, auditInfo);
 
-        /** restore email -- reload the profile since answermappings may have changed it */
+        /** restore email -- reload the pr5ofile since answermappings may have changed it */
         profile = profileService.find(profile.getId()).orElseThrow();
         profile.setDoNotEmail(false);
         profileService.update(profile, auditInfo);
@@ -239,7 +239,7 @@ public class EnrolleeImportService {
     }
 
     private void importKitRequests(Map<String, String> enrolleeMap, UUID adminId, Enrollee enrollee) {
-        new KitRequestFormatter().listFromStringMap(enrolleeMap).stream().map(
+        new KitRequestFormatter(new ExportOptions()).listFromStringMap(enrolleeMap).stream().map(
                 kitRequestDto -> kitRequestService.create(convertKitRequestDto(adminId, enrollee, kitRequestDto))).toList();
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -7,10 +7,7 @@ import bio.terra.pearl.core.model.dataimport.*;
 import bio.terra.pearl.core.model.export.ExportOptions;
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.kit.KitType;
-import bio.terra.pearl.core.model.participant.Enrollee;
-import bio.terra.pearl.core.model.participant.ParticipantUser;
-import bio.terra.pearl.core.model.participant.PortalParticipantUser;
-import bio.terra.pearl.core.model.participant.Profile;
+import bio.terra.pearl.core.model.participant.*;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
 import bio.terra.pearl.core.model.workflow.HubResponse;
@@ -288,10 +285,11 @@ public class EnrolleeImportService {
             profileService.update(regResult.profile(), auditInfo);
 
             HubResponse<Enrollee> response = enrollmentService.enroll(regResult.portalParticipantUser(), studyEnv.getEnvironmentName(),
-                    studyShortcode, regResult.participantUser(), regResult.portalParticipantUser(), null, enrolleeInfo.isSubject());
+                    studyShortcode, regResult.participantUser(), regResult.portalParticipantUser(),
+                    null, enrolleeInfo.isSubject(), EnrolleeSourceType.IMPORT);
             Enrollee newEnrollee = response.getEnrollee();
             //update createdAt
-            if (newEnrollee.getCreatedAt() != null) {
+            if (enrolleeInfo.getCreatedAt() != null) {
                 timeShiftPopulateDao.changeEnrolleeCreationTime(response.getEnrollee().getId(), enrolleeInfo.getCreatedAt());
             }
             if (regResult.participantUser().getCreatedAt() != null) {

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/BeanListModuleFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/BeanListModuleFormatter.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.core.service.export.formatters.module;
 
+import bio.terra.pearl.core.model.export.ExportOptions;
 import bio.terra.pearl.core.model.survey.QuestionChoice;
 import bio.terra.pearl.core.service.export.EnrolleeExportData;
 import bio.terra.pearl.core.service.export.formatters.ExportFormatUtils;
@@ -14,6 +15,10 @@ import java.util.Map;
 @Slf4j
 /** ModuleFormatter for just listing properties of a thing -- e.g. fields from a profile */
 public abstract class BeanListModuleFormatter<T> extends ModuleFormatter<T, PropertyItemFormatter<T>> {
+
+    public BeanListModuleFormatter(ExportOptions options, String moduleName, String displayName) {
+        super(options, moduleName, displayName);
+    }
 
     @Override
     public String getColumnSubHeader(PropertyItemFormatter itemFormatter, boolean isOtherDescription, QuestionChoice choice, int moduleRepeatNum) {

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/BeanModuleFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/BeanModuleFormatter.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.core.service.export.formatters.module;
 
+import bio.terra.pearl.core.model.export.ExportOptions;
 import bio.terra.pearl.core.model.survey.QuestionChoice;
 import bio.terra.pearl.core.service.export.EnrolleeExportData;
 import bio.terra.pearl.core.service.export.formatters.ExportFormatUtils;
@@ -7,12 +8,17 @@ import bio.terra.pearl.core.service.export.formatters.item.PropertyItemFormatter
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 @Slf4j
 /** ModuleFormatter for just listing properties of a thing -- e.g. fields from a profile */
 public abstract class BeanModuleFormatter<T> extends ModuleFormatter<T, PropertyItemFormatter<T>> {
+
+    public BeanModuleFormatter(ExportOptions options, String moduleName, String displayName) {
+        super(options, moduleName, displayName);
+    }
 
     @Override
     public String getColumnSubHeader(PropertyItemFormatter itemFormatter, boolean isOtherDescription, QuestionChoice choice, int moduleRepeatNum) {

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeFormatter.java
@@ -9,16 +9,18 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class EnrolleeFormatter extends BeanModuleFormatter<Enrollee> {
-    public static final String ENROLLEE_MODULE_NAME = "enrollee";
     public static final List<String> INCLUDED_PROPERTIES = List.of(
             "shortcode", "consented", "createdAt", "subject"
     );
 
     public EnrolleeFormatter(ExportOptions exportOptions) {
-        itemFormatters = INCLUDED_PROPERTIES.stream().map(propName -> new PropertyItemFormatter<Enrollee>(propName, Enrollee.class))
+        super(exportOptions, "enrollee", "Enrollee");
+    }
+
+    @Override
+    protected List<PropertyItemFormatter<Enrollee>> generateItemFormatters(ExportOptions options) {
+        return INCLUDED_PROPERTIES.stream().map(propName -> new PropertyItemFormatter<>(propName, Enrollee.class))
                 .collect(Collectors.toList());
-        moduleName = ENROLLEE_MODULE_NAME;
-        displayName = "Enrollee";
     }
 
     @Override

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeFormatter.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 
 public class EnrolleeFormatter extends BeanModuleFormatter<Enrollee> {
     public static final List<String> INCLUDED_PROPERTIES = List.of(
-            "shortcode", "consented", "createdAt", "subject"
+            "shortcode", "consented", "createdAt", "subject", "source"
     );
 
     public EnrolleeFormatter(ExportOptions exportOptions) {

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeRelationFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeRelationFormatter.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.core.service.export.formatters.module;
 
+import bio.terra.pearl.core.model.export.ExportOptions;
 import bio.terra.pearl.core.model.participant.EnrolleeRelation;
 import bio.terra.pearl.core.service.export.EnrolleeExportData;
 import bio.terra.pearl.core.service.export.formatters.item.PropertyItemFormatter;
@@ -9,16 +10,18 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class EnrolleeRelationFormatter extends BeanListModuleFormatter<EnrolleeRelation> {
-    private static final String MODULE_NAME = "relation";
     private static final List<String> INCLUDED_PROPERTIES =
             List.of("enrollee.shortcode", "relationshipType", "beginDate", "endDate", "familyRelationship", "family.shortcode");
 
-    public EnrolleeRelationFormatter() {
-        itemFormatters = INCLUDED_PROPERTIES.stream()
+    public EnrolleeRelationFormatter(ExportOptions exportOptions) {
+        super(exportOptions, "relation",  "Relations");
+    }
+
+    @Override
+    protected List<PropertyItemFormatter<EnrolleeRelation>> generateItemFormatters(ExportOptions options) {
+        return INCLUDED_PROPERTIES.stream()
                 .map(propName -> new PropertyItemFormatter<>(propName, EnrolleeRelation.class))
                 .collect(Collectors.toList());
-        moduleName = MODULE_NAME;
-        displayName = "Relations";
     }
 
     @Override

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/FamilyFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/FamilyFormatter.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.core.service.export.formatters.module;
 
+import bio.terra.pearl.core.model.export.ExportOptions;
 import bio.terra.pearl.core.model.participant.Family;
 import bio.terra.pearl.core.service.export.EnrolleeExportData;
 import bio.terra.pearl.core.service.export.formatters.item.PropertyItemFormatter;
@@ -9,16 +10,18 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class FamilyFormatter extends BeanListModuleFormatter<Family> {
-    private static final String MODULE_NAME = "family";
     private static final List<String> INCLUDED_PROPERTIES =
         List.of("shortcode", "proband.shortcode");
 
-    public FamilyFormatter() {
-        itemFormatters = INCLUDED_PROPERTIES.stream()
+    public FamilyFormatter(ExportOptions options) {
+        super(options, "family", "Families");
+    }
+
+    @Override
+    protected List<PropertyItemFormatter<Family>> generateItemFormatters(ExportOptions options) {
+        return INCLUDED_PROPERTIES.stream()
                 .map(propName -> new PropertyItemFormatter<>(propName, Family.class))
                 .collect(Collectors.toList());
-        moduleName = MODULE_NAME;
-        displayName = "Families";
     }
 
     @Override

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/KitRequestFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/KitRequestFormatter.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.core.service.export.formatters.module;
 
+import bio.terra.pearl.core.model.export.ExportOptions;
 import bio.terra.pearl.core.model.kit.KitRequestStatus;
 import bio.terra.pearl.core.service.export.EnrolleeExportData;
 import bio.terra.pearl.core.service.export.formatters.item.KitTypeFormatter;
@@ -14,19 +15,22 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class KitRequestFormatter extends BeanListModuleFormatter<KitRequestDto> {
-    private static final String KIT_REQUEST_MODULE_NAME = "sample_kit";
     private static final List<String> KIT_REQUEST_INCLUDED_PROPERTIES =
             List.of("status", "sentToAddress", "sentAt", "receivedAt", "createdAt", "labeledAt",
                     "trackingNumber", "returnTrackingNumber", "skipAddressValidation");
 
-    public KitRequestFormatter() {
+    public KitRequestFormatter(ExportOptions options) {
+        super(options, "sample_kit", "Sample kit");
+    }
+
+    @Override
+    protected List<PropertyItemFormatter<KitRequestDto>> generateItemFormatters(ExportOptions options) {
         itemFormatters = KIT_REQUEST_INCLUDED_PROPERTIES.stream()
-                .map(propName -> new PropertyItemFormatter<KitRequestDto>(propName, KitRequestDto.class))
+                .map(propName -> new PropertyItemFormatter<>(propName, KitRequestDto.class))
                 .collect(Collectors.toList());
         // we have to handle kitType separately because we'll need to match it to the kitType name
         itemFormatters.add(new KitTypeFormatter());
-        moduleName = KIT_REQUEST_MODULE_NAME;
-        displayName = "Sample kit";
+        return itemFormatters;
     }
 
     @Override

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ModuleFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ModuleFormatter.java
@@ -1,17 +1,20 @@
 package bio.terra.pearl.core.service.export.formatters.module;
 
+import bio.terra.pearl.core.model.export.ExportOptions;
 import bio.terra.pearl.core.model.survey.QuestionChoice;
 import bio.terra.pearl.core.service.export.EnrolleeExportData;
 import bio.terra.pearl.core.service.export.formatters.ExportFormatUtils;
 import bio.terra.pearl.core.service.export.formatters.item.ItemFormatter;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.NotImplementedException;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Getter
 public abstract class ModuleFormatter<T, F extends ItemFormatter<T>> {
@@ -20,6 +23,13 @@ public abstract class ModuleFormatter<T, F extends ItemFormatter<T>> {
     @Setter
     protected int maxNumRepeats = 1;
     protected List<F> itemFormatters = new ArrayList<>();
+
+    protected ModuleFormatter(ExportOptions options, String moduleName, String displayName) {
+        this.moduleName = moduleName;
+        this.displayName = displayName;
+        this.itemFormatters = generateItemFormatters(options);
+        filterItemFormatters(options);
+    }
 
     public String getColumnKey(F itemFormatter, boolean isOtherDescription, QuestionChoice choice, int moduleRepeatNum) {
         if (moduleRepeatNum > 1) {
@@ -31,6 +41,16 @@ public abstract class ModuleFormatter<T, F extends ItemFormatter<T>> {
                     itemFormatter.getBaseColumnKey());
        }
         return "%s%s%s".formatted(moduleName, ExportFormatUtils.COLUMN_NAME_DELIMITER,  itemFormatter.getBaseColumnKey());
+    }
+
+    protected abstract List<F> generateItemFormatters(ExportOptions options);
+    protected void filterItemFormatters(ExportOptions options) {
+        if (options.getIncludeFields() != null && !options.getIncludeFields().isEmpty()) {
+            itemFormatters = itemFormatters.stream()
+                    .filter(itemFormatter -> ArrayUtils.contains(options.getIncludeFields().toArray(),
+                            getColumnKey(itemFormatter, false, null, 1)))
+                    .collect(Collectors.toList());
+        }
     }
 
     public String getColumnHeader(F itemFormatter, boolean isOtherDescription, QuestionChoice choice, int moduleRepeatNum) {

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ParticipantUserFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ParticipantUserFormatter.java
@@ -9,14 +9,16 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class ParticipantUserFormatter extends BeanModuleFormatter<ParticipantUser> {
-    public static final String PARTICIPANT_USER_MODULE_NAME = "account";
     public static final List<String> INCLUDED_PROPERTIES = List.of("shortcode", "username", "createdAt");
 
     public ParticipantUserFormatter(ExportOptions exportOptions) {
-        itemFormatters = INCLUDED_PROPERTIES.stream().map(propName -> new PropertyItemFormatter<ParticipantUser>(propName, ParticipantUser.class))
+        super(exportOptions, "account", "Account");
+    }
+
+    @Override
+    protected List<PropertyItemFormatter<ParticipantUser>> generateItemFormatters(ExportOptions options) {
+        return INCLUDED_PROPERTIES.stream().map(propName -> new PropertyItemFormatter<>(propName, ParticipantUser.class))
                 .collect(Collectors.toList());
-        moduleName = PARTICIPANT_USER_MODULE_NAME;
-        displayName = "Account";
     }
 
     @Override

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ProfileFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ProfileFormatter.java
@@ -12,8 +12,6 @@ import java.util.stream.Collectors;
 
 
 public class ProfileFormatter extends BeanModuleFormatter<Profile> {
-    private static final String PROFILE_MODULE_NAME = "profile";
-    private static final String ADDRESS_SUBMODULE_NAME = "address";
     private static final List<String> PROFILE_EXCLUDED_PROPERTIES = List.of("id", "createdAt",
             "lastUpdatedAt", "mailingAddress", "mailingAddressId", "class");
     private static final List<String> MAILING_ADDRESS_EXCLUDED_PROPERTIES = List.of("id", "createdAt",
@@ -25,14 +23,18 @@ public class ProfileFormatter extends BeanModuleFormatter<Profile> {
     }
 
     public ProfileFormatter(ExportOptions exportOptions) {
-        itemFormatters = ExportFormatUtils.getIncludedProperties(Profile.class, PROFILE_EXCLUDED_PROPERTIES)
+        super(exportOptions, "profile", "Enrollee profile");
+    }
+
+    @Override
+    protected List<PropertyItemFormatter<Profile>> generateItemFormatters(ExportOptions options) {
+        List<PropertyItemFormatter<Profile>> formatters = ExportFormatUtils.getIncludedProperties(Profile.class, PROFILE_EXCLUDED_PROPERTIES)
                 .stream().map(propName -> new PropertyItemFormatter<Profile>(propName, Profile.class))
                 .collect(Collectors.toList());
-        itemFormatters.addAll(ExportFormatUtils.getIncludedProperties(MailingAddress.class, MAILING_ADDRESS_EXCLUDED_PROPERTIES)
+        formatters.addAll(ExportFormatUtils.getIncludedProperties(MailingAddress.class, MAILING_ADDRESS_EXCLUDED_PROPERTIES)
                 .stream().map(propName -> new PropertyItemFormatter<Profile>("mailingAddress." + propName, Profile.class))
                 .toList());
-        moduleName = PROFILE_MODULE_NAME;
-        displayName = "Enrollee profile";
+        return formatters;
     }
 
     @Override

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/StudyFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/StudyFormatter.java
@@ -1,0 +1,36 @@
+package bio.terra.pearl.core.service.export.formatters.module;
+
+import bio.terra.pearl.core.model.export.ExportOptions;
+import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.study.Study;
+import bio.terra.pearl.core.service.export.EnrolleeExportData;
+import bio.terra.pearl.core.service.export.formatters.item.PropertyItemFormatter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class StudyFormatter extends BeanModuleFormatter<Study> {
+    public static final List<String> INCLUDED_PROPERTIES = List.of(
+            "shortcode"
+    );
+
+    public StudyFormatter(ExportOptions exportOptions) {
+        super(exportOptions, "study", "Study");
+    }
+
+    @Override
+    protected List<PropertyItemFormatter<Study>> generateItemFormatters(ExportOptions options) {
+        return INCLUDED_PROPERTIES.stream().map(propName -> new PropertyItemFormatter<>(propName, Study.class))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Study getBean(EnrolleeExportData enrolleeExportData) {
+        return enrolleeExportData.getStudy();
+    }
+
+    @Override
+    public Study newBean() {
+        return new Study();
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatter.java
@@ -38,18 +38,25 @@ public class SurveyFormatter extends ModuleFormatter<SurveyResponse, ItemFormatt
                            List<SurveyQuestionDefinition> questionDefs,
                            List<EnrolleeExportData> data,
                            ObjectMapper objectMapper) {
+        super(exportOptions,
+                stableId,
+                // get the most recent survey by sorting in descending version order
+                surveys.stream().sorted(Comparator.comparingInt(Survey::getVersion).reversed()).findFirst().get().getName());
         this.objectMapper = objectMapper;
-        itemFormatters.add(new PropertyItemFormatter("lastUpdatedAt", SurveyResponse.class));
-        itemFormatters.add(new PropertyItemFormatter("complete", SurveyResponse.class));
-
-        buildItemFormatters(exportOptions, questionDefs, data);
-        // get the most recent survey by sorting in descending version order
-        Survey latestSurvey = surveys.stream().sorted(Comparator.comparingInt(Survey::getVersion).reversed()).findFirst().get();
-        displayName = latestSurvey.getName();
-        moduleName = stableId;
+        generateAnswerItemFormatters(exportOptions, questionDefs, data);
+        filterItemFormatters(exportOptions);
     }
 
-    private void buildItemFormatters(
+    @Override
+    protected List<ItemFormatter<SurveyResponse>> generateItemFormatters(ExportOptions options) {
+        // Note that we generate and add answer formatters to this list later in the constructor
+        List<ItemFormatter<SurveyResponse>> formatters = new ArrayList<>();
+        formatters.add(new PropertyItemFormatter<>("lastUpdatedAt", SurveyResponse.class));
+        formatters.add(new PropertyItemFormatter<>("complete", SurveyResponse.class));
+        return formatters;
+    }
+
+    private void generateAnswerItemFormatters(
             ExportOptions exportOptions,
             List<SurveyQuestionDefinition> questionDefs,
             List<EnrolleeExportData> data) {

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatter.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;

--- a/core/src/main/java/bio/terra/pearl/core/service/export/integration/ExportIntegrationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/integration/ExportIntegrationService.java
@@ -47,6 +47,13 @@ public class ExportIntegrationService extends CrudService<ExportIntegration, Exp
         return newIntegration;
     }
 
+    public ExportIntegration update(ExportIntegration integration) {
+        ExportOptions updatedOpts = exportOptionsDao.update(integration.getExportOptions());
+        ExportIntegration newIntegration = super.update(integration);
+        newIntegration.setExportOptions(updatedOpts);
+        return newIntegration;
+    }
+
     public ExportIntegrationJob doExport(ExportIntegration integration, ResponsibleEntity operator) {
         ExternalExporter exporter = externalExporters.get(integration.getDestinationType());
         return doExport(exporter, integration, operator);

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/EnrolleeReminderService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/EnrolleeReminderService.java
@@ -3,6 +3,7 @@ package bio.terra.pearl.core.service.notification;
 import bio.terra.pearl.core.dao.workflow.ParticipantTaskDao;
 import bio.terra.pearl.core.model.notification.Trigger;
 import bio.terra.pearl.core.model.notification.TriggerType;
+import bio.terra.pearl.core.model.participant.EnrolleeSourceType;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.workflow.TaskType;
 import bio.terra.pearl.core.service.rule.EnrolleeContext;
@@ -73,15 +74,24 @@ public class EnrolleeReminderService {
 
         NotificationContextInfo envContext = notificationDispatcher.loadContextInfo(trigger);
 
-        for (ParticipantTaskDao.EnrolleeWithTasks enrolleeWithTask : enrolleesWithTasks) {
-            // this isn't an optimized match -- we're assuming the number of reminders we send on any given run for a single
-            // config will likely be < 100
-            EnrolleeContext ruleData = enrolleeData.stream()
-                    .filter(erd -> erd.getEnrollee().getId().equals(enrolleeWithTask.getEnrolleeId())).findFirst().get();
+        for (EnrolleeContext enrolleeContext : enrolleeData) {
             // don't send non-consent task reminders to enrollees who haven't consented
-            if (trigger.getTaskType().equals(TaskType.CONSENT) || ruleData.getEnrollee().isConsented()) {
-                notificationDispatcher.dispatchNotification(trigger, ruleData, envContext);
+            if (shouldSendReminder(enrolleeContext, trigger)) {
+                notificationDispatcher.dispatchNotification(trigger, enrolleeContext, envContext);
             }
         }
+    }
+
+    public boolean shouldSendReminder(EnrolleeContext enrolleeContext, Trigger trigger) {
+        // don't send reminders other than consents for enrollees who haven't consented
+        if (!trigger.getTaskType().equals(TaskType.CONSENT) && !enrolleeContext.getEnrollee().isConsented()) {
+            return false;
+        }
+        // don't send reminders to enrollees who were imported but haven't consented -- we want them to use invitation emails
+        if (enrolleeContext.getEnrollee().getSource().equals(EnrolleeSourceType.IMPORT) &&
+                 enrolleeContext.getParticipantUser().getLastLogin() == null) {
+            return false;
+        }
+        return true;
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/rule/EnrolleeContextService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/rule/EnrolleeContextService.java
@@ -36,10 +36,12 @@ public class EnrolleeContextService {
     /**
      * useful for bulk-fetching enrollees for processing
      * this isn't terribly optimized -- we could do the join in the DB.  But this is assuming that the number of enrollees
-     *  is ~5-30, not 1000+, and so the main goal is just making sure we only do 4 total DB roundtrips
+     *  is ~5-30, not 1000+, and so the main goal is just making sure we only do 4 total DB roundtrips.
+     *
+     *  This returns the context for each enrollee in the order of the input list
      */
     public List<EnrolleeContext> fetchData(List<UUID> enrolleeIds) {
-        List<Enrollee> enrollees = enrolleeService.findAll(enrolleeIds);
+        List<Enrollee> enrollees = enrolleeService.findAllPreserveOrder(enrolleeIds);
         List<Profile> profiles = profileService.findAllWithMailingAddressPreserveOrder(enrollees.stream().map(Enrollee::getProfileId).toList());
         List<ParticipantUser> users = participantUserService.findAllPreserveOrder(enrollees.stream().map(Enrollee::getParticipantUserId).toList());
         List<EnrolleeContext> ruleData = IntStream.range(0, enrollees.size()).mapToObj(i ->

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
@@ -122,6 +122,18 @@ public class EnrollmentService {
                                         PortalParticipantUser ppUser,
                                         UUID preEnrollResponseId,
                                         boolean isSubject) {
+        return enroll(operator, envName, studyShortcode, user, ppUser, preEnrollResponseId, isSubject, EnrolleeSourceType.PORTAL_SITE);
+    }
+
+    @Transactional
+    public HubResponse<Enrollee> enroll(PortalParticipantUser operator,
+                                        EnvironmentName envName,
+                                        String studyShortcode,
+                                        ParticipantUser user,
+                                        PortalParticipantUser ppUser,
+                                        UUID preEnrollResponseId,
+                                        boolean isSubject,
+                                        EnrolleeSourceType source) {
         log.info("creating enrollee for user {}, study {}", user.getId(), studyShortcode);
         StudyEnvironment studyEnv = studyEnvironmentService.findByStudy(studyShortcode, envName)
                 .orElseThrow(() -> new NotFoundException("Study environment %s %s not found".formatted(studyShortcode, envName)));
@@ -134,7 +146,7 @@ public class EnrollmentService {
 
         // if the user is signed up, but not a subject, we can just return the existing enrollee,
         // otherwise create a new one for them
-        Enrollee enrollee = findOrCreateEnrolleeForEnrollment(user, ppUser, studyEnv, studyShortcode, preEnrollResponseId, isSubject);
+        Enrollee enrollee = findOrCreateEnrolleeForEnrollment(user, ppUser, studyEnv, studyShortcode, preEnrollResponseId, isSubject, source);
 
         if (preEnrollResponse != null) {
             preEnrollResponse.setCreatingParticipantUserId(user.getId());
@@ -152,7 +164,9 @@ public class EnrollmentService {
         return hubResponse;
     }
 
-    private Enrollee findOrCreateEnrolleeForEnrollment(ParticipantUser user, PortalParticipantUser ppUser, StudyEnvironment studyEnv, String studyShortcode, UUID preEnrollResponseId, boolean isSubjectEnrollment) {
+    private Enrollee findOrCreateEnrolleeForEnrollment(ParticipantUser user, PortalParticipantUser ppUser, StudyEnvironment studyEnv,
+                                                       String studyShortcode, UUID preEnrollResponseId, boolean isSubjectEnrollment,
+                                                       EnrolleeSourceType source) {
         return enrolleeService
                 .findByParticipantUserIdAndStudyEnv(user.getId(), studyShortcode, studyEnv.getEnvironmentName())
                 .filter(e -> {
@@ -175,6 +189,7 @@ public class EnrollmentService {
                             .profileId(ppUser.getProfileId())
                             .preEnrollmentResponseId(preEnrollResponseId)
                             .subject(isSubjectEnrollment)
+                            .source(source)
                             .build();
                     return enrolleeService.create(newEnrollee);
                 });
@@ -217,7 +232,7 @@ public class EnrollmentService {
                 .surveyId(preEnrollResponse.getSurveyId())
                 .portalParticipantUserId(ppUser.getId())
                 .build();
-        
+
         // process any answers that need to be propagated elsewhere to the data model
         answerProcessingService.processAllAnswerMappings(
                 enrollee,

--- a/core/src/main/resources/db/changelog/changesets/2024_10_15_adding_export_fields.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_10_15_adding_export_fields.yaml
@@ -1,0 +1,7 @@
+databaseChangeLog:
+  - changeSet:
+      id: "export_options_include_fields"
+      author: dbush
+      changes:
+        - sql:
+            sql: ALTER TABLE export_options ADD COLUMN include_fields text[];

--- a/core/src/main/resources/db/changelog/changesets/2024_10_16_enrollee_source.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_10_16_enrollee_source.yaml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: "enrollee_source"
+      author: dbush
+      changes:
+        - addColumn:
+            tableName: enrollee
+            columns:
+              - column: { name: source, type: text }
+        - sql:
+            sql: "UPDATE enrollee SET source = 'PORTAL_SITE';"
+        - sql:
+            sql: "UPDATE enrollee SET source = 'IMPORT' from import_item where created_enrollee_id = enrollee.id;"
+        - addNotNullConstraint:
+            tableName: enrollee
+            columnName: source

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -338,6 +338,9 @@ databaseChangeLog:
   - include:
       file: changesets/2024_10_15_adding_export_fields.yaml
       relativeToChangelogFile: true
+  - include:
+        file: changesets/2024_10_16_enrollee_source.yaml
+        relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -335,6 +335,9 @@ databaseChangeLog:
   - include:
       file: changesets/2024_10_08_portal_last_login.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2024_10_15_adding_export_fields.yaml
+      relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/core/src/test/java/bio/terra/pearl/core/dao/BaseJdbiDaoTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/BaseJdbiDaoTests.java
@@ -42,8 +42,9 @@ public class BaseJdbiDaoTests extends BaseSpringBootTest {
     public void testGenerateInsertFields() {
         SimpleModelDao testDao = new SimpleModelDao(null);
         List<String> fields = testDao.insertFields;
+        // 'id','relatedStudy', and 'surveyList' should not be included
         String[] expectedFields = new String[]{"createdAt", "lastUpdatedAt", "boolField",
-                "intField", "doubleField", "stringField", "uuidField", "instantField"};
+                "intField", "doubleField", "stringField", "uuidField", "instantField", "stringList"};
         assertThat(fields.toString(), fields, containsInAnyOrder(expectedFields));
     }
 
@@ -56,6 +57,8 @@ public class BaseJdbiDaoTests extends BaseSpringBootTest {
         private UUID uuidField;
         private Instant instantField;
         private Study relatedStudy;
+        private List<String> stringList;
+        private List<Survey> surveyList;
     }
 
     private class SimpleModelDao extends BaseJdbiDao<SimpleModel> {

--- a/core/src/test/java/bio/terra/pearl/core/dao/BaseMutableJdbiTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/BaseMutableJdbiTests.java
@@ -16,20 +16,18 @@ public class BaseMutableJdbiTests {
     public void testGenerateUpdateFieldString() {
         BaseMutableJdbiTests.SimpleModelDao testDao = new BaseMutableJdbiTests.SimpleModelDao(null);
         // notably, this should NOT contain 'created_at'
-        Assertions.assertEquals("bool_field = :boolField," +
-                        " instant_field = :instantField, int_field = :intField, last_updated_at = :lastUpdatedAt," +
-                        " string_field = :stringField, uuid_field = :uuidField",
+        Assertions.assertEquals("bool_field = :boolField, int_field = :intField, string_field = :stringField, uuid_field = :uuidField, instant_field = :instantField, last_updated_at = :lastUpdatedAt",
                 testDao.updateFieldString);
     }
 
     @Test
     public void testUpsertSql() {
         BaseMutableJdbiTests.SimpleModelDao testDao = new BaseMutableJdbiTests.SimpleModelDao(null);
-        Assertions.assertEquals("insert into simple_model (bool_field, created_at, instant_field, int_field, last_updated_at, string_field, uuid_field) " +
-                        "values (:boolField, :createdAt, :instantField, :intField, :lastUpdatedAt, :stringField, :uuidField) " +
+        Assertions.assertEquals("insert into simple_model (bool_field, int_field, string_field, uuid_field, instant_field, created_at, last_updated_at) " +
+                        "values (:boolField, :intField, :stringField, :uuidField, :instantField, :createdAt, :lastUpdatedAt) " +
                         "on conflict (uuid_field) do update set " +
-                        "bool_field = excluded.bool_field, instant_field = excluded.instant_field, int_field = excluded.int_field, " +
-                        "last_updated_at = excluded.last_updated_at, string_field = excluded.string_field, uuid_field = excluded.uuid_field",
+                        "bool_field = excluded.bool_field, int_field = excluded.int_field, string_field = excluded.string_field, " +
+                        "uuid_field = excluded.uuid_field, instant_field = excluded.instant_field, last_updated_at = excluded.last_updated_at",
                 testDao.getUpsertQuerySql("uuid_field"));
     }
 

--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeExportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeExportServiceTests.java
@@ -99,6 +99,22 @@ public class EnrolleeExportServiceTests extends BaseSpringBootTest {
 
     @Test
     @Transactional
+    public void testExportIncludeFields(TestInfo testInfo) throws Exception {
+        String testName = getTestName(testInfo);
+        StudyEnvironment studyEnv = studyEnvironmentFactory.buildPersisted(testName);
+        enrolleeFactory.buildPersisted(testName, studyEnv, new Profile());
+
+        ExportOptionsWithExpression opts = ExportOptionsWithExpression.builder()
+                .fileFormat(ExportFileFormat.TSV)
+                .includeFields(List.of("enrollee.shortcode", "profile.familyName")).build();
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        enrolleeExportService.export(opts, studyEnv.getId(), stream);
+
+        assertThat(stream.toString(), startsWith("enrollee.shortcode\tprofile.familyName\nShortcode"));
+    }
+
+    @Test
+    @Transactional
     public void testExportWithProxies(TestInfo testInfo) {
         String testName = getTestName(testInfo);
         StudyEnvironmentBundle studyEnvBundle = studyEnvironmentFactory.buildBundle(testName, EnvironmentName.live);

--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
@@ -17,6 +17,7 @@ import bio.terra.pearl.core.model.export.ExportOptions;
 import bio.terra.pearl.core.model.kit.KitRequestStatus;
 import bio.terra.pearl.core.model.kit.KitType;
 import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.participant.EnrolleeSourceType;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.model.participant.Profile;
 import bio.terra.pearl.core.model.survey.*;
@@ -577,6 +578,7 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
         assertThat(user.getUsername(), equalTo(userExpected.getUsername()));
         assertThat(user.getCreatedAt(), equalTo(userExpected.getCreatedAt()));
         assertThat(enrollee.getCreatedAt(), equalTo(enrolleeExpected.getCreatedAt()));
+        assertThat(enrollee.getSource(), equalTo(EnrolleeSourceType.IMPORT));
 
         //load profile
         Profile profile = profileService.find(enrollee.getProfileId()).orElseThrow();

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/EnrolleeFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/EnrolleeFormatterTests.java
@@ -21,7 +21,7 @@ public class EnrolleeFormatterTests {
                 .createdAt(Instant.parse("2023-08-21T05:17:25.00Z"))
                 .build();
         EnrolleeFormatter moduleFormatter = new EnrolleeFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(enrollee, null, null, null, null, null, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, enrollee, null, null, null, null, null, null, null, null);
         Map<String, String> valueMap = moduleFormatter.toStringMap(exportData);
 
         assertThat(valueMap.get("enrollee.shortcode"), equalTo("TESTER"));

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/FamilyFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/FamilyFormatterTests.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.core.service.export.formatters;
 
+import bio.terra.pearl.core.model.export.ExportOptions;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.Family;
 import bio.terra.pearl.core.service.export.EnrolleeExportData;
@@ -25,7 +26,7 @@ public class FamilyFormatterTests {
                 .proband(Enrollee.builder().shortcode("HDPROBAND2").build())
                 .shortcode("F_FAM2")
                 .build();
-        FamilyFormatter familyFormatter = new FamilyFormatter();
+        FamilyFormatter familyFormatter = new FamilyFormatter(new ExportOptions());
         EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null, null, null, null, null, List.of(family1, family2));
         Map<String, String> enrolleeMap = familyFormatter.toStringMap(exportData);
 

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/FamilyFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/FamilyFormatterTests.java
@@ -27,7 +27,7 @@ public class FamilyFormatterTests {
                 .shortcode("F_FAM2")
                 .build();
         FamilyFormatter familyFormatter = new FamilyFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null, null, null, null, null, List.of(family1, family2));
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null, null, null, null, null, null, List.of(family1, family2));
         Map<String, String> enrolleeMap = familyFormatter.toStringMap(exportData);
 
         assertThat(enrolleeMap.size(), equalTo(4));

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/KitRequestFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/KitRequestFormatterTests.java
@@ -39,7 +39,7 @@ public class KitRequestFormatterTests {
                 .createdAt(Instant.now().minus(1, java.time.temporal.ChronoUnit.DAYS))
                 .build()
         );
-        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null, null, null, kitRequests, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null, null, null, null, kitRequests, null, null);
         Map<String, String> valueMap = moduleFormatter.toStringMap(exportData);
 
         // the older kit should be first

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/KitRequestFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/KitRequestFormatterTests.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.core.service.export.formatters;
 
+import bio.terra.pearl.core.model.export.ExportOptions;
 import bio.terra.pearl.core.model.kit.KitRequestStatus;
 import bio.terra.pearl.core.model.kit.KitType;
 import bio.terra.pearl.core.service.export.EnrolleeExportData;
@@ -23,7 +24,7 @@ public class KitRequestFormatterTests {
             KitType.builder().id(UUID.randomUUID()).name("type1").build(),
             KitType.builder().id(UUID.randomUUID()).name("type2").build()
         );
-        KitRequestFormatter moduleFormatter = new KitRequestFormatter();
+        KitRequestFormatter moduleFormatter = new KitRequestFormatter(new ExportOptions());
         String sentDate = "2023-11-17T14:57:59.548Z";
         List<KitRequestDto> kitRequests = List.of(
             KitRequestDto.builder()

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ParticipantUserFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ParticipantUserFormatterTests.java
@@ -22,7 +22,7 @@ public class ParticipantUserFormatterTests {
                 .createdAt(Instant.parse("2023-08-21T05:17:25.00Z"))
                 .build();
         ParticipantUserFormatter moduleFormatter = new ParticipantUserFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(null, participantUser, null, null, null, null, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, participantUser, null, null, null, null, null, null, null);
         Map<String, String> valueMap = moduleFormatter.toStringMap(exportData);
 
         assertThat(valueMap.get("account.username"), equalTo(participantUser.getUsername()));

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ProfileFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ProfileFormatterTests.java
@@ -26,7 +26,7 @@ public class ProfileFormatterTests {
                         .build())
                 .build();
         ProfileFormatter moduleFormatter = new ProfileFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(null, null, profile, null, null, null, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, profile, null, null, null, null, null, null);
         Map<String, String> enrolleeMap = moduleFormatter.toStringMap(exportData);
 
         assertThat(enrolleeMap.get("profile.familyName"), equalTo("Tester"));
@@ -42,7 +42,7 @@ public class ProfileFormatterTests {
                 .familyName("Tester")
                 .build();
         ProfileFormatter moduleFormatter = new ProfileFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(null, null, profile, null, null, null, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, profile, null, null, null, null, null, null);
         Map<String, String> enrolleeMap = moduleFormatter.toStringMap(exportData);
 
         assertThat(enrolleeMap.get("profile.familyName"), equalTo("Tester"));

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatterTests.java
@@ -43,7 +43,7 @@ public class SurveyFormatterTests extends BaseSpringBootTest {
                 .surveyResponseId(testResponse.getId())
                 .stringValue("easyValue")
                 .build();
-        EnrolleeExportData enrolleeExportData = new EnrolleeExportData(null, null, null,
+        EnrolleeExportData enrolleeExportData = new EnrolleeExportData(null,null, null, null,
                 List.of(answer), null, List.of(testResponse), null, null, null);
         Map<String, String> valueMap = moduleFormatter.toStringMap(enrolleeExportData);
 

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/EnrolleeReminderServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/EnrolleeReminderServiceTests.java
@@ -11,11 +11,13 @@ import bio.terra.pearl.core.model.notification.Notification;
 import bio.terra.pearl.core.model.notification.NotificationDeliveryType;
 import bio.terra.pearl.core.model.notification.Trigger;
 import bio.terra.pearl.core.model.notification.TriggerType;
+import bio.terra.pearl.core.model.participant.EnrolleeSourceType;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
 import bio.terra.pearl.core.model.workflow.TaskStatus;
 import bio.terra.pearl.core.model.workflow.TaskType;
+import bio.terra.pearl.core.service.participant.EnrolleeService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,6 +57,54 @@ public class EnrolleeReminderServiceTests extends BaseSpringBootTest {
     assertThat(notificationList, hasSize(1));
     assertThat(notificationList.get(0).getTriggerId(), equalTo(savedConfig.getId()));
   }
+
+  @Test
+  @Transactional
+  public void testSurveyRemindersDontSendToUnconsented(TestInfo info) {
+    PortalEnvironment portalEnv = portalEnvironmentFactory.buildPersisted(getTestName(info));
+    StudyEnvironment studyEnv = studyEnvironmentFactory.buildPersisted(portalEnv, getTestName(info));
+    EnrolleeBundle enrolleeBundle = enrolleeFactory.buildWithPortalUser(getTestName(info), portalEnv, studyEnv);
+    ParticipantTask newTask1 = participantTaskFactory.buildPersisted(enrolleeBundle, TaskStatus.NEW, TaskType.SURVEY);
+
+    Trigger config = Trigger.builder()
+            .triggerType(TriggerType.TASK_REMINDER)
+            .taskType(TaskType.SURVEY)
+            .afterMinutesIncomplete(0)
+            .deliveryType(NotificationDeliveryType.EMAIL)
+            .studyEnvironmentId(studyEnv.getId())
+            .portalEnvironmentId(portalEnv.getId())
+            .build();
+    triggerService.create(config);
+    enrolleeReminderService.sendTaskReminders(studyEnv);
+
+    List<Notification> notificationList = notificationDao.findByEnrolleeId(enrolleeBundle.enrollee().getId());
+    assertThat(notificationList, hasSize(0));
+  }
+
+  @Test
+  @Transactional
+  public void testRemindersDontSendToImported(TestInfo info) {
+    PortalEnvironment portalEnv = portalEnvironmentFactory.buildPersisted(getTestName(info));
+    StudyEnvironment studyEnv = studyEnvironmentFactory.buildPersisted(portalEnv, getTestName(info));
+    EnrolleeBundle enrolleeBundle = enrolleeFactory.buildWithPortalUser(getTestName(info), portalEnv, studyEnv);
+    enrolleeBundle.enrollee().setSource(EnrolleeSourceType.IMPORT);
+    enrolleeService.update(enrolleeBundle.enrollee());
+    ParticipantTask newTask1 = participantTaskFactory.buildPersisted(enrolleeBundle, TaskStatus.NEW, TaskType.CONSENT);
+    Trigger config = Trigger.builder()
+            .triggerType(TriggerType.TASK_REMINDER)
+            .taskType(TaskType.CONSENT)
+            .afterMinutesIncomplete(0)
+            .deliveryType(NotificationDeliveryType.EMAIL)
+            .studyEnvironmentId(studyEnv.getId())
+            .portalEnvironmentId(portalEnv.getId())
+            .build();
+    triggerService.create(config);
+    enrolleeReminderService.sendTaskReminders(studyEnv);
+
+    List<Notification> notificationList = notificationDao.findByEnrolleeId(enrolleeBundle.enrollee().getId());
+    assertThat(notificationList, hasSize(0));
+  }
+
   @Autowired
   private ParticipantTaskFactory participantTaskFactory;
   @Autowired
@@ -69,4 +119,6 @@ public class EnrolleeReminderServiceTests extends BaseSpringBootTest {
   private TriggerService triggerService;
   @Autowired
   private EnrolleeFactory enrolleeFactory;
+  @Autowired
+  private EnrolleeService enrolleeService;
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/search/EnrolleeSearchExpressionParserTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/search/EnrolleeSearchExpressionParserTest.java
@@ -24,58 +24,67 @@ class EnrolleeSearchExpressionParserTest extends BaseSpringBootTest {
         EnrolleeSearchExpression searchExp = enrolleeSearchExpressionParser.parseRule(rule);
 
         Query query = searchExp.generateQuery(fakeStudyEnvId);
-        assertEquals("select enrollee.consented as enrollee_consented, " +
-                        "enrollee.created_at as enrollee_created_at, " +
-                        "enrollee.id as enrollee_id, " +
-                        "enrollee.last_updated_at as enrollee_last_updated_at, " +
-                        "enrollee.participant_user_id as enrollee_participant_user_id, " +
-                        "enrollee.pre_enrollment_response_id as enrollee_pre_enrollment_response_id, " +
-                        "enrollee.profile_id as enrollee_profile_id, enrollee.shortcode as enrollee_shortcode, " +
-                        "enrollee.study_environment_id as enrollee_study_environment_id, " +
-                        "enrollee.subject as enrollee_subject, profile.birth_date as profile_birth_date, " +
-                        "profile.contact_email as profile_contact_email, profile.created_at as profile_created_at, " +
-                        "profile.do_not_email as profile_do_not_email, " +
-                        "profile.do_not_email_solicit as profile_do_not_email_solicit, " +
-                        "profile.family_name as profile_family_name, profile.given_name as profile_given_name, " +
-                        "profile.id as profile_id, profile.last_updated_at as profile_last_updated_at, " +
-                        "profile.mailing_address_id as profile_mailing_address_id, " +
-                        "profile.phone_number as profile_phone_number, " +
-                        "profile.preferred_language as profile_preferred_language, " +
-                        "profile.sex_at_birth as profile_sex_at_birth, " +
-                        "answer_diagnosis.answer_type as answer_diagnosis_answer_type, " +
-                        "answer_diagnosis.boolean_value as answer_diagnosis_boolean_value, " +
-                        "answer_diagnosis.created_at as answer_diagnosis_created_at, " +
-                        "answer_diagnosis.creating_admin_user_id as answer_diagnosis_creating_admin_user_id, " +
-                        "answer_diagnosis.creating_participant_user_id as answer_diagnosis_creating_participant_user_id, " +
-                        "answer_diagnosis.enrollee_id as answer_diagnosis_enrollee_id, " +
-                        "answer_diagnosis.id as answer_diagnosis_id, " +
-                        "answer_diagnosis.last_updated_at as answer_diagnosis_last_updated_at, " +
-                        "answer_diagnosis.number_value as answer_diagnosis_number_value, " +
-                        "answer_diagnosis.object_value as answer_diagnosis_object_value, " +
-                        "answer_diagnosis.other_description as answer_diagnosis_other_description, " +
-                        "answer_diagnosis.question_stable_id as answer_diagnosis_question_stable_id, " +
-                        "answer_diagnosis.string_value as answer_diagnosis_string_value, " +
-                        "answer_diagnosis.survey_response_id as answer_diagnosis_survey_response_id, " +
-                        "answer_diagnosis.survey_stable_id as answer_diagnosis_survey_stable_id, " +
-                        "answer_diagnosis.survey_version as answer_diagnosis_survey_version, " +
-                        "answer_diagnosis.viewed_language as answer_diagnosis_viewed_language, " +
-                        "mailing_address.city as mailing_address_city, " +
-                        "mailing_address.country as mailing_address_country, " +
-                        "mailing_address.created_at as mailing_address_created_at, " +
-                        "mailing_address.id as mailing_address_id, " +
-                        "mailing_address.last_updated_at as mailing_address_last_updated_at, " +
-                        "mailing_address.postal_code as mailing_address_postal_code, " +
-                        "mailing_address.state as mailing_address_state, " +
-                        "mailing_address.street1 as mailing_address_street1, " +
-                        "mailing_address.street2 as mailing_address_street2 " +
-                        "from enrollee enrollee " +
-                        "left outer join profile profile on (enrollee.profile_id = profile.id) " +
-                        "left outer join answer answer_diagnosis on (enrollee.id = answer_diagnosis.enrollee_id) " +
-                        "left outer join mailing_address mailing_address on (profile.mailing_address_id = mailing_address.id) " +
-                        "where (((mailing_address.country = ?) or (mailing_address.country = ?)) " +
-                        "and (answer_diagnosis.survey_stable_id = ? AND answer_diagnosis.question_stable_id = ?) " +
-                        "and (answer_diagnosis.string_value = ?) and (EXTRACT('YEAR' FROM AGE(profile.birth_date)) > ?) " +
-                        "and (enrollee.study_environment_id = ?))",
+        assertEquals("""
+                        select enrollee.participant_user_id as enrollee_participant_user_id, \
+                        enrollee.profile_id as enrollee_profile_id, \
+                        enrollee.study_environment_id as enrollee_study_environment_id, \
+                        enrollee.pre_enrollment_response_id as enrollee_pre_enrollment_response_id, \
+                        enrollee.shortcode as enrollee_shortcode, \
+                        enrollee.subject as enrollee_subject, \
+                        enrollee.consented as enrollee_consented, \
+                        enrollee.id as enrollee_id, \
+                        enrollee.created_at as enrollee_created_at, \
+                        enrollee.last_updated_at as enrollee_last_updated_at, \
+                        profile.given_name as profile_given_name, \
+                        profile.family_name as profile_family_name, \
+                        profile.mailing_address_id as profile_mailing_address_id, \
+                        profile.preferred_language as profile_preferred_language, \
+                        profile.contact_email as profile_contact_email, \
+                        profile.do_not_email as profile_do_not_email, \
+                        profile.do_not_email_solicit as profile_do_not_email_solicit, \
+                        profile.birth_date as profile_birth_date, \
+                        profile.phone_number as profile_phone_number, \
+                        profile.sex_at_birth as profile_sex_at_birth, \
+                        profile.id as profile_id, \
+                        profile.created_at as profile_created_at, \
+                        profile.last_updated_at as profile_last_updated_at, \
+                        answer_diagnosis.creating_admin_user_id as answer_diagnosis_creating_admin_user_id, \
+                        answer_diagnosis.creating_participant_user_id as answer_diagnosis_creating_participant_user_id, \
+                        answer_diagnosis.survey_response_id as answer_diagnosis_survey_response_id, \
+                        answer_diagnosis.enrollee_id as answer_diagnosis_enrollee_id, \
+                        answer_diagnosis.question_stable_id as answer_diagnosis_question_stable_id, \
+                        answer_diagnosis.survey_stable_id as answer_diagnosis_survey_stable_id, \
+                        answer_diagnosis.other_description as answer_diagnosis_other_description, \
+                        answer_diagnosis.survey_version as answer_diagnosis_survey_version, \
+                        answer_diagnosis.viewed_language as answer_diagnosis_viewed_language, \
+                        answer_diagnosis.answer_type as answer_diagnosis_answer_type, \
+                        answer_diagnosis.string_value as answer_diagnosis_string_value, \
+                        answer_diagnosis.object_value as answer_diagnosis_object_value, \
+                        answer_diagnosis.number_value as answer_diagnosis_number_value, \
+                        answer_diagnosis.boolean_value as answer_diagnosis_boolean_value, \
+                        answer_diagnosis.id as answer_diagnosis_id, \
+                        answer_diagnosis.created_at as answer_diagnosis_created_at, \
+                        answer_diagnosis.last_updated_at as answer_diagnosis_last_updated_at, \
+                        mailing_address.street1 as mailing_address_street1, \
+                        mailing_address.street2 as mailing_address_street2, \
+                        mailing_address.state as mailing_address_state, \
+                        mailing_address.country as mailing_address_country, \
+                        mailing_address.city as mailing_address_city, \
+                        mailing_address.postal_code as mailing_address_postal_code, \
+                        mailing_address.id as mailing_address_id, \
+                        mailing_address.created_at as mailing_address_created_at, \
+                        mailing_address.last_updated_at as mailing_address_last_updated_at \
+                        from enrollee enrollee \
+                        left outer join profile profile on (enrollee.profile_id = profile.id) \
+                        left outer join answer answer_diagnosis on (enrollee.id = answer_diagnosis.enrollee_id) \
+                        left outer join mailing_address mailing_address on (profile.mailing_address_id = mailing_address.id) \
+                        where (((mailing_address.country = ?) or (mailing_address.country = ?)) \
+                        and (answer_diagnosis.survey_stable_id = ? \
+                        AND answer_diagnosis.question_stable_id = ?) \
+                        and (answer_diagnosis.string_value = ?) \
+                        and (EXTRACT('YEAR' FROM AGE(profile.birth_date)) > ?) \
+                        and (enrollee.study_environment_id = ?))\
+                        """,
                 query.getSQL());
 
         assertEquals(7, query.getBindValues().size());

--- a/core/src/test/java/bio/terra/pearl/core/service/search/EnrolleeSearchExpressionParserTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/search/EnrolleeSearchExpressionParserTest.java
@@ -32,6 +32,7 @@ class EnrolleeSearchExpressionParserTest extends BaseSpringBootTest {
                         enrollee.shortcode as enrollee_shortcode, \
                         enrollee.subject as enrollee_subject, \
                         enrollee.consented as enrollee_consented, \
+                        enrollee.source as enrollee_source, \
                         enrollee.id as enrollee_id, \
                         enrollee.created_at as enrollee_created_at, \
                         enrollee.last_updated_at as enrollee_last_updated_at, \

--- a/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
@@ -13,10 +13,7 @@ import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.kit.KitRequestStatus;
 import bio.terra.pearl.core.model.kit.KitType;
 import bio.terra.pearl.core.model.notification.Trigger;
-import bio.terra.pearl.core.model.participant.Enrollee;
-import bio.terra.pearl.core.model.participant.ParticipantUser;
-import bio.terra.pearl.core.model.participant.PortalParticipantUser;
-import bio.terra.pearl.core.model.participant.Profile;
+import bio.terra.pearl.core.model.participant.*;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.survey.*;
@@ -358,8 +355,14 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
         Enrollee enrollee;
         List<ParticipantTask> tasks;
         if (popDto.isSimulateSubmissions()) {
-            HubResponse<Enrollee> hubResponse = enrollmentService.enroll(ppUser, environmentName, context.getStudyShortcode(),
-                    attachedUser, ppUser, popDto.getPreEnrollmentResponseId(), true);
+            HubResponse<Enrollee> hubResponse = enrollmentService.enroll(ppUser,
+                    environmentName,
+                    context.getStudyShortcode(),
+                    attachedUser,
+                    ppUser,
+                    popDto.getPreEnrollmentResponseId(),
+                    true,
+                    popDto.getSource() == null ? EnrolleeSourceType.PORTAL_SITE : popDto.getSource());
             enrollee = hubResponse.getEnrollee();
             tasks = hubResponse.getTasks();
             // we want the shortcode to not be random so that test enrollee urls are consistent, so set it manually

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/invited.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/invited.json
@@ -1,6 +1,7 @@
 {
   "linkedUsernameKey": "invited",
   "shortcode": "HDINVI",
+  "source": "IMPORT",
   "simulateSubmissions": true,
   "surveyResponseDtos": [
     {

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
@@ -106,6 +106,7 @@ public class PopulateDemoTest extends BasePopulatePortalsTest {
     private void checkKeyedEnrollee(List<Enrollee> sandboxEnrollees) {
         Enrollee enrollee = sandboxEnrollees.stream().filter(sandboxEnrollee -> "HDINVI".equals(sandboxEnrollee.getShortcode()))
                 .findFirst().get();
+        assertThat(enrollee.getSource(), equalTo(EnrolleeSourceType.IMPORT));
         ParticipantUser user = participantUserService.find(enrollee.getParticipantUserId()).get();
         assertThat(user.getUsername().contains("+invited-"), equalTo(true));
         assertThat(user.getUsername(), endsWith("broadinstitute.org"));

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -272,7 +272,8 @@ export type ExportOptions = {
   includeSubHeaders?: boolean,
   excludeModules?: string[],
   filterString?: string,
-  rowLimit?: number
+  rowLimit?: number,
+  includeFields: string[]
 }
 
 export type ExportData = {
@@ -1101,25 +1102,23 @@ export default {
   exportEnrollees(portalShortcode: string, studyShortcode: string,
     envName: string, exportOptions: ExportOptions):
     Promise<Response> {
-    const exportOptionsParams = exportOptions as Record<string, unknown>
-    let url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/export/data?`
-    url += queryString.stringify(exportOptionsParams)
-    return fetch(url, this.getGetInit())
+    const url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/export/data`
+    return fetch(url, {
+      method: 'POST',
+      headers: this.getInitHeaders(),
+      body: JSON.stringify(exportOptions)
+    })
   },
 
   exportDictionary(portalShortcode: string, studyShortcode: string,
     envName: string, exportOptions: ExportOptions):
     Promise<Response> {
-    const exportOptionsParams = exportOptions as Record<string, unknown>
-    let url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/export/dictionary?`
-    const searchParams = new URLSearchParams()
-    for (const prop in exportOptionsParams) {
-      if (exportOptionsParams[prop] !== undefined) {
-        searchParams.set(prop, (exportOptionsParams[prop] as string | boolean).toString())
-      }
-    }
-    url += searchParams.toString()
-    return fetch(url, this.getGetInit())
+    const url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/export/dictionary`
+    return fetch(url, {
+      method: 'POST',
+      headers: this.getInitHeaders(),
+      body: JSON.stringify(exportOptions)
+    })
   },
 
   async fetchExportIntegrations(studyEnvParams: StudyEnvParams): Promise<ExportIntegration[]> {

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -1153,6 +1153,17 @@ export default {
     return await this.processJsonResponse(response)
   },
 
+  async saveExportIntegration(studyEnvParams: StudyEnvParams, integration: ExportIntegration):
+    Promise<ExportIntegration> {
+    const url = `${baseStudyEnvUrlFromParams(studyEnvParams)}/exportIntegrations/${integration.id}`
+    const response = await fetch(url, {
+      method: 'PATCH',
+      headers: this.getInitHeaders(),
+      body: JSON.stringify(integration)
+    })
+    return await this.processJsonResponse(response)
+  },
+
   async fetchExportIntegrationJobs(studyEnvParams: StudyEnvParams): Promise<ExportIntegrationJob[]> {
     const url = `${baseStudyEnvUrlFromParams(studyEnvParams)}/exportIntegrationJobs`
     const response = await fetch(url, this.getGetInit())

--- a/ui-admin/src/study/export/ExportDataModal.tsx
+++ b/ui-admin/src/study/export/ExportDataModal.tsx
@@ -108,7 +108,7 @@ export function ExportOptionsForm({ exportOptions, setExportOptions }:
     !exportOptions.filterString?.includes('{enrollee.subject} = true')
 
 
-  return <form onSubmit={e => e.preventDefault()}>
+  return <div>
     <div className="py-2">
       <p className="fw-bold mb-1">
         Data format
@@ -246,7 +246,7 @@ export function ExportOptionsForm({ exportOptions, setExportOptions }:
       see the <Link to="https://broad-juniper.zendesk.com/hc/en-us/articles/18259824756123" target="_blank">
       help page</Link>.
     </div>
-  </form>
+  </div>
 }
 
 export default ExportDataModal

--- a/ui-admin/src/study/export/ExportDataModal.tsx
+++ b/ui-admin/src/study/export/ExportDataModal.tsx
@@ -36,7 +36,8 @@ const DEFAULT_EXPORT_OPTS: ExportOptions = {
   includeSubHeaders: true,
   onlyIncludeMostRecent: true,
   filterString: undefined,
-  excludeModules: []
+  excludeModules: [],
+  includeFields: []
 }
 
 const MODULE_EXCLUDE_OPTIONS: Record<string, string> = { surveys: 'Surveys', profile: 'Profile', account: 'Account' }
@@ -218,6 +219,24 @@ export function ExportOptionsForm({ exportOptions, setExportOptions }:
           isMulti={true} value={selectedOptions}
           inputId={selectInputId}
           onChange={onChange}/>
+        <div className="d-flex pt-3 ps-2">
+          <label className="" htmlFor="exportFields">
+            Only include fields:
+          </label>
+          <InfoPopup content={<span>
+                Space-or-comma delimited list of field names. e.g. <pre>enrollee.shortcode</pre>
+            If any fields are specified here, only those fields will be included in the export.
+          </span>}/>
+        </div>
+
+        <textarea name="exportFields" id="exportFields" cols={70} value={exportOptions.includeFields?.join(' ')}
+          onChange={e => setExportOptions({
+            ...exportOptions,
+            includeFields: e.target.value ? e.target.value
+              .replace(/[\s,]+/g, ' ')
+              .split(' ') : []
+          })}
+          className="me-1"/>
       </div>
     </div> }
     <hr/>

--- a/ui-admin/src/study/export/integrations/ExportIntegrationView.tsx
+++ b/ui-admin/src/study/export/integrations/ExportIntegrationView.tsx
@@ -44,12 +44,23 @@ export default function ExportIntegrationView({ studyEnvContext }: { studyEnvCon
     })
   }
 
+  const saveIntegration = async () => {
+    if (!integration) {
+      return
+    }
+    doApiLoad(async () => {
+      const savedIntegration = await Api.saveExportIntegration(paramsFromContext(studyEnvContext), integration)
+      Store.addNotification(successNotification(`Saved`))
+      setIntegration(savedIntegration)
+    })
+  }
+
   return <div className="container-fluid p-4">
     {renderPageHeader('Export Integration')}
     <LoadingSpinner isLoading={isLoading}>
       { integration && <ExportIntegrationForm integration={integration} setIntegration={setIntegration} /> }
       <div className="mt-5">
-        <Button variant="primary" onClick={() => {}} className="me-3">Save</Button>
+        <Button variant="primary" onClick={saveIntegration} className="me-3">Save</Button>
         <Button variant="secondary" outline={true} className="me-5"
           onClick={() => navigate(studyEnvExportIntegrationJobsPath(paramsFromContext(studyEnvContext)))}>
           View run history


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds the ability to specify a list of fields to limit the columns in the export to just those fields.

![image](https://github.com/user-attachments/assets/69fa9b5a-c70e-4304-af09-7b5152519c6f)

along the way, this 

-  refactored some of the Formatter class structure to make so the filtering logic could be somewhat centralized.  
-  converted the export APIs from GET to POST -- having them as GETs was a nicer representation of what they were, but as the params got more complex and longer, a POST felt more appropriate.
-  Updated BaseJdbDao to automatically recognize List<String> as a type that can be persisted.  Because this uses a different field-instrospection library, the order in which the fields are returned is slightly different.  This required updating some tests which had hardcoded sql equality checks--I confirmed the new and old sql was functionally identical, just with different field ordering. 
- Implemented a "save" method for ExportIntegrations

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy ApiAdminApp
4. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/export/dataBrowser
5. click Download, and then under advanced options, specify one or more field names (the field names are the same as the column headers in the export, e.g. "enrollee.shortcode"
6. confirm the download contains only those columns