### PR TITLE
[JN-1456] make it easier to add new search terms

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/search/EnrolleeSearchExpressionParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/EnrolleeSearchExpressionParser.java
@@ -196,7 +196,7 @@ public class EnrolleeSearchExpressionParser {
     }
 
     private SearchTerm parseVariableTerm(String variable) {
-        return getTermParser(variable).parse(variable);
+        return getTermParser(variable).parseVariable(variable);
     }
 
     private SearchTermParser getTermParser(String variable) {

--- a/core/src/main/java/bio/terra/pearl/core/service/search/EnrolleeSearchExpressionParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/EnrolleeSearchExpressionParser.java
@@ -53,7 +53,6 @@ public class EnrolleeSearchExpressionParser {
                 profileTermParser,
                 taskTermParser,
                 userTermParser
-
         );
     }
 
@@ -197,8 +196,7 @@ public class EnrolleeSearchExpressionParser {
     }
 
     private SearchTerm parseVariableTerm(String variable) {
-        SearchTermParser termParser = getTermParser(variable);
-        return termParser.parse(variable);
+        return getTermParser(variable).parse(variable);
     }
 
     private SearchTermParser getTermParser(String variable) {

--- a/core/src/main/java/bio/terra/pearl/core/service/search/EnrolleeSearchExpressionParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/EnrolleeSearchExpressionParser.java
@@ -10,7 +10,10 @@ import bio.terra.pearl.core.service.export.ExportOptionsWithExpression;
 import bio.terra.pearl.core.service.rule.RuleParsingErrorListener;
 import bio.terra.pearl.core.service.rule.RuleParsingException;
 import bio.terra.pearl.core.service.search.expressions.*;
-import bio.terra.pearl.core.service.search.terms.*;
+import bio.terra.pearl.core.service.search.terms.SearchTerm;
+import bio.terra.pearl.core.service.search.terms.SearchTermParser;
+import bio.terra.pearl.core.service.search.terms.SearchValue;
+import bio.terra.pearl.core.service.search.terms.UserInputTerm;
 import bio.terra.pearl.core.service.search.terms.functions.LowerFunction;
 import bio.terra.pearl.core.service.search.terms.functions.MaxFunction;
 import bio.terra.pearl.core.service.search.terms.functions.MinFunction;
@@ -39,21 +42,15 @@ public class EnrolleeSearchExpressionParser {
 
     private final List<SearchTermParser> searchTermParsers;
 
-    public EnrolleeSearchExpressionParser(EnrolleeDao enrolleeDao, ProfileDao profileDao, AgeTermParser ageTermParser, AnswerTermParser answerTermParser, EnrolleeTermParser enrolleeTermParser, FamilyTermParser familyTermParser, LatestKitTermParser latestKitTermParser, PortalUserTermParser portalUserTermParser, ProfileTermParser profileTermParser, TaskTermParser taskTermParser, UserTermParser userTermParser) {
+    public EnrolleeSearchExpressionParser(EnrolleeDao enrolleeDao,
+                                          ProfileDao profileDao,
+                                          // any subclass of SearchTermParser with @Service annotation
+                                          // will be included
+                                          List<SearchTermParser> parsers) {
         this.enrolleeDao = enrolleeDao;
         this.profileDao = profileDao;
 
-        searchTermParsers = List.of(
-                ageTermParser,
-                answerTermParser,
-                enrolleeTermParser,
-                familyTermParser,
-                latestKitTermParser,
-                portalUserTermParser,
-                profileTermParser,
-                taskTermParser,
-                userTermParser
-        );
+        searchTermParsers = parsers;
     }
 
     public Map<String, SearchValueTypeDefinition> getFacets(UUID studyEnvId) {

--- a/core/src/main/java/bio/terra/pearl/core/service/search/EnrolleeSearchService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/EnrolleeSearchService.java
@@ -3,69 +3,30 @@ package bio.terra.pearl.core.service.search;
 import bio.terra.pearl.core.dao.search.EnrolleeSearchExpressionDao;
 import bio.terra.pearl.core.model.search.EnrolleeSearchExpressionResult;
 import bio.terra.pearl.core.model.search.SearchValueTypeDefinition;
-import bio.terra.pearl.core.model.survey.QuestionChoice;
-import bio.terra.pearl.core.model.survey.Survey;
-import bio.terra.pearl.core.model.survey.SurveyQuestionDefinition;
-import bio.terra.pearl.core.service.search.terms.*;
-import bio.terra.pearl.core.service.survey.SurveyService;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.postgresql.util.PSQLException;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
-
-import static bio.terra.pearl.core.service.search.terms.SearchValue.SearchValueType.NUMBER;
-import static bio.terra.pearl.core.service.search.terms.SearchValue.SearchValueType.STRING;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
 
 @Service
 public class EnrolleeSearchService {
     private final EnrolleeSearchExpressionDao enrolleeSearchExpressionDao;
-    private final SurveyService surveyService;
     private final EnrolleeSearchExpressionParser enrolleeSearchExpressionParser;
-    private final ObjectMapper objectMapper;
 
 
     public EnrolleeSearchService(EnrolleeSearchExpressionDao enrolleeSearchExpressionDao,
-                                 SurveyService surveyService,
-                                 EnrolleeSearchExpressionParser enrolleeSearchExpressionParser,
-                                 ObjectMapper objectMapper) {
+                                 EnrolleeSearchExpressionParser enrolleeSearchExpressionParser) {
         this.enrolleeSearchExpressionDao = enrolleeSearchExpressionDao;
-        this.surveyService = surveyService;
         this.enrolleeSearchExpressionParser = enrolleeSearchExpressionParser;
-        this.objectMapper = objectMapper;
     }
 
 
     public Map<String, SearchValueTypeDefinition> getExpressionSearchFacetsForStudyEnv(UUID studyEnvId) {
-
-        Map<String, SearchValueTypeDefinition> fields = new HashMap<>();
-        // profile fields
-        ProfileTerm.FIELDS.forEach((term, type) -> fields.put("profile." + term, type));
-        // enrollee fields
-        EnrolleeTerm.FIELDS.forEach((term, type) -> fields.put("enrollee." + term, type));
-        // latest kit fields
-        LatestKitTerm.FIELDS.forEach((term, type) -> fields.put("latestKit." + term, type));
-        PortalUserTerm.FIELDS.forEach((term, type) -> fields.put("portalUser." + term, type));
-        // age
-        fields.put("age", SearchValueTypeDefinition.builder().type(NUMBER).build());
-        // answers
-        List<Survey> surveys = surveyService.findByStudyEnvironmentIdWithContent(studyEnvId);
-        for (Survey survey : surveys) {
-            // task fields
-            TaskTerm.FIELDS.forEach((term, type) -> fields.put("task." + survey.getStableId() + "." + term, type));
-            // answer fields
-            surveyService
-                    .getSurveyQuestionDefinitions(survey)
-                    .forEach(def -> {
-                        fields.put(
-                                "answer." + def.getSurveyStableId() + "." + def.getQuestionStableId(),
-                                convertQuestionDefinitionToSearchType(def));
-                    });
-        }
-
-        return fields;
+        return enrolleeSearchExpressionParser.getFacets(studyEnvId);
     }
 
     public List<EnrolleeSearchExpressionResult> executeSearchExpression(UUID studyEnvId, String expression, EnrolleeSearchOptions opts) {
@@ -96,41 +57,5 @@ public class EnrolleeSearchService {
 
     public List<EnrolleeSearchExpressionResult> executeSearchExpression(UUID studyEnvId, String expression) {
         return executeSearchExpression(studyEnvId, expression, EnrolleeSearchOptions.builder().build());
-    }
-
-    public SearchValueTypeDefinition convertQuestionDefinitionToSearchType(SurveyQuestionDefinition def) {
-        SearchValueTypeDefinition.SearchValueTypeDefinitionBuilder<?, ?> builder = SearchValueTypeDefinition.builder();
-
-        if (Objects.nonNull(def.getChoices()) && !def.getChoices().isEmpty()) {
-            List<QuestionChoice> choices = new ArrayList<>();
-            try {
-                choices = objectMapper.readValue(def.getChoices(), new TypeReference<List<QuestionChoice>>() {
-                        })
-                        .stream()
-                        .map(choice -> {
-                            if (Objects.isNull(choice.stableId()) || choice.stableId().isEmpty()) {
-                                return new QuestionChoice(choice.text(), choice.text());
-                            }
-                            if (Objects.isNull(choice.text()) || choice.text().isEmpty()) {
-                                return new QuestionChoice(choice.stableId(), choice.stableId());
-                            }
-                            return choice;
-                        })
-                        .toList();
-            } catch (Exception e) {
-                // ignore
-            }
-            builder.choices(choices);
-        }
-
-        return builder
-                .allowOtherDescription(def.isAllowOtherDescription())
-                .type(getSearchValueType(def))
-                .allowMultiple(def.isAllowMultiple())
-                .build();
-    }
-
-    private SearchValue.SearchValueType getSearchValueType(SurveyQuestionDefinition def) {
-        return STRING;
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/AgeTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/AgeTermParser.java
@@ -1,0 +1,34 @@
+package bio.terra.pearl.core.service.search.terms;
+
+import bio.terra.pearl.core.dao.participant.ProfileDao;
+import bio.terra.pearl.core.model.search.SearchValueTypeDefinition;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static bio.terra.pearl.core.service.search.terms.SearchValue.SearchValueType.NUMBER;
+
+@Service
+public class AgeTermParser implements SearchTermParser<AgeTerm> {
+    private final ProfileDao profileDao;
+
+    public AgeTermParser(ProfileDao profileDao) {
+        this.profileDao = profileDao;
+    }
+
+    @Override
+    public AgeTerm parse(String term) {
+        return new AgeTerm(profileDao);
+    }
+
+    @Override
+    public String getTermName() {
+        return "age";
+    }
+
+    @Override
+    public Map<String, SearchValueTypeDefinition> getFacets(UUID studyEnvId) {
+        return Map.of("age", SearchValueTypeDefinition.builder().type(NUMBER).build());
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/AgeTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/AgeTermParser.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 import static bio.terra.pearl.core.service.search.terms.SearchValue.SearchValueType.NUMBER;
 
 @Service
-public class AgeTermParser implements SearchTermParser<AgeTerm> {
+public class AgeTermParser extends SearchTermParser<AgeTerm> {
     private final ProfileDao profileDao;
 
     public AgeTermParser(ProfileDao profileDao) {

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/AnswerTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/AnswerTermParser.java
@@ -1,0 +1,102 @@
+package bio.terra.pearl.core.service.search.terms;
+
+import bio.terra.pearl.core.dao.survey.AnswerDao;
+import bio.terra.pearl.core.model.search.SearchValueTypeDefinition;
+import bio.terra.pearl.core.model.survey.QuestionChoice;
+import bio.terra.pearl.core.model.survey.Survey;
+import bio.terra.pearl.core.model.survey.SurveyQuestionDefinition;
+import bio.terra.pearl.core.service.survey.SurveyService;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+import static bio.terra.pearl.core.service.search.terms.SearchValue.SearchValueType.STRING;
+
+@Service
+public class AnswerTermParser implements SearchTermParser<AnswerTerm> {
+    private final AnswerDao answerDao;
+    private final SurveyService surveyService;
+    private final ObjectMapper objectMapper;
+
+    public AnswerTermParser(ObjectMapper objectMapper, AnswerDao answerDao, SurveyService surveyService) {
+        this.objectMapper = objectMapper;
+        this.answerDao = answerDao;
+        this.surveyService = surveyService;
+    }
+
+    @Override
+    public AnswerTerm parse(String term) {
+        List<String> arguments = getArguments(term, 2);
+
+        if (arguments.size() != 2) {
+            throw new IllegalArgumentException("Answer terms must be in the format {answer.surveyStableId.questionStableId}. Instead, got: " + term);
+        }
+
+        return new AnswerTerm(answerDao, arguments.get(0), arguments.get(1));
+    }
+
+    @Override
+    public String getTermName() {
+        return "answer";
+    }
+
+    @Override
+    public Map<String, SearchValueTypeDefinition> getFacets(UUID studyEnvId) {
+        Map<String, SearchValueTypeDefinition> fields = new HashMap<>();
+
+        List<Survey> surveys = surveyService.findByStudyEnvironmentIdWithContent(studyEnvId);
+        for (Survey survey : surveys) {
+            // task fields
+            TaskTerm.FIELDS.forEach((term, type) -> fields.put("task." + survey.getStableId() + "." + term, type));
+            // answer fields
+            surveyService
+                    .getSurveyQuestionDefinitions(survey)
+                    .forEach(def -> {
+                        fields.put(
+                                "answer." + def.getSurveyStableId() + "." + def.getQuestionStableId(),
+                                convertQuestionDefinitionToSearchType(def));
+                    });
+        }
+
+        return fields;
+    }
+
+    public SearchValueTypeDefinition convertQuestionDefinitionToSearchType(SurveyQuestionDefinition def) {
+        SearchValueTypeDefinition.SearchValueTypeDefinitionBuilder<?, ?> builder = SearchValueTypeDefinition.builder();
+
+        if (Objects.nonNull(def.getChoices()) && !def.getChoices().isEmpty()) {
+            List<QuestionChoice> choices = new ArrayList<>();
+            try {
+                choices = objectMapper.readValue(def.getChoices(), new TypeReference<List<QuestionChoice>>() {
+                        })
+                        .stream()
+                        .map(choice -> {
+                            if (Objects.isNull(choice.stableId()) || choice.stableId().isEmpty()) {
+                                return new QuestionChoice(choice.text(), choice.text());
+                            }
+                            if (Objects.isNull(choice.text()) || choice.text().isEmpty()) {
+                                return new QuestionChoice(choice.stableId(), choice.stableId());
+                            }
+                            return choice;
+                        })
+                        .toList();
+            } catch (Exception e) {
+                // ignore
+            }
+            builder.choices(choices);
+        }
+
+        return builder
+                .allowOtherDescription(def.isAllowOtherDescription())
+                .type(getSearchValueType(def))
+                .allowMultiple(def.isAllowMultiple())
+                .build();
+    }
+
+    private SearchValue.SearchValueType getSearchValueType(SurveyQuestionDefinition def) {
+        return STRING;
+    }
+
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/AnswerTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/AnswerTermParser.java
@@ -15,7 +15,7 @@ import java.util.*;
 import static bio.terra.pearl.core.service.search.terms.SearchValue.SearchValueType.STRING;
 
 @Service
-public class AnswerTermParser implements SearchTermParser<AnswerTerm> {
+public class AnswerTermParser extends SearchTermParser<AnswerTerm> {
     private final AnswerDao answerDao;
     private final SurveyService surveyService;
     private final ObjectMapper objectMapper;
@@ -28,7 +28,7 @@ public class AnswerTermParser implements SearchTermParser<AnswerTerm> {
 
     @Override
     public AnswerTerm parse(String term) {
-        List<String> arguments = getArguments(term, 2);
+        List<String> arguments = splitArguments(term, 2);
 
         if (arguments.size() != 2) {
             throw new IllegalArgumentException("Answer terms must be in the format {answer.surveyStableId.questionStableId}. Instead, got: " + term);

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/AnswerTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/AnswerTermParser.java
@@ -48,9 +48,6 @@ public class AnswerTermParser implements SearchTermParser<AnswerTerm> {
 
         List<Survey> surveys = surveyService.findByStudyEnvironmentIdWithContent(studyEnvId);
         for (Survey survey : surveys) {
-            // task fields
-            TaskTerm.FIELDS.forEach((term, type) -> fields.put("task." + survey.getStableId() + "." + term, type));
-            // answer fields
             surveyService
                     .getSurveyQuestionDefinitions(survey)
                     .forEach(def -> {

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/EnrolleeTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/EnrolleeTermParser.java
@@ -1,0 +1,25 @@
+package bio.terra.pearl.core.service.search.terms;
+
+import bio.terra.pearl.core.model.search.SearchValueTypeDefinition;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class EnrolleeTermParser implements SearchTermParser<EnrolleeTerm> {
+    @Override
+    public EnrolleeTerm parse(String term) {
+        return new EnrolleeTerm(getArgument(term));
+    }
+
+    @Override
+    public String getTermName() {
+        return "enrollee";
+    }
+
+    @Override
+    public Map<String, SearchValueTypeDefinition> getFacets(UUID studyEnvId) {
+        return addTermPrefix(EnrolleeTerm.FIELDS);
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/EnrolleeTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/EnrolleeTermParser.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import java.util.UUID;
 
 @Service
-public class EnrolleeTermParser implements SearchTermParser<EnrolleeTerm> {
+public class EnrolleeTermParser extends SearchTermParser<EnrolleeTerm> {
     @Override
-    public EnrolleeTerm parse(String term) {
-        return new EnrolleeTerm(getArgument(term));
+    public EnrolleeTerm parse(String field) {
+        return new EnrolleeTerm(field);
     }
 
     @Override

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/FamilyTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/FamilyTermParser.java
@@ -8,15 +8,15 @@ import java.util.Map;
 import java.util.UUID;
 
 @Service
-public class FamilyTermParser implements SearchTermParser<FamilyTerm> {
+public class FamilyTermParser extends SearchTermParser<FamilyTerm> {
     private final FamilyDao familyDao;
     public FamilyTermParser(FamilyDao familyDao) {
         this.familyDao = familyDao;
     }
 
     @Override
-    public FamilyTerm parse(String term) {
-        return new FamilyTerm(familyDao, getArgument(term));
+    public FamilyTerm parse(String field) {
+        return new FamilyTerm(familyDao, field);
     }
 
     @Override

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/FamilyTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/FamilyTermParser.java
@@ -1,0 +1,31 @@
+package bio.terra.pearl.core.service.search.terms;
+
+import bio.terra.pearl.core.dao.participant.FamilyDao;
+import bio.terra.pearl.core.model.search.SearchValueTypeDefinition;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class FamilyTermParser implements SearchTermParser<FamilyTerm> {
+    private final FamilyDao familyDao;
+    public FamilyTermParser(FamilyDao familyDao) {
+        this.familyDao = familyDao;
+    }
+
+    @Override
+    public FamilyTerm parse(String term) {
+        return new FamilyTerm(familyDao, getArgument(term));
+    }
+
+    @Override
+    public String getTermName() {
+        return "family";
+    }
+
+    @Override
+    public Map<String, SearchValueTypeDefinition> getFacets(UUID studyEnvId) {
+        return addTermPrefix(FamilyTerm.FIELDS);
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/LatestKitTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/LatestKitTermParser.java
@@ -8,15 +8,15 @@ import java.util.Map;
 import java.util.UUID;
 
 @Service
-public class LatestKitTermParser implements SearchTermParser<LatestKitTerm> {
+public class LatestKitTermParser extends SearchTermParser<LatestKitTerm> {
     private final KitRequestDao kitRequestDao;
     public LatestKitTermParser(KitRequestDao kitRequestDao) {
         this.kitRequestDao = kitRequestDao;
     }
 
     @Override
-    public LatestKitTerm parse(String term) {
-        return new LatestKitTerm(kitRequestDao, getArgument(term));
+    public LatestKitTerm parse(String field) {
+        return new LatestKitTerm(kitRequestDao, field);
     }
 
     @Override

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/LatestKitTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/LatestKitTermParser.java
@@ -1,0 +1,31 @@
+package bio.terra.pearl.core.service.search.terms;
+
+import bio.terra.pearl.core.dao.kit.KitRequestDao;
+import bio.terra.pearl.core.model.search.SearchValueTypeDefinition;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class LatestKitTermParser implements SearchTermParser<LatestKitTerm> {
+    private final KitRequestDao kitRequestDao;
+    public LatestKitTermParser(KitRequestDao kitRequestDao) {
+        this.kitRequestDao = kitRequestDao;
+    }
+
+    @Override
+    public LatestKitTerm parse(String term) {
+        return new LatestKitTerm(kitRequestDao, getArgument(term));
+    }
+
+    @Override
+    public String getTermName() {
+        return "latestKit";
+    }
+
+    @Override
+    public Map<String, SearchValueTypeDefinition> getFacets(UUID studyEnvId) {
+        return addTermPrefix(LatestKitTerm.FIELDS);
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/PortalUserTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/PortalUserTermParser.java
@@ -1,0 +1,31 @@
+package bio.terra.pearl.core.service.search.terms;
+
+import bio.terra.pearl.core.dao.participant.PortalParticipantUserDao;
+import bio.terra.pearl.core.model.search.SearchValueTypeDefinition;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class PortalUserTermParser implements SearchTermParser<PortalUserTerm> {
+    private final PortalParticipantUserDao portalParticipantUserDao;
+    public PortalUserTermParser(PortalParticipantUserDao portalParticipantUserDao) {
+        this.portalParticipantUserDao = portalParticipantUserDao;
+    }
+
+    @Override
+    public PortalUserTerm parse(String term) {
+        return new PortalUserTerm(portalParticipantUserDao, getArgument(term));
+    }
+
+    @Override
+    public String getTermName() {
+        return "portalUser";
+    }
+
+    @Override
+    public Map<String, SearchValueTypeDefinition> getFacets(UUID studyEnvId) {
+        return addTermPrefix(PortalUserTerm.FIELDS);
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/PortalUserTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/PortalUserTermParser.java
@@ -8,15 +8,15 @@ import java.util.Map;
 import java.util.UUID;
 
 @Service
-public class PortalUserTermParser implements SearchTermParser<PortalUserTerm> {
+public class PortalUserTermParser extends SearchTermParser<PortalUserTerm> {
     private final PortalParticipantUserDao portalParticipantUserDao;
     public PortalUserTermParser(PortalParticipantUserDao portalParticipantUserDao) {
         this.portalParticipantUserDao = portalParticipantUserDao;
     }
 
     @Override
-    public PortalUserTerm parse(String term) {
-        return new PortalUserTerm(portalParticipantUserDao, getArgument(term));
+    public PortalUserTerm parse(String field) {
+        return new PortalUserTerm(portalParticipantUserDao, field);
     }
 
     @Override

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/ProfileTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/ProfileTermParser.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.UUID;
 
 @Service
-public class ProfileTermParser implements SearchTermParser<ProfileTerm> {
+public class ProfileTermParser extends SearchTermParser<ProfileTerm> {
     private final ProfileDao profileDao;
     private final MailingAddressDao mailingAddressDao;
 
@@ -19,8 +19,8 @@ public class ProfileTermParser implements SearchTermParser<ProfileTerm> {
     }
 
     @Override
-    public ProfileTerm parse(String term) {
-        return new ProfileTerm(profileDao, mailingAddressDao, getArgument(term));
+    public ProfileTerm parse(String field) {
+        return new ProfileTerm(profileDao, mailingAddressDao, field);
     }
 
     @Override

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/ProfileTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/ProfileTermParser.java
@@ -1,0 +1,35 @@
+package bio.terra.pearl.core.service.search.terms;
+
+import bio.terra.pearl.core.dao.participant.MailingAddressDao;
+import bio.terra.pearl.core.dao.participant.ProfileDao;
+import bio.terra.pearl.core.model.search.SearchValueTypeDefinition;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class ProfileTermParser implements SearchTermParser<ProfileTerm> {
+    private final ProfileDao profileDao;
+    private final MailingAddressDao mailingAddressDao;
+
+    public ProfileTermParser(ProfileDao profileDao, MailingAddressDao mailingAddressDao) {
+        this.profileDao = profileDao;
+        this.mailingAddressDao = mailingAddressDao;
+    }
+
+    @Override
+    public ProfileTerm parse(String term) {
+        return new ProfileTerm(profileDao, mailingAddressDao, getArgument(term));
+    }
+
+    @Override
+    public String getTermName() {
+        return "profile";
+    }
+
+    @Override
+    public Map<String, SearchValueTypeDefinition> getFacets(UUID studyEnvId) {
+        return addTermPrefix(ProfileTerm.FIELDS);
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/SearchTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/SearchTermParser.java
@@ -56,8 +56,6 @@ public interface SearchTermParser<T extends SearchTerm> {
         variable = stripBraces(variable);
 
         List<String> split = List.of(variable.split("\\.", 2));
-        System.out.println(split);
-        System.out.println(this.getTermName());
         if (split.getFirst().equals(this.getTermName())) {
             return split.get(1);
         }
@@ -71,6 +69,9 @@ public interface SearchTermParser<T extends SearchTerm> {
         return variable;
     }
 
+    /**
+     * Add the term prefix to the facets. E.g., "givenName" -> "profile.givenName"
+     */
     default Map<String, SearchValueTypeDefinition> addTermPrefix(Map<String, SearchValueTypeDefinition> facets) {
         Map<String, SearchValueTypeDefinition> newFacets = new HashMap<>();
         for (Map.Entry<String, SearchValueTypeDefinition> entry : facets.entrySet()) {

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/SearchTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/SearchTermParser.java
@@ -1,0 +1,82 @@
+package bio.terra.pearl.core.service.search.terms;
+
+import bio.terra.pearl.core.model.search.SearchValueTypeDefinition;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Interface for parsing search terms.
+ */
+public interface SearchTermParser<T extends SearchTerm> {
+    /**
+     * Parse the term string into a search term.
+     */
+    T parse(String variable);
+
+    /**
+     * Get the facets that can be used in a search expression for the given study environment.
+     */
+    Map<String, SearchValueTypeDefinition> getFacets(UUID studyEnvId);
+
+    /**
+     * The name of the term. E.g., AgeTermParser would return "age".
+     */
+    String getTermName();
+
+    /**
+     * Check if the variable matches this term parser.
+     */
+    default Boolean match(String variable) {
+        variable = stripBraces(variable);
+        return variable.equals(this.getTermName()) || variable.startsWith(this.getTermName() + ".");
+    };
+
+    /**
+     * Splits variable into arguments, e.g. "answer.surveyStableId.questionStableId" -> ["surveyStableId", "questionStableId"]
+     */
+    default List<String> getArguments(String variable) {
+        return List.of(getArgument(variable).split("\\."));
+    }
+
+    /**
+     * Splits variable into arguments based on limit
+     * e.g. with limit 2 "answer.arg1.arg2.arg3" -> ["arg1", "arg2.arg3"]
+     */
+    default List<String> getArguments(String variable, int limit) {
+        return List.of(getArgument(variable).split("\\.", limit + 1));
+    }
+
+    /**
+     * Get the argument portion of the variable, e.g. "answer.surveyStableId.questionStableId" -> "surveyStableId.questionStableId"
+     */
+    default String getArgument(String variable) {
+        variable = stripBraces(variable);
+
+        List<String> split = List.of(variable.split("\\.", 2));
+        System.out.println(split);
+        System.out.println(this.getTermName());
+        if (split.getFirst().equals(this.getTermName())) {
+            return split.get(1);
+        }
+        return variable;
+    }
+
+    default String stripBraces(String variable) {
+        if (variable.startsWith("{") && variable.endsWith("}")) {
+            return variable.substring(1, variable.length() - 1);
+        }
+        return variable;
+    }
+
+    default Map<String, SearchValueTypeDefinition> addTermPrefix(Map<String, SearchValueTypeDefinition> facets) {
+        Map<String, SearchValueTypeDefinition> newFacets = new HashMap<>();
+        for (Map.Entry<String, SearchValueTypeDefinition> entry : facets.entrySet()) {
+            newFacets.put(this.getTermName() + "." + entry.getKey(), entry.getValue());
+        }
+        return newFacets;
+    }
+
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/TaskTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/TaskTermParser.java
@@ -38,7 +38,6 @@ public class TaskTermParser implements SearchTermParser<TaskTerm> {
         Map<String, SearchValueTypeDefinition> fields = new HashMap<>();
         List<Survey> surveys = surveyService.findByStudyEnvironmentIdWithContent(studyEnvId);
         for (Survey survey : surveys) {
-            // task fields
             TaskTerm.FIELDS.forEach((term, type) -> fields.put("task." + survey.getStableId() + "." + term, type));
         }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/TaskTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/TaskTermParser.java
@@ -1,0 +1,47 @@
+package bio.terra.pearl.core.service.search.terms;
+
+import bio.terra.pearl.core.dao.workflow.ParticipantTaskDao;
+import bio.terra.pearl.core.model.search.SearchValueTypeDefinition;
+import bio.terra.pearl.core.model.survey.Survey;
+import bio.terra.pearl.core.service.survey.SurveyService;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class TaskTermParser implements SearchTermParser<TaskTerm> {
+    private final ParticipantTaskDao participantTaskDao;
+    private final SurveyService surveyService;
+
+    public TaskTermParser(ParticipantTaskDao participantTaskDao, SurveyService surveyService) {
+        this.participantTaskDao = participantTaskDao;
+        this.surveyService = surveyService;
+    }
+
+    @Override
+    public TaskTerm parse(String term) {
+        List<String> arguments = getArguments(term, 2);
+
+        return new TaskTerm(participantTaskDao, arguments.get(0), arguments.get(1));
+    }
+
+    @Override
+    public String getTermName() {
+        return "task";
+    }
+
+    @Override
+    public Map<String, SearchValueTypeDefinition> getFacets(UUID studyEnvId) {
+        Map<String, SearchValueTypeDefinition> fields = new HashMap<>();
+        List<Survey> surveys = surveyService.findByStudyEnvironmentIdWithContent(studyEnvId);
+        for (Survey survey : surveys) {
+            // task fields
+            TaskTerm.FIELDS.forEach((term, type) -> fields.put("task." + survey.getStableId() + "." + term, type));
+        }
+
+        return fields;
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/TaskTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/TaskTermParser.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import java.util.UUID;
 
 @Service
-public class TaskTermParser implements SearchTermParser<TaskTerm> {
+public class TaskTermParser extends SearchTermParser<TaskTerm> {
     private final ParticipantTaskDao participantTaskDao;
     private final SurveyService surveyService;
 
@@ -23,7 +23,11 @@ public class TaskTermParser implements SearchTermParser<TaskTerm> {
 
     @Override
     public TaskTerm parse(String term) {
-        List<String> arguments = getArguments(term, 2);
+        List<String> arguments = splitArguments(term, 2);
+
+        if (arguments.size() != 2) {
+            throw new IllegalArgumentException("Task term must have two arguments: {task.taskStableId.field}. Instead, got: " + term);
+        }
 
         return new TaskTerm(participantTaskDao, arguments.get(0), arguments.get(1));
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/UserTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/UserTermParser.java
@@ -1,0 +1,32 @@
+package bio.terra.pearl.core.service.search.terms;
+
+import bio.terra.pearl.core.dao.participant.ParticipantUserDao;
+import bio.terra.pearl.core.model.search.SearchValueTypeDefinition;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class UserTermParser implements SearchTermParser<UserTerm> {
+    private final ParticipantUserDao participantUserDao;
+
+    public UserTermParser(ParticipantUserDao participantUserDao) {
+        this.participantUserDao = participantUserDao;
+    }
+
+    @Override
+    public UserTerm parse(String term) {
+        return new UserTerm(participantUserDao, getArgument(term));
+    }
+
+    @Override
+    public String getTermName() {
+        return "user";
+    }
+
+    @Override
+    public Map<String, SearchValueTypeDefinition> getFacets(UUID studyEnvId) {
+        return addTermPrefix(UserTerm.FIELDS);
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/UserTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/UserTermParser.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import java.util.UUID;
 
 @Service
-public class UserTermParser implements SearchTermParser<UserTerm> {
+public class UserTermParser extends SearchTermParser<UserTerm> {
     private final ParticipantUserDao participantUserDao;
 
     public UserTermParser(ParticipantUserDao participantUserDao) {
@@ -16,8 +16,8 @@ public class UserTermParser implements SearchTermParser<UserTerm> {
     }
 
     @Override
-    public UserTerm parse(String term) {
-        return new UserTerm(participantUserDao, getArgument(term));
+    public UserTerm parse(String field) {
+        return new UserTerm(participantUserDao, field);
     }
 
     @Override

--- a/core/src/test/java/bio/terra/pearl/core/service/search/EnrolleeSearchServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/search/EnrolleeSearchServiceTest.java
@@ -198,8 +198,7 @@ class EnrolleeSearchServiceTest extends BaseSpringBootTest {
                 .map(val -> new QuestionChoice(val.name(), val.name()))
                 .collect(Collectors.toList());
 
-        Assertions.assertEquals(30, results.size());
-        Map.ofEntries(
+        Map<String, SearchValueTypeDefinition> expected = Map.ofEntries(
                 Map.entry("profile.givenName", SearchValueTypeDefinition.builder().type(STRING).build()),
                 Map.entry("profile.familyName", SearchValueTypeDefinition.builder().type(STRING).build()),
                 Map.entry("profile.name", SearchValueTypeDefinition.builder().type(STRING).build()),
@@ -234,8 +233,17 @@ class EnrolleeSearchServiceTest extends BaseSpringBootTest {
                 Map.entry("portalUser.createdAt", SearchValueTypeDefinition.builder().type(INSTANT).build()),
                 Map.entry("portalUser.lastLogin", SearchValueTypeDefinition.builder().type(INSTANT).build()),
                 Map.entry("age", SearchValueTypeDefinition.builder().type(NUMBER).build()),
-                Map.entry("latestKit.status", SearchValueTypeDefinition.builder().type(STRING).choices(kitStatusChoices).build())
-        ).forEach((key, value) -> {
+                Map.entry("latestKit.status", SearchValueTypeDefinition.builder().type(STRING).choices(kitStatusChoices).build()),
+                Map.entry("user.username", SearchValueTypeDefinition.builder().type(STRING).build()),
+                Map.entry("user.createdAt", SearchValueTypeDefinition.builder().type(INSTANT).build()),
+                Map.entry("user.lastLogin", SearchValueTypeDefinition.builder().type(INSTANT).build()),
+                Map.entry("family.shortcode", SearchValueTypeDefinition.builder().type(STRING).build())
+        );
+
+        Assertions.assertEquals(expected.keySet(), results.keySet());
+
+        Assertions.assertEquals(expected.size(), results.size());
+        expected.forEach((key, value) -> {
             Assertions.assertTrue(results.containsKey(key), "Key not found: " + key);
             Assertions.assertEquals(value, results.get(key), "Wrong value for key: " + key + ", expected: " + value + " got: " + results.get(key));
         });


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

I'm not 100% sure I prefer this way of doing this, it adds a lot of boilerplate. But it should be easier to add a new search expression. There are only 3 things you need to add: term, term parser, and the module mapper in the dao. Any of these missing will be very obvious, so, even if there's still a bunch of places to add things, there shouldn't be mysteriously missing things.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

