### PR TITLE
[JN-1587] make instants more robust from search exp UI

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/SearchTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/SearchTermParser.java
@@ -45,7 +45,6 @@ public abstract class SearchTermParser<T extends SearchTerm> {
     protected abstract T parse(String arguments);
 
     /**
-     <<<<<<< HEAD
      * Parse the term string into a search term for the given study environment.
      */
     protected T parse(String study, String arguments) {
@@ -53,18 +52,13 @@ public abstract class SearchTermParser<T extends SearchTerm> {
     }
 
     /**
-     =======
-     >>>>>>> origin/development
      * Get the facets that can be used in a search expression for the given study environment.
      */
     public abstract Map<String, SearchValueTypeDefinition> getFacets(UUID studyEnvId);
 
     /**
      * The name of the term. E.g., AgeTermParser would return "age".
-     <<<<<<< HEAD
      * Any variable that starts with this name will be parsed by this parser.
-     =======
-     >>>>>>> origin/development
      */
     public abstract String getTermName();
 

--- a/ui-admin/src/util/formatQueryBuilderAsSearchExp.tsx
+++ b/ui-admin/src/util/formatQueryBuilderAsSearchExp.tsx
@@ -66,6 +66,13 @@ export const createEnrolleeSearchExpressionRuleProcessor = (facets: ExpressionSe
           } else {
             processedValue = trimIfString(value)
           }
+        } else if (typeDefinition.type === 'INSTANT') {
+          const parsedDate = Date.parse(value)
+          if (isNaN(parsedDate)) {
+            throw new Error(`Invalid date: ${value}`)
+          }
+
+          processedValue = `'${new Date(parsedDate).toISOString()}'`
         } else {
           processedValue = `'${escape(value, escapeQuotes)}'`
         }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Search expression UI would create instants that wouldn't work with Instant.parse but would work with SQL, so sometimes they would work and sometimes they wouldn't. They also wouldn't provide any timezone. Now, they will provide ISO compliant dates with UTC timezone.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- play around with search exp UI for dates
- e.g. add a search exp to a survey using enrollee.createdAt with the basic UI (e.g. {createdAt} > yesterday) and make sure it works when you enroll a new user