### PR TITLE
[JN-1407] document request survey type

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/fileupload/ParticipantFileDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/fileupload/ParticipantFileDao.java
@@ -5,6 +5,9 @@ import bio.terra.pearl.core.model.fileupload.ParticipantFile;
 import org.jdbi.v3.core.Jdbi;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.UUID;
+
 @Component
 public class ParticipantFileDao extends BaseJdbiDao<ParticipantFile> {
     public ParticipantFileDao(Jdbi jdbi) {
@@ -16,4 +19,17 @@ public class ParticipantFileDao extends BaseJdbiDao<ParticipantFile> {
         return ParticipantFile.class;
     }
 
+    public List<ParticipantFile> findBySurveyResponseId(UUID surveyResponseId) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("""
+                                select file.* from %s file
+                                inner join participant_file_survey_response file_response on file.id = file_response.participant_file_id
+                                where file_response.survey_response_id = :surveyResponseId
+                                """.formatted(tableName))
+                        .bind("surveyResponseId", surveyResponseId)
+                        .mapTo(clazz)
+                        .stream()
+                        .toList()
+        );
+    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/dao/fileupload/ParticipantFileSurveyResponseDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/fileupload/ParticipantFileSurveyResponseDao.java
@@ -1,0 +1,25 @@
+package bio.terra.pearl.core.dao.fileupload;
+
+import bio.terra.pearl.core.dao.BaseJdbiDao;
+import bio.terra.pearl.core.model.survey.ParticipantFileSurveyResponse;
+import org.jdbi.v3.core.Jdbi;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class ParticipantFileSurveyResponseDao extends BaseJdbiDao<ParticipantFileSurveyResponse> {
+    public ParticipantFileSurveyResponseDao(Jdbi jdbi) {
+        super(jdbi);
+    }
+
+    @Override
+    protected Class<ParticipantFileSurveyResponse> getClazz() {
+        return ParticipantFileSurveyResponse.class;
+    }
+
+    public List<ParticipantFileSurveyResponse> findBySurveyResponseId(UUID surveyResponseId) {
+        return findAllByProperty("survey_response_id", surveyResponseId);
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyResponseDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyResponseDao.java
@@ -1,19 +1,24 @@
 package bio.terra.pearl.core.dao.survey;
 
 import bio.terra.pearl.core.dao.BaseMutableJdbiDao;
+import bio.terra.pearl.core.dao.fileupload.ParticipantFileDao;
+import bio.terra.pearl.core.model.fileupload.ParticipantFile;
 import bio.terra.pearl.core.model.survey.Answer;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
-import java.util.*;
 import org.jdbi.v3.core.Jdbi;
 import org.springframework.stereotype.Component;
 
+import java.util.*;
+
 @Component
 public class SurveyResponseDao extends BaseMutableJdbiDao<SurveyResponse> {
-    private AnswerDao answerDao;
+    private final AnswerDao answerDao;
+    private final ParticipantFileDao participantFileDao;
 
-    public SurveyResponseDao(Jdbi jdbi, AnswerDao answerDao) {
+    public SurveyResponseDao(Jdbi jdbi, AnswerDao answerDao, ParticipantFileDao participantFileDao) {
         super(jdbi);
         this.answerDao = answerDao;
+        this.participantFileDao = participantFileDao;
     }
 
 
@@ -55,6 +60,12 @@ public class SurveyResponseDao extends BaseMutableJdbiDao<SurveyResponse> {
     public SurveyResponse attachAnswers(SurveyResponse response) {
         List<Answer> answers = answerDao.findByResponse(response.getId());
         response.setAnswers(answers);
+        return response;
+    }
+
+    public SurveyResponse attachParticipantFiles(SurveyResponse response) {
+        List<ParticipantFile> participantFiles = participantFileDao.findBySurveyResponseId(response.getId());
+        response.setParticipantFiles(participantFiles);
         return response;
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/ParticipantFileSurveyResponse.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/ParticipantFileSurveyResponse.java
@@ -1,0 +1,34 @@
+package bio.terra.pearl.core.model.survey;
+
+import bio.terra.pearl.core.model.BaseEntity;
+import bio.terra.pearl.core.model.audit.ResponsibleEntity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+public class ParticipantFileSurveyResponse extends BaseEntity {
+    private UUID participantFileId;
+    private UUID surveyResponseId;
+
+    public UUID creatingParticipantUserId;
+    public UUID creatingAdminUserId;
+
+    public void setResponsibleUser(ResponsibleEntity responsibleEntity) {
+        if (responsibleEntity == null) {
+            return;
+        }
+        if (responsibleEntity.getParticipantUser() != null) {
+            this.creatingParticipantUserId = responsibleEntity.getParticipantUser().getId();
+        }
+        if (responsibleEntity.getAdminUser() != null) {
+            this.creatingAdminUserId = responsibleEntity.getAdminUser().getId();
+        }
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/SurveyResponse.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/SurveyResponse.java
@@ -1,16 +1,17 @@
 package bio.terra.pearl.core.model.survey;
 
 import bio.terra.pearl.core.model.BaseEntity;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-
 import bio.terra.pearl.core.model.audit.ResponsibleEntity;
+import bio.terra.pearl.core.model.fileupload.ParticipantFile;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 /**
  * container for response data from a given survey instance.
@@ -25,6 +26,8 @@ public class SurveyResponse extends BaseEntity {
     private UUID surveyId;
     @Builder.Default
     private List<Answer> answers = new ArrayList<>();
+    @Builder.Default
+    private List<ParticipantFile> participantFiles = new ArrayList<>();
     @Builder.Default
     private boolean complete = false;
     // a json map of userId -> an object with information about where that particular user left off

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/SurveyType.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/SurveyType.java
@@ -4,5 +4,6 @@ public enum SurveyType {
     CONSENT, // for consent forms
     RESEARCH, // for surveys intended to be included in the research dataset of a study
     OUTREACH, // for surveys intended for outreach purposes, e.g. to collect marketing/feedback information
-    ADMIN // for surveys intended for study staff purposes, e.g. for data entry
+    ADMIN, // for surveys intended for study staff purposes, e.g. for data entry
+    DOCUMENT_REQUEST, // for surveys intended to request documents from participants
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/workflow/TaskType.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/workflow/TaskType.java
@@ -6,5 +6,6 @@ public enum TaskType {
     OUTREACH, // an outreach activity -- not essential for research
     KIT_REQUEST,
     ADMIN_FORM, // a form for study staff to complete -- not visible to participants
-    ADMIN_NOTE // a task associated with a participant note -- not visible to participants
+    ADMIN_NOTE, // a task associated with a participant note -- not visible to participants
+    DOCUMENT_REQUEST, // a request for documents from a participant
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
@@ -175,7 +175,7 @@ public class EnrolleeExportService {
         return moduleFormatters;
     }
 
-    List<SurveyType> SURVEY_TYPE_EXPORT_ORDER = List.of(SurveyType.CONSENT, SurveyType.RESEARCH, SurveyType.OUTREACH);
+    List<SurveyType> SURVEY_TYPE_EXPORT_ORDER = List.of(SurveyType.CONSENT, SurveyType.RESEARCH, SurveyType.DOCUMENT_REQUEST, SurveyType.OUTREACH);
 
     /**
      * returns a ModuleExportInfo for each unique survey stableId that has ever been attached to the studyEnvironment

--- a/core/src/main/java/bio/terra/pearl/core/service/fileupload/ParticipantFileService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/fileupload/ParticipantFileService.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.io.InputStream;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -26,5 +27,9 @@ public class ParticipantFileService extends ImmutableEntityService<ParticipantFi
         UUID fileId = fileStorageBackend.uploadFile(file);
         participantFile.setExternalFileId(fileId);
         return dao.create(participantFile);
+    }
+
+    public List<ParticipantFile> findBySurveyResponseId(UUID surveyResponseId) {
+        return dao.findBySurveyResponseId(surveyResponseId);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/fileupload/ParticipantFileSurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/fileupload/ParticipantFileSurveyResponseService.java
@@ -1,0 +1,22 @@
+package bio.terra.pearl.core.service.fileupload;
+
+import bio.terra.pearl.core.dao.fileupload.ParticipantFileSurveyResponseDao;
+import bio.terra.pearl.core.model.survey.ParticipantFileSurveyResponse;
+import bio.terra.pearl.core.service.ImmutableEntityService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Slf4j
+public class ParticipantFileSurveyResponseService extends ImmutableEntityService<ParticipantFileSurveyResponse, ParticipantFileSurveyResponseDao> {
+    public ParticipantFileSurveyResponseService(ParticipantFileSurveyResponseDao dao) {
+        super(dao);
+    }
+
+    public List<ParticipantFileSurveyResponse> findBySurveyResponseId(UUID surveyResponseId) {
+        return dao.findBySurveyResponseId(surveyResponseId);
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -4,6 +4,7 @@ import bio.terra.pearl.core.dao.survey.SurveyResponseDao;
 import bio.terra.pearl.core.model.audit.DataAuditInfo;
 import bio.terra.pearl.core.model.audit.ParticipantDataChange;
 import bio.terra.pearl.core.model.audit.ResponsibleEntity;
+import bio.terra.pearl.core.model.fileupload.ParticipantFile;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.PortalParticipantUser;
 import bio.terra.pearl.core.model.survey.*;
@@ -13,8 +14,9 @@ import bio.terra.pearl.core.model.workflow.TaskStatus;
 import bio.terra.pearl.core.model.workflow.TaskType;
 import bio.terra.pearl.core.service.CascadeProperty;
 import bio.terra.pearl.core.service.CrudService;
-import bio.terra.pearl.core.service.ImmutableEntityService;
 import bio.terra.pearl.core.service.exception.NotFoundException;
+import bio.terra.pearl.core.service.fileupload.ParticipantFileService;
+import bio.terra.pearl.core.service.fileupload.ParticipantFileSurveyResponseService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
 import bio.terra.pearl.core.service.survey.event.EnrolleeSurveyEvent;
 import bio.terra.pearl.core.service.workflow.EventService;
@@ -35,13 +37,16 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
     private final ParticipantDataChangeService participantDataChangeService;
     private final EventService eventService;
     public static final String CONSENTED_ANSWER_STABLE_ID = "consented";
+    private final ParticipantFileSurveyResponseService participantFileSurveyResponseService;
+    private final ParticipantFileService participantFileService;
 
-    public SurveyResponseService(SurveyResponseDao dao, AnswerService answerService,
+    public SurveyResponseService(SurveyResponseDao dao,
+                                 AnswerService answerService,
                                  SurveyService surveyService,
                                  ParticipantTaskService participantTaskService,
                                  StudyEnvironmentSurveyService studyEnvironmentSurveyService,
                                  AnswerProcessingService answerProcessingService,
-                                 ParticipantDataChangeService participantDataChangeService, EventService eventService) {
+                                 ParticipantDataChangeService participantDataChangeService, EventService eventService, ParticipantFileSurveyResponseService participantFileSurveyResponseService, ParticipantFileService participantFileService) {
         super(dao);
         this.answerService = answerService;
         this.surveyService = surveyService;
@@ -50,6 +55,8 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         this.answerProcessingService = answerProcessingService;
         this.participantDataChangeService = participantDataChangeService;
         this.eventService = eventService;
+        this.participantFileSurveyResponseService = participantFileSurveyResponseService;
+        this.participantFileService = participantFileService;
     }
 
     public List<SurveyResponse> findByEnrolleeId(UUID enrolleeId) {
@@ -152,6 +159,9 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         allAnswers.addAll(existingAnswers);
         response.setAnswers(allAnswers);
 
+        List<ParticipantFile> updatedFiles = createOrUpdateParticipantFiles(response, responseDto.getParticipantFiles(), operator);
+        response.setParticipantFiles(updatedFiles);
+
         DataAuditInfo auditInfo = DataAuditInfo.builder()
                 .enrolleeId(enrollee.getId())
                 .surveyId(survey.getId())
@@ -170,7 +180,7 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
                 auditInfo);
 
         // now update the task status and response id
-        task = updateTaskToResponse(task, response, updatedAnswers, auditInfo);
+        task = updateTaskToResponse(task, response, updatedAnswers, updatedFiles, auditInfo);
         EnrolleeSurveyEvent event = eventService.publishEnrolleeSurveyEvent(enrollee, response, ppUser, task);
 
         logger.info("SurveyResponse received -- enrollee: {}, surveyStabledId: {}", enrollee.getShortcode(), survey.getStableId());
@@ -213,9 +223,9 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
     }
 
     protected ParticipantTask updateTaskToResponse(ParticipantTask task, SurveyResponse response,
-                                                   List<Answer> updatedAnswers, DataAuditInfo auditInfo) {
+                                                   List<Answer> updatedAnswers, List<ParticipantFile> updatedFiles, DataAuditInfo auditInfo) {
         task.setSurveyResponseId(response.getId());
-        TaskStatus updatedStatus = computeNewStatus(task, response, updatedAnswers);
+        TaskStatus updatedStatus = computeNewStatus(task, response, updatedAnswers, updatedFiles);
         if (task.getStatus() != updatedStatus || task.getSurveyResponseId() != response.getId()) {
             task.setStatus(updatedStatus);
             task.setSurveyResponseId(response.getId());
@@ -224,7 +234,7 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         return task;
     }
 
-    protected static TaskStatus computeNewStatus(ParticipantTask task, SurveyResponse response, List<Answer> updatedAnswers) {
+    protected static TaskStatus computeNewStatus(ParticipantTask task, SurveyResponse response, List<Answer> updatedAnswers, List<ParticipantFile> files) {
         if (task.getStatus() == TaskStatus.COMPLETE) {
             // task statuses shouldn't ever change from complete to not
             return TaskStatus.COMPLETE;
@@ -238,10 +248,10 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
             } else {
                 return TaskStatus.COMPLETE;
             }
-        } else if (task.getStatus() == TaskStatus.NEW && updatedAnswers.size() == 0) {
+        } else if (task.getStatus() == TaskStatus.NEW && updatedAnswers.size() == 0 && files.size() == 0) {
             // if the task is new and no answers we submitted, this is just indicating the survey was viewed
             return TaskStatus.VIEWED;
-        } else if (updatedAnswers.size() > 0) {
+        } else if (updatedAnswers.size() > 0 || files.size() > 0) {
             return TaskStatus.IN_PROGRESS;
         }
         // nothing has changed, so keep the status the same
@@ -333,6 +343,34 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         answer.setEnrolleeId(response.getEnrolleeId());
         answer.inferTypeIfMissing();
         return answerService.create(answer);
+    }
+
+    @Transactional
+    protected List<ParticipantFile> createOrUpdateParticipantFiles(SurveyResponse response, List<ParticipantFile> participantFiles, ResponsibleEntity operator) {
+        List<ParticipantFileSurveyResponse> existingParticipantFileSurveyResponses = participantFileSurveyResponseService.findBySurveyResponseId(response.getId());
+
+        // delete links to any files no longer in list (does not delete underlying participant file)
+        for (ParticipantFileSurveyResponse existingResponse : existingParticipantFileSurveyResponses) {
+            if (!participantFiles.stream().anyMatch(pf -> pf.getId().equals(existingResponse.getParticipantFileId()))) {
+                participantFileSurveyResponseService.delete(existingResponse.getId(), Set.of());
+            }
+        }
+
+        // create link to any new files
+        for (ParticipantFile file : participantFiles) {
+            if (!existingParticipantFileSurveyResponses.stream().anyMatch(pfsr -> pfsr.getParticipantFileId().equals(file.getId()))) {
+                ParticipantFileSurveyResponse participantFileSurveyResponse = ParticipantFileSurveyResponse.builder()
+                        .participantFileId(file.getId())
+                        .surveyResponseId(response.getId())
+                        .build();
+
+                participantFileSurveyResponse.setResponsibleUser(operator);
+
+                participantFileSurveyResponseService.create(participantFileSurveyResponse);
+            }
+        }
+
+        return participantFileService.findBySurveyResponseId(response.getId());
     }
 
     @Override

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
@@ -320,7 +320,8 @@ public class SurveyTaskDispatcher {
             SurveyType.CONSENT, TaskType.CONSENT,
             SurveyType.RESEARCH, TaskType.SURVEY,
             SurveyType.OUTREACH, TaskType.OUTREACH,
-            SurveyType.ADMIN, TaskType.ADMIN_FORM
+            SurveyType.ADMIN, TaskType.ADMIN_FORM,
+            SurveyType.DOCUMENT_REQUEST, TaskType.DOCUMENT_REQUEST
     );
 
     /**

--- a/core/src/main/resources/db/changelog/changesets/2024_11_07_create_participant_file_survey_response_table.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2024_11_07_create_participant_file_survey_response_table.yaml
@@ -1,0 +1,24 @@
+databaseChangeLog:
+  - changeSet:
+      id: "create_participant_file_survey_response_table"
+      author: connorlbark
+      changes:
+        - createTable:
+            tableName: participant_file_survey_response
+            columns:
+              - column:
+                  { name: id, type: uuid, defaultValueComputed: gen_random_uuid(), constraints: { nullable: false, primaryKey: true } }
+              - column:
+                  { name: created_at, type: datetime, constraints: { nullable: false } }
+              - column:
+                  { name: last_updated_at, type: datetime, constraints: { nullable: false } }
+              - column:
+                  { name: participant_file_id, type: uuid, constraints: { nullable: false, foreignKeyName: fk_participant_file_survey_response_participant_file_id, references: participant_file(id) } }
+              - column:
+                  { name: survey_response_id, type: uuid, constraints: { nullable: false, foreignKeyName: fk_participant_file_survey_response_survey_response_id, references: survey_response(id) } }
+              - column:
+                  { name: creating_participant_user_id, type: uuid, constraints: { foreignKeyName: fk_creating_participant_participant_file_survey_response, references: participant_user(id) } }
+              - column:
+                  { name: creating_admin_user_id, type: uuid, constraints: { foreignKeyName: fk_creating_admin_participant_file_survey_response, references: admin_user(id) } }
+
+

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -353,6 +353,9 @@ databaseChangeLog:
   - include:
       file: changesets/2024_10_31_create_participant_file_table.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2024_11_07_create_participant_file_survey_response_table.yaml
+      relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
@@ -3,8 +3,9 @@ package bio.terra.pearl.core.service.survey;
 import bio.terra.pearl.core.BaseSpringBootTest;
 import bio.terra.pearl.core.factory.DaoTestUtils;
 import bio.terra.pearl.core.factory.StudyEnvironmentBundle;
-import bio.terra.pearl.core.factory.participant.EnrolleeBundle;
 import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
+import bio.terra.pearl.core.factory.fileupload.ParticipantFileFactory;
+import bio.terra.pearl.core.factory.participant.EnrolleeBundle;
 import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
 import bio.terra.pearl.core.factory.participant.PortalParticipantUserFactory;
 import bio.terra.pearl.core.factory.survey.AnswerFactory;
@@ -13,12 +14,14 @@ import bio.terra.pearl.core.factory.survey.SurveyResponseFactory;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.audit.ParticipantDataChange;
 import bio.terra.pearl.core.model.audit.ResponsibleEntity;
+import bio.terra.pearl.core.model.fileupload.ParticipantFile;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.model.participant.PortalParticipantUser;
 import bio.terra.pearl.core.model.survey.*;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
 import bio.terra.pearl.core.model.workflow.TaskStatus;
+import bio.terra.pearl.core.service.fileupload.ParticipantFileService;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.participant.ParticipantUserService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
@@ -65,6 +68,10 @@ public class SurveyResponseServiceTests extends BaseSpringBootTest {
     private SurveyTaskDispatcher surveyTaskDispatcher;
     @Autowired
     private StudyEnvironmentFactory studyEnvironmentFactory;
+    @Autowired
+    private ParticipantFileFactory participantFileFactory;
+    @Autowired
+    private ParticipantFileService participantFileService;
 
     @Test
     @Transactional
@@ -248,6 +255,65 @@ public class SurveyResponseServiceTests extends BaseSpringBootTest {
         // check that the answers were created
         SurveyResponse savedResponse = surveyResponseService.findByEnrolleeId(enrolleeBundle.enrollee().getId()).get(0);
         assertThat(answerService.findByResponse(savedResponse.getId()), hasSize(2));
+    }
+
+    @Test
+    @Transactional
+    public void testUpdateResponseWithFile(TestInfo testInfo) {
+        // create a survey and an enrollee with one task to complete that survey
+        String testName = getTestName(testInfo);
+        EnrolleeBundle enrolleeBundle = enrolleeFactory.buildWithPortalUser(testName);
+        Survey survey = surveyFactory.buildPersisted(testName);
+        StudyEnvironmentSurvey configuredSurvey = surveyFactory.attachToEnv(survey, enrolleeBundle.enrollee().getStudyEnvironmentId(), true);
+
+        ParticipantTask task = surveyTaskDispatcher.buildTask(enrolleeBundle.enrollee(), enrolleeBundle.portalParticipantUser(), configuredSurvey, survey);
+        task = participantTaskService.create(task, getAuditInfo(testInfo));
+        assertThat(task.getStatus(), equalTo(TaskStatus.NEW));
+
+        // create a response with no answers
+        SurveyResponse response = SurveyResponse.builder()
+                .enrolleeId(enrolleeBundle.enrollee().getId())
+                .creatingParticipantUserId(enrolleeBundle.enrollee().getParticipantUserId())
+                .surveyId(survey.getId())
+                .complete(false)
+                .answers(List.of())
+                .build();
+
+        surveyResponseService.updateResponse(response, new ResponsibleEntity(enrolleeBundle.participantUser()), null,
+                enrolleeBundle.portalParticipantUser(), enrolleeBundle.enrollee(), task.getId(), survey.getPortalId());
+
+        // check that the response was created and task status updated to viewed
+        task = participantTaskService.find(task.getId()).orElseThrow();
+        assertThat(task.getStatus(), equalTo(TaskStatus.VIEWED));
+
+        // now an updated response with one Answer
+        ParticipantFile file = participantFileFactory.buildPersisted(enrolleeBundle.enrollee());
+
+        response = SurveyResponse.builder()
+                .enrolleeId(enrolleeBundle.enrollee().getId())
+                .creatingParticipantUserId(enrolleeBundle.enrollee().getParticipantUserId())
+                .surveyId(survey.getId())
+                .complete(false)
+                .participantFiles(List.of(file))
+                .build();
+
+        surveyResponseService.updateResponse(response, new ResponsibleEntity(enrolleeBundle.participantUser()), null,
+                enrolleeBundle.portalParticipantUser(), enrolleeBundle.enrollee(), task.getId(), survey.getPortalId());
+
+        // check that the response was created and task status updated to viewed
+        task = participantTaskService.find(task.getId()).orElseThrow();
+        assertThat(task.getStatus(), equalTo(TaskStatus.IN_PROGRESS));
+        // check that the answers were created
+        SurveyResponse savedResponse = surveyResponseService.findByEnrolleeId(enrolleeBundle.enrollee().getId()).get(0);
+        assertThat(participantFileService.findBySurveyResponseId(savedResponse.getId()), hasSize(1));
+
+
+        savedResponse.setParticipantFiles(List.of());
+        surveyResponseService.updateResponse(savedResponse, new ResponsibleEntity(enrolleeBundle.participantUser()), null,
+                enrolleeBundle.portalParticipantUser(), enrolleeBundle.enrollee(), task.getId(), survey.getPortalId());
+
+        assertThat(participantFileService.findBySurveyResponseId(savedResponse.getId()), hasSize(0));
+
     }
 
     @Test

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/fileupload/ParticipantFileFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/fileupload/ParticipantFileFactory.java
@@ -1,0 +1,62 @@
+package bio.terra.pearl.core.factory.fileupload;
+
+import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
+import bio.terra.pearl.core.model.fileupload.ParticipantFile;
+import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.survey.ParticipantFileSurveyResponse;
+import bio.terra.pearl.core.service.fileupload.ParticipantFileService;
+import bio.terra.pearl.core.service.fileupload.ParticipantFileSurveyResponseService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class ParticipantFileFactory {
+    @Autowired
+    public ParticipantFileService participantFileService;
+
+    @Autowired
+    public ParticipantFileSurveyResponseService participantFileSurveyResponseService;
+
+    @Autowired
+    public EnrolleeFactory enrolleeFactory;
+
+
+    public ParticipantFile.ParticipantFileBuilder builder() {
+        return ParticipantFile
+                .builder()
+                .externalFileId(UUID.randomUUID())
+                .fileName("testFile.csv")
+                .fileType("csv");
+    }
+
+    public ParticipantFile.ParticipantFileBuilder builderWithDependencies(Enrollee enrollee) {
+        return builder()
+                .enrolleeId(enrollee.getId());
+    }
+
+    public ParticipantFile.ParticipantFileBuilder builderWithDependencies(String testName) {
+        return builderWithDependencies(enrolleeFactory.buildPersisted(testName));
+    }
+
+    public ParticipantFile buildPersisted(ParticipantFile.ParticipantFileBuilder builder) {
+        return participantFileService.create(builder.build());
+    }
+
+    public ParticipantFile buildPersisted(String testName) {
+        return buildPersisted(builderWithDependencies(testName));
+    }
+
+    public ParticipantFile buildPersisted(Enrollee enrollee) {
+        return buildPersisted(builderWithDependencies(enrollee));
+    }
+
+    public ParticipantFileSurveyResponse attachToSurveyResponse(ParticipantFile participantFile, UUID surveyResponseId) {
+        ParticipantFileSurveyResponse participantFileSurveyResponse = ParticipantFileSurveyResponse.builder()
+                .participantFileId(participantFile.getId())
+                .surveyResponseId(surveyResponseId)
+                .build();
+        return participantFileSurveyResponseService.create(participantFileSurveyResponse);
+    }
+}


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Idea: Document requests are a new kind of survey. We attach files to document requests like we attach answers. This slightly muddies the intuitive "in progress" logic, as it could be that there is an answer OR there is a participant file. Otherwise, I think it neatly fits into survey logic.

What's left is that we need to create an API for uploading files. Then, the frontend for a document request will interact directly with the file upload API and then attach those files to the survey response. When the survey response is sent to the backend, the new code from this PR will attach it to the survey response.

Potentially, a far in the future world could have these files being referenced in answers. For example, there's a multi-upload file, and you can match a particular upload to a particular clinician, or something. But that's definitely an advanced need that won't be common. But it would be supported with this approach.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- n/a, verify unit tests make sense
- follow up admin UX pr will add admin view of this + synthetic data & populate capability