### PR TITLE
[JN-1571] removing unused endpoint

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeController.java
@@ -3,7 +3,6 @@ package bio.terra.pearl.api.admin.controller.enrollee;
 import bio.terra.pearl.api.admin.api.EnrolleeApi;
 import bio.terra.pearl.api.admin.service.auth.AuthUtilService;
 import bio.terra.pearl.api.admin.service.auth.context.PortalEnrolleeAuthContext;
-import bio.terra.pearl.api.admin.service.auth.context.PortalStudyEnvAuthContext;
 import bio.terra.pearl.api.admin.service.enrollee.EnrolleeExtService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeController.java
@@ -100,19 +100,6 @@ public class EnrolleeController implements EnrolleeApi {
     }
   }
 
-  @Override
-  public ResponseEntity<Object> enrolleesWithKits(
-      String portalShortcode, String studyShortcode, String envName) {
-    AdminUser adminUser = authUtilService.requireAdminUser(request);
-    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
-
-    List<Enrollee> enrollees =
-        enrolleeExtService.findForKitManagement(
-            PortalStudyEnvAuthContext.of(
-                adminUser, portalShortcode, studyShortcode, environmentName));
-    return ResponseEntity.ok(enrollees);
-  }
-
   public record WithdrawnResponse(UUID withdrawnEnrolleeId) {}
 
   public record WithdrawalParams(EnrolleeWithdrawalReason reason, String note) {}

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeExtService.java
@@ -38,12 +38,6 @@ public class EnrolleeExtService {
     this.studyEnvironmentService = studyEnvironmentService;
   }
 
-  @EnforcePortalStudyEnvPermission(permission = "participant_data_view")
-  public List<Enrollee> findForKitManagement(PortalStudyEnvAuthContext authContext) {
-    return enrolleeService.findForKitManagement(
-        authContext.getStudyShortcode(), authContext.getEnvironmentName());
-  }
-
   @EnforcePortalEnrolleePermission(permission = "participant_data_view")
   public Enrollee findWithAdminLoad(PortalEnrolleeAuthContext authContext) {
     return enrolleeService.loadForAdminView(authContext.getEnrollee());

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeExtService.java
@@ -2,9 +2,7 @@ package bio.terra.pearl.api.admin.service.enrollee;
 
 import bio.terra.pearl.api.admin.service.auth.AuthUtilService;
 import bio.terra.pearl.api.admin.service.auth.EnforcePortalEnrolleePermission;
-import bio.terra.pearl.api.admin.service.auth.EnforcePortalStudyEnvPermission;
 import bio.terra.pearl.api.admin.service.auth.context.PortalEnrolleeAuthContext;
-import bio.terra.pearl.api.admin.service.auth.context.PortalStudyEnvAuthContext;
 import bio.terra.pearl.core.model.audit.ParticipantDataChange;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.EnrolleeWithdrawalReason;

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -2190,21 +2190,6 @@ paths:
               schema: { type: object }
         '500':
           $ref: '#/components/responses/ServerError'
-  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/enrolleesWithKits:
-    get:
-      summary: Gets a list of enrollees with tasks and kit requests
-      tags: [ enrollee ]
-      operationId: enrolleesWithKits
-      parameters:
-        - *portalShortcodeParam
-        - *studyShortcodeParam
-        - *envNameParam
-      responses:
-        '200':
-          description: enrollee list
-          content: *jsonContent
-        '500':
-          $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/kits:
     get:
       summary: Gets a list of kits for a study

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeService.java
@@ -159,40 +159,6 @@ public class EnrolleeService extends CrudService<Enrollee, EnrolleeDao> {
         return enrollee;
     }
 
-    /**
-     * Fetches enrollees, loading all details needed for the kit management view -- currently tasks and kits.
-     * Reduces database round-trips by fetching entities from each table and performing in-memory joins.
-     * Uses Streams to reduce the number of iterations over collections of entities:
-     *  - Streams enrollees into two lists: enrollees and enrollee IDs
-     *    - avoids separately collecting IDs from entities
-     *    - retains order of results (not otherwise guaranteed when using something like Collectors.toMap())
-     *  - Streams tasks and kits into maps grouped by enrollee ID
-     *    - avoids separate iteration to build these maps
-     *  All that remains is a single traversal through the enrollee list to attach their tasks and kits.
-     */
-    @Transactional
-    public List<Enrollee> findForKitManagement(String studyShortcode, EnvironmentName envName) {
-        StudyEnvironment studyEnvironment = studyEnvironmentService.verifyStudy(studyShortcode, envName);
-        Pair<List<Enrollee>, List<UUID>> enrolleesAndIds = dao.streamByStudyEnvironmentId(studyEnvironment.getId())
-                .collect(Collectors.teeing(Collectors.toList(),
-                        Collectors.mapping(Enrollee::getId, Collectors.toList()),
-                Pair::of
-        ));
-
-        List<Enrollee> enrollees = enrolleesAndIds.getFirst();
-        List<UUID> enrolleeIds = enrolleesAndIds.getSecond();
-
-        Map<UUID, List<KitRequestDto>> kitsByEnrolleeId = kitRequestService.findByEnrollees(enrollees);
-        Map<UUID, List<ParticipantTask>> tasksByEnrolleeId = participantTaskDao.findByEnrolleeIds(enrolleeIds);
-
-        enrollees.forEach(enrollee -> {
-            // Be sure to set empty collections to indicate that they are empty instead of not initialized
-            enrollee.setParticipantTasks(tasksByEnrolleeId.getOrDefault(enrollee.getId(), Collections.emptyList()));
-            enrollee.setKitRequests(kitsByEnrolleeId.getOrDefault(enrollee.getId(), Collections.emptyList()));
-        });
-        return enrollees;
-    }
-
     public Optional<Enrollee> findByPreEnrollResponseId(UUID preEnrollResponseId) {
         return dao.findByPreEnrollResponseId(preEnrollResponseId);
     }

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -1034,16 +1034,6 @@ export default {
     return await this.processJsonResponse(response)
   },
 
-  async fetchEnrolleesWithKits(
-    portalShortcode: string,
-    studyShortcode: string,
-    envName: string
-  ): Promise<Enrollee[]> {
-    const url = `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/enrolleesWithKits`
-    const response = await fetch(url, this.getGetInit())
-    return await this.processJsonResponse(response)
-  },
-
   async findRelationsByTargetShortcode(
     portalShortcode: string,
     studyShortcode: string,


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Forgot to include this in the prior change -- this removes the old endpoints that used to power the kit enrollee list page

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. no functional changes, just confirm https://localhost:3000/demo/studies/heartdemo/env/sandbox/kits/eligible still loads