### PR TITLE
[JN-1473] adding simple manual assignment

### DIFF
--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -346,6 +346,7 @@ export type ParticipantTaskAssignDto = {
   // if true, the enrolleeIds list will be ignored and tasks will be assigned to all enrollees
   // not already having the task in the duplicate window
   assignAllUnassigned: boolean
+  overrideEligibility: boolean
 }
 
 export type TaskUpdateSpec = {

--- a/ui-admin/src/study/participants/survey/SurveyAssignModal.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyAssignModal.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react'
+import { Modal } from 'react-bootstrap'
+import Api, { Survey } from 'api/api'
+import { doApiLoad } from 'api/api-utils'
+import LoadingSpinner from 'util/LoadingSpinner'
+import { failureNotification, successNotification } from 'util/notifications'
+import { Store } from 'react-notifications-component'
+import { Enrollee, StudyEnvParams } from '@juniper/ui-core'
+
+/** Renders a modal for an admin to submit a sample collection kit request. */
+export default function SurveyAssignModal({
+  studyEnvParams, enrollee, survey,
+  onDismiss, onSubmit
+}: {
+  studyEnvParams: StudyEnvParams,
+  onDismiss: () => void,
+  survey: Survey,
+  enrollee: Enrollee,
+  onSubmit: () => void }) {
+  const [isLoading, setIsLoading] = useState(false)
+  const [overrideEligibility, setOverrideEligibility] = useState(false)
+  const handleSubmit = async () => {
+    doApiLoad(async () => {
+      const tasks = await Api.assignParticipantTasksToEnrollees(studyEnvParams, {
+        taskType: 'SURVEY', // type is just used to determine the dispatcher, not the created task type
+        targetStableId: survey.stableId,
+        targetAssignedVersion: survey.version,
+        enrolleeIds: [enrollee.id],
+        assignAllUnassigned: false,
+        overrideEligibility
+      })
+      if (tasks.length > 0) {
+        Store.addNotification(successNotification(`Task assigned - ${survey.name}`))
+      } else {
+        Store.addNotification(failureNotification('Task not assigned - this may be because the participant ' +
+          'is not eligible.'))
+      }
+      onSubmit()
+    }, { setIsLoading })
+  }
+
+  return <Modal show={true} onHide={onDismiss}>
+    <Modal.Header closeButton>
+      <Modal.Title>Assign task</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>
+      <form onSubmit={e => e.preventDefault()}>
+        <div>
+          Assign <b>{survey.name}</b> to enrollee {enrollee.shortcode}
+        </div>
+        <div>
+          <label className="form-control border-0">
+            <input type="checkbox" name="includeUnconsented" checked={overrideEligibility}
+              onChange={e => setOverrideEligibility(e.target.checked)}
+              className="me-1"/>
+            Assign even if they do not meet eligibility criteria
+          </label>
+        </div>
+      </form>
+    </Modal.Body>
+    <Modal.Footer>
+      <LoadingSpinner isLoading={isLoading}>
+        <button className='btn btn-primary' onClick={handleSubmit}>Assign</button>
+        <button className='btn btn-secondary' onClick={onDismiss}>Cancel</button>
+      </LoadingSpinner>
+    </Modal.Footer>
+  </Modal>
+}
+

--- a/ui-admin/src/study/participants/survey/SurveyResponseView.test.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyResponseView.test.tsx
@@ -1,15 +1,15 @@
-import { setupRouterTest } from '@juniper/ui-core'
+import { renderWithRouter, setupRouterTest } from '@juniper/ui-core'
 import {
   mockAnswer,
   mockConfiguredSurvey,
-  mockEnrollee,
+  mockEnrollee, mockParticipantTask,
   mockStudyEnvContext,
   mockSurveyResponse
 } from 'test-utils/mocking-utils'
 import { render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import { userEvent } from '@testing-library/user-event'
-import { RawEnrolleeSurveyView } from './SurveyResponseView'
+import SurveyResponseView, { RawEnrolleeSurveyView } from './SurveyResponseView'
 import { userHasPermission } from 'user/UserProvider'
 import Api from 'api/api'
 
@@ -19,6 +19,36 @@ jest.mock('user/UserProvider', () => ({
 }))
 
 jest.spyOn(Api, 'fetchEnrolleeChangeRecords').mockResolvedValue([])
+
+describe('SurveyResponseView', () => {
+  test('Displays assignment button if unassigned', async () => {
+    renderWithRouter(<SurveyResponseView enrollee={mockEnrollee()}
+      updateResponseMap={jest.fn()}
+      studyEnvContext={mockStudyEnvContext()}
+      responseMap={{
+        someSurvey: {
+          tasks: [], responses: [],
+          survey: mockConfiguredSurvey()
+        }
+      }} onUpdate={jest.fn()}/>, ['/someSurvey'], ':surveyStableId')
+    expect(screen.getByText('Not assigned')).toBeVisible()
+    expect(screen.getByText('Assign')).toBeVisible()
+  })
+
+  test('Displays response if assigned', async () => {
+    renderWithRouter(<SurveyResponseView enrollee={mockEnrollee()}
+      updateResponseMap={jest.fn()}
+      studyEnvContext={mockStudyEnvContext()}
+      responseMap={{
+        someSurvey: {
+          tasks: [mockParticipantTask('SURVEY', 'NEW')], responses: [],
+          survey: mockConfiguredSurvey()
+        }
+      }} onUpdate={jest.fn()}/>, ['/someSurvey'], ':surveyStableId')
+    expect(screen.getByText('Not Started')).toBeVisible()
+  })
+})
+
 
 describe('RawEnrolleeSurveyView', () => {
   jest.clearAllMocks()

--- a/ui-admin/src/study/participants/survey/SurveyResponseView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyResponseView.tsx
@@ -78,7 +78,8 @@ export default function SurveyResponseView({ enrollee, responseMap, updateRespon
     <h4>{surveyAndResponses.survey.survey.name}</h4>
     { !isAssigned && <div className="d-flex align-items-center">
       <span className="text-muted fst-italic me-4">Not assigned</span>
-      <Button variant={'secondary'} onClick={() => setShowAssignModal(!showAssignModal)} className="ms-2">
+      <Button variant={'secondary'} outline={true}
+        onClick={() => setShowAssignModal(!showAssignModal)} className="ms-2">
         Assign
       </Button>
     </div>}


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds the ability to assign unassigned surveys to individual enrollees, with the option to override eligibility criteria.

![image](https://github.com/user-attachments/assets/e42abcc2-0af5-4a88-aafb-7b427bbcc575)

![image](https://github.com/user-attachments/assets/9ef05a03-ef68-40ce-84e1-fedaea8fd83f)

Unassigning/deleting tasks is a topic for later PR. 

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants/HDSALK/surveys/massachusettsSurvey
2. click "assign"
3. click "Assign" (without overriding eligibility check)
4. confirm you see a message that the assignment was not performed
5. repeat, but this check the box for overriding the criteria
6. confirm task is assigned.