### PR TITLE
[JN-1527] adding timezone to study/export

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/export/EnrolleeExportExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/export/EnrolleeExportExtService.java
@@ -4,27 +4,38 @@ import bio.terra.pearl.api.admin.service.auth.AuthUtilService;
 import bio.terra.pearl.api.admin.service.auth.EnforcePortalStudyEnvPermission;
 import bio.terra.pearl.api.admin.service.auth.context.PortalStudyEnvAuthContext;
 import bio.terra.pearl.core.model.export.ExportOptions;
+import bio.terra.pearl.core.model.study.StudyEnvironmentConfig;
 import bio.terra.pearl.core.service.export.DictionaryExportService;
 import bio.terra.pearl.core.service.export.EnrolleeExportService;
 import bio.terra.pearl.core.service.export.ExportOptionsWithExpression;
+import bio.terra.pearl.core.service.study.StudyEnvironmentConfigService;
 import java.io.OutputStream;
 import org.springframework.stereotype.Service;
 
 @Service
 public class EnrolleeExportExtService {
-  private EnrolleeExportService enrolleeExportService;
-  private DictionaryExportService dictionaryExportService;
+  private final EnrolleeExportService enrolleeExportService;
+  private final DictionaryExportService dictionaryExportService;
+  private final StudyEnvironmentConfigService studyEnvironmentConfigService;
 
   public EnrolleeExportExtService(
       EnrolleeExportService enrolleeExportService,
-      DictionaryExportService dictionaryExportService) {
+      DictionaryExportService dictionaryExportService,
+      StudyEnvironmentConfigService studyEnvironmentConfigService) {
     this.enrolleeExportService = enrolleeExportService;
     this.dictionaryExportService = dictionaryExportService;
+    this.studyEnvironmentConfigService = studyEnvironmentConfigService;
   }
 
   @EnforcePortalStudyEnvPermission(permission = "participant_data_view")
   public void export(
       PortalStudyEnvAuthContext authContext, ExportOptionsWithExpression options, OutputStream os) {
+    if (options.getTimeZone() == null) {
+      StudyEnvironmentConfig studyEnvConfig =
+          studyEnvironmentConfigService.findByStudyEnvironmentId(
+              authContext.getStudyEnvironment().getId());
+      options.setTimeZone(studyEnvConfig.getTimeZone());
+    }
     enrolleeExportService.export(options, authContext.getStudyEnvironment().getId(), os);
   }
 

--- a/core/src/main/java/bio/terra/pearl/core/model/export/ExportOptions.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/export/ExportOptions.java
@@ -2,12 +2,11 @@ package bio.terra.pearl.core.model.export;
 
 import bio.terra.pearl.core.model.BaseEntity;
 import bio.terra.pearl.core.service.export.ExportFileFormat;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,4 +30,10 @@ public class ExportOptions extends BaseEntity {
     private List<String> excludeModules = new ArrayList<>();
     @Builder.Default
     private List<String> includeFields = new ArrayList<>();
+    private String timeZone; // defaults to null since the default is to use the study home time zone
+
+    @JsonIgnore
+    public ZoneId getZoneId() {
+        return timeZone == null ? null : ZoneId.of(timeZone);
+    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/portal/PortalEnvironmentConfig.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/portal/PortalEnvironmentConfig.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
+import java.util.TimeZone;
+
 @Getter
 @Setter
 @SuperBuilder

--- a/core/src/main/java/bio/terra/pearl/core/model/study/StudyEnvironmentConfig.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/study/StudyEnvironmentConfig.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
+import java.time.ZoneId;
+
 @Getter @Setter @SuperBuilder
 @NoArgsConstructor
 public class StudyEnvironmentConfig extends BaseEntity {
@@ -48,4 +50,12 @@ public class StudyEnvironmentConfig extends BaseEntity {
      */
     @Builder.Default
     private boolean enableInPersonKits = false;
+
+    /**
+     * the "home" timezone of the study (e.g. where the study staff is located).  For now, this only impacts export behavior
+     * This is a ZoneId stored as a String
+     */
+    @Builder.Default
+    private String timeZone = ZoneId.of("America/New_York").toString();
+
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -571,6 +571,9 @@ public class EnrolleeImportService {
     // preserving response creation and task creation/completion
     // is important for recurring surveys
     private void shiftTime(SurveyResponse surveyResponse, ParticipantTask relatedTask, SurveyFormatter formatter, Map<String, String> enrolleeMap, ZoneId zoneId) {
+        if (zoneId == null) {
+            zoneId = ZoneId.of("America/New_York");
+        }
         // make sure the task reflects created and completion status
         // so that recurrences are properly scheduled
         String completedAtKey = formatter.getModuleName() + ExportFormatUtils.COLUMN_NAME_DELIMITER + "completedAt";

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/ExportFormatUtils.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/ExportFormatUtils.java
@@ -59,7 +59,7 @@ public class ExportFormatUtils {
         }
         return Instant.from(
                 DateTimeFormatter.ofPattern(ANALYSIS_DATE_TIME_FORMAT)
-                        .withZone(timeZone) // for now do everything in UTC
+                        .withZone(timeZone)
                         .parse(instantString)
         );
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/ExportFormatUtils.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/ExportFormatUtils.java
@@ -48,24 +48,25 @@ public class ExportFormatUtils {
         return LocalDate.parse(localDateString, DateTimeFormatter.ofPattern(ANALYSIS_DATE_FORMAT));
     }
 
-    public static String formatInstant(Instant instant) {
+    public static String formatInstant(Instant instant, ZoneId timeZone) {
         return DateTimeFormatter.ofPattern(ANALYSIS_DATE_TIME_FORMAT)
-                .withZone(ZoneOffset.UTC).format(instant);
+                .withZone(timeZone).format(instant);
     }
 
-    public static Instant importInstant(String instantString) {
+    public static Instant importInstant(String instantString, ZoneId timeZone) {
         if (StringUtils.isBlank(instantString)) {
             return null;
         }
         return Instant.from(
                 DateTimeFormatter.ofPattern(ANALYSIS_DATE_TIME_FORMAT)
-                        .withZone(ZoneId.of("Z")) // for now do everything in UTC
+                        .withZone(timeZone) // for now do everything in UTC
                         .parse(instantString)
         );
     }
 
-    /** simple property formatter -- just branches on the class of the thing to format */
-    public static String formatForExport(Object value) {
+    /** simple property formatter -- just branches on the class of the thing to format.
+     * note that time zone has to be provided so that UTC-stored timestamps can be converted correctly */
+    public static String formatForExport(Object value, ZoneId timeZone) {
         if (value == null) {
             return NULL_STRING;
         }
@@ -74,7 +75,7 @@ public class ExportFormatUtils {
         } else if (LocalDate.class.isInstance(value)) {
             return formatLocalDate((LocalDate) value);
         } else if (Instant.class.isInstance(value)) {
-            return formatInstant((Instant) value);
+            return formatInstant((Instant) value, timeZone);
         }
         return value.toString();
     }
@@ -99,9 +100,9 @@ public class ExportFormatUtils {
                         StringUtils.capitalize(spacedString)), " ");
     }
 
-    public static Object getValueFromString(String exportString, DataValueExportType dataType) {
+    public static Object getValueFromString(String exportString, DataValueExportType dataType, ZoneId zoneId) {
         if (dataType.equals(DataValueExportType.DATE_TIME)) {
-            return ExportFormatUtils.importInstant(exportString);
+            return ExportFormatUtils.importInstant(exportString, zoneId);
         } else if (dataType.equals(DataValueExportType.DATE)) {
             return ExportFormatUtils.importLocalDate(exportString);
         } else if (dataType.equals(DataValueExportType.BOOLEAN)) {

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/item/AnswerItemFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/item/AnswerItemFormatter.java
@@ -168,7 +168,7 @@ public class AnswerItemFormatter extends ItemFormatter<SurveyResponseWithTaskDto
             answer.setAnswerType(AnswerType.OBJECT);
             answer.setObjectValue(exportString);
         } else {
-            answer.setValueAndType(ExportFormatUtils.getValueFromString(exportString, dataType));
+            answer.setValueAndType(ExportFormatUtils.getValueFromString(exportString, dataType, zoneId));
         }
         response.getAnswers().add(answer);
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/item/ItemFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/item/ItemFormatter.java
@@ -9,6 +9,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
+import java.time.ZoneId;
+
 /** An 'item' corresponds to either a survey question or a specific field of a data model */
 @Getter @SuperBuilder @NoArgsConstructor
 public abstract class ItemFormatter<T> {
@@ -23,6 +25,7 @@ public abstract class ItemFormatter<T> {
 
     @Setter
     protected boolean importable = true;
+    protected ZoneId zoneId;
 
 
     /** if this item maps to a single column in the export, this function is trivial.

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/item/KitTypeFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/item/KitTypeFormatter.java
@@ -6,10 +6,12 @@ import bio.terra.pearl.core.service.kit.KitRequestDto;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.beanutils.PropertyUtils;
 
+import java.time.ZoneId;
+
 @Slf4j
 public class KitTypeFormatter extends PropertyItemFormatter<KitRequestDto> {
-    public KitTypeFormatter() {
-        super("kitType", KitRequestDto.class);
+    public KitTypeFormatter(ZoneId zoneId) {
+        super("kitType", KitRequestDto.class, zoneId);
         this.baseColumnKey = "kitType";
         this.dataType = DataValueExportType.STRING;
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/item/PropertyItemFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/item/PropertyItemFormatter.java
@@ -11,6 +11,7 @@ import org.apache.commons.beanutils.PropertyUtils;
 import java.beans.BeanInfo;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
+import java.time.ZoneId;
 import java.util.Arrays;
 
 import static bio.terra.pearl.core.service.export.formatters.ExportFormatUtils.DATA_TYPE_MAP;
@@ -23,18 +24,16 @@ public class PropertyItemFormatter<T> extends ItemFormatter<T> {
     @Getter
     private Class<?> propertyClass;
 
-    public PropertyItemFormatter(String propertyName, Class<T> beanClass) {
-        this.propertyName = propertyName;
-        this.propertyClass = getPropertyClass(beanClass, propertyName);
-        this.dataType = DATA_TYPE_MAP.getOrDefault(propertyClass, DataValueExportType.STRING);
-        this.baseColumnKey = propertyName;
+    public PropertyItemFormatter(String propertyName, Class<T> beanClass, ZoneId zoneId) {
+        this(propertyName, beanClass, propertyName, zoneId);
     }
 
-    public PropertyItemFormatter(String propertyName, Class<T> beanClass, String alias) {
+    public PropertyItemFormatter(String propertyName, Class<T> beanClass, String alias, ZoneId zoneId) {
         this.propertyName = propertyName;
         this.propertyClass = getPropertyClass(beanClass, propertyName);
         this.dataType = DATA_TYPE_MAP.getOrDefault(propertyClass, DataValueExportType.STRING);
         this.baseColumnKey = alias;
+        this.zoneId = zoneId;
     }
 
     public Class<?> getPropertyClass(Class<?> beanClass, String propertyName) {
@@ -76,7 +75,7 @@ public class PropertyItemFormatter<T> extends ItemFormatter<T> {
      * the metadata will include information on the actual data type
      */
     public String getExportString(T bean) {
-        return ExportFormatUtils.formatForExport(getRawExportValue(bean));
+        return ExportFormatUtils.formatForExport(getRawExportValue(bean), zoneId);
     }
 
 
@@ -87,7 +86,7 @@ public class PropertyItemFormatter<T> extends ItemFormatter<T> {
          * the application default
          */
         if (exportString != null) {
-            Object value = ExportFormatUtils.getValueFromString(exportString, dataType);
+            Object value = ExportFormatUtils.getValueFromString(exportString, dataType, zoneId);
             try {
                 PropertyUtils.setNestedProperty(bean, getPropertyName(), value);
             } catch (NestedNullException e) {

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/item/PropertyItemFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/item/PropertyItemFormatter.java
@@ -33,7 +33,7 @@ public class PropertyItemFormatter<T> extends ItemFormatter<T> {
         this.propertyClass = getPropertyClass(beanClass, propertyName);
         this.dataType = DATA_TYPE_MAP.getOrDefault(propertyClass, DataValueExportType.STRING);
         this.baseColumnKey = alias;
-        this.zoneId = zoneId;
+        this.zoneId = zoneId == null ? ZoneId.of("America/New_York") : zoneId;
     }
 
     public Class<?> getPropertyClass(Class<?> beanClass, String propertyName) {

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeFormatter.java
@@ -19,7 +19,7 @@ public class EnrolleeFormatter extends BeanModuleFormatter<Enrollee> {
 
     @Override
     protected List<PropertyItemFormatter<Enrollee>> generateItemFormatters(ExportOptions options) {
-        return INCLUDED_PROPERTIES.stream().map(propName -> new PropertyItemFormatter<>(propName, Enrollee.class))
+        return INCLUDED_PROPERTIES.stream().map(propName -> new PropertyItemFormatter<>(propName, Enrollee.class, options.getZoneId()))
                 .collect(Collectors.toList());
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeRelationFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeRelationFormatter.java
@@ -20,7 +20,7 @@ public class EnrolleeRelationFormatter extends BeanListModuleFormatter<EnrolleeR
     @Override
     protected List<PropertyItemFormatter<EnrolleeRelation>> generateItemFormatters(ExportOptions options) {
         return INCLUDED_PROPERTIES.stream()
-                .map(propName -> new PropertyItemFormatter<>(propName, EnrolleeRelation.class))
+                .map(propName -> new PropertyItemFormatter<>(propName, EnrolleeRelation.class, options.getZoneId()))
                 .collect(Collectors.toList());
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/FamilyFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/FamilyFormatter.java
@@ -20,7 +20,7 @@ public class FamilyFormatter extends BeanListModuleFormatter<Family> {
     @Override
     protected List<PropertyItemFormatter<Family>> generateItemFormatters(ExportOptions options) {
         return INCLUDED_PROPERTIES.stream()
-                .map(propName -> new PropertyItemFormatter<>(propName, Family.class))
+                .map(propName -> new PropertyItemFormatter<>(propName, Family.class, options.getZoneId()))
                 .collect(Collectors.toList());
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/KitRequestFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/KitRequestFormatter.java
@@ -26,10 +26,10 @@ public class KitRequestFormatter extends BeanListModuleFormatter<KitRequestDto> 
     @Override
     protected List<PropertyItemFormatter<KitRequestDto>> generateItemFormatters(ExportOptions options) {
         itemFormatters = KIT_REQUEST_INCLUDED_PROPERTIES.stream()
-                .map(propName -> new PropertyItemFormatter<>(propName, KitRequestDto.class))
+                .map(propName -> new PropertyItemFormatter<>(propName, KitRequestDto.class, options.getZoneId()))
                 .collect(Collectors.toList());
         // we have to handle kitType separately because we'll need to match it to the kitType name
-        itemFormatters.add(new KitTypeFormatter());
+        itemFormatters.add(new KitTypeFormatter(options.getZoneId()));
         return itemFormatters;
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ParticipantUserFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ParticipantUserFormatter.java
@@ -17,7 +17,7 @@ public class ParticipantUserFormatter extends BeanModuleFormatter<ParticipantUse
 
     @Override
     protected List<PropertyItemFormatter<ParticipantUser>> generateItemFormatters(ExportOptions options) {
-        return INCLUDED_PROPERTIES.stream().map(propName -> new PropertyItemFormatter<>(propName, ParticipantUser.class))
+        return INCLUDED_PROPERTIES.stream().map(propName -> new PropertyItemFormatter<>(propName, ParticipantUser.class, options.getZoneId()))
                 .collect(Collectors.toList());
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ProfileFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ProfileFormatter.java
@@ -29,10 +29,10 @@ public class ProfileFormatter extends BeanModuleFormatter<Profile> {
     @Override
     protected List<PropertyItemFormatter<Profile>> generateItemFormatters(ExportOptions options) {
         List<PropertyItemFormatter<Profile>> formatters = ExportFormatUtils.getIncludedProperties(Profile.class, PROFILE_EXCLUDED_PROPERTIES)
-                .stream().map(propName -> new PropertyItemFormatter<Profile>(propName, Profile.class))
+                .stream().map(propName -> new PropertyItemFormatter<Profile>(propName, Profile.class, options.getZoneId()))
                 .collect(Collectors.toList());
         formatters.addAll(ExportFormatUtils.getIncludedProperties(MailingAddress.class, MAILING_ADDRESS_EXCLUDED_PROPERTIES)
-                .stream().map(propName -> new PropertyItemFormatter<Profile>("mailingAddress." + propName, Profile.class))
+                .stream().map(propName -> new PropertyItemFormatter<Profile>("mailingAddress." + propName, Profile.class, options.getZoneId()))
                 .toList());
         return formatters;
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ProxyFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ProxyFormatter.java
@@ -29,7 +29,7 @@ public class ProxyFormatter extends BeanListModuleFormatter<ParticipantUser> {
 
     @Override
     protected List<PropertyItemFormatter<ParticipantUser>> generateItemFormatters(ExportOptions options) {
-        return INCLUDED_PROPERTIES.stream().map(propName -> new PropertyItemFormatter<ParticipantUser>(propName, ParticipantUser.class))
+        return INCLUDED_PROPERTIES.stream().map(propName -> new PropertyItemFormatter<ParticipantUser>(propName, ParticipantUser.class, options.getZoneId()))
                 .collect(Collectors.toList());
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/StudyFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/StudyFormatter.java
@@ -20,7 +20,7 @@ public class StudyFormatter extends BeanModuleFormatter<Study> {
 
     @Override
     protected List<PropertyItemFormatter<Study>> generateItemFormatters(ExportOptions options) {
-        return INCLUDED_PROPERTIES.stream().map(propName -> new PropertyItemFormatter<>(propName, Study.class))
+        return INCLUDED_PROPERTIES.stream().map(propName -> new PropertyItemFormatter<>(propName, Study.class, options.getZoneId()))
                 .collect(Collectors.toList());
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatter.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.BeanUtils;
 
+import java.time.ZoneId;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -54,14 +55,14 @@ public class SurveyFormatter extends ModuleFormatter<SurveyResponseWithTaskDto, 
     protected List<ItemFormatter<SurveyResponseWithTaskDto>> generateItemFormatters(ExportOptions options) {
         // Note that we generate and add answer formatters to this list later in the constructor
         List<ItemFormatter<SurveyResponseWithTaskDto>> formatters = new ArrayList<>();
-        formatters.add(new PropertyItemFormatter<>("lastUpdatedAt", SurveyResponseWithTaskDto.class));
-        formatters.add(new PropertyItemFormatter<>("createdAt", SurveyResponseWithTaskDto.class));
+        formatters.add(new PropertyItemFormatter<>("lastUpdatedAt", SurveyResponseWithTaskDto.class, options.getZoneId()));
+        formatters.add(new PropertyItemFormatter<>("createdAt", SurveyResponseWithTaskDto.class, options.getZoneId()));
 
-        PropertyItemFormatter<SurveyResponseWithTaskDto> taskCompletedFormatter = new PropertyItemFormatter<>("task.completedAt", SurveyResponseWithTaskDto.class, "completedAt");
+        PropertyItemFormatter<SurveyResponseWithTaskDto> taskCompletedFormatter = new PropertyItemFormatter<>("task.completedAt", SurveyResponseWithTaskDto.class, "completedAt", options.getZoneId());
         taskCompletedFormatter.setImportable(false); // task will be null at time of initial import, but time shifting will occur after
         formatters.add(taskCompletedFormatter);
 
-        formatters.add(new PropertyItemFormatter<>("complete", SurveyResponseWithTaskDto.class));
+        formatters.add(new PropertyItemFormatter<>("complete", SurveyResponseWithTaskDto.class, options.getZoneId()));
         return formatters;
     }
 

--- a/core/src/main/resources/db/changelog/changesets/2025_01_15_study_time_zone.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2025_01_15_study_time_zone.yaml
@@ -1,0 +1,24 @@
+databaseChangeLog:
+  - changeSet:
+      id: "study_time_zone"
+      author: dbush
+      changes:
+        - addColumn:
+            tableName: study_environment_config
+            columns:
+              - column: { name: time_zone, type: text, defaultValue: "America/New_York"}  # per stackoverflow, this is the best way to store time zone
+        - addColumn:
+            tableName: export_options
+            columns:
+              - column: { name: time_zone, type: text }  # this defaults to null because the default is to use the study time zone
+        - sql:
+            sql:
+              update study_environment_config set time_zone = 'Europe/London' 
+              from study_environment 
+              join study on study_environment.study_id = study.id
+              where study_environment.study_environment_config_id = study_environment_config.id and
+              study.shortcode IN ('hh_registry', 'cmyop', 'pacing', 'pregheart'); # hearthive studies
+
+        - dropColumn: # carryover from prior PR
+            tableName: trigger
+            columnName: update_task_target_stable_id

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -377,6 +377,9 @@ databaseChangeLog:
   - include:
       file: changesets/2025_01_09_attach_language_text_to_local_site_content.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2025_01_15_study_time_zone.yaml
+      relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
@@ -22,6 +22,7 @@ import bio.terra.pearl.core.service.admin.AdminUserService;
 import bio.terra.pearl.core.service.export.dataimport.ImportFileFormat;
 import bio.terra.pearl.core.service.export.dataimport.ImportItemService;
 import bio.terra.pearl.core.service.export.dataimport.ImportService;
+import bio.terra.pearl.core.service.export.formatters.ExportFormatUtils;
 import bio.terra.pearl.core.service.kit.KitRequestDto;
 import bio.terra.pearl.core.service.kit.KitRequestService;
 import bio.terra.pearl.core.service.participant.*;
@@ -40,8 +41,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.ByteArrayInputStream;
-import java.time.Instant;
-import java.time.LocalDate;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -107,6 +108,16 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
                 .build();
     }
 
+    private Instant instantFromZone(String timeString, ZoneId zoneId) {
+        return Instant.from(
+                DateTimeFormatter.ofPattern(ExportFormatUtils.ANALYSIS_DATE_TIME_FORMAT)
+                        .withZone(zoneId) // for now do everything in UTC
+                        .parse(timeString));
+    }
+
+    private Instant instantFromZone(String timeString) {
+        return  instantFromZone(timeString, ZoneId.of("America/New_York"));
+    }
 
     @Test
     @Transactional
@@ -124,9 +135,9 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
 
         /*create participantUser, enrollee, profile with expected data to assert*/
         Enrollee enrolleeExpected = new Enrollee();
-        enrolleeExpected.setCreatedAt(Instant.parse("2024-05-09T13:38:00Z"));
+        enrolleeExpected.setCreatedAt(instantFromZone("2024-05-09 01:38PM"));
         ParticipantUser userExpected = new ParticipantUser();
-        userExpected.setCreatedAt(Instant.parse("2024-05-09T13:37:00Z"));
+        userExpected.setCreatedAt(instantFromZone("2024-05-09 01:37PM"));
         userExpected.setUsername("userName1");
         Profile profileExpected = new Profile();
         profileExpected.setBirthDate(LocalDate.parse("1980-10-10"));
@@ -135,9 +146,9 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
         verifyParticipant(imports.get(0), studyEnvId, userExpected, enrolleeExpected, profileExpected);
 
         Enrollee enrolleeExpected2 = new Enrollee();
-        enrolleeExpected2.setCreatedAt(Instant.parse("2024-05-11T10:00:00Z"));
+        enrolleeExpected2.setCreatedAt(instantFromZone("2024-05-11 10:00AM"));
         ParticipantUser userExpected2 = new ParticipantUser();
-        userExpected2.setCreatedAt(Instant.parse("2024-05-11T10:00:00Z"));
+        userExpected2.setCreatedAt(instantFromZone("2024-05-11 10:00AM"));
         userExpected2.setUsername("userName2");
         Profile profileExpected2 = new Profile();
         profileExpected2.setContactEmail(userExpected2.getUsername());
@@ -173,10 +184,10 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
         verifyImport(dataImportUpdate, 2);
         /*create participantUser, enrollee, profile with expected data to assert*/
         ParticipantUser userExpected = new ParticipantUser();
-        userExpected.setCreatedAt(Instant.parse("2024-05-09T13:37:00Z"));
+        userExpected.setCreatedAt(instantFromZone("2024-05-09 01:37PM"));
         userExpected.setUsername("userName1");
         Enrollee enrolleeExpected = new Enrollee();
-        enrolleeExpected.setCreatedAt(Instant.parse("2024-05-09T13:38:00Z"));
+        enrolleeExpected.setCreatedAt(instantFromZone("2024-05-09 01:38PM"));
         Profile profileExpected = new Profile();
         profileExpected.setId(enrollee.getProfileId()); //should be same profile
         profileExpected.setBirthDate(LocalDate.parse("1982-10-10"));
@@ -187,9 +198,9 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
         ParticipantUser user2 = participantUserService.find(imports.get(1).getCreatedParticipantUserId()).orElseThrow();
         Enrollee enrollee2 = enrolleeService.findByParticipantUserIdAndStudyEnvId(user2.getId(), studyEnvId).orElseThrow();
         Enrollee enrolleeExpected2 = new Enrollee();
-        enrolleeExpected2.setCreatedAt(Instant.parse("2024-05-11T10:00:00Z"));
+        enrolleeExpected2.setCreatedAt(instantFromZone("2024-05-11 10:00AM"));
         ParticipantUser userExpected2 = new ParticipantUser();
-        userExpected2.setCreatedAt(Instant.parse("2024-05-11T10:00:00Z"));
+        userExpected2.setCreatedAt(instantFromZone("2024-05-11 10:00AM"));
         userExpected2.setUsername("userName2");
         Profile profileExpected2 = new Profile();
         profileExpected2.setId(enrollee2.getProfileId()); //should be same profile
@@ -217,7 +228,7 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
                 .kitType(salivaKit)
                 .status(KitRequestStatus.SENT)
                 .trackingNumber("KITTRACKNUMBER12345")
-                .createdAt(Instant.parse("2024-05-09T10:10:00Z"))
+                .createdAt(instantFromZone("2024-05-09 10:10AM"))
                 .build();
         kitRequestDtoList.add(kitRequestDto);
         verifyKitRequests(dataImport.getImportItems().get(0), kitRequestDtoList);
@@ -239,13 +250,13 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
                 .kitType(salivaKit)
                 .status(KitRequestStatus.SENT)
                 .trackingNumber("KITTRACKNUMBER_1")
-                .createdAt(Instant.parse("2024-05-09T10:10:00Z"))
+                .createdAt(instantFromZone("2024-05-09 10:10AM"))
                 .build();
         KitRequestDto kitRequestDto2 = KitRequestDto.builder()
                 .kitType(salivaKit)
                 .status(KitRequestStatus.RECEIVED)
                 .trackingNumber("KITTRACKNUMBER_2")
-                .createdAt(Instant.parse("2024-05-21T11:10:00Z"))
+                .createdAt(instantFromZone("2024-05-21 11:10AM"))
                 .build();
         kitRequestDtoList.add(kitRequestDto);
         kitRequestDtoList.add(kitRequestDto2);
@@ -284,10 +295,10 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
         Enrollee enrolleeUpd = enrolleeService.findByParticipantUserIdAndStudyEnvId(userUpd.getId(), studyEnvId).orElseThrow();
         /*create participantUser, enrollee, profile with expected data to assert*/
         ParticipantUser userExpected = new ParticipantUser();
-        userExpected.setCreatedAt(Instant.parse("2024-05-09T13:37:00Z"));
+        userExpected.setCreatedAt(instantFromZone("2024-05-09 01:37PM"));
         userExpected.setUsername("userName1");
         Enrollee enrolleeExpected = new Enrollee();
-        enrolleeExpected.setCreatedAt(Instant.parse("2024-05-09T13:38:00Z"));
+        enrolleeExpected.setCreatedAt(instantFromZone("2024-05-09 01:38PM"));
         Profile profileExpected = new Profile();
         profileExpected.setBirthDate(LocalDate.parse("1990-10-10"));
         verifyParticipant(importItem, setupData2.bundle.getStudyEnv().getId(), userExpected, enrolleeExpected, profileExpected);
@@ -789,13 +800,13 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
 
         SurveyResponse response = responses.get(0);
 
-        assertThat(response.getCreatedAt(), equalTo(Instant.parse("2023-08-20T05:17:00Z")));
-        assertThat(response.getLastUpdatedAt(), equalTo(Instant.parse("2023-08-21T05:17:00Z")));
+        assertThat(response.getCreatedAt(), equalTo(instantFromZone("2023-08-20 05:17AM")));
+        assertThat(response.getLastUpdatedAt(), equalTo(instantFromZone("2023-08-21 05:17AM")));
 
         PortalParticipantUser ppUser = portalParticipantUserService.findForEnrollee(enrollee);
 
         ParticipantTask task = participantTaskService.findTaskForActivity(ppUser.getId(), bundle.getStudyEnv().getId(), survey.getStableId()).orElseThrow();
-        assertThat(task.getCompletedAt(), equalTo(Instant.parse("2023-08-22T05:17:00Z")));
+        assertThat(task.getCompletedAt(), equalTo(instantFromZone("2023-08-22 05:17AM")));
 
     }
 

--- a/core/src/test/java/bio/terra/pearl/core/service/export/TsvExporterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/TsvExporterTests.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 
@@ -25,13 +26,15 @@ import static org.hamcrest.core.IsEqual.equalTo;
 public class TsvExporterTests extends BaseSpringBootTest {
     @Autowired
     ObjectMapper objectMapper;
+    private ZoneId defaultZoneId = ZoneId.of("America/New_York");
+
     @Test
     public void testBasicExport() throws Exception {
         EnrolleeFormatter sampleFormatter = new EnrolleeFormatter(new ExportOptions());
         // replace the formatters with a simple set we control
         sampleFormatter.getItemFormatters().clear();
-        sampleFormatter.getItemFormatters().add(new PropertyItemFormatter<Enrollee>("shortcode", Enrollee.class));
-        sampleFormatter.getItemFormatters().add(new PropertyItemFormatter<Enrollee>("consented", Enrollee.class));
+        sampleFormatter.getItemFormatters().add(new PropertyItemFormatter<Enrollee>("shortcode", Enrollee.class, defaultZoneId));
+        sampleFormatter.getItemFormatters().add(new PropertyItemFormatter<Enrollee>("consented", Enrollee.class, defaultZoneId));
         Map<String, String> valueMap = Map.of("enrollee.shortcode", "ABCDEF",
                 "enrollee.consented", "false");
         String outString = getExportResult(List.of(valueMap), List.of(sampleFormatter));
@@ -44,8 +47,8 @@ public class TsvExporterTests extends BaseSpringBootTest {
         // replace the formatters with a simple set we control
         // replace the formatters with a simple set we control
         sampleFormatter.getItemFormatters().clear();
-        sampleFormatter.getItemFormatters().add(new PropertyItemFormatter<Enrollee>("shortcode", Enrollee.class));
-        sampleFormatter.getItemFormatters().add(new PropertyItemFormatter<Enrollee>("consented", Enrollee.class));
+        sampleFormatter.getItemFormatters().add(new PropertyItemFormatter<Enrollee>("shortcode", Enrollee.class, defaultZoneId));
+        sampleFormatter.getItemFormatters().add(new PropertyItemFormatter<Enrollee>("consented", Enrollee.class, defaultZoneId));
         Map<String, String> valueMap = Map.of("enrollee.shortcode", "ABCD\"EF",
                 "enrollee.consented", "fa\tlse");
         String outString = getExportResult(List.of(valueMap), List.of(sampleFormatter));

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/EnrolleeFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/EnrolleeFormatterTests.java
@@ -7,6 +7,7 @@ import bio.terra.pearl.core.service.export.formatters.module.EnrolleeFormatter;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -26,6 +27,7 @@ public class EnrolleeFormatterTests {
 
         assertThat(valueMap.get("enrollee.shortcode"), equalTo("TESTER"));
         assertThat(valueMap.get("enrollee.consented"), equalTo("true"));
-        assertThat(valueMap.get("enrollee.createdAt"), equalTo("2023-08-21 05:17AM"));
+        assertThat(valueMap.get("enrollee.createdAt"), equalTo(ExportFormatUtils.formatInstant(enrollee.getCreatedAt(),
+                ZoneId.of("America/New_York"))));
     }
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ParticipantUserFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ParticipantUserFormatterTests.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Map;
 import java.util.UUID;
 
@@ -38,7 +39,7 @@ public class ParticipantUserFormatterTests {
         ParticipantUserFormatter moduleFormatter = new ParticipantUserFormatter(new ExportOptions());
         ParticipantUser user = moduleFormatter.fromStringMap(UUID.randomUUID(), valueMap);
         assertThat(user.getUsername(), equalTo(valueMap.get("account.username")));
-        assertThat(ExportFormatUtils.formatInstant(user.getCreatedAt()),
+    assertThat(ExportFormatUtils.formatInstant(user.getCreatedAt(), ZoneId.of("UTC")),
                 equalTo(valueMap.get("account.createdAt")));
     }
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ParticipantUserFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ParticipantUserFormatterTests.java
@@ -18,16 +18,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ParticipantUserFormatterTests {
     @Test
     public void testToStringMap() {
-        ParticipantUser participantUser = ParticipantUser.builder()
+        ParticipantUser user = ParticipantUser.builder()
                 .username("tester-" + RandomStringUtils.randomAlphabetic(5))
                 .createdAt(Instant.parse("2023-08-21T05:17:25.00Z"))
                 .build();
         ParticipantUserFormatter moduleFormatter = new ParticipantUserFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(null, null, participantUser, null, null, null, null, null, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, user, null, null, null, null, null, null, null, null);
         Map<String, String> valueMap = moduleFormatter.toStringMap(exportData);
 
-        assertThat(valueMap.get("account.username"), equalTo(participantUser.getUsername()));
-        assertThat(valueMap.get("account.createdAt"), equalTo("2023-08-21 05:17AM"));
+        assertThat(valueMap.get("account.username"), equalTo(user.getUsername()));
+        assertThat(valueMap.get("account.createdAt"), ExportFormatUtils.formatInstant(user.getCreatedAt(),
+                        ZoneId.of("America/New_York")), equalTo(valueMap.get("account.createdAt")));
     }
 
     @Test
@@ -39,7 +40,7 @@ public class ParticipantUserFormatterTests {
         ParticipantUserFormatter moduleFormatter = new ParticipantUserFormatter(new ExportOptions());
         ParticipantUser user = moduleFormatter.fromStringMap(UUID.randomUUID(), valueMap);
         assertThat(user.getUsername(), equalTo(valueMap.get("account.username")));
-    assertThat(ExportFormatUtils.formatInstant(user.getCreatedAt(), ZoneId.of("UTC")),
+    assertThat(ExportFormatUtils.formatInstant(user.getCreatedAt(), ZoneId.of("America/New_York")),
                 equalTo(valueMap.get("account.createdAt")));
     }
 }

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateOurhealthTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateOurhealthTest.java
@@ -122,6 +122,7 @@ public class PopulateOurhealthTest extends BasePopulatePortalsTest {
                 .onlyIncludeMostRecent(true)
                 .fileFormat(ExportFileFormat.TSV)
                 .rowLimit(null)
+                .timeZone("America/New_York")
                 .build();
         List<EnrolleeExportData> enrolleeExportData = enrolleeExportService.loadEnrolleeExportData(sandboxEnvironmentId, options);
         List<ModuleFormatter> moduleInfos = enrolleeExportService.generateModuleInfos(options, sandboxEnvironmentId, enrolleeExportData);

--- a/ui-admin/src/study/settings/SettingsView.test.tsx
+++ b/ui-admin/src/study/settings/SettingsView.test.tsx
@@ -99,8 +99,7 @@ describe('Portal Settings', () => {
         'emailSourceAddress': 'testing@test.com',
         'initialized': true,
         'password': 'broad_institute',
-        'passwordProtected': false,
-        timeZone: 'America/New_York'
+        'passwordProtected': false
       })
   })
 })

--- a/ui-admin/src/study/settings/SettingsView.test.tsx
+++ b/ui-admin/src/study/settings/SettingsView.test.tsx
@@ -99,7 +99,8 @@ describe('Portal Settings', () => {
         'emailSourceAddress': 'testing@test.com',
         'initialized': true,
         'password': 'broad_institute',
-        'passwordProtected': false
+        'passwordProtected': false,
+        timeZone: 'America/New_York'
       })
   })
 })

--- a/ui-admin/src/study/settings/SettingsView.test.tsx
+++ b/ui-admin/src/study/settings/SettingsView.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { setupRouterTest } from '@juniper/ui-core'
+import { renderWithRouter, setupRouterTest } from '@juniper/ui-core'
 import {
   mockPortalContext,
   mockPortalEnvironmentConfig,
@@ -107,14 +107,12 @@ describe('Portal Settings', () => {
 
 describe('Study Settings', () => {
   test('renders study settings', async () => {
-    const { RoutedComponent } = setupRouterTest(<MockUserProvider user={mockAdminUser(true)}>
+    renderWithRouter(<MockUserProvider user={mockAdminUser(true)}>
       <LoadedSettingsView
         studyEnvContext={mockStudyEnvContext()}
         portalContext={mockPortalContext()}
       />
     </MockUserProvider>, ['/enrollment'])
-
-    render(RoutedComponent)
 
     // renders general settings
 
@@ -136,32 +134,28 @@ describe('Study Settings', () => {
   })
   test('updates study settings', async () => {
     const mock = jest.spyOn(Api, 'updateStudyEnvironmentConfig')
+      .mockImplementation(jest.fn())
 
     const portalContext = mockPortalContext()
     const studyEnvContext = mockStudyEnvContext()
 
-    const { RoutedComponent } = setupRouterTest(<MockUserProvider user={mockAdminUser(true)}>
+    renderWithRouter(<MockUserProvider user={mockAdminUser(true)}>
       <LoadedSettingsView
-        studyEnvContext={studyEnvContext}
-        portalContext={portalContext}
+        studyEnvContext={mockStudyEnvContext()}
+        portalContext={mockPortalContext()}
       />
+      <ReactNotifications/>
     </MockUserProvider>, ['/enrollment'])
-
-    render(RoutedComponent)
 
     // renders general settings
 
     expect(screen.getByText('Study Enrollment Settings')).toBeInTheDocument()
 
-    await act(async () => {
-      await userEvent.clear(screen.getByLabelText('password'))
-      await userEvent.type(screen.getByLabelText('password'), 'super_secret')
-    })
 
-    await act(async () => {
-      await userEvent.click(screen.getByText('Save study settings'))
-    })
+    await userEvent.clear(screen.getByLabelText('password'))
+    await userEvent.type(screen.getByLabelText('password'), 'super_secret')
 
+    await userEvent.click(screen.getByText('Save study settings'))
 
     expect(mock).toHaveBeenCalledWith(
       portalContext.portal.shortcode,
@@ -176,7 +170,8 @@ describe('Study Settings', () => {
         'passwordProtected': false,
         'useDevDsmRealm': false,
         'useStubDsm': false,
-        'enableInPersonKits': false
+        'enableInPersonKits': false,
+        timeZone: 'America/New_York'
       }
     )
   })

--- a/ui-admin/src/study/settings/SettingsView.tsx
+++ b/ui-admin/src/study/settings/SettingsView.tsx
@@ -241,7 +241,7 @@ const SettingsPage = ({
   return <div>
     <h2 className="h4">{title}</h2>
     {children}
-    <div>
+    <div className="py-3">
       {savePortalConfig && <Button
         variant="primary"
         onClick={savePortalConfig}

--- a/ui-admin/src/study/settings/study/StudyEnrollmentSettings.tsx
+++ b/ui-admin/src/study/settings/study/StudyEnrollmentSettings.tsx
@@ -10,6 +10,9 @@ import {
   userHasPermission,
   useUser
 } from 'user/UserProvider'
+import { useNonNullReactSingleSelect } from '../../../util/react-select-utils'
+import Select from 'react-select'
+
 
 export const StudyEnrollmentSettings = (
   {
@@ -22,6 +25,19 @@ export const StudyEnrollmentSettings = (
     updateConfig: (key: keyof StudyEnvironmentConfig, value: unknown) => void
   }) => {
   const { user } = useUser()
+
+  // @ts-ignore
+  const {
+    onChange: onTimeZoneChange,
+    options: timeZoneOptions,
+    selectedOption: selectedTimeZone,
+    selectInputId: timeZoneSelectId
+  } = useNonNullReactSingleSelect<string>(
+    // Intl won't be recognized by TypeScript until we upgrade to 5.1+, so do some funky casting for now
+    (Intl as unknown as {supportedValuesOf: (key: string) => string[]}).supportedValuesOf('timeZone'),
+    timeZone => ({ label: timeZone, value: timeZone }),
+    (opt: string) => updateConfig('timeZone', opt),
+    config.timeZone)
 
   return <div>
     <p>Configure whether participants can access study content, such as surveys and consents.</p>
@@ -59,7 +75,6 @@ export const StudyEnrollmentSettings = (
           onChange={e => updateConfig('acceptingProxyEnrollment', e.target.checked)}/>
       </label>
     </div>
-
     {
       userHasPermission(user, studyEnvContext.portal.id, 'prototype') && (
         <div>
@@ -71,5 +86,17 @@ export const StudyEnrollmentSettings = (
         </div>
       )
     }
+    <div>
+      <label className="form-label" htmlFor={timeZoneSelectId}>
+        Study staff time zone <InfoPopup content={
+          <span>
+            The &quot;home&quot; time zone for the study.
+          This only determines times used in data exported from the portal.
+            Participants and staff users see things in their own time zone when using the website.
+          </span>}/>
+      </label>
+      <Select options={timeZoneOptions} onChange={onTimeZoneChange}
+        value={selectedTimeZone} inputId={timeZoneSelectId}/>
+    </div>
   </div>
 }

--- a/ui-admin/src/study/settings/study/StudyEnrollmentSettings.tsx
+++ b/ui-admin/src/study/settings/study/StudyEnrollmentSettings.tsx
@@ -34,7 +34,7 @@ export const StudyEnrollmentSettings = (
     selectInputId: timeZoneSelectId
   } = useNonNullReactSingleSelect<string>(
     // Intl won't be recognized by TypeScript until we upgrade to 5.1+, so do some funky casting for now
-    (Intl as unknown as {supportedValuesOf: (key: string) => string[]}).supportedValuesOf('timeZone'),
+    (Intl as unknown as {supportedValuesOf: (key: string) => string[]}).supportedValuesOf?.('timeZone') ?? [],
     timeZone => ({ label: timeZone, value: timeZone }),
     (opt: string) => updateConfig('timeZone', opt),
     config.timeZone)

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -196,7 +196,8 @@ export const mockStudyEnvironmentConfig = (): StudyEnvironmentConfig => {
     acceptingProxyEnrollment: false,
     useDevDsmRealm: false,
     useStubDsm: false,
-    enableInPersonKits: false
+    enableInPersonKits: false,
+    timeZone: 'America/New_York'
   }
 }
 

--- a/ui-core/src/types/study.ts
+++ b/ui-core/src/types/study.ts
@@ -44,6 +44,7 @@ export type StudyEnvironmentConfig = {
   useStubDsm: boolean
   useDevDsmRealm: boolean
   enableInPersonKits: boolean
+  timeZone: string
 }
 
 export type StudyEnvironmentSurvey = {

--- a/ui-participant/src/test-utils/test-portal-factory.tsx
+++ b/ui-participant/src/test-utils/test-portal-factory.tsx
@@ -56,7 +56,8 @@ export const mockStudyEnv = (): StudyEnvironment => {
       password: 'password',
       useDevDsmRealm: true,
       useStubDsm: true,
-      enableInPersonKits: true
+      enableInPersonKits: true,
+      timeZone: 'America/New_York'
     },
     configuredSurveys: [],
     triggers: []


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

As usual, anything involving time takes about 100 more lines of code than expected.  This adds a "time zone" to study environments (defaulting to US/New York) that gets used by default when exporting.  

![image](https://github.com/user-attachments/assets/f7e117c8-8708-4764-99c7-3b151c3f59a7)

For now, I haven't added the option to configure this specifically in the export UX, because we want to encourage consistent timezone usage, and so it should be at the study level.  

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy apiAdminApp
2. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants
3. add a new synthetic participant of "consented" type
4. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/export/dataBrowser?showPreview=true
5. confirm the new enrollee shows up with a createdAt time that matches your local time (assuming you are in EDT)
