### PR TITLE
[JN-1453] Add freetext editor to survey question designer

### DIFF
--- a/ui-admin/src/forms/designer/split/FormElementFreetextEditor.tsx
+++ b/ui-admin/src/forms/designer/split/FormElementFreetextEditor.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react'
 import { Textarea } from 'components/forms/Textarea'
 import { questionFromRawText } from '../../../util/juniperSurveyUtils'
 
-export const FreetextEditor = ({ question, onChange }: {
+export const FormElementFreetextEditor = ({ question, onChange }: {
     question: Question, onChange: (newQuestion: Question) => void
 }) => {
   const [freetext, setFreetext] = useState<string>('')

--- a/ui-admin/src/forms/designer/split/FreetextEditor.tsx
+++ b/ui-admin/src/forms/designer/split/FreetextEditor.tsx
@@ -1,0 +1,34 @@
+import { Question, QuestionType } from '@juniper/ui-core'
+import React, { useState } from 'react'
+import { Textarea } from 'components/forms/Textarea'
+import { questionFromRawText } from '../../../util/juniperSurveyUtils'
+
+export const FreetextEditor = ({ question, onChange }: {
+    question: Question, onChange: (newQuestion: Question) => void
+}) => {
+  const [freetext, setFreetext] = useState<string>('')
+
+  return <Textarea
+    className="form-control mb-3 p-2"
+    value={freetext}
+    rows={15}
+    onChange={value => {
+      setFreetext(value)
+      const newQuestionObj = questionFromRawText(value)
+      const newType = newQuestionObj.type as QuestionType
+      //questionFromRawText can only reasonably predict the type of question, it's choices, and it's text.
+      //We'll pick those three fields out and allow the user to decide the rest of the fields explicitly.
+      onChange({
+        ...question,
+        type: newType,
+        title: newQuestionObj.title || '',
+        choices: newQuestionObj.choices
+      } as Question)
+    }}
+    label={'Freetext'}
+    labelClassname={'mb-0'}
+    infoContent={`Paste in question text to automatically generate a survey question. For text questions, 
+    simply paste in the text. For radio and dropdown questions, paste the question text followed by
+    a new option on each line.`}
+  />
+}

--- a/ui-admin/src/forms/designer/split/SplitFormElementDesigner.tsx
+++ b/ui-admin/src/forms/designer/split/SplitFormElementDesigner.tsx
@@ -14,6 +14,7 @@ import { isEqual } from 'lodash'
 import { FormElementEditor } from './FormElementEditor'
 import { FormElementJsonEditor } from './FormElementJsonEditor'
 import { FormElementOptions } from './controls/FormElementOptions'
+import { FreetextEditor } from './FreetextEditor'
 
 /* Note that this component is memoized using React.memo
  * Since survey pages can contain many elements, we need to be mindful of
@@ -31,6 +32,7 @@ export const SplitFormElementDesigner = memo(({
     editedContent: FormContent, onChange: (newContent: FormContent) => void
 }) => {
   const [showJsonEditor, setShowJsonEditor] = useState(false)
+  const [showFreetextMode, setShowFreetextMode] = useState(false)
 
   // Chop the survey down to just the specific question that we're editing, so we can display
   // a preview using the SurveyJS survey component.
@@ -51,13 +53,35 @@ export const SplitFormElementDesigner = memo(({
       <FormElementOptions
         showJsonEditor={showJsonEditor}
         setShowJsonEditor={setShowJsonEditor}
+        showFreetextMode={showFreetextMode}
+        setShowFreetextMode={setShowFreetextMode}
         elementIndex={elementIndex}
         element={element}
         currentPageNo={currentPageNo}
         editedContent={editedContent}
         onChange={onChange}
       />
-      { !showJsonEditor ?
+      { showFreetextMode &&
+        <FreetextEditor
+          question={element as Question}
+          onChange={newQuestion => {
+            const newContent = { ...editedContent }
+            newContent.pages[currentPageNo].elements[elementIndex] = newQuestion
+            onChange(newContent)
+          }}
+        />
+      }
+      { showJsonEditor &&
+        <FormElementJsonEditor
+          question={element as Question}
+          onChange={newQuestion => {
+            const newContent = { ...editedContent }
+            newContent.pages[currentPageNo].elements[elementIndex] = newQuestion
+            onChange(newContent)
+          }}
+        />
+      }
+      { !showJsonEditor && !showFreetextMode &&
         <FormElementEditor
           element={element}
           elementIndex={elementIndex}
@@ -66,14 +90,6 @@ export const SplitFormElementDesigner = memo(({
           onChange={onChange}
           currentLanguage={currentLanguage}
           supportedLanguages={supportedLanguages}
-        /> :
-        <FormElementJsonEditor
-          question={element as Question}
-          onChange={newQuestion => {
-            const newContent = { ...editedContent }
-            newContent.pages[currentPageNo].elements[elementIndex] = newQuestion
-            onChange(newContent)
-          }}
         />
       }
     </div>

--- a/ui-admin/src/forms/designer/split/SplitFormElementDesigner.tsx
+++ b/ui-admin/src/forms/designer/split/SplitFormElementDesigner.tsx
@@ -14,7 +14,7 @@ import { isEqual } from 'lodash'
 import { FormElementEditor } from './FormElementEditor'
 import { FormElementJsonEditor } from './FormElementJsonEditor'
 import { FormElementOptions } from './controls/FormElementOptions'
-import { FreetextEditor } from './FreetextEditor'
+import { FormElementFreetextEditor } from './FormElementFreetextEditor'
 
 /* Note that this component is memoized using React.memo
  * Since survey pages can contain many elements, we need to be mindful of
@@ -62,7 +62,7 @@ export const SplitFormElementDesigner = memo(({
         onChange={onChange}
       />
       { showFreetextMode &&
-        <FreetextEditor
+        <FormElementFreetextEditor
           question={element as Question}
           onChange={newQuestion => {
             const newContent = { ...editedContent }

--- a/ui-admin/src/forms/designer/split/controls/FormElementOptions.tsx
+++ b/ui-admin/src/forms/designer/split/controls/FormElementOptions.tsx
@@ -1,12 +1,14 @@
 import React from 'react'
 import { IconButton } from 'components/forms/Button'
-import { faClone, faCode } from '@fortawesome/free-solid-svg-icons'
+import { faClone, faCode, faKeyboard } from '@fortawesome/free-solid-svg-icons'
 import { ListElementController } from 'portal/siteContent/designer/components/ListElementController'
 import { FormContent, FormElement } from '@juniper/ui-core'
 
 type FormElementOptionsProps = {
     showJsonEditor: boolean,
     setShowJsonEditor: (show: boolean) => void,
+    showFreetextMode: boolean,
+    setShowFreetextMode: (show: boolean) => void,
     elementIndex: number,
     element: FormElement,
     currentPageNo: number,
@@ -17,6 +19,8 @@ type FormElementOptionsProps = {
 export const FormElementOptions = ({
   showJsonEditor,
   setShowJsonEditor,
+  showFreetextMode,
+  setShowFreetextMode,
   elementIndex,
   element,
   currentPageNo,
@@ -27,8 +31,14 @@ export const FormElementOptions = ({
     <div className="d-flex justify-content-end">
       <div className="d-flex border rounded-3 rounded-top-0 border-top-0 bg-light">
         <IconButton icon={faCode}
+          disabled={showFreetextMode}
           aria-label={showJsonEditor ? 'Switch to designer' : 'Switch to JSON editor'}
           onClick={() => setShowJsonEditor(!showJsonEditor)}
+        />
+        <IconButton icon={faKeyboard}
+          disabled={showJsonEditor}
+          aria-label={showFreetextMode ? 'Switch to designer' : 'Switch to freetext editor'}
+          onClick={() => setShowFreetextMode(!showFreetextMode)}
         />
         <IconButton icon={faClone}
           aria-label={'Clone'}

--- a/ui-admin/src/forms/designer/split/controls/FormElementOptions.tsx
+++ b/ui-admin/src/forms/designer/split/controls/FormElementOptions.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { IconButton } from 'components/forms/Button'
-import { faClone, faCode, faKeyboard } from '@fortawesome/free-solid-svg-icons'
+import { faClone, faCode, faKeyboard, faWandMagicSparkles } from '@fortawesome/free-solid-svg-icons'
 import { ListElementController } from 'portal/siteContent/designer/components/ListElementController'
 import { FormContent, FormElement } from '@juniper/ui-core'
 
@@ -32,10 +32,15 @@ export const FormElementOptions = ({
       <div className="d-flex border rounded-3 rounded-top-0 border-top-0 bg-light">
         <IconButton icon={faCode}
           disabled={showFreetextMode}
-          aria-label={showJsonEditor ? 'Switch to designer' : 'Switch to JSON editor'}
+          aria-label={
+            showJsonEditor ?
+              'Switch to designer' :
+              showFreetextMode ? 'You must exit the freetext editor to switch to JSON editor' :
+                'Switch to JSON editor'
+          }
           onClick={() => setShowJsonEditor(!showJsonEditor)}
         />
-        <IconButton icon={faKeyboard}
+        <IconButton icon={showFreetextMode ? faKeyboard : faWandMagicSparkles}
           disabled={showJsonEditor}
           aria-label={showFreetextMode ? 'Switch to designer' : 'Switch to freetext editor'}
           onClick={() => setShowFreetextMode(!showFreetextMode)}


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

<img width="925" alt="Screenshot 2024-12-17 at 8 15 35 AM" src="https://github.com/user-attachments/assets/b0455d96-7dc1-4991-a35b-50b481ba2727" />

<img width="925" alt="Screenshot 2024-12-17 at 8 15 45 AM" src="https://github.com/user-attachments/assets/009f497b-ae0c-4dcf-8d39-f8cc8bcc6bad" />


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Go to the survey designer: https://localhost:3000/demo/studies/heartdemo/env/sandbox/forms/surveys/hd_hd_basicInfo
Click the new freetext button
Enter in some text, ensuring it creates text and radio questions correctly

```
Foo
Bar
Baz
```