### PR TITLE
[JN-1539] fixing portal select in create user

### DIFF
--- a/ui-admin/src/user/CreateUserModal.test.tsx
+++ b/ui-admin/src/user/CreateUserModal.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { mockPortal, renderInPortalRouter } from 'test-utils/mocking-utils'
+import { screen } from '@testing-library/react'
+import { mockAdminUser } from '../test-utils/user-mocking-utils'
+import Api from 'api/api'
+import CreateUserModal from './CreateUserModal'
+import { userEvent } from '@testing-library/user-event'
+import { select } from 'react-select-event'
+
+describe('CreateUserModal', () => {
+  test('Portal select functions', async () => {
+    jest.spyOn(Api, 'fetchRoles').mockResolvedValue([])
+    const createSpy = jest.spyOn(Api, 'createPortalUser').mockResolvedValue(mockAdminUser(false))
+    const portals = [{
+      ...mockPortal(),
+      shortcode: 'test1',
+      name: 'P1'
+    }, {
+      ...mockPortal(),
+      shortcode: 'test2',
+      name: 'P2'
+    }]
+
+    renderInPortalRouter(portals[1],
+      <CreateUserModal onDismiss={jest.fn()} portals={portals} userCreated={jest.fn()} />)
+    await userEvent.type(screen.getByLabelText('Email'), 'foo@bar.com')
+    await userEvent.click(screen.getByText('Create'))
+
+    expect(createSpy).toHaveBeenCalledWith({
+      username: 'foo@bar.com', superuser: false, portalShortcode: 'test1', roleNames: []
+    })
+
+    createSpy.mockClear()
+    await select(screen.getByLabelText('Portal'), ['P2'])
+    await userEvent.click(screen.getByText('Create'))
+    expect(createSpy).toHaveBeenCalledWith({
+      username: 'foo@bar.com', superuser: false, portalShortcode: 'test2', roleNames: []
+    })
+  })
+})

--- a/ui-admin/src/user/CreateUserModal.tsx
+++ b/ui-admin/src/user/CreateUserModal.tsx
@@ -26,8 +26,6 @@ const CreateUserModal = ({ onDismiss, portals, userCreated }:
     portalShortcode: portals.length > 0 ? portals[0].shortcode : null,
     roleNames: []
   })
-  const portalOpts = portals.map(portal => ({ label: portal.name, value: portal.shortcode }))
-  const selectedPortalOpt = portalOpts.find(portalOpt => portalOpt.value === newUser.portalShortcode)
   const [roles, setRoles] = useState<Role[]>([])
 
   const { isLoading: rolesLoading } = useLoadingEffect(async () => {
@@ -45,7 +43,7 @@ const CreateUserModal = ({ onDismiss, portals, userCreated }:
     portals.find(portal => portal.shortcode === newUser.portalShortcode))
 
   const createUser = async () => {
-    doApiLoad(async () => {
+    await doApiLoad(async () => {
       let createdUser: AdminUser
       if (!newUser.superuser) {
         createdUser = await Api.createPortalUser(newUser)

--- a/ui-admin/src/user/CreateUserModal.tsx
+++ b/ui-admin/src/user/CreateUserModal.tsx
@@ -89,7 +89,7 @@ const CreateUserModal = ({ onDismiss, portals, userCreated }:
             </label>
           </div> }
           { !newUser.superuser && <div>
-            <div>
+            <div className="mb-3">
               <PortalSelector portals={portals}
                 selectedPortal={portals.find(p => p.shortcode === newUser.portalShortcode)}
                 setSelectedPortal={portal => setNewUser({

--- a/ui-admin/src/user/CreateUserModal.tsx
+++ b/ui-admin/src/user/CreateUserModal.tsx
@@ -37,11 +37,6 @@ const CreateUserModal = ({ onDismiss, portals, userCreated }:
     setRoles(fetchedRoles)
   })
 
-  useReactSingleSelect<Portal>(portals,
-    portal => ({ label: portal.name, value: portal }),
-    (opt: Portal | undefined) => setNewUser({ ...newUser, portalShortcode: opt?.shortcode ?? null }),
-    portals.find(portal => portal.shortcode === newUser.portalShortcode))
-
   const createUser = async () => {
     await doApiLoad(async () => {
       let createdUser: AdminUser

--- a/ui-admin/src/user/CreateUserModal.tsx
+++ b/ui-admin/src/user/CreateUserModal.tsx
@@ -9,6 +9,9 @@ import { Store } from 'react-notifications-component'
 import Select from 'react-select'
 import { doApiLoad, useLoadingEffect } from '../api/api-utils'
 import { RoleSelector } from './AdminUserDetail'
+import useReactSingleSelect from '../util/react-select-utils'
+
+const DEFAULT_ROLE = 'study_admin'
 
 /** creates a new admin user */
 const CreateUserModal = ({ onDismiss, portals, userCreated }:
@@ -16,23 +19,30 @@ const CreateUserModal = ({ onDismiss, portals, userCreated }:
                              portals: Portal[], userCreated: () => void
                            }) => {
   const [isLoading, setIsLoading] = useState(false)
-  const [portalShortcode, setPortalShortcode] =
-    useState<string | null>(portals.length > 0 ? portals[0].shortcode : null)
   const { user } = useUser()
   const [newUser, setNewUser] = useState<AdminUserParams>({
     username: '',
     superuser: false,
-    portalShortcode,
-    roleNames: ['study_admin']
+    portalShortcode: portals.length > 0 ? portals[0].shortcode : null,
+    roleNames: []
   })
   const portalOpts = portals.map(portal => ({ label: portal.name, value: portal.shortcode }))
-  const selectedPortalOpt = portalOpts.find(portalOpt => portalOpt.value === portalShortcode)
+  const selectedPortalOpt = portalOpts.find(portalOpt => portalOpt.value === newUser.portalShortcode)
   const [roles, setRoles] = useState<Role[]>([])
 
-  useLoadingEffect(async () => {
+  const { isLoading: rolesLoading } = useLoadingEffect(async () => {
     const fetchedRoles = await Api.fetchRoles()
+    setNewUser({
+      ...newUser,
+      roleNames: fetchedRoles.filter(role => role.name === DEFAULT_ROLE).map(role => role.name)
+    })
     setRoles(fetchedRoles)
   })
+
+  useReactSingleSelect<Portal>(portals,
+    portal => ({ label: portal.name, value: portal }),
+    (opt: Portal | undefined) => setNewUser({ ...newUser, portalShortcode: opt?.shortcode ?? null }),
+    portals.find(portal => portal.shortcode === newUser.portalShortcode))
 
   const createUser = async () => {
     doApiLoad(async () => {
@@ -59,12 +69,12 @@ const CreateUserModal = ({ onDismiss, portals, userCreated }:
       <form onSubmit={e => e.preventDefault()}>
         <div className="py-2">
           <div className="mb-3">
-            <label className="form-label">
+            <label className="form-label d-block">
               Email
               <input type="email" value={newUser.username} className="form-control"
                 onChange={e => setNewUser({ ...newUser, username: e.target.value })}/>
-              <span className="form-text">Email must be a Microsoft- or Google-based account</span>
             </label>
+            <span className="form-text ps-3">Email must be a Microsoft- or Google-based account</span>
           </div>
           {user?.superuser && <div className="mb-3">
             <span>Superuser</span><br/>
@@ -80,11 +90,12 @@ const CreateUserModal = ({ onDismiss, portals, userCreated }:
           </div> }
           { !newUser.superuser && <div>
             <div>
-              <label className="w-100 mb-3">
-                Portal
-                <Select options={portalOpts} value={selectedPortalOpt} isDisabled={portalOpts.length < 2}
-                  onChange={opt => setPortalShortcode(opt?.value ?? null)}/>
-              </label>
+              <PortalSelector portals={portals}
+                selectedPortal={portals.find(p => p.shortcode === newUser.portalShortcode)}
+                setSelectedPortal={portal => setNewUser({
+                  ...newUser,
+                  portalShortcode: portal?.shortcode ?? null
+                })}/>
             </div>
             <div>
               <RoleSelector roles={roles} selectedRoleNames={newUser.roleNames} setSelectedRoleNames={roleNames =>
@@ -95,7 +106,7 @@ const CreateUserModal = ({ onDismiss, portals, userCreated }:
       </form>
     </Modal.Body>
     <Modal.Footer>
-      <LoadingSpinner isLoading={isLoading}>
+      <LoadingSpinner isLoading={isLoading || rolesLoading}>
         <button className="btn btn-primary" onClick={createUser} disabled={!isUserValid}>Create</button>
         <button className="btn btn-secondary" onClick={onDismiss}>Cancel</button>
       </LoadingSpinner>
@@ -104,3 +115,19 @@ const CreateUserModal = ({ onDismiss, portals, userCreated }:
 }
 
 export default CreateUserModal
+
+export const PortalSelector = ({ portals, selectedPortal, setSelectedPortal }: {
+    portals: Portal[], selectedPortal?: Portal, setSelectedPortal: (portal?: Portal) => void
+    }) => {
+  const { onChange, options, selectedOption, selectInputId } = useReactSingleSelect<Portal>(portals,
+    portal => ({ label: portal.name, value: portal }),
+    (opt: Portal | undefined) => setSelectedPortal(opt),
+    portals.find(portal => portal.shortcode === selectedPortal?.shortcode))
+
+  return <>
+    <label className="form-label" htmlFor={selectInputId}>
+        Portal
+    </label>
+    <Select options={options} value={selectedOption} onChange={onChange} inputId={selectInputId}/>
+  </>
+}


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Fixes the portal select in the add new user dialog.  Previously, changing it had no effect.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  have more than one portal populated
2. go to https://localhost:3000/users
3.  create a new user in each of the portals, confirm the user is created in the portal you selected