### PR TITLE
[JN-1493] adding deployment zone helm var

### DIFF
--- a/terraform/gcp/k8s/environments/dev.yaml
+++ b/terraform/gcp/k8s/environments/dev.yaml
@@ -1,6 +1,7 @@
 gcpProject: broad-juniper-dev
 gcpRegion: us-central1
 adminUrl: juniper-cmi.dev
+deploymentZone: dev
 appVersion: 1.4.63
 replicas: 1
 # "portals" adds certificates for each portal - both for the juniper-cmi.dev subdomains and the custom domain

--- a/terraform/gcp/k8s/environments/prod.yaml
+++ b/terraform/gcp/k8s/environments/prod.yaml
@@ -1,6 +1,7 @@
 gcpProject: broad-juniper-prod
 gcpRegion: us-central1
 adminUrl: juniper-cmi.org
+deploymentZone: prod
 replicas: 3
 # "portals" adds certificates for each portal - both for the admin subdomains and the custom domain
 portals:

--- a/terraform/gcp/k8s/templates/admin-deployment.yml
+++ b/terraform/gcp/k8s/templates/admin-deployment.yml
@@ -93,7 +93,7 @@ spec:
             - name: DATABASE_NAME
               value: "d2p"
             - name: DEPLOYMENT_ZONE
-              value: dev
+              value: {{ .Values.deploymentZone }}
             - name: ADMIN_API_HOSTNAME
               value: {{ .Values.adminUrl }}
             - name: ADMIN_UI_HOSTNAME


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds a variable to distinguish dev/prod deployments


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

After merge/deploy, confirm the sidebar coloring of the dev and prod environments are correct