### PR TITLE
[JN-1570] Unpin ubuntu runner image + update Playwright

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,6 +61,8 @@ jobs:
           echo "Application start timed out after 5 minutes"
           exit 1
         fi
+    - name: Install Playwright
+      run: npm install -g @playwright/test
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
     - name: Run Playwright tests

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,6 +61,8 @@ jobs:
           echo "Application start timed out after 5 minutes"
           exit 1
         fi
+    - name: Install dependencies
+      run: npm ci
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
     - name: Run Playwright tests

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,8 +61,6 @@ jobs:
           echo "Application start timed out after 5 minutes"
           exit 1
         fi
-    - name: Install Playwright
-      run: npm install -g @playwright/test
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
     - name: Run Playwright tests

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,10 +61,8 @@ jobs:
           echo "Application start timed out after 5 minutes"
           exit 1
         fi
-    - name: Install dependencies
-      run: npm ci
     - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
+      run: npx -w e2e-tests playwright install --with-deps
     - name: Run Playwright tests
       run: npm -w e2e-tests test
     - name: Upload test results

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     services:
       postgres:
         image: postgres
@@ -96,7 +96,7 @@ jobs:
   # Run DSP App Sec Trivy Scanner on PRs
   dispatch-trivy:
     needs: [ build ]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     if: github.event_name == 'pull_request'
 
@@ -110,7 +110,7 @@ jobs:
 
   dispatch-tag:
     needs: [ build ]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     # Only tag a new release if prior steps were successful and triggering commit is a merge to mainline
     if: success() && github.ref == 'refs/heads/development'

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   get-version-tag:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
@@ -29,7 +29,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token:  'write'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.build-publish.outputs.published-image }}
     steps:
@@ -64,7 +64,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token:  'write'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.build-publish.outputs.published-image }}
     steps:
@@ -119,7 +119,7 @@ jobs:
       id-token: 'write'
   
   notify-upon-completion:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     if: always()
     needs: [set-version-in-dev, get-version-tag]
     steps:

--- a/.github/workflows/juniper-eng-infra-upload-image.yml
+++ b/.github/workflows/juniper-eng-infra-upload-image.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   get-version-tag:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
@@ -28,7 +28,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token:  'write'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.juniper-eng-build-publish.outputs.published-image }}
     steps:
@@ -50,7 +50,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token:  'write'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.juniper-eng-build-publish.outputs.published-image }}
     steps:

--- a/.github/workflows/require-ticket.yml
+++ b/.github/workflows/require-ticket.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   require_ticket:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check for ticket in PR title
         id: validate

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   sonar-java:
     name: SonarCloud Java
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,7 +50,7 @@ jobs:
 
   sonar-typescript:
     name: SonarCloud TypeScript
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         subproject: ['ui-admin', 'ui-core', 'ui-participant']

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   tag-job:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -3,7 +3,7 @@ on: workflow_dispatch
 
 jobs:
   trivy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",
-    "@playwright/test": "^1.42.1"
+    "@playwright/test": "^1.50.0"
   },
   "dependencies": {
     "dotenv": "^16.4.5"

--- a/e2e-tests/src/lib/fixtures/demo-fixture.ts
+++ b/e2e-tests/src/lib/fixtures/demo-fixture.ts
@@ -1,9 +1,8 @@
-import { expect, Fixtures } from '@playwright/test'
-import { fixtureBase as base } from 'src/lib/fixtures/fixture-base'
+import { Fixtures, expect, test as baseTest } from '@playwright/test'
 import Home from 'pages/demo/home'
 
 // Use this fixture in OurHealth study tests
-export const test = base.extend<Fixtures>({
+export const test = baseTest.extend<Fixtures>({
   page: async ({ baseURL, page }, use) => {
     await page.goto(baseURL!)
     const home = new Home(page)

--- a/e2e-tests/src/lib/fixtures/ourhealth-fixture.ts
+++ b/e2e-tests/src/lib/fixtures/ourhealth-fixture.ts
@@ -1,9 +1,8 @@
-import { Fixtures, expect } from '@playwright/test'
-import { fixtureBase as base } from 'src/lib/fixtures/fixture-base'
+import { Fixtures, expect, test as baseTest } from '@playwright/test'
 import Home from 'pages/ourhealth/home'
 
 // Use this fixture in OurHealth study tests
-export const test = base.extend<Fixtures>({
+export const test = baseTest.extend<Fixtures>({
   page: async ({ baseURL, page }, use) => {
     await page.goto(baseURL!)
     const home = new Home(page)

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,22 @@
       },
       "devDependencies": {
         "@faker-js/faker": "^8.4.1",
-        "@playwright/test": "^1.42.1"
+        "@playwright/test": "^1.50.0"
+      }
+    },
+    "e2e-tests/node_modules/@playwright/test": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.0.tgz",
+      "integrity": "sha512-ZGNXbt+d65EGjBORQHuYKj+XhCewlwpnSd/EDuLPZGSiEWmgOJB5RmMCCYGy5aMfTs9wx61RivfDKi8H/hcMvw==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.50.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "e2e-tests/node_modules/dotenv": {
@@ -87,6 +102,36 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "e2e-tests/node_modules/playwright": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.0.tgz",
+      "integrity": "sha512-+GinGfGTrd2IfX1TA4N2gNmeIksSb+IAe589ZH+FlmpV3MYTx6+buChGIuDLQwrGNCw2lWibqV50fU510N7S+w==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.50.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "e2e-tests/node_modules/playwright-core": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.0.tgz",
+      "integrity": "sha512-CXkSSlr4JaZs2tZHI40DsZUN/NIwgaUPsyLuOAaIZp2CyF2sN5MM5NJsyB188lFSSozFxQ5fPT4qM+f0tH/6wQ==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4254,21 +4299,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz",
-      "integrity": "sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==",
-      "dev": true,
-      "dependencies": {
-        "playwright": "1.42.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/@plotly/d3": {
@@ -14566,36 +14596,6 @@
         "pathe": "^1.1.2"
       }
     },
-    "node_modules/playwright": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
-      "integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
-      "dev": true,
-      "dependencies": {
-        "playwright-core": "1.42.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
-      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
-      "dev": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/plotly.js": {
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-2.30.0.tgz",
@@ -21879,14 +21879,39 @@
       "version": "file:e2e-tests",
       "requires": {
         "@faker-js/faker": "^8.4.1",
-        "@playwright/test": "^1.42.1",
+        "@playwright/test": "^1.50.0",
         "dotenv": "^16.4.5"
       },
       "dependencies": {
+        "@playwright/test": {
+          "version": "1.50.0",
+          "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.0.tgz",
+          "integrity": "sha512-ZGNXbt+d65EGjBORQHuYKj+XhCewlwpnSd/EDuLPZGSiEWmgOJB5RmMCCYGy5aMfTs9wx61RivfDKi8H/hcMvw==",
+          "dev": true,
+          "requires": {
+            "playwright": "1.50.0"
+          }
+        },
         "dotenv": {
           "version": "16.4.5",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
           "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="
+        },
+        "playwright": {
+          "version": "1.50.0",
+          "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.0.tgz",
+          "integrity": "sha512-+GinGfGTrd2IfX1TA4N2gNmeIksSb+IAe589ZH+FlmpV3MYTx6+buChGIuDLQwrGNCw2lWibqV50fU510N7S+w==",
+          "dev": true,
+          "requires": {
+            "fsevents": "2.3.2",
+            "playwright-core": "1.50.0"
+          }
+        },
+        "playwright-core": {
+          "version": "1.50.0",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.0.tgz",
+          "integrity": "sha512-CXkSSlr4JaZs2tZHI40DsZUN/NIwgaUPsyLuOAaIZp2CyF2sN5MM5NJsyB188lFSSozFxQ5fPT4qM+f0tH/6wQ==",
+          "dev": true
         }
       }
     },
@@ -22680,15 +22705,6 @@
             "is-wsl": "^2.2.0"
           }
         }
-      }
-    },
-    "@playwright/test": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz",
-      "integrity": "sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==",
-      "dev": true,
-      "requires": {
-        "playwright": "1.42.1"
       }
     },
     "@plotly/d3": {
@@ -30434,22 +30450,6 @@
         "mlly": "^1.7.2",
         "pathe": "^1.1.2"
       }
-    },
-    "playwright": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
-      "integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
-      "dev": true,
-      "requires": {
-        "fsevents": "2.3.2",
-        "playwright-core": "1.42.1"
-      }
-    },
-    "playwright-core": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
-      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
-      "dev": true
     },
     "plotly.js": {
       "version": "2.30.0",


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Reverts runner image to `ubuntu-latest` and updates to latest Playwright, which comes with the newly-missing dependencies.

Also updates some test fixtures to work with the new Playwright version.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Confirm e2e tests still pass locally
Observe the green check marks on this PR