### PR TITLE
[JN-1429] add study shortcode to export

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/participant/Enrollee.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/participant/Enrollee.java
@@ -34,6 +34,8 @@ public class Enrollee extends BaseEntity {
     @Builder.Default
     private boolean subject = true; // whether this Enrollee is a primary subject of the study (as opposed to just a proxy or family member)
     private boolean consented;
+    @Builder.Default
+    private EnrolleeSourceType source = EnrolleeSourceType.PORTAL_SITE;
 
     @Builder.Default
     private List<FamilyEnrollee> familyEnrollees = new ArrayList<>();

--- a/core/src/main/java/bio/terra/pearl/core/model/participant/EnrolleeSourceType.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/participant/EnrolleeSourceType.java
@@ -1,0 +1,6 @@
+package bio.terra.pearl.core.model.participant;
+
+public enum EnrolleeSourceType {
+    IMPORT, // the enrollee data was imported from an external source
+    PORTAL_SITE // default, they came in through standard signup flow
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportData.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportData.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.service.export;
 
 import bio.terra.pearl.core.model.participant.*;
+import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.model.survey.Answer;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
@@ -14,6 +15,7 @@ import java.util.List;
 
 @Getter @Setter @Builder @AllArgsConstructor
 public class EnrolleeExportData {
+    private Study study;
     private Enrollee enrollee;
     private ParticipantUser participantUser;
     private Profile profile;

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
@@ -7,6 +7,7 @@ import bio.terra.pearl.core.model.export.ExportOptions;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.EnrolleeRelation;
 import bio.terra.pearl.core.model.search.EnrolleeSearchExpressionResult;
+import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.study.StudyEnvironmentConfig;
 import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
@@ -24,6 +25,7 @@ import bio.terra.pearl.core.service.search.EnrolleeSearchOptions;
 import bio.terra.pearl.core.service.study.StudyEnvironmentConfigService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
+import bio.terra.pearl.core.service.study.StudyService;
 import bio.terra.pearl.core.service.survey.SurveyResponseService;
 import bio.terra.pearl.core.service.survey.SurveyService;
 import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
@@ -55,6 +57,7 @@ public class EnrolleeExportService {
     private final FamilyService familyService;
     private final EnrolleeSearchExpressionDao enrolleeSearchExpressionDao;
     private final StudyEnvironmentConfigService studyEnvironmentConfigService;
+    private final StudyService studyService;
 
     public EnrolleeExportService(ProfileService profileService,
                                  AnswerDao answerDao,
@@ -67,7 +70,9 @@ public class EnrolleeExportService {
                                  EnrolleeRelationService enrolleeRelationService,
                                  ObjectMapper objectMapper,
                                  FamilyService familyService,
-                                 EnrolleeSearchExpressionDao enrolleeSearchExpressionDao, StudyEnvironmentConfigService studyEnvironmentConfigService) {
+                                 EnrolleeSearchExpressionDao enrolleeSearchExpressionDao,
+                                 StudyEnvironmentConfigService studyEnvironmentConfigService,
+                                 StudyService studyService) {
         this.profileService = profileService;
         this.answerDao = answerDao;
         this.surveyQuestionDefinitionDao = surveyQuestionDefinitionDao;
@@ -83,6 +88,7 @@ public class EnrolleeExportService {
         this.familyService = familyService;
         this.enrolleeSearchExpressionDao = enrolleeSearchExpressionDao;
         this.studyEnvironmentConfigService = studyEnvironmentConfigService;
+        this.studyService = studyService;
     }
 
     /**
@@ -100,7 +106,9 @@ public class EnrolleeExportService {
     }
 
     public List<EnrolleeExportData> loadEnrolleeExportData(UUID studyEnvironmentId, ExportOptionsWithExpression exportOptions) {
+        Study study = studyService.findByStudyEnvironmentId(studyEnvironmentId).orElseThrow();
         return loadEnrolleesForExport(
+                study,
                 studyEnvironmentConfigService.findByStudyEnvironmentId(studyEnvironmentId),
                 loadEnrollees(studyEnvironmentId, exportOptions.getFilterExpression(), exportOptions.getRowLimit()));
     }
@@ -148,6 +156,7 @@ public class EnrolleeExportService {
     public List<ModuleFormatter> generateModuleInfos(ExportOptions exportOptions, UUID studyEnvironmentId, List<EnrolleeExportData> enrolleeExportData) {
         List<ModuleFormatter> allSimpleFormatters = List.of(
                 new EnrolleeFormatter(exportOptions),
+                new StudyFormatter(exportOptions),
                 new ParticipantUserFormatter(exportOptions),
                 new ProfileFormatter(exportOptions),
                 new KitRequestFormatter(exportOptions),
@@ -214,19 +223,20 @@ public class EnrolleeExportService {
         return moduleFormatters;
     }
 
-    protected List<EnrolleeExportData> loadEnrolleesForExport(StudyEnvironmentConfig config,
+    protected List<EnrolleeExportData> loadEnrolleesForExport(Study study,
+                                                              StudyEnvironmentConfig config,
                                                               List<Enrollee> enrollees) {
-
         // for now, load each enrollee individually.  Later we'll want more sophisticated batching strategies
         return enrollees
                 .stream()
-                .map(enrollee -> loadEnrolleeData(config, enrollee))
+                .map(enrollee -> loadEnrolleeData(study, config, enrollee))
                 .toList();
     }
 
-    protected EnrolleeExportData loadEnrolleeData(StudyEnvironmentConfig config,
+    protected EnrolleeExportData loadEnrolleeData(Study study, StudyEnvironmentConfig config,
                                                   Enrollee enrollee) {
         return new EnrolleeExportData(
+                study,
                 enrollee,
                 participantUserService.find(enrollee.getParticipantUserId()).orElseThrow(),
                 profileService.loadWithMailingAddress(enrollee.getProfileId()).get(),

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -7,10 +7,7 @@ import bio.terra.pearl.core.model.dataimport.*;
 import bio.terra.pearl.core.model.export.ExportOptions;
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.kit.KitType;
-import bio.terra.pearl.core.model.participant.Enrollee;
-import bio.terra.pearl.core.model.participant.ParticipantUser;
-import bio.terra.pearl.core.model.participant.PortalParticipantUser;
-import bio.terra.pearl.core.model.participant.Profile;
+import bio.terra.pearl.core.model.participant.*;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
 import bio.terra.pearl.core.model.workflow.HubResponse;
@@ -288,10 +285,11 @@ public class EnrolleeImportService {
             profileService.update(regResult.profile(), auditInfo);
 
             HubResponse<Enrollee> response = enrollmentService.enroll(regResult.portalParticipantUser(), studyEnv.getEnvironmentName(),
-                    studyShortcode, regResult.participantUser(), regResult.portalParticipantUser(), null, enrolleeInfo.isSubject());
+                    studyShortcode, regResult.participantUser(), regResult.portalParticipantUser(),
+                    null, enrolleeInfo.isSubject(), EnrolleeSourceType.IMPORT);
             Enrollee newEnrollee = response.getEnrollee();
             //update createdAt
-            if (newEnrollee.getCreatedAt() != null) {
+            if (enrolleeInfo.getCreatedAt() != null) {
                 timeShiftPopulateDao.changeEnrolleeCreationTime(response.getEnrollee().getId(), enrolleeInfo.getCreatedAt());
             }
             if (regResult.participantUser().getCreatedAt() != null) {

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeFormatter.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 
 public class EnrolleeFormatter extends BeanModuleFormatter<Enrollee> {
     public static final List<String> INCLUDED_PROPERTIES = List.of(
-            "shortcode", "consented", "createdAt", "subject"
+            "shortcode", "consented", "createdAt", "subject", "source"
     );
 
     public EnrolleeFormatter(ExportOptions exportOptions) {

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/StudyFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/StudyFormatter.java
@@ -1,0 +1,36 @@
+package bio.terra.pearl.core.service.export.formatters.module;
+
+import bio.terra.pearl.core.model.export.ExportOptions;
+import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.study.Study;
+import bio.terra.pearl.core.service.export.EnrolleeExportData;
+import bio.terra.pearl.core.service.export.formatters.item.PropertyItemFormatter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class StudyFormatter extends BeanModuleFormatter<Study> {
+    public static final List<String> INCLUDED_PROPERTIES = List.of(
+            "shortcode"
+    );
+
+    public StudyFormatter(ExportOptions exportOptions) {
+        super(exportOptions, "study", "Study");
+    }
+
+    @Override
+    protected List<PropertyItemFormatter<Study>> generateItemFormatters(ExportOptions options) {
+        return INCLUDED_PROPERTIES.stream().map(propName -> new PropertyItemFormatter<>(propName, Study.class))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Study getBean(EnrolleeExportData enrolleeExportData) {
+        return enrolleeExportData.getStudy();
+    }
+
+    @Override
+    public Study newBean() {
+        return new Study();
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/EnrolleeReminderService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/EnrolleeReminderService.java
@@ -3,6 +3,7 @@ package bio.terra.pearl.core.service.notification;
 import bio.terra.pearl.core.dao.workflow.ParticipantTaskDao;
 import bio.terra.pearl.core.model.notification.Trigger;
 import bio.terra.pearl.core.model.notification.TriggerType;
+import bio.terra.pearl.core.model.participant.EnrolleeSourceType;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.workflow.TaskType;
 import bio.terra.pearl.core.service.rule.EnrolleeContext;
@@ -73,15 +74,24 @@ public class EnrolleeReminderService {
 
         NotificationContextInfo envContext = notificationDispatcher.loadContextInfo(trigger);
 
-        for (ParticipantTaskDao.EnrolleeWithTasks enrolleeWithTask : enrolleesWithTasks) {
-            // this isn't an optimized match -- we're assuming the number of reminders we send on any given run for a single
-            // config will likely be < 100
-            EnrolleeContext ruleData = enrolleeData.stream()
-                    .filter(erd -> erd.getEnrollee().getId().equals(enrolleeWithTask.getEnrolleeId())).findFirst().get();
+        for (EnrolleeContext enrolleeContext : enrolleeData) {
             // don't send non-consent task reminders to enrollees who haven't consented
-            if (trigger.getTaskType().equals(TaskType.CONSENT) || ruleData.getEnrollee().isConsented()) {
-                notificationDispatcher.dispatchNotification(trigger, ruleData, envContext);
+            if (shouldSendReminder(enrolleeContext, trigger)) {
+                notificationDispatcher.dispatchNotification(trigger, enrolleeContext, envContext);
             }
         }
+    }
+
+    public boolean shouldSendReminder(EnrolleeContext enrolleeContext, Trigger trigger) {
+        // don't send reminders other than consents for enrollees who haven't consented
+        if (!trigger.getTaskType().equals(TaskType.CONSENT) && !enrolleeContext.getEnrollee().isConsented()) {
+            return false;
+        }
+        // don't send reminders to enrollees who were imported but haven't consented -- we want them to use invitation emails
+        if (enrolleeContext.getEnrollee().getSource().equals(EnrolleeSourceType.IMPORT) &&
+                 enrolleeContext.getParticipantUser().getLastLogin() == null) {
+            return false;
+        }
+        return true;
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/rule/EnrolleeContextService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/rule/EnrolleeContextService.java
@@ -36,10 +36,12 @@ public class EnrolleeContextService {
     /**
      * useful for bulk-fetching enrollees for processing
      * this isn't terribly optimized -- we could do the join in the DB.  But this is assuming that the number of enrollees
-     *  is ~5-30, not 1000+, and so the main goal is just making sure we only do 4 total DB roundtrips
+     *  is ~5-30, not 1000+, and so the main goal is just making sure we only do 4 total DB roundtrips.
+     *
+     *  This returns the context for each enrollee in the order of the input list
      */
     public List<EnrolleeContext> fetchData(List<UUID> enrolleeIds) {
-        List<Enrollee> enrollees = enrolleeService.findAll(enrolleeIds);
+        List<Enrollee> enrollees = enrolleeService.findAllPreserveOrder(enrolleeIds);
         List<Profile> profiles = profileService.findAllWithMailingAddressPreserveOrder(enrollees.stream().map(Enrollee::getProfileId).toList());
         List<ParticipantUser> users = participantUserService.findAllPreserveOrder(enrollees.stream().map(Enrollee::getParticipantUserId).toList());
         List<EnrolleeContext> ruleData = IntStream.range(0, enrollees.size()).mapToObj(i ->

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
@@ -122,6 +122,18 @@ public class EnrollmentService {
                                         PortalParticipantUser ppUser,
                                         UUID preEnrollResponseId,
                                         boolean isSubject) {
+        return enroll(operator, envName, studyShortcode, user, ppUser, preEnrollResponseId, isSubject, EnrolleeSourceType.PORTAL_SITE);
+    }
+
+    @Transactional
+    public HubResponse<Enrollee> enroll(PortalParticipantUser operator,
+                                        EnvironmentName envName,
+                                        String studyShortcode,
+                                        ParticipantUser user,
+                                        PortalParticipantUser ppUser,
+                                        UUID preEnrollResponseId,
+                                        boolean isSubject,
+                                        EnrolleeSourceType source) {
         log.info("creating enrollee for user {}, study {}", user.getId(), studyShortcode);
         StudyEnvironment studyEnv = studyEnvironmentService.findByStudy(studyShortcode, envName)
                 .orElseThrow(() -> new NotFoundException("Study environment %s %s not found".formatted(studyShortcode, envName)));
@@ -134,7 +146,7 @@ public class EnrollmentService {
 
         // if the user is signed up, but not a subject, we can just return the existing enrollee,
         // otherwise create a new one for them
-        Enrollee enrollee = findOrCreateEnrolleeForEnrollment(user, ppUser, studyEnv, studyShortcode, preEnrollResponseId, isSubject);
+        Enrollee enrollee = findOrCreateEnrolleeForEnrollment(user, ppUser, studyEnv, studyShortcode, preEnrollResponseId, isSubject, source);
 
         if (preEnrollResponse != null) {
             preEnrollResponse.setCreatingParticipantUserId(user.getId());
@@ -152,7 +164,9 @@ public class EnrollmentService {
         return hubResponse;
     }
 
-    private Enrollee findOrCreateEnrolleeForEnrollment(ParticipantUser user, PortalParticipantUser ppUser, StudyEnvironment studyEnv, String studyShortcode, UUID preEnrollResponseId, boolean isSubjectEnrollment) {
+    private Enrollee findOrCreateEnrolleeForEnrollment(ParticipantUser user, PortalParticipantUser ppUser, StudyEnvironment studyEnv,
+                                                       String studyShortcode, UUID preEnrollResponseId, boolean isSubjectEnrollment,
+                                                       EnrolleeSourceType source) {
         return enrolleeService
                 .findByParticipantUserIdAndStudyEnv(user.getId(), studyShortcode, studyEnv.getEnvironmentName())
                 .filter(e -> {
@@ -175,6 +189,7 @@ public class EnrollmentService {
                             .profileId(ppUser.getProfileId())
                             .preEnrollmentResponseId(preEnrollResponseId)
                             .subject(isSubjectEnrollment)
+                            .source(source)
                             .build();
                     return enrolleeService.create(newEnrollee);
                 });
@@ -217,7 +232,7 @@ public class EnrollmentService {
                 .surveyId(preEnrollResponse.getSurveyId())
                 .portalParticipantUserId(ppUser.getId())
                 .build();
-        
+
         // process any answers that need to be propagated elsewhere to the data model
         answerProcessingService.processAllAnswerMappings(
                 enrollee,

--- a/core/src/main/resources/db/changelog/changesets/2024_10_16_enrollee_source.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_10_16_enrollee_source.yaml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: "enrollee_source"
+      author: dbush
+      changes:
+        - addColumn:
+            tableName: enrollee
+            columns:
+              - column: { name: source, type: text }
+        - sql:
+            sql: "UPDATE enrollee SET source = 'PORTAL_SITE';"
+        - sql:
+            sql: "UPDATE enrollee SET source = 'IMPORT' from import_item where created_enrollee_id = enrollee.id;"
+        - addNotNullConstraint:
+            tableName: enrollee
+            columnName: source

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -338,6 +338,9 @@ databaseChangeLog:
   - include:
       file: changesets/2024_10_15_adding_export_fields.yaml
       relativeToChangelogFile: true
+  - include:
+        file: changesets/2024_10_16_enrollee_source.yaml
+        relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
@@ -17,6 +17,7 @@ import bio.terra.pearl.core.model.export.ExportOptions;
 import bio.terra.pearl.core.model.kit.KitRequestStatus;
 import bio.terra.pearl.core.model.kit.KitType;
 import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.participant.EnrolleeSourceType;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.model.participant.Profile;
 import bio.terra.pearl.core.model.survey.*;
@@ -577,6 +578,7 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
         assertThat(user.getUsername(), equalTo(userExpected.getUsername()));
         assertThat(user.getCreatedAt(), equalTo(userExpected.getCreatedAt()));
         assertThat(enrollee.getCreatedAt(), equalTo(enrolleeExpected.getCreatedAt()));
+        assertThat(enrollee.getSource(), equalTo(EnrolleeSourceType.IMPORT));
 
         //load profile
         Profile profile = profileService.find(enrollee.getProfileId()).orElseThrow();

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/EnrolleeFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/EnrolleeFormatterTests.java
@@ -21,7 +21,7 @@ public class EnrolleeFormatterTests {
                 .createdAt(Instant.parse("2023-08-21T05:17:25.00Z"))
                 .build();
         EnrolleeFormatter moduleFormatter = new EnrolleeFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(enrollee, null, null, null, null, null, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, enrollee, null, null, null, null, null, null, null, null);
         Map<String, String> valueMap = moduleFormatter.toStringMap(exportData);
 
         assertThat(valueMap.get("enrollee.shortcode"), equalTo("TESTER"));

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/FamilyFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/FamilyFormatterTests.java
@@ -27,7 +27,7 @@ public class FamilyFormatterTests {
                 .shortcode("F_FAM2")
                 .build();
         FamilyFormatter familyFormatter = new FamilyFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null, null, null, null, null, List.of(family1, family2));
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null, null, null, null, null, null, List.of(family1, family2));
         Map<String, String> enrolleeMap = familyFormatter.toStringMap(exportData);
 
         assertThat(enrolleeMap.size(), equalTo(4));

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/KitRequestFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/KitRequestFormatterTests.java
@@ -39,7 +39,7 @@ public class KitRequestFormatterTests {
                 .createdAt(Instant.now().minus(1, java.time.temporal.ChronoUnit.DAYS))
                 .build()
         );
-        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null, null, null, kitRequests, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null, null, null, null, kitRequests, null, null);
         Map<String, String> valueMap = moduleFormatter.toStringMap(exportData);
 
         // the older kit should be first

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ParticipantUserFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ParticipantUserFormatterTests.java
@@ -22,7 +22,7 @@ public class ParticipantUserFormatterTests {
                 .createdAt(Instant.parse("2023-08-21T05:17:25.00Z"))
                 .build();
         ParticipantUserFormatter moduleFormatter = new ParticipantUserFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(null, participantUser, null, null, null, null, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, participantUser, null, null, null, null, null, null, null);
         Map<String, String> valueMap = moduleFormatter.toStringMap(exportData);
 
         assertThat(valueMap.get("account.username"), equalTo(participantUser.getUsername()));

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ProfileFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ProfileFormatterTests.java
@@ -26,7 +26,7 @@ public class ProfileFormatterTests {
                         .build())
                 .build();
         ProfileFormatter moduleFormatter = new ProfileFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(null, null, profile, null, null, null, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, profile, null, null, null, null, null, null);
         Map<String, String> enrolleeMap = moduleFormatter.toStringMap(exportData);
 
         assertThat(enrolleeMap.get("profile.familyName"), equalTo("Tester"));
@@ -42,7 +42,7 @@ public class ProfileFormatterTests {
                 .familyName("Tester")
                 .build();
         ProfileFormatter moduleFormatter = new ProfileFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(null, null, profile, null, null, null, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, profile, null, null, null, null, null, null);
         Map<String, String> enrolleeMap = moduleFormatter.toStringMap(exportData);
 
         assertThat(enrolleeMap.get("profile.familyName"), equalTo("Tester"));

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatterTests.java
@@ -43,7 +43,7 @@ public class SurveyFormatterTests extends BaseSpringBootTest {
                 .surveyResponseId(testResponse.getId())
                 .stringValue("easyValue")
                 .build();
-        EnrolleeExportData enrolleeExportData = new EnrolleeExportData(null, null, null,
+        EnrolleeExportData enrolleeExportData = new EnrolleeExportData(null,null, null, null,
                 List.of(answer), null, List.of(testResponse), null, null, null);
         Map<String, String> valueMap = moduleFormatter.toStringMap(enrolleeExportData);
 

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/EnrolleeReminderServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/EnrolleeReminderServiceTests.java
@@ -11,11 +11,13 @@ import bio.terra.pearl.core.model.notification.Notification;
 import bio.terra.pearl.core.model.notification.NotificationDeliveryType;
 import bio.terra.pearl.core.model.notification.Trigger;
 import bio.terra.pearl.core.model.notification.TriggerType;
+import bio.terra.pearl.core.model.participant.EnrolleeSourceType;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
 import bio.terra.pearl.core.model.workflow.TaskStatus;
 import bio.terra.pearl.core.model.workflow.TaskType;
+import bio.terra.pearl.core.service.participant.EnrolleeService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,6 +57,54 @@ public class EnrolleeReminderServiceTests extends BaseSpringBootTest {
     assertThat(notificationList, hasSize(1));
     assertThat(notificationList.get(0).getTriggerId(), equalTo(savedConfig.getId()));
   }
+
+  @Test
+  @Transactional
+  public void testSurveyRemindersDontSendToUnconsented(TestInfo info) {
+    PortalEnvironment portalEnv = portalEnvironmentFactory.buildPersisted(getTestName(info));
+    StudyEnvironment studyEnv = studyEnvironmentFactory.buildPersisted(portalEnv, getTestName(info));
+    EnrolleeBundle enrolleeBundle = enrolleeFactory.buildWithPortalUser(getTestName(info), portalEnv, studyEnv);
+    ParticipantTask newTask1 = participantTaskFactory.buildPersisted(enrolleeBundle, TaskStatus.NEW, TaskType.SURVEY);
+
+    Trigger config = Trigger.builder()
+            .triggerType(TriggerType.TASK_REMINDER)
+            .taskType(TaskType.SURVEY)
+            .afterMinutesIncomplete(0)
+            .deliveryType(NotificationDeliveryType.EMAIL)
+            .studyEnvironmentId(studyEnv.getId())
+            .portalEnvironmentId(portalEnv.getId())
+            .build();
+    triggerService.create(config);
+    enrolleeReminderService.sendTaskReminders(studyEnv);
+
+    List<Notification> notificationList = notificationDao.findByEnrolleeId(enrolleeBundle.enrollee().getId());
+    assertThat(notificationList, hasSize(0));
+  }
+
+  @Test
+  @Transactional
+  public void testRemindersDontSendToImported(TestInfo info) {
+    PortalEnvironment portalEnv = portalEnvironmentFactory.buildPersisted(getTestName(info));
+    StudyEnvironment studyEnv = studyEnvironmentFactory.buildPersisted(portalEnv, getTestName(info));
+    EnrolleeBundle enrolleeBundle = enrolleeFactory.buildWithPortalUser(getTestName(info), portalEnv, studyEnv);
+    enrolleeBundle.enrollee().setSource(EnrolleeSourceType.IMPORT);
+    enrolleeService.update(enrolleeBundle.enrollee());
+    ParticipantTask newTask1 = participantTaskFactory.buildPersisted(enrolleeBundle, TaskStatus.NEW, TaskType.CONSENT);
+    Trigger config = Trigger.builder()
+            .triggerType(TriggerType.TASK_REMINDER)
+            .taskType(TaskType.CONSENT)
+            .afterMinutesIncomplete(0)
+            .deliveryType(NotificationDeliveryType.EMAIL)
+            .studyEnvironmentId(studyEnv.getId())
+            .portalEnvironmentId(portalEnv.getId())
+            .build();
+    triggerService.create(config);
+    enrolleeReminderService.sendTaskReminders(studyEnv);
+
+    List<Notification> notificationList = notificationDao.findByEnrolleeId(enrolleeBundle.enrollee().getId());
+    assertThat(notificationList, hasSize(0));
+  }
+
   @Autowired
   private ParticipantTaskFactory participantTaskFactory;
   @Autowired
@@ -69,4 +119,6 @@ public class EnrolleeReminderServiceTests extends BaseSpringBootTest {
   private TriggerService triggerService;
   @Autowired
   private EnrolleeFactory enrolleeFactory;
+  @Autowired
+  private EnrolleeService enrolleeService;
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/search/EnrolleeSearchExpressionParserTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/search/EnrolleeSearchExpressionParserTest.java
@@ -32,6 +32,7 @@ class EnrolleeSearchExpressionParserTest extends BaseSpringBootTest {
                         enrollee.shortcode as enrollee_shortcode, \
                         enrollee.subject as enrollee_subject, \
                         enrollee.consented as enrollee_consented, \
+                        enrollee.source as enrollee_source, \
                         enrollee.id as enrollee_id, \
                         enrollee.created_at as enrollee_created_at, \
                         enrollee.last_updated_at as enrollee_last_updated_at, \

--- a/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
@@ -13,10 +13,7 @@ import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.kit.KitRequestStatus;
 import bio.terra.pearl.core.model.kit.KitType;
 import bio.terra.pearl.core.model.notification.Trigger;
-import bio.terra.pearl.core.model.participant.Enrollee;
-import bio.terra.pearl.core.model.participant.ParticipantUser;
-import bio.terra.pearl.core.model.participant.PortalParticipantUser;
-import bio.terra.pearl.core.model.participant.Profile;
+import bio.terra.pearl.core.model.participant.*;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.survey.*;
@@ -358,8 +355,14 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
         Enrollee enrollee;
         List<ParticipantTask> tasks;
         if (popDto.isSimulateSubmissions()) {
-            HubResponse<Enrollee> hubResponse = enrollmentService.enroll(ppUser, environmentName, context.getStudyShortcode(),
-                    attachedUser, ppUser, popDto.getPreEnrollmentResponseId(), true);
+            HubResponse<Enrollee> hubResponse = enrollmentService.enroll(ppUser,
+                    environmentName,
+                    context.getStudyShortcode(),
+                    attachedUser,
+                    ppUser,
+                    popDto.getPreEnrollmentResponseId(),
+                    true,
+                    popDto.getSource() == null ? EnrolleeSourceType.PORTAL_SITE : popDto.getSource());
             enrollee = hubResponse.getEnrollee();
             tasks = hubResponse.getTasks();
             // we want the shortcode to not be random so that test enrollee urls are consistent, so set it manually

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/invited.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/invited.json
@@ -1,6 +1,7 @@
 {
   "linkedUsernameKey": "invited",
   "shortcode": "HDINVI",
+  "source": "IMPORT",
   "simulateSubmissions": true,
   "surveyResponseDtos": [
     {

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
@@ -106,6 +106,7 @@ public class PopulateDemoTest extends BasePopulatePortalsTest {
     private void checkKeyedEnrollee(List<Enrollee> sandboxEnrollees) {
         Enrollee enrollee = sandboxEnrollees.stream().filter(sandboxEnrollee -> "HDINVI".equals(sandboxEnrollee.getShortcode()))
                 .findFirst().get();
+        assertThat(enrollee.getSource(), equalTo(EnrolleeSourceType.IMPORT));
         ParticipantUser user = participantUserService.find(enrollee.getParticipantUserId()).get();
         assertThat(user.getUsername().contains("+invited-"), equalTo(true));
         assertThat(user.getUsername(), endsWith("broadinstitute.org"));


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds a trivial StudyFormatter for extracting the shortcode of the study and including it in the export.

![image](https://github.com/user-attachments/assets/033a331f-4dab-4b69-b5d3-e8c5ea65832b)


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy apiAdminApp
2. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/export/dataBrowser
3. confirm `study.shortcode` appears in the list, in between the enrollee and account info