### PR TITLE
[JN-1534] allow renaming studies

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/study/StudyController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/study/StudyController.java
@@ -57,4 +57,16 @@ public class StudyController implements StudyApi {
             EnvironmentName.valueOfCaseInsensitive(envName));
     return ResponseEntity.ok(studies);
   }
+
+  @Override
+  public ResponseEntity<Object> update(String portalShortcode, String studyShortcode, Object body) {
+    AdminUser operator = requestService.requireAdminUser(request);
+    Study study = objectMapper.convertValue(body, Study.class);
+
+    study =
+        studyExtService.updateStudy(
+            PortalStudyAuthContext.of(operator, portalShortcode, studyShortcode), study);
+
+    return ResponseEntity.ok(study);
+  }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/study/StudyController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/study/StudyController.java
@@ -64,7 +64,7 @@ public class StudyController implements StudyApi {
     Study study = objectMapper.convertValue(body, Study.class);
 
     study =
-        studyExtService.updateStudy(
+        studyExtService.update(
             PortalStudyAuthContext.of(operator, portalShortcode, studyShortcode), study);
 
     return ResponseEntity.ok(study);

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/AuthUtilService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/auth/AuthUtilService.java
@@ -19,7 +19,10 @@ import bio.terra.pearl.core.service.survey.SurveyService;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.stereotype.Service;
 
 /** Utility service for common auth-related methods */

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/study/StudyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/study/StudyExtService.java
@@ -12,6 +12,7 @@ import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.study.StudyEnvironmentConfig;
 import bio.terra.pearl.core.service.CascadeProperty;
+import bio.terra.pearl.core.service.exception.PermissionDeniedException;
 import bio.terra.pearl.core.service.exception.internal.InternalServerException;
 import bio.terra.pearl.core.service.study.PortalStudyService;
 import bio.terra.pearl.core.service.study.StudyService;
@@ -136,5 +137,16 @@ public class StudyExtService {
                 StudyEnvironmentConfig.builder().initialized(initialized).build())
             .build();
     return studyEnv;
+  }
+
+  @EnforcePortalStudyPermission(permission = AuthUtilService.BASE_PERMISSION)
+  public Study updateStudy(PortalStudyAuthContext authContext, Study study) {
+    study.setId(authContext.getPortalStudy().getStudyId());
+    if (!study.getShortcode().equals(authContext.getStudyShortcode())
+        && !authContext.getOperator().isSuperuser()) {
+      throw new PermissionDeniedException("Study shortcode cannot be changed");
+    }
+
+    return studyService.update(study);
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/study/StudyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/study/StudyExtService.java
@@ -140,13 +140,16 @@ public class StudyExtService {
   }
 
   @EnforcePortalStudyPermission(permission = "study_settings_edit")
-  public Study update(PortalStudyAuthContext authContext, Study study) {
-    study.setId(authContext.getPortalStudy().getStudyId());
-    if (!study.getShortcode().equals(authContext.getStudyShortcode())
+  public Study update(PortalStudyAuthContext authContext, Study studyUpdate) {
+    Study study = studyService.find(authContext.getPortalStudy().getStudyId()).orElseThrow();
+
+    if (!study.getShortcode().equals(studyUpdate.getShortcode())
         && !authContext.getOperator().isSuperuser()) {
       throw new PermissionDeniedException("Study shortcode cannot be changed");
     }
 
+    study.setName(studyUpdate.getName());
+    study.setShortcode(studyUpdate.getShortcode());
     return studyService.update(study);
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/study/StudyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/study/StudyExtService.java
@@ -139,8 +139,8 @@ public class StudyExtService {
     return studyEnv;
   }
 
-  @EnforcePortalStudyPermission(permission = AuthUtilService.BASE_PERMISSION)
-  public Study updateStudy(PortalStudyAuthContext authContext, Study study) {
+  @EnforcePortalStudyPermission(permission = "study_settings_edit")
+  public Study update(PortalStudyAuthContext authContext, Study study) {
     study.setId(authContext.getPortalStudy().getStudyId());
     if (!study.getShortcode().equals(authContext.getStudyShortcode())
         && !authContext.getOperator().isSuperuser()) {

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -399,6 +399,22 @@ paths:
           description: no content
         '500':
           $ref: '#/components/responses/ServerError'
+    put:
+      summary: updates a study
+      tags: [ study ]
+      operationId: update
+      parameters:
+        - *portalShortcodeParam
+        - *studyShortcodeParam
+      requestBody:
+        required: true
+        content: *jsonContent
+      responses:
+        '200':
+          description: updated study object
+          content: *jsonContent
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/kitTypes:
     get:
       summary: Gets the kit types for a study

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/study/StudyExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/study/StudyExtServiceTests.java
@@ -64,7 +64,7 @@ public class StudyExtServiceTests extends BaseSpringBootTest {
                 AuthUtilService.BASE_PERMISSION, List.of(SuperuserOnly.class)),
             "getStudiesWithEnvs",
             AuthAnnotationSpec.withPortalPerm(AuthUtilService.BASE_PERMISSION),
-            "updateStudy",
+            "update",
             AuthAnnotationSpec.withPortalStudyPerm("study_settings_edit")));
   }
 
@@ -129,6 +129,7 @@ public class StudyExtServiceTests extends BaseSpringBootTest {
   }
 
   @Test
+  @Transactional
   public void testOnlySuperuserCanUpdateShortcode(TestInfo info) {
     baseSeedPopulator.populateRolesAndPermissions();
     Portal portal = portalFactory.buildPersistedWithEnvironments(getTestName(info));
@@ -141,7 +142,7 @@ public class StudyExtServiceTests extends BaseSpringBootTest {
     Assertions.assertThrows(
         PermissionDeniedException.class,
         () ->
-            studyExtService.updateStudy(
+            studyExtService.update(
                 PortalStudyAuthContext.of(operator, portal.getShortcode(), study.getShortcode()),
                 Study.builder().shortcode("newShortcode").name("newName").build()));
 
@@ -149,7 +150,7 @@ public class StudyExtServiceTests extends BaseSpringBootTest {
     Study updatedStudy = studyService.findByShortcode(study.getShortcode()).get();
     assertThat(updatedStudy.getShortcode(), equalTo(study.getShortcode()));
 
-    studyExtService.updateStudy(
+    studyExtService.update(
         PortalStudyAuthContext.of(operator, portal.getShortcode(), study.getShortcode()),
         Study.builder().shortcode(study.getShortcode()).name("newName").build());
 
@@ -160,7 +161,7 @@ public class StudyExtServiceTests extends BaseSpringBootTest {
 
     AdminUser superuser = adminUserFactory.buildPersisted(getTestName(info), true);
 
-    studyExtService.updateStudy(
+    studyExtService.update(
         PortalStudyAuthContext.of(superuser, portal.getShortcode(), study.getShortcode()),
         Study.builder().shortcode("newShortcode").name("newName").build());
 

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/study/StudyExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/study/StudyExtServiceTests.java
@@ -12,7 +12,10 @@ import bio.terra.pearl.api.admin.service.auth.AuthUtilService;
 import bio.terra.pearl.api.admin.service.auth.SuperuserOnly;
 import bio.terra.pearl.api.admin.service.auth.context.PortalAuthContext;
 import bio.terra.pearl.api.admin.service.auth.context.PortalStudyAuthContext;
+import bio.terra.pearl.core.factory.StudyFactory;
+import bio.terra.pearl.core.factory.admin.AdminUserBundle;
 import bio.terra.pearl.core.factory.admin.AdminUserFactory;
+import bio.terra.pearl.core.factory.admin.PortalAdminUserFactory;
 import bio.terra.pearl.core.factory.portal.PortalEnvironmentFactory;
 import bio.terra.pearl.core.factory.portal.PortalFactory;
 import bio.terra.pearl.core.model.EnvironmentName;
@@ -20,10 +23,12 @@ import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
+import bio.terra.pearl.core.service.exception.PermissionDeniedException;
 import bio.terra.pearl.core.service.notification.TriggerService;
 import bio.terra.pearl.core.service.study.PortalStudyService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import bio.terra.pearl.core.service.study.StudyService;
+import bio.terra.pearl.populate.service.BaseSeedPopulator;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -38,10 +43,13 @@ public class StudyExtServiceTests extends BaseSpringBootTest {
   @Autowired private PortalFactory portalFactory;
   @Autowired private PortalEnvironmentFactory portalEnvironmentFactory;
   @Autowired private AdminUserFactory adminUserFactory;
+  @Autowired private PortalAdminUserFactory portalAdminUserFactory;
   @Autowired private StudyEnvironmentService studyEnvironmentService;
   @Autowired private StudyService studyService;
   @Autowired private PortalStudyService portalStudyService;
   @Autowired private TriggerService triggerService;
+  @Autowired private StudyFactory studyFactory;
+  @Autowired private BaseSeedPopulator baseSeedPopulator;
 
   @Test
   public void allMethodsAuthed(TestInfo info) {
@@ -49,13 +57,15 @@ public class StudyExtServiceTests extends BaseSpringBootTest {
         studyExtService,
         Map.of(
             "create",
-                AuthAnnotationSpec.withPortalPerm(
-                    AuthUtilService.BASE_PERMISSION, List.of(SuperuserOnly.class)),
+            AuthAnnotationSpec.withPortalPerm(
+                AuthUtilService.BASE_PERMISSION, List.of(SuperuserOnly.class)),
             "delete",
-                AuthAnnotationSpec.withPortalStudyPerm(
-                    AuthUtilService.BASE_PERMISSION, List.of(SuperuserOnly.class)),
+            AuthAnnotationSpec.withPortalStudyPerm(
+                AuthUtilService.BASE_PERMISSION, List.of(SuperuserOnly.class)),
             "getStudiesWithEnvs",
-                AuthAnnotationSpec.withPortalPerm(AuthUtilService.BASE_PERMISSION)));
+            AuthAnnotationSpec.withPortalPerm(AuthUtilService.BASE_PERMISSION),
+            "updateStudy",
+            AuthAnnotationSpec.withPortalStudyPerm("study_settings_edit")));
   }
 
   @Test
@@ -116,5 +126,46 @@ public class StudyExtServiceTests extends BaseSpringBootTest {
             .orElseThrow();
 
     Assertions.assertEquals(6, triggerService.findByStudyEnvironmentId(sandboxEnv.getId()).size());
+  }
+
+  @Test
+  public void testOnlySuperuserCanUpdateShortcode(TestInfo info) {
+    baseSeedPopulator.populateRolesAndPermissions();
+    Portal portal = portalFactory.buildPersistedWithEnvironments(getTestName(info));
+    AdminUserBundle operatorBundle =
+        portalAdminUserFactory.buildPersistedWithRoles(
+            getTestName(info), portal, List.of("study_admin"));
+    AdminUser operator = operatorBundle.user();
+    Study study = studyFactory.buildPersisted(portal.getId(), getTestName(info));
+
+    Assertions.assertThrows(
+        PermissionDeniedException.class,
+        () ->
+            studyExtService.updateStudy(
+                PortalStudyAuthContext.of(operator, portal.getShortcode(), study.getShortcode()),
+                Study.builder().shortcode("newShortcode").name("newName").build()));
+
+    // Confirm that the study was not updated
+    Study updatedStudy = studyService.findByShortcode(study.getShortcode()).get();
+    assertThat(updatedStudy.getShortcode(), equalTo(study.getShortcode()));
+
+    studyExtService.updateStudy(
+        PortalStudyAuthContext.of(operator, portal.getShortcode(), study.getShortcode()),
+        Study.builder().shortcode(study.getShortcode()).name("newName").build());
+
+    // Confirm that the study was updated
+    updatedStudy = studyService.findByShortcode(study.getShortcode()).get();
+
+    assertThat(updatedStudy.getName(), equalTo("newName"));
+
+    AdminUser superuser = adminUserFactory.buildPersisted(getTestName(info), true);
+
+    studyExtService.updateStudy(
+        PortalStudyAuthContext.of(superuser, portal.getShortcode(), study.getShortcode()),
+        Study.builder().shortcode("newShortcode").name("newName").build());
+
+    // Confirm that the study was updated
+    updatedStudy = studyService.findByShortcode("newShortcode").get();
+    assertThat(updatedStudy.getId(), equalTo(study.getId()));
   }
 }

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -27,8 +27,8 @@ import {
   StudyEnvParams,
   Survey,
   SurveyResponse,
-  Trigger,
-  SystemSettings
+  SystemSettings,
+  Trigger
 } from '@juniper/ui-core'
 import queryString from 'query-string'
 import {
@@ -586,6 +586,16 @@ export default {
       headers: this.getInitHeaders()
     })
     return await this.processResponse(response)
+  },
+
+  async updateStudy(portalShortcode: string, studyShortcode: string, study: Study): Promise<Study> {
+    const url = `${basePortalUrl(portalShortcode)}/studies/${studyShortcode}`
+    const response = await fetch(url, {
+      method: 'PUT',
+      headers: this.getInitHeaders(),
+      body: JSON.stringify(study)
+    })
+    return await this.processJsonResponse(response)
   },
 
   async getPortalMedia(portalShortcode: string): Promise<SiteMediaMetadata[]> {

--- a/ui-admin/src/portal/dashboard/widgets/StudyWidget.tsx
+++ b/ui-admin/src/portal/dashboard/widgets/StudyWidget.tsx
@@ -1,17 +1,30 @@
 import { Button } from 'components/forms/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faGear, faPlus, faTrash } from '@fortawesome/free-solid-svg-icons'
+import {
+  faGear,
+  faPencil,
+  faPlus,
+  faTrash
+} from '@fortawesome/free-solid-svg-icons'
 import CreateNewStudyModal from 'study/CreateNewStudyModal'
 import { Link } from 'react-router-dom'
 import { studyParticipantsPath } from 'portal/PortalRouter'
 import { getMediaUrl } from 'api/api'
-import { Portal, Study } from '@juniper/ui-core'
+import {
+  Portal,
+  Study
+} from '@juniper/ui-core'
 import React, { useState } from 'react'
 import { useUser } from 'user/UserProvider'
 import { DropdownButton } from 'study/participants/survey/SurveyResponseView'
 import DeleteStudyModal from 'study/adminTasks/DeleteStudyModal'
 import { useNavContext } from 'navbar/NavContextProvider'
-import { InfoCard, InfoCardBody, InfoCardHeader } from 'components/InfoCard'
+import {
+  InfoCard,
+  InfoCardBody,
+  InfoCardHeader
+} from 'components/InfoCard'
+import { UpdateStudyModal } from 'study/adminTasks/UpdateStudyModal'
 
 export const StudyWidget = ({ portal }: { portal: Portal }) => {
   const [showNewStudyModal, setShowNewStudyModal] = useState(false)
@@ -64,6 +77,7 @@ const StudyControls = ({ portal, study, primaryStudy }: {
 }) => {
   const { reload } = useNavContext()
   const [showDeleteStudyModal, setShowDeleteStudyModal] = useState(false)
+  const [showUpdateStudyModal, setShowUpdateStudyModal] = useState(false)
 
   return (
     <li key={`${portal.shortcode}-${study.shortcode}`}
@@ -93,6 +107,10 @@ const StudyControls = ({ portal, study, primaryStudy }: {
           </Button>
           <div className="dropdown-menu" aria-labelledby={`editStudyMenu-${study.shortcode}`}>
             <DropdownButton
+              onClick={() => setShowUpdateStudyModal(true)}
+              label="Update study"
+              icon={faPencil}/>
+            <DropdownButton
               onClick={() => setShowDeleteStudyModal(true)}
               className="text-danger"
               icon={faTrash}
@@ -104,6 +122,13 @@ const StudyControls = ({ portal, study, primaryStudy }: {
                 portal={portal}
                 reload={reload}
                 onDismiss={() => setShowDeleteStudyModal(false)}/>
+            }
+            {showUpdateStudyModal &&
+                <UpdateStudyModal
+                  study={study}
+                  portal={portal}
+                  reload={reload}
+                  onClose={() => setShowUpdateStudyModal(false)}/>
             }
           </div>
         </div>

--- a/ui-admin/src/study/adminTasks/UpdateStudyModal.tsx
+++ b/ui-admin/src/study/adminTasks/UpdateStudyModal.tsx
@@ -44,7 +44,7 @@ export const UpdateStudyModal = ({
           onChange={e => setName(e.target.value)}
         />
         <RequireUserPermission superuser>
-          <label className="form-label">Shortcode</label>
+          <label className="form-label mt-2">Shortcode</label>
           <input
             className="form-control"
             value={shortcode}

--- a/ui-admin/src/study/adminTasks/UpdateStudyModal.tsx
+++ b/ui-admin/src/study/adminTasks/UpdateStudyModal.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import {
+  Portal,
+  Study
+} from '@juniper/ui-core'
+import Modal from 'react-bootstrap/Modal'
+import Api from 'api/api'
+import { RequireUserPermission } from 'util/RequireUserPermission'
+
+export const UpdateStudyModal = ({
+  study,
+  portal,
+  reload,
+  onClose
+}: {
+  study: Study,
+  portal: Portal,
+  reload: () => void,
+  onClose: () => void
+}) => {
+  const [name, setName] = React.useState(study.name)
+  const [shortcode, setShortcode] = React.useState(study.shortcode)
+
+  const updateStudy = async () => {
+    // update the study
+    await Api.updateStudy(portal.shortcode, study.shortcode, { name, shortcode, studyEnvironments: [] })
+    reload()
+    onClose()
+  }
+
+  return <Modal show={true} onHide={onClose}>
+    <Modal.Header closeButton>
+      <Modal.Title>Update Study</Modal.Title>
+      <div className="ms-4">
+        {study.name}
+      </div>
+    </Modal.Header>
+    <Modal.Body>
+      <div className="mb-3">
+        <label className="form-label">Study Name</label>
+        <input
+          className="form-control"
+          value={name}
+          onChange={e => setName(e.target.value)}
+        />
+        <RequireUserPermission superuser>
+          <label className="form-label">Shortcode</label>
+          <input
+            className="form-control"
+            value={shortcode}
+            onChange={e => setShortcode(e.target.value)}/>
+        </RequireUserPermission>
+      </div>
+    </Modal.Body>
+    <Modal.Footer>
+      <button
+        className="btn btn-primary"
+        onClick={updateStudy}
+      >Update Study</button>
+      <button className="btn btn-secondary" onClick={onClose}>Close</button>
+    </Modal.Footer>
+  </Modal>
+}


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)


Allows renaming studies.

<img width="1671" alt="Screenshot 2024-12-11 at 11 24 12 AM" src="https://github.com/user-attachments/assets/5194a4f9-616e-4eba-8d5e-a7d84eb49216" />
<img width="1671" alt="Screenshot 2024-12-11 at 11 24 29 AM" src="https://github.com/user-attachments/assets/ec7ea586-8c1f-4f43-acbe-c51b027c0e63" />


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Go to Heart Demo portal dashboard
- Click gear icon, click "Update Study", rename name and change stableid
- Confirm it worked
- Go into non-superuser mode and verify the modal only shows the name field