### PR TITLE
[JN-1454] adding result to export job table

### DIFF
--- a/ui-admin/src/study/export/integrations/ExportIntegrationJobList.tsx
+++ b/ui-admin/src/study/export/integrations/ExportIntegrationJobList.tsx
@@ -60,6 +60,9 @@ export default function ExportIntegrationJobList({ studyEnvContext }:
   }, {
     header: 'Status',
     accessorKey: 'status'
+  }, {
+    header: 'Result',
+    accessorKey: 'result'
   }]
 
   const table = useReactTable({


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds the result to the job table
<img width="1036" alt="image" src="https://github.com/user-attachments/assets/5268f5cc-64b4-48bf-b8a2-37d9351176af">
this is mostly for Whitney to have something to include in her slack messages to me--the errors are likely not going to be user-actionable unless Airtable's error messages are unexpectedly useful

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/export/integrations
2. pick an integration, and run it
3. on the job list, confirm the result appears (likely a 403 failure for changing the structure of the table)