### PR TITLE
[no ticket yet] make gcp artifact upload more secure

### DIFF
--- a/terraform/infra/github_artifact_registry.tf
+++ b/terraform/infra/github_artifact_registry.tf
@@ -31,10 +31,11 @@ resource "google_iam_workload_identity_pool_provider" "github_actions_pool_provi
     "attribute.repository_id"    = "assertion.repository_id"
     "attribute.repository_owner" = "assertion.repository_owner"
     "attribute.repository_owner_id" = "assertion.repository_owner_id"
+    "attribute.ref"              = "assertion.ref"
   }
 
   # NOTE: this is what restricts external access, this ids are from github
-  attribute_condition = "assertion.repository_owner_id == '393552' && assertion.repository_id == '566938309'"
+  attribute_condition = "assertion.repository_owner_id == '393552' && assertion.repository_id == '566938309' && assertion.ref == 'refs/heads/development'"
   oidc {
     allowed_audiences = []
     issuer_uri = "https://token.actions.githubusercontent.com"


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Some random slack thread pointed out that you can actually, technically, use these SA keys to change our artifacts from any branch unless you specify a ref. So, this ref check makes our artifact registry more secure because some random person can't come in and open a PR and then trigger uploading some malicious images. With this, it would fail - image uploads must come from the development branch.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- n/a, we'll have to see if it works when I merge or if it fails to upload!