### PR TITLE
[JN-1447] Participant task merge -- recurring surveys

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/participant/merge/MergePair.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/merge/MergePair.java
@@ -22,16 +22,14 @@ public class MergePair<T extends BaseEntity> {
 
     public static <D extends BaseEntity> List<MergePair<D>> pairLists(List<D> sourceList, List<D> targetList, BiFunction<D, D, Boolean> comparator) {
         List<MergePair<D>> pairs = new ArrayList<>();
+        List<D> targetsToMatch = new ArrayList<>(targetList);
         for (D source : sourceList) {
-            D target = targetList.stream().filter(t -> comparator.apply(source, t)).findFirst().orElse(null);
+            D target = targetsToMatch.stream().filter(t -> comparator.apply(source, t)).findFirst().orElse(null);
             pairs.add(new MergePair<D>(source, target));
+            targetsToMatch.remove(target);
         }
-        for (D target : targetList) {
-            D source = sourceList.stream().filter(t -> comparator.apply(target, t)).findFirst().orElse(null);
-            // we only need to add unmatched targets -- matched will have been handled in the loop above
-            if (source == null) {
-                pairs.add(new MergePair<D>(source, target));
-            }
+        for (D target : targetsToMatch) {
+            pairs.add(new MergePair<D>(null, target));
         }
         return pairs;
     }

--- a/core/src/test/java/bio/terra/pearl/core/service/participant/merge/ParticipantMergeServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/participant/merge/ParticipantMergeServiceTests.java
@@ -11,6 +11,7 @@ import bio.terra.pearl.core.factory.survey.SurveyFactory;
 import bio.terra.pearl.core.factory.survey.SurveyResponseFactory;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.audit.DataAuditInfo;
+import bio.terra.pearl.core.model.audit.ResponsibleEntity;
 import bio.terra.pearl.core.model.notification.NotificationDeliveryType;
 import bio.terra.pearl.core.model.notification.Trigger;
 import bio.terra.pearl.core.model.notification.TriggerEventType;
@@ -19,6 +20,7 @@ import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.EnrolleeWithdrawalReason;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.model.participant.WithdrawnEnrollee;
+import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
 import bio.terra.pearl.core.model.workflow.HubResponse;
@@ -27,6 +29,7 @@ import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.participant.ParticipantUserService;
 import bio.terra.pearl.core.service.participant.WithdrawnEnrolleeService;
 import bio.terra.pearl.core.service.survey.SurveyResponseService;
+import bio.terra.pearl.core.service.survey.SurveyTaskDispatcher;
 import bio.terra.pearl.core.service.workflow.EnrollmentService;
 import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
 import bio.terra.pearl.core.service.workflow.RegistrationService;
@@ -73,6 +76,8 @@ public class ParticipantMergeServiceTests extends BaseSpringBootTest {
     private TriggerFactory triggerFactory;
     @Autowired
     private EmailTemplateFactory emailTemplateFactory;
+    @Autowired
+    private SurveyTaskDispatcher surveyTaskDispatcher;
 
     /** merge two enrollees who each have a single not-started survey task */
     @Test
@@ -261,15 +266,14 @@ public class ParticipantMergeServiceTests extends BaseSpringBootTest {
         assertThat(surveyResponseService.findByEnrolleeId(targetBundle.enrollee().getId()), hasSize(4));
     }
 
-    /** merge two enrollees who each have a survey task with a response */
+    /** merge two enrollees who have different numbers of responses to a survey */
     @Test
     @Transactional
     public void testRecurringSurveyTaskMerge(TestInfo info) {
         StudyEnvironmentBundle studyEnvBundle = studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.sandbox);
         Survey survey1 = surveyFactory.buildPersisted(getTestName(info), studyEnvBundle.getPortal().getId());
-        surveyFactory.attachToEnv(survey1, studyEnvBundle.getStudyEnv().getId(), true);
+        StudyEnvironmentSurvey studyEnvSurvey = surveyFactory.attachToEnv(survey1, studyEnvBundle.getStudyEnv().getId(), true);
 
-        // note we use the 'enroll' factory method so that tasks are added
         EnrolleeBundle sourceBundle = enrolleeFactory.enroll("source@test.com", studyEnvBundle.getPortal().getShortcode(),
                 studyEnvBundle.getStudy().getShortcode(), studyEnvBundle.getStudyEnv().getEnvironmentName());
 
@@ -285,10 +289,10 @@ public class ParticipantMergeServiceTests extends BaseSpringBootTest {
                         survey1.getStableId(),
                         "question1", "target1", true, targetBundle)
                 .getResponse();
-        
+        // manually create a second task (this is easier than futzing with dates)
+        ParticipantTask task2 = surveyTaskDispatcher.assign(List.of(targetBundle.enrollee()), studyEnvSurvey, true, new ResponsibleEntity(getTestName(info))).get(0);
         SurveyResponse responseT2 = surveyResponseFactory.submitStringAnswer(
-                        survey1.getStableId(),
-                        "question1", "target2", true, targetBundle)
+                        task2, "question1", "target2", true, targetBundle)
                 .getResponse();
 
         ParticipantUserMerge merge = participantMergePlanService.planMerge(sourceBundle.participantUser(), targetBundle.participantUser(),
@@ -296,31 +300,12 @@ public class ParticipantMergeServiceTests extends BaseSpringBootTest {
 
         assertThat(merge.getEnrollees(), hasSize(1));
         List<MergeAction<ParticipantTask, ?>> taskMerges = merge.getEnrollees().get(0).getMergePlan().getTasks();
-        // there should be 3 task 'pairs'
-        assertThat(taskMerges, hasSize(3));
-        for (MergeAction<ParticipantTask, ?> taskMerge : taskMerges) {
-            if (Objects.equal(taskMerge.getSource().getTargetStableId(), survey1.getStableId())) {
-                assertThat(taskMerge.getTarget().getTargetStableId(), equalTo(survey1.getStableId()));
-                assertThat(taskMerge.getAction(), equalTo(MergeAction.Action.MOVE_SOURCE));
-            } else if (Objects.equal(taskMerge.getSource().getTargetStableId(), survey2.getStableId())) {
-                assertThat(taskMerge.getTarget().getTargetStableId(), equalTo(survey2.getStableId()));
-                assertThat(taskMerge.getAction(), equalTo(MergeAction.Action.MOVE_SOURCE_DELETE_TARGET));
-            } else if (Objects.equal(taskMerge.getTarget().getTargetStableId(), survey3.getStableId())) {
-                assertThat(taskMerge.getSource().getTargetStableId(), equalTo(survey3.getStableId()));
-                assertThat(taskMerge.getAction(), equalTo(MergeAction.Action.DELETE_SOURCE));
-            } else {
-                throw new RuntimeException("unexpected task merge");
-            }
-        }
+        // there should be 2 task 'pairs'
+        assertThat(taskMerges, hasSize(2));
+
         participantMergeService.applyMerge(merge, DataAuditInfo.builder().systemProcess("test").build());
         assertThat(participantTaskService.findByEnrolleeId(sourceBundle.enrollee().getId()), hasSize(0));
         List<ParticipantTask> tasks = participantTaskService.findByEnrolleeId(targetBundle.enrollee().getId());
-        assertThat(tasks, hasSize(4));
-        // two tasks for survey 1, and 1 task for each of the others
-        assertThat(tasks.stream().map(ParticipantTask::getTargetStableId).toList(),
-                containsInAnyOrder(survey1.getStableId(), survey1.getStableId(), survey2.getStableId(), survey3.getStableId()));
-        assertThat(tasks.stream().map(ParticipantTask::getSurveyResponseId).toList(),
-                containsInAnyOrder(responseSt2.getId(), responseTt1.getId(), response_Tt3.getId(), responseSt1.getId()));
-        assertThat(surveyResponseService.findByEnrolleeId(targetBundle.enrollee().getId()), hasSize(4));
+        assertThat(tasks, hasSize(3));
     }
 }

--- a/core/src/testFixtures/java/bio/terra/pearl/core/factory/survey/SurveyFactory.java
+++ b/core/src/testFixtures/java/bio/terra/pearl/core/factory/survey/SurveyFactory.java
@@ -62,11 +62,13 @@ public class SurveyFactory {
     }
 
     public StudyEnvironmentSurvey attachToEnv(Survey survey, UUID studyEnvironmentId, boolean active, int surveyOrder) {
-        return studyEnvironmentSurveyService.create(StudyEnvironmentSurvey.builder()
+        StudyEnvironmentSurvey studyEnvironmentSurvey = studyEnvironmentSurveyService.create(StudyEnvironmentSurvey.builder()
                 .surveyId(survey.getId())
                 .active(active)
                 .surveyOrder(surveyOrder)
                 .studyEnvironmentId(studyEnvironmentId)
                 .build());
+        studyEnvironmentSurvey.setSurvey(survey);
+        return studyEnvironmentSurvey;
     }
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Updates the merge logic to behave correctly if the source and target have differing numbers of tasks for a given survey

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  Confirm unit test makes sense and passes