### PR TITLE
[JN-649] fix btn-secondary styling

### DIFF
--- a/ui-admin/src/App.css
+++ b/ui-admin/src/App.css
@@ -20,11 +20,9 @@
 }
 
 .btn-secondary:focus, .btn-secondary:hover {
-  background-color: transparent;
   color:#4D72AA;
-  font-weight: bold;
   border: none;
-  box-shadow: none;
+  background: rgba(77, 114, 170, 0.1);
 }
 
 a {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Before, when you hovered over a btn secondary it would bold, which would change size and move everything around it. This keeps it the same size.

Before
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/3f5d0312-41a9-4cb0-b44f-33afc53895e8">


After
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/5660f26a-fa7e-459e-b5e6-05128c9bc0e7">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Go to website editor and hover over the add page button
