### PR TITLE
[JN-1106] Cancel queued autosaves after form submission

### DIFF
--- a/ui-core/src/autoSaveUtils.test.tsx
+++ b/ui-core/src/autoSaveUtils.test.tsx
@@ -1,0 +1,29 @@
+
+import { useAutosaveEffect } from './autoSaveUtils'
+import { act, renderHook } from '@testing-library/react'
+
+jest.useFakeTimers()
+
+describe('useAutosaveEffect', () => {
+  it('should allow an autosave saveFn to be cancelled', () => {
+    const saveFn = jest.fn()
+    const autoSaveInterval = 1000
+
+    const { result } = renderHook(() => useAutosaveEffect(saveFn, autoSaveInterval))
+
+    // Fast-forward until the first autosave is called
+    act(() => { jest.advanceTimersByTime(autoSaveInterval) })
+
+    // Verify the autosave was called
+    expect(saveFn).toHaveBeenCalledTimes(1)
+
+    // Call the cancel function
+    act(() => { result.current() })
+
+    // Fast-forward again (advance by 2 intervals to be extra sure)
+    act(() => { jest.advanceTimersByTime(autoSaveInterval * 2) })
+
+    // Verify the autosave function was not called again after being cancelled
+    expect(saveFn).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ui-core/src/autoSaveUtils.ts
+++ b/ui-core/src/autoSaveUtils.ts
@@ -1,19 +1,30 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 /** Executes the save function at the specified interval, but only starting the interval after the
  * previous call returns, guaranteed no overlapping saves */
 export function useAutosaveEffect(saveFn: () => void, autoSaveInterval: number) {
+  const timeoutHandleRef = useRef<number | null>(null)
+
   useEffect(() => {
-    let timeoutHandle: number
     // run saveFn at the specified interval
     (function loop() {
-      timeoutHandle = window.setTimeout(() => {
+      timeoutHandleRef.current = window.setTimeout(() => {
         saveFn()
         loop()
       }, autoSaveInterval)
     })()
+
     return () => {
-      window.clearTimeout(timeoutHandle)
+      if (timeoutHandleRef.current !== null) {
+        window.clearTimeout(timeoutHandleRef.current)
+      }
     }
   }, [saveFn])
+
+  // Return a function to cancel any queued saveFn
+  return () => {
+    if (timeoutHandleRef.current !== null) {
+      window.clearTimeout(timeoutHandleRef.current)
+    }
+  }
 }

--- a/ui-core/src/components/forms/PagedSurveyView.tsx
+++ b/ui-core/src/components/forms/PagedSurveyView.tsx
@@ -126,7 +126,7 @@ export function PagedSurveyView({
 
   /** Submit the response to the server */
   const onComplete = async () => {
-    cancelAutosave()
+    if (cancelAutosave) { cancelAutosave() }
     if (!surveyModel || !refreshSurvey) {
       return
     }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Updates the autosave effect to return a function that allows the caller to cancel a queued up autosave.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

This is pretty difficult to test. You'll get the most bang for buck by regression testing to ensure that autosave still behaves as expected. Otherwise observe the test.