### PR TITLE
[JN-1551] cleanup issues with multiple 'other' on checkboxes

### DIFF
--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/massachusettsSurvey.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/massachusettsSurvey.json
@@ -55,7 +55,7 @@
                 "value": "mit",
                 "otherStableId": "schoolsMitDetail",
                 "otherText": {
-                    "en": "What did you study at MIT?",
+                    "en": "What did you, {profile.givenName}, study at MIT?",
                     "es": "¿Qué estudiaste en MIT?"
                 },
                 "otherPlaceholder": {
@@ -68,7 +68,7 @@
                   "value": "harvard",
                   "otherStableId": "schoolsHarvardDetail",
                   "otherText": {
-                    "en": "What did you study at Harvard?",
+                    "en": "What did you, {profile.givenName}, study at Harvard?",
                     "es": "¿Qué estudiaste en Harvard?"
                   },
                   "otherPlaceholder": {
@@ -81,7 +81,7 @@
                 "value": "northeastern",
                 "otherStableId": "schoolsNortheasternDetail",
                 "otherText": {
-                    "en": "What did you study at Northeastern?",
+                    "en": "What did you, {profile.givenName}, study at Northeastern?",
                     "es": "¿Qué estudiaste en Northeastern?"
                 },
                 "otherPlaceholder": {
@@ -94,7 +94,7 @@
                 "value": "bu",
                 "otherStableId": "schoolsBuDetail",
                 "otherText": {
-                    "en": "What did you study at Boston University?",
+                    "en": "What did you, {profile.givenName}, study at Boston University?",
                     "es": "¿Qué estudiaste en Boston University?"
                 },
                 "otherPlaceholder": {

--- a/ui-admin/src/study/participants/survey/AnswerEditHistory.tsx
+++ b/ui-admin/src/study/participants/survey/AnswerEditHistory.tsx
@@ -1,19 +1,30 @@
-import { CalculatedValue, Question } from 'survey-core'
-import { Answer, instantToDefaultString, PortalEnvironmentLanguage } from '@juniper/ui-core'
+import {
+  Answer,
+  instantToDefaultString,
+  PortalEnvironmentLanguage
+} from '@juniper/ui-core'
 import { DataChangeRecord } from 'api/api'
 import { useAdminUserContext } from 'providers/AdminUserProvider'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faArrowRight, faChevronDown, faHistory, faPencil } from '@fortawesome/free-solid-svg-icons'
+import {
+  faArrowRight,
+  faChevronDown,
+  faHistory,
+  faPencil
+} from '@fortawesome/free-solid-svg-icons'
 import { AdminUser } from 'api/adminUser'
 import React from 'react'
-import { getDisplayValue } from './SurveyFullDataView'
+import {
+  getDisplayValue,
+  QuestionMetadata
+} from './SurveyFullDataView'
 import { sortBy } from 'lodash'
 
 /**
  * Renders a dropdown with the edit history for a question response
  */
 export const AnswerEditHistory = ({ question, answer, editHistory, supportedLanguages }: {
-    question: Question | CalculatedValue, answer: Answer,
+  question: QuestionMetadata, answer: Answer,
   editHistory: DataChangeRecord[], supportedLanguages: PortalEnvironmentLanguage[]
 }) => {
   const { users } = useAdminUserContext()
@@ -74,7 +85,7 @@ const renderChangeRecordSimple = (changeRecord: DataChangeRecord) => {
  * been made to the answer, we backtrack through the change records to find the original answer.
  */
 const renderOriginalAnswer = (
-  question: Question | CalculatedValue, answer: Answer, changeRecords: DataChangeRecord[], users: AdminUser[]
+  question: QuestionMetadata, answer: Answer, changeRecords: DataChangeRecord[], users: AdminUser[]
 ) => {
   const originalChangeRecord = sortBy(changeRecords, 'createdAt')[0]
   return <div className="dropdown-item d-flex align-items-center" style={{ pointerEvents: 'none' }}>

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.test.tsx
@@ -1,47 +1,63 @@
-import { render, screen } from '@testing-library/react'
+import {
+  render,
+  screen
+} from '@testing-library/react'
 import React from 'react'
 
-import { getDisplayValue, ItemDisplay } from './SurveyFullDataView'
-import { Question } from 'survey-core'
+import {
+  getDisplayValue,
+  ItemDisplay,
+  QuestionMetadata,
+  toQuestionMetadata
+} from './SurveyFullDataView'
 import { Answer } from '@juniper/ui-core'
 import { DataChangeRecord } from 'api/api'
 import { AnswerEditHistory } from './AnswerEditHistory'
 import { userEvent } from '@testing-library/user-event'
+import {
+  CalculatedValue,
+  Question
+} from 'survey-core'
 
+const mockQuestionMetadata: QuestionMetadata = {
+  visible: true, type: 'text', stableId: 'testQ', derived: false, title: 'test question'
+}
 
 describe('getDisplayValue', () => {
   it('renders a plaintext value', async () => {
-    const question: Question = { isVisible: true, getType: () => 'text' } as Question
+    const question: QuestionMetadata = mockQuestionMetadata
     const answer: Answer = { stringValue: 'test123', questionStableId: 'testQ' } as Answer
     render(<span>{getDisplayValue(answer, question)}</span>)
     expect(screen.getByText('test123')).toBeTruthy()
   })
 
   it('renders a choice value', async () => {
-    const question: Question = {
-      isVisible: true,
-      getType: () => 'radiogroup',
+    const question: QuestionMetadata = {
+      ...mockQuestionMetadata,
+      type: 'radiogroup',
       choices: [{
         text: 'option 1', value: 'option1Val'
       }, {
         text: 'option 2', value: 'option2Val'
       }]
-    } as unknown as Question
+    }
+
     const answer: Answer = { stringValue: 'option2Val', questionStableId: 'testQ' } as Answer
     render(<span>{getDisplayValue(answer, question)}</span>)
     expect(screen.getByText('option 2')).toBeTruthy()
   })
 
   it('renders a free text other description', async () => {
-    const question: Question = {
-      isVisible: true,
-      getType: () => 'radiogroup',
+    const question: QuestionMetadata = {
+      ...mockQuestionMetadata,
+      type: 'radiogroup',
       choices: [{
         text: 'option 1', value: 'option1Val'
       }, {
         text: 'option 2', value: 'option2Val'
       }]
-    } as unknown as Question
+    }
+
     const answer: Answer = {
       stringValue: 'option2Val', questionStableId: 'testQ',
       otherDescription: 'more detail'
@@ -51,9 +67,9 @@ describe('getDisplayValue', () => {
   })
 
   it('renders a choice array value', async () => {
-    const question: Question = {
-      isVisible: true,
-      getType: () => 'checkbox',
+    const question: QuestionMetadata = {
+      ...mockQuestionMetadata,
+      type: 'checkbox',
       choices: [{
         text: 'option 1', value: 'option1Val'
       }, {
@@ -63,7 +79,8 @@ describe('getDisplayValue', () => {
       }, {
         text: 'option 4', value: 'option4Val'
       }]
-    } as unknown as Question
+    }
+
     const answer: Answer = {
       objectValue: JSON.stringify(['option2Val', 'option4Val']),
       questionStableId: 'testQ'
@@ -73,32 +90,28 @@ describe('getDisplayValue', () => {
   })
 
   it('renders a signaturepad as an image', async () => {
-    const question = {
-      name: 'testQ', text: 'test question',
-      isVisible: true, type: 'signaturepad',
-      getType: () => 'signaturepad'
+    const question: QuestionMetadata = {
+      ...mockQuestionMetadata,
+      type: 'signaturepad'
     }
+
     const answer: Answer = { stringValue: 'data:image/png;base64, test123', questionStableId: 'testQ' } as Answer
-    render(<span>{getDisplayValue(answer, question as unknown as Question)}</span>)
+    render(<span>{getDisplayValue(answer, question)}</span>)
     expect(screen.getByRole('img')).toHaveAttribute('src', 'data:image/png;base64, test123')
     expect(screen.queryByText('data:image/png;base64, test123')).not.toBeInTheDocument()
   })
 
   it('renders a malformed object value as an error', async () => {
-    const question = {
-      name: 'testQ', text: 'test question',
-      isVisible: true,
-      getType: () => 'text'
-    }
+    const question: QuestionMetadata = mockQuestionMetadata
     const answer: Answer = { objectValue: '{dfaf }}', questionStableId: 'testQ' } as Answer
-    render(<span>{getDisplayValue(answer, question as unknown as Question)}</span>)
+    render(<span>{getDisplayValue(answer, question)}</span>)
     expect(screen.getByText('[[ parse error ]]')).toBeInTheDocument()
   })
 })
 
 describe('ItemDisplay', () => {
   it('renders the language used to answer a question', async () => {
-    const question = { name: 'testQ', text: 'test question', isVisible: true, getType: () => 'text' }
+    const question = mockQuestionMetadata
     const answer: Answer = {
       stringValue: 'test123',
       questionStableId: 'testQ',
@@ -108,7 +121,7 @@ describe('ItemDisplay', () => {
     const answerMap: Record<string, Answer> = {}
     answerMap[answer.questionStableId] = answer
     render(<ItemDisplay
-      question={question as unknown as Question}
+      question={question}
       answerMap={answerMap}
       surveyVersion={1}
       supportedLanguages={[{ languageCode: 'es', languageName: 'Spanish', id: '' }]}
@@ -119,7 +132,7 @@ describe('ItemDisplay', () => {
   })
 
   it('renders correctly if a viewedLanguage is not specified', async () => {
-    const question = { name: 'testQ', text: 'test question', isVisible: true, getType: () => 'text' }
+    const question = mockQuestionMetadata
     const answer: Answer = {
       stringValue: 'test123',
       questionStableId: 'testQ',
@@ -128,7 +141,7 @@ describe('ItemDisplay', () => {
     const answerMap: Record<string, Answer> = {}
     answerMap[answer.questionStableId] = answer
     render(<ItemDisplay
-      question={question as unknown as Question}
+      question={question}
       answerMap={answerMap}
       surveyVersion={1}
       supportedLanguages={[{ languageCode: 'en', languageName: 'English', id: '' }]}
@@ -138,7 +151,7 @@ describe('ItemDisplay', () => {
   })
 
   it('does not render a language name if it doesnt match a supported language', async () => {
-    const question = { name: 'testQ', text: 'test question', isVisible: true, getType: () => 'text' }
+    const question = mockQuestionMetadata
     const answer: Answer = {
       stringValue: 'test123',
       questionStableId: 'testQ',
@@ -148,7 +161,7 @@ describe('ItemDisplay', () => {
     const answerMap: Record<string, Answer> = {}
     answerMap[answer.questionStableId] = answer
     render(<ItemDisplay
-      question={question as unknown as Question}
+      question={question}
       answerMap={answerMap}
       surveyVersion={1}
       supportedLanguages={[{ languageCode: 'es', languageName: 'Spanish', id: '' }]}
@@ -158,7 +171,7 @@ describe('ItemDisplay', () => {
   })
 
   it('renders an edit history button if the question has been edited', async () => {
-    const question = { name: 'testQ', text: 'test question', isVisible: true, getType: () => 'text' }
+    const question = mockQuestionMetadata
     const answer: Answer = {
       stringValue: 'test123',
       questionStableId: 'testQ',
@@ -180,7 +193,7 @@ describe('ItemDisplay', () => {
     const answerMap: Record<string, Answer> = {}
     answerMap[answer.questionStableId] = answer
     render(<ItemDisplay
-      question={question as unknown as Question}
+      question={question}
       answerMap={answerMap}
       surveyVersion={2}
       editHistory={[changeRecord]}
@@ -195,12 +208,7 @@ describe('ItemDisplay', () => {
   })
 
   it('renders the full edit history for a question', async () => {
-    const question = {
-      name: 'testQ',
-      text: 'test question',
-      isVisible: true,
-      getType: () => 'text'
-    } as unknown as Question
+    const question = mockQuestionMetadata
 
     const answer: Answer = {
       stringValue: 'test123',
@@ -238,5 +246,111 @@ describe('ItemDisplay', () => {
 
     expect(screen.getByText('Answered on', { exact: false })).toBeInTheDocument()
     expect(screen.getAllByText('Edited on', { exact: false })).toHaveLength(2)
+  })
+})
+
+describe('toQuestionMetadata', () => {
+  it('converts basic question', async () => {
+    const question = {
+      name: 'testQ',
+      title: 'test question',
+      getType: () => 'text',
+      isVisible: true
+    } as Question
+
+    expect(toQuestionMetadata(question)).toEqual([
+      {
+        stableId: 'testQ',
+        title: 'test question',
+        type: 'text',
+        visible: true,
+        derived: false
+      }
+    ])
+  })
+
+  it('converts calculated values', async () => {
+    const question = {
+      name: 'testQ',
+      getType: () => 'calculatedvalue'
+    } as unknown as CalculatedValue
+
+    expect(toQuestionMetadata(question)).toEqual([
+      {
+        stableId: 'testQ',
+        title: 'testQ',
+        type: 'calculatedvalue',
+        visible: true,
+        derived: true
+      }
+    ])
+  })
+
+  it('adds choices to question', async () => {
+    const question = {
+      name: 'testChoiceQ',
+      title: 'test question w choices',
+      getType: () => 'checkbox',
+      isVisible: true,
+      choices: [
+        { value: 'option1', text: 'Option 1' },
+        { value: 'option2', text: 'Option 2' }
+      ]
+    } as unknown as Question
+
+    expect(toQuestionMetadata(question)).toEqual([
+      {
+        stableId: 'testChoiceQ',
+        title: 'test question w choices',
+        type: 'checkbox',
+        visible: true,
+        derived: false,
+        choices: [
+          { value: 'option1', text: 'Option 1' },
+          { value: 'option2', text: 'Option 2' }
+        ]
+      }
+    ])
+  })
+
+  it('adds other questions', async () => {
+    const question = {
+      name: 'testChoiceQ',
+      title: 'test question w choices',
+      getType: () => 'checkbox',
+      isVisible: true,
+      choices: [
+        { value: 'option1', text: 'Option 1', jsonObj: { otherStableId: 'otherQ1', otherText: 'Other question 1' } },
+        { value: 'option2', text: 'Option 2', jsonObj: { otherStableId: 'otherQ2', otherText: 'Other question 2' } }
+      ]
+    } as unknown as Question
+
+    expect(toQuestionMetadata(question)).toEqual([
+      {
+        stableId: 'testChoiceQ',
+        title: 'test question w choices',
+        type: 'checkbox',
+        visible: true,
+        derived: false,
+        choices: [
+          { value: 'option1', text: 'Option 1' },
+          { value: 'option2', text: 'Option 2' }
+        ]
+      },
+      {
+        stableId: 'otherQ1',
+        title: 'Other question 1',
+        type: 'text',
+        visible: true,
+        derived: false
+      },
+      {
+        stableId: 'otherQ2',
+        title: 'Other question 2',
+        type: 'text',
+        visible: true,
+        derived: false
+      }
+    ])
   })
 })

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -30,6 +30,10 @@ import { renderTruncatedText } from 'util/pageUtils'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
 import { doApiLoad } from 'api/api-utils'
 import { AnswerEditHistory } from './AnswerEditHistory'
+import {
+  isNil,
+  isString
+} from 'lodash'
 
 type SurveyFullDataViewProps = {
   responseId?: string,
@@ -38,6 +42,18 @@ type SurveyFullDataViewProps = {
   resumeData?: string,
   enrollee?: Enrollee,
   studyEnvContext: StudyEnvContextT
+}
+
+type QuestionMetadata = {
+  stableId: string
+  title: string
+  derived: boolean
+  visible: boolean
+  type: string
+  choices?: {
+    text: string
+    value: string
+  }[]
 }
 
 /** renders every item in a survey response */
@@ -53,9 +69,9 @@ export default function SurveyFullDataView({
   answers.forEach(answer => {
     answerMap[answer.questionStableId] = answer
   })
-  let questions = getQuestionsWithComputedValues(surveyJsModel)
+  let questions = getQuestionsWithComputedValues(surveyJsModel).flatMap(toQuestionMetadata)
   if (!showAllQuestions) {
-    questions = questions.filter(q => !!answerMap[q.name])
+    questions = questions.filter(q => !!answerMap[q.stableId])
   }
 
   const portalEnv = studyEnvContext.portal.portalEnvironments.find((env: PortalEnvironment) =>
@@ -114,7 +130,7 @@ export default function SurveyFullDataView({
 }
 
 type ItemDisplayProps = {
-  question: Question | CalculatedValue,
+  question: QuestionMetadata,
   answerMap: Record<string, Answer>,
   surveyVersion: number,
   showFullQuestions: boolean,
@@ -129,16 +145,16 @@ type ItemDisplayProps = {
 export const ItemDisplay = ({
   question, answerMap, surveyVersion, showFullQuestions, supportedLanguages, editHistory = []
 }: ItemDisplayProps) => {
-  const answer = answerMap[question.name]
+  const answer = answerMap[question.stableId]
   const editHistoryForQuestion = editHistory
-    .filter(changeRecord => changeRecord.fieldName === question.name)
+    .filter(changeRecord => changeRecord.fieldName === question.stableId)
     .sort((a, b) => b.createdAt - a.createdAt)
   const displayValue = getDisplayValue(answer, question)
-  let stableIdText = question.name
+  let stableIdText = question.stableId
   if (answer && answer.surveyVersion !== surveyVersion) {
     stableIdText = `${answer.questionStableId} v${answer.surveyVersion}`
   }
-  if ((question as CalculatedValue).expression) {
+  if (question.derived) {
     stableIdText += ' -- derived'
   }
 
@@ -162,10 +178,10 @@ export const ItemDisplay = ({
 
 /** renders the value of the answer, either as plaintext, a matched choice, or an image for signatures */
 export const getDisplayValue = (answer: Answer,
-  question: Question | QuestionWithChoices | CalculatedValue): React.ReactNode => {
+  question: QuestionMetadata): React.ReactNode => {
   const isCalculatedValue = !!(question as CalculatedValue).expression
   if (!answer) {
-    if (!(question as Question).isVisible || isCalculatedValue) {
+    if (!question.visible || isCalculatedValue) {
       return <span className="text-muted fst-italic fw-normal">n/a</span>
     } else {
       return <span className="text-muted fst-italic fw-normal">no answer</span>
@@ -174,7 +190,7 @@ export const getDisplayValue = (answer: Answer,
   const answerValue = answer.stringValue ?? answer.numberValue ?? answer.objectValue ?? answer.booleanValue
 
   let displayValue: React.ReactNode = answerValue
-  if ((question as Question).choices?.length) {
+  if (!isNil(question.choices)) {
     if (answer.objectValue) {
       try {
         const valueArray = JSON.parse(answer.objectValue)
@@ -197,7 +213,7 @@ export const getDisplayValue = (answer: Answer,
       displayValue = renderParseError(answer.objectValue)
     }
   }
-  if (question.getType() === 'signaturepad') {
+  if (question.type === 'signaturepad') {
     displayValue = <img src={answer.stringValue}/>
   }
   if (answer.otherDescription) {
@@ -216,14 +232,11 @@ const renderParseError = (value: string) => {
  * matches the answer stableId with the choice of the question.  note that this is not yet version-safe
  * and so, e.g.,  answers to choices that no longer exist may not render correctly
  */
-export const getTextForChoice = (value: string | number | boolean | undefined, question: Question) => {
-  return question.choices.find((choice: ItemValue)  => choice.value === value)?.text ?? value
+export const getTextForChoice = (value: string | number | boolean | undefined, question: QuestionMetadata) => {
+  return question.choices?.find((choice: ItemValue) => choice.value === value)?.text ?? value
 }
 
-type QuestionWithChoices = Question & {
-  choices: ItemValue[]
-}
-type ItemValue = { text: string, value: string }
+type ItemValue = { text: string, value: string, jsonObj?: { [index: string]: string } }
 
 
 /** gets the question text -- truncates it at 100 chars */
@@ -268,5 +281,53 @@ export function getQuestionsWithComputedValues(model: SurveyModel) {
       }
     })
   return questionsAndVals
+}
+
+const toQuestionMetadata = (question: Question | CalculatedValue): QuestionMetadata[] => {
+  if (question.getType() === 'calculatedvalue') {
+    return [{ stableId: question.name, title: question.name, derived: true, visible: true, type: 'calculatedvalue' }]
+  }
+
+  // checkboxes can have multiple other questions stemming from them,
+  // so we need to generate the metadata for those as well
+  const otherQuestions: QuestionMetadata[] = []
+  let choices: { text: string, value: string }[] | undefined = undefined
+  if ((question as Question).choices?.length) {
+    choices = [];
+    ((question as Question).choices as ItemValue[]).forEach(choice => {
+      if (choice.jsonObj?.otherStableId) {
+        otherQuestions.push(otherQuestionMetadata(choice))
+      }
+      choices?.push({ text: choice.text, value: choice.value })
+    })
+  }
+
+  const questionMetadata = {
+    stableId: question.name,
+    title: (question as Question).title,
+    derived: false,
+    choices,
+    type: question.getType(),
+    visible: (question as Question).isVisible
+  }
+  return [questionMetadata, ...otherQuestions]
+}
+
+const otherQuestionMetadata = (otherQuestion: ItemValue): QuestionMetadata => {
+  return {
+    stableId: otherQuestion.jsonObj!.otherStableId,
+    title: renderInEnglish(otherQuestion.jsonObj?.otherText || otherQuestion.jsonObj!.otherStableId || ''),
+    derived: false,
+    visible: true,
+    type: 'text'
+  }
+}
+
+const renderInEnglish = (title: string | { [index: string]: string }) => {
+  if (isString(title)) {
+    return title
+  }
+
+  return title['en'] || title['default'] || ''
 }
 

--- a/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyFullDataView.tsx
@@ -44,7 +44,7 @@ type SurveyFullDataViewProps = {
   studyEnvContext: StudyEnvContextT
 }
 
-type QuestionMetadata = {
+export type QuestionMetadata = {
   stableId: string
   title: string
   derived: boolean
@@ -179,7 +179,7 @@ export const ItemDisplay = ({
 /** renders the value of the answer, either as plaintext, a matched choice, or an image for signatures */
 export const getDisplayValue = (answer: Answer,
   question: QuestionMetadata): React.ReactNode => {
-  const isCalculatedValue = !!(question as CalculatedValue).expression
+  const isCalculatedValue = question.type === 'calculatedvalue'
   if (!answer) {
     if (!question.visible || isCalculatedValue) {
       return <span className="text-muted fst-italic fw-normal">n/a</span>
@@ -194,13 +194,13 @@ export const getDisplayValue = (answer: Answer,
     if (answer.objectValue) {
       try {
         const valueArray = JSON.parse(answer.objectValue)
-        const textArray = valueArray.map((value: string | number) => getTextForChoice(value, question as Question))
+        const textArray = valueArray.map((value: string | number) => getTextForChoice(value, question))
         displayValue = JSON.stringify(textArray)
       } catch (e) {
         displayValue = renderParseError(answer.objectValue)
       }
     } else {
-      displayValue = getTextForChoice(answerValue, question as Question)
+      displayValue = getTextForChoice(answerValue, question)
     }
   }
   if (answer.booleanValue !== undefined) {
@@ -241,13 +241,12 @@ type ItemValue = { text: string, value: string, jsonObj?: { [index: string]: str
 
 /** gets the question text -- truncates it at 100 chars */
 export const renderQuestionText = (answer: Answer,
-  question: Question | CalculatedValue,
+  question: QuestionMetadata,
   showFullQuestions: boolean) => {
   if (!question) {
     return <span>-</span>
   }
-  const questionText = (question as Question).title
-  return renderTruncatedText(questionText, showFullQuestions ? 10000 : 100)
+  return renderTruncatedText(question.title, showFullQuestions ? 10000 : 100)
 }
 
 /**
@@ -283,7 +282,7 @@ export function getQuestionsWithComputedValues(model: SurveyModel) {
   return questionsAndVals
 }
 
-const toQuestionMetadata = (question: Question | CalculatedValue): QuestionMetadata[] => {
+export const toQuestionMetadata = (question: Question | CalculatedValue): QuestionMetadata[] => {
   if (question.getType() === 'calculatedvalue') {
     return [{ stableId: question.name, title: question.name, derived: true, visible: true, type: 'calculatedvalue' }]
   }

--- a/ui-core/src/surveyUtils.tsx
+++ b/ui-core/src/surveyUtils.tsx
@@ -4,6 +4,8 @@ import {
   cloneDeep,
   get,
   isNil,
+  isObject,
+  isString,
   set
 } from 'lodash'
 import {
@@ -420,3 +422,22 @@ export function SurveyFooter({ survey, surveyModel }: { survey: Survey, surveyMo
   </div>
 }
 
+export const replaceSurveyVariables = (text: string, surveyModel: SurveyModel): string => {
+  // could probably be more efficient, but performance seems OK
+  for (const variable of surveyModel.getVariableNames()) {
+    text = replaceVariable(text, variable, surveyModel)
+  }
+  return text
+}
+
+const replaceVariable = (text: string, variableName: string, surveyModel: SurveyModel): string => {
+  const value = surveyModel.getVariable(variableName)
+  if (isString(value)) {
+    return text.replace(`{${variableName}}`, value)
+  } else if (isObject(value)) {
+    Object.keys(value).forEach(key => {
+      text = replaceVariable(text, `${variableName}.${key}`, surveyModel)
+    })
+  }
+  return text
+}

--- a/ui-core/src/surveyjs/checkbox-multiple-other.tsx
+++ b/ui-core/src/surveyjs/checkbox-multiple-other.tsx
@@ -16,7 +16,7 @@ import {
   isEmpty,
   isString
 } from 'lodash'
-import { replaceSurveyVariables } from 'src/surveyUtils'
+import { replaceSurveyVariables } from '../surveyUtils'
 
 // see https://surveyjs.io/form-library/examples/create-custom-question-renderer/reactjs#content-code
 // for details on how to create a custom renderer

--- a/ui-core/src/surveyjs/checkbox-multiple-other.tsx
+++ b/ui-core/src/surveyjs/checkbox-multiple-other.tsx
@@ -16,6 +16,7 @@ import {
   isEmpty,
   isString
 } from 'lodash'
+import { replaceSurveyVariables } from 'src/surveyUtils'
 
 // see https://surveyjs.io/form-library/examples/create-custom-question-renderer/reactjs#content-code
 // for details on how to create a custom renderer
@@ -95,13 +96,14 @@ export class SurveyQuestionCheckboxMultipleOther extends SurveyQuestionCheckbox 
     const survey: SurveyModel = this.question.survey as SurveyModel
 
     const text = otherText && renderLocString(otherText, survey.getLocale())
+
     const placeholder = otherPlaceholder && renderLocString(otherPlaceholder, survey.getLocale())
 
     return <>
       <OtherTextbox
         stableId={otherStableId}
-        title={text}
-        placeholder={placeholder}
+        title={text && replaceSurveyVariables(text, survey)}
+        placeholder={placeholder && replaceSurveyVariables(placeholder, survey)}
         value={survey.getValue(otherStableId)}
         onChange={(val: string) => survey.setValue(otherStableId, val)}
       />


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Since the other questions weren't "real" questions they weren't showing up in the enrollee overview page for surveys. Since we relied on full surveyjs questions, I refactored it to use a more condensed type of only the things we need to know - this has the advantage of a lot less ugly casting and typescript workarounds across the page.

Also, variables (profile.givenName, etc.) weren't being rendered

<img width="1244" alt="image" src="https://github.com/user-attachments/assets/2c757a1f-f7cb-4f6f-9f7f-24c4e35aa536" />


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Fill out mass survey, filling out some other questions for schools
- Observe that they show up on the enrollee overview page (with history)