### PR TITLE
[JN-1139] Study team widget cleanup

### DIFF
--- a/ui-admin/src/portal/dashboard/widgets/StudyTeamWidget.tsx
+++ b/ui-admin/src/portal/dashboard/widgets/StudyTeamWidget.tsx
@@ -40,17 +40,21 @@ export const StudyTeamWidget = ({ portal }: { portal: Portal }) => {
       </InfoCardHeader>
       <InfoCardBody>
         <LoadingSpinner isLoading={isLoadingRoles || isLoadingUsers}>
-          { /* filter out superusers; they transcend portals */ }
-          {users.filter(u => !u.superuser).map(user => {
-            return (
-              <div className={'mb-1'} key={user.id}>{user.username}
-                {user.portalAdminUsers![0].portalAdminUserRoles.map(role => {
-                  return <span key={`${user.id}-${role.id}`} className="ms-1 badge bg-primary">
-                    {roles.find(r => r.id === role.roleId)?.displayName}</span>
-                })}
-              </div>
-            )
-          })}
+          {users.length === 0 ?
+            <div className={'text-muted fst-italic'}>No team members</div> :
+            <ul className='list-unstyled mb-0'>
+              { /* filter out superusers; they transcend portals */ }
+              {users.filter(u => !u.superuser).map(user => {
+                return (
+                  <li className={'mb-1'} key={user.id}>{user.username}
+                    {user.portalAdminUsers![0].portalAdminUserRoles.map(role => {
+                      return <span key={`${user.id}-${role.id}`} className="ms-1 badge bg-primary">
+                        {roles.find(r => r.id === role.roleId)?.displayName}</span>
+                    })}
+                  </li>
+                )
+              })}
+            </ul>}
         </LoadingSpinner>
       </InfoCardBody>
     </InfoCard>


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

From team testing. If team members didn't have any assigned roles, they'd all group together on the same line. Also adds a message when you do not have any team members.

Before:
<img width="512" alt="Screenshot 2024-11-19 at 2 25 51 PM" src="https://github.com/user-attachments/assets/ba908f4c-ec8a-466d-9741-97f8cbfcda1a">


After
<img width="507" alt="Screenshot 2024-11-19 at 2 26 56 PM" src="https://github.com/user-attachments/assets/dcca78fb-7750-4309-9d97-1374d9aa53e6">

<img width="519" alt="Screenshot 2024-11-19 at 2 25 03 PM" src="https://github.com/user-attachments/assets/3b27c9ce-7679-4e9b-b27b-46f795ce764f">




#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Repopulate OurHealth
Remove all roles from team members
Confirm UX looks better