### PR TITLE
[JN-1525] adds subject to participant list

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
   },
   "scripts": {
     "test": "npm -w ui-core test && npm -w ui-admin test && npm -w ui-participant test",
-    "lint": "npm -w ui-core run build && eslint --max-warnings=0 e2e-tests/src ui-admin/src ui-core/src ui-participant/src"
+    "lint": "npm -w ui-core run build && eslint --max-warnings=0 e2e-tests/src ui-admin/src ui-core/src ui-participant/src",
+    "admin-dev-local": "VITE_UNAUTHED_LOGIN=true HTTPS=true DANGEROUSLY_DISABLE_HOST_CHECK=true npm -w ui-admin start",
+    "admin-dev": "HTTPS=true npm -w ui-admin start"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.2.0",

--- a/ui-admin/src/study/participants/participantList/ParticipantListTable.test.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantListTable.test.tsx
@@ -1,11 +1,10 @@
-import { renderWithRouter, setupRouterTest } from '@juniper/ui-core'
+import { renderWithRouter } from '@juniper/ui-core'
 import {
   mockEnrolleeSearchExpressionResult,
   mockStudyEnvContext
 } from 'test-utils/mocking-utils'
 import {
   act,
-  render,
   screen,
   waitFor
 } from '@testing-library/react'
@@ -14,9 +13,9 @@ import ParticipantListTable from 'study/participants/participantList/Participant
 import { userEvent } from '@testing-library/user-event'
 
 
-describe('Participant List', () => {
-  test('should be able to download participant list', async () => {
-    const { RoutedComponent } = setupRouterTest(<ParticipantListTable
+describe('Participant List Table', () => {
+  test('shows expected columns', async () => {
+    renderWithRouter(<ParticipantListTable
       studyEnvContext={mockStudyEnvContext()}
       participantList={[
         mockEnrolleeSearchExpressionResult()
@@ -24,7 +23,29 @@ describe('Participant List', () => {
       reload={jest.fn()}
     />)
 
-    render(RoutedComponent)
+
+    await waitFor(async () => {
+      expect(screen.queryByText('Shortcode')).toBeVisible()
+    })
+    const expectedCols = ['Created', 'Last login', 'Consented']
+    expectedCols.forEach(colName => {
+      expect(screen.getByText(colName)).toBeInTheDocument()
+    })
+
+    const hiddenCols = ['Given Name', 'Family Name', 'Username', 'Contact Email', 'Is subject']
+    hiddenCols.forEach(colName => {
+      expect(screen.queryByText(colName)).not.toBeInTheDocument()
+    })
+  })
+
+  test('should be able to download participant list', async () => {
+    renderWithRouter(<ParticipantListTable
+      studyEnvContext={mockStudyEnvContext()}
+      participantList={[
+        mockEnrolleeSearchExpressionResult()
+      ]}
+      reload={jest.fn()}
+    />)
 
     await act(async () => {
       await userEvent.click(await screen.findByLabelText('Download table'))
@@ -45,29 +66,5 @@ describe('Participant List', () => {
     })
 
     expect(window.URL.createObjectURL).toHaveBeenCalled()
-  })
-
-  test('shows expected columns', async () => {
-    renderWithRouter(<ParticipantListTable
-      studyEnvContext={mockStudyEnvContext()}
-      participantList={[
-        mockEnrolleeSearchExpressionResult()
-      ]}
-      reload={jest.fn()}
-    />)
-
-
-    await waitFor(async () => {
-      expect(await screen.findByText('Shortcode')).toBeInTheDocument()
-    })
-    const expectedCols = ['Created', 'Last login', 'Consented']
-    expectedCols.forEach(colName => {
-      expect(screen.getByText(colName)).toBeInTheDocument()
-    })
-
-    const hiddenCols = ['Given Name', 'Family Name', 'Username', 'Contact Email', 'Subject']
-    hiddenCols.forEach(colName => {
-      expect(screen.queryByText(colName)).not.toBeInTheDocument()
-    })
   })
 })

--- a/ui-admin/src/study/participants/participantList/ParticipantListTable.test.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantListTable.test.tsx
@@ -1,4 +1,4 @@
-import { setupRouterTest } from '@juniper/ui-core'
+import { renderWithRouter, setupRouterTest } from '@juniper/ui-core'
 import {
   mockEnrolleeSearchExpressionResult,
   mockStudyEnvContext
@@ -45,5 +45,29 @@ describe('Participant List', () => {
     })
 
     expect(window.URL.createObjectURL).toHaveBeenCalled()
+  })
+
+  test('shows expected columns', async () => {
+    renderWithRouter(<ParticipantListTable
+      studyEnvContext={mockStudyEnvContext()}
+      participantList={[
+        mockEnrolleeSearchExpressionResult()
+      ]}
+      reload={jest.fn()}
+    />)
+
+
+    await waitFor(async () => {
+      expect(await screen.findByText('Shortcode')).toBeInTheDocument()
+    })
+    const expectedCols = ['Created', 'Last login', 'Consented']
+    expectedCols.forEach(colName => {
+      expect(screen.getByText(colName)).toBeInTheDocument()
+    })
+
+    const hiddenCols = ['Given Name', 'Family Name', 'Username', 'Contact Email', 'Subject']
+    hiddenCols.forEach(colName => {
+      expect(screen.queryByText(colName)).not.toBeInTheDocument()
+    })
   })
 })

--- a/ui-admin/src/study/participants/participantList/ParticipantListTable.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantListTable.tsx
@@ -79,7 +79,8 @@ function ParticipantListTable({
   const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({
     'givenName': false,
     'familyName': false,
-    'contactEmail': false
+    'contactEmail': false,
+    'subject': false
   })
 
 
@@ -166,6 +167,19 @@ function ParticipantListTable({
       meta: {
         columnType: 'string'
       }
+    }, {
+      id: 'subject',
+      header: 'Research subject',
+      accessorKey: 'enrollee.subject',
+      meta: {
+        columnType: 'boolean',
+        filterOptions: [
+          { value: true, label: 'Subject' },
+          { value: false, label: 'Not a subject (e.g. is only a proxy)' }
+        ]
+      },
+      filterFn: 'equals',
+      cell: info => info.getValue() ? <FontAwesomeIcon icon={faCheck}/> : ''
     }, {
       header: 'Consented',
       accessorKey: 'enrollee.consented',

--- a/ui-admin/src/study/participants/participantList/ParticipantListTable.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantListTable.tsx
@@ -169,7 +169,7 @@ function ParticipantListTable({
       }
     }, {
       id: 'subject',
-      header: 'Research subject',
+      header: 'Is subject',
       accessorKey: 'enrollee.subject',
       meta: {
         columnType: 'boolean',


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds subject to the participant list 
![image](https://github.com/user-attachments/assets/7447800a-9bf1-4f55-8923-1befe850c002)

This is hidden by default since it will only be useful for A-T and other studies with proxies

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants
2. confirm 'subject' is not initially shown 
3. Add it from the column select, confirm it appears