### PR TITLE
[JN-1585] workflow view cleanups

### DIFF
--- a/ui-admin/src/navbar/AdminSidebar.test.tsx
+++ b/ui-admin/src/navbar/AdminSidebar.test.tsx
@@ -30,7 +30,7 @@ test('renders the superuser menu for superusers', async () => {
       <AdminSidebar config={testConfig}/>
     </MockUserProvider>)
   render(RoutedComponent)
-  expect(screen.getByText('Superuser functions')).toBeInTheDocument()
+  expect(screen.getByText('Superuser Functions')).toBeInTheDocument()
 })
 
 test('menu components collapse on click', async () => {
@@ -39,11 +39,11 @@ test('menu components collapse on click', async () => {
       <AdminSidebar config={testConfig}/>
     </MockUserProvider>)
   render(RoutedComponent)
-  expect(screen.getByText('All users')).toBeVisible()
-  await userEvent.click(screen.getByText('Superuser functions'))
-  waitFor(() => expect(screen.queryByText('All users')).not.toBeVisible())
-  await userEvent.click(screen.getByText('Superuser functions'))
-  waitFor(() => expect(screen.queryByText('All users')).toBeVisible())
+  expect(screen.getByText('All Users')).toBeVisible()
+  await userEvent.click(screen.getByText('Superuser Functions'))
+  waitFor(() => expect(screen.queryByText('All Users')).not.toBeVisible())
+  await userEvent.click(screen.getByText('Superuser Functions'))
+  waitFor(() => expect(screen.queryByText('All Users')).toBeVisible())
 })
 
 test('does not render the superuser menu for  regular users', async () => {
@@ -52,6 +52,6 @@ test('does not render the superuser menu for  regular users', async () => {
       <AdminSidebar config={testConfig}/>
     </MockUserProvider>)
   render(RoutedComponent)
-  expect(screen.queryByText('Superuser functions')).toBeNull()
+  expect(screen.queryByText('Superuser Functions')).toBeNull()
 })
 

--- a/ui-admin/src/navbar/AdminSidebar.tsx
+++ b/ui-admin/src/navbar/AdminSidebar.tsx
@@ -76,10 +76,10 @@ const AdminSidebar = ({ config }: { config: Config }) => {
         { currentStudy && <StudySidebar study={currentStudy} portalList={portalList}
           portalShortcode={portalShortcode!}/> }
 
-        {user?.superuser && <CollapsableMenu header={'Superuser functions'} content={
+        {user?.superuser && <CollapsableMenu header={'Superuser Functions'} content={
           <ul className="list-unstyled">
             <li className="mb-2">
-              <NavLink to="/users" className={sidebarNavLinkClasses}>All users</NavLink>
+              <NavLink to="/users" className={sidebarNavLinkClasses}>All Users</NavLink>
             </li>
             <li className="mb-2">
               <NavLink to="/populate" className={sidebarNavLinkClasses}>Populate</NavLink>

--- a/ui-admin/src/navbar/StudySidebar.tsx
+++ b/ui-admin/src/navbar/StudySidebar.tsx
@@ -111,7 +111,7 @@ export const StudySidebar = ({ study, portalList, portalShortcode }:
           <NavLink to={studyEnvWorkflowPath({
             portalShortcode, studyShortcode: study.shortcode, envName: 'sandbox'
           })}
-          className={sidebarNavLinkClasses} style={navStyleFunc}>Participant flow</NavLink>
+          className={sidebarNavLinkClasses} style={navStyleFunc}>Participant Flow</NavLink>
         </li>
         <li className="mb-2">
           <NavLink to={studyEnvFormsPath(portalShortcode, study.shortcode, 'sandbox')}

--- a/ui-admin/src/study/workflow/WorkflowView.tsx
+++ b/ui-admin/src/study/workflow/WorkflowView.tsx
@@ -17,8 +17,7 @@ import { useLoadingEffect } from 'api/api-utils'
 import LoadingSpinner from 'util/LoadingSpinner'
 import CreateTriggerModal from '../notifications/CreateTriggerModal'
 import {
-  faAsterisk,
-  faCodeBranch, faEdit,
+  faAsterisk, faEdit, faFilter,
   faTasks
 } from '@fortawesome/free-solid-svg-icons'
 import { faCalendarAlt, faClipboard, faEnvelope,   faCheckSquare } from '@fortawesome/free-regular-svg-icons'
@@ -105,7 +104,7 @@ export default function WorkflowView({ studyEnvContext, portalContext }:
             setShowCreateModal={setShowCreateModal}/></h3>
 
         <ul className="list-unstyled">
-          { triggers.filter(trigger => trigger.eventType === 'STUDY_ENROLLMENT')
+          { triggers.filter(trigger => trigger.eventType === 'STUDY_ENROLLMENT' && trigger.triggerType !== 'AD_HOC')
             .map(trigger =>
               <TriggerListItem trigger={trigger} key={trigger.id} studyEnvParams={paramsFromContext(studyEnvContext)}/>
             )
@@ -163,7 +162,8 @@ export default function WorkflowView({ studyEnvContext, portalContext }:
             </h4>
           </div>
           <ul className="list-unstyled">
-            { triggers.filter(trigger => trigger.taskType === 'SURVEY' && trigger.filterTargetStableIds.length === 0)
+            { triggers.filter(trigger => (trigger.taskType === 'SURVEY' && trigger.filterTargetStableIds.length === 0)
+              && trigger.triggerType !== 'AD_HOC')
               .map(trigger =>
                 <TriggerListItem trigger={trigger} key={trigger.id}
                   studyEnvParams={paramsFromContext(studyEnvContext)}/>
@@ -205,8 +205,8 @@ export default function WorkflowView({ studyEnvContext, portalContext }:
       <li className={boxClasses}>
         <h3 className="h5">Kits</h3>
         <ul className="list-unstyled">
-          { triggers.filter(trigger => trigger.eventType === 'KIT_SENT' ||
-            trigger.eventType === 'KIT_RECEIVED' || trigger.taskType === 'KIT_REQUEST')
+          { triggers.filter(trigger => (trigger.eventType === 'KIT_SENT' || trigger.eventType === 'KIT_RECEIVED' ||
+            trigger.taskType === 'KIT_REQUEST'))
             .map(trigger =>
               <TriggerListItem trigger={trigger} key={trigger.id} studyEnvParams={paramsFromContext(studyEnvContext)}/>
             )
@@ -272,12 +272,12 @@ const SurveyListItem = ({ studyEnvSurvey, studyEnvParams, triggers, triggerOpts,
 
   return <li className="py-2">
     <div className={'d-flex align-items-center'}>
-      { survey.eligibilityRule && <span className="me-2 text-muted fst-italic">
-        <InfoPopup content={survey.eligibilityRule} marginClass="me-2"
-          target={<FontAwesomeIcon icon={faCodeBranch} title="conditional logic"/>}/>
-      </span> }
       { survey.surveyType === 'CONSENT' && <FontAwesomeIcon icon={faCheckSquare} className="me-2"/> }
       { survey.surveyType === 'RESEARCH' && <FontAwesomeIcon icon={faClipboard} className="me-2"/> }
+      { survey.eligibilityRule && <span className="me-2 text-muted fst-italic">
+        <InfoPopup content={survey.eligibilityRule} marginClass="me-2"
+          target={<FontAwesomeIcon icon={faFilter} title="conditional logic"/>}/>
+      </span> }
       { survey.required && <span className="me-2 text-muted">
         <FontAwesomeIcon icon={faAsterisk} title={'required'}/>
       </span> }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Cleans up some casing and stops some ad-hoc triggers from showing up two places.  changes the conditional survey icon from a branch to a filter

![image](https://github.com/user-attachments/assets/34aaccaf-7842-493c-a7b6-39a609568e46)

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/workflow
2. confirm casing is title case everywhere