### PR TITLE
[JN-1436] sorting export fields in order of column includes

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/datarepo/DataRepoExportService.java
@@ -225,7 +225,7 @@ public class DataRepoExportService {
             List<ModuleFormatter> moduleFormatters = enrolleeExportService.generateModuleInfos(exportOptions, studyEnvironmentId, List.of());
             List<Map<String, String>> enrolleeMaps = enrolleeExportService.generateExportMaps(List.of(), moduleFormatters);
 
-            TsvExporter tsvExporter = new TsvExporter(moduleFormatters, enrolleeMaps, ExportFileFormat.TSV);
+            TsvExporter tsvExporter = new TsvExporter(moduleFormatters, enrolleeMaps, ExportFileFormat.TSV, null);
 
             tsvExporter.applyToEveryColumn((moduleExportInfo, itemExportInfo, choice, isOtherDescription, moduleRepeatNum) -> tdrColumns.add(new TdrColumn(
                     DataRepoExportUtils.juniperToDataRepoColumnName(moduleExportInfo.getColumnKey(itemExportInfo, choice, isOtherDescription, moduleRepeatNum)),

--- a/core/src/main/java/bio/terra/pearl/core/service/export/DataDictionaryExcelExporter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/DataDictionaryExcelExporter.java
@@ -48,7 +48,7 @@ public class DataDictionaryExcelExporter extends ExcelExporter {
      * initializes the dictionary and internal spreadsheet
      */
     public DataDictionaryExcelExporter(List<ModuleFormatter> moduleFormatters, ObjectMapper objectMapper) {
-        super(moduleFormatters, null);
+        super(moduleFormatters, null, null);
         wrapStyle = workbook.createCellStyle();
         wrapStyle.setWrapText(true);
         boldStyle = workbook.createCellStyle();

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
@@ -101,7 +101,7 @@ public class EnrolleeExportService {
 
         List<ModuleFormatter> moduleFormatters = generateModuleInfos(exportOptions, studyEnvironmentId, enrolleeExportData);
         List<Map<String, String>> enrolleeMaps = generateExportMaps(enrolleeExportData, moduleFormatters);
-        BaseExporter exporter = getExporter(exportOptions.getFileFormat(), moduleFormatters, enrolleeMaps);
+        BaseExporter exporter = getExporter(exportOptions.getFileFormat(), moduleFormatters, enrolleeMaps, exportOptions.getIncludeFields());
         exporter.export(os, exportOptions.isIncludeSubHeaders());
     }
 
@@ -263,13 +263,13 @@ public class EnrolleeExportService {
     }
 
     protected BaseExporter getExporter(ExportFileFormat fileFormat, List<ModuleFormatter> moduleFormatters,
-                                       List<Map<String, String>> enrolleeMaps) {
+                                       List<Map<String, String>> enrolleeMaps, List<String> columnSorting) {
         if (fileFormat.equals(ExportFileFormat.JSON)) {
-            return new JsonExporter(moduleFormatters, enrolleeMaps, objectMapper);
+            return new JsonExporter(moduleFormatters, enrolleeMaps, columnSorting, objectMapper);
         } else if (fileFormat.equals(ExportFileFormat.EXCEL)) {
-            return new ExcelExporter(moduleFormatters, enrolleeMaps);
+            return new ExcelExporter(moduleFormatters, enrolleeMaps, columnSorting);
         }
-        return new TsvExporter(moduleFormatters, enrolleeMaps, fileFormat);
+        return new TsvExporter(moduleFormatters, enrolleeMaps, fileFormat, columnSorting);
     }
 
 

--- a/core/src/main/java/bio/terra/pearl/core/service/export/ExcelExporter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/ExcelExporter.java
@@ -22,8 +22,8 @@ public class ExcelExporter extends BaseExporter {
     protected final SXSSFSheet sheet;
     private static final String SHEET_NAME = "Participants";
 
-    public ExcelExporter(List<ModuleFormatter> moduleFormatters, List<Map<String, String>> enrolleeMaps) {
-        super(moduleFormatters, enrolleeMaps);
+    public ExcelExporter(List<ModuleFormatter> moduleFormatters, List<Map<String, String>> enrolleeMaps, List<String> columnSorting) {
+        super(moduleFormatters, enrolleeMaps, columnSorting);
         workbook = new SXSSFWorkbook(ROW_ACCESS_WINDOW_SIZE);
         sheet = workbook.createSheet(getSheetName());
         sheet.trackAllColumnsForAutoSizing();

--- a/core/src/main/java/bio/terra/pearl/core/service/export/JsonExporter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/JsonExporter.java
@@ -13,9 +13,9 @@ public class JsonExporter extends BaseExporter {
 
     private final ObjectMapper objectMapper;
 
-    public JsonExporter(List<ModuleFormatter> moduleFormatters, List<Map<String, String>> enrolleeMaps,
+    public JsonExporter(List<ModuleFormatter> moduleFormatters, List<Map<String, String>> enrolleeMaps, List<String> columnSorting,
                         ObjectMapper objectMapper) {
-        super(moduleFormatters, enrolleeMaps);
+        super(moduleFormatters, enrolleeMaps, columnSorting);
         this.objectMapper = objectMapper;
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/export/TsvExporter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/TsvExporter.java
@@ -14,8 +14,9 @@ import java.util.Map;
 public class TsvExporter extends BaseExporter {
     private final ExportFileFormat fileFormat;
 
-    public TsvExporter(List<ModuleFormatter> moduleExportInfos, List<Map<String, String>> enrolleeMaps, ExportFileFormat fileFormat) {
-        super(moduleExportInfos, enrolleeMaps);
+    public TsvExporter(List<ModuleFormatter> moduleExportInfos, List<Map<String, String>> enrolleeMaps, ExportFileFormat fileFormat,
+                       List<String> columnSorting) {
+        super(moduleExportInfos, enrolleeMaps, columnSorting);
         if (!List.of(ExportFileFormat.CSV, ExportFileFormat.TSV).contains(fileFormat)) {
             throw new IllegalArgumentException("Invalid file format for TsvExporter: " + fileFormat);
         }
@@ -23,7 +24,7 @@ public class TsvExporter extends BaseExporter {
     }
 
     public TsvExporter(List<ModuleFormatter> moduleExportInfos, List<Map<String, String>> enrolleeMaps) {
-        this(moduleExportInfos, enrolleeMaps, ExportFileFormat.TSV);
+        this(moduleExportInfos, enrolleeMaps, ExportFileFormat.TSV, null);
     }
 
     /**

--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeExportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeExportServiceTests.java
@@ -4,6 +4,7 @@ import bio.terra.pearl.core.BaseSpringBootTest;
 import bio.terra.pearl.core.factory.StudyEnvironmentBundle;
 import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
 import bio.terra.pearl.core.factory.participant.EnrolleeAndProxy;
+import bio.terra.pearl.core.factory.participant.EnrolleeBundle;
 import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
 import bio.terra.pearl.core.factory.survey.AnswerFactory;
 import bio.terra.pearl.core.factory.survey.SurveyFactory;
@@ -111,6 +112,33 @@ public class EnrolleeExportServiceTests extends BaseSpringBootTest {
         enrolleeExportService.export(opts, studyEnv.getId(), stream);
 
         assertThat(stream.toString(), startsWith("enrollee.shortcode\tprofile.familyName\nShortcode"));
+    }
+
+    @Test
+    @Transactional
+    public void testExportIncludeFieldsSorted(TestInfo testInfo) {
+        String testName = getTestName(testInfo);
+        StudyEnvironmentBundle studyEnvBundle = studyEnvironmentFactory.buildBundle(testName, EnvironmentName.irb);
+        EnrolleeBundle enrolleeBundle = enrolleeFactory.buildWithPortalUser(testName, studyEnvBundle.getPortalEnv(), studyEnvBundle.getStudyEnv());
+
+        ExportOptionsWithExpression opts = ExportOptionsWithExpression.builder()
+                .fileFormat(ExportFileFormat.TSV)
+                .includeFields(List.of("profile.familyName", "enrollee.shortcode", "account.username" )).build();
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        enrolleeExportService.export(opts, studyEnvBundle.getStudyEnv().getId(), stream);
+
+        assertThat(stream.toString(), startsWith("profile.familyName\tenrollee.shortcode\taccount.username\nFamily Name"));
+        // fun fact -- empty strings are typically left blank, but TSV export will quote the first column for safety if it's empty.
+        assertThat(stream.toString(), endsWith("\n\"\"\t%s\t%s\n".formatted(enrolleeBundle.enrollee().getShortcode(), enrolleeBundle.participantUser().getUsername())));
+
+        opts = ExportOptionsWithExpression.builder()
+                .fileFormat(ExportFileFormat.TSV)
+                .includeFields(List.of("account.username", "profile.familyName", "enrollee.shortcode")).build();
+        stream = new ByteArrayOutputStream();
+        enrolleeExportService.export(opts, studyEnvBundle.getStudyEnv().getId(), stream);
+
+        assertThat(stream.toString(), startsWith("account.username\tprofile.familyName\tenrollee.shortcode\nUsername"));
+        assertThat(stream.toString(), endsWith("\n%s\t\t%s\n".formatted(enrolleeBundle.participantUser().getUsername(), enrolleeBundle.enrollee().getShortcode())));
     }
 
     @Test
@@ -578,7 +606,7 @@ public class EnrolleeExportServiceTests extends BaseSpringBootTest {
         List<ModuleFormatter> moduleFormatters = enrolleeExportService.generateModuleInfos(new ExportOptions(), studyEnv.getId(), exportData);
         List<Map<String, String>> exportMaps = enrolleeExportService.generateExportMaps(exportData, moduleFormatters);
 
-        BaseExporter exporter = enrolleeExportService.getExporter(ExportFileFormat.CSV, moduleFormatters, exportMaps);
+        BaseExporter exporter = enrolleeExportService.getExporter(ExportFileFormat.CSV, moduleFormatters, exportMaps, null);
         List<String> columnKeys = exporter.getColumnKeys();
         List<String> columnHeaders = exporter.getHeaderRow();
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

At Whitney's request, sorting the fields if they are explicitly specified.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  redeploy apiAdminApp
2. do a data export https://localhost:3000/demo/studies/heartdemo/env/sandbox/export/dataBrowser with fields explicitly specified 
3. confirm the export shows only those fields