### PR TITLE
[JN-1441] recurrring surveys

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/ScheduledSurveyAssignmentService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/ScheduledSurveyAssignmentService.java
@@ -1,0 +1,29 @@
+package bio.terra.pearl.api.admin.service.forms;
+
+import bio.terra.pearl.core.service.notification.EnrolleeReminderService;
+import bio.terra.pearl.core.service.survey.SurveyTaskDispatcher;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Slf4j
+public class ScheduledSurveyAssignmentService {
+    private final SurveyTaskDispatcher surveyTaskDispatcher;
+
+    public ScheduledSurveyAssignmentService(SurveyTaskDispatcher surveyTaskDispatcher) {
+        this.surveyTaskDispatcher = surveyTaskDispatcher;
+    }
+
+    @Scheduled(
+            fixedDelay = 60 * 60 * 1000,
+            initialDelay = 5 * 1000) // wait an hour between executions, start after 5 seconds
+    @SchedulerLock(
+            name = "ScheduledSurveyAssignmentService.assignScheduledSurveys",
+            lockAtMostFor = "500s",
+            lockAtLeastFor = "10s")
+    public void assignScheduledSurveys() {
+        log.info("Scheduled survey processing beginning");
+        surveyTaskDispatcher.assignScheduledSurveys();
+        log.info("Scheduled survey processing complete");
+    }
+}

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/ScheduledSurveyAssignmentService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/ScheduledSurveyAssignmentService.java
@@ -1,6 +1,5 @@
 package bio.terra.pearl.api.admin.service.forms;
 
-import bio.terra.pearl.core.service.notification.EnrolleeReminderService;
 import bio.terra.pearl.core.service.survey.SurveyTaskDispatcher;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
@@ -8,22 +7,22 @@ import org.springframework.scheduling.annotation.Scheduled;
 
 @Slf4j
 public class ScheduledSurveyAssignmentService {
-    private final SurveyTaskDispatcher surveyTaskDispatcher;
+  private final SurveyTaskDispatcher surveyTaskDispatcher;
 
-    public ScheduledSurveyAssignmentService(SurveyTaskDispatcher surveyTaskDispatcher) {
-        this.surveyTaskDispatcher = surveyTaskDispatcher;
-    }
+  public ScheduledSurveyAssignmentService(SurveyTaskDispatcher surveyTaskDispatcher) {
+    this.surveyTaskDispatcher = surveyTaskDispatcher;
+  }
 
-    @Scheduled(
-            fixedDelay = 60 * 60 * 1000,
-            initialDelay = 5 * 1000) // wait an hour between executions, start after 5 seconds
-    @SchedulerLock(
-            name = "ScheduledSurveyAssignmentService.assignScheduledSurveys",
-            lockAtMostFor = "500s",
-            lockAtLeastFor = "10s")
-    public void assignScheduledSurveys() {
-        log.info("Scheduled survey processing beginning");
-        surveyTaskDispatcher.assignScheduledSurveys();
-        log.info("Scheduled survey processing complete");
-    }
+  @Scheduled(
+      fixedDelay = 60 * 60 * 1000,
+      initialDelay = 5 * 1000) // wait an hour between executions, start after 5 seconds
+  @SchedulerLock(
+      name = "ScheduledSurveyAssignmentService.assignScheduledSurveys",
+      lockAtMostFor = "500s",
+      lockAtLeastFor = "10s")
+  public void assignScheduledSurveys() {
+    log.info("Scheduled survey processing beginning");
+    surveyTaskDispatcher.assignScheduledSurveys();
+    log.info("Scheduled survey processing complete");
+  }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/notifications/ScheduledEnrolleeReminderService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/notifications/ScheduledEnrolleeReminderService.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 public class ScheduledEnrolleeReminderService {
-  private EnrolleeReminderService enrolleeReminderService;
+  private final EnrolleeReminderService enrolleeReminderService;
 
   public ScheduledEnrolleeReminderService(EnrolleeReminderService enrolleeReminderService) {
     this.enrolleeReminderService = enrolleeReminderService;

--- a/core/src/main/java/bio/terra/pearl/core/dao/dataimport/TimeShiftDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/dataimport/TimeShiftDao.java
@@ -10,10 +10,10 @@ import java.util.UUID;
  * collection of methods for timeshifting records in otherwise unpermissible ways
  */
 @Component
-public class TimeShiftPopulateDao {
+public class TimeShiftDao {
     private Jdbi jdbi;
 
-    public TimeShiftPopulateDao(Jdbi jdbi) {
+    public TimeShiftDao(Jdbi jdbi) {
         this.jdbi = jdbi;
     }
 
@@ -56,6 +56,15 @@ public class TimeShiftPopulateDao {
                 handle.createUpdate("update participant_task set completed_at = :completionTime where id = :taskId;")
                         .bind("taskId", taskId)
                         .bind("completionTime", completionTime)
+                        .execute()
+        );
+    }
+
+    public void changeTaskCreationTime(UUID taskId, Instant creationTime) {
+        jdbi.withHandle(handle ->
+                handle.createUpdate("update participant_task set created_at = :creationTime where id = :taskId;")
+                        .bind("taskId", taskId)
+                        .bind("creationTime", creationTime)
                         .execute()
         );
     }

--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeDao.java
@@ -14,6 +14,8 @@ import org.jdbi.v3.core.statement.Query;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -116,35 +118,6 @@ public class EnrolleeDao extends BaseMutableJdbiDao<Enrollee> {
         updateProperty(enrolleeId, "consented", consented);
     }
 
-    public List<Enrollee> findUnassignedToTask(UUID studyEnvironmentId,
-                                         String targetStableId,
-                                         Integer targetAssignedVersion) {
-
-        return jdbi.withHandle(handle -> {
-            String versionWhereClause = "";
-            if (targetAssignedVersion != null) {
-                versionWhereClause = " and target_assigned_version = :targetAssignedVersion";
-            }
-            Query query = handle.createQuery("""
-                                    select * from enrollee
-                                     where id 
-                                     not in
-                                     (select distinct enrollee_id from participant_task 
-                                        where study_environment_id = :studyEnvironmentId
-                                        and participant_task.target_stable_id = :targetStableId
-                                        %s
-                                     )
-                                     and study_environment_id = :studyEnvironmentId;
-                            """.formatted(versionWhereClause))
-                    .bind("targetStableId", targetStableId)
-                    .bind("studyEnvironmentId", studyEnvironmentId);
-            if (targetAssignedVersion != null) {
-                query = query.bind("targetAssignedVersion", targetAssignedVersion);
-            }
-            return query.mapTo(clazz).list();
-        });
-    }
-
     public Optional<Enrollee> findByParticipantUserIdAndStudyEnvId(UUID participantUserId, UUID studyEnvId) {
         return findByTwoProperties("participant_user_id", participantUserId, "study_environment_id", studyEnvId);
     }
@@ -184,4 +157,57 @@ public class EnrolleeDao extends BaseMutableJdbiDao<Enrollee> {
     public Optional<Enrollee> findByShortcodeAndStudyEnvId(String enrolleeShortcode, UUID studyEnvId) {
         return findByTwoProperties("shortcode", enrolleeShortcode, "study_environment_id", studyEnvId);
     }
+
+
+    public List<Enrollee> findUnassignedToTask(UUID studyEnvironmentId,
+                                               String targetStableId,
+                                               Integer targetAssignedVersion) {
+
+        return jdbi.withHandle(handle -> {
+            String versionWhereClause = "";
+            if (targetAssignedVersion != null) {
+                versionWhereClause = " and target_assigned_version = :targetAssignedVersion";
+            }
+            Query query = handle.createQuery("""
+                            select enrollee.* from enrollee  
+                            left join participant_task 
+                            on (enrollee.id = participant_task.enrollee_id 
+                                 and participant_task.target_stable_id = :targetStableId
+                                 %s
+                                 )              
+                             where enrollee.study_environment_id = :studyEnvironmentId                         
+                             and participant_task.id IS NULL                                                                   
+                        """.formatted(versionWhereClause))
+                    .bind("targetStableId", targetStableId)
+                    .bind("studyEnvironmentId", studyEnvironmentId);
+            if (targetAssignedVersion != null) {
+                query = query.bind("targetAssignedVersion", targetAssignedVersion);
+            }
+            return query.mapTo(clazz).list();
+        });
+    }
+
+
+    /** returns enrollees who were assigned a tasks with the given target stable id in the past */
+    public List<Enrollee> findWithTaskInPast(UUID studyEnvironmentId,
+                                              String taskTargetStableId,
+                                              Duration minTimeSinceMostRecent) {
+        Instant minTimeSinceMostRecentInstant = Instant.now().minus(minTimeSinceMostRecent);
+        return jdbi.withHandle(handle ->
+                handle.createQuery("""
+                        with enrollee_times as (select enrollee_id as task_enrollee_id, MAX(created_at) as most_recent_task_time
+                          from participant_task where target_stable_id = :taskTargetStableId group by enrollee_id)
+                        select enrollee.* from enrollee 
+                        join enrollee_times on enrollee.id = task_enrollee_id
+                        where study_environment_id = :studyEnvironmentId
+                        and most_recent_task_time < :minTimeSinceCreationInstant
+                        """)
+                        .bind("studyEnvironmentId", studyEnvironmentId)
+                        .bind("taskTargetStableId", taskTargetStableId)
+                        .bind("minTimeSinceCreationInstant", minTimeSinceMostRecentInstant)
+                        .mapTo(clazz)
+                        .list()
+        );
+    }
+
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/RecurrenceType.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/RecurrenceType.java
@@ -1,0 +1,7 @@
+package bio.terra.pearl.core.model.survey;
+
+public enum RecurrenceType {
+    NONE,
+    LONGITUDINAL, // when it recurs, each instance is a new response
+    UPDATE  // when it recurs, update existing response (e.g 'what is your address?')
+}

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/Survey.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/Survey.java
@@ -42,7 +42,7 @@ public class Survey extends BaseEntity implements Versioned, PortalAttached {
     private boolean required = false; // whether this is required before other non-required surveys can be taken
     // how many days between offerings of this survey (e.g. 365 for one year)
     private Integer recurrenceIntervalDays;
-    // how many days after being eligible (e.g. after consent, or rule triggering) to offer the survey
+    // how many days after enrollment this survey is first offered
     private Integer daysAfterEligible;
     private String eligibilityRule;
     @Builder.Default

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/Survey.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/Survey.java
@@ -37,7 +37,7 @@ public class Survey extends BaseEntity implements Versioned, PortalAttached {
     private List<String> referencedQuestions = new ArrayList<>();
 
     @Builder.Default
-    private boolean recur = false;
+    private RecurrenceType recurrenceType = RecurrenceType.NONE;
     @Builder.Default
     private boolean required = false; // whether this is required before other non-required surveys can be taken
     // how many days between offerings of this survey (e.g. 365 for one year)

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -1,6 +1,6 @@
 package bio.terra.pearl.core.service.export;
 
-import bio.terra.pearl.core.dao.dataimport.TimeShiftPopulateDao;
+import bio.terra.pearl.core.dao.dataimport.TimeShiftDao;
 import bio.terra.pearl.core.model.audit.DataAuditInfo;
 import bio.terra.pearl.core.model.audit.ResponsibleEntity;
 import bio.terra.pearl.core.model.dataimport.*;
@@ -78,7 +78,7 @@ public class EnrolleeImportService {
     private final ParticipantUserService participantUserService;
     private final PortalService portalService;
     private final PortalParticipantUserService portalParticipantUserService;
-    private final TimeShiftPopulateDao timeShiftPopulateDao;
+    private final TimeShiftDao timeShiftDao;
     private final ImportService importService;
     private final ImportItemService importItemService;
     private final KitRequestService kitRequestService;
@@ -89,7 +89,7 @@ public class EnrolleeImportService {
                                  ProfileService profileService, EnrolleeExportService enrolleeExportService,
                                  SurveyResponseService surveyResponseService, ParticipantTaskService participantTaskService, PortalService portalService,
                                  ImportService importService, ImportItemService importItemService, SurveyTaskDispatcher surveyTaskDispatcher,
-                                 TimeShiftPopulateDao timeShiftPopulateDao, EnrolleeService enrolleeService, ParticipantUserService participantUserService,
+                                 TimeShiftDao timeShiftDao, EnrolleeService enrolleeService, ParticipantUserService participantUserService,
                                  PortalParticipantUserService portalParticipantUserService, KitRequestService kitRequestService) {
         this.registrationService = registrationService;
         this.enrollmentService = enrollmentService;
@@ -101,7 +101,7 @@ public class EnrolleeImportService {
         this.importService = importService;
         this.importItemService = importItemService;
         this.surveyTaskDispatcher = surveyTaskDispatcher;
-        this.timeShiftPopulateDao = timeShiftPopulateDao;
+        this.timeShiftDao = timeShiftDao;
         this.enrolleeService = enrolleeService;
         this.participantUserService = participantUserService;
         this.portalParticipantUserService = portalParticipantUserService;
@@ -290,10 +290,10 @@ public class EnrolleeImportService {
             Enrollee newEnrollee = response.getEnrollee();
             //update createdAt
             if (enrolleeInfo.getCreatedAt() != null) {
-                timeShiftPopulateDao.changeEnrolleeCreationTime(response.getEnrollee().getId(), enrolleeInfo.getCreatedAt());
+                timeShiftDao.changeEnrolleeCreationTime(response.getEnrollee().getId(), enrolleeInfo.getCreatedAt());
             }
             if (regResult.participantUser().getCreatedAt() != null) {
-                timeShiftPopulateDao.changeParticipantAccountCreationTime(response.getEnrollee().getParticipantUserId(), participantUserInfo.getCreatedAt());
+                timeShiftDao.changeParticipantAccountCreationTime(response.getEnrollee().getParticipantUserId(), participantUserInfo.getCreatedAt());
             }
             return newEnrollee;
         });

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeService.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
+import java.time.Duration;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -257,6 +258,10 @@ public class EnrolleeService extends CrudService<Enrollee, EnrolleeDao> {
                                      String targetStableId,
                                      Integer targetAssignedVersion) {
         return dao.findUnassignedToTask(studyEnvironmentId, targetStableId, targetAssignedVersion);
+    }
+
+    public List<Enrollee> findWithTaskInPast(UUID studyEnvId, String taskTargetStableId, Duration minTimeSinceMostRecent ) {
+        return dao.findWithTaskInPast(studyEnvId, taskTargetStableId, minTimeSinceMostRecent);
     }
 
     public Optional<Enrollee> findByParticipantUserIdAndStudyEnvId(UUID participantUserId, UUID studyEnvId) {

--- a/core/src/main/java/bio/terra/pearl/core/service/rule/EnrolleeContextService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/rule/EnrolleeContextService.java
@@ -41,6 +41,9 @@ public class EnrolleeContextService {
      *  This returns the context for each enrollee in the order of the input list
      */
     public List<EnrolleeContext> fetchData(List<UUID> enrolleeIds) {
+        if (enrolleeIds.isEmpty()) {
+            return List.of();
+        }
         List<Enrollee> enrollees = enrolleeService.findAllPreserveOrder(enrolleeIds);
         List<Profile> profiles = profileService.findAllWithMailingAddressPreserveOrder(enrollees.stream().map(Enrollee::getProfileId).toList());
         List<ParticipantUser> users = participantUserService.findAllPreserveOrder(enrollees.stream().map(Enrollee::getParticipantUserId).toList());

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
@@ -288,7 +288,7 @@ public class SurveyTaskDispatcher {
         // TODO JN-977: this logic will need to change because we will need to support surveys for proxies
         return enrolleeContext.getEnrollee().isSubject() &&
                 (survey.getDaysAfterEligible() == null ||
-                        enrolleeContext.getEnrollee().getCreatedAt().minus(survey.getDaysAfterEligible(), ChronoUnit.DAYS).isBefore(Instant.now())) &&
+                        enrolleeContext.getEnrollee().getCreatedAt().plus(survey.getDaysAfterEligible(), ChronoUnit.DAYS).isBefore(Instant.now())) &&
                 enrolleeSearchExpressionParser
                 .parseRule(survey.getEligibilityRule())
                 .evaluate(new EnrolleeSearchContext(enrolleeContext.getEnrollee(), enrolleeContext.getProfile()));
@@ -343,7 +343,7 @@ public class SurveyTaskDispatcher {
      * a new one
      */
     public static boolean isRecurrenceWindowOpen(StudyEnvironmentSurvey studySurvey, ParticipantTask pastTask) {
-        if (studySurvey.getSurvey().getRecurrenceType() != RecurrenceType.NONE) {
+        if (studySurvey.getSurvey().getRecurrenceType() == RecurrenceType.NONE) {
             return false;
         }
         Instant pastCutoffTime = ZonedDateTime.now(ZoneOffset.UTC)

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/ParticipantTaskService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/ParticipantTaskService.java
@@ -46,7 +46,7 @@ public class ParticipantTaskService extends ParticipantDataAuditedService<Partic
         return dao.findByPortalParticipantUserId(ppUserId);
     }
 
-    public List<ParticipantTask> findAdminTasksByStudyEnvironmentId(UUID studyEnvId) {
+    public List<ParticipantTask> findByStudyEnvironmentId(UUID studyEnvId) {
         return dao.findByStudyEnvironmentId(studyEnvId);
     }
 

--- a/core/src/main/resources/db/changelog/changesets/2024_10_21_recurrence_type.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_10_21_recurrence_type.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: "recurrence_type"
+      author: dbush
+      changes:
+        - addColumn:
+            tableName: survey
+            columns:
+              - column: { name: recurrence_type, type: text }

--- a/core/src/main/resources/db/changelog/changesets/2024_10_21_recurrence_type.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_10_21_recurrence_type.yaml
@@ -6,4 +6,4 @@ databaseChangeLog:
         - addColumn:
             tableName: survey
             columns:
-              - column: { name: recurrence_type, type: text }
+              - column: { name: recurrence_type, type: text, constraints: { nullable: false }, defaultValue: 'NONE'}

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -341,6 +341,9 @@ databaseChangeLog:
   - include:
         file: changesets/2024_10_16_enrollee_source.yaml
         relativeToChangelogFile: true
+  - include:
+        file: changesets/2024_10_21_recurrence_type.yaml
+        relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
@@ -284,5 +284,21 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
         assertThat(tasks.stream().map(ParticipantTask::getTargetStableId).toList(), containsInAnyOrder("medForm", "followUp"));
     }
 
+    @Test
+    @Transactional
+    public void testAssign(TestInfo testInfo) {
+        StudyEnvironmentBundle sandboxBundle = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.sandbox);
+        AdminUser operator = adminUserFactory.buildPersisted(getTestName(testInfo), true);
+        EnrolleeBundle sandbox1 = enrolleeFactory.buildWithPortalUser(getTestName(testInfo), sandboxBundle.getPortalEnv(), sandboxBundle.getStudyEnv());
+        EnrolleeBundle sandbox2 = enrolleeFactory.buildWithPortalUser(getTestName(testInfo), sandboxBundle.getPortalEnv(), sandboxBundle.getStudyEnv());
+        Survey survey = surveyFactory.buildPersisted(getTestName(testInfo));
+        surveyFactory.attachToEnv(survey, sandboxBundle.getStudyEnv().getId(), true);
+        ParticipantTaskAssignDto assignDto = new ParticipantTaskAssignDto(TaskType.SURVEY, survey.getStableId(), survey.getVersion(), null, true, true );
+        surveyTaskDispatcher.assign(assignDto, sandboxBundle.getStudyEnv().getId(), new ResponsibleEntity(operator));
+        List<ParticipantTask> participantTasks = participantTaskService.findTasksByStudyAndTarget(sandboxBundle.getStudyEnv().getId(), List.of(survey.getStableId()));
+        assertThat(participantTasks, hasSize(2));
+    }
+
+
 
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
@@ -286,13 +286,18 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
 
     @Test
     @Transactional
-    public void testAssign(TestInfo testInfo) {
+    public void testDelayAssign(TestInfo testInfo) {
         StudyEnvironmentBundle sandboxBundle = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.sandbox);
         AdminUser operator = adminUserFactory.buildPersisted(getTestName(testInfo), true);
-        EnrolleeBundle sandbox1 = enrolleeFactory.buildWithPortalUser(getTestName(testInfo), sandboxBundle.getPortalEnv(), sandboxBundle.getStudyEnv());
-        EnrolleeBundle sandbox2 = enrolleeFactory.buildWithPortalUser(getTestName(testInfo), sandboxBundle.getPortalEnv(), sandboxBundle.getStudyEnv());
-        Survey survey = surveyFactory.buildPersisted(getTestName(testInfo));
+        Survey survey = surveyFactory.builder(getTestName(testInfo)).daysAfterEligible(1).build();
         surveyFactory.attachToEnv(survey, sandboxBundle.getStudyEnv().getId(), true);
+
+        EnrolleeBundle sandbox1 = enrolleeFactory.enroll(getTestName(testInfo), sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
+        EnrolleeBundle sandbox2 = enrolleeFactory.enroll(getTestName(testInfo), sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
+
+        List<ParticipantTask> tasks = participantTaskService.f
+
+
         ParticipantTaskAssignDto assignDto = new ParticipantTaskAssignDto(TaskType.SURVEY, survey.getStableId(), survey.getVersion(), null, true, true );
         surveyTaskDispatcher.assign(assignDto, sandboxBundle.getStudyEnv().getId(), new ResponsibleEntity(operator));
         List<ParticipantTask> participantTasks = participantTaskService.findTasksByStudyAndTarget(sandboxBundle.getStudyEnv().getId(), List.of(survey.getStableId()));

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.service.survey;
 
 import bio.terra.pearl.core.BaseSpringBootTest;
+import bio.terra.pearl.core.dao.dataimport.TimeShiftDao;
 import bio.terra.pearl.core.factory.StudyEnvironmentBundle;
 import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
 import bio.terra.pearl.core.factory.admin.AdminUserFactory;
@@ -12,8 +13,10 @@ import bio.terra.pearl.core.factory.survey.SurveyFactory;
 import bio.terra.pearl.core.factory.survey.SurveyResponseFactory;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.model.audit.DataAuditInfo;
 import bio.terra.pearl.core.model.audit.ResponsibleEntity;
 import bio.terra.pearl.core.model.participant.Profile;
+import bio.terra.pearl.core.model.survey.RecurrenceType;
 import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
@@ -26,6 +29,8 @@ import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -50,11 +55,13 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
     private AdminUserFactory adminUserFactory;
     @Autowired
     private SurveyResponseFactory surveyResponseFactory;
+    @Autowired
+    private TimeShiftDao timeShiftDao;
 
 
     @Test
     void testIsDuplicateTask() {
-        Survey survey = Survey.builder().recur(false).build();
+        Survey survey = Survey.builder().recurrenceType(RecurrenceType.NONE).build();
         StudyEnvironmentSurvey studyEnvironmentSurvey = StudyEnvironmentSurvey.builder()
                 .survey(survey)
                 .build();
@@ -85,7 +92,7 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
 
     @Test
     void testIsDuplicateForTaskTypes() {
-        Survey survey = Survey.builder().recur(false).build();
+        Survey survey = Survey.builder().recurrenceType(RecurrenceType.NONE).build();
         StudyEnvironmentSurvey studyEnvironmentSurvey = StudyEnvironmentSurvey.builder()
                 .survey(survey)
                 .build();
@@ -287,23 +294,65 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
     @Test
     @Transactional
     public void testDelayAssign(TestInfo testInfo) {
+        // create a 1-day delayed survey, confirm it doesn't get assigned until the delay has passed
         StudyEnvironmentBundle sandboxBundle = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.sandbox);
-        AdminUser operator = adminUserFactory.buildPersisted(getTestName(testInfo), true);
-        Survey survey = surveyFactory.builder(getTestName(testInfo)).daysAfterEligible(1).build();
+        Survey survey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(testInfo))
+                        .portalId(sandboxBundle.getPortal().getId())
+                .daysAfterEligible(1));
         surveyFactory.attachToEnv(survey, sandboxBundle.getStudyEnv().getId(), true);
 
-        EnrolleeBundle sandbox1 = enrolleeFactory.enroll(getTestName(testInfo), sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
-        EnrolleeBundle sandbox2 = enrolleeFactory.enroll(getTestName(testInfo), sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
+        EnrolleeBundle sandbox1 = enrolleeFactory.enroll(getTestName(testInfo) + "1", sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
+        EnrolleeBundle sandbox2 = enrolleeFactory.enroll(getTestName(testInfo) + "2", sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
 
-        List<ParticipantTask> tasks = participantTaskService.f
+        List<ParticipantTask> tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
+        assertThat(tasks, hasSize(0));
+        timeShiftDao.changeEnrolleeCreationTime(sandbox1.enrollee().getId(), Instant.now().minus(3, ChronoUnit.DAYS));
 
+        // should assign to sandbox1 since it was created more than 1 day ago
+        surveyTaskDispatcher.assignScheduledSurveys();
+        tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
+        assertThat(tasks, hasSize(1));
+        assertThat(tasks.get(0).getEnrolleeId(), equalTo(sandbox1.enrollee().getId()));
+        assertThat(tasks.get(0).getTargetStableId(), equalTo(survey.getStableId()));
 
-        ParticipantTaskAssignDto assignDto = new ParticipantTaskAssignDto(TaskType.SURVEY, survey.getStableId(), survey.getVersion(), null, true, true );
-        surveyTaskDispatcher.assign(assignDto, sandboxBundle.getStudyEnv().getId(), new ResponsibleEntity(operator));
-        List<ParticipantTask> participantTasks = participantTaskService.findTasksByStudyAndTarget(sandboxBundle.getStudyEnv().getId(), List.of(survey.getStableId()));
-        assertThat(participantTasks, hasSize(2));
+        // task will not get assigned twice to the same enrollee
+        surveyTaskDispatcher.assignScheduledSurveys();
+        tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
+        assertThat(tasks, hasSize(1));
     }
 
+    @Test
+    @Transactional
+    public void testRecurringAssign(TestInfo testInfo) {
+        // create a 7-day recurring survey, confirm it gets reassigned
+        StudyEnvironmentBundle sandboxBundle = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.sandbox);
+        Survey survey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(testInfo))
+                .portalId(sandboxBundle.getPortal().getId())
+                .recurrenceType(RecurrenceType.LONGITUDINAL)
+                .recurrenceIntervalDays(7));
+        surveyFactory.attachToEnv(survey, sandboxBundle.getStudyEnv().getId(), true);
 
+        EnrolleeBundle sandbox1 = enrolleeFactory.enroll(getTestName(testInfo) + "1", sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
+        EnrolleeBundle sandbox2 = enrolleeFactory.enroll(getTestName(testInfo) + "2", sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
+        EnrolleeBundle sandbox3 = enrolleeFactory.enroll(getTestName(testInfo) + "3", sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
 
+        List<ParticipantTask> tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
+        // task should be assigned to all enrollees on creation
+        assertThat(tasks, hasSize(3));
+
+        // delete the first enrollee's task
+        participantTaskService.delete(tasks.stream().filter(task ->
+                task.getEnrolleeId().equals(sandbox1.enrollee().getId())).findFirst().get().getId(), DataAuditInfo.builder().systemProcess(getTestName(testInfo)).build());
+        // change the second enrollee's task time to 8 days ago
+        timeShiftDao.changeTaskCreationTime(tasks.stream().filter(task ->
+                task.getEnrolleeId().equals(sandbox2.enrollee().getId())).findFirst().get().getId(), Instant.now().minus(8, ChronoUnit.DAYS));
+
+        // this should not assign to 1 (since it has no prior task) or 3 (since its task was assigned recently)
+        surveyTaskDispatcher.assignScheduledSurveys();
+        tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
+        assertThat(tasks, hasSize(3));
+        assertThat(participantTaskService.findByEnrolleeId(sandbox1.enrollee().getId()), hasSize(0));
+        assertThat(participantTaskService.findByEnrolleeId(sandbox2.enrollee().getId()), hasSize(2));
+        assertThat(participantTaskService.findByEnrolleeId(sandbox3.enrollee().getId()), hasSize(1));
+    }
 }

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/participant/ParticipantTaskFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/participant/ParticipantTaskFactory.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.core.factory.participant;
 
+import bio.terra.pearl.core.dao.dataimport.TimeShiftDao;
 import bio.terra.pearl.core.model.audit.DataAuditInfo;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
 import bio.terra.pearl.core.model.workflow.TaskStatus;
@@ -9,10 +10,14 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
+
 @Service
 public class ParticipantTaskFactory {
   @Autowired
   ParticipantTaskService participantTaskService;
+  @Autowired
+  TimeShiftDao timeShiftDao;
 
   public static ParticipantTask.ParticipantTaskBuilder DEFAULT_BUILDER = ParticipantTask.builder()
           .status(TaskStatus.NEW)
@@ -49,6 +54,10 @@ public class ParticipantTaskFactory {
 
   /** auto-sets the enrollee and environment-related fields, otherwise builds the task as provided */
   public ParticipantTask buildPersisted(EnrolleeBundle enrolleeBundle, ParticipantTask.ParticipantTaskBuilder builder) {
+    return buildPersisted(enrolleeBundle, builder, null);
+  }
+
+  public ParticipantTask buildPersisted(EnrolleeBundle enrolleeBundle, ParticipantTask.ParticipantTaskBuilder builder, Instant createdAt) {
     DataAuditInfo auditInfo = DataAuditInfo.builder().systemProcess(
             DataAuditInfo.systemProcessName(getClass(), "buildPersisted")
     ).build();
@@ -57,10 +66,12 @@ public class ParticipantTaskFactory {
             .studyEnvironmentId(enrolleeBundle.enrollee().getStudyEnvironmentId())
             .portalParticipantUserId(enrolleeBundle.portalParticipantUser().getId())
             .build();
-    return participantTaskService.create(task, auditInfo);
+    task = participantTaskService.create(task, auditInfo);
+    if (createdAt != null) {
+      timeShiftDao.changeTaskCreationTime(task.getId(), createdAt);
+      task.setCreatedAt(createdAt);
+    }
+    return task;
   }
-
-
-
 
 }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
@@ -1,7 +1,7 @@
 package bio.terra.pearl.populate.service;
 
 import bio.terra.pearl.core.dao.admin.AdminUserDao;
-import bio.terra.pearl.core.dao.dataimport.TimeShiftPopulateDao;
+import bio.terra.pearl.core.dao.dataimport.TimeShiftDao;
 import bio.terra.pearl.core.dao.kit.KitTypeDao;
 import bio.terra.pearl.core.dao.survey.PreEnrollmentResponseDao;
 import bio.terra.pearl.core.dao.survey.SurveyQuestionDefinitionDao;
@@ -81,7 +81,7 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
                              NotificationService notificationService, AnswerProcessingService answerProcessingService,
                              EnrollmentService enrollmentService, ProfileService profileService,
                              WithdrawnEnrolleeService withdrawnEnrolleeService,
-                             TimeShiftPopulateDao timeShiftPopulateDao,
+                             TimeShiftDao timeShiftDao,
                              KitRequestService kitRequestService, KitTypeDao kitTypeDao, AdminUserDao adminUserDao,
                              ParticipantNotePopulator participantNotePopulator,
                              ParticipantUserPopulateDao participantUserPopulateDao, PortalParticipantUserPopulator portalParticipantUserPopulator, ObjectMapper objectMapper, PortalService portalService,
@@ -101,7 +101,7 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
         this.profileService = profileService;
         this.withdrawnEnrolleeService = withdrawnEnrolleeService;
         this.participantNotePopulator = participantNotePopulator;
-        this.timeShiftPopulateDao = timeShiftPopulateDao;
+        this.timeShiftDao = timeShiftDao;
         this.kitRequestService = kitRequestService;
         this.kitTypeDao = kitTypeDao;
         this.adminUserDao = adminUserDao;
@@ -170,9 +170,9 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
                     .updateResponse(response, responsibleUser, responsePopDto.getJustification(), ppUser, enrollee, task.getId(), survey.getPortalId());
             savedResponse = hubResponse.getResponse();
             if (responsePopDto.isTimeShifted()) {
-                timeShiftPopulateDao.changeSurveyResponseTime(savedResponse.getId(), responsePopDto.shiftedInstant());
+                timeShiftDao.changeSurveyResponseTime(savedResponse.getId(), responsePopDto.shiftedInstant());
                 if (responsePopDto.isComplete()) {
-                    timeShiftPopulateDao.changeTaskCompleteTime(task.getId(), responsePopDto.shiftedInstant());
+                    timeShiftDao.changeTaskCompleteTime(task.getId(), responsePopDto.shiftedInstant());
                 }
             }
         } else {
@@ -255,7 +255,7 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
                 .build();
         kitRequest = kitRequestService.create(kitRequest);
         if (kitRequestPopDto.getCreatedAt() != null) {
-            timeShiftPopulateDao.changeKitCreationTime(kitRequest.getId(), kitRequestPopDto.getCreatedAt());
+            timeShiftDao.changeKitCreationTime(kitRequest.getId(), kitRequestPopDto.getCreatedAt());
         }
         enrollee.getKitRequests().add(
                 new KitRequestDto(kitRequest, kitType, enrollee.getShortcode(), objectMapper));
@@ -428,7 +428,7 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
             participantNotePopulator.populate(enrollee, notePopDto);
         }
         if (popDto.isTimeShifted()) {
-            timeShiftPopulateDao.changeEnrolleeCreationTime(enrollee.getId(), popDto.shiftedInstant());
+            timeShiftDao.changeEnrolleeCreationTime(enrollee.getId(), popDto.shiftedInstant());
         }
         if (popDto.isWithdrawn()) {
             withdrawnEnrolleeService.withdrawEnrollee(enrollee, DataAuditInfo.builder().systemProcess("populateEnrolleeData").build());
@@ -627,7 +627,7 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
     private final EnrollmentService enrollmentService;
     private final ProfileService profileService;
     private final WithdrawnEnrolleeService withdrawnEnrolleeService;
-    private final TimeShiftPopulateDao timeShiftPopulateDao;
+    private final TimeShiftDao timeShiftDao;
     private final KitRequestService kitRequestService;
     private final KitTypeDao kitTypeDao;
     private final AdminUserDao adminUserDao;

--- a/populate/src/main/java/bio/terra/pearl/populate/service/ParticipantNotePopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/ParticipantNotePopulator.java
@@ -1,7 +1,7 @@
 package bio.terra.pearl.populate.service;
 
 import bio.terra.pearl.core.dao.admin.AdminUserDao;
-import bio.terra.pearl.core.dao.dataimport.TimeShiftPopulateDao;
+import bio.terra.pearl.core.dao.dataimport.TimeShiftDao;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.ParticipantNote;
@@ -23,16 +23,16 @@ public class ParticipantNotePopulator {
     private final PortalParticipantUserService portalParticipantUserService;
     private final AdminUserDao adminUserDao;
     private final ParticipantNoteService participantNoteService;
-    private final TimeShiftPopulateDao timeShiftPopulateDao;
+    private final TimeShiftDao timeShiftDao;
 
     public ParticipantNotePopulator(AdminUserDao adminUserDao,
                                     ParticipantNoteService participantNoteService,
-                                    TimeShiftPopulateDao timeShiftPopulateDao,
+                                    TimeShiftDao timeShiftDao,
                                     ParticipantTaskService participantTaskService,
                                     PortalParticipantUserService portalParticipantUserService) {
         this.adminUserDao = adminUserDao;
         this.participantNoteService = participantNoteService;
-        this.timeShiftPopulateDao = timeShiftPopulateDao;
+        this.timeShiftDao = timeShiftDao;
         this.participantTaskService = participantTaskService;
         this.portalParticipantUserService = portalParticipantUserService;
     }
@@ -52,7 +52,7 @@ public class ParticipantNotePopulator {
                 .build();
         participantNote = participantNoteService.create(participantNote);
         if (notePopDto.isTimeShifted()) {
-            timeShiftPopulateDao.changeParticipantNoteTime(participantNote.getId(), notePopDto.shiftedInstant());
+            timeShiftDao.changeParticipantNoteTime(participantNote.getId(), notePopDto.shiftedInstant());
         }
 
         if (notePopDto.getTask() != null) {
@@ -73,10 +73,10 @@ public class ParticipantNotePopulator {
                     .build();
             adminTask = participantTaskService.create(adminTask, null);
             if (notePopDto.isTimeShifted() && !taskDto.isTimeShifted()) {
-                timeShiftPopulateDao.changeAdminTaskCreationTime(participantNote.getId(), notePopDto.shiftedInstant());
+                timeShiftDao.changeAdminTaskCreationTime(participantNote.getId(), notePopDto.shiftedInstant());
             }
             if (taskDto.isTimeShifted()) {
-                timeShiftPopulateDao.changeAdminTaskCreationTime(adminTask.getId(), taskDto.shiftedInstant());
+                timeShiftDao.changeAdminTaskCreationTime(adminTask.getId(), taskDto.shiftedInstant());
             }
         }
         return participantNote;

--- a/populate/src/main/java/bio/terra/pearl/populate/service/PortalEnvironmentChangeRecordPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/PortalEnvironmentChangeRecordPopulator.java
@@ -1,6 +1,6 @@
 package bio.terra.pearl.populate.service;
 
-import bio.terra.pearl.core.dao.dataimport.TimeShiftPopulateDao;
+import bio.terra.pearl.core.dao.dataimport.TimeShiftDao;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.publishing.PortalEnvironmentChangeRecord;
 import bio.terra.pearl.core.service.CascadeProperty;
@@ -18,15 +18,15 @@ import java.util.Optional;
 public class PortalEnvironmentChangeRecordPopulator extends BasePopulator<PortalEnvironmentChangeRecord, PortalEnvironmentChangeRecordPopDto, PortalPopulateContext> {
     private final PortalEnvironmentChangeRecordService portalEnvironmentChangeRecordService;
     private final AdminUserService adminUserService;
-    private final TimeShiftPopulateDao timeShiftPopulateDao;
+    private final TimeShiftDao timeShiftDao;
     private final PortalService portalService;
 
     public PortalEnvironmentChangeRecordPopulator(PortalEnvironmentChangeRecordService portalEnvironmentChangeRecordService,
-                                                  AdminUserService adminUserService, TimeShiftPopulateDao timeShiftPopulateDao,
+                                                  AdminUserService adminUserService, TimeShiftDao timeShiftDao,
                                                   PortalService portalService) {
         this.portalEnvironmentChangeRecordService = portalEnvironmentChangeRecordService;
         this.adminUserService = adminUserService;
-        this.timeShiftPopulateDao = timeShiftPopulateDao;
+        this.timeShiftDao = timeShiftDao;
         this.portalService = portalService;
     }
 
@@ -69,7 +69,7 @@ public class PortalEnvironmentChangeRecordPopulator extends BasePopulator<Portal
     public PortalEnvironmentChangeRecord createNew(PortalEnvironmentChangeRecordPopDto popDto, PortalPopulateContext context, boolean overwrite) throws IOException {
         PortalEnvironmentChangeRecord changeRecord = portalEnvironmentChangeRecordService.create(popDto);
         if (popDto.isTimeShifted()) {
-            timeShiftPopulateDao.changeEnrolleeCreationTime(changeRecord.getId(), popDto.shiftedInstant());
+            timeShiftDao.changeEnrolleeCreationTime(changeRecord.getId(), popDto.shiftedInstant());
         }
         return changeRecord;
     }

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/lifestyle.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/lifestyle.json
@@ -3,7 +3,6 @@
   "version": 1,
   "name": "Lifestyle",
   "footer": "Resources used for this survey:\n * Tobacco Use Supplement to the Current Population Survey (TUS&#8209;CPS)\n * American Thoracic Society Division of Lung Disease questionnaire (ATS&nbsp;&#8209;&nbsp;DLD&nbsp;&#8209;&nbsp;78)\n * Million Veterans Program\n * Prostate, Lung, Colorectal, and Ovarian (PLCO) Cancer Screening Trial\n * Population Assessment of Tobacco and Health (PATH)\n * National Epidemiologic Survey on Alcohol and Related Conditions (NESARC)\n * Alcohol Use Disorders Identification Test (AUDIT&#8209;C)\n * NM ASSIST (NIDA-Modified Alcohol, Smoking, and Substance Involvement Screening Test)",
-  "recur": true,
   "recurrenceIntervalDays": 7,
   "jsonContent": {
     "title": {

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/lifestyle.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/lifestyle.json
@@ -3,6 +3,8 @@
   "version": 1,
   "name": "Lifestyle",
   "footer": "Resources used for this survey:\n * Tobacco Use Supplement to the Current Population Survey (TUS&#8209;CPS)\n * American Thoracic Society Division of Lung Disease questionnaire (ATS&nbsp;&#8209;&nbsp;DLD&nbsp;&#8209;&nbsp;78)\n * Million Veterans Program\n * Prostate, Lung, Colorectal, and Ovarian (PLCO) Cancer Screening Trial\n * Population Assessment of Tobacco and Health (PATH)\n * National Epidemiologic Survey on Alcohol and Related Conditions (NESARC)\n * Alcohol Use Disorders Identification Test (AUDIT&#8209;C)\n * NM ASSIST (NIDA-Modified Alcohol, Smoking, and Substance Involvement Screening Test)",
+  "recur": true,
+  "recurrenceIntervalDays": 7,
   "jsonContent": {
     "title": {
       "en": "Lifestyle",

--- a/ui-admin/src/study/surveys/FormOptionsModal.tsx
+++ b/ui-admin/src/study/surveys/FormOptionsModal.tsx
@@ -74,7 +74,11 @@ export const FormOptions = ({ studyEnvContext, initialWorkingForm, updateWorking
                                 updateWorkingForm: (props: SaveableFormProps) => void
                               }) => {
   const workingForm = initialWorkingForm as Survey
-  const { onChange, options, selectedOption, selectInputId } =
+  const {
+    onChange: onRecurrenceTypeChange,
+    options: recurrenceOpts,
+    selectedOption: selectedRecurrenceType, selectInputId: recurrenceSelectInputId
+  } =
     useNonNullReactSingleSelect(RECURRENCE_OPTS.map(opt => opt.value),
       val => RECURRENCE_OPTS.find(opt => opt.value === val)!,
       (val: string) => updateWorkingForm({
@@ -152,18 +156,18 @@ export const FormOptions = ({ studyEnvContext, initialWorkingForm, updateWorking
               </label>
             </label>
             <div className="d-flex align-items-center mb-4">
-              <label className="pe-2" htmlFor={selectInputId}>
+              <label className="pe-2" htmlFor={recurrenceSelectInputId}>
                 Recurrence:
               </label>
-              <Select inputId={selectInputId}
+              <Select inputId={recurrenceSelectInputId}
                 styles={{
                   control: baseStyles => ({
                     ...baseStyles,
                     minWidth: '13em'
                   })
                 }}
-                options={options} onChange={onChange}
-                value={selectedOption}/>
+                options={recurrenceOpts} onChange={onRecurrenceTypeChange}
+                value={selectedRecurrenceType}/>
               <label className="d-flex align-items-center ms-3">
                 every <TextInput value={workingForm.recurrenceIntervalDays} type="number" min={1} max={9999}
                   className="mx-2"

--- a/ui-admin/src/study/surveys/FormOptionsModal.tsx
+++ b/ui-admin/src/study/surveys/FormOptionsModal.tsx
@@ -15,6 +15,7 @@ import {
 import InfoPopup from 'components/forms/InfoPopup'
 import { StudyEnvContextT } from '../StudyEnvironmentRouter'
 import { LazySearchQueryBuilder } from 'search/LazySearchQueryBuilder'
+import { TextInput } from '../../components/forms/TextInput'
 
 
 /** component for selecting versions of a form */
@@ -111,6 +112,43 @@ export const FormOptions = ({ studyEnvContext, initialWorkingForm, updateWorking
                 })}
               /> Allow study staff to edit participant responses
             </label>}
+            <label className="form-label d-flex align-items-center">
+              <label className="form-label pe-2">
+                <input type="checkbox" checked={!!workingForm.daysAfterEligible}
+                  onChange={e => updateWorkingForm({
+                    ...workingForm,
+                    daysAfterEligible: e.target.checked ? 365 : undefined
+                  })}
+                /> Delay assigning this survey
+              </label>
+              <label className="form-label d-flex align-items-center">
+                <TextInput value={workingForm.daysAfterEligible} type="number" min={1} max={9999}
+                  className="mx-2"
+                  onChange={val => updateWorkingForm({
+                    ...workingForm, daysAfterEligible: parseInt(val)
+                  })}
+                /> <span className="text-nowrap">days after enrollment</span>
+              </label>
+            </label>
+            <div className="d-flex align-items-center">
+              <label className="form-label pe-2">
+                <input type="checkbox" checked={workingForm.recur}
+                  onChange={e => updateWorkingForm({
+                    ...workingForm,
+                    recur: e.target.checked,
+                    recurrenceIntervalDays: e.target.checked ? workingForm.recurrenceIntervalDays : undefined
+                  })}
+                /> This survey recurs
+              </label>
+              <label className="form-label d-flex align-items-center">
+                every <TextInput value={workingForm.recurrenceIntervalDays} type="number" min={1} max={9999}
+                  className="mx-2"
+                  onChange={val => updateWorkingForm({
+                    ...workingForm, recurrenceIntervalDays: parseInt(val), recur: true
+                  })}
+                /> days
+              </label>
+            </div>
             <h3 className="h6 mt-4">Eligibility Rule</h3>
             <div className="mb-2">
               <LazySearchQueryBuilder

--- a/ui-admin/src/study/surveys/SurveyView.tsx
+++ b/ui-admin/src/study/surveys/SurveyView.tsx
@@ -24,7 +24,8 @@ export type SaveableFormProps = {
   autoAssign?: boolean
   assignToExistingEnrollees?: boolean
   rule?: string
-  recur: boolean
+  recurrenceType: string
+  prepopulate: boolean
   recurrenceIntervalDays?: number
   daysAfterEligible?: number
   allowAdminEdit?: boolean

--- a/ui-admin/src/study/surveys/SurveyView.tsx
+++ b/ui-admin/src/study/surveys/SurveyView.tsx
@@ -24,6 +24,9 @@ export type SaveableFormProps = {
   autoAssign?: boolean
   assignToExistingEnrollees?: boolean
   rule?: string
+  recur: boolean
+  recurrenceIntervalDays?: number
+  daysAfterEligible?: number
   allowAdminEdit?: boolean
   allowParticipantStart?: boolean
   autoUpdateTaskAssignments?: boolean

--- a/ui-core/src/types/forms.ts
+++ b/ui-core/src/types/forms.ts
@@ -40,6 +40,7 @@ export type Survey = VersionedForm & {
   autoUpdateTaskAssignments: boolean
   recur: boolean
   recurrenceIntervalDays: number
+  daysAfterEligible?: number
   allowAdminEdit: boolean
   allowParticipantStart: boolean
   allowParticipantReedit: boolean

--- a/ui-core/src/types/forms.ts
+++ b/ui-core/src/types/forms.ts
@@ -38,7 +38,7 @@ export type Survey = VersionedForm & {
   autoAssign: boolean
   assignToExistingEnrollees: boolean
   autoUpdateTaskAssignments: boolean
-  recur: boolean
+  recurrenceType: 'NONE' | 'LONGITUDINAL' | 'UPDATE'
   recurrenceIntervalDays: number
   daysAfterEligible?: number
   allowAdminEdit: boolean


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds infrastructure for recurring and delayed surveys in the task dispatcher and survey creation UX.  This does not include participant UX, populate support, admin UX for viewing multiple responses, or export capability. 

<img width="717" alt="image" src="https://github.com/user-attachments/assets/133c6dd4-2afb-41cc-b97a-9396af193e22">
 

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  redeploy ApiAdminApp
2. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/forms/surveys/hd_hd_basicInfo
3. futz with the new configuration options, confirm they save appropriately
4. review the unit tests, confirm you understand the logic