### PR TITLE
[JN-1475] Low-hanging fruit memory/query improvements for enrollee export

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/ParticipantUserDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/ParticipantUserDao.java
@@ -31,6 +31,10 @@ public class ParticipantUserDao extends BaseMutableJdbiDao<ParticipantUser> {
       return findByProperty("shortcode", shortcode);
    }
 
+   public List<ParticipantUser> findByParticipantUserIds(List<UUID> participantUserIds) {
+      return findAllByPropertyCollection("id", participantUserIds);
+   }
+
    public Optional<ParticipantUser> findByEnrolleeId(UUID enrolleeId) {
       return jdbi.withHandle(handle -> handle.createQuery("""
                       SELECT pu.* FROM participant_user pu

--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/ProfileDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/ProfileDao.java
@@ -5,6 +5,7 @@ import bio.terra.pearl.core.model.participant.Profile;
 import org.jdbi.v3.core.Jdbi;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -29,5 +30,15 @@ public class ProfileDao extends BaseMutableJdbiDao<Profile> {
             }
         });
         return profileOpt;
+    }
+
+    public List<Profile> loadAllWithMailingAddress(List<UUID> profileIds) {
+        List<Profile> profiles = findAll(profileIds);
+        profiles.forEach(profile -> {
+            if (profile.getMailingAddressId() != null) {
+                profile.setMailingAddress(mailingAddressDao.find(profile.getMailingAddressId()).get());
+            }
+        });
+        return profiles;
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/dao/survey/AnswerDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/survey/AnswerDao.java
@@ -5,10 +5,8 @@ import bio.terra.pearl.core.model.survey.Answer;
 import org.jdbi.v3.core.Jdbi;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Component
 public class AnswerDao extends BaseMutableJdbiDao<Answer> {
@@ -52,6 +50,11 @@ public class AnswerDao extends BaseMutableJdbiDao<Answer> {
 
     public List<Answer> findByEnrollee(UUID enrolleeId) {
         return findAllByProperty("enrollee_id", enrolleeId);
+    }
+
+    public Map<UUID, List<Answer>> findByEnrolleeIds(Collection<UUID> enrolleeIds) {
+        return findAllByPropertyCollection("enrollee_id", enrolleeIds)
+                .stream().collect(Collectors.groupingBy(Answer::getEnrolleeId, Collectors.toList()));
     }
 
     public List<Answer> findByEnrolleeAndSurvey(UUID enrolleeId, String surveyStableId) {

--- a/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyResponseDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyResponseDao.java
@@ -9,6 +9,7 @@ import org.jdbi.v3.core.Jdbi;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Component
 public class SurveyResponseDao extends BaseMutableJdbiDao<SurveyResponse> {
@@ -29,6 +30,11 @@ public class SurveyResponseDao extends BaseMutableJdbiDao<SurveyResponse> {
 
     public List<SurveyResponse> findByEnrolleeId(UUID enrolleeId) {
         return findAllByProperty("enrollee_id", enrolleeId);
+    }
+
+    public Map<UUID, List<SurveyResponse>> findByEnrolleeIds(Collection<UUID> enrolleeIds) {
+        return findAllByPropertyCollection("enrollee_id", enrolleeIds)
+                .stream().collect(Collectors.groupingBy(SurveyResponse::getEnrolleeId, Collectors.toList()));
     }
 
     /**

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
@@ -222,6 +222,8 @@ public class EnrolleeExportService {
         List<UUID> profileIds = enrollees.stream().map(Enrollee::getProfileId).toList();
         List<UUID> participantUserIds = enrollees.stream().map(Enrollee::getParticipantUserId).toList();
 
+        // batch load the following modules to reduce the number of queries and reduce the memory footprint of data exports.
+        // eventually, the in-clauses of these sql queries will be too large, and we'll need to batch load these in smaller chunks
         Map<UUID, Profile> profiles = profileService.loadAllWithMailingAddress(profileIds);
         Map<UUID, ParticipantUser> participantUsers = participantUserService.findByParticipantUserIds(participantUserIds);
         Map<UUID, List<Answer>> answers = answerDao.findByEnrolleeIds(enrolleeIds);

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeRelationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeRelationService.java
@@ -19,6 +19,8 @@ import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static java.util.Arrays.stream;
+
 @Service
 public class EnrolleeRelationService extends ParticipantDataAuditedService<EnrolleeRelation, EnrolleeRelationDao> {
     private final EnrolleeService enrolleeService;

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeRelationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeRelationService.java
@@ -19,8 +19,6 @@ import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static java.util.Arrays.stream;
-
 @Service
 public class EnrolleeRelationService extends ParticipantDataAuditedService<EnrolleeRelation, EnrolleeRelationDao> {
     private final EnrolleeService enrolleeService;

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/ParticipantUserService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/ParticipantUserService.java
@@ -8,10 +8,8 @@ import bio.terra.pearl.core.service.CrudService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 public class ParticipantUserService extends CrudService<ParticipantUser, ParticipantUserDao> {
@@ -62,6 +60,12 @@ public class ParticipantUserService extends CrudService<ParticipantUser, Partici
 
     public Optional<ParticipantUser> findByEnrolleeId(UUID enrolleeId) {
         return dao.findByEnrolleeId(enrolleeId);
+    }
+
+    public Map<UUID, ParticipantUser> findByParticipantUserIds(List<UUID> participantUserIds) {
+        return dao.findByParticipantUserIds(participantUserIds)
+                .stream()
+                .collect(Collectors.toMap(ParticipantUser::getId, participantUser -> participantUser));
     }
 
     public List<ParticipantUser> findAllByPortalEnv(UUID portalId, EnvironmentName envName) {

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/ProfileService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/ProfileService.java
@@ -13,10 +13,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 public class ProfileService extends ParticipantDataAuditedService<Profile, ProfileDao> {
@@ -39,6 +38,11 @@ public class ProfileService extends ParticipantDataAuditedService<Profile, Profi
 
     public Optional<Profile> loadWithMailingAddress(UUID profileId) {
         return dao.loadWithMailingAddress(profileId);
+    }
+
+    public Map<UUID, Profile> loadAllWithMailingAddress(List<UUID> profileIds) {
+        return dao.loadAllWithMailingAddress(profileIds).stream()
+                .collect(Collectors.toMap(Profile::getId, Function.identity()));
     }
 
     @Transactional

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -63,6 +63,10 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         return dao.findByEnrolleeId(enrolleeId);
     }
 
+    public Map<UUID, List<SurveyResponse>> findByEnrolleeIds(List<UUID> enrolleeIds) {
+        return dao.findByEnrolleeIds(enrolleeIds);
+    }
+
     public Optional<SurveyResponse> findOneWithAnswers(UUID responseId) {
         return dao.findOneWithAnswers(responseId);
     }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Takes care of some low-hanging fruit in enrollee export by batch loading several modules. Obviously this drastically reduces the number of queries, but the more important bit is that the memory footprint for `loadEnrolleeExportData` was reduced by about 30-40% in OurHealth (with ~1000 enrollees, very little data, but the same survey configurations as production, so the same number of columns). The results were consistently repeatable, here's one before/after screenshot:

Before:
<img width="1435" alt="Screenshot 2024-11-13 at 12 53 19 PM" src="https://github.com/user-attachments/assets/82e0730d-ec59-4cad-a639-bf35c04d8026">

After:
<img width="1444" alt="Screenshot 2024-11-13 at 12 54 20 PM" src="https://github.com/user-attachments/assets/dff4a7a0-a96a-4449-a067-98c27e18fb55">

Obviously from the screenshots, there are other areas we can improve on. Notably:

* `CSVPrinter.printRecord` is very memory intensive- requiring about half a gig in this test (to write a measley 5.4MB TSV...). I didn't see an immediate obvious way to reduce this so I left it alone for the time being.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Confirm data export still works as expected