### PR TITLE
[JN-1589] add trcc certs

### DIFF
--- a/terraform/gcp/k8s/environments/prod.yaml
+++ b/terraform/gcp/k8s/environments/prod.yaml
@@ -17,6 +17,7 @@ portals:
   - name: hearthive
     customDomain: thehearthive.org
   - name: trccproject
+    customDomain: trccproject.org
   - name: rgp
   - name: cmi
 b2c:


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Now that trccproject.org is pointing to juniper, we can create the certs.


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

