### PR TITLE
[JN-1506] Fix admin sidebar for non superusers

### DIFF
--- a/ui-admin/src/navbar/AdminSidebar.tsx
+++ b/ui-admin/src/navbar/AdminSidebar.tsx
@@ -1,6 +1,13 @@
-import React, { useEffect, useState } from 'react'
+import React, {
+  useEffect,
+  useState
+} from 'react'
 import { useUser } from '../user/UserProvider'
-import { Link, NavLink, useParams } from 'react-router-dom'
+import {
+  Link,
+  NavLink,
+  useParams
+} from 'react-router-dom'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCaretRight } from '@fortawesome/free-solid-svg-icons'
 import { Study } from '@juniper/ui-core'
@@ -37,9 +44,6 @@ const AdminSidebar = ({ config }: { config: Config }) => {
     studyList = portalList.flatMap(portal => portal.portalStudies.map(ps => ps.study))
   }
 
-  if (!user || (!user.superuser && !portalShortcode)) {
-    return <div></div>
-  }
   const currentStudy = studyList.find(study => study.shortcode === studyShortcode)
 
   const color = ZONE_COLORS[config.deploymentZone] || ZONE_COLORS['prod']
@@ -50,6 +54,10 @@ const AdminSidebar = ({ config }: { config: Config }) => {
       setOpen(false)
     }
   }, [])
+
+  if (!user || (!user.superuser && !portalShortcode)) {
+    return <div></div>
+  }
 
   return <div style={{ backgroundColor: color, minHeight: '100vh', minWidth: open ? '250px' : '50px' }}
     className="p-2 pt-3">


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Before, going to the homepage of juniper (where you select a portal) would be broken for non-superusers. This is because react will freak out if you `return` early (there can't be any hooks that are conditional - since we had a useEffect between the returns, react didn't like it).

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- log in as heartdemostaff
- click "Home" & select portal