### PR TITLE
[JN-1502] Fix infinite spinner when clicking Register from pre-enroll

### DIFF
--- a/ui-core/src/participant/ParticipantNavbar.tsx
+++ b/ui-core/src/participant/ParticipantNavbar.tsx
@@ -109,6 +109,8 @@ export function ParticipantNavbar(props: NavbarProps) {
       studyEnv.environmentName === portalEnv.environmentName))?.study.studyEnvironments[0]
 
   const mainJoinPath = getMainJoinLink(portal.portalStudies, portalEnv.portalEnvironmentConfig)
+  //we need to note whether the user is in the process of enrolling in a study.
+  //if they are, clicking the register button should keep them on their current page
   const isUserEnrolling = location.pathname.startsWith(mainJoinPath)
 
   return <nav {...navProps} className={classNames('navbar navbar-expand-lg navbar-light', props.className)}>

--- a/ui-core/src/participant/ParticipantNavbar.tsx
+++ b/ui-core/src/participant/ParticipantNavbar.tsx
@@ -108,6 +108,9 @@ export function ParticipantNavbar(props: NavbarProps) {
     pStudy.study.studyEnvironments.find(studyEnv =>
       studyEnv.environmentName === portalEnv.environmentName))?.study.studyEnvironments[0]
 
+  const mainJoinPath = getMainJoinLink(portal.portalStudies, portalEnv.portalEnvironmentConfig)
+  const isUserEnrolling = location.pathname.startsWith(mainJoinPath)
+
   return <nav {...navProps} className={classNames('navbar navbar-expand-lg navbar-light', props.className)}>
     <div className="container-fluid">
       <NavLink to="/" className="navbar-brand">
@@ -157,7 +160,7 @@ export function ParticipantNavbar(props: NavbarProps) {
                     'd-flex justify-content-center',
                     'mb-3 mb-lg-0 ms-lg-3'
                   )}
-                  to={getMainJoinLink(portal.portalStudies, portalEnv.portalEnvironmentConfig)}
+                  to={isUserEnrolling ? '#' : mainJoinPath}
                 >
                   {i18n('navbarJoin')}
                 </NavLink>


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

This is the quicker fix, and I think it's also probably the right one for the moment. If a user is already in the middle of a pre-enroll and they click on Register again, this prevents them from losing their current progress in the form or registration flow.

The alternative is to muck with the StudyEnrollRouter quite a bit, which I didn't have much luck with. And it's a bit hairy anyway so this drastically reduces the surface area/risk. We may want to refactor that eventually, though.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Go to https://sandbox.demo.localhost:3001/studies/heartdemo/join/preEnroll
Click Register
Confirm you don't see a loading spinner or lose registration progress