### PR TITLE
[JN-1447] test cleanup

### DIFF
--- a/ui-admin/src/forms/FormContentJsonEditor.test.tsx
+++ b/ui-admin/src/forms/FormContentJsonEditor.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import React from 'react'
 
 import { FormContent } from '@juniper/ui-core'
@@ -27,79 +27,11 @@ const formContent: FormContent = {
   ]
 }
 
-// TODO (JN-1384): Fix tests / create new tests for the new JSON editor.
 describe('FormContentJsonEditor', () => {
   // eslint-disable-next-line jest/expect-expect
-  it('renders form content as JSON', () => {
+  it('renders form content as JSON', async () => {
     // Act
-    render(<FormContentJsonEditor initialValue={formContent} onChange={jest.fn()}/>)
-
-    // Assert
-    // const expectedContent = JSON.stringify(formContent, null, 2).replace(/\s+/g, ' ') // Collapse whitespace
+    await act(async () => render(<FormContentJsonEditor initialValue={formContent} onChange={jest.fn()}/>))
+    expect(screen.getByText('"Last name"')).toBeInTheDocument()
   })
-  //
-  // eslint-disable-next-line jest/no-commented-out-tests
-  // it('sets readonly attribute on textarea', () => {
-  //   // Act
-  //   render(<FormContentJsonEditor initialValue={formContent} readOnly onChange={jest.fn()} />)
-  //
-  //   // Assert
-  //   const textArea = screen.getByRole('textbox')
-  //   expect(textArea).toHaveAttribute('readOnly')
-  // })
-  //
-  // eslint-disable-next-line jest/no-commented-out-tests
-  // it('calls onChange when edited with valid JSON', async () => {
-  //   // Arrange
-  //   const user = userEvent.setup()
-  //
-  //   const onChange = jest.fn()
-  //   render(<FormContentJsonEditor initialValue={formContent} onChange={onChange} />)
-  //
-  //   // Act
-  //   const textArea = screen.getByRole('textbox')
-  //   // Replaces "First name" with "Given name"
-  //   await act(() => user.type(textArea, 'Given', { initialSelectionStart: 159, initialSelectionEnd: 164 }))
-  //
-  //   // Assert
-  //   const expectedEditedContent = cloneDeep(formContent)
-  //   ;(expectedEditedContent.pages[0].elements[0] as TitledQuestion).title = 'Given name'
-  //
-  //   expect(onChange).toHaveBeenCalledWith([], expectedEditedContent)
-  // })
-  //
-  // eslint-disable-next-line jest/no-commented-out-tests
-  // it('calls onChange when edited with invalid JSON', async () => {
-  //   // Arrange
-  //   const user = userEvent.setup()
-  //
-  //   const onChange = jest.fn()
-  //   render(<FormContentJsonEditor initialValue={formContent} onChange={onChange} />)
-  //
-  //   // Act
-  //   const textArea = screen.getByRole('textbox')
-  //   // Removes quotes around "First name"
-  //   await act(() => user.type(textArea, 'First name', { initialSelectionStart: 158, initialSelectionEnd: 170 }))
-  //
-  //   // Assert
-  //   expect(onChange).toHaveBeenCalledWith(
-  //     [expect.stringContaining('Unexpected token')], undefined)
-  // })
-  //
-  // eslint-disable-next-line jest/no-commented-out-tests
-  // it('shows feedback when edited with invalid JSON', async () => {
-  //   // Arrange
-  //   const user = userEvent.setup()
-  //
-  //   const onChange = jest.fn()
-  //   render(<FormContentJsonEditor initialValue={formContent} onChange={onChange} />)
-  //
-  //   // Act
-  //   const textArea = screen.getByRole('textbox')
-  //   // Removes quotes around "First name"
-  //   await act(() => user.type(textArea, 'First name', { initialSelectionStart: 158, initialSelectionEnd: 170 }))
-  //
-  //   // Assert
-  //   expect(textArea).toHaveClass('is-invalid')
-  // })
 })

--- a/ui-admin/src/forms/FormPreview.test.tsx
+++ b/ui-admin/src/forms/FormPreview.test.tsx
@@ -47,8 +47,6 @@ describe('FormPreview', () => {
         <FormPreview formContent={formContent} currentLanguage={MOCK_ENGLISH_LANGUAGE}/>
       </MockI18nProvider>)
 
-
-    screen.debug()
     // Assert
     screen.getAllByText('First name')
     screen.getAllByText('Last name')

--- a/ui-admin/src/forms/designer/SplitCalculatedValueDesigner.test.tsx
+++ b/ui-admin/src/forms/designer/SplitCalculatedValueDesigner.test.tsx
@@ -79,6 +79,8 @@ describe('SplitCalculatedValueDesigner', () => {
     expect(screen.getAllByText('Insert derived value')).toHaveLength(3)
   })
   it('has question preview for calculated values', async () => {
+    // mock the warning console so it's not spammed with surveyJs warnings
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
     const content: FormContent = {
       title: 'title',
       pages: [{

--- a/ui-admin/src/forms/designer/split/controls/PageNavigationControls.tsx
+++ b/ui-admin/src/forms/designer/split/controls/PageNavigationControls.tsx
@@ -32,7 +32,7 @@ export const PageNavigationControls = ({ currentPageNo, content, setCurrentPageN
     }
   }
 
-  const numPages = content.pages.length
+  const numPages = content.pages?.length ?? 0
 
   return (
     <div className="d-flex align-items-center">

--- a/ui-admin/src/portal/siteContent/HtmlPageEditView.test.tsx
+++ b/ui-admin/src/portal/siteContent/HtmlPageEditView.test.tsx
@@ -1,5 +1,5 @@
 import {
-  render,
+  act,
   screen
 } from '@testing-library/react'
 import React from 'react'
@@ -9,21 +9,22 @@ import { userEvent } from '@testing-library/user-event'
 import { sectionTemplates } from './sectionTemplates'
 import {
   MockI18nProvider,
-  setupRouterTest
+  renderWithRouter
 } from '@juniper/ui-core'
 import { mockPortalEnvContext } from 'test-utils/mocking-utils'
 import { Store } from 'react-notifications-component'
+import Api from 'api/api'
 
-jest.spyOn(Store, 'addNotification').mockImplementation(() => '')
+function mockStoreAndApi() {
+  jest.spyOn(Api, 'getPortalMedia').mockResolvedValue([])
+  jest.spyOn(Store, 'addNotification').mockImplementation(() => '')
+}
 
-jest.mock('api/api', () => ({
-  ...jest.requireActual('api/api'),
-  getPortalMedia: jest.fn().mockResolvedValue([])
-}))
 
 test('readOnly disables insert new section button', async () => {
+  mockStoreAndApi()
   const siteContent = mockSiteContent()
-  const { RoutedComponent } = setupRouterTest(
+  await act(async () => renderWithRouter(
     <MockI18nProvider>
       <HtmlPageEditView
         htmlPage={siteContent.localizedSiteContents[0].pages[0]}
@@ -34,17 +35,16 @@ test('readOnly disables insert new section button', async () => {
         updateNavbarItems={jest.fn()}
         portalEnvContext={mockPortalEnvContext('sandbox')}
         siteHasInvalidSection={false} footerSection={undefined} updateFooter={jest.fn()}/>
-    </MockI18nProvider>)
-  render(RoutedComponent)
+    </MockI18nProvider>))
   expect(screen.getAllByLabelText('Insert a blank section')[0]).toHaveAttribute('aria-disabled', 'true')
 })
 
 test('Insert Section button calls updatePage with a new blank HERO_WITH_IMAGE section', async () => {
-  //Arrange
+  mockStoreAndApi()
   const siteContent = mockSiteContent()
   const mockUpdatePageFn = jest.fn()
   const mockPage = siteContent.localizedSiteContents[0].pages[0]
-  const { RoutedComponent } = setupRouterTest(
+  await act(async () => renderWithRouter(
     <MockI18nProvider>
       <HtmlPageEditView
         htmlPage={mockPage}
@@ -54,8 +54,7 @@ test('Insert Section button calls updatePage with a new blank HERO_WITH_IMAGE se
         updateNavbarItems={jest.fn()}
         portalEnvContext={mockPortalEnvContext('sandbox')}
         siteHasInvalidSection={false} footerSection={undefined} updateFooter={jest.fn()}/>
-    </MockI18nProvider>)
-  render(RoutedComponent)
+    </MockI18nProvider>))
 
   //Act
   const insertSectionButton = screen.getAllByLabelText('Insert a blank section')[1]
@@ -73,8 +72,9 @@ test('Insert Section button calls updatePage with a new blank HERO_WITH_IMAGE se
 })
 
 test('invalid JSON disables Insert Section button', async () => {
+  mockStoreAndApi()
   const siteContent = mockSiteContent()
-  const { RoutedComponent } = setupRouterTest(
+  await act(async () => renderWithRouter(
     <MockI18nProvider>
       <HtmlPageEditView
         htmlPage={siteContent.localizedSiteContents[0].pages[0]}
@@ -84,8 +84,7 @@ test('invalid JSON disables Insert Section button', async () => {
         updateNavbarItems={jest.fn()}
         portalEnvContext={mockPortalEnvContext('sandbox')}
         siteHasInvalidSection={true} footerSection={undefined} updateFooter={jest.fn()}/>
-    </MockI18nProvider>)
-  render(RoutedComponent)
+    </MockI18nProvider>))
   const sectionButtons= await screen.findAllByLabelText('Insert a blank section')
 
   sectionButtons.forEach(button => {

--- a/ui-admin/src/study/surveys/FormOptions.test.tsx
+++ b/ui-admin/src/study/surveys/FormOptions.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import React from 'react'
 import { mockExpressionApis, mockStudyEnvContext, mockSurvey } from 'test-utils/mocking-utils'
 import FormOptionsModal from './FormOptionsModal'
@@ -47,13 +47,14 @@ describe('FormOptions', () => {
   test('admin forms should be admin-editable by default', async () => {
     mockExpressionApis()
     const updateWorkingForm = jest.fn()
-    render(<FormOptionsModal
-      studyEnvContext={studyEnvContext}
-      workingForm={mockSurvey('ADMIN')}
-      updateWorkingForm={updateWorkingForm}
-      onDismiss={jest.fn()}
-    />)
-
+    await act(() => {
+      render(<FormOptionsModal
+        studyEnvContext={studyEnvContext}
+        workingForm={mockSurvey('ADMIN')}
+        updateWorkingForm={updateWorkingForm}
+        onDismiss={jest.fn()}
+      />)
+    })
     //we don't display this option, because it's assumed to be true for admin forms
     expect(screen.queryByText('Allow study staff to edit participant responses')).not.toBeInTheDocument()
   })


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

This cleans up some tests that were polluting the console log while they were running. No functional changes

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

run npm -w ui-admin test
confirm tests pass and console output isn't as bad as it was