### PR TITLE
[JN-1535] survey breadcrumb

### DIFF
--- a/ui-admin/src/forms/FormContentEditor.tsx
+++ b/ui-admin/src/forms/FormContentEditor.tsx
@@ -7,8 +7,7 @@ import {
 import {
   AnswerMapping,
   FormContent,
-  PortalEnvironmentLanguage,
-  VersionedForm
+  PortalEnvironmentLanguage
 } from '@juniper/ui-core'
 
 import {
@@ -28,7 +27,6 @@ import { SplitCalculatedValueDesigner } from 'forms/designer/SplitCalculatedValu
 type FormContentEditorProps = {
   initialContent: string
   initialAnswerMappings: AnswerMapping[]
-  visibleVersionPreviews: VersionedForm[]
   supportedLanguages: PortalEnvironmentLanguage[]
   currentLanguage: PortalEnvironmentLanguage
   readOnly: boolean

--- a/ui-admin/src/populate/ExtractPortal.tsx
+++ b/ui-admin/src/populate/ExtractPortal.tsx
@@ -12,7 +12,7 @@ import { Store } from 'react-notifications-component'
 /** control for downloading portal configs as a zip file */
 export default function ExtractPortal({ initialPortalShortcode }: {initialPortalShortcode: string}) {
   const [portalShortcode, setPortalShortcode] = useState(initialPortalShortcode)
-  const [isLoading, setIsLoading] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
 
   const [onlyExtractActiveVersions, setOnlyExtractActiveVersions] = useState(false)
 

--- a/ui-admin/src/populate/PopulatePortalControl.tsx
+++ b/ui-admin/src/populate/PopulatePortalControl.tsx
@@ -9,7 +9,7 @@ import { useFileUploadButton } from 'util/uploadUtils'
 /** control for invoking the populate portal API */
 export default function PopulatePortalControl() {
   const [isLoading, setIsLoading] = useState(false)
-  const [isOverwrite, setIsOverwrite] = useState(false)
+  const [isOverwrite, setIsOverwrite] = useState(true)
   const [shortcodeOverride, setShortcodeOverride] = useState('')
   const [fileName, setFileName] = useState('')
   const { file, FileChooser } = useFileUploadButton(() => 1)
@@ -52,11 +52,12 @@ export default function PopulatePortalControl() {
 
       <OverwriteControl isOverwrite={isOverwrite} setIsOverwrite={setIsOverwrite}
         text={<span>
-                If no, no existing data or forms are touched,
-                except for synthetic participants which are refreshed.<br/>
                 If yes, existing participants, surveys, and site content will be destroyed, and everything reset to
                 from the files.  This method will fail if there are participants in the live environment who
                 have not been withdrawn.  This option has no effect if &quot;Shortcode override&quot; is set.
+          <br/>If no, no existing data or forms are touched,
+                except for synthetic participants which are refreshed,
+          and best effort is made to upgrade versions in place
         </span>}/>
       <div>
         <PopulateButton onClick={populate} isLoading={isLoading}/>

--- a/ui-admin/src/study/StudyEnvironmentRouter.tsx
+++ b/ui-admin/src/study/StudyEnvironmentRouter.tsx
@@ -9,6 +9,7 @@ import {
 import { StudyParams } from 'study/StudyRouter'
 
 import {
+  Link,
   Route,
   Routes,
   useNavigate,
@@ -55,7 +56,7 @@ import LoadedSettingsView from './settings/SettingsView'
 import { ENVIRONMENT_ICON_MAP } from 'util/publishUtils'
 import SiteContentLoader from '../portal/siteContent/SiteContentLoader'
 import PortalDashboard from '../portal/dashboard/PortalDashboard'
-import { mailingListPath } from '../portal/PortalRouter'
+import { mailingListPath, PortalEnvContext } from '../portal/PortalRouter'
 import { PortalAdminUserRouter } from '../user/AdminUserRouter'
 
 export type StudyEnvContextT = { study: Study, currentEnv: StudyEnvironment, currentEnvPath: string, portal: Portal }
@@ -148,23 +149,9 @@ function StudyEnvironmentRouter({ study }: { study: Study }) {
           <Route path="export/dataRepo/datasets" element={<DatasetList studyEnvContext={studyEnvContext}/>}/>
           <Route path="export/dataRepo/datasets/:datasetName"
             element={<DatasetDashboard studyEnvContext={studyEnvContext}/>}/>
-          <Route path="forms">
-            <Route path="preReg" element={<PreRegView studyEnvContext={studyEnvContext}
-              portalEnvContext={portalEnvContext}/>}/>
-            <Route path="preEnroll">
-              <Route path=":surveyStableId" element={<PreEnrollView studyEnvContext={studyEnvContext}/>}/>
-              <Route path="*" element={<div>Unknown preEnroll page</div>}/>
-            </Route>
-            <Route path="surveys">
-              <Route path=":surveyStableId">
-                <Route path=":version" element={<SurveyView studyEnvContext={studyEnvContext}/>}/>
-                <Route index element={<SurveyView studyEnvContext={studyEnvContext}/>}/>
-              </Route>
-              <Route path="scratch" element={<QuestionScratchbox/>}/>
-              <Route path="*" element={<div>Unknown survey page</div>}/>
-            </Route>
-            <Route index element={<StudyContent studyEnvContext={studyEnvContext}/>}/>
-          </Route>
+          <Route path="forms/*" element={<StudyFormsRouter studyEnvContext={studyEnvContext}
+            portalEnvContext={portalEnvContext}/>}/>
+
           <Route path="adminTasks">
             <Route index element={<AdminTaskList studyEnvContext={studyEnvContext}/>}/>
           </Route>
@@ -173,6 +160,31 @@ function StudyEnvironmentRouter({ study }: { study: Study }) {
       </I18nProvider>
     </ApiProvider>
   </div>
+}
+const StudyFormsRouter = ({ studyEnvContext, portalEnvContext }:
+  {studyEnvContext: StudyEnvContextT, portalEnvContext: PortalEnvContext}) => {
+  return <>
+    <NavBreadcrumb value={studyEnvFormsParamsPath(paramsFromContext(studyEnvContext))}>
+      <Link to={studyEnvFormsParamsPath(paramsFromContext(studyEnvContext))}>forms</Link>
+    </NavBreadcrumb>
+    <Routes>
+      <Route path="preReg" element={<PreRegView studyEnvContext={studyEnvContext}
+        portalEnvContext={portalEnvContext}/>}/>
+      <Route path="preEnroll">
+        <Route path=":surveyStableId" element={<PreEnrollView studyEnvContext={studyEnvContext}/>}/>
+        <Route path="*" element={<div>Unknown preEnroll page</div>}/>
+      </Route>
+      <Route path="surveys">
+        <Route path=":surveyStableId">
+          <Route path=":version" element={<SurveyView studyEnvContext={studyEnvContext}/>}/>
+          <Route index element={<SurveyView studyEnvContext={studyEnvContext}/>}/>
+        </Route>
+        <Route path="scratch" element={<QuestionScratchbox/>}/>
+        <Route path="*" element={<div>Unknown survey page</div>}/>
+      </Route>
+      <Route index element={<StudyContent studyEnvContext={studyEnvContext}/>}/>
+    </Routes>
+  </>
 }
 
 export default StudyEnvironmentRouter
@@ -222,6 +234,11 @@ export const portalEnvPath = (portalShortcode: string, envName: string) => {
 /** surveys, consents, etc.. */
 export const studyEnvFormsPath = (portalShortcode: string, studyShortcode: string, envName: string) => {
   return `/${portalShortcode}/studies/${studyShortcode}/env/${envName}/forms`
+}
+
+/** convenience for the above method from study params */
+export const studyEnvFormsParamsPath = (studyEnvParams: StudyEnvParams) => {
+  return studyEnvFormsPath(studyEnvParams.portalShortcode, studyEnvParams.studyShortcode, studyEnvParams.envName)
 }
 
 /** helper for path to configure study notifications */

--- a/ui-admin/src/study/StudyEnvironmentRouter.tsx
+++ b/ui-admin/src/study/StudyEnvironmentRouter.tsx
@@ -165,7 +165,7 @@ const StudyFormsRouter = ({ studyEnvContext, portalEnvContext }:
   {studyEnvContext: StudyEnvContextT, portalEnvContext: PortalEnvContext}) => {
   return <>
     <NavBreadcrumb value={studyEnvFormsParamsPath(paramsFromContext(studyEnvContext))}>
-      <Link to={studyEnvFormsParamsPath(paramsFromContext(studyEnvContext))}>forms</Link>
+      <Link to={studyEnvFormsParamsPath(paramsFromContext(studyEnvContext))}>Forms</Link>
     </NavBreadcrumb>
     <Routes>
       <Route path="preReg" element={<PreRegView studyEnvContext={studyEnvContext}

--- a/ui-admin/src/study/surveys/SurveyEditorView.tsx
+++ b/ui-admin/src/study/surveys/SurveyEditorView.tsx
@@ -256,14 +256,17 @@ const SurveyEditorView = (props: SurveyEditorViewProps) => {
           onFormContentChange={(newValidationErrors, newContent) => {
             if (isEmpty(newValidationErrors)) {
               setShowErrors(false)
-              setDraft({ ...currentForm, ...draft, content: JSON.stringify(newContent), date: Date.now() })
+              setDraft({
+                ...currentForm, ...draft as FormDraft,
+                content: JSON.stringify(newContent), date: Date.now()
+              })
             }
             setValidationErrors(newValidationErrors)
           }}
           onAnswerMappingChange={(newValidationErrors, newAnswerMappings) => {
             if (isEmpty(newValidationErrors)) {
               setDraft({
-                ...draft,
+                ...draft as FormDraft,
                 content: draft?.content || currentForm.content,
                 answerMappings: newAnswerMappings,
                 date: Date.now()


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

I was unable to reproduce the publishing bug, desptie extracting gVASCs configs.  And they're not blocked anymore, so I'm going to mark that as a "don't worry about for now".  But while I was there I cleaned up some survey editing typescript and added a breadcrumb for study forms

![image](https://github.com/user-attachments/assets/dd3313db-bcb2-4744-8503-60c300a8df5f)


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/forms/surveys/hd_hd_famHx
2. confirm you see the 'forms' breadcrumb at the top
