### PR TITLE
[JN-1565] language text override UI

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/i18n/LanguageTextDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/i18n/LanguageTextDao.java
@@ -66,4 +66,8 @@ public class LanguageTextDao extends BaseMutableJdbiDao<LanguageText> {
     public void deleteByLocalSite(UUID localSiteId) {
         deleteByProperty("localized_site_content_id", localSiteId);
     }
+
+    public List<LanguageText> findByLocalSiteId(UUID id) {
+        return findAllByProperty("localized_site_content_id", id);
+    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/dao/site/SiteContentDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/site/SiteContentDao.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.dao.site;
 
 import bio.terra.pearl.core.dao.BaseVersionedJdbiDao;
+import bio.terra.pearl.core.dao.i18n.LanguageTextDao;
 import bio.terra.pearl.core.model.site.HtmlPage;
 import bio.terra.pearl.core.model.site.HtmlSection;
 import bio.terra.pearl.core.model.site.NavbarItem;
@@ -15,18 +16,20 @@ import java.util.stream.Collectors;
 
 @Component
 public class SiteContentDao extends BaseVersionedJdbiDao<SiteContent> {
+    private final LanguageTextDao languageTextDao;
     private LocalizedSiteContentDao localizedSiteContentDao;
     private NavbarItemDao navbarItemDao;
     private HtmlPageDao htmlPageDao;
     private HtmlSectionDao htmlSectionDao;
 
     public SiteContentDao(Jdbi jdbi, LocalizedSiteContentDao localizedSiteContentDao, NavbarItemDao navbarItemDao,
-                          HtmlPageDao htmlPageDao, HtmlSectionDao htmlSectionDao) {
+                          HtmlPageDao htmlPageDao, HtmlSectionDao htmlSectionDao, LanguageTextDao languageTextDao) {
         super(jdbi);
         this.localizedSiteContentDao = localizedSiteContentDao;
         this.navbarItemDao = navbarItemDao;
         this.htmlPageDao = htmlPageDao;
         this.htmlSectionDao = htmlSectionDao;
+        this.languageTextDao = languageTextDao;
     }
 
     @Override
@@ -88,6 +91,7 @@ public class SiteContentDao extends BaseVersionedJdbiDao<SiteContent> {
                             // add only the top level items, the children are already attached
                             navbarItems.stream().filter(item -> item.getParentNavbarItemId() == null).toList()
                     );
+            localSite.setLanguageTextOverrides(languageTextDao.findByLocalSiteId(localSite.getId()));
             if (localSite.getFooterSectionId() != null) {
                 localSite.setFooterSection(htmlSectionDao.find(localSite.getFooterSectionId()).get());
             }

--- a/core/src/main/java/bio/terra/pearl/core/model/i18n/LanguageText.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/i18n/LanguageText.java
@@ -23,7 +23,6 @@ public class LanguageText extends BaseEntity {
     // if site content attached, it will go through
     // standard publishing workflows.
 
-
     // nullable; if null, it's the default language text.
     //           if specified, then it's a portal-specific
     //           override for the default language text

--- a/core/src/main/java/bio/terra/pearl/core/service/site/LocalizedSiteContentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/site/LocalizedSiteContentService.java
@@ -69,7 +69,9 @@ public class LocalizedSiteContentService extends ImmutableEntityService<Localize
             languageText.setLocalizedSiteContentId(savedSite.getId());
             languageText.setLanguage(savedSite.getLanguage());
 
-            languageTextService.create(languageText);
+            LanguageText createdLanguageText = languageTextService.create(languageText);
+
+            savedSite.getLanguageTextOverrides().add(createdLanguageText);
         }
 
         HtmlPage landingPage = localSite.getLandingPage();

--- a/ui-admin/src/portal/siteContent/LanguageTextOverridesEditor.tsx
+++ b/ui-admin/src/portal/siteContent/LanguageTextOverridesEditor.tsx
@@ -48,7 +48,7 @@ const isEditable = (row: LanguageTextRow): row is EditableLanguageText => {
 }
 
 /**
- * Table which allows viewing, deleting, and creating new answer mappings.
+ * Table which allows viewing, deleting, and creating text overrides.
  */
 export default function LanguageTextOverridesEditor(
   {

--- a/ui-admin/src/portal/siteContent/LanguageTextOverridesEditor.tsx
+++ b/ui-admin/src/portal/siteContent/LanguageTextOverridesEditor.tsx
@@ -218,20 +218,6 @@ export default function LanguageTextOverridesEditor(
   </div>
 }
 
-const LanguageTextInput = (
-  { value, onChange } : { value: string, onChange: (val: string) => void }
-) => {
-  const [val, setVal] = useState(value)
-  return <TextInput
-    aria-label={'Language text override text'}
-    onChange={newVal => {
-      setVal(newVal)
-      onChange(newVal)
-    }}
-    value={val}
-  />
-}
-
 const DeleteOverrideModal = (
   { onConfirm, onCancel } : { onConfirm: () => void, onCancel: () => void }
 ) => {

--- a/ui-admin/src/portal/siteContent/LanguageTextOverridesEditor.tsx
+++ b/ui-admin/src/portal/siteContent/LanguageTextOverridesEditor.tsx
@@ -1,0 +1,256 @@
+import React, {
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
+import {
+  faCheck,
+  faPlus,
+  faX
+} from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import {
+  LanguageText,
+  useI18n
+} from '@juniper/ui-core'
+import {
+  isEmpty,
+  isNil
+} from 'lodash'
+import {
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle
+} from 'react-bootstrap'
+import {
+  ColumnDef,
+  getCoreRowModel,
+  useReactTable
+} from '@tanstack/react-table'
+import { basicTableLayout } from '../../util/tableUtils'
+import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan'
+import { TextInput } from 'components/forms/TextInput'
+import Select from 'react-select'
+
+
+type EditableLanguageText = Partial<LanguageText> & { isEditing: boolean }
+type LanguageTextRow = LanguageText | EditableLanguageText
+const isEditable = (row: LanguageTextRow): row is EditableLanguageText => {
+  return !isNil((row as EditableLanguageText).isEditing)
+}
+
+/**
+ * Table which allows viewing, deleting, and creating new answer mappings.
+ */
+export default function LanguageTextOverridesEditor(
+  {
+    initialLanguageTextOverrides, onChange
+  } : {
+    initialLanguageTextOverrides: LanguageText[], onChange: (newLanguageTexts: LanguageText[]) => void
+  }
+) {
+  const {
+    languageTexts,
+    selectedLanguage
+  } = useI18n()
+
+  const languageKeys = Object.keys(languageTexts)
+
+  const [languageTextOverrides, setLanguageTextOverrides] = useState<LanguageText[]>(initialLanguageTextOverrides || [])
+
+  const [overrideSelectedForDeletion, setOverrideSelectedForDeletion] = useState<LanguageText | null>(null)
+
+
+  useEffect(() => {
+    for (const override of languageTextOverrides) {
+      languageTexts[override.keyName] = override.text
+    }
+  }, [languageTextOverrides])
+
+  // state for new mapping
+  const [newOverride, setNewOverride] = useState<EditableLanguageText>({ isEditing: false })
+
+
+  const deleteLanguageTextOverride = async () => {
+    if (overrideSelectedForDeletion) {
+      const newOverrides = languageTextOverrides.filter(m => m.keyName !== overrideSelectedForDeletion.keyName)
+      onChange(newOverrides)
+      setLanguageTextOverrides(newOverrides)
+      setOverrideSelectedForDeletion(null)
+    }
+  }
+
+  const saveNewLanguageTextOverride = async (override: LanguageText) => {
+    const newOverrides = [...languageTextOverrides, override]
+
+    onChange(newOverrides)
+    setLanguageTextOverrides(newOverrides)
+    setNewOverride({ isEditing: false })
+  }
+
+  const onChangeNewOverrideKey = (key: string) => {
+    if (languageKeys.includes(key)) {
+      setNewOverride({ ...newOverride, keyName: key, text: languageTexts[key] })
+    }
+  }
+
+  const onChangeNewOverrideText = (text: string) => {
+    setNewOverride({ ...newOverride, text })
+  }
+
+  const setIsEditing = (isEditing: boolean) => {
+    setNewOverride({ ...newOverride, isEditing })
+  }
+
+  const languageTextOverrideTextRef = useRef(null)
+
+  const columns = useMemo<ColumnDef<LanguageTextRow>[]>(() => [
+    {
+      header: 'Key Name',
+      accessorKey: 'keyName',
+      cell: ({ row }) => {
+        const value = row.original.keyName
+        if (isEditable(row.original)) {
+          return row.original.isEditing && <Select
+            aria-label={'New language text override key'}
+            options={languageKeys.map(key => {
+              return {
+                value: key,
+                label: key,
+                isDisabled: languageTextOverrides.some(m => m.keyName === key)
+              }
+            })}
+            value={row.original.keyName && {
+              value: row.original.keyName,
+              label: row.original.keyName
+            }}
+            onChange={e => e && onChangeNewOverrideKey(e.value)}
+          />
+        }
+        return value
+      }
+    },
+    {
+      header: 'Text',
+      accessorKey: 'text',
+      cell: ({ row }) => {
+        const value = row.original.text
+        if (isEditable(row.original)) {
+          return row.original.isEditing && <TextInput
+            ref={languageTextOverrideTextRef}
+            disabled={isEmpty(newOverride.keyName)}
+            readOnly={isEmpty(newOverride.keyName)}
+            autoFocus={!isEmpty(newOverride.keyName)}
+            key='new-override-text'
+            aria-label={'New language text override text'}
+            onChange={val => onChangeNewOverrideText(val)}
+            value={row.original.text || ''}
+          />
+        }
+        return value
+      }
+    },
+    {
+      header: 'Language',
+      accessorKey: 'language',
+      cell: ({ row }) => row.original?.language
+    },
+    {
+      header: 'Actions',
+      id: 'actions',
+      cell: ({ row }) => {
+        if (isEditable(row.original)) {
+          if (!row.original.isEditing) {
+            return <button
+              className='btn btn-primary border-0'
+              onClick={() => setIsEditing(true)}>
+              <FontAwesomeIcon icon={faPlus} aria-label={'Create New Answer Mapping'}/>
+            </button>
+          }
+
+          return <>
+            <button
+              className='btn btn-success me-2'
+              onClick={() => saveNewLanguageTextOverride({
+                keyName: newOverride.keyName as string,
+                text: newOverride.text as string,
+                language: selectedLanguage
+              })}>
+              <FontAwesomeIcon icon={faCheck} aria-label={'Accept new language text override'}/>
+            </button>
+            <button className='btn btn-danger' onClick={() => setIsEditing(false)}>
+              <FontAwesomeIcon icon={faX} aria-label={'Cancel new language text override'}/>
+            </button>
+          </>
+        }
+        return <button className='btn btn-outline-danger border-0' onClick={() => {
+          setOverrideSelectedForDeletion(row.original as LanguageText)
+        }}>
+          <FontAwesomeIcon icon={faTrashCan} aria-label={'Delete language text override'}/>
+        </button>
+      }
+    }
+  ], [newOverride, languageTextOverrides])
+
+  const data = useMemo(
+    () => (languageTextOverrides as LanguageTextRow[]).concat(newOverride),
+    [languageTextOverrides, newOverride])
+
+  const table = useReactTable<LanguageTextRow>({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel()
+  })
+
+  return <div className='px-3 pt-1'>
+    <p>
+      This page allows you to override any default text across the participant website.
+    </p>
+    {basicTableLayout(table, { tdClass: 'col-1 ' })}
+    {overrideSelectedForDeletion && <DeleteOverrideModal
+      onConfirm={deleteLanguageTextOverride}
+      onCancel={() => setOverrideSelectedForDeletion(null)}/>}
+    <div>
+    </div>
+  </div>
+}
+
+const LanguageTextInput = (
+  { value, onChange } : { value: string, onChange: (val: string) => void }
+) => {
+  const [val, setVal] = useState(value)
+  return <TextInput
+    aria-label={'Language text override text'}
+    onChange={newVal => {
+      setVal(newVal)
+      onChange(newVal)
+    }}
+    value={val}
+  />
+}
+
+const DeleteOverrideModal = (
+  { onConfirm, onCancel } : { onConfirm: () => void, onCancel: () => void }
+) => {
+  return <Modal onHide={onCancel} show={true}>
+    <ModalHeader>
+      <ModalTitle>
+        Are you sure you want to delete this language text override?
+      </ModalTitle>
+    </ModalHeader>
+    <ModalBody>
+      This action cannot be undone.
+    </ModalBody>
+    <ModalFooter>
+      <button className='btn btn-danger' onClick={onConfirm}>
+        Yes
+      </button>
+      <button className='btn btn-secondary' onClick={onCancel}>
+        No
+      </button>
+    </ModalFooter>
+  </Modal>
+}

--- a/ui-admin/src/portal/siteContent/LanguageTextOverridesEditor.tsx
+++ b/ui-admin/src/portal/siteContent/LanguageTextOverridesEditor.tsx
@@ -238,7 +238,9 @@ export default function LanguageTextOverridesEditor(
 
   return <div className='px-3 pt-1'>
     <p>
-      This page allows you to override any default text across the participant website.
+      This page allows you to override any text in the participant application not found in your website content.
+      If you are unable to find the key of the text you would like to override, please contact Juniper support for
+      assistance.
     </p>
     {basicTableLayout(table, { tdClass: 'col-1 ' })}
     {overrideSelectedForDeletion && <DeleteOverrideModal

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -388,6 +388,24 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
               </ErrorBoundary>
             </Tab>
             <Tab
+              eventKey={'systemTextOverride'}
+              title={'Text Overrides'}
+              disabled={hasInvalidSection}
+            >
+              <ErrorBoundary>
+                <LanguageTextOverridesEditor
+                  initialLanguageTextOverrides={localContent.languageTextOverrides}
+                  onChange={overrides => {
+                    const updatedLocalContent = {
+                      ...localContent,
+                      languageTextOverrides: overrides
+                    }
+                    updateLocalContent(updatedLocalContent)
+                  }}
+                />
+              </ErrorBoundary>
+            </Tab>
+            <Tab
               eventKey="preview"
               title="Preview"
               disabled={hasInvalidSection}
@@ -404,24 +422,6 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
                   }
                   <SiteFooter footerSection={localContent.footerSection}/>
                 </ApiProvider>
-              </ErrorBoundary>
-            </Tab>
-            <Tab
-              eventKey={'systemTextOverride'}
-              title={'System Text Overrides'}
-              disabled={hasInvalidSection}
-            >
-              <ErrorBoundary>
-                <LanguageTextOverridesEditor
-                  initialLanguageTextOverrides={localContent.languageTextOverrides}
-                  onChange={overrides => {
-                    const updatedLocalContent = {
-                      ...localContent,
-                      languageTextOverrides: overrides
-                    }
-                    updateLocalContent(updatedLocalContent)
-                  }}
-                />
               </ErrorBoundary>
             </Tab>
           </Tabs> }

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -393,16 +393,20 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
               disabled={hasInvalidSection}
             >
               <ErrorBoundary>
-                <LanguageTextOverridesEditor
-                  initialLanguageTextOverrides={localContent.languageTextOverrides}
-                  onChange={overrides => {
-                    const updatedLocalContent = {
-                      ...localContent,
-                      languageTextOverrides: overrides
-                    }
-                    updateLocalContent(updatedLocalContent)
-                  }}
-                />
+                <ApiProvider api={previewApi}>
+                  <LanguageTextOverridesEditor
+                    portalEnvContext={portalEnvContext}
+                    localContent={localContent}
+                    selectedLanguage={selectedLanguage?.languageCode || ''}
+                    onChange={overrides => {
+                      const updatedLocalContent = {
+                        ...localContent,
+                        languageTextOverrides: overrides
+                      }
+                      updateLocalContent(updatedLocalContent)
+                    }}
+                  />
+                </ApiProvider>
               </ErrorBoundary>
             </Tab>
             <Tab

--- a/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
+++ b/ui-admin/src/portal/siteContent/SiteContentEditor.tsx
@@ -47,6 +47,7 @@ import _cloneDeep from 'lodash/cloneDeep'
 import TranslationModal from './TranslationModal'
 import useLanguageSelectorFromParam from '../languages/useLanguageSelector'
 import { NavbarPreview } from 'portal/siteContent/NavbarPreview'
+import LanguageTextOverridesEditor from 'portal/siteContent/LanguageTextOverridesEditor'
 
 type InitializedSiteContentViewProps = {
   siteContent: SiteContent
@@ -403,6 +404,24 @@ const SiteContentEditor = (props: InitializedSiteContentViewProps) => {
                   }
                   <SiteFooter footerSection={localContent.footerSection}/>
                 </ApiProvider>
+              </ErrorBoundary>
+            </Tab>
+            <Tab
+              eventKey={'systemTextOverride'}
+              title={'System Text Overrides'}
+              disabled={hasInvalidSection}
+            >
+              <ErrorBoundary>
+                <LanguageTextOverridesEditor
+                  initialLanguageTextOverrides={localContent.languageTextOverrides}
+                  onChange={overrides => {
+                    const updatedLocalContent = {
+                      ...localContent,
+                      languageTextOverrides: overrides
+                    }
+                    updateLocalContent(updatedLocalContent)
+                  }}
+                />
               </ErrorBoundary>
             </Tab>
           </Tabs> }

--- a/ui-admin/src/test-utils/mock-site-content.tsx
+++ b/ui-admin/src/test-utils/mock-site-content.tsx
@@ -9,7 +9,8 @@ import {
 import {
   ApiContextT,
   HtmlSection,
-  HubResponse, SystemSettings
+  HubResponse,
+  SystemSettings
 } from '@juniper/ui-core'
 
 /** mock site content */
@@ -36,7 +37,8 @@ export const mockLocalSiteContent = (): LocalSiteContent => {
     ],
     landingPage: mockLandingPage(),
     navLogoVersion: 1,
-    navLogoCleanFileName: 'fakeLogo.png'
+    navLogoCleanFileName: 'fakeLogo.png',
+    languageTextOverrides: []
   }
 }
 

--- a/ui-core/src/types/landingPageConfig.ts
+++ b/ui-core/src/types/landingPageConfig.ts
@@ -10,12 +10,19 @@ export type LocalSiteContent = {
   language: string
   navbarItems: NavbarItem[]
   pages: HtmlPage[]
+  languageTextOverrides: LanguageText[]
   landingPage: HtmlPage
   navLogoCleanFileName: string
   navLogoVersion: number
   footerSection?: HtmlSection
   primaryBrandColor?: string
   dashboardBackgroundColor?: string
+}
+
+export type LanguageText = {
+  keyName: string
+  text: string
+  language: string
 }
 
 export type HtmlPage = {

--- a/ui-participant/src/test-utils/test-portal-factory.tsx
+++ b/ui-participant/src/test-utils/test-portal-factory.tsx
@@ -3,7 +3,8 @@ import {
   LocalSiteContent,
   Portal,
   PortalEnvironment,
-  PortalEnvironmentConfig, PortalStudy,
+  PortalEnvironmentConfig,
+  PortalStudy,
   SiteContent,
   Study,
   StudyEnvironment
@@ -105,7 +106,8 @@ export const mockLocalSiteContent = (): LocalSiteContent => {
     pages: [],
     landingPage: mockHtmlPage(),
     navLogoCleanFileName: 'navLogo.png',
-    navLogoVersion: 1
+    navLogoVersion: 1,
+    languageTextOverrides: []
   }
 }
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

<img width="1637" alt="image" src="https://github.com/user-attachments/assets/ff632ea8-7cad-4422-acf7-83168bd4c5cd" />


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Repopulate demo
- Observe that there's already a language text override
- Observe that it's reflected in the preview
- Add a new override for `navbarLogin`
- Don't save, go to preview - observe it's reflected
- Save
- Go to participant view - observe your change in sandbox, not in irb
- Publish it to irb
- Observe it propagated