### PR TITLE
[JN-1358] HOC for refreshing state on environment switch

### DIFF
--- a/ui-admin/src/study/StudyEnvironmentRouter.tsx
+++ b/ui-admin/src/study/StudyEnvironmentRouter.tsx
@@ -49,10 +49,10 @@ import DataImportView from '../portal/DataImportView'
 import DataImportList from '../portal/DataImportList'
 import FamilyRouter from './families/FamilyRouter'
 import { KitScanner } from './kits/kitcollection/KitScanner'
-import { LoadedSettingsView } from 'study/settings/SettingsView'
 import ExportIntegrationList from './export/integrations/ExportIntegrationList'
 import ExportIntegrationView from './export/integrations/ExportIntegrationView'
 import ExportIntegrationJobList from './export/integrations/ExportIntegrationJobList'
+import LoadedSettingsView from './settings/SettingsView'
 
 export type StudyEnvContextT = { study: Study, currentEnv: StudyEnvironment, currentEnvPath: string, portal: Portal }
 
@@ -126,7 +126,7 @@ function StudyEnvironmentRouter({ study }: { study: Study }) {
             portalEnv={portalEnv}/>}/>
           <Route path="dataImports" element={<DataImportList studyEnvContext={studyEnvContext}/>}/>
           <Route path="dataImports/:dataImportId" element={<DataImportView studyEnvContext={studyEnvContext}/>}/>
-          <Route path="settings/*" element={<LoadedSettingsView key={currentEnv.environmentName}
+          <Route path="settings/*" element={<LoadedSettingsView
             studyEnvContext={studyEnvContext}
             portalContext={portalContext}/>}
           />

--- a/ui-admin/src/study/settings/SettingsView.test.tsx
+++ b/ui-admin/src/study/settings/SettingsView.test.tsx
@@ -10,7 +10,6 @@ import {
   render,
   screen
 } from '@testing-library/react'
-import { LoadedSettingsView } from 'study/settings/SettingsView'
 import { userEvent } from '@testing-library/user-event'
 import Api from 'api/api'
 import { ReactNotifications } from 'react-notifications-component'
@@ -18,6 +17,7 @@ import {
   mockAdminUser,
   MockUserProvider
 } from 'test-utils/user-mocking-utils'
+import LoadedSettingsView from './SettingsView'
 
 jest.mock('api/api', () => ({
   ...jest.requireActual('api/api'),

--- a/ui-admin/src/study/settings/SettingsView.tsx
+++ b/ui-admin/src/study/settings/SettingsView.tsx
@@ -28,10 +28,11 @@ import { doApiLoad } from 'api/api-utils'
 import { Store } from 'react-notifications-component'
 import { successNotification } from 'util/notifications'
 import LoadingSpinner from 'util/LoadingSpinner'
+import { withResetOnEnvChange } from '../../util/withResetOnEnvChange'
 
 
 /** shows a url-routable settings page for both the portal and the selected study */
-export function LoadedSettingsView(
+function LoadedSettingsView(
   {
     studyEnvContext,
     portalContext
@@ -214,6 +215,8 @@ export function LoadedSettingsView(
     </div>
   </div>
 }
+
+export default withResetOnEnvChange(LoadedSettingsView)
 
 /** gets classes to apply to nav links */
 function getLinkCssClasses({ isActive }: { isActive: boolean }) {

--- a/ui-admin/src/study/settings/SettingsView.tsx
+++ b/ui-admin/src/study/settings/SettingsView.tsx
@@ -28,7 +28,7 @@ import { doApiLoad } from 'api/api-utils'
 import { Store } from 'react-notifications-component'
 import { successNotification } from 'util/notifications'
 import LoadingSpinner from 'util/LoadingSpinner'
-import { withStateResetOnEnvChange } from '../../util/withStateResetOnEnvChange'
+import { withStateResetOnEnvChange } from 'util/withStateResetOnEnvChange'
 
 
 /** shows a url-routable settings page for both the portal and the selected study */

--- a/ui-admin/src/study/settings/SettingsView.tsx
+++ b/ui-admin/src/study/settings/SettingsView.tsx
@@ -28,7 +28,7 @@ import { doApiLoad } from 'api/api-utils'
 import { Store } from 'react-notifications-component'
 import { successNotification } from 'util/notifications'
 import LoadingSpinner from 'util/LoadingSpinner'
-import { withResetOnEnvChange } from '../../util/withResetOnEnvChange'
+import { withResetOnEnvChange } from 'util/withResetOnEnvChange'
 
 
 /** shows a url-routable settings page for both the portal and the selected study */

--- a/ui-admin/src/study/settings/SettingsView.tsx
+++ b/ui-admin/src/study/settings/SettingsView.tsx
@@ -28,7 +28,7 @@ import { doApiLoad } from 'api/api-utils'
 import { Store } from 'react-notifications-component'
 import { successNotification } from 'util/notifications'
 import LoadingSpinner from 'util/LoadingSpinner'
-import { withResetOnEnvChange } from 'util/withResetOnEnvChange'
+import { withStateResetOnEnvChange } from '../../util/withStateResetOnEnvChange'
 
 
 /** shows a url-routable settings page for both the portal and the selected study */
@@ -216,7 +216,7 @@ function LoadedSettingsView(
   </div>
 }
 
-export default withResetOnEnvChange(LoadedSettingsView)
+export default withStateResetOnEnvChange(LoadedSettingsView)
 
 /** gets classes to apply to nav links */
 function getLinkCssClasses({ isActive }: { isActive: boolean }) {

--- a/ui-admin/src/util/withResetOnEnvChange.tsx
+++ b/ui-admin/src/util/withResetOnEnvChange.tsx
@@ -1,0 +1,20 @@
+import React, { ComponentType, useEffect, useState } from 'react'
+import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
+
+export const withResetOnEnvChange = <T, >(WrappedComponent: ComponentType<T>) => {
+  const WithResetOnEnvChange = (props: T & { studyEnvContext: StudyEnvContextT }) => {
+    const { studyEnvContext } = props
+    const [key, setKey] = useState(studyEnvContext.currentEnvPath)
+
+    useEffect(() => {
+      setKey(studyEnvContext.currentEnvPath)
+    }, [studyEnvContext.currentEnvPath])
+
+    return <WrappedComponent key={key} {...(props as T)} />
+  }
+
+  WithResetOnEnvChange.displayName = `
+    WithResetOnEnvChange(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`
+
+  return WithResetOnEnvChange
+}

--- a/ui-admin/src/util/withResetOnEnvChange.tsx
+++ b/ui-admin/src/util/withResetOnEnvChange.tsx
@@ -10,11 +10,11 @@ export const withResetOnEnvChange = <T, >(WrappedComponent: ComponentType<T>) =>
       setKey(studyEnvContext.currentEnvPath)
     }, [studyEnvContext.currentEnvPath])
 
-    return <WrappedComponent key={key} {...(props as T)} />
+    return <WrappedComponent key={key} {...props} />
   }
 
-  WithResetOnEnvChange.displayName = `
-    WithResetOnEnvChange(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`
+  WithResetOnEnvChange.displayName =
+    `WithResetOnEnvChange(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`
 
   return WithResetOnEnvChange
 }

--- a/ui-admin/src/util/withStateResetOnEnvChange.test.tsx
+++ b/ui-admin/src/util/withStateResetOnEnvChange.test.tsx
@@ -1,24 +1,29 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { render, screen } from '@testing-library/react'
 import { withStateResetOnEnvChange } from './withStateResetOnEnvChange'
 import { mockStudyEnvContext } from 'test-utils/mocking-utils'
+import { userEvent } from '@testing-library/user-event'
 
-const MockComponent = ({ text }: { text: string }) => {
-  return <div data-testid="mock-component">{text}</div>
+const MockComponent = () => {
+  const [input, setInput] = useState<string>('')
+  return <div data-testid="mock-component">
+    <input data-testid="mock-input" value={input} onChange={e => setInput(e.target.value)} />
+  </div>
 }
 
 const WrappedComponent = withStateResetOnEnvChange(MockComponent)
 
-test('resets component state when studyEnvContext changes', () => {
+test('resets component state when studyEnvContext changes', async () => {
   const { rerender } = render(
-    <WrappedComponent studyEnvContext={{ ...mockStudyEnvContext(), currentEnvPath: 'mystudy/sandbox' }} text="sandbox"/>
+    <WrappedComponent studyEnvContext={{ ...mockStudyEnvContext(), currentEnvPath: 'mystudy/sandbox' }}/>
   )
 
-  expect(screen.getByTestId('mock-component')).toHaveTextContent('sandbox')
+  await userEvent.type(screen.getByTestId('mock-input'), 'hello sandbox')
+  expect(screen.getByTestId('mock-input')).toHaveValue('hello sandbox')
 
   rerender(
-    <WrappedComponent studyEnvContext={{ ...mockStudyEnvContext(), currentEnvPath: 'mystudy/live' }} text="live"/>
+    <WrappedComponent studyEnvContext={{ ...mockStudyEnvContext(), currentEnvPath: 'mystudy/live' }}/>
   )
 
-  expect(screen.getByTestId('mock-component')).toHaveTextContent('live')
+  expect(screen.getByTestId('mock-input')).toHaveValue('')
 })

--- a/ui-admin/src/util/withStateResetOnEnvChange.test.tsx
+++ b/ui-admin/src/util/withStateResetOnEnvChange.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { withStateResetOnEnvChange } from './withStateResetOnEnvChange'
+import { mockStudyEnvContext } from 'test-utils/mocking-utils'
+
+const MockComponent = ({ text }: { text: string }) => {
+  return <div data-testid="mock-component">{text}</div>
+}
+
+const WrappedComponent = withStateResetOnEnvChange(MockComponent)
+
+test('resets component state when studyEnvContext changes', () => {
+  const { rerender } = render(
+    <WrappedComponent studyEnvContext={{ ...mockStudyEnvContext(), currentEnvPath: 'mystudy/sandbox' }} text="sandbox"/>
+  )
+
+  expect(screen.getByTestId('mock-component')).toHaveTextContent('sandbox')
+
+  rerender(
+    <WrappedComponent studyEnvContext={{ ...mockStudyEnvContext(), currentEnvPath: 'mystudy/live' }} text="live"/>
+  )
+
+  expect(screen.getByTestId('mock-component')).toHaveTextContent('live')
+})

--- a/ui-admin/src/util/withStateResetOnEnvChange.tsx
+++ b/ui-admin/src/util/withStateResetOnEnvChange.tsx
@@ -1,16 +1,10 @@
-import React, { ComponentType, useEffect, useState } from 'react'
+import React, { ComponentType } from 'react'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
 
 export const withStateResetOnEnvChange = <T, >(WrappedComponent: ComponentType<T>) => {
   const WithStateResetOnEnvChange = (props: T & { studyEnvContext: StudyEnvContextT }) => {
     const { studyEnvContext } = props
-    const [key, setKey] = useState(studyEnvContext.currentEnvPath)
-
-    useEffect(() => {
-      setKey(studyEnvContext.currentEnvPath)
-    }, [studyEnvContext.currentEnvPath])
-
-    return <WrappedComponent key={key} {...props} />
+    return <WrappedComponent key={studyEnvContext.currentEnvPath} {...props} />
   }
 
   WithStateResetOnEnvChange.displayName =

--- a/ui-admin/src/util/withStateResetOnEnvChange.tsx
+++ b/ui-admin/src/util/withStateResetOnEnvChange.tsx
@@ -1,8 +1,8 @@
 import React, { ComponentType, useEffect, useState } from 'react'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
 
-export const withResetOnEnvChange = <T, >(WrappedComponent: ComponentType<T>) => {
-  const WithResetOnEnvChange = (props: T & { studyEnvContext: StudyEnvContextT }) => {
+export const withStateResetOnEnvChange = <T, >(WrappedComponent: ComponentType<T>) => {
+  const WithStateResetOnEnvChange = (props: T & { studyEnvContext: StudyEnvContextT }) => {
     const { studyEnvContext } = props
     const [key, setKey] = useState(studyEnvContext.currentEnvPath)
 
@@ -13,8 +13,8 @@ export const withResetOnEnvChange = <T, >(WrappedComponent: ComponentType<T>) =>
     return <WrappedComponent key={key} {...props} />
   }
 
-  WithResetOnEnvChange.displayName =
-    `WithResetOnEnvChange(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`
+  WithStateResetOnEnvChange.displayName =
+    `WithStateResetOnEnvChange(${WrappedComponent.displayName || WrappedComponent.name || 'Component'})`
 
-  return WithResetOnEnvChange
+  return WithStateResetOnEnvChange
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds a helper higher order component that wraps components that need to have their state reset when switching environments. This simplifies the usages of these components because we no longer need to remember to manually add a `key` prop or reset the state in some other way, which should reduce state-related bugs.

I applied this to LoadedSiteSettings, which was the most recent example of needing to do this.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/settings
Edit some values
Confirm that switching between the environments clears any unsaved changes and displays the correct values for the selected env