### PR TITLE
[JN-1425] fixing enrollee merge bug

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/participant/merge/MergeAction.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/merge/MergeAction.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.service.participant.merge;
 
 import bio.terra.pearl.core.model.BaseEntity;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -35,10 +36,12 @@ public class MergeAction<T extends BaseEntity, MP> {
         this.mergePlan = mergePlan;
     }
 
+    @JsonIgnore
     public T getSource() {
         return pair.getSource();
     }
 
+    @JsonIgnore
     public T getTarget() {
         return pair.getTarget();
     }

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -409,7 +409,7 @@ export type ParticipantUserMerge = {
 export type MergeAction<T, MP> = {
   pair: MergePair<T>
   action: MergeActionAction
-  mergePlan: MP
+  mergePlan?: MP
 }
 
 export type EnrolleeMergePlan = {

--- a/ui-admin/src/study/participants/merge/ParticipantMergeView.test.tsx
+++ b/ui-admin/src/study/participants/merge/ParticipantMergeView.test.tsx
@@ -1,0 +1,101 @@
+import { mockStudyEnvContext, renderInPortalRouter } from 'test-utils/mocking-utils'
+import Api, { ParticipantUserMerge } from 'api/api'
+import React from 'react'
+import { waitFor, screen } from '@testing-library/react'
+import ParticipantMergeView from './ParticipantMergeView'
+
+test('renders a one-sided enrollee merge', async () => {
+  const mergePlan: ParticipantUserMerge = {
+    'users': {
+      'pair': {
+        'source': {
+          'id': '05726fff-16d5-49cd-bac7-d09f1c3ca75d',
+          'createdAt': 0,
+          'username': 'someone@gmail.com',
+          'shortcode': 'ACC_SOME',
+          lastLogin: 0,
+          token: '1'
+        },
+        'target': {
+          'id': 'bfd74b55-8730-444f-9904-7ffa9436c6cd',
+          'createdAt': 0,
+          'username': 'SOMEONE@gmail.com',
+          'shortcode': 'ACC_OTHER',
+          lastLogin: 0,
+          token: '1'
+        }
+      },
+      'action': 'DELETE_SOURCE'
+    },
+    'ppUsers': {
+      'pair': {
+        'source': {
+          'id': '7c1472bd-f069-4ca3-98ee-fe95513ac675',
+          'createdAt': 0,
+          'lastLogin': 0,
+          'profile': {
+            'id': 'd1d3d01b-5ec7-49f4-9946-27669560042f',
+            'givenName': 'somebody',
+            'familyName': 'fam',
+            'preferredLanguage': 'en',
+            'contactEmail': 'gavredhead@gmail.com',
+            'doNotEmail': false,
+            'doNotEmailSolicit': false,
+            'birthDate': [
+              2000,
+              1,
+              1
+            ]
+          }
+        },
+        'target': {
+          'id': 'cf7207b8-9cef-48f1-b289-bf7dcedb08a8',
+          'createdAt': 0,
+          'profile': {
+            'id': '4ca732af-061d-4c85-94f9-75877457862d',
+            'preferredLanguage': '',
+            'contactEmail': 'Gavredhead@gmail.com',
+            'doNotEmail': false,
+            'doNotEmailSolicit': false
+          },
+          'lastLogin': 0
+        }
+      },
+      'action': 'DELETE_SOURCE'
+    },
+    'enrollees': [
+      {
+        'pair': {
+          'source': {
+            'id': 'bfa9fc3b-a9fc-4b2f-977b-06044905344f',
+            'createdAt': 0,
+            'lastUpdatedAt': 0,
+            'participantUserId': '05726fff-16d5-49cd-bac7-d09f1c3ca75d',
+            'profileId': 'd1d3d01b-5ec7-49f4-9946-27669560042f',
+            'studyEnvironmentId': '745f7f60-c201-402f-817e-d3917f44b024',
+            'shortcode': 'ENCODE',
+            'subject': true,
+            'consented': false,
+            'familyEnrollees': [],
+            'surveyResponses': [],
+            'participantTasks': [],
+            'participantNotes': [],
+            'kitRequests': [],
+            'relations': [],
+            profile: {}
+          }
+        },
+        'action': 'MOVE_SOURCE'
+      }
+    ]
+  }
+  jest.spyOn(Api, 'fetchMergePlan').mockResolvedValue(mergePlan)
+  const studyEnvContext = mockStudyEnvContext()
+  renderInPortalRouter(studyEnvContext.portal,
+    <ParticipantMergeView studyEnvContext={studyEnvContext} source={'some@test.com'}
+      target={'dupe@test.com'} onUpdate={jest.fn()}/>)
+
+  await waitFor(() => expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument())
+
+  expect(screen.getByText('ENCODE')).toBeInTheDocument()
+})

--- a/ui-admin/src/study/participants/merge/ParticipantMergeView.tsx
+++ b/ui-admin/src/study/participants/merge/ParticipantMergeView.tsx
@@ -108,20 +108,11 @@ export default function ParticipantMergeView({ source, target, studyEnvContext, 
 
 function EnrolleeMergePlanView({ enrolleeMerge,  studyEnvParams }:
   {enrolleeMerge: MergeAction<Enrollee, EnrolleeMergePlan>, studyEnvParams: StudyEnvParams }) {
-  const sortedTasks = enrolleeMerge.mergePlan.tasks.sort((a, b) =>
-    taskComparator(a.pair.source ?? a.pair.target, b.pair.source ?? b.pair.target))
-  return <div className="mx-4">
-    { enrolleeMerge.pair.source &&
-      <Link to={studyEnvParticipantPath(studyEnvParams, enrolleeMerge.pair.source.shortcode)}>
-        { enrolleeMerge.pair.source.shortcode }
-      </Link> }
-
-    {mergeArrow}
-    { enrolleeMerge.pair.target &&
-      <Link to={studyEnvParticipantPath(studyEnvParams, enrolleeMerge.pair.target.shortcode)}>
-        { enrolleeMerge.pair.target.shortcode }
-      </Link> }
-    <table>
+  let taskTable = <span></span>
+  if (enrolleeMerge.mergePlan?.tasks) {
+    const sortedTasks = enrolleeMerge.mergePlan.tasks.sort((a, b) =>
+      taskComparator(a.pair.source ?? a.pair.target, b.pair.source ?? b.pair.target))
+    taskTable = <table>
       <thead>
         <tr>
           <th>task</th>
@@ -135,6 +126,19 @@ function EnrolleeMergePlanView({ enrolleeMerge,  studyEnvParams }:
           <MergeTaskView taskMerge={taskMerge} key={index}/>) }
       </tbody>
     </table>
+  }
+
+  return <div className="mx-4">
+    { enrolleeMerge.pair.source &&
+      <Link to={studyEnvParticipantPath(studyEnvParams, enrolleeMerge.pair.source.shortcode)}>
+        { enrolleeMerge.pair.source.shortcode }
+      </Link> }
+    {mergeArrow}
+    { enrolleeMerge.pair.target &&
+      <Link to={studyEnvParticipantPath(studyEnvParams, enrolleeMerge.pair.target.shortcode)}>
+        { enrolleeMerge.pair.target.shortcode }
+      </Link> }
+    {taskTable}
   </div>
 }
 

--- a/ui-admin/src/study/participants/participantList/PortalUserList.tsx
+++ b/ui-admin/src/study/participants/participantList/PortalUserList.tsx
@@ -21,6 +21,7 @@ import { tabLinkStyle } from 'util/subNavStyles'
 import ParticipantMergeView from '../merge/ParticipantMergeView'
 import useParticipantDupeTab from '../merge/UseParticipantDupeTab'
 import { ParticipantListViewSwitcher } from './ParticipantListViewSwitcher'
+import ErrorBoundary from '../../../util/ErrorBoundary'
 
 export type ParticipantUserWithEnrollees = ParticipantUser & {
   enrollees: Enrollee[]
@@ -158,11 +159,12 @@ export default function PortalUserList({ studyEnvContext }:
           </NavLink>
         })}
       </div>
-      <Routes>
-        { tabs.map(tab => <Route path={tab.path} key={tab.path} element={tab.component}/>)}
-        <Route index element={<Navigate to={tabs[0].path} replace={true}/>}/>
-      </Routes>
-
+      <ErrorBoundary>
+        <Routes>
+          { tabs.map(tab => <Route path={tab.path} key={tab.path} element={tab.component}/>)}
+          <Route index element={<Navigate to={tabs[0].path} replace={true}/>}/>
+        </Routes>
+      </ErrorBoundary>
     </LoadingSpinner>
   </div>
 }

--- a/ui-core/src/types/user.ts
+++ b/ui-core/src/types/user.ts
@@ -28,7 +28,7 @@ export type ParticipantUser = {
 
 export type PortalParticipantUser = {
     id: string
-    createdAt: string
+    createdAt: number
     lastLogin: number
     profile?: Profile
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

The merge modal bugged out if trying to merge the case where one account had an enrollee in a study, but the other did not.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  redeploy apiAdminApp
2. go to `https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants/accounts/merge`
3. plan a merge with `unenrolled@test.com` into `jsalk@test.com` (or vice-versa)
4. confirm it renders and can merge
