### PR TITLE
[JN-1545] Column per kit type on 'Eligible for kit' view

### DIFF
--- a/ui-admin/src/study/kits/KitEnrolleeSelection.test.tsx
+++ b/ui-admin/src/study/kits/KitEnrolleeSelection.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { screen } from '@testing-library/react'
+import KitEnrolleeSelection from './KitEnrolleeSelection'
+import { asMockedFn, KitType, renderWithRouter } from '@juniper/ui-core'
+import { mockKitType, mockStudyEnvContext } from 'test-utils/mocking-utils'
+import Api from 'api/api'
+
+jest.mock('api/api', () => ({
+  fetchKitTypes: jest.fn(),
+  fetchEnrolleesWithKits: jest.fn().mockResolvedValue([])
+}))
+
+describe('KitEnrolleeSelection', () => {
+  it('should show a column for each kit type', async () => {
+    const mockKitTypes: KitType[] = [
+      mockKitType(),
+      {
+        ...mockKitType(),
+        name: 'another',
+        displayName: 'Another'
+      }
+    ]
+
+    asMockedFn(Api.fetchKitTypes).mockResolvedValue(mockKitTypes)
+
+    renderWithRouter(<KitEnrolleeSelection studyEnvContext={mockStudyEnvContext()}/>)
+
+    for (const kitType of mockKitTypes) {
+      expect(await screen.findByText(`${kitType.displayName} kit requested`)).toBeInTheDocument()
+    }
+  })
+})

--- a/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
+++ b/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
@@ -48,7 +48,6 @@ export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvCont
   ])
   const [rowSelection, setRowSelection] = useState<Record<string, boolean>>({})
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({})
-
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([
     { id: 'consented', value: true },
     { id: 'requiredSurveysComplete', value: true }

--- a/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
+++ b/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
@@ -97,6 +97,20 @@ export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvCont
     ).length
   }
 
+  const kitTypeColumns = currentEnv.kitTypes.map(kitType => ({
+    header: `${kitType} requested`,
+    id: `${kitType}Requested`,
+    accessorFn: (enrollee: Enrollee) => enrollee.kitRequests.some(request => request.kitType === kitType),
+    meta: {
+      columnType: 'boolean',
+      filterOptions: [
+        { value: true, label: 'Requested' },
+        { value: false, label: 'Not Requested' }
+      ]
+    },
+    filterFn: 'equals',
+    cell: checkboxColumnCell
+  }))
 
   const columns: ColumnDef<EnrolleeRow, string | boolean | number>[] = [{
     id: 'select',


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

![screencapture-localhost-3000-ourhealth-studies-ourheart-env-sandbox-kits-eligible-2025-01-14-13_42_33](https://github.com/user-attachments/assets/bf45e5d0-3401-4bc0-b77a-ac148c2aea9f)


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Confirm OurHealth sandbox has more than one kit type configured: https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/settings/kits
Go to the Eligible for kit view and confirm you can see a column for each kit type: https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/kits/eligible
Confirm filters work as expected
