### PR TITLE
[JN-1500] adding lastLogin and username to overview

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/participant/ParticipantUserController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/participant/ParticipantUserController.java
@@ -7,6 +7,7 @@ import bio.terra.pearl.api.admin.service.participant.ParticipantUserExtService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
@@ -32,5 +33,16 @@ public class ParticipantUserController implements ParticipantUserApi {
         this.participantUserExtService.list(
             PortalEnvAuthContext.of(
                 user, portalShortcode, EnvironmentName.valueOfCaseInsensitive(envName))));
+  }
+
+  @Override
+  public ResponseEntity<Object> findWithPortalUser(
+      String portalShortcode, String envName, UUID participantUserId) {
+    AdminUser user = authUtilService.requireAdminUser(request);
+    return ResponseEntity.ok(
+        this.participantUserExtService.findWithPortalUser(
+            PortalEnvAuthContext.of(
+                user, portalShortcode, EnvironmentName.valueOfCaseInsensitive(envName)),
+            participantUserId));
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/participant/ParticipantUserExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/participant/ParticipantUserExtService.java
@@ -1,31 +1,34 @@
 package bio.terra.pearl.api.admin.service.participant;
 
-import bio.terra.pearl.api.admin.service.auth.EnforcePortalPermission;
+import bio.terra.pearl.api.admin.service.auth.EnforcePortalEnvPermission;
 import bio.terra.pearl.api.admin.service.auth.context.PortalEnvAuthContext;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
+import bio.terra.pearl.core.model.participant.PortalParticipantUser;
+import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.participant.ParticipantUserService;
-import bio.terra.pearl.core.service.study.StudyEnvironmentService;
+import bio.terra.pearl.core.service.participant.PortalParticipantUserService;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.stereotype.Service;
 
 @Service
 public class ParticipantUserExtService {
   private final ParticipantUserService participantUserService;
   private final EnrolleeService enrolleeService;
-  private final StudyEnvironmentService studyEnvironmentService;
+  private final PortalParticipantUserService portalParticipantUserService;
 
   public ParticipantUserExtService(
       ParticipantUserService participantUserService,
       EnrolleeService enrolleeService,
-      StudyEnvironmentService studyEnvironmentService) {
+      PortalParticipantUserService portalParticipantUserService) {
     this.participantUserService = participantUserService;
     this.enrolleeService = enrolleeService;
-    this.studyEnvironmentService = studyEnvironmentService;
+    this.portalParticipantUserService = portalParticipantUserService;
   }
 
-  @EnforcePortalPermission(permission = "participant_data_view")
+  @EnforcePortalEnvPermission(permission = "participant_data_view")
   public ParticipantUsersWithEnrollees list(PortalEnvAuthContext authContext) {
     List<ParticipantUser> participantUsers =
         participantUserService.findAllByPortalEnv(
@@ -35,5 +38,22 @@ public class ParticipantUserExtService {
             authContext.getPortal().getId(), authContext.getEnvironmentName());
     enrolleeService.attachProfiles(enrollees);
     return new ParticipantUsersWithEnrollees(participantUsers, enrollees);
+  }
+
+  @EnforcePortalEnvPermission(permission = "participant_data_view")
+  public ParticipantUser findWithPortalUser(
+      PortalEnvAuthContext authContext, UUID participantUserId) {
+    ParticipantUser participantUser =
+        participantUserService
+            .find(participantUserId)
+            .orElseThrow(() -> new NotFoundException("Participant user not found"));
+    // we throw the same exception if the PortalParticipantUser isn't found, to prevent
+    // admins from seeing information from other portals
+    PortalParticipantUser portalParticipantUser =
+        portalParticipantUserService
+            .findOne(participantUser.getId(), authContext.getPortalEnvironment().getId())
+            .orElseThrow(() -> new NotFoundException("Participant user not found"));
+    participantUser.setPortalParticipantUsers(List.of(portalParticipantUser));
+    return participantUser;
   }
 }

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -531,6 +531,21 @@ paths:
           content: *jsonContent
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/env/{envName}/participantUsers/{id}:
+    get:
+      summary: lists all the participant users for the given portal environment
+      tags: [ participantUser ]
+      operationId: findWithPortalUser
+      parameters:
+        - *portalShortcodeParam
+        - *envNameParam
+        - { name: id, in: path, required: true, schema: { type: string, format: uuid } }
+      responses:
+        '200':
+          description: the participantuser with the portalParticipantUser object included too
+          content: *jsonContent
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/env/{envName}/participantUsers/merge/plan:
     post:
       summary: gets a merge plan for the given participant users. This does not perform the merge.

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -823,6 +823,12 @@ export default {
     return await this.processJsonResponse(response)
   },
 
+  async fetchParticipantUser(portalShortcode: string, envName: string, id: string): Promise<ParticipantUser> {
+    const response = await fetch(`${basePortalUrl(portalShortcode)}/env/${envName}/participantUsers/${id}`,
+      this.getGetInit())
+    return await this.processJsonResponse(response)
+  },
+
   async fetchMergePlan(portalShortcode: string, envName: string, sourceEmail: string, targetEmail: string):
     Promise<ParticipantUserMerge> {
     const response = await fetch(`${basePortalUrl(portalShortcode)}/env/${envName}/participantUsers/merge/plan`, {

--- a/ui-admin/src/components/InfoCard.tsx
+++ b/ui-admin/src/components/InfoCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { isEmpty } from 'lodash'
+import classNames from 'classnames'
 
 
 /**
@@ -82,16 +83,18 @@ export function InfoCardBody({ children }: { children: React.ReactNode }) {
  * One row of data in the card, where the title is on the left-hand side and the values are on the right.
  */
 export function InfoCardRow(
-  { title, children }: {
+  { title, children, condensed }: {
         title: string,
-        children: React.ReactNode
+        children: React.ReactNode,
+        condensed?: boolean
     }
 ) {
+  const marginBottom = condensed ? 'mb-2' : 'mb-4'
   return <>
-    <div className="w-25 fw-bold mb-4 mt-2" aria-label={title}>
+    <div className={classNames('w-25 fw-bold mt-2', marginBottom)} aria-label={title}>
       {title}
     </div>
-    <div className="w-75 mb-4">
+    <div className={classNames('w-75', marginBottom)}>
       {children}
     </div>
   </>
@@ -103,12 +106,13 @@ export function InfoCardRow(
  * If the value(s) provided are empty, then "None provided" is displayed.
  */
 export function InfoCardValue(
-  { title, values }: {
+  { title, values, condensed }: {
         title: string,
-        values: string[]
+        values: string[],
+        condensed?: boolean
     }
 ) {
-  return <InfoCardRow title={title}>
+  return <InfoCardRow title={title} condensed={condensed}>
     {(isEmpty(values) || values.every(isEmpty)) && <p className="fst-italic mb-0 mt-2 text-muted">None provided</p>}
     {
       values.filter(val => !isEmpty(val)).map((val, idx) => (

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeOverview.test.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeOverview.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+import { mockEnrollee, mockStudyEnvContext } from 'test-utils/mocking-utils'
+import { screen, waitFor } from '@testing-library/react'
+import { renderWithRouter } from '@juniper/ui-core'
+import Api from 'api/api'
+import {
+  mockParticipantUser,
+  mockPortalParticipantUser
+} from '@juniper/ui-participant/src/test-utils/test-participant-factory'
+import EnrolleeOverview from './EnrolleeOverview'
+
+test('renders enrollee participantUser info', async () => {
+  jest.spyOn(Api, 'findRelationsByTargetShortcode').mockResolvedValue([])
+  jest.spyOn(Api, 'fetchParticipantUser').mockResolvedValue({
+    ...mockParticipantUser(),
+    username: 'someone',
+    portalParticipantUsers: [{
+      ...mockPortalParticipantUser(),
+      lastLogin: 1626825600000
+    }]
+  })
+
+  renderWithRouter(<EnrolleeOverview
+    enrollee={mockEnrollee()}
+    studyEnvContext={mockStudyEnvContext()} onUpdate={jest.fn()}/>)
+
+  await waitFor(() => expect(screen.getByText('someone')).toBeInTheDocument())
+})

--- a/ui-core/src/types/user.ts
+++ b/ui-core/src/types/user.ts
@@ -24,6 +24,7 @@ export type ParticipantUser = {
     token: string
     lastLogin: number
     createdAt: number
+    portalParticipantUsers?: PortalParticipantUser[]
 }
 
 export type PortalParticipantUser = {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds last login and username to the admin enrollee overview.  This adds a new "condensed" option for info cards so the admin view has less scrolling.

<img width="864" alt="image" src="https://github.com/user-attachments/assets/9c9faab5-3263-4b1d-8da7-e1f8d72acdd7">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy apiAdminApp
2. go to `https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants/HDSALK`
3. confirm you now see username and last login time in the overview