### PR TITLE
[JN-1529] add prod b2c values to helm chart

### DIFF
--- a/terraform/gcp/envs/prod.tfvars
+++ b/terraform/gcp/envs/prod.tfvars
@@ -7,7 +7,7 @@ dns_ttl = 300
 admin_url = "juniper-cmi.org"
 environment = "prod"
 # note: automatically creates DNS records for these portals under the admin domain
-portals = ["demo"]
+portals = ["demo", "hearthive", "ourhealth", "trccproject", "gvasc"]
 admin_dnssec = "off"
 k8s_namespace = "juniper-prod"
 
@@ -16,6 +16,21 @@ customer_urls = {
   demo = {
     url    = "juniperdemostudy.org"
     dnssec = "off"
+  }
+
+  gvasc = {
+    url    = "gvascstudy.org"
+    dnssec = "off"
+  }
+
+  hearthive = {
+      url    = "thehearthive.org"
+      dnssec = "off"
+  }
+
+  ourhealth = {
+      url    = "ourhealthstudy.org"
+      dnssec = "off"
   }
 }
 

--- a/terraform/gcp/k8s/environments/dev.yaml
+++ b/terraform/gcp/k8s/environments/dev.yaml
@@ -2,7 +2,8 @@ gcpProject: broad-juniper-dev
 gcpRegion: us-central1
 adminUrl: juniper-cmi.dev
 deploymentZone: dev
-appVersion: 1.4.63
+appVersion: 1.4.141
+enableMaintenanceMode: true
 replicas: 1
 # "portals" adds certificates for each portal - both for the juniper-cmi.dev subdomains and the custom domain
 portals:

--- a/terraform/gcp/k8s/environments/prod.yaml
+++ b/terraform/gcp/k8s/environments/prod.yaml
@@ -2,6 +2,8 @@ gcpProject: broad-juniper-prod
 gcpRegion: us-central1
 adminUrl: juniper-cmi.org
 deploymentZone: prod
+appVersion: 1.4.138
+enableMaintenanceMode: true
 replicas: 3
 # "portals" adds certificates for each portal - both for the admin subdomains and the custom domain
 portals:
@@ -9,13 +11,32 @@ portals:
     customDomain: juniperdemostudy.org
 b2c:
   admin:
-    clientId: 705c09dc-5cca-43d3-ae06-07de78bad29a
-    tenantName: ddpdevb2c
-    policyName: B2C_1A_ddp_admin_signup_signin_dev
+    clientId: f02b3816-af49-4a78-a2a5-b929c78a6c47
+    tenantName: broadjuniperadmin
+    policyName: B2C_1A_ddp_admin_signup_signin_admin-prod
   portals:
+    ourhealth:
+      tenantName: ourhealthstudy
+      clientId: 810055b4-eafc-488e-bc9c-eaa8dd759685
+      policyName: B2C_1A_ddp_participant_signup_signin_ourhealth-prod
+      changePasswordPolicyName: B2C_1A_ddp_participant_change_password_ourhealth-prod
+    hearthive:
+      tenantName: hearthive
+      clientId: ede6cbb1-a2c3-44c0-9a8a-496d48d6f307
+      policyName: B2C_1A_ddp_participant_signup_signin_hearthive-prod
+      changePasswordPolicyName: B2C_1A_ddp_participant_change_password_hearthive-prod
+    gvasc:
+      tenantName: gvascprod
+      clientId: 84192db4-8a68-4f9c-9bd0-b104a24f62f9
+      policyName: B2C_1A_ddp_participant_signup_signin_gvasc-prod
+      changePasswordPolicyName: B2C_1A_ddp_participant_change_password_gvasc-prod
+    atcp:
+      tenantName: does-not-exist
+      clientId: does-not-exist
+      policyName: does-not-exist
+      changePasswordPolicyName: does-not-exist
     demo:
-      changePasswordPolicyName: B2C_1A_ddp_participant_change_password_demo-dev
-      clientId: 37d95cc4-7c71-465e-9fc2-66be9a54c202
-      policyName: B2C_1A_ddp_participant_signup_signin_demo-dev
-      tenantName: juniperdemodev
-
+      tenantName: juniperdemoprod
+      clientId: 895c5f41-5a84-4863-b34c-c84d297006e3
+      policyName: B2C_1A_ddp_participant_signup_signin_demo-prod
+      changePasswordPolicyName: B2C_1A_ddp_participant_change_password_demo-prod


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

We'll use this to do our first manual production deployment. After then, we'll merge this and any future production deployments will have the proper b2c values.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- double check the b2c values are correct