### PR TITLE
[JN-1530] add mixpanel and airtable secret, sendgrid DNS

### DIFF
--- a/api-admin/src/main/resources/application-gcp.yml
+++ b/api-admin/src/main/resources/application-gcp.yml
@@ -16,6 +16,10 @@ env:
   addrValidation:
     smartyAuthId: ${sm://${SMARTY_AUTH_ID_SECRET_ID}}
     smartyAuthToken: ${sm://${SMARTY_AUTH_TOKEN_SECRET_ID}}
+  mixpanel:
+    token: ${sm://${MIXPANEL_TOKEN_SECRET_ID}}
+  airtable:
+    authToken: ${sm://${AIRTABLE_AUTH_TOKEN_SECRET_ID}}
 spring:
   cloud:
     gcp:

--- a/terraform/gcp/dns_customer.tf
+++ b/terraform/gcp/dns_customer.tf
@@ -72,3 +72,26 @@ resource "google_dns_record_set" "irb_portal_customer_url" {
   ttl          = var.dns_ttl
   type         = "CNAME"
 }
+
+resource "google_dns_record_set" "additional_customer_records" {
+  # for each customer, create a record for each additional record (e.g. sendgrid, dmarc, etc.)
+  for_each = {
+      for index, item in flatten([
+        for customer_key, dns_config in var.customer_urls : [
+          for dns_record in dns_config.additional_records : {
+            customer_key        = customer_key
+            name   = dns_record.name
+            type   = dns_record.type
+            ttl    = dns_record.ttl
+            value  = dns_record.value
+        }
+        ]
+      ]) : index => item # for_each expects maps, so convert the list of objects to a map
+  }
+
+  managed_zone = google_dns_managed_zone.customer_dns_zone[each.value.customer_key].name
+  name = each.value.name
+  type         = each.value.type
+  rrdatas      = [each.value.value]
+  ttl          = each.value.ttl
+}

--- a/terraform/gcp/envs/dev.tfvars
+++ b/terraform/gcp/envs/dev.tfvars
@@ -14,6 +14,7 @@ customer_urls = {
   demo = {
     url    = "juniperdemostudy.dev"
     dnssec = "off"
+    additional_records = []
   }
 }
 

--- a/terraform/gcp/envs/prod.tfvars
+++ b/terraform/gcp/envs/prod.tfvars
@@ -7,7 +7,7 @@ dns_ttl = 300
 admin_url = "juniper-cmi.org"
 environment = "prod"
 # note: automatically creates DNS records for these portals under the admin domain
-portals = ["demo"]
+portals = ["demo", "hearthive", "ourhealth", "trccproject", "gvasc"]
 admin_dnssec = "off"
 k8s_namespace = "juniper-prod"
 
@@ -16,6 +16,21 @@ customer_urls = {
   demo = {
     url    = "juniperdemostudy.org"
     dnssec = "off"
+  }
+
+  gvasc = {
+    url    = "gvascstudy.org"
+    dnssec = "off"
+  }
+
+  hearthive = {
+      url    = "thehearthive.org"
+      dnssec = "off"
+  }
+
+  ourhealth = {
+      url    = "ourhealthstudy.org"
+      dnssec = "off"
   }
 }
 

--- a/terraform/gcp/envs/prod.tfvars
+++ b/terraform/gcp/envs/prod.tfvars
@@ -7,7 +7,7 @@ dns_ttl = 300
 admin_url = "juniper-cmi.org"
 environment = "prod"
 # note: automatically creates DNS records for these portals under the admin domain
-portals = ["demo"]
+portals = ["demo", "atcp", "ourhealth", "hearthive", "rgp", "cmi"]
 admin_dnssec = "off"
 k8s_namespace = "juniper-prod"
 
@@ -16,6 +16,79 @@ customer_urls = {
   demo = {
     url    = "juniperdemostudy.org"
     dnssec = "off"
+    additional_records = []
+  }
+  hearthive = {
+    url    = "thehearthive.org"
+    dnssec = "off"
+    additional_records = [
+      {
+        name = "s1._domainkey"
+        type = "CNAME"
+        ttl = 3600
+        value = "s1.domainkey.u33588015.wl016.sendgrid.net"
+      },
+      {
+        name = "s2._domainkey"
+        type = "CNAME"
+        ttl = 3600
+        value = "s2.domainkey.u33588015.wl016.sendgrid.net"
+      },
+      {
+        name = "em6454"
+        type = "CNAME"
+        ttl = 3600
+        value = "u33588015.wl016.sendgrid.net"
+      },
+      {
+        name = "url9076"
+        type = "CNAME"
+        ttl = 3600
+        value = "sendgrid.net"
+      },
+      {
+        name = "_dmarc"
+        type = "TXT"
+        ttl = 3600
+        value = "v=DMARC1; p=none;"
+      },
+      {
+        name = "33588015"
+        type = "CNAME"
+        ttl = 3600
+        value = "sendgrid.net"
+      }
+    ]
+  }
+  ourhealth = {
+    url    = "ourhealthstudy.org"
+    dnssec = "off"
+    additional_records = [
+      {
+        name = "s1._domainkey"
+        type = "CNAME"
+        ttl = 3600
+        value = "s1.domainkey.u33588015.wl016.sendgrid.net."
+      },
+      {
+        name = "s2._domainkey"
+        type = "CNAME"
+        ttl = 3600
+        value = "s2.domainkey.u33588015.wl016.sendgrid.net."
+      },
+      {
+        name = "em1287"
+        type = "CNAME"
+        ttl = 3600
+        value = "u33588015.wl016.sendgrid.net."
+      },
+      {
+        name = "em1800"
+        type = "CNAME"
+        ttl = 3600
+        value = "u32431094.wl095.sendgrid.net."
+      }
+    ]
   }
 }
 

--- a/terraform/gcp/k8s/environments/dev.yaml
+++ b/terraform/gcp/k8s/environments/dev.yaml
@@ -2,8 +2,7 @@ gcpProject: broad-juniper-dev
 gcpRegion: us-central1
 adminUrl: juniper-cmi.dev
 deploymentZone: dev
-appVersion: 1.4.141
-enableMaintenanceMode: true
+appVersion: 1.4.142
 replicas: 1
 # "portals" adds certificates for each portal - both for the juniper-cmi.dev subdomains and the custom domain
 portals:

--- a/terraform/gcp/k8s/environments/dev.yaml
+++ b/terraform/gcp/k8s/environments/dev.yaml
@@ -2,7 +2,8 @@ gcpProject: broad-juniper-dev
 gcpRegion: us-central1
 adminUrl: juniper-cmi.dev
 deploymentZone: dev
-appVersion: 1.4.63
+appVersion: 1.4.141
+enableMaintenanceMode: true
 replicas: 1
 # "portals" adds certificates for each portal - both for the juniper-cmi.dev subdomains and the custom domain
 portals:

--- a/terraform/gcp/k8s/environments/dev.yaml
+++ b/terraform/gcp/k8s/environments/dev.yaml
@@ -20,10 +20,10 @@ b2c:
     policyName: B2C_1A_ddp_admin_signup_signin_dev
   portals:
     atcp:
-      changePasswordPolicyName: does-not-exist
-      clientId: does-not-exist
-      policyName: does-not-exist
-      tenantName: does-not-exist
+      changePasswordPolicyName: B2C_1A_ddp_participant_change_password_atcp-dev
+      clientId: 2408089d-2dc5-46f6-bfdd-cb0c8c4c13d1
+      policyName: B2C_1A_ddp_participant_signup_signin_atcp-dev
+      tenantName: juniperatcpdev
     cmi:
       changePasswordPolicyName: B2C_1A_ddp_participant_change_password_cmi-dev
       clientId: 0cdfdafd-75fb-4e36-b6a2-c00e79c86bb0

--- a/terraform/gcp/k8s/environments/dev.yaml
+++ b/terraform/gcp/k8s/environments/dev.yaml
@@ -2,7 +2,6 @@ gcpProject: broad-juniper-dev
 gcpRegion: us-central1
 adminUrl: juniper-cmi.dev
 deploymentZone: dev
-appVersion: 1.4.142
 replicas: 1
 # "portals" adds certificates for each portal - both for the juniper-cmi.dev subdomains and the custom domain
 portals:

--- a/terraform/gcp/k8s/environments/prod.yaml
+++ b/terraform/gcp/k8s/environments/prod.yaml
@@ -2,7 +2,6 @@ gcpProject: broad-juniper-prod
 gcpRegion: us-central1
 adminUrl: juniper-cmi.org
 deploymentZone: prod
-appVersion: 1.4.138
 enableMaintenanceMode: true
 replicas: 3
 # "portals" adds certificates for each portal - both for the admin subdomains and the custom domain

--- a/terraform/gcp/k8s/environments/prod.yaml
+++ b/terraform/gcp/k8s/environments/prod.yaml
@@ -2,6 +2,8 @@ gcpProject: broad-juniper-prod
 gcpRegion: us-central1
 adminUrl: juniper-cmi.org
 deploymentZone: prod
+appVersion: 1.4.138
+enableMaintenanceMode: true
 replicas: 3
 # "portals" adds certificates for each portal - both for the admin subdomains and the custom domain
 portals:
@@ -9,13 +11,32 @@ portals:
     customDomain: juniperdemostudy.org
 b2c:
   admin:
-    clientId: 705c09dc-5cca-43d3-ae06-07de78bad29a
-    tenantName: ddpdevb2c
-    policyName: B2C_1A_ddp_admin_signup_signin_dev
+    clientId: f02b3816-af49-4a78-a2a5-b929c78a6c47
+    tenantName: broadjuniperadmin
+    policyName: B2C_1A_ddp_admin_signup_signin_admin-prod
   portals:
+    ourhealth:
+      tenantName: ourhealthstudy
+      clientId: 810055b4-eafc-488e-bc9c-eaa8dd759685
+      policyName: B2C_1A_ddp_participant_signup_signin_ourhealth-prod
+      changePasswordPolicyName: B2C_1A_ddp_participant_change_password_ourhealth-prod
+    hearthive:
+      tenantName: hearthive
+      clientId: ede6cbb1-a2c3-44c0-9a8a-496d48d6f307
+      policyName: B2C_1A_ddp_participant_signup_signin_hearthive-prod
+      changePasswordPolicyName: B2C_1A_ddp_participant_change_password_hearthive-prod
+    gvasc:
+      tenantName: gvascprod
+      clientId: 84192db4-8a68-4f9c-9bd0-b104a24f62f9
+      policyName: B2C_1A_ddp_participant_signup_signin_gvasc-prod
+      changePasswordPolicyName: B2C_1A_ddp_participant_change_password_gvasc-prod
+    atcp:
+      tenantName: does-not-exist
+      clientId: does-not-exist
+      policyName: does-not-exist
+      changePasswordPolicyName: does-not-exist
     demo:
-      changePasswordPolicyName: B2C_1A_ddp_participant_change_password_demo-dev
-      clientId: 37d95cc4-7c71-465e-9fc2-66be9a54c202
-      policyName: B2C_1A_ddp_participant_signup_signin_demo-dev
-      tenantName: juniperdemodev
-
+      tenantName: juniperdemoprod
+      clientId: 895c5f41-5a84-4863-b34c-c84d297006e3
+      policyName: B2C_1A_ddp_participant_signup_signin_demo-prod
+      changePasswordPolicyName: B2C_1A_ddp_participant_change_password_demo-prod

--- a/terraform/gcp/k8s/templates/admin-deployment.yml
+++ b/terraform/gcp/k8s/templates/admin-deployment.yml
@@ -139,9 +139,9 @@ spec:
               value: tdr-sa-creds
             - name: TDR_EXPORT_STORAGE_ACCOUNT_KEY_SECRET_ID
               value: tdr-storage-account-key
-            - name: MIXPANEL_TOKEN
+            - name: MIXPANEL_TOKEN_SECRET_ID
               value: mixpanel-token
-            - name: AIRTABLE_AUTH_TOKEN
+            - name: AIRTABLE_AUTH_TOKEN_SECRET_ID
               value: airtable-auth-token
           resources:
             requests:

--- a/terraform/gcp/k8s/templates/admin-deployment.yml
+++ b/terraform/gcp/k8s/templates/admin-deployment.yml
@@ -139,6 +139,10 @@ spec:
               value: tdr-sa-creds
             - name: TDR_EXPORT_STORAGE_ACCOUNT_KEY_SECRET_ID
               value: tdr-storage-account-key
+            - name: MIXPANEL_TOKEN
+              value: mixpanel-token
+            - name: AIRTABLE_AUTH_TOKEN
+              value: airtable-auth-token
           resources:
             requests:
               # The proxy's memory use scales linearly with the number of active

--- a/terraform/gcp/k8s/templates/participant-deployment.yml
+++ b/terraform/gcp/k8s/templates/participant-deployment.yml
@@ -137,6 +137,8 @@ spec:
               value: tdr-sa-creds
             - name: TDR_EXPORT_STORAGE_ACCOUNT_KEY_SECRET_ID
               value: tdr-storage-account-key
+            - name: MIXPANEL_TOKEN
+              value: mixpanel-token
           resources:
             requests:
               memory: "2Gi"

--- a/terraform/gcp/k8s/templates/participant-deployment.yml
+++ b/terraform/gcp/k8s/templates/participant-deployment.yml
@@ -137,7 +137,7 @@ spec:
               value: tdr-sa-creds
             - name: TDR_EXPORT_STORAGE_ACCOUNT_KEY_SECRET_ID
               value: tdr-storage-account-key
-            - name: MIXPANEL_TOKEN
+            - name: MIXPANEL_TOKEN_SECRET_ID
               value: mixpanel-token
           resources:
             requests:

--- a/terraform/gcp/secrets.tf
+++ b/terraform/gcp/secrets.tf
@@ -43,3 +43,24 @@ resource "google_secret_manager_secret" "smarty_auth_token" {
     auto {}
   }
 }
+
+resource "google_secret_manager_secret" "smarty_auth_token" {
+  secret_id = "smarty-auth-token"
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret" "mixpanel_token" {
+  secret_id = "mixpanel-token"
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret" "airtable_auth_token" {
+  secret_id = "airtable-auth-token"
+  replication {
+    auto {}
+  }
+}

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -62,6 +62,12 @@ variable "customer_urls" {
   type = map(object({
     url = string
     dnssec = string
+    additional_records = list(object({
+      name = string
+      type = string
+      ttl = number
+      value = string
+    }))
   }))
   description = "Customer URLs"
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds airtable and mixpanel secrets, and adds sendgrid-linked DNS records for email validation

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

