### PR TITLE
[JN-1471] adding scheduled export service

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/scheduled/ScheduledDataRepoExportService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/scheduled/ScheduledDataRepoExportService.java
@@ -1,4 +1,4 @@
-package bio.terra.pearl.api.admin.service;
+package bio.terra.pearl.api.admin.service.scheduled;
 
 import bio.terra.pearl.core.service.datarepo.DataRepoExportService;
 import com.google.common.collect.ImmutableSet;

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/scheduled/ScheduledEnrolleeReminderService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/scheduled/ScheduledEnrolleeReminderService.java
@@ -1,4 +1,4 @@
-package bio.terra.pearl.api.admin.service.notifications;
+package bio.terra.pearl.api.admin.service.scheduled;
 
 import bio.terra.pearl.core.service.notification.EnrolleeReminderService;
 import lombok.extern.slf4j.Slf4j;

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/scheduled/ScheduledExportService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/scheduled/ScheduledExportService.java
@@ -1,14 +1,9 @@
 package bio.terra.pearl.api.admin.service.scheduled;
 
 import bio.terra.pearl.core.model.audit.ResponsibleEntity;
-import bio.terra.pearl.core.service.datarepo.DataRepoExportService;
 import bio.terra.pearl.core.service.export.integration.ExportIntegrationService;
-import com.google.common.collect.ImmutableSet;
-import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.core.env.Environment;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -17,24 +12,23 @@ import org.springframework.stereotype.Service;
 public class ScheduledExportService {
   private final ExportIntegrationService exportIntegrationService;
 
-  public ScheduledExportService(
-          ExportIntegrationService exportIntegrationService) {
+  public ScheduledExportService(ExportIntegrationService exportIntegrationService) {
     this.exportIntegrationService = exportIntegrationService;
   }
 
-
   /**
-   * Run at 1:00AM once per day. We're _very_ generous with lockAtMostFor
-   * because this only runs once per day and we expect the process will take a while.
+   * Run at 1:00AM once per day. We're _very_ generous with lockAtMostFor because this only runs
+   * once per day and we expect the process will take a while.
    */
   @Scheduled(cron = "0 0 1 * * *")
   @SchedulerLock(
-          name = "ScheduledExportService.runScheduledExports",
-          lockAtLeastFor = "1m",
-          lockAtMostFor = "360m")
+      name = "ScheduledExportService.runScheduledExports",
+      lockAtLeastFor = "1m",
+      lockAtMostFor = "360m")
   public void runExportIntegrations() {
     log.info("Running export integrations");
-    exportIntegrationService.doAllExports(new ResponsibleEntity("ScheduledExportService.runExportIntegrations"));
+    exportIntegrationService.doAllExports(
+        new ResponsibleEntity("ScheduledExportService.runExportIntegrations"));
     log.info("Finished export integrations.");
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/scheduled/ScheduledExportService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/scheduled/ScheduledExportService.java
@@ -1,0 +1,40 @@
+package bio.terra.pearl.api.admin.service.scheduled;
+
+import bio.terra.pearl.core.model.audit.ResponsibleEntity;
+import bio.terra.pearl.core.service.datarepo.DataRepoExportService;
+import bio.terra.pearl.core.service.export.integration.ExportIntegrationService;
+import com.google.common.collect.ImmutableSet;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.core.env.Environment;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class ScheduledExportService {
+  private final ExportIntegrationService exportIntegrationService;
+
+  public ScheduledExportService(
+          ExportIntegrationService exportIntegrationService) {
+    this.exportIntegrationService = exportIntegrationService;
+  }
+
+
+  /**
+   * Run at 1:00AM once per day. We're _very_ generous with lockAtMostFor
+   * because this only runs once per day and we expect the process will take a while.
+   */
+  @Scheduled(cron = "0 0 1 * * *")
+  @SchedulerLock(
+          name = "ScheduledExportService.runScheduledExports",
+          lockAtLeastFor = "1m",
+          lockAtMostFor = "360m")
+  public void runExportIntegrations() {
+    log.info("Running export integrations");
+    exportIntegrationService.doAllExports(new ResponsibleEntity("ScheduledExportService.runExportIntegrations"));
+    log.info("Finished export integrations.");
+  }
+}

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/scheduled/ScheduledKitStatusService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/scheduled/ScheduledKitStatusService.java
@@ -1,4 +1,4 @@
-package bio.terra.pearl.api.admin.service;
+package bio.terra.pearl.api.admin.service.scheduled;
 
 import bio.terra.pearl.core.service.kit.KitRequestService;
 import lombok.extern.slf4j.Slf4j;

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/scheduled/ScheduledSendgridEventFetcher.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/scheduled/ScheduledSendgridEventFetcher.java
@@ -1,6 +1,8 @@
-package bio.terra.pearl.api.admin.service.notifications;
+package bio.terra.pearl.api.admin.service.scheduled;
 
 import java.util.concurrent.TimeUnit;
+
+import bio.terra.pearl.api.admin.service.notifications.SendgridEventService;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/scheduled/ScheduledSendgridEventFetcher.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/scheduled/ScheduledSendgridEventFetcher.java
@@ -1,8 +1,7 @@
 package bio.terra.pearl.api.admin.service.scheduled;
 
-import java.util.concurrent.TimeUnit;
-
 import bio.terra.pearl.api.admin.service.notifications.SendgridEventService;
+import java.util.concurrent.TimeUnit;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/scheduled/ScheduledSurveyAssignmentService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/scheduled/ScheduledSurveyAssignmentService.java
@@ -1,4 +1,4 @@
-package bio.terra.pearl.api.admin.service.forms;
+package bio.terra.pearl.api.admin.service.scheduled;
 
 import bio.terra.pearl.core.service.survey.SurveyTaskDispatcher;
 import lombok.extern.slf4j.Slf4j;

--- a/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
@@ -250,7 +250,8 @@ public abstract class BaseJdbiDao<T extends BaseEntity> implements JdbiDao<T> {
         );
     }
 
-    /* fetches all the entities with a child attached.  For example, if the parent table has a column "portal_environment_config_id" and
+    /**
+     *  fetches all the entities with a child attached.  For example, if the parent table has a column "portal_environment_config_id" and
      * a field portalEnvironmentConfig, this method could be used to fetch the portal environments with the configs already hydrated
      * and do so in a single SQL query instead of performing n queries to attach children to n parents
      */

--- a/core/src/main/java/bio/terra/pearl/core/dao/export/ExportIntegrationDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/export/ExportIntegrationDao.java
@@ -7,16 +7,22 @@ import org.jdbi.v3.core.Jdbi;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.UUID;
 
 @Component
 public class ExportIntegrationDao extends BaseMutableJdbiDao<ExportIntegration> implements StudyEnvAttachedDao<ExportIntegration> {
-    public ExportIntegrationDao(Jdbi jdbi) {
+    private final ExportOptionsDao exportOptionsDao;
+    public ExportIntegrationDao(Jdbi jdbi, ExportOptionsDao exportOptionsDao) {
         super(jdbi);
+        this.exportOptionsDao = exportOptionsDao;
     }
 
     @Override
     protected Class<ExportIntegration> getClazz() {
         return ExportIntegration.class;
+    }
+
+    public List<ExportIntegration> findAllActiveWithOptions() {
+        return findAllByPropertyWithChildren("enabled", true
+                , "exportOptionsId", "exportOptions", exportOptionsDao);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/integration/ExportIntegrationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/integration/ExportIntegrationService.java
@@ -7,6 +7,9 @@ import bio.terra.pearl.core.model.export.ExportDestinationType;
 import bio.terra.pearl.core.model.export.ExportIntegration;
 import bio.terra.pearl.core.model.export.ExportIntegrationJob;
 import bio.terra.pearl.core.model.export.ExportOptions;
+import bio.terra.pearl.core.model.notification.Trigger;
+import bio.terra.pearl.core.model.notification.TriggerType;
+import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.service.CrudService;
 import bio.terra.pearl.core.service.export.ExportOptionsWithExpression;
 import bio.terra.pearl.core.service.search.EnrolleeSearchExpressionParser;
@@ -52,6 +55,13 @@ public class ExportIntegrationService extends CrudService<ExportIntegration, Exp
         ExportIntegration newIntegration = super.update(integration);
         newIntegration.setExportOptions(updatedOpts);
         return newIntegration;
+    }
+
+    public void doAllExports(ResponsibleEntity operator) {
+        List<ExportIntegration> integrations = dao.findAllActiveWithOptions();
+        for (ExportIntegration integration : integrations) {
+            doExport(integration, operator);
+        }
     }
 
     public ExportIntegrationJob doExport(ExportIntegration integration, ResponsibleEntity operator) {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds a scheduled service to run all active exports at 1:00AM.  this also groups all the scheduled services together in a single package.  IMHO this makes it easier to get a sense of what runs when, and we really don't want the scheduled services to have business logic in them anywhere.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  edit the cron in the ScheduledExportService to a time coming up
2. redeploy ApiAdminApp
3. confirm the job runs at the time you specified