### PR TITLE
[JN-1517] fixing export margin

### DIFF
--- a/ui-admin/src/study/export/ExportDataBrowser.tsx
+++ b/ui-admin/src/study/export/ExportDataBrowser.tsx
@@ -141,7 +141,7 @@ const ExportDataBrowser = ({ studyEnvContext }: {studyEnvContext: StudyEnvContex
     onRowSelectionChange: setRowSelection
   })
 
-  return <div className="container-fluid px-4 py-2">
+  return <div className="container-fluid px-4 py-2 align-items-start">
     { renderPageHeader('Data Export') }
     <ExportOptionsForm setExportOptions={setExportOptions} exportOptions={exportOptions}/>
     <div className="align-items-center my-4">

--- a/ui-admin/src/study/export/ExportOptionsForm.tsx
+++ b/ui-admin/src/study/export/ExportOptionsForm.tsx
@@ -46,7 +46,7 @@ function ExportOptionsForm({ exportOptions, setExportOptions }:
     enrolledAfter: enrolledAfter ? new Date(enrolledAfter) : undefined
   }
 
-  return <div>
+  return <div className="container-md ms-0">
     <div className="py-2">
       <p className="fw-bold mb-1">
         Data format


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

fixes date controls so they don't run off the page

<img width="1006" alt="image" src="https://github.com/user-attachments/assets/29c566b2-b305-402b-b3dd-55baddaa8d85">


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/export/dataBrowser?showPreview=true
2. open "advanced options"
3. confirm controls appear in reasonable places