### PR TITLE
[JN-1561] site content links open in new tab

### DIFF
--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/landingPage.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/landingPage.json
@@ -54,7 +54,7 @@
     "sectionType": "HERO_WITH_IMAGE",
     "sectionConfigJson": {
       "title": "Who can join?",
-      "blurb": "Anyone who is:\n\n* Living in the United States\n * Older than 18 years old\n * Comfortable filling out surveys in English\n * Of South Asian Ancestry*\n\n&nbsp;\n\n*Self-identified ancestry from one of the South Asian countries defined by the American Heart Association as Bangladesh, Bhutan, India, the Maldives, Nepal, Pakistan, and Sri Lanka.",
+      "blurb": "Anyone who is:\n\n* Living in the United States\n * Older than 18 years old\n * Comfortable filling out surveys in English\n * Of South Asian Ancestry*\n\n&nbsp;\n\n*Self-identified ancestry from one of the South Asian countries defined by the [American Heart Association](https://www.heart.org) as Bangladesh, Bhutan, India, the Maldives, Nepal, Pakistan, and Sri Lanka.",
       "fullWidth": true,
       "buttons": [
         {"text": "Get Started",

--- a/ui-core/src/participant/landing/Markdown.test.tsx
+++ b/ui-core/src/participant/landing/Markdown.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+import { InlineMarkdown, Markdown } from './Markdown'
+
+describe('Markdown', () => {
+  it('renders links to open in new tab', () => {
+    render(<Markdown>Some [link](https://example.com) is here</Markdown>)
+    expect(screen.getByText('link')).toHaveAttribute('target', '_blank')
+  })
+
+  it('renders relative links not to open in new tab', () => {
+    render(<Markdown>Some [link](/other/page) is here</Markdown>)
+    expect(screen.getByText('link')).toHaveAttribute('target', '')
+  })
+
+  it('renders inline links to open in new tab', () => {
+    render(<InlineMarkdown>Some [link](https://example.com) is here</InlineMarkdown>)
+    expect(screen.getByText('link')).toHaveAttribute('target', '_blank')
+  })
+})

--- a/ui-core/src/participant/landing/Markdown.tsx
+++ b/ui-core/src/participant/landing/Markdown.tsx
@@ -13,8 +13,20 @@ export const Markdown = (props: MarkdownProps) => {
   const { children, className, style } = props
   return (
     <div className={classNames('markdown', className)} style={style}>
-      <ReactMarkdown>{children}</ReactMarkdown>
+      <ReactMarkdown components={{ a: LinkRenderer }}>{children}</ReactMarkdown>
     </div>
+  )
+}
+
+/**
+ * Makes all non-relative links open in a new tab.  Adapted from
+ * https://stackoverflow.com/questions/69119798/react-markdown-links-dont-open-in-a-new-tab-despite-using-target-blank
+ */
+function LinkRenderer(props: { href?: string, children: React.ReactNode }) {
+  return (
+    <a href={props.href} target={props.href?.startsWith('/') ? '' : '_blank'} rel="noreferrer">
+      {props.children}
+    </a>
   )
 }
 
@@ -25,5 +37,7 @@ type InlineMarkdownProps = {
 /** Render Markdown without a wrapping paragraph tag. */
 export const InlineMarkdown = (props: InlineMarkdownProps) => {
   const { children } = props
-  return <ReactMarkdown disallowedElements={['p']} unwrapDisallowed>{children}</ReactMarkdown>
+  return <ReactMarkdown disallowedElements={['p']} unwrapDisallowed components={{ a: LinkRenderer }}>
+    {children}
+  </ReactMarkdown>
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

We generally want to not have people lose progress, focus, etc, so the default behavior is to have links open in new tabs.  The exception is local relative links, which are used for navigation, (and most notably, for "join" links).  We might eventually want to support a custom parameter, but for now I think it's best/simplest to avoid diverging from standard markdown syntax

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. repopulate demo
2. go to https://sandbox.demo.localhost:3001/
3. click on the "American Heart Association" link ~halfway down the page
![image](https://github.com/user-attachments/assets/e15c84bb-0e16-4190-8970-e1ea4312d874)
4. confirm it opens in a new tab
5. click on the "join" link in the FAQ
![image](https://github.com/user-attachments/assets/c3535f8e-ebbc-444c-938f-a76d66817e28)

6. confirm it does not open in a new tab
