### PR TITLE
[JN-1581] Prevent duplicate kit labels during in-person kit assignment

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/kit/KitRequestDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/kit/KitRequestDao.java
@@ -28,6 +28,10 @@ public class KitRequestDao extends BaseMutableJdbiDao<KitRequest> {
         return super.findAllByProperty("enrollee_id", enrolleeId);
     }
 
+    public List<KitRequest> findAllByKitLabel(String kitLabel) {
+        return findAllByProperty("kit_label", kitLabel);
+    }
+
     public Optional<KitRequest> findByEnrolleeAndLabel(UUID enrolleeId, String kitLabel) {
         return findByTwoProperties("enrollee_id", enrolleeId, "kit_label", kitLabel);
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
@@ -105,7 +105,13 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
         This only creates the kit request in Juniper, it does not send the request to Pepper.
         Once the kit is collected by staff later on, the kit request will be sent to Pepper as "returnOnly".
      */
-    private KitRequestDto createNewInPersonKitRequest(AdminUser operator, Enrollee enrollee, KitRequestCreationDto kitRequestCreationDto) {
+    protected KitRequestDto createNewInPersonKitRequest(AdminUser operator, Enrollee enrollee, KitRequestCreationDto kitRequestCreationDto) {
+        //we need to make sure that there aren't any kits with the same label already assigned
+        List<KitRequest> kits = dao.findAllByKitLabel(kitRequestCreationDto.kitLabel);
+        if (!kits.isEmpty()) {
+            throw new IllegalArgumentException("Kit with label %s already exists".formatted(kitRequestCreationDto.kitLabel));
+        }
+
         KitRequest inPersonKitRequest = KitRequest.builder().kitType(kitTypeDao.findByName(kitRequestCreationDto.kitType).get())
                 .id(daoUtils.generateUUID())
                 .kitTypeId(kitTypeDao.findByName(kitRequestCreationDto.kitType).get().getId())

--- a/core/src/main/resources/db/changelog/changesets/2025_01_24_kit_label_unique_constraint.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2025_01_24_kit_label_unique_constraint.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: "kit_label_unique_constraint"
+      author: mbemis
+      changes:
+        - addUniqueConstraint:
+            tableName: kit_request
+            constraintName: uc_kit_request_kit_label
+            columnNames: kit_label

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -383,6 +383,9 @@ databaseChangeLog:
   - include:
       file: changesets/2025_01_15_study_time_zone.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2025_01_24_kit_label_unique_constraint.yaml
+      relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
@@ -293,6 +293,25 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
 
     @Transactional
     @Test
+    public void testAssignDuplicateKitErrors(TestInfo testInfo) {
+        String testName = getTestName(testInfo);
+        AdminUser adminUser = adminUserFactory.buildPersisted(getTestName(testInfo));
+        EnrolleeBundle enrolleeBundle = enrolleeFactory.buildWithPortalUser(getTestName(testInfo));
+        Enrollee enrollee = enrolleeBundle.enrollee();
+        KitType kitType = kitTypeFactory.buildPersisted(testName);
+        KitRequestService.KitRequestCreationDto kitRequestCreationDto = new KitRequestService.KitRequestCreationDto(kitType.getName(), DistributionMethod.IN_PERSON, "testLabel", false);
+        KitRequestDto kitRequest = kitRequestService.createNewInPersonKitRequest(adminUser, enrollee, kitRequestCreationDto);
+
+        assertThat(kitRequest.getStatus(), equalTo(KitRequestStatus.CREATED));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> kitRequestService.createNewInPersonKitRequest(adminUser, enrollee, kitRequestCreationDto)
+        );
+    }
+
+    @Transactional
+    @Test
     public void testCollectInPersonKit(TestInfo testInfo) throws JsonProcessingException {
         String testName = getTestName(testInfo);
         AdminUser adminUser = adminUserFactory.buildPersisted(getTestName(testInfo));


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Prevents duplicate kit labels during in-person kit assignment

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Re-start admin API
Go to https://localhost:3000/ourhealth/studies/ourheart/env/sandbox/kits/scan
Using manual kit override, assign a kit to OHSALK with label `foo`
Repeat that flow, and confirm you receive an error "Kit with label foo already exists"
Now confirm you can still collect the `foo` kit