### PR TITLE
[JN-1476] Allow hyphens in page path

### DIFF
--- a/ui-admin/src/portal/siteContent/AddPageModal.test.tsx
+++ b/ui-admin/src/portal/siteContent/AddPageModal.test.tsx
@@ -80,4 +80,29 @@ describe('AddPageModal', () => {
       }]
     })
   })
+
+  test('validates page path characters', async () => {
+    const { RoutedComponent } = setupRouterTest(<AddPageModal
+      onDismiss={jest.fn()}
+      insertNewPage={jest.fn()}
+      portalEnv={mockPortalEnvironment('sandbox')}
+      portalShortcode={'test'}
+    />)
+
+    render(RoutedComponent)
+
+    const pageTitleInput = screen.getByLabelText('Page Title')
+    const pagePathInput = screen.getByLabelText('Page Path')
+    const createButton = screen.getByText('Create')
+
+    await userEvent.type(pageTitleInput, 'My New Page')
+    await userEvent.type(pagePathInput, 'new-page-path')
+
+    expect(createButton).toBeEnabled()
+
+    await userEvent.clear(pagePathInput)
+    await userEvent.type(pagePathInput, 'new_page_path')
+
+    expect(createButton).toBeDisabled()
+  })
 })

--- a/ui-admin/src/portal/siteContent/AddPageModal.tsx
+++ b/ui-admin/src/portal/siteContent/AddPageModal.tsx
@@ -48,7 +48,7 @@ const AddPageModal = ({ portalEnv, portalShortcode, insertNewPage, onDismiss }: 
   const isItemValid = (page: HtmlPage) => {
     return page.path.length > 0
       && page.title.length > 0
-      && /^[a-zA-Z0-9]+$/.test(page.path) // is alphanumeric
+      && /^[a-zA-Z0-9-]+$/.test(page.path) // is alphanumeric
   }
 
   const clearFields = () => {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

https://broadinstitute.slack.com/archives/C042QNA6C3S/p1730828773305259

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Try creating a new page with a hyphen in the path
https://localhost:3000/demo/env/sandbox/siteContent?lang=en
Confirm you're allowed to do so