### PR TITLE
[JN-1483] Fix default live participant url

### DIFF
--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -1785,7 +1785,11 @@ export default {
     if (portalEnvConfig?.participantHostname) {
       return `https://${portalEnvConfig.participantHostname}`
     }
-    const participantHost = `${envName}.${portalShortcode}.${uiHostname}`
+
+    // live is a special case where we don't include the env name in the url
+    const participantHost = envName === 'live' ?
+        `${portalShortcode}.${uiHostname}` :
+        `${envName}.${portalShortcode}.${uiHostname}`
     return `https://${participantHost}`
   },
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

When a study doesn't have a custom domain configured, the participant url for the live environment was incorrect in the admin tool. We do not provision live subdomains, so this should just link out to {portalShortcode}.juniper.terra.bio for live

This was impacting gvasc

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Go to https://localhost:3000/ourhealth/env/live/siteContent
Confirm Participant view goes to https://ourhealth.localhost:3001/