### PR TITLE
[JN-1588] extract all local site contents

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/site/LocalizedSiteContentDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/site/LocalizedSiteContentDao.java
@@ -27,7 +27,7 @@ public class LocalizedSiteContentDao  extends BaseJdbiDao<LocalizedSiteContent> 
     public Optional<LocalizedSiteContent> findBySiteContent(UUID siteContentId, String language) {
         return findByTwoProperties("site_content_id", siteContentId, "language", language);
     }
-
+    
     /**
      * clears the landing page Id from the specified site content.  this is necessary in some cases to enable
      * deletion, since localizedSiteContent can be bidirectionally linked to an htmlPage

--- a/core/src/main/java/bio/terra/pearl/core/dao/site/SiteContentDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/site/SiteContentDao.java
@@ -1,10 +1,7 @@
 package bio.terra.pearl.core.dao.site;
 
 import bio.terra.pearl.core.dao.BaseVersionedJdbiDao;
-import bio.terra.pearl.core.model.site.HtmlPage;
-import bio.terra.pearl.core.model.site.HtmlSection;
-import bio.terra.pearl.core.model.site.NavbarItem;
-import bio.terra.pearl.core.model.site.SiteContent;
+import bio.terra.pearl.core.model.site.*;
 import org.jdbi.v3.core.Jdbi;
 import org.springframework.stereotype.Component;
 
@@ -59,39 +56,49 @@ public class SiteContentDao extends BaseVersionedJdbiDao<SiteContent> {
     /** attaches all the content (pages, sections, navbar) children for the given language to the SiteContent */
     public void attachChildContent(SiteContent siteContent, String language) {
         localizedSiteContentDao.findBySiteContent(siteContent.getId(), language).ifPresent(localSite -> {
-            siteContent.getLocalizedSiteContents().add(localSite);
-            List<NavbarItem> navbarItems = navbarItemDao.findByLocalSiteId(localSite.getId());
-            List<HtmlPage> htmlPages = htmlPageDao.findByLocalSite(localSite.getId());
-            List<HtmlSection> htmlSections = htmlSectionDao.findByLocalizedSite(localSite.getId());
-            navbarItems.forEach(item -> {
-                // attach the children of this item, if they exist
-                item.setItems(
-                        navbarItems
-                                .stream()
-                                .filter(childItem -> item.getId().equals(childItem.getParentNavbarItemId()))
-                                .toList());
-            });
-            htmlPages.forEach(page -> {
-                page.getSections().addAll(htmlSections.stream().filter(section ->
-                        page.getId().equals(section.getHtmlPageId())
-                ).collect(Collectors.toList()));
-            });
-
-            localSite.setPages(htmlPages.stream().filter(page -> !page.getId().equals(localSite.getLandingPageId())).toList());
-
-            localSite.setLandingPage(htmlPages.stream()
-                    .filter(page -> page.getId().equals(localSite.getLandingPageId()))
-                    .findFirst().orElse(null));
-            localSite
-                    .getNavbarItems()
-                    .addAll(
-                            // add only the top level items, the children are already attached
-                            navbarItems.stream().filter(item -> item.getParentNavbarItemId() == null).toList()
-                    );
-            if (localSite.getFooterSectionId() != null) {
-                localSite.setFooterSection(htmlSectionDao.find(localSite.getFooterSectionId()).get());
-            }
+            attachLocalSite(siteContent, localSite);
         });
+    }
+
+    public void attachAllChildContent(SiteContent siteContent) {
+        localizedSiteContentDao.findBySiteContent(siteContent.getId()).forEach(localSite -> {
+            attachLocalSite(siteContent, localSite);
+        });
+    }
+
+    private void attachLocalSite(SiteContent siteContent, LocalizedSiteContent localSite) {
+        siteContent.getLocalizedSiteContents().add(localSite);
+        List<NavbarItem> navbarItems = navbarItemDao.findByLocalSiteId(localSite.getId());
+        List<HtmlPage> htmlPages = htmlPageDao.findByLocalSite(localSite.getId());
+        List<HtmlSection> htmlSections = htmlSectionDao.findByLocalizedSite(localSite.getId());
+        navbarItems.forEach(item -> {
+            // attach the children of this item, if they exist
+            item.setItems(
+                    navbarItems
+                            .stream()
+                            .filter(childItem -> item.getId().equals(childItem.getParentNavbarItemId()))
+                            .toList());
+        });
+        htmlPages.forEach(page -> {
+            page.getSections().addAll(htmlSections.stream().filter(section ->
+                    page.getId().equals(section.getHtmlPageId())
+            ).collect(Collectors.toList()));
+        });
+
+        localSite.setPages(htmlPages.stream().filter(page -> !page.getId().equals(localSite.getLandingPageId())).toList());
+
+        localSite.setLandingPage(htmlPages.stream()
+                .filter(page -> page.getId().equals(localSite.getLandingPageId()))
+                .findFirst().orElse(null));
+        localSite
+                .getNavbarItems()
+                .addAll(
+                        // add only the top level items, the children are already attached
+                        navbarItems.stream().filter(item -> item.getParentNavbarItemId() == null).toList()
+                );
+        if (localSite.getFooterSectionId() != null) {
+            localSite.setFooterSection(htmlSectionDao.find(localSite.getFooterSectionId()).get());
+        }
     }
 
     public int getNextVersion(String cleanFileName, String portalShortcode) {

--- a/core/src/main/java/bio/terra/pearl/core/service/site/SiteContentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/site/SiteContentService.java
@@ -30,6 +30,10 @@ public class SiteContentService extends VersionedEntityService<SiteContent, Site
         dao.attachChildContent(siteContent, language);
     }
 
+    public void attachAllChildContent(SiteContent siteContent) {
+        dao.attachAllChildContent(siteContent);
+    }
+
     @Override
     public SiteContent create(SiteContent siteContent) {
         SiteContent savedSite = dao.create(siteContent);

--- a/populate/src/main/java/bio/terra/pearl/populate/service/extract/SiteContentExtractor.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/extract/SiteContentExtractor.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.populate.service.extract;
 
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.site.*;
+import bio.terra.pearl.core.service.portal.PortalEnvironmentLanguageService;
 import bio.terra.pearl.core.service.site.SiteContentService;
 import bio.terra.pearl.populate.dto.site.*;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -20,20 +21,23 @@ public class SiteContentExtractor {
 
     private final SiteContentService siteContentService;
     private final ObjectMapper objectMapper;
+    private final PortalEnvironmentLanguageService portalEnvironmentLanguageService;
 
-    public SiteContentExtractor(SiteContentService siteContentService, @Qualifier("extractionObjectMapper") ObjectMapper objectMapper) {
+    public SiteContentExtractor(SiteContentService siteContentService, @Qualifier("extractionObjectMapper") ObjectMapper objectMapper, PortalEnvironmentLanguageService portalEnvironmentLanguageService) {
         this.siteContentService = siteContentService;
         this.objectMapper = objectMapper;
         this.objectMapper.addMixIn(NavbarItem .class, NavbarItemMixin.class);
         this.objectMapper.addMixIn(HtmlSection.class, HtmlSectionMixin.class);
+        this.portalEnvironmentLanguageService = portalEnvironmentLanguageService;
     }
 
     public void writeSiteContents(Portal portal, ExtractPopulateContext context) {
         List<SiteContent> siteContents = context.isExtractActiveVersionsOnly()
                 ? siteContentService.findActiveContentByPortalId(portal.getId())
                 : siteContentService.findByPortalId(portal.getId());
+
         for (SiteContent siteContent : siteContents) {
-            siteContentService.attachChildContent(siteContent, "en");
+            siteContentService.attachAllChildContent(siteContent);
             writeSiteContent(siteContent, context);
         }
     }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/extract/SiteContentExtractor.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/extract/SiteContentExtractor.java
@@ -2,7 +2,6 @@ package bio.terra.pearl.populate.service.extract;
 
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.site.*;
-import bio.terra.pearl.core.service.portal.PortalEnvironmentLanguageService;
 import bio.terra.pearl.core.service.site.SiteContentService;
 import bio.terra.pearl.populate.dto.site.*;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -21,14 +20,12 @@ public class SiteContentExtractor {
 
     private final SiteContentService siteContentService;
     private final ObjectMapper objectMapper;
-    private final PortalEnvironmentLanguageService portalEnvironmentLanguageService;
 
-    public SiteContentExtractor(SiteContentService siteContentService, @Qualifier("extractionObjectMapper") ObjectMapper objectMapper, PortalEnvironmentLanguageService portalEnvironmentLanguageService) {
+    public SiteContentExtractor(SiteContentService siteContentService, @Qualifier("extractionObjectMapper") ObjectMapper objectMapper) {
         this.siteContentService = siteContentService;
         this.objectMapper = objectMapper;
         this.objectMapper.addMixIn(NavbarItem .class, NavbarItemMixin.class);
         this.objectMapper.addMixIn(HtmlSection.class, HtmlSectionMixin.class);
-        this.portalEnvironmentLanguageService = portalEnvironmentLanguageService;
     }
 
     public void writeSiteContents(Portal portal, ExtractPopulateContext context) {

--- a/populate/src/test/java/bio/terra/pearl/populate/BasePopulatePortalsTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/BasePopulatePortalsTest.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.populate;
 
 import bio.terra.pearl.core.dao.dashboard.ParticipantDashboardAlertDao;
+import bio.terra.pearl.core.dao.site.LocalizedSiteContentDao;
 import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
 import bio.terra.pearl.core.service.export.DictionaryExportService;
 import bio.terra.pearl.core.service.export.EnrolleeExportService;
@@ -91,4 +92,6 @@ public abstract class BasePopulatePortalsTest extends BaseSpringBootTest {
     protected BaseSeedPopulator baseSeedPopulator;
     @Autowired
     protected EnrolleeSearchExpressionParser enrolleeSearchExpressionParser;
+    @Autowired
+    protected LocalizedSiteContentDao localSiteContentDao;
 }

--- a/populate/src/test/java/bio/terra/pearl/populate/extract/PortalExtractTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/extract/PortalExtractTest.java
@@ -3,6 +3,7 @@ package bio.terra.pearl.populate.extract;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
+import bio.terra.pearl.core.model.site.LocalizedSiteContent;
 import bio.terra.pearl.core.model.site.SiteContent;
 import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
@@ -19,11 +20,14 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.zip.ZipInputStream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -61,7 +65,15 @@ public class PortalExtractTest extends BasePopulatePortalsTest {
         assertThat(studyService.findByPortalId(restoredPortal.getId()), hasSize(1));
         assertThat(emailTemplateService.findByPortalId(restoredPortal.getId()), hasSize(13));
         // confirm both the old and current versions of the site content got populated
-        assertThat(siteContentService.findByPortalId(restoredPortal.getId()), hasSize(2));
+
+        List<SiteContent> allSiteContent = siteContentService.findByPortalId(restoredPortal.getId()).stream().sorted(Comparator.comparing(SiteContent::getVersion, Comparator.reverseOrder())).toList();
+        assertThat(allSiteContent, hasSize(2));
+
+        SiteContent latestSiteContent = allSiteContent.get(0);
+        List<LocalizedSiteContent> localizedSiteContents = localSiteContentDao.findBySiteContent(latestSiteContent.getId());
+        assertThat(localizedSiteContents, hasSize(3));
+        assertThat(localizedSiteContents.stream().map(LocalizedSiteContent::getLanguage).collect(Collectors.toSet()),
+                equalTo(Set.of("en", "es", "dev")));
 
         // confirm the sandbox got configured
         Study study = studyService.findByPortalId(restoredPortal.getId()).get(0);


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

I need to translate all of A-T's languages, and I plan to do that by editing a portal extract directly. It was easier to write this code (which will be generally useful anyway) than to manually go in and add these files.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- populate demo
- extract
- repopulate
- observe spanish/dev is still there