### PR TITLE
[JN-1139] Add website back to sidebar

### DIFF
--- a/ui-admin/src/navbar/StudySidebar.tsx
+++ b/ui-admin/src/navbar/StudySidebar.tsx
@@ -7,6 +7,7 @@ import {
   useNavigate
 } from 'react-router-dom'
 import {
+  siteContentPath,
   studyKitsPath,
   studyParticipantsPath
 } from 'portal/PortalRouter'
@@ -96,6 +97,10 @@ export const StudySidebar = ({ study, portalList, portalShortcode }:
         }
       </ul>}/>
       <CollapsableMenu header={'Design & Build'} content={<ul className="list-unstyled">
+        <li className="mb-2">
+          <NavLink to={siteContentPath(portalShortcode, 'sandbox')}
+            className={sidebarNavLinkClasses} style={navStyleFunc}>Website</NavLink>
+        </li>
         <li className="mb-2">
           <NavLink to={studyEnvFormsPath(portalShortcode, study.shortcode, 'sandbox')}
             className={sidebarNavLinkClasses} style={navStyleFunc}>Forms &amp; Surveys</NavLink>


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

it's back 

<img width="276" alt="Screenshot 2024-11-19 at 1 09 09 PM" src="https://github.com/user-attachments/assets/c5fea211-592f-4086-af97-5d34ea47e83b">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

