### PR TITLE
[JN-1231] extract only active content

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/internal/PopulateController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/internal/PopulateController.java
@@ -179,11 +179,13 @@ public class PopulateController implements PopulateApi {
   }
 
   @Override
-  public ResponseEntity<Resource> extractPortal(String portalShortcode) {
+  public ResponseEntity<Resource> extractPortal(
+      String portalShortcode, Boolean extractPublishedVersionsOnly) {
     AdminUser operator = authUtilService.requireAdminUser(request);
     try {
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
-      populateExtService.extractPortal(OperatorAuthContext.of(operator), portalShortcode, baos);
+      populateExtService.extractPortal(
+          OperatorAuthContext.of(operator), portalShortcode, baos, extractPublishedVersionsOnly);
       return ResponseEntity.ok().body(new ByteArrayResource(baos.toByteArray()));
     } catch (IOException e) {
       throw new InternalServerErrorException("Error exporting portal", e);

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/internal/PopulateController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/internal/PopulateController.java
@@ -180,12 +180,12 @@ public class PopulateController implements PopulateApi {
 
   @Override
   public ResponseEntity<Resource> extractPortal(
-      String portalShortcode, Boolean extractPublishedVersionsOnly) {
+      String portalShortcode, Boolean extractActiveVersionsOnly) {
     AdminUser operator = authUtilService.requireAdminUser(request);
     try {
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
       populateExtService.extractPortal(
-          OperatorAuthContext.of(operator), portalShortcode, baos, extractPublishedVersionsOnly);
+          OperatorAuthContext.of(operator), portalShortcode, baos, extractActiveVersionsOnly);
       return ResponseEntity.ok().body(new ByteArrayResource(baos.toByteArray()));
     } catch (IOException e) {
       throw new InternalServerErrorException("Error exporting portal", e);

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/PopulateExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/PopulateExtService.java
@@ -183,9 +183,9 @@ public class PopulateExtService {
       OperatorAuthContext authContext,
       String portalShortcode,
       OutputStream os,
-      boolean extractPublishedVersionsOnly)
+      boolean extractActiveVersionsOnly)
       throws IOException {
-    portalExtractService.extract(portalShortcode, os, extractPublishedVersionsOnly);
+    portalExtractService.extract(portalShortcode, os, extractActiveVersionsOnly);
   }
 
   @Transactional

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/PopulateExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/PopulateExtService.java
@@ -180,8 +180,12 @@ public class PopulateExtService {
 
   @SuperuserOnly
   public void extractPortal(
-      OperatorAuthContext authContext, String portalShortcode, OutputStream os) throws IOException {
-    portalExtractService.extract(portalShortcode, os);
+      OperatorAuthContext authContext,
+      String portalShortcode,
+      OutputStream os,
+      boolean extractPublishedVersionsOnly)
+      throws IOException {
+    portalExtractService.extract(portalShortcode, os, extractPublishedVersionsOnly);
   }
 
   @Transactional

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -1841,7 +1841,7 @@ paths:
       operationId: extractPortal
       parameters:
         - *portalShortcodeParam
-        - { name: onlyExtractPublishedVersions, in: query, required: false, schema: { type: boolean, default: false } }
+        - { name: onlyExtractActiveVersions, in: query, required: false, schema: { type: boolean, default: false } }
       responses:
         '200':
           description: zip file of portal configs

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -1841,6 +1841,7 @@ paths:
       operationId: extractPortal
       parameters:
         - *portalShortcodeParam
+        - { name: onlyExtractPublishedVersions, in: query, required: false, schema: { type: boolean, default: false } }
       responses:
         '200':
           description: zip file of portal configs

--- a/core/src/main/java/bio/terra/pearl/core/dao/site/SiteContentDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/site/SiteContentDao.java
@@ -108,10 +108,9 @@ public class SiteContentDao extends BaseVersionedJdbiDao<SiteContent> {
     public List<SiteContent> findPublishedContentByPortalId(UUID portalId) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("""
-                                 select distinct on (sc.id) sc.* from site_content sc
+                                 select sc.* from site_content sc
                                  inner join portal_environment pe on sc.id = pe.site_content_id
                                  where pe.portal_id = :portalId
-                                 order by sc.id, sc.version desc
                                 """)
                         .bind("portalId", portalId)
                         .mapTo(getClazz())

--- a/core/src/main/java/bio/terra/pearl/core/dao/site/SiteContentDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/site/SiteContentDao.java
@@ -105,7 +105,7 @@ public class SiteContentDao extends BaseVersionedJdbiDao<SiteContent> {
         ) + 1;
     }
 
-    public List<SiteContent> findPublishedContentByPortalId(UUID portalId) {
+    public List<SiteContent> findActiveContentByPortalId(UUID portalId) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("""
                                  select sc.* from site_content sc

--- a/core/src/main/java/bio/terra/pearl/core/dao/site/SiteContentDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/site/SiteContentDao.java
@@ -104,4 +104,18 @@ public class SiteContentDao extends BaseVersionedJdbiDao<SiteContent> {
                         .one()
         ) + 1;
     }
+
+    public List<SiteContent> findPublishedContentByPortalId(UUID portalId) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("""
+                                 select distinct on (sc.id) sc.* from site_content sc
+                                 inner join portal_environment pe on sc.id = pe.site_content_id
+                                 where pe.portal_id = :portalId
+                                 order by sc.id, sc.version desc
+                                """)
+                        .bind("portalId", portalId)
+                        .mapTo(getClazz())
+                        .list()
+        );
+    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyDao.java
@@ -101,7 +101,7 @@ public class SurveyDao extends BaseVersionedJdbiDao<Survey> {
         return Survey.class;
     }
 
-    public List<Survey> findPublishedSurveysByPortalIdNoPreEnrolls(UUID portalId) {
+    public List<Survey> findActiveSurveysByPortalIdNoPreEnrolls(UUID portalId) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("""
                                 select s.* from survey s
@@ -114,7 +114,7 @@ public class SurveyDao extends BaseVersionedJdbiDao<Survey> {
         );
     }
 
-    public List<Survey> findPublishedPreEnrolleeSurveysByPortalId(UUID portalId) {
+    public List<Survey> findActivePreEnrolleeSurveysByPortalId(UUID portalId) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("""
                                 select s.* from survey s

--- a/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyDao.java
@@ -101,12 +101,27 @@ public class SurveyDao extends BaseVersionedJdbiDao<Survey> {
         return Survey.class;
     }
 
-    public List<Survey> findPublishedSurveysByPortalId(UUID portalId) {
+    public List<Survey> findPublishedSurveysByPortalIdNoPreEnrolls(UUID portalId) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("""
                                 select s.* from survey s
                                 inner join study_environment_survey ses on s.id = ses.survey_id and ses.active = true
                                 where s.portal_id = :portalId
+                                """)
+                        .bind("portalId", portalId)
+                        .mapTo(clazz)
+                        .list()
+        );
+    }
+
+    public List<Survey> findPublishedPreEnrolleeSurveysByPortalId(UUID portalId) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("""
+                                select s.* from survey s
+                                inner join portal on s.portal_id = portal.id
+                                inner join portal_study ps on portal.id = ps.portal_id
+                                inner join study_environment se on ps.study_id = se.study_id
+                                where s.portal_id = :portalId and s.id = se.pre_enroll_survey_id
                                 """)
                         .bind("portalId", portalId)
                         .mapTo(clazz)

--- a/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyDao.java
@@ -100,4 +100,17 @@ public class SurveyDao extends BaseVersionedJdbiDao<Survey> {
     protected Class<Survey> getClazz() {
         return Survey.class;
     }
+
+    public List<Survey> findPublishedSurveysByPortalId(UUID portalId) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("""
+                                select s.* from survey s
+                                inner join study_environment_survey ses on s.id = ses.survey_id and ses.active = true
+                                where s.portal_id = :portalId
+                                """)
+                        .bind("portalId", portalId)
+                        .mapTo(clazz)
+                        .list()
+        );
+    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/site/SiteContentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/site/SiteContentService.java
@@ -113,7 +113,7 @@ public class SiteContentService extends VersionedEntityService<SiteContent, Site
         }
     }
 
-    public List<SiteContent> findPublishedContentByPortalId(UUID portalId) {
-        return dao.findPublishedContentByPortalId(portalId);
+    public List<SiteContent> findActiveContentByPortalId(UUID portalId) {
+        return dao.findActiveContentByPortalId(portalId);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/site/SiteContentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/site/SiteContentService.java
@@ -112,4 +112,8 @@ public class SiteContentService extends VersionedEntityService<SiteContent, Site
             section.setHtmlPageId(null);
         }
     }
+
+    public List<SiteContent> findPublishedContentByPortalId(UUID portalId) {
+        return dao.findPublishedContentByPortalId(portalId);
+    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyService.java
@@ -218,10 +218,10 @@ public class SurveyService extends VersionedEntityService<Survey, SurveyDao> {
         survey.setAnswerMappings(answerMappingDao.findBySurveyId(survey.getId()));
     }
 
-    public List<Survey> findPublishedSurveysByPortalId(UUID portalId) {
-        List<Survey> surveys = dao.findPublishedSurveysByPortalIdNoPreEnrolls(portalId);
+    public List<Survey> findActiveSurveysByPortalId(UUID portalId) {
+        List<Survey> surveys = dao.findActiveSurveysByPortalIdNoPreEnrolls(portalId);
 
-        surveys.addAll(dao.findPublishedPreEnrolleeSurveysByPortalId(portalId));
+        surveys.addAll(dao.findActivePreEnrolleeSurveysByPortalId(portalId));
 
         return surveys;
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyService.java
@@ -219,6 +219,10 @@ public class SurveyService extends VersionedEntityService<Survey, SurveyDao> {
     }
 
     public List<Survey> findPublishedSurveysByPortalId(UUID portalId) {
-        return dao.findPublishedSurveysByPortalId(portalId);
+        List<Survey> surveys = dao.findPublishedSurveysByPortalIdNoPreEnrolls(portalId);
+
+        surveys.addAll(dao.findPublishedPreEnrolleeSurveysByPortalId(portalId));
+
+        return surveys;
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyService.java
@@ -218,4 +218,7 @@ public class SurveyService extends VersionedEntityService<Survey, SurveyDao> {
         survey.setAnswerMappings(answerMappingDao.findBySurveyId(survey.getId()));
     }
 
+    public List<Survey> findPublishedSurveysByPortalId(UUID portalId) {
+        return dao.findPublishedSurveysByPortalId(portalId);
+    }
 }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/SurveyPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/SurveyPopulator.java
@@ -2,9 +2,10 @@ package bio.terra.pearl.populate.service;
 
 import bio.terra.pearl.core.dao.survey.AnswerMappingDao;
 import bio.terra.pearl.core.dao.survey.SurveyQuestionDefinitionDao;
-import bio.terra.pearl.core.model.portal.Portal;
-import bio.terra.pearl.core.model.survey.*;
-import bio.terra.pearl.core.service.CascadeProperty;
+import bio.terra.pearl.core.model.survey.AnswerMapping;
+import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
+import bio.terra.pearl.core.model.survey.Survey;
+import bio.terra.pearl.core.model.survey.SurveyQuestionDefinition;
 import bio.terra.pearl.core.service.portal.PortalService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
 import bio.terra.pearl.core.service.survey.SurveyService;
@@ -16,10 +17,12 @@ import bio.terra.pearl.populate.service.contexts.PortalPopulateContext;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
 
 /** populator for surveys and consent forms */
 @Service

--- a/populate/src/main/java/bio/terra/pearl/populate/service/extract/ExtractPopulateContext.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/extract/ExtractPopulateContext.java
@@ -74,4 +74,8 @@ public class ExtractPopulateContext {
     public String getFileNameForEntity(UUID entityId) {
         return writtenEntities.get(entityId);
     }
+
+    public boolean hasEntityBeenWritten(UUID entityId) {
+        return writtenEntities.containsKey(entityId);
+    }
 }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/extract/ExtractPopulateContext.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/extract/ExtractPopulateContext.java
@@ -19,11 +19,15 @@ public class ExtractPopulateContext {
     @Getter
     private final PortalPopDto portalPopDto;
 
-    public ExtractPopulateContext(Portal portal, ZipOutputStream zipOut) {
+    @Getter
+    private boolean extractPublishedVersionsOnly;
+
+    public ExtractPopulateContext(Portal portal, ZipOutputStream zipOut, boolean extractPublishedVersionsOnly) {
         this.zipOut = zipOut;
         portalPopDto = new PortalPopDto();
         portalPopDto.setShortcode(portal.getShortcode());
         portalPopDto.setName(portal.getName());
+        this.extractPublishedVersionsOnly = extractPublishedVersionsOnly;
     }
 
     /** write a file to the zip file, but only if it hasn't already been written */

--- a/populate/src/main/java/bio/terra/pearl/populate/service/extract/ExtractPopulateContext.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/extract/ExtractPopulateContext.java
@@ -20,14 +20,14 @@ public class ExtractPopulateContext {
     private final PortalPopDto portalPopDto;
 
     @Getter
-    private boolean extractPublishedVersionsOnly;
+    private boolean extractActiveVersionsOnly;
 
-    public ExtractPopulateContext(Portal portal, ZipOutputStream zipOut, boolean extractPublishedVersionsOnly) {
+    public ExtractPopulateContext(Portal portal, ZipOutputStream zipOut, boolean extractActiveVersionsOnly) {
         this.zipOut = zipOut;
         portalPopDto = new PortalPopDto();
         portalPopDto.setShortcode(portal.getShortcode());
         portalPopDto.setName(portal.getName());
-        this.extractPublishedVersionsOnly = extractPublishedVersionsOnly;
+        this.extractActiveVersionsOnly = extractActiveVersionsOnly;
     }
 
     /** write a file to the zip file, but only if it hasn't already been written */

--- a/populate/src/main/java/bio/terra/pearl/populate/service/extract/ExtractPopulateContext.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/extract/ExtractPopulateContext.java
@@ -74,8 +74,4 @@ public class ExtractPopulateContext {
     public String getFileNameForEntity(UUID entityId) {
         return writtenEntities.get(entityId);
     }
-
-    public boolean hasEntityBeenWritten(UUID entityId) {
-        return writtenEntities.containsKey(entityId);
-    }
 }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/extract/PortalExtractService.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/extract/PortalExtractService.java
@@ -8,8 +8,8 @@ import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.study.PortalStudy;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentConfigService;
-import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentLanguageService;
+import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
 import bio.terra.pearl.core.service.portal.PortalService;
 import bio.terra.pearl.core.service.portal.exception.PortalConfigMissing;
 import bio.terra.pearl.populate.dto.PortalEnvironmentPopDto;
@@ -66,11 +66,11 @@ public class PortalExtractService {
         this.objectMapper.addMixIn(Portal.class, PortalMixin.class);
     }
 
-    public void extract(String portalShortcode, OutputStream os) throws IOException {
+    public void extract(String portalShortcode, OutputStream os, boolean extractPublishedVersionsOnly) throws IOException {
         Portal portal = portalService.findOneByShortcode(portalShortcode)
                 .orElseThrow(() -> new NotFoundException("Portal not found: " + portalShortcode));
         ZipOutputStream zipOut = new ZipOutputStream(os);
-        ExtractPopulateContext context = new ExtractPopulateContext(portal, zipOut);
+        ExtractPopulateContext context = new ExtractPopulateContext(portal, zipOut, extractPublishedVersionsOnly);
         mediaExtractor.writeMedia(portal, context);
         siteContentExtractor.writeSiteContents(portal, context);
         surveyExtractor.writeSurveys(portal, context);

--- a/populate/src/main/java/bio/terra/pearl/populate/service/extract/PortalExtractService.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/extract/PortalExtractService.java
@@ -66,11 +66,11 @@ public class PortalExtractService {
         this.objectMapper.addMixIn(Portal.class, PortalMixin.class);
     }
 
-    public void extract(String portalShortcode, OutputStream os, boolean extractPublishedVersionsOnly) throws IOException {
+    public void extract(String portalShortcode, OutputStream os, boolean extractActiveVersionsOnly) throws IOException {
         Portal portal = portalService.findOneByShortcode(portalShortcode)
                 .orElseThrow(() -> new NotFoundException("Portal not found: " + portalShortcode));
         ZipOutputStream zipOut = new ZipOutputStream(os);
-        ExtractPopulateContext context = new ExtractPopulateContext(portal, zipOut, extractPublishedVersionsOnly);
+        ExtractPopulateContext context = new ExtractPopulateContext(portal, zipOut, extractActiveVersionsOnly);
         mediaExtractor.writeMedia(portal, context);
         siteContentExtractor.writeSiteContents(portal, context);
         surveyExtractor.writeSurveys(portal, context);

--- a/populate/src/main/java/bio/terra/pearl/populate/service/extract/SiteContentExtractor.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/extract/SiteContentExtractor.java
@@ -29,7 +29,9 @@ public class SiteContentExtractor {
     }
 
     public void writeSiteContents(Portal portal, ExtractPopulateContext context) {
-        List<SiteContent> siteContents = siteContentService.findByPortalId(portal.getId());
+        List<SiteContent> siteContents = context.isExtractPublishedVersionsOnly()
+                ? siteContentService.findPublishedContentByPortalId(portal.getId())
+                : siteContentService.findByPortalId(portal.getId());
         for (SiteContent siteContent : siteContents) {
             siteContentService.attachChildContent(siteContent, "en");
             writeSiteContent(siteContent, context);

--- a/populate/src/main/java/bio/terra/pearl/populate/service/extract/SiteContentExtractor.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/extract/SiteContentExtractor.java
@@ -29,8 +29,8 @@ public class SiteContentExtractor {
     }
 
     public void writeSiteContents(Portal portal, ExtractPopulateContext context) {
-        List<SiteContent> siteContents = context.isExtractPublishedVersionsOnly()
-                ? siteContentService.findPublishedContentByPortalId(portal.getId())
+        List<SiteContent> siteContents = context.isExtractActiveVersionsOnly()
+                ? siteContentService.findActiveContentByPortalId(portal.getId())
                 : siteContentService.findByPortalId(portal.getId());
         for (SiteContent siteContent : siteContents) {
             siteContentService.attachChildContent(siteContent, "en");

--- a/populate/src/main/java/bio/terra/pearl/populate/service/extract/StudyExtractor.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/extract/StudyExtractor.java
@@ -86,13 +86,17 @@ public class StudyExtractor {
         studyEnvPopDto.setStudyEnvironmentConfig(
                 studyEnvironmentConfigService.find(studyEnv.getStudyEnvironmentConfigId()).orElseThrow(StudyEnvConfigMissing::new)
         );
-        if (studyEnv.getPreEnrollSurveyId() != null) {
+        if (studyEnv.getPreEnrollSurveyId() != null && context.hasEntityBeenWritten(studyEnv.getPreEnrollSurveyId())) {
             SurveyExtractor.SurveyPopDtoStub surveyPopDtoStub = new SurveyExtractor.SurveyPopDtoStub();
             surveyPopDtoStub.setPopulateFileName("../../" + context.getFileNameForEntity(studyEnv.getPreEnrollSurveyId()));
             studyEnvPopDto.setPreEnrollSurveyDto(surveyPopDtoStub);
         }
         List<StudyEnvironmentSurvey> studyEnvSurveys = studyEnvironmentSurveyService.findAllByStudyEnvId(studyEnv.getId(), null);
         for (StudyEnvironmentSurvey studyEnvSurvey : studyEnvSurveys) {;
+            if (!context.hasEntityBeenWritten(studyEnvSurvey.getSurveyId())) {
+                continue;
+            }
+
             StudyEnvironmentSurveyPopDto studyEnvSurveyPopDto = new StudyEnvironmentSurveyPopDto();
             BeanUtils.copyProperties(studyEnvSurvey, studyEnvSurveyPopDto, "id", "studyEnvironmentId", "surveyId");
             studyEnvSurveyPopDto.setPopulateFileName("../../" + context.getFileNameForEntity(studyEnvSurvey.getSurveyId()));

--- a/populate/src/main/java/bio/terra/pearl/populate/service/extract/StudyExtractor.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/extract/StudyExtractor.java
@@ -86,17 +86,13 @@ public class StudyExtractor {
         studyEnvPopDto.setStudyEnvironmentConfig(
                 studyEnvironmentConfigService.find(studyEnv.getStudyEnvironmentConfigId()).orElseThrow(StudyEnvConfigMissing::new)
         );
-        if (studyEnv.getPreEnrollSurveyId() != null && context.hasEntityBeenWritten(studyEnv.getPreEnrollSurveyId())) {
+        if (studyEnv.getPreEnrollSurveyId() != null) {
             SurveyExtractor.SurveyPopDtoStub surveyPopDtoStub = new SurveyExtractor.SurveyPopDtoStub();
             surveyPopDtoStub.setPopulateFileName("../../" + context.getFileNameForEntity(studyEnv.getPreEnrollSurveyId()));
             studyEnvPopDto.setPreEnrollSurveyDto(surveyPopDtoStub);
         }
-        List<StudyEnvironmentSurvey> studyEnvSurveys = studyEnvironmentSurveyService.findAllByStudyEnvId(studyEnv.getId(), null);
+        List<StudyEnvironmentSurvey> studyEnvSurveys = studyEnvironmentSurveyService.findAllByStudyEnvId(studyEnv.getId(), context.isExtractActiveVersionsOnly() ? true : null);
         for (StudyEnvironmentSurvey studyEnvSurvey : studyEnvSurveys) {;
-            if (!context.hasEntityBeenWritten(studyEnvSurvey.getSurveyId())) {
-                continue;
-            }
-
             StudyEnvironmentSurveyPopDto studyEnvSurveyPopDto = new StudyEnvironmentSurveyPopDto();
             BeanUtils.copyProperties(studyEnvSurvey, studyEnvSurveyPopDto, "id", "studyEnvironmentId", "surveyId");
             studyEnvSurveyPopDto.setPopulateFileName("../../" + context.getFileNameForEntity(studyEnvSurvey.getSurveyId()));

--- a/populate/src/main/java/bio/terra/pearl/populate/service/extract/SurveyExtractor.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/extract/SurveyExtractor.java
@@ -25,8 +25,8 @@ public class SurveyExtractor {
 
     /** writes all versions of all surveys to the zip file */
     public void writeSurveys(Portal portal, ExtractPopulateContext context) {
-        List<Survey> surveys = context.isExtractPublishedVersionsOnly()
-                ? surveyService.findPublishedSurveysByPortalId(portal.getId())
+        List<Survey> surveys = context.isExtractActiveVersionsOnly()
+                ? surveyService.findActiveSurveysByPortalId(portal.getId())
                 : surveyService.findByPortalId(portal.getId());
         for (Survey survey : surveys) {
             surveyService.attachAnswerMappings(survey);

--- a/populate/src/main/java/bio/terra/pearl/populate/service/extract/SurveyExtractor.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/extract/SurveyExtractor.java
@@ -25,7 +25,9 @@ public class SurveyExtractor {
 
     /** writes all versions of all surveys to the zip file */
     public void writeSurveys(Portal portal, ExtractPopulateContext context) {
-        List<Survey> surveys = surveyService.findByPortalId(portal.getId());
+        List<Survey> surveys = context.isExtractPublishedVersionsOnly()
+                ? surveyService.findPublishedSurveysByPortalId(portal.getId())
+                : surveyService.findByPortalId(portal.getId());
         for (Survey survey : surveys) {
             surveyService.attachAnswerMappings(survey);
             writeSurvey(survey, context);

--- a/populate/src/test/java/bio/terra/pearl/populate/extract/PortalExtractTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/extract/PortalExtractTest.java
@@ -71,7 +71,7 @@ public class PortalExtractTest extends BasePopulatePortalsTest {
 
     @Test
     @Transactional
-    public void testExtractOnlyPublishedVersion() throws Exception {
+    public void testExtractOnlyActiveVersions() throws Exception {
         baseSeedPopulator.populateRolesAndPermissions();
         // populate a portal, then see if we can extract it, delete it, and repopulate it
 
@@ -89,13 +89,13 @@ public class PortalExtractTest extends BasePopulatePortalsTest {
         ZipInputStream zis = new ZipInputStream(new FileInputStream(tmpFileName));
         Portal restoredPortal = portalPopulator.populateFromZipFile(zis, true, null);
 
-        List<Survey> onlyPublishedSurveys = surveyService.findByPortalId(restoredPortal.getId());
-        List<SiteContent> onlyPublishedSiteContent = siteContentService.findByPortalId(restoredPortal.getId());
+        List<Survey> onlyActiveSurveys = surveyService.findByPortalId(restoredPortal.getId());
+        List<SiteContent> onlyActiveSiteContent = siteContentService.findByPortalId(restoredPortal.getId());
 
         assertEquals(431, allSurveyVersions.size());
         assertEquals(63, allSiteContentVersions.size());
-        assertEquals(12, onlyPublishedSurveys.size());
-        assertEquals(1, onlyPublishedSiteContent.size());
+        assertEquals(12, onlyActiveSurveys.size());
+        assertEquals(1, onlyActiveSiteContent.size());
 
     }
 

--- a/populate/src/test/java/bio/terra/pearl/populate/extract/PortalExtractTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/extract/PortalExtractTest.java
@@ -38,7 +38,7 @@ public class PortalExtractTest extends BasePopulatePortalsTest {
         String tmpFileName = "/tmp/demo-%s.zip".formatted(RandomStringUtils.randomAlphanumeric(8));
         File tmpFile = new File(tmpFileName);
         FileOutputStream fos = new FileOutputStream(tmpFile);
-        portalExtractService.extract("demo", fos);
+        portalExtractService.extract("demo", fos, false);
         fos.close();
 
         // we technically don't need this manual delete since the populate below should include a delete, but just to be sure...

--- a/populate/src/test/java/bio/terra/pearl/populate/extract/PortalExtractTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/extract/PortalExtractTest.java
@@ -3,8 +3,10 @@ package bio.terra.pearl.populate.extract;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
+import bio.terra.pearl.core.model.site.SiteContent;
 import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
+import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.service.portal.PortalService;
 import bio.terra.pearl.populate.BasePopulatePortalsTest;
 import bio.terra.pearl.populate.service.contexts.FilePopulateContext;
@@ -17,11 +19,13 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.util.List;
 import java.util.Set;
 import java.util.zip.ZipInputStream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PortalExtractTest extends BasePopulatePortalsTest {
 
@@ -63,6 +67,36 @@ public class PortalExtractTest extends BasePopulatePortalsTest {
         StudyEnvironment sandboxEnv = studyEnvironmentService.findByStudy(study.getShortcode(), EnvironmentName.sandbox).orElseThrow();
         assertThat(triggerService.findByStudyEnvironmentId(sandboxEnv.getId()), hasSize(8));
         assertThat(studyEnvironmentKitTypeService.findKitTypesByStudyEnvironmentId(sandboxEnv.getId()), hasSize(1));
+    }
+
+    @Test
+    @Transactional
+    public void testExtractOnlyPublishedVersion() throws Exception {
+        baseSeedPopulator.populateRolesAndPermissions();
+        // populate a portal, then see if we can extract it, delete it, and repopulate it
+
+        Portal portal = portalPopulator.populate(new FilePopulateContext("portals/hearthive/portal.json"), true);
+
+        List<Survey> allSurveyVersions = surveyService.findByPortalId(portal.getId());
+        List<SiteContent> allSiteContentVersions = siteContentService.findByPortalId(portal.getId());
+
+        String tmpFileName = "/tmp/demo-%s.zip".formatted(RandomStringUtils.randomAlphanumeric(8));
+        File tmpFile = new File(tmpFileName);
+        FileOutputStream fos = new FileOutputStream(tmpFile);
+        portalExtractService.extract("hearthive", fos, true);
+        fos.close();
+
+        ZipInputStream zis = new ZipInputStream(new FileInputStream(tmpFileName));
+        Portal restoredPortal = portalPopulator.populateFromZipFile(zis, true, null);
+
+        List<Survey> onlyPublishedSurveys = surveyService.findByPortalId(restoredPortal.getId());
+        List<SiteContent> onlyPublishedSiteContent = siteContentService.findByPortalId(restoredPortal.getId());
+
+        assertEquals(431, allSurveyVersions.size());
+        assertEquals(63, allSiteContentVersions.size());
+        assertEquals(12, onlyPublishedSurveys.size());
+        assertEquals(1, onlyPublishedSiteContent.size());
+
     }
 
 }

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -1707,10 +1707,10 @@ export default {
     return await this.processJsonResponse(response)
   },
 
-  async extractPortal(portalShortcode: string, onlyExtractPublishedVersion: boolean) {
+  async extractPortal(portalShortcode: string, onlyExtractActiveVersions: boolean) {
     const url = `${
       basePopulateUrl()
-    }/portal/${portalShortcode}/extract?onlyExtractPublishedVersions=${onlyExtractPublishedVersion}`
+    }/portal/${portalShortcode}/extract?onlyExtractActiveVersions=${onlyExtractActiveVersions}`
     const response = await fetch(url, this.getGetInit())
     return this.processResponse(response)
   },

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -1707,8 +1707,10 @@ export default {
     return await this.processJsonResponse(response)
   },
 
-  async extractPortal(portalShortcode: string) {
-    const url = `${basePopulateUrl()}/portal/${portalShortcode}/extract`
+  async extractPortal(portalShortcode: string, onlyExtractPublishedVersion: boolean) {
+    const url = `${
+      basePopulateUrl()
+    }/portal/${portalShortcode}/extract?onlyExtractPublishedVersions=${onlyExtractPublishedVersion}`
     const response = await fetch(url, this.getGetInit())
     return this.processResponse(response)
   },

--- a/ui-admin/src/populate/ExtractPortal.tsx
+++ b/ui-admin/src/populate/ExtractPortal.tsx
@@ -14,11 +14,11 @@ export default function ExtractPortal({ initialPortalShortcode }: {initialPortal
   const [portalShortcode, setPortalShortcode] = useState(initialPortalShortcode)
   const [isLoading, setIsLoading] = useState(false)
 
-  const [onlyExtractPublishedVersions, setOnlyExtractPublishedVersions] = useState(false)
+  const [onlyExtractActiveVersions, setOnlyExtractActiveVersions] = useState(false)
 
   const doExport = async () => {
     doApiLoad(async () => {
-      const response = await Api.extractPortal(portalShortcode, onlyExtractPublishedVersions)
+      const response = await Api.extractPortal(portalShortcode, onlyExtractActiveVersions)
       const blob = await response.blob()
       const fileName = `${currentIsoDate()}-${portalShortcode}-config.zip`
       saveBlobAsDownload(blob, fileName)
@@ -39,11 +39,11 @@ export default function ExtractPortal({ initialPortalShortcode }: {initialPortal
       <input
         className="form-check-input"
         type="checkbox"
-        value={onlyExtractPublishedVersions.toString()}
-        onChange={e => setOnlyExtractPublishedVersions(e.target.checked)}
+        value={onlyExtractActiveVersions.toString()}
+        onChange={e => setOnlyExtractActiveVersions(e.target.checked)}
         id="onlyPublishedVersions"/>
       <label className="form-check-label" htmlFor="onlyPublishedVersions">
-        Only extract published content
+        Only extract active content
       </label>
     </div>
     <br/>

--- a/ui-admin/src/populate/ExtractPortal.tsx
+++ b/ui-admin/src/populate/ExtractPortal.tsx
@@ -14,9 +14,11 @@ export default function ExtractPortal({ initialPortalShortcode }: {initialPortal
   const [portalShortcode, setPortalShortcode] = useState(initialPortalShortcode)
   const [isLoading, setIsLoading] = useState(false)
 
+  const [onlyExtractPublishedVersions, setOnlyExtractPublishedVersions] = useState(false)
+
   const doExport = async () => {
     doApiLoad(async () => {
-      const response = await Api.extractPortal(portalShortcode)
+      const response = await Api.extractPortal(portalShortcode, onlyExtractPublishedVersions)
       const blob = await response.blob()
       const fileName = `${currentIsoDate()}-${portalShortcode}-config.zip`
       saveBlobAsDownload(blob, fileName)
@@ -26,10 +28,24 @@ export default function ExtractPortal({ initialPortalShortcode }: {initialPortal
 
   return <form onSubmit={e => {
     e.preventDefault()
-    if (!isLoading) { doExport() }
+    if (!isLoading) {
+      doExport()
+    }
   }}>
     <h3>Extract portal</h3>
     <PortalShortcodeControl portalShortcode={portalShortcode} setPortalShortcode={setPortalShortcode}/>
+    <br/>
+    <div className="form-check">
+      <input
+        className="form-check-input"
+        type="checkbox"
+        value={onlyExtractPublishedVersions.toString()}
+        onChange={e => setOnlyExtractPublishedVersions(e.target.checked)}
+        id="onlyPublishedVersions"/>
+      <label className="form-check-label" htmlFor="onlyPublishedVersions">
+        Only extract published content
+      </label>
+    </div>
     <br/>
     <Button variant="primary" type="button" onClick={doExport} disabled={isLoading}>
       {isLoading ? <LoadingSpinner/> : 'Download configs'}


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

While there are more versioned objects, this _only_ deals with site content and surveys. They're really the only things that are making the extracts huge.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
- populate hearthive
- for extra completeness, make some changes to surveys and to site content to create versions in different environments
- extract with `only active content` checked & repopulate
- observe that the downloaded zip file was small & that there is no history in the repopoulated portal
