### PR TITLE
[JN-1503] Fix participant survey double scrollbar

### DIFF
--- a/ui-core/src/surveyjs/surveyJsStyle.scss
+++ b/ui-core/src/surveyjs/surveyJsStyle.scss
@@ -23,6 +23,10 @@
   }
 }
 
+.sd-progress__text {
+  padding: 1em 0em 0em 0em;
+}
+
 //scale down all html headers for mobile devices
 @media (max-width: 768px) {
   .sd-html h1 {

--- a/ui-participant/src/studies/enroll/PreEnroll.tsx
+++ b/ui-participant/src/studies/enroll/PreEnroll.tsx
@@ -91,7 +91,7 @@ export default function PreEnrollView({ enrollContext, survey }:
     <div style={{ background: '#f3f3f3' }} className="flex-grow-1">
       <SurveyReviewModeButton surveyModel={surveyModel} envName={studyEnv.environmentName}/>
       <SurveyAutoCompleteButton surveyModel={surveyModel} envName={studyEnv.environmentName}/>
-      {SurveyComponent}
+      <div className="mb-2">{SurveyComponent}</div>
     </div>
   )
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

The issue wasn't isolated to pre-enrolls, although that's where we first noticed it. The issue is actually related to the CSS for surveys with certain progress bars, i.e.` "progressBarType": "requiredQuestions"`

This overrides the bit of CSS that was causing the double scrollbar

Before
![before](https://github.com/user-attachments/assets/af1c5496-5b72-4084-998f-18e4ab577b9d)

After
![after](https://github.com/user-attachments/assets/e6439c59-7c64-4b71-a3a9-c3c3926b8eaf)


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Go to pre-enroll for heartdemo https://sandbox.demo.localhost:3001/studies/heartdemo/join/preEnroll

Confirm no double scrollbar