### PR TITLE
[JN-565] fix trigger editing for inactive triggers

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/notifications/TriggerExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/notifications/TriggerExtService.java
@@ -61,7 +61,7 @@ public class TriggerExtService {
   @EnforcePortalStudyEnvPermission(permission = AuthUtilService.BASE_PERMISSION)
   public Optional<Trigger> find(PortalStudyEnvAuthContext authContext, UUID configId) {
 
-    Optional<Trigger> configOpt = triggerService.find(configId);
+    Optional<Trigger> configOpt = triggerService.find(configId).filter(Trigger::isActive);
     configOpt.ifPresent(
         config -> {
           verifyTrigger(authContext, config);

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/notifications/TriggerExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/notifications/TriggerExtService.java
@@ -16,12 +16,11 @@ import bio.terra.pearl.core.service.notification.email.EmailTemplateService;
 import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
 import bio.terra.pearl.core.service.rule.EnrolleeContext;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class TriggerExtService {

--- a/ui-admin/src/study/notifications/TriggerDesigner.tsx
+++ b/ui-admin/src/study/notifications/TriggerDesigner.tsx
@@ -84,6 +84,10 @@ export const TriggerDesigner = (
   }
 
   return <div>
+    {!workingTrigger.active &&
+        <div className="alert alert-warning mt-0">
+            This trigger is no longer active. Inactive triggers cannot be edited.
+        </div>}
 
     <TriggerDesignerEditor
       studyEnvContext={studyEnvContext}
@@ -93,8 +97,17 @@ export const TriggerDesigner = (
     />
 
     <div className="d-flex justify-content-center mt-2">
-      <button type="button" className="btn btn-primary" onClick={saveConfig}>Save</button>
-      <button type="button" className="btn btn-danger ms-4" onClick={() => setShowDeleteModal(true)}>Delete</button>
+      <button type="button" className="btn btn-primary" disabled={!workingTrigger.active} onClick={saveConfig}>
+        Save
+      </button>
+      <button
+        type="button"
+        className="btn btn-danger ms-4"
+        disabled={!workingTrigger.active}
+        onClick={() => setShowDeleteModal(true)}
+      >
+        Delete
+      </button>
     </div>
 
     {showDeleteModal && (

--- a/ui-admin/src/study/notifications/TriggerList.tsx
+++ b/ui-admin/src/study/notifications/TriggerList.tsx
@@ -104,7 +104,7 @@ export default function TriggerList({ studyEnvContext, portalContext }:
           </li> }
         </ul>
       </div> }
-      <div className="flex-grow-1 bg-white p-3">
+      <div className="flex-grow-1 bg-white px-3">
         <Routes>
           <Route path="triggers/:triggerId"
             element={<TriggerDesigner studyEnvContext={studyEnvContext}


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Makes you unable to change inactive triggers. 

<img width="1229" alt="image" src="https://github.com/user-attachments/assets/a0ea0497-1d72-48cd-bd64-629a92b1c5d1">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Edit a trigger
- Hit the back button
- Observe that it shows you a helpful message and disables saving