### PR TITLE
[JN-1430] adding distribution method to export

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/KitRequestFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/KitRequestFormatter.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 
 public class KitRequestFormatter extends BeanListModuleFormatter<KitRequestDto> {
     private static final List<String> KIT_REQUEST_INCLUDED_PROPERTIES =
-            List.of("status", "sentToAddress", "sentAt", "receivedAt", "createdAt", "labeledAt", "kitLabel",
+            List.of("status", "distributionMethod", "sentToAddress", "sentAt", "receivedAt", "createdAt", "labeledAt", "kitLabel",
                     "trackingNumber", "returnTrackingNumber", "skipAddressValidation");
 
     public KitRequestFormatter(ExportOptions options) {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Aarushi just asked for this, and it made sense.  Also, I couldn't let Matt get away with all the one-word-change PRs...

<img width="1166" alt="image" src="https://github.com/user-attachments/assets/8793ba1b-81f8-4d2a-afb2-f754ba6acf32">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy apiAdminApp
2. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/export/dataBrowser
3. confirm sampleKit.distributionMethod appears