### PR TITLE
[JN-1560] fix missing trcc export fields

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatter.java
@@ -73,16 +73,15 @@ public class SurveyFormatter extends ModuleFormatter<SurveyResponseWithTaskDto, 
         // the export order of the most recent version
         Collection<List<SurveyQuestionDefinition>> questionDefsByStableId = questionDefs.stream().collect(groupingBy(
                 SurveyQuestionDefinition::getQuestionStableId
-        )).values().stream().sorted(Comparator.comparingInt(a -> a.get(0).getExportOrder())).toList();
+                ))
+                .values()
+                .stream()
+                .sorted(Comparator.comparingInt(a -> a.get(0).getExportOrder()))
+                .map(questionVersions -> questionVersions.stream().sorted(Comparator.comparing(SurveyQuestionDefinition::getSurveyVersion, Collections.reverseOrder())).toList())
+                .toList();
 
         for (List<SurveyQuestionDefinition> questionVersions : questionDefsByStableId) {
-
-            Optional<SurveyQuestionDefinition> mostRecentOpt = getLatest(questionVersions);
-            if (mostRecentOpt.isEmpty()) {
-                continue;
-            }
-
-            SurveyQuestionDefinition mostRecent = mostRecentOpt.get();
+            SurveyQuestionDefinition mostRecent = questionVersions.getFirst();
 
             if (List.of("signaturepad", "html").contains(mostRecent.getQuestionType())) {
                 continue;
@@ -98,10 +97,6 @@ public class SurveyFormatter extends ModuleFormatter<SurveyResponseWithTaskDto, 
             itemFormatters.addAll(buildChildrenItemFormatters(exportOptions, questionDefsByStableId, data, mostRecent));
 
         }
-    }
-
-    private Optional<SurveyQuestionDefinition> getLatest(List<SurveyQuestionDefinition> questionVersions) {
-        return questionVersions.stream().max(Comparator.comparing(SurveyQuestionDefinition::getSurveyVersion));
     }
 
     private Collection<List<SurveyQuestionDefinition>> getChildrenOf(Collection<List<SurveyQuestionDefinition>> questionDefs, SurveyQuestionDefinition parent) {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

We weren't actually getting the latest survey question definition, and earlier versions of these questions were `html` so it was skipping them on export.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- import what trcc is on prod
- go to sandbox data export
- observe that researchConsentForm.consentSignatureDate and researchAssentForm.assentSignatureDate show up