### PR TITLE
[JN-1457] Fix a bunch of deprecation warnings

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/admin/AdminUserController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/admin/AdminUserController.java
@@ -6,7 +6,6 @@ import bio.terra.pearl.api.admin.service.auth.AuthUtilService;
 import bio.terra.pearl.api.admin.service.auth.context.OperatorAuthContext;
 import bio.terra.pearl.api.admin.service.auth.context.PortalAuthContext;
 import bio.terra.pearl.core.model.admin.AdminUser;
-import bio.terra.pearl.core.service.admin.PortalAdminUserRoleService;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
@@ -22,21 +21,18 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class AdminUserController implements AdminUserApi {
-  private AdminUserExtService adminUserExtService;
-  private AuthUtilService authUtilService;
-  private PortalAdminUserRoleService portalAdminUserRoleService;
-  private HttpServletRequest request;
-  private ObjectMapper objectMapper;
+  private final AdminUserExtService adminUserExtService;
+  private final AuthUtilService authUtilService;
+  private final HttpServletRequest request;
+  private final ObjectMapper objectMapper;
 
   public AdminUserController(
       AdminUserExtService adminUserExtService,
       AuthUtilService authUtilService,
-      PortalAdminUserRoleService portalAdminUserRoleService,
       HttpServletRequest request,
       ObjectMapper objectMapper) {
     this.adminUserExtService = adminUserExtService;
     this.authUtilService = authUtilService;
-    this.portalAdminUserRoleService = portalAdminUserRoleService;
     this.request = request;
     this.objectMapper = objectMapper;
   }
@@ -76,7 +72,7 @@ public class AdminUserController implements AdminUserApi {
     AdminUser createdUser =
         adminUserExtService.createSuperuser(
             OperatorAuthContext.of(operator), newUser.getUsername());
-    return new ResponseEntity(createdUser, HttpStatus.CREATED);
+    return new ResponseEntity<>(createdUser, HttpStatus.CREATED);
   }
 
   /**
@@ -91,7 +87,7 @@ public class AdminUserController implements AdminUserApi {
             PortalAuthContext.of(operator, portalShortcode),
             newUser.getUsername(),
             newUser.getRoleNames());
-    return new ResponseEntity(createdUser, HttpStatus.CREATED);
+    return new ResponseEntity<>(createdUser, HttpStatus.CREATED);
   }
 
   @Override

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/ConfigExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/ConfigExtServiceTests.java
@@ -89,8 +89,10 @@ public class ConfigExtServiceTests {
             testPepperConfig,
             testAddrConfig,
             airtableConfig);
+    @SuppressWarnings("unchecked")
     Map<String, ?> dsmConfigMap =
         (Map<String, ?>) configExtService.getInternalConfigMap(user).get("pepperDsmConfig");
+    @SuppressWarnings("unchecked")
     Map<String, ?> addressValidationConfigMap =
         (Map<String, ?>) configExtService.getInternalConfigMap(user).get("addrValidationConfig");
     assertThat(dsmConfigMap.get("basePath"), equalTo("basePath1"));

--- a/core/src/test/java/bio/terra/pearl/core/service/address/SmartyInternationalAddressValidationServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/address/SmartyInternationalAddressValidationServiceTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.IOException;
 
@@ -20,7 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 
 class SmartyInternationalAddressValidationServiceTest extends BaseSpringBootTest {
 
-    @MockBean
+    @MockitoBean
     private SmartyClient mockSmartyClient;
 
     // all the candidates below come from real responses via

--- a/core/src/test/java/bio/terra/pearl/core/service/address/SmartyUSAddressValidationServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/address/SmartyUSAddressValidationServiceTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.io.IOException;
 import java.util.List;
@@ -21,7 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 
 class SmartyUSAddressValidationServiceTest extends BaseSpringBootTest {
 
-    @MockBean
+    @MockitoBean
     private SmartyClient mockSmartyClient;
 
     // all the candidates below come from real responses via

--- a/core/src/test/java/bio/terra/pearl/core/service/fileupload/ParticipantFileServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/fileupload/ParticipantFileServiceTest.java
@@ -8,7 +8,7 @@ import bio.terra.pearl.core.service.fileupload.backends.LocalFileStorageBackend;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.ByteArrayInputStream;
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.when;
 class ParticipantFileServiceTest extends BaseSpringBootTest {
 
 
-    @MockBean
+    @MockitoBean
     private LocalFileStorageBackend localFileStorageBackend;
 
     @Autowired

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
@@ -37,8 +37,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
@@ -559,11 +559,11 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
     }
 
 
-    @MockBean
+    @MockitoBean
     private StubPepperDSMClient mockPepperDSMClient;
-    @MockBean
+    @MockitoBean
     private LivePepperDSMClient livePepperDSMClient;
-    @MockBean
+    @MockitoBean
     private EventService mockEventService;
     @Autowired
     private AdminUserFactory adminUserFactory;

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/KitTaskDispatcherTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/KitTaskDispatcherTest.java
@@ -22,14 +22,14 @@ import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 class KitTaskDispatcherTest extends BaseSpringBootTest {
 
     @Autowired
     private EnrolleeFactory enrolleeFactory;
-    @MockBean
+    @MockitoBean
     private ParticipantTaskService mockTaskService;
 
     @Test

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientTest.java
@@ -18,9 +18,9 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
@@ -45,7 +45,7 @@ public class LivePepperDSMClientTest extends BaseSpringBootTest {
     private KitRequestFactory kitRequestFactory;
     @Autowired
     private ObjectMapper objectMapper;
-    @MockBean
+    @MockitoBean
     private LivePepperDSMClient.PepperDSMConfig pepperDSMConfig;
 
     // select the LivePepperDSMClient @Component, not PepperDSMClientProvider.getLivePepperDSMClient()


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

After accepting a bunch of recent updates from Dependabot, we've accumulated a lot of compilation warnings, mostly due to `@MockBean` being replaced with `@MockitoBean`

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Run `./gradlew clean test`
Confirm there isn't very much console spam