### PR TITLE
[JN-1432] Add kit label (mf barcode) to data export

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/KitRequestFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/KitRequestFormatter.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 
 public class KitRequestFormatter extends BeanListModuleFormatter<KitRequestDto> {
     private static final List<String> KIT_REQUEST_INCLUDED_PROPERTIES =
-            List.of("status", "sentToAddress", "sentAt", "receivedAt", "createdAt", "labeledAt",
+            List.of("status", "sentToAddress", "sentAt", "receivedAt", "createdAt", "labeledAt", "kitLabel",
                     "trackingNumber", "returnTrackingNumber", "skipAddressValidation");
 
     public KitRequestFormatter(ExportOptions options) {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

This field was missing from data export.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Do an export and confirm that the kit label was exported