### PR TITLE
[JN-1459] fix surveyjs styling on mobile

### DIFF
--- a/ui-core/src/surveyjs/surveyJsStyle.scss
+++ b/ui-core/src/surveyjs/surveyJsStyle.scss
@@ -23,6 +23,39 @@
   }
 }
 
+//scale down all html headers for mobile devices
+@media (max-width: 768px) {
+  .sd-html h1 {
+    font-size: 1.5em;
+    line-height: 1.8em;
+  }
+
+  .sd-html h2 {
+    font-size: 1.25em;
+    line-height: 1.5em;
+  }
+
+  .sd-html h3 {
+    font-size: 1.1em;
+    line-height: 1.32em;
+  }
+
+  .sd-html h4 {
+    font-size: 1em;
+    line-height: 1.2em;
+  }
+
+  .sd-html h5 {
+    font-size: 0.9em;
+    line-height: 1.08em;
+  }
+
+  .sd-html h6 {
+    font-size: 0.8em;
+    line-height: 0.96em;
+  }
+}
+
 .sd-html p:only-child {
   margin-bottom: 0;
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

I'm honestly not sure if this is the right approach. It seems like the previous styling was actually coming from media breakpoints that Bootstrap provided. It seems weird that Bootstrap styling could bleed into SurveyJS styling, so I think how it works currently is correct. But for backwards compatibility, I added a few custom media breakpoints for headers. Style guides seem to recommend a line height ratio of 1.2x the font size, so that's where these numbers come from.

The benefits are that it saves us from having to manually update existing study surveys, and saves us from the potentially massive headache of having to deal with the fact that participants have already completed or been assigned previous versions of these surveys (and thus may see the broken styling)

The cons are that now we're maintaining a little bit of custom styling, but we were already inadvertently doing that by letting Bootstrap css bleed in.

Before (apologies for the absurdly long screenshot)
https://github.com/user-attachments/assets/43eee6dd-d7f6-4d7d-9341-6154f8059bdc
https://github.com/user-attachments/assets/37265388-94e3-4d88-b374-04acd805baaf

After 
https://github.com/user-attachments/assets/2c49347f-9a8b-4ddc-87a1-e368019b610c
https://github.com/user-attachments/assets/d1a9fe50-cdfe-46c7-8131-d8aba129f325


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Load up OurHealth consent on mobile
Confirm the styling seems reasonable
Click through some other surveys