### PR TITLE
[JN-1569] Temporarily pin runner image to ubuntu-22.04

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgres

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     services:
       postgres:
         image: postgres

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -3,7 +3,7 @@ on: workflow_dispatch
 
 jobs:
   trivy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

This is a very temporary fix to get CI working again. Playwright doesn't have the proper dependencies available with ubuntu 24.04, which was just rolled out as the latest version. See breaking changes here: https://github.com/actions/runner-images/issues/10636

The slightly more involved fix is to use ubuntu-latest, update to latest Playwright (and any other dependencies that may be lost/broken), and then fix our Playwright tests to work with the latest version (the Dependabot PR was seeing repeatable failures with the latest version)

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Note the green checks on this PR.