### PR TITLE
[JN-1489] fixing survey ordering bug on populate

### DIFF
--- a/populate/src/main/java/bio/terra/pearl/populate/service/SurveyPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/SurveyPopulator.java
@@ -58,7 +58,7 @@ public class SurveyPopulator extends BasePopulator<Survey, SurveyPopDto, PortalP
     }
 
     public StudyEnvironmentSurvey convertConfiguredSurvey(StudyEnvironmentSurveyPopDto configuredSurveyDto,
-                                                          int index, FilePopulateContext context, String portalShortcode) {
+                                                          FilePopulateContext context, String portalShortcode) {
         StudyEnvironmentSurvey configuredSurvey = new StudyEnvironmentSurvey();
         BeanUtils.copyProperties(configuredSurveyDto, configuredSurvey);
         Survey survey;
@@ -70,7 +70,6 @@ public class SurveyPopulator extends BasePopulator<Survey, SurveyPopDto, PortalP
         }
         configuredSurvey.setSurveyId(survey.getId());
         configuredSurvey.setSurvey(survey);
-        configuredSurvey.setSurveyOrder(index);
         return configuredSurvey;
     }
 

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
@@ -45,6 +45,7 @@
         "populateFileName": "surveys/preEnroll.json"
       },
       "configuredSurveyDtos": [
+        {"populateFileName": "surveys/ourHealthConsent.json"},
         {"populateFileName": "surveys/basic.json"},
         {"populateFileName": "surveys/cardioHistory.json"},
         {"populateFileName": "surveys/medicalHistory.json"},
@@ -57,7 +58,6 @@
         {"populateFileName": "surveys/socialHealthV3.json"},
         {"populateFileName": "surveys/lostInterest.json"},
         {"populateFileName": "surveys/depressionOutreach.json"},
-        {"populateFileName": "surveys/ourHealthConsent.json"},
         {"populateFileName": "surveys/massachusettsSurvey.json"}
       ],
       "triggerDtos": [{


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Populate was naively taking survey order from the index of the config in the populate file.  This is no longer appropriate given that we now have different survey types, and sometimes populate past versions of a survey.  AFAIK this bug has no user-visible impacts, since the relative ordering is still correct.  But it means that HeartHive's survey orders are a mess in prod since at one point HeartHive was extracted and repopulated from the extract.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy apiAdminApp
2. repopulate demo
3. run `select ses.id, environment_name, ses.survey_order, active, stable_id, version from study_environment_survey ses join survey on survey_id = survey.id join study_environment on study_environment_id = study_environment.id join study on study.id = study_environment.study_id where shortcode  = 'heartdemo' order by environment_name, survey_order;`
4. confirm you see that all three versions of the social health survey in sandbox got assigned order '7'
```
fae62185-0d47-40e4-8d7a-6e2cb28b27e9 | sandbox          |            0 | t      | depressionOutreach  |       1
 bc837fd6-f7e8-4df5-bd85-cabe1d4c5b01 | sandbox          |            0 | t      | hd_hd_basicInfo     |       1
 11553862-d64e-4bac-9834-7c9a8e350b9f | sandbox          |            0 | t      | hd_hd_consent       |       1
 8a3d034a-404d-4d5a-bf4c-e7d1eeba638c | sandbox          |            1 | t      | hd_hd_cardioHx      |       1
 0e903486-8bdb-4833-bc3b-d523b512bd79 | sandbox          |            2 | t      | hd_hd_medHx         |       1
 a84cfba3-0d4c-41e4-96d1-9bf60486c92a | sandbox          |            3 | t      | hd_hd_famHx         |       1
 84c58b92-705e-40e1-ae4f-3aaf10bd8fe9 | sandbox          |            4 | t      | hd_hd_medList       |       1
 e42e6b35-dfbb-4932-a8bd-6c03efe5f11e | sandbox          |            5 | t      | hd_hd_lifestyle     |       1
 4cc8ba8a-a464-47b3-b4a4-daa941fd761d | sandbox          |            6 | t      | hd_hd_mental        |       1
 a1d4c264-e0da-4436-a62d-35205ecf6960 | sandbox          |            7 | f      | hd_hd_socialHealth  |       1
 2e5f252a-df55-4805-8e80-85843002df7a | sandbox          |            7 | f      | hd_hd_socialHealth  |       2
 52822d14-c122-4a22-a346-df042767e022 | sandbox          |            7 | t      | hd_hd_socialHealth  |       3
 587c3003-0e8e-4a57-b727-b704e96979d1 | sandbox          |            8 | t      | hd_hd_lost_interest |       1
 e3cd23a5-ac9b-4050-9819-79679641ca5f | sandbox          |            9 | t      | massachusettsSurvey |       1
```
