### PR TITLE
[JN-1480] Standardize test coverage reporting, fix admin and participant reports

### DIFF
--- a/api-admin/build.gradle
+++ b/api-admin/build.gradle
@@ -68,5 +68,18 @@ copyWebApp.dependsOn(rootProject.bundleAdminUI)
 jibDockerBuild.dependsOn('copyWebApp')
 
 test {
-    useJUnitPlatform ()
+    useJUnitPlatform {
+        // By default, exclude `@IntegrationTest`s
+        excludeTags "integration"
+    }
+    finalizedBy jacocoTestReport // report is always generated after tests run
+}
+
+jacocoTestReport {
+    dependsOn test // tests are required to run before generating the report
+}
+
+jacoco {
+    toolVersion = "0.8.9"
+    reportsDirectory = layout.buildDirectory.dir('code-coverage')
 }

--- a/api-admin/build.gradle
+++ b/api-admin/build.gradle
@@ -77,6 +77,11 @@ test {
 
 jacocoTestReport {
     dependsOn test // tests are required to run before generating the report
+    classDirectories.setFrom(
+        files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: ['bio/terra/pearl/api/admin/api'])
+        })
+    )
 }
 
 jacoco {

--- a/api-participant/build.gradle
+++ b/api-participant/build.gradle
@@ -80,5 +80,18 @@ task createUnfingerprintedAssets(type: Copy) {
 jibDockerBuild.dependsOn('createUnfingerprintedAssets')
 
 test {
-    useJUnitPlatform ()
+    useJUnitPlatform {
+        // By default, exclude `@IntegrationTest`s
+        excludeTags "integration"
+    }
+    finalizedBy jacocoTestReport // report is always generated after tests run
+}
+
+jacocoTestReport {
+    dependsOn test // tests are required to run before generating the report
+}
+
+jacoco {
+    toolVersion = "0.8.9"
+    reportsDirectory = layout.buildDirectory.dir('code-coverage')
 }

--- a/api-participant/build.gradle
+++ b/api-participant/build.gradle
@@ -89,6 +89,11 @@ test {
 
 jacocoTestReport {
     dependsOn test // tests are required to run before generating the report
+    classDirectories.setFrom(
+        files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: ['bio/terra/pearl/api/participant/api'])
+        })
+    )
 }
 
 jacoco {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -107,7 +107,7 @@ jacocoTestReport {
 
 jacoco {
     toolVersion = "0.8.9"
-    reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir')
+    reportsDirectory = layout.buildDirectory.dir('code-coverage')
 }
 
 // Explicitly run `@IntegrationTest`s that are excluded from default test runs: `./gradlew integrationTest`

--- a/pepper-import/build.gradle
+++ b/pepper-import/build.gradle
@@ -61,5 +61,5 @@ jacocoTestReport {
 
 jacoco {
     toolVersion = "0.8.9"
-    reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir')
+    reportsDirectory = layout.buildDirectory.dir('code-coverage')
 }

--- a/populate/build.gradle
+++ b/populate/build.gradle
@@ -45,5 +45,5 @@ jacocoTestReport {
 
 jacoco {
     toolVersion = "0.8.9"
-    reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir')
+    reportsDirectory = layout.buildDirectory.dir('code-coverage')
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

At some point, code coverage reports stopped being generated for api-admin and api-participant. This fixes that and also standardizes the directory structure across java modules

Code coverage confluence page has been updated with new file paths and latest numbers: https://broadworkbench.atlassian.net/wiki/spaces/PEARL/pages/2842230785/Code+coverage

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Run `./gradlew clean jacocoTestReport`

Confirm code coverage is reported in the following directories:

`/juniper/api-admin/build/code-coverage/test/html/index.html`
`/juniper/api-participant/build/code-coverage/test/html/index.html`
`/juniper/core/build/code-coverage/test/html/index.html`
`/juniper/populate/build/code-coverage/test/html/index.html`