### PR TITLE
[JN-1466] rename GCP dev namespace to juniper-dev

### DIFF
--- a/terraform/gcp/cluster_service_account.tf
+++ b/terraform/gcp/cluster_service_account.tf
@@ -26,19 +26,6 @@ resource "google_project_iam_binding" "cluster-log-writer" {
   ]
 }
 
-resource "google_artifact_registry_repository_iam_binding" "cluster-artifact-registry-reader" {
-  role   = "roles/artifactregistry.reader"
-  repository = "juniper"
-  members = [
-    "serviceAccount:${google_service_account.cluster_service_account.email}"
-  ]
-
-  # create it in the infra project not the current project
-  project = var.infra_project
-  location = var.infra_region
-  provider = google.infra
-}
-
 # As far as I can tell, the GKE service account that manages the cluster cannot be changed, but
 # it needs to be able to access the KMS key to encrypt and decrypt the database.
 resource "google_kms_key_ring_iam_binding" "cluster-key-ring" {

--- a/terraform/gcp/envs/dev.tfvars
+++ b/terraform/gcp/envs/dev.tfvars
@@ -7,8 +7,7 @@ admin_url = "juniper-cmi.dev"
 environment = "dev"
 # note: automatically creates DNS records for these portals under the admin domain
 portals = ["demo", "atcp", "ourhealth", "hearthive", "rgp", "cmi"]
-infra_project = "broad-juniper-eng-infra"
-infra_region = "us-central1"
+k8s_namespace = "juniper-dev"
 
 # creates DNS records for these customer URLs
 customer_urls = {

--- a/terraform/gcp/envs/prod.tfvars
+++ b/terraform/gcp/envs/prod.tfvars
@@ -8,8 +8,6 @@ admin_url = "juniper-cmi.org"
 environment = "prod"
 # note: automatically creates DNS records for these portals under the admin domain
 portals = ["demo"]
-infra_project = "broad-juniper-eng-infra"
-infra_region = "us-central1"
 admin_dnssec = "off"
 k8s_namespace = "juniper-prod"
 

--- a/terraform/gcp/k8s/environments/dev.yaml
+++ b/terraform/gcp/k8s/environments/dev.yaml
@@ -1,6 +1,7 @@
 gcpProject: broad-juniper-dev
 gcpRegion: us-central1
 adminUrl: juniper-cmi.dev
+appVersion: 1.4.63
 replicas: 1
 # "portals" adds certificates for each portal - both for the juniper-cmi.dev subdomains and the custom domain
 portals:

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -3,13 +3,6 @@ provider "google" {
   region      = var.region
 }
 
-# need to create some IAM binding to read artifact registry in infra project
-provider "google" {
-  project = var.infra_project
-  region  = var.infra_region
-  alias  = "infra"
-}
-
 data "google_client_config" "provider" {}
 
 # state is stored remotely in GCS bucket

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -66,16 +66,6 @@ variable "customer_urls" {
   description = "Customer URLs"
 }
 
-variable "infra_project" {
-  type = string
-  description = "Infra project"
-}
-
-variable "infra_region" {
-  type = string
-  description = "Infra region"
-}
-
 variable "admin_dnssec" {
     type = string
     default = "on"

--- a/terraform/infra/artfiact_registry_access.tf
+++ b/terraform/infra/artfiact_registry_access.tf
@@ -1,0 +1,8 @@
+resource "google_artifact_registry_repository_iam_binding" "cluster-artifact-registry-reader" {
+  role   = "roles/artifactregistry.reader"
+  repository = "juniper"
+  members = [
+    "serviceAccount:juniper-cluster@broad-juniper-dev.iam.gserviceaccount.com",
+    "serviceAccount:juniper-cluster@broad-juniper-prod.iam.gserviceaccount.com"
+  ]
+}


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Also, does some cleanup to make our service account linking to the infra project be handled just in the infra project - by creating dev/prod permissions to read the artifact in separate workspaces, it confused terraform & would try to delete the prod one when creating the dev one and vice versa. Probably better to separate them, anyway...

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- n/a, test out juniper-cmi.dev / juniperdemostudy.dev