### PR TITLE
[JN-1491] downgrading no matching state to warning

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/log/LogEventType.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/log/LogEventType.java
@@ -2,8 +2,10 @@ package bio.terra.pearl.core.model.log;
 
 public enum LogEventType {
   ERROR, // an error occurred
+  WARN, // something that might be a concern, but does not require action
   ACCESS, // someone requesting a resource
   EVENT, // an ApplicationEvent was fired
   STATS, // stats measurement -- e.g. webVitals
   INFO // something interesting that isn't an error
+
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/log/LogEventType.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/log/LogEventType.java
@@ -7,5 +7,4 @@ public enum LogEventType {
   EVENT, // an ApplicationEvent was fired
   STATS, // stats measurement -- e.g. webVitals
   INFO // something interesting that isn't an error
-
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/LoggingService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/LoggingService.java
@@ -47,6 +47,8 @@ public class LoggingService {
     String eventString = formatEventString(createdEvent);
     if (LogEventType.ERROR.equals(event.getEventType())) {
       logger.error(eventString);
+    } else if (LogEventType.WARN.equals(event.getEventType())) {
+      logger.warn(eventString);
     } else {
       logger.info(eventString);
     }

--- a/ui-core/src/types/logging.ts
+++ b/ui-core/src/types/logging.ts
@@ -1,6 +1,6 @@
 export type LogEvent = {
     id?: string,
-    eventType: 'ERROR' | 'ACCESS' | 'EVENT' | 'STATS' | 'INFO'
+    eventType: 'ERROR' | 'ACCESS' | 'EVENT' | 'STATS' | 'INFO' | 'WARN',
     eventName: string,
     stackTrace?: string,
     eventDetail?: string,

--- a/ui-participant/src/util/loggingUtils.ts
+++ b/ui-participant/src/util/loggingUtils.ts
@@ -62,6 +62,11 @@ export type ErrorEventDetail = {
   responseCode?: number
 }
 
+/** events that are triggered as errors but we want to treat as warnings */
+const warningEvents = [
+  'No matching state found in storage'
+]
+
 /** specific helper function for logging an error */
 export const logError = (detail: ErrorEventDetail, stackTrace: string | undefined, eventName= 'jserror') => {
   if (!isBrowserCompatible()) {
@@ -73,10 +78,12 @@ export const logError = (detail: ErrorEventDetail, stackTrace: string | undefine
     })
   } else {
     log({
-      eventType: 'ERROR',
+      eventType: warningEvents.includes(detail.message) ? 'WARN' : 'ERROR',
       eventName,
       eventDetail: `${stringify(detail)}\n${window.location.href}`,
       stackTrace
     })
   }
 }
+
+


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Downgrades "No matching state" to a warning, since this error is user-recoverable and often user-caused (either by browser cookie settings or misuse of B2C link

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  insert a `throw new Error('No matching state found in storage')` somewhere in the participant UI
2. confirm it gets logged as a WARN, not an error