### PR TITLE
[JN-TBD] Refactoring pre-enroll surveys

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/study/AttachSurvey.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/study/AttachSurvey.java
@@ -1,0 +1,7 @@
+package bio.terra.pearl.core.dao.study;
+
+
+public enum AttachSurvey {
+    WITH_CONTENT, // include the content json of the survey
+    WITHOUT_CONTENT  // exclude the content from the retrieval
+}

--- a/core/src/main/java/bio/terra/pearl/core/dao/study/StudyDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/study/StudyDao.java
@@ -84,9 +84,9 @@ public class StudyDao  extends BaseMutableJdbiDao<Study> {
      * So, for example, if a portal has two studies, this might return the 'sandbox' environment for
      * both studies
      */
-    public List<Study> findWithPreregContent(String portalShortcode, EnvironmentName envName) {
+    public List<Study> findWithPreEnrollContent(String portalShortcode, EnvironmentName envName) {
         List<Study> studies = findByPortal(portalShortcode);
-        List<StudyEnvironment> studyEnvs =  studyEnvironmentDao.findWithPreregContent(portalShortcode, envName);
+        List<StudyEnvironment> studyEnvs =  studyEnvironmentDao.findWithPreEnrollContent(portalShortcode, envName);
         for (Study study : studies) {
             Optional<StudyEnvironment> studyEnvOpt = studyEnvs.stream()
                     .filter(studyEnv -> studyEnv.getStudyId().equals(study.getId())).findFirst();

--- a/core/src/main/java/bio/terra/pearl/core/dao/study/StudyEnvironmentDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/study/StudyEnvironmentDao.java
@@ -6,6 +6,7 @@ import bio.terra.pearl.core.dao.survey.SurveyDao;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.notification.Trigger;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
+import bio.terra.pearl.core.model.survey.SurveyType;
 import bio.terra.pearl.core.service.survey.SurveyService;
 import java.util.List;
 import java.util.Optional;
@@ -74,15 +75,16 @@ public class StudyEnvironmentDao extends BaseMutableJdbiDao<StudyEnvironment> {
      * returns all the studies associated with the given portal for the given environment
      * So, for example, if a portal has two studies, this might return the 'sandbox' environment for
      * both studies
+     * this attaches the pre-enroll survey so that the "join" process can be done without a separate load
      */
-    public List<StudyEnvironment> findWithPreregContent(String portalShortcode, EnvironmentName envName) {
-        List<String> primaryCols = getQueryColumns.stream().map(col -> "a." + col)
-                .collect(Collectors.toList());
+    public List<StudyEnvironment> findWithPreEnrollContent(String portalShortcode, EnvironmentName envName) {
         List<StudyEnvironment> studyEnvs = jdbi.withHandle(handle ->
-                handle.createQuery("select " + StringUtils.join(primaryCols, ", ") + " from " + tableName
-                                + " a join portal_study on a.study_id = portal_study.study_id "
-                                + " join portal on portal_study.portal_id = portal.id"
-                                + " where portal.shortcode = :portalShortcode and a.environment_name = :environmentName")
+                handle.createQuery("""
+                                    select a.* from %s a 
+                                    join portal_study on a.study_id = portal_study.study_id
+                                    join portal on portal_study.portal_id = portal.id
+                                    where portal.shortcode = :portalShortcode and a.environment_name = :environmentName
+                                    """.formatted(tableName))
                         .bind("portalShortcode", portalShortcode)
                         .bind("environmentName", envName)
                         .mapTo(clazz)
@@ -91,9 +93,8 @@ public class StudyEnvironmentDao extends BaseMutableJdbiDao<StudyEnvironment> {
         for (StudyEnvironment studyEnv : studyEnvs) {
             studyEnv.setStudyEnvironmentConfig(studyEnvironmentConfigDao
                     .find(studyEnv.getStudyEnvironmentConfigId()).get());
-            if (studyEnv.getPreEnrollSurveyId() != null) {
-                studyEnv.setPreEnrollSurvey(surveyDao.find(studyEnv.getPreEnrollSurveyId()).get());
-            }
+            studyEnv.setConfiguredSurveys(studyEnvironmentSurveyDao
+                    .findAllByTypeWithContent(List.of(studyEnv.getId()), SurveyType.PRE_ENROLL, true));
         };
         return studyEnvs;
     }
@@ -103,9 +104,6 @@ public class StudyEnvironmentDao extends BaseMutableJdbiDao<StudyEnvironment> {
         UUID studyEnvId = studyEnv.getId();
         studyEnv.setStudyEnvironmentConfig(studyEnvironmentConfigDao.find(studyEnv.getStudyEnvironmentConfigId()).get());
         studyEnv.setConfiguredSurveys(studyEnvironmentSurveyDao.findAllWithSurvey(studyEnvId, true));
-        if (studyEnv.getPreEnrollSurveyId() != null) {
-            studyEnv.setPreEnrollSurvey(surveyService.find(studyEnv.getPreEnrollSurveyId()).get());
-        }
         List<Trigger> triggers = triggerDao.findByStudyEnvironmentId(studyEnvId, true);
         triggerDao.attachTemplates(triggers);
         studyEnv.setTriggers(triggers);

--- a/core/src/main/java/bio/terra/pearl/core/dao/study/StudyEnvironmentDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/study/StudyEnvironmentDao.java
@@ -94,7 +94,7 @@ public class StudyEnvironmentDao extends BaseMutableJdbiDao<StudyEnvironment> {
             studyEnv.setStudyEnvironmentConfig(studyEnvironmentConfigDao
                     .find(studyEnv.getStudyEnvironmentConfigId()).get());
             studyEnv.setConfiguredSurveys(studyEnvironmentSurveyDao
-                    .findAllByTypeWithContent(List.of(studyEnv.getId()), SurveyType.PRE_ENROLL, true));
+                    .findAllByType(List.of(studyEnv.getId()), SurveyType.PRE_ENROLL, true, AttachSurvey.WITH_CONTENT));
         };
         return studyEnvs;
     }

--- a/core/src/main/java/bio/terra/pearl/core/dao/study/StudyEnvironmentSurveyDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/study/StudyEnvironmentSurveyDao.java
@@ -5,6 +5,7 @@ import bio.terra.pearl.core.dao.StudyEnvAttachedDao;
 import bio.terra.pearl.core.dao.survey.SurveyDao;
 import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
 import bio.terra.pearl.core.model.survey.Survey;
+import bio.terra.pearl.core.model.survey.SurveyType;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.Query;
 import org.springframework.context.annotation.Lazy;
@@ -124,6 +125,34 @@ public class StudyEnvironmentSurveyDao extends BaseMutableJdbiDao<StudyEnvironme
                         .bind("excludeId", excludeId)
                         .mapTo(Integer.class)
                         .one()) > 0;
+    }
+
+    public List<StudyEnvironmentSurvey> findAllByTypeWithContent(List<UUID> studyEnvIds, SurveyType surveyType, Boolean active) {
+        List<StudyEnvironmentSurvey> studyEnvSurveys = jdbi.withHandle(handle -> {
+            Query query = handle.createQuery("""
+                                select a.* from %s a
+                                    join survey on survey.id = a.survey_id
+                                    where a.study_environment_id IN (<studyEnvIds>)
+                                    %s
+                                    %s
+                                    order by survey.stable_id asc, survey_order asc;
+                                """.formatted(
+                            tableName,
+                            surveyType != null ? " and survey.survey_type = :surveyType" : "",
+                            active != null ? " and a.active = :active" : ""))
+                    .bind("surveyType", surveyType)
+                    .bindList("studyEnvIds", studyEnvIds);
+            if (active != null) {
+                query = query.bind("active", active);
+            }
+            if (surveyType != null) {
+                query = query.bind("surveyType", surveyType);
+            }
+            return query.mapTo(clazz)
+                    .list();
+        });
+        attachSurveys(studyEnvSurveys, ATTACH_SURVEY.WITH_CONTENT);
+        return studyEnvSurveys;
     }
 
     protected enum ATTACH_SURVEY {

--- a/core/src/main/java/bio/terra/pearl/core/dao/study/StudyEnvironmentSurveyDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/study/StudyEnvironmentSurveyDao.java
@@ -89,19 +89,19 @@ public class StudyEnvironmentSurveyDao extends BaseMutableJdbiDao<StudyEnvironme
     /** gets all the study environment surveys and attaches the relevant survey objects in a batch */
     public List<StudyEnvironmentSurvey> findAllWithSurvey(UUID studyEnvId, Boolean active) {
         List<StudyEnvironmentSurvey> studyEnvSurvs = findAll(List.of(studyEnvId), null, active);
-        attachSurveys(studyEnvSurvs, ATTACH_SURVEY.WITH_CONTENT);
+        attachSurveys(studyEnvSurvs, AttachSurvey.WITH_CONTENT);
         return studyEnvSurvs;
     }
 
-    public List<StudyEnvironmentSurvey> findAllWithSurveyNoContent(List<UUID> studyEnvironmentIds, String stableId, Boolean active) {
+    public List<StudyEnvironmentSurvey>  findAllWithSurveyNoContent(List<UUID> studyEnvironmentIds, String stableId, Boolean active) {
         List<StudyEnvironmentSurvey> studyEnvSurveys = findAll(studyEnvironmentIds, stableId, active);
-        attachSurveys(studyEnvSurveys, ATTACH_SURVEY.WITHOUT_CONTENT);
+        attachSurveys(studyEnvSurveys, AttachSurvey.WITHOUT_CONTENT);
         return studyEnvSurveys;
     }
 
-    protected void attachSurveys(List<StudyEnvironmentSurvey> studyEnvSurveys, ATTACH_SURVEY attach) {
+    protected void attachSurveys(List<StudyEnvironmentSurvey> studyEnvSurveys, AttachSurvey attach) {
         List<UUID> surveyIds = studyEnvSurveys.stream().map(ses -> ses.getSurveyId()).collect(Collectors.toList());
-        List<Survey> surveys = attach.equals(ATTACH_SURVEY.WITH_CONTENT) ? surveyDao.findAll(surveyIds) : surveyDao.findAllNoContent(surveyIds);
+        List<Survey> surveys = attach.equals(AttachSurvey.WITH_CONTENT) ? surveyDao.findAll(surveyIds) : surveyDao.findAllNoContent(surveyIds);
         for (StudyEnvironmentSurvey ses : studyEnvSurveys) {
             ses.setSurvey(surveys.stream().filter(survey -> survey.getId().equals(ses.getSurveyId()))
                     .findFirst().orElseThrow());
@@ -127,7 +127,7 @@ public class StudyEnvironmentSurveyDao extends BaseMutableJdbiDao<StudyEnvironme
                         .one()) > 0;
     }
 
-    public List<StudyEnvironmentSurvey> findAllByTypeWithContent(List<UUID> studyEnvIds, SurveyType surveyType, Boolean active) {
+    public List<StudyEnvironmentSurvey> findAllByType(List<UUID> studyEnvIds, SurveyType surveyType, Boolean active, AttachSurvey attach) {
         List<StudyEnvironmentSurvey> studyEnvSurveys = jdbi.withHandle(handle -> {
             Query query = handle.createQuery("""
                                 select a.* from %s a
@@ -151,12 +151,7 @@ public class StudyEnvironmentSurveyDao extends BaseMutableJdbiDao<StudyEnvironme
             return query.mapTo(clazz)
                     .list();
         });
-        attachSurveys(studyEnvSurveys, ATTACH_SURVEY.WITH_CONTENT);
+        attachSurveys(studyEnvSurveys, attach);
         return studyEnvSurveys;
-    }
-
-    protected enum ATTACH_SURVEY {
-        WITH_CONTENT, // include the content json of the survey
-        WITHOUT_CONTENT  // exclude the content from the retrieval
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/SurveyType.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/SurveyType.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.model.survey;
 
 public enum SurveyType {
+    PRE_ENROLL, // for prenrollment surveys
     CONSENT, // for consent forms
     RESEARCH, // for surveys intended to be included in the research dataset of a study
     OUTREACH, // for surveys intended for outreach purposes, e.g. to collect marketing/feedback information

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
@@ -163,7 +163,7 @@ public class EnrolleeExportService {
         return moduleFormatters;
     }
 
-    List<SurveyType> SURVEY_TYPE_EXPORT_ORDER = List.of(SurveyType.CONSENT, SurveyType.RESEARCH, SurveyType.DOCUMENT_REQUEST, SurveyType.OUTREACH);
+    List<SurveyType> SURVEY_TYPE_EXPORT_ORDER = List.of(SurveyType.PRE_ENROLL, SurveyType.CONSENT, SurveyType.RESEARCH, SurveyType.DOCUMENT_REQUEST, SurveyType.OUTREACH);
 
     /**
      * returns a ModuleExportInfo for each unique survey stableId that has ever been attached to the studyEnvironment
@@ -171,19 +171,6 @@ public class EnrolleeExportService {
      */
     protected List<SurveyFormatter> generateSurveyModules(ExportOptions exportOptions, UUID studyEnvironmentId, List<EnrolleeExportData> enrolleeExportData) {
         List<SurveyFormatter> moduleFormatters = new ArrayList<>();
-        // now add the pre-enrollment survey (if it exists)
-        StudyEnvironment studyEnvironment = studyEnvironmentService.find(studyEnvironmentId).orElseThrow();
-        if (studyEnvironment.getPreEnrollSurveyId() != null) {
-            Survey preEnrollSurvey = surveyService.find(studyEnvironment.getPreEnrollSurveyId()).orElseThrow();
-            List<SurveyQuestionDefinition> preEnrollSurveyQuestionDefinitions = surveyQuestionDefinitionDao.findAllBySurveyIds(List.of(preEnrollSurvey.getId()));
-            moduleFormatters.add(new SurveyFormatter(
-                    exportOptions,
-                    preEnrollSurvey.getStableId(),
-                    List.of(preEnrollSurvey),
-                    preEnrollSurveyQuestionDefinitions,
-                    enrolleeExportData,
-                    objectMapper));
-        }
 
         // get all surveys that have ever been attached to the StudyEnvironment, including inactive ones
         List<StudyEnvironmentSurvey> configuredSurveys = studyEnvironmentSurveyService.findAllByStudyEnvIdWithSurvey(studyEnvironmentId, null);

--- a/core/src/main/java/bio/terra/pearl/core/service/portal/PortalService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/portal/PortalService.java
@@ -126,7 +126,7 @@ public class PortalService extends CrudService<Portal, PortalDao> {
             Optional<PortalEnvironment> portalEnv = portalEnvironmentService
                     .loadWithParticipantSiteContent(portal.getShortcode(), environmentName, language);
             portal.getPortalEnvironments().add(portalEnv.get());
-            List<Study> studies = studyService.findWithPreregContent(portal.getShortcode(), environmentName);
+            List<Study> studies = studyService.findWithPreEnrollContent(portal.getShortcode(), environmentName);
             for (Study study : studies) {
                 portal.getPortalStudies().add(
                         PortalStudy.builder().study(study).build()

--- a/core/src/main/java/bio/terra/pearl/core/service/study/StudyEnvironmentSurveyService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/study/StudyEnvironmentSurveyService.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.core.service.study;
 
+import bio.terra.pearl.core.dao.study.AttachSurvey;
 import bio.terra.pearl.core.dao.study.StudyEnvironmentSurveyDao;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.publishing.ListChange;
@@ -8,6 +9,7 @@ import bio.terra.pearl.core.model.publishing.VersionedConfigChange;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
 import bio.terra.pearl.core.model.survey.Survey;
+import bio.terra.pearl.core.model.survey.SurveyType;
 import bio.terra.pearl.core.service.CrudService;
 import java.util.List;
 import java.util.Optional;
@@ -91,6 +93,10 @@ public class StudyEnvironmentSurveyService extends CrudService<StudyEnvironmentS
 
     public List<StudyEnvironmentSurvey> findAllWithSurveyNoContent(List<UUID> studyEnvIds, String stableId, Boolean active) {
         return dao.findAllWithSurveyNoContent(studyEnvIds, stableId, active);
+    }
+
+    public List<StudyEnvironmentSurvey> findAllByType(List<UUID> studyEnvIds, SurveyType type, Boolean active, AttachSurvey attachSurvey) {
+        return dao.findAllByType(studyEnvIds, type, active, attachSurvey);
     }
 
     public void deleteBySurveyId(UUID surveyId) {

--- a/core/src/main/java/bio/terra/pearl/core/service/study/StudyService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/study/StudyService.java
@@ -65,8 +65,8 @@ public class StudyService extends CrudService<Study, StudyDao> {
         }
     }
 
-    public List<Study> findWithPreregContent(String portalShortcode, EnvironmentName envName) {
-        List<Study> studies = dao.findWithPreregContent(portalShortcode, envName);
+    public List<Study> findWithPreEnrollContent(String portalShortcode, EnvironmentName envName) {
+        List<Study> studies = dao.findWithPreEnrollContent(portalShortcode, envName);
         studies.forEach(this::attachStudyEnvironmentKitTypes);
 
         return studies;

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
@@ -111,6 +111,7 @@ public class SurveyTaskDispatcher extends TaskDispatcher<SurveyTaskConfigDto> {
             SurveyType.RESEARCH, TaskType.SURVEY,
             SurveyType.OUTREACH, TaskType.OUTREACH,
             SurveyType.ADMIN, TaskType.ADMIN_FORM,
+            SurveyType.PRE_ENROLL, TaskType.SURVEY, // pre-enroll surveys are NOT typically assigned as tasks
             SurveyType.DOCUMENT_REQUEST, TaskType.DOCUMENT_REQUEST
     );
 

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.core.service.workflow;
 
+import bio.terra.pearl.core.dao.study.AttachSurvey;
 import bio.terra.pearl.core.dao.survey.AnswerMappingDao;
 import bio.terra.pearl.core.dao.survey.PreEnrollmentResponseDao;
 import bio.terra.pearl.core.model.EnvironmentName;
@@ -17,6 +18,7 @@ import bio.terra.pearl.core.service.participant.ParticipantUserService;
 import bio.terra.pearl.core.service.participant.PortalParticipantUserService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentConfigService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
+import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
 import bio.terra.pearl.core.service.study.exception.StudyEnvConfigMissing;
 import bio.terra.pearl.core.service.survey.AnswerProcessingService;
 import bio.terra.pearl.core.service.survey.SurveyParseUtils;
@@ -54,6 +56,7 @@ public class EnrollmentService {
     private final AnswerMappingDao answerMappingDao;
     private final SurveyResponseService surveyResponseService;
     private final AnswerProcessingService answerProcessingService;
+    private final StudyEnvironmentSurveyService studyEnvironmentSurveyService;
 
     public EnrollmentService(SurveyService surveyService,
                              PreEnrollmentResponseDao preEnrollmentResponseDao,
@@ -67,7 +70,8 @@ public class EnrollmentService {
                              ParticipantUserService participantUserService,
                              AnswerMappingDao answerMappingDao,
                              SurveyResponseService surveyResponseService,
-                             AnswerProcessingService answerProcessingService) {
+                             AnswerProcessingService answerProcessingService,
+                             StudyEnvironmentSurveyService studyEnvironmentSurveyService) {
         this.surveyService = surveyService;
         this.preEnrollmentResponseDao = preEnrollmentResponseDao;
         this.studyEnvironmentService = studyEnvironmentService;
@@ -82,6 +86,7 @@ public class EnrollmentService {
         this.answerMappingDao = answerMappingDao;
         this.surveyResponseService = surveyResponseService;
         this.answerProcessingService = answerProcessingService;
+        this.studyEnvironmentSurveyService = studyEnvironmentSurveyService;
     }
 
     /**
@@ -370,11 +375,13 @@ public class EnrollmentService {
                                                             UUID preEnrollResponseId,
                                                             UUID participantUserId,
                                                             boolean isSubject) {
-        if (studyEnv.getPreEnrollSurveyId() == null) {
-            // no pre-enroll required
-            return null;
-        }
         if (preEnrollResponseId == null) {
+            List<StudyEnvironmentSurvey> preEnrollSurveys = studyEnvironmentSurveyService.findAllByType(
+                    List.of(studyEnv.getId()), SurveyType.PRE_ENROLL, true, AttachSurvey.WITHOUT_CONTENT);
+            if (preEnrollSurveys.isEmpty()) {
+                // no pre-enroll required
+                return null;
+            }
             if (isSubject) {
                 log.warn("Could not match enrollee to pre-enrollment survey results; user {}", participantUserId);
             }

--- a/core/src/main/resources/db/changelog/changesets/2025_01_27_prenroll_type.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2025_01_27_prenroll_type.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: "preenroll_type"
+      author: dbush
+      changes:
+        - sql:
+            sql:
+              insert into study_environment_survey (study_environment_id, created_at, last_updated_at, survey_id, survey_order, active)
+              select id, now(), now(), pre_enroll_survey_id as survey_id, 1, true from study_environment where pre_enroll_survey_id is not null;
+        - sql:
+            sql:
+              update survey set survey_type = 'PRE_ENROLL', auto_assign = false where stable_id in (select 
+              stable_id from survey join study_environment on pre_enroll_survey_id = survey.id);

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -392,7 +392,7 @@ databaseChangeLog:
   - include:
       file: changesets/2025_02_05_create_relation_indices.yaml
       relativeToChangelogFile: true
- - include:
+  - include:
       file: changesets/2025_01_27_prenroll_type.yaml
       relativeToChangelogFile: true
 

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -386,6 +386,9 @@ databaseChangeLog:
   - include:
       file: changesets/2025_01_24_kit_label_unique_constraint.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2025_01_27_prenroll_type.yaml
+      relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentServiceTests.java
@@ -15,10 +15,7 @@ import bio.terra.pearl.core.model.participant.PortalParticipantUser;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.study.StudyEnvironmentConfig;
-import bio.terra.pearl.core.model.survey.Answer;
-import bio.terra.pearl.core.model.survey.ParsedPreEnrollResponse;
-import bio.terra.pearl.core.model.survey.PreEnrollmentResponse;
-import bio.terra.pearl.core.model.survey.Survey;
+import bio.terra.pearl.core.model.survey.*;
 import bio.terra.pearl.core.model.workflow.HubResponse;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.participant.ParticipantUserService;
@@ -27,6 +24,7 @@ import bio.terra.pearl.core.service.portal.PortalService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentConfigService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import bio.terra.pearl.core.service.study.StudyService;
+import bio.terra.pearl.core.service.survey.SurveyResponseService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -67,15 +65,19 @@ public class EnrollmentServiceTests extends BaseSpringBootTest {
     private ParticipantUserService participantUserService;
     @Autowired
     private EnrolleeService enrolleeService;
+    @Autowired
+    private SurveyResponseService surveyResponseService;
 
     @Test
     @Transactional
     public void testAnonymousPreEnroll(TestInfo testInfo) throws JsonProcessingException {
         PortalEnvironment portalEnv = portalEnvironmentFactory.buildPersisted(getTestName(testInfo));
         StudyEnvironment studyEnv = studyEnvironmentFactory.buildPersisted(portalEnv, getTestName(testInfo));
-        Survey survey = surveyFactory.buildPersisted(getTestName(testInfo), portalEnv.getPortalId());
-        studyEnv.setPreEnrollSurveyId(survey.getId());
-        studyEnvironmentService.update(studyEnv);
+        Survey survey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(testInfo))
+                .surveyType(SurveyType.PRE_ENROLL)
+                .portalId(portalEnv.getPortalId()));
+
+        surveyFactory.attachToEnv(survey, studyEnv.getId(), true);
         String studyShortcode = studyService.find(studyEnv.getStudyId()).get().getShortcode();
 
         List<Answer> answers = AnswerFactory.fromMap(Map.of(
@@ -99,6 +101,14 @@ public class EnrollmentServiceTests extends BaseSpringBootTest {
         HubResponse hubResponse = enrollmentService.enroll(userBundle.ppUser(), studyEnv.getEnvironmentName(), studyShortcode,
                 userBundle.user(), userBundle.ppUser(), savedResponse.getId(), false);
         assertThat(hubResponse.getEnrollee(), notNullValue());
+
+        // now check that the response is backfilled to a SurveyResponse
+        List<SurveyResponse> responses = surveyResponseService.findByEnrolleeId(hubResponse.getEnrollee().getId());
+        assertThat(responses, hasSize(1));
+        assertThat(responses.get(0).getSurveyId(), equalTo(survey.getId()));
+        List<Answer> responseAnswers = surveyResponseService.findOneWithAnswers(responses.get(0).getId()).get().getAnswers();
+        assertThat(answers, hasSize(2));
+
     }
 
     /**
@@ -111,14 +121,13 @@ public class EnrollmentServiceTests extends BaseSpringBootTest {
     public void testEnrollDoesNotRequirePreEnroll(TestInfo testInfo) {
         PortalEnvironment portalEnv = portalEnvironmentFactory.buildPersisted(getTestName(testInfo));
         StudyEnvironment studyEnv = studyEnvironmentFactory.buildPersisted(portalEnv, getTestName(testInfo));
-        Survey survey = surveyFactory.buildPersisted(getTestName(testInfo));
-        studyEnv.setPreEnrollSurveyId(survey.getId());
-        studyEnvironmentService.update(studyEnv);
+        Survey survey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(testInfo))
+                .surveyType(SurveyType.PRE_ENROLL)
+                .portalId(portalEnv.getPortalId()));
+        surveyFactory.attachToEnv(survey, studyEnv.getId(), true);
         ParticipantUserFactory.ParticipantUserAndPortalUser userBundle = participantUserFactory.buildPersisted(portalEnv,
                 getTestName(testInfo));
         String studyShortcode = studyService.find(studyEnv.getStudyId()).get().getShortcode();
-
-        String portalShortcode = portalService.find(portalEnv.getPortalId()).get().getShortcode();
 
         HubResponse hubResponse = enrollmentService.enroll(userBundle.ppUser(), studyEnv.getEnvironmentName(), studyShortcode,
                 userBundle.user(), userBundle.ppUser(), null, false);
@@ -141,7 +150,7 @@ public class EnrollmentServiceTests extends BaseSpringBootTest {
         String portalShortcode = portalService.find(portalEnv.getPortalId()).get().getShortcode();
         Assertions.assertThrows(IllegalArgumentException.class, () -> {
             enrollmentService.enroll(userBundle.ppUser(), studyEnv.getEnvironmentName(), studyShortcode, userBundle.user(), userBundle.ppUser(),
-                   null, false);
+                    null, false);
         });
     }
 
@@ -158,9 +167,10 @@ public class EnrollmentServiceTests extends BaseSpringBootTest {
 
         String studyShortcode = studyService.find(studyEnv.getStudyId()).get().getShortcode();
 
-        Survey survey = surveyFactory.buildPersisted(getTestName(testInfo), portalEnv.getPortalId());
-        studyEnv.setPreEnrollSurveyId(survey.getId());
-        studyEnvironmentService.update(studyEnv);
+        Survey survey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(testInfo))
+                .surveyType(SurveyType.PRE_ENROLL)
+                .portalId(portalEnv.getPortalId()));
+        surveyFactory.attachToEnv(survey, studyEnv.getId(), true);
 
         List<Answer> answers = AnswerFactory.fromMap(Map.of(
                 "qualified", true,

--- a/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentWorkflowTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentWorkflowTests.java
@@ -169,10 +169,10 @@ public class EnrollmentWorkflowTests extends BaseSpringBootTest {
 
         // now try to complete the survey
         SurveyResponse survResponse = SurveyResponse.builder()
-                        .answers(AnswerFactory.fromMap(Map.of("sampleQuestion", "foo")))
-                        .complete(true)
-                        .resumeData("stuff")
-                        .build();
+                .answers(AnswerFactory.fromMap(Map.of("sampleQuestion", "foo")))
+                .complete(true)
+                .resumeData("stuff")
+                .build();
         hubResponse = surveyResponseService.updateResponse(survResponse, new ResponsibleEntity(userBundle.user()), null, userBundle.ppUser(),
                 enrollee, surveyTasks.get(0).getId(), survey.getPortalId());
         List<ParticipantTask> updatedTasks = participantTaskService.findByEnrolleeId(enrollee.getId());
@@ -195,16 +195,11 @@ public class EnrollmentWorkflowTests extends BaseSpringBootTest {
         Study study = studyEnvBundle.getStudy();
 
         Survey preEnrollmentSurvey = surveyFactory.buildPersisted(getTestName(info));
-        StudyEnvironmentSurvey.builder()
-                .surveyId(preEnrollmentSurvey.getId())
-                .studyEnvironmentId(studyEnv.getId())
-                .build();
+        Survey survey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .surveyType(SurveyType.PRE_ENROLL)
+                .portalId(portalEnv.getPortalId()));
 
-        studyEnv.setPreEnrollSurveyId(preEnrollmentSurvey.getId());
-        studyEnvironmentService.update(
-                studyEnv
-        );
-
+        surveyFactory.attachToEnv(survey, studyEnv.getId(), true);
         String preEnrollmentSurveyResponseData = """
                 [{"questionStableId": "proxyQuestion","surveyVersion":0,"viewedLanguage":"en","stringValue":"false"},
                 {"createdAt":1710527339.202811000,"lastUpdatedAt":1710527339.202811000,"questionStableId":"qualified","surveyVersion":0,"booleanValue":true}]""";
@@ -298,7 +293,7 @@ public class EnrollmentWorkflowTests extends BaseSpringBootTest {
         surveyFactory.attachToEnv(consent, studyEnv.getId(), true);
 
         HubResponse<Enrollee> hubResponse1 = enrollmentService.enrollAsProxy(studyEnv.getEnvironmentName(), studyShortcode, userBundle.user(), userBundle.ppUser(),
-                 null);
+                null);
         Enrollee proxyEnrollee = hubResponse1.getEnrollee();
         HubResponse<Enrollee> hubResponse2 = enrollmentService.enrollAsProxy(studyEnv.getEnvironmentName(), studyShortcode,userBundle.user(), userBundle.ppUser(),
                 null);
@@ -416,12 +411,11 @@ public class EnrollmentWorkflowTests extends BaseSpringBootTest {
         StudyEnvironmentConfig config = studyEnvironmentConfigService.find(studyEnv.getStudyEnvironmentConfigId()).get();
         config.setAcceptingProxyEnrollment(true);
         studyEnvironmentConfigService.update(config);
-        Survey preEnrollmentSurvey = surveyFactory.buildPersisted(getTestName(info));
-        StudyEnvironmentSurvey.builder()
-                .surveyId(preEnrollmentSurvey.getId())
-                .studyEnvironmentId(studyEnv.getId())
-                .build();
-        studyEnv.setPreEnrollSurveyId(preEnrollmentSurvey.getId());
+        Survey preEnrollmentSurvey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .surveyType(SurveyType.PRE_ENROLL)
+                .portalId(portalEnv.getPortalId()));
+
+        surveyFactory.attachToEnv(preEnrollmentSurvey, studyEnv.getId(), true);
         studyEnvironmentService.update(studyEnv);
         String proxyQuestionStableId = "proxyQuestion";
         preEnrollmentSurveyFactory.buildPersistedProxyAnswerMapping(getTestName(info), preEnrollmentSurvey.getId(), proxyQuestionStableId);

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
@@ -48,10 +48,8 @@
         "initialized": true,
         "enableInPersonKits": true
       },
-      "preEnrollSurveyDto": {
-        "populateFileName": "surveys/preEnroll.json"
-      },
       "configuredSurveyDtos": [
+        {"populateFileName": "surveys/preEnroll.json"},
         {"populateFileName": "surveys/ourHealthConsent.json"},
         {"populateFileName": "surveys/basic.json"},
         {"populateFileName": "surveys/cardioHistory.json"},
@@ -217,10 +215,8 @@
         "initialized": true,
         "enableInPersonKits": true
       },
-      "preEnrollSurveyDto": {
-        "populateFileName": "surveys/preEnroll.json"
-      },
       "configuredSurveyDtos": [
+        {"populateFileName": "surveys/preEnroll.json"},
         {"populateFileName": "surveys/basic.json"},
         {"populateFileName": "surveys/cardioHistory.json"},
         {"populateFileName": "surveys/medicalHistory.json"},
@@ -275,10 +271,8 @@
         "initialized": true,
         "enableInPersonKits": true
       },
-      "preEnrollSurveyDto": {
-        "populateFileName": "surveys/preEnroll.json"
-      },
       "configuredSurveyDtos": [
+        {"populateFileName": "surveys/preEnroll.json"},
         {"populateFileName": "surveys/basic.json"},
         {"populateFileName": "surveys/cardioHistory.json"},
         {"populateFileName": "surveys/medicalHistory.json"},

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
@@ -2,6 +2,7 @@
   "stableId": "hd_hd_preenroll",
   "version": 1,
   "name": "Pre-enroll",
+  "surveyType": "PRE_ENROLL",
   "answerMappings": [
     {
       "questionStableId": "proxy_enrollment",

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/study.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/study.json
@@ -31,10 +31,8 @@
         "initialized": true,
         "enableInPersonKits": true
       },
-      "preEnrollSurveyDto": {
-        "populateFileName": "surveys/preEnroll.json"
-      },
       "configuredSurveyDtos": [
+        {"populateFileName": "surveys/preenroll.json"},
         {"populateFileName": "surveys/basic.json"},
         {"populateFileName": "surveys/cardioHistory.json"},
         {"populateFileName": "surveys/medicalHistory.json"},

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/study.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/study.json
@@ -32,7 +32,7 @@
         "enableInPersonKits": true
       },
       "configuredSurveyDtos": [
-        {"populateFileName": "surveys/preenroll.json"},
+        {"populateFileName": "surveys/preEnroll.json"},
         {"populateFileName": "surveys/basic.json"},
         {"populateFileName": "surveys/cardioHistory.json"},
         {"populateFileName": "surveys/medicalHistory.json"},

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/preEnroll.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/surveys/preEnroll.json
@@ -2,6 +2,7 @@
   "stableId": "oh_oh_preenroll",
   "version": 1,
   "name": "Pre-enroll",
+  "surveyType": "PRE_ENROLL",
   "jsonContent": {
     "title": "OurHealth pre-enroll",
     "logoPosition": "right",

--- a/ui-admin/src/study/StudyContent.tsx
+++ b/ui-admin/src/study/StudyContent.tsx
@@ -43,9 +43,6 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
   const { currentEnv } = studyEnvContext
   const portalContext = useContext(PortalContext) as PortalContextT
 
-
-  const preEnrollSurvey = currentEnv.preEnrollSurvey
-  const isReadOnlyEnv = !(currentEnv.environmentName === 'sandbox')
   const [configuredSurveys, setConfiguredSurveys] = useState<StudyEnvironmentSurveyNamed[]>([])
   const [showArchiveSurveyModal, setShowArchiveSurveyModal] = useState(false)
   const [showDeleteSurveyModal, setShowDeleteSurveyModal] = useState(false)

--- a/ui-admin/src/study/StudyContent.tsx
+++ b/ui-admin/src/study/StudyContent.tsx
@@ -7,11 +7,9 @@ import {
   paramsFromContext,
   StudyEnvContextT
 } from './StudyEnvironmentRouter'
-import { Link } from 'react-router-dom'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus'
 import CreateSurveyModal from './surveys/CreateSurveyModal'
-import { faEllipsisH } from '@fortawesome/free-solid-svg-icons'
 import ArchiveSurveyModal from './surveys/ArchiveSurveyModal'
 import DeleteSurveyModal from './surveys/DeleteSurveyModal'
 import {
@@ -20,8 +18,7 @@ import {
   SurveyType
 } from '@juniper/ui-core'
 import {
-  Button,
-  IconButton
+  Button
 } from 'components/forms/Button'
 import CreatePreEnrollSurveyModal from './surveys/CreatePreEnrollSurveyModal'
 import { renderPageHeader } from 'util/pageUtils'
@@ -85,6 +82,7 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
   const consentSurveyStableIds = getUniqueStableIdsForType(configuredSurveys, 'CONSENT')
   const adminFormStableIds = getUniqueStableIdsForType(configuredSurveys, 'ADMIN')
   const documnetRequestStableIds = getUniqueStableIdsForType(configuredSurveys, 'DOCUMENT_REQUEST')
+  const preEnrollStableIds = getUniqueStableIdsForType(configuredSurveys, 'PRE_ENROLL')
 
   return <div className="container-fluid px-4 py-2">
     { renderPageHeader('Forms & Surveys') }
@@ -92,38 +90,27 @@ function StudyContent({ studyEnvContext }: {studyEnvContext: StudyEnvContextT}) 
       <div className="col-12">
         { currentEnv.studyEnvironmentConfig.initialized && <ul className="list-unstyled">
           <li className="mb-3 rounded-2 p-3" style={{ background: '#efefef' }}>
-            <h6>Pre-enrollment Questionnaire</h6>
+            <h2 className="h6">Pre-Enroll Surveys</h2>
             <div className="flex-grow-1 pt-3">
-              {preEnrollSurvey && <ul className="list-unstyled">
-                <li className="d-flex align-items-center">
-                  <Link to={`preEnroll/${preEnrollSurvey.stableId}?readOnly=${isReadOnlyEnv}`}>
-                    {preEnrollSurvey.name} <span className="detail">v{preEnrollSurvey.version}</span>
-                  </Link>
-
-                  {!isReadOnlyEnv && <div className="nav-item dropdown ms-1">
-                    <IconButton icon={faEllipsisH} data-bs-toggle="dropdown"
-                      aria-expanded="false" aria-label="configure pre-enroll menu"/>
-                    <div className="dropdown-menu">
-                      <ul className="list-unstyled">
-                        <li>
-                          <button className="dropdown-item"
-                            onClick={() => alert('To remove a pre-enroll survey, contact support')}>
-                              Remove
-                          </button>
-                        </li>
-                      </ul>
-                    </div>
-                  </div>}
-                </li>
-              </ul>}
-              {(!preEnrollSurvey && !isReadOnlyEnv) && <Button variant="secondary"
-                data-testid={'addPreEnroll'}
-                onClick={() => {
-                  setShowCreatePreEnrollModal(!showCreatePreEnrollSurveyModal)
+              <SurveyEnvironmentTable
+                key={studyEnvContext.currentEnvPath}
+                stableIds={preEnrollStableIds}
+                studyEnvParams={paramsFromContext(studyEnvContext)}
+                configuredSurveys={configuredSurveys}
+                setSelectedSurveyConfig={setSelectedSurveyConfig}
+                updateConfiguredSurveys={updateConfiguredSurveys}
+                setShowDeleteSurveyModal={setShowDeleteSurveyModal}
+                setShowArchiveSurveyModal={setShowArchiveSurveyModal}
+                showArchiveSurveyModal={showArchiveSurveyModal}
+                showDeleteSurveyModal={showDeleteSurveyModal}
+              />
+              <div>
+                <Button variant="secondary" data-testid={'addPreenrollSurvey'} onClick={() => {
+                  setCreateSurveyType('PRE_ENROLL')
                 }}>
-                <FontAwesomeIcon icon={faPlus}/> Add
-              </Button>
-              }
+                  <FontAwesomeIcon icon={faPlus}/> Add
+                </Button>
+              </div>
             </div>
           </li>
           <li className="mb-3 rounded-2 p-3" style={{ background: '#efefef' }}>

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeView.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeView.tsx
@@ -112,6 +112,10 @@ export function LoadedEnrolleeView({ enrollee, studyEnvContext, onUpdate }: {
     })
   }
 
+  const preEnrollSurvey = surveys
+    .find(survey => survey.survey.surveyType === 'PRE_ENROLL')?.survey
+
+
   return <div className="ParticipantView mt-3 ps-4">
     <NavBreadcrumb value={enrollee?.shortcode || ''}>
       <Link to={`${currentEnvPath}/participants/${enrollee.shortcode}`}>
@@ -139,7 +143,7 @@ export function LoadedEnrolleeView({ enrollee, studyEnvContext, onUpdate }: {
               <li style={navListItemStyle}>
                 <CollapsableMenu header={'Forms'} headerClass="text-black" content={
                   <ul className="list-unstyled">
-                    {currentEnv.preEnrollSurvey && <li className="mb-2">
+                    {preEnrollSurvey && <li className="mb-2">
                       <NavLink to="preRegistration" className={getLinkCssClasses}>
                           PreEnrollment
                       </NavLink>
@@ -216,8 +220,8 @@ export function LoadedEnrolleeView({ enrollee, studyEnvContext, onUpdate }: {
                 <Route path="profile" element={<EnrolleeProfile enrollee={enrollee}
                   studyEnvContext={studyEnvContext}
                   onUpdate={onUpdate}/>}/>
-                {currentEnv.preEnrollSurvey && <Route path="preRegistration/*" element={
-                  <PreEnrollmentView preEnrollSurvey={currentEnv.preEnrollSurvey}
+                {preEnrollSurvey && <Route path="preRegistration/*" element={
+                  <PreEnrollmentView preEnrollSurvey={preEnrollSurvey}
                     preEnrollResponse={enrollee.preEnrollmentResponse}
                     studyEnvContext={studyEnvContext}/>
                 }/>}

--- a/ui-admin/src/study/workflow/WorkflowView.tsx
+++ b/ui-admin/src/study/workflow/WorkflowView.tsx
@@ -4,14 +4,13 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus'
 import {
   paramsFromContext,
-  StudyEnvContextT, studyEnvFormsParamsPath,
-  studyEnvPreEnrollPath, studyEnvSurveyPath,
+  StudyEnvContextT, studyEnvFormsParamsPath, studyEnvSurveyPath,
   studyEnvTriggerPath, studyEnvWorkflowPath,
   triggerPath
 } from '../StudyEnvironmentRouter'
 import { renderPageHeader } from 'util/pageUtils'
 import { LoadedPortalContextT } from '../../portal/PortalProvider'
-import { StudyEnvironmentSurvey, StudyEnvParams, Survey, Trigger } from '@juniper/ui-core'
+import { StudyEnvironmentSurvey, StudyEnvParams, Trigger } from '@juniper/ui-core'
 import Api from 'api/api'
 import { useLoadingEffect } from 'api/api-utils'
 import LoadingSpinner from 'util/LoadingSpinner'
@@ -34,7 +33,6 @@ export default function WorkflowView({ studyEnvContext, portalContext }:
   const navigate = useNavigate()
   const [triggers, setTriggers] = useState<Trigger[]>([])
   const [studyEnvSurveys, setStudyEnvSurveys] = useState<StudyEnvironmentSurvey[]>([])
-  const [preEnrollSurvey, setPreEnrollSurvey] = useState<Survey>()
   const [triggerOpts, setTriggerOpts] = useState<Partial<Trigger>>({})
   const [previousEnv, setPreviousEnv] = useState<string>(currentEnv.environmentName)
   const [showCreateModal, setShowCreateModal] = useState(false)
@@ -49,10 +47,6 @@ export default function WorkflowView({ studyEnvContext, portalContext }:
       Api.findConfiguredSurveys(portalContext.portal.shortcode, studyEnvContext.study.shortcode,
         currentEnv.environmentName, true, undefined)
     ])
-    if (currentEnv.preEnrollSurveyId) {
-      const preEnrollSurvey = await Api.getSurveyById(portalContext.portal.shortcode, currentEnv.preEnrollSurveyId)
-      setPreEnrollSurvey(preEnrollSurvey)
-    }
     setTriggers(triggerList)
     setStudyEnvSurveys(_sortBy(surveyList, 'surveyOrder'))
   }, [currentEnv.environmentName, studyEnvContext.study.shortcode])
@@ -71,6 +65,9 @@ export default function WorkflowView({ studyEnvContext, portalContext }:
     setShowCreateModal(false)
   }
 
+  const preEnrollSurvey = studyEnvSurveys
+    .find(survey => survey.survey.surveyType === 'PRE_ENROLL')?.survey
+
   const formEditLink = <Link to={studyEnvFormsParamsPath(paramsFromContext(studyEnvContext))}>
     <FontAwesomeIcon icon={faEdit} className="ms-2 fa-xs fw-normal"/>
   </Link>
@@ -86,8 +83,9 @@ export default function WorkflowView({ studyEnvContext, portalContext }:
           { preEnrollSurvey &&
             <div>
               <FontAwesomeIcon icon={faClipboard} className="me-2"/>
-              <Link to={studyEnvPreEnrollPath(paramsFromContext(studyEnvContext), preEnrollSurvey.stableId)}>
-                {preEnrollSurvey.name}
+              <Link to={studyEnvSurveyPath(paramsFromContext(studyEnvContext),
+                preEnrollSurvey.stableId, preEnrollSurvey.version)}>
+                { preEnrollSurvey.name}
               </Link>
             </div>
           }

--- a/ui-core/src/types/forms.ts
+++ b/ui-core/src/types/forms.ts
@@ -30,7 +30,7 @@ export type VersionedForm = {
   footer?: string
 }
 
-export type SurveyType = 'RESEARCH' | 'OUTREACH' | 'CONSENT' | 'ADMIN' | 'DOCUMENT_REQUEST'
+export type SurveyType = 'RESEARCH' | 'OUTREACH' | 'CONSENT' | 'ADMIN' | 'DOCUMENT_REQUEST' | 'PRE_ENROLL'
 export type RecurrenceType = 'NONE' | 'LONGITUDINAL' | 'UPDATE'
 export type Survey = VersionedForm & {
   surveyType: SurveyType

--- a/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
+++ b/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
@@ -12,8 +12,7 @@ import {
 import { usePortalEnv } from 'providers/PortalProvider'
 import Api, {
   Portal,
-  StudyEnvironment,
-  Survey
+  StudyEnvironment
 } from 'api/api'
 import NavBar from 'Navbar'
 import PreEnrollView from './PreEnroll'
@@ -97,7 +96,8 @@ function StudyEnrollOutletMatched(props: StudyEnrollOutletMatchedProps) {
 
   const navigate = useNavigate()
   const [preEnrollResponseId, setPreEnrollResponseId] = usePreEnrollResponseId()
-  const [preEnrollSatisfied, setPreEnrollSatisfied] = useState(!studyEnv.preEnrollSurvey)
+  const preEnrollSurvey = getPreEnrollSurvey(studyEnv)
+  const [preEnrollSatisfied, setPreEnrollSatisfied] = useState(!preEnrollSurvey)
 
   const [hasProvidedPassword, setHasProvidedPassword] = useHasProvidedStudyPassword(studyShortcode)
   const mustProvidePassword = studyEnv.studyEnvironmentConfig.passwordProtected && !hasProvidedPassword
@@ -189,7 +189,8 @@ function StudyEnrollOutletMatched(props: StudyEnrollOutletMatchedProps) {
     isSubjectEnrollment: !!matchedEnrollee && !matchedEnrollee.subject,
     isProxyEnrollment
   }
-  const hasPreEnroll = !!enrollContext.studyEnv.preEnrollSurvey
+
+  const hasPreEnroll = !!preEnrollSurvey
 
   if (isLoading) { return <PageLoadingIndicator/> }
   return <>
@@ -206,7 +207,7 @@ function StudyEnrollOutletMatched(props: StudyEnrollOutletMatchedProps) {
           {skipPreEnroll &&
             <Route path="preEnroll/*" element={<PortalRegistrationRouter portal={portal} returnTo={null}/>}/>}
           {hasPreEnroll && <Route path="preEnroll" element={
-            <PreEnrollView enrollContext={enrollContext} survey={enrollContext.studyEnv.preEnrollSurvey as Survey}/>
+            <PreEnrollView enrollContext={enrollContext} survey={preEnrollSurvey!.survey}/>
           }/>}
           <Route path="ineligible" element={<StudyIneligible portal={portal} studyName={studyName}/>}/>
           <Route path="register/*" element={<PortalRegistrationRouter portal={portal} returnTo={null}/>}/>
@@ -238,4 +239,8 @@ export function handleNewStudyEnroll(
     }
     navigate('/hub', { replace: true, state: hubUpdate })
   }
+}
+
+const getPreEnrollSurvey = (studyEnv: StudyEnvironment) => {
+  return studyEnv.configuredSurveys.find(ses => ses.survey.surveyType === 'PRE_ENROLL')
 }

--- a/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
+++ b/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
@@ -243,4 +243,5 @@ export function handleNewStudyEnroll(
 
 const getPreEnrollSurvey = (studyEnv: StudyEnvironment) => {
   return studyEnv.configuredSurveys.find(ses => ses.survey.surveyType === 'PRE_ENROLL')
+    ?? studyEnv.preEnrollSurvey
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Updates pre-enrollment surveys to be a survey type, rather than have a dedicated data model attribute.  this refactor will need to be done in two stages in order to avoid downtime. Stage 1 (this PR) migrates existing pre-enroll surveys and updates the frontend to read the migrated versions, but does not remove the data fields.  Stage 2 would remove the data field

The big advantage of this is an overall simplification of our data model, and corresponding improvements in the UX.  For example, this gives us the ability to publish pre-enroll surveys individually, which we did not have before.  the downside is that this no longer enforces that a study env can only have a single pre-enrollment survey, so we'll have to think about what that means.

Note that this temporarily punts the issue of being able to create multiple pre-enroll surveys in the admin tool.  We'll clean up the admin tool when we also remove all the old preEnrollSurveyId questions

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1. redeploy apiParticipantApp
2. go to https://sandbox.demo.localhost:3001 
3. join, confirm pre-enroll processes correctly.
4. redeploy apiAdminApp
5. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/forms
6. confirm you can view/edit/publish the pre-enroll survey
