### PR TITLE
[JN-1440] Workaround fix for DSM not returning tracking number for returnOnly kits

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
@@ -412,7 +412,9 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
             setKitDates(kitRequest, pepperKit);
             // for now just copy these over on each update, since there is currently no reason to make it conditional
             kitRequest.setTrackingNumber(pepperKit.getTrackingNumber());
-            kitRequest.setReturnTrackingNumber(pepperKit.getReturnTrackingNumber());
+            if(pepperKit.getReturnTrackingNumber() != null) {
+                kitRequest.setReturnTrackingNumber(pepperKit.getReturnTrackingNumber());
+            }
             kitRequest.setErrorMessage(pepperKit.getErrorMessage());
             dao.update(kitRequest);
         } catch (JsonProcessingException e) {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

DSM does not currently return the returnTrackingNumber for return only kits. This causes issues when we refresh kit statuses nightly- the tracking number that was scanned into Juniper will be nulled out by the response from DSM. Not a huge deal because I confirmed with Kiara that DSM retains that information, but would be good to get it fixed.

I am not sure yet how long it will take for this to be fixed in DSM, so this adds a temporary workaround that checks if the returnTrackingNumber is null before resetting it to whatever value is returned by DSM. I'll work with Sampath to get this prioritized on their end but I don't think they need to do any sort of emergency release to fix it, so it'll be faster for us to implement this fix.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Reboot admin api
Switch ourhealth sandbox to use live dsm
Run through the scan kit flow to assign a kit
Collect that kit
Go to the kits list and refresh kit statuses
Confirm the return tracking number did not get replaced by a null value

