### PR TITLE
[JN-1513] fix markdown issues

### DIFF
--- a/ui-core/src/surveyUtils.tsx
+++ b/ui-core/src/surveyUtils.tsx
@@ -396,11 +396,13 @@ export function useSurveyJSModel(
 
 /** apply markdown to the given surveyJS entity */
 export const applyMarkdown = (sender: SurveyModel, options: TextMarkdownEvent) => {
-  const markdownText = micromark(options.text)
+  const markdownText = micromark(options.text).trim()
   // chop off <p> tags.
   // See https://surveyjs.io/form-library/examples/edit-survey-questions-markdown/reactjs#content-code
   if (markdownText.startsWith('<p>') && markdownText.endsWith('</p>')) {
     options.html = markdownText.substring(3, markdownText.length - 4)
+  } else {
+    options.html = markdownText
   }
 }
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

AT aggressively uses markdown. Dunno if it broke before or after surveyjs upgrade but our markdown was wonky and only sometimes got applied.

![image](https://github.com/user-attachments/assets/0ec72cd9-623c-47e4-8f50-1046523d0e1b)



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- add markdown to different quesitons and make sure it always applies
- make sure existing surveys look good / the same