### PR TITLE
[JN-1588] Defer to DSM as source of truth for kit mf barcodes

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
@@ -415,6 +415,7 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
             if(pepperKit.getReturnTrackingNumber() != null) {
                 kitRequest.setReturnTrackingNumber(pepperKit.getReturnTrackingNumber());
             }
+            kitRequest.setKitLabel(pepperKit.getMfBarcode());
             kitRequest.setErrorMessage(pepperKit.getErrorMessage());
             dao.update(kitRequest);
         } catch (JsonProcessingException e) {

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperKit.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperKit.java
@@ -23,6 +23,7 @@ public class PepperKit {
     private String trackingScanBy;
     private String trackingNumber;
     private String returnTrackingNumber;
+    private String mfBarcode;
     private String deactivationReason;
     private String deactivationDate;
     private String errorMessage;

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
@@ -190,6 +190,7 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
                 .juniperKitId(kitRequest.getId().toString())
                 .currentStatus(PepperKitStatus.SENT.pepperString)
                 .scanDate(sentDate)
+                .mfBarcode("1234567890")
                 .errorMessage(errorMessage)
                 .build();
         when(mockPepperDSMClient.fetchKitStatus(any(), eq(kitRequest.getId()))).thenReturn(pepperKit);
@@ -200,6 +201,7 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
 
         KitRequest savedKit = kitRequestDao.find(kitRequest.getId()).get();
         assertThat(savedKit.getStatus(), equalTo(KitRequestStatus.SENT));
+        assertThat(savedKit.getKitLabel(), equalTo("1234567890"));
         assertThat(savedKit.getErrorMessage(), equalTo(errorMessage));
         assertThat(savedKit.getSentAt(), equalTo(Instant.parse(sentDate)));
     }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Resets the kit label field to match whatever DSM returns during kit status refresh.

Needed for OurHealth- they had 4 kits collected with "n/a" kit labels. Sampath set these to the correct values in DSM so GP can scan them is, and this adds logic to automatically pick those changes up.

It's unclear to me what workflow they're using and how they got into this state. Would be curious to follow up with them.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Enable live DSM for OurHealth sandbox
Assign a new in-person kit and collect it (collecting it is the step that creates the kit request in DSM)
Update the kit label to be `n/a` i.e. `update kit_request set kit_label='n/a' where id='...';`
Refresh kit statuses for OurHealth sandbox
Confirm kit label is set back to what it originally was