### PR TITLE
[JN-1563] Publish fix

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/export/integration/ExportIntegrationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/integration/ExportIntegrationService.java
@@ -180,9 +180,4 @@ public class ExportIntegrationService extends CrudService<ExportIntegration, Exp
             update(destIntegration);
         }
     }
-
-    @Override
-    public List<String> getAdditionalPublishIgnoreProps() {
-        return List.of("exportOptions", "exportOptionsId", "destinationUrl");
-    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/publishing/StudyEnvPublishable.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/publishing/StudyEnvPublishable.java
@@ -14,11 +14,11 @@ public interface StudyEnvPublishable {
     void applyDiff( StudyEnvironmentChange change, StudyEnvironment destEnv, PortalEnvironment destPortalEnv);
 
     default List<String> getPublishIgnoreProps() {
-        return Stream.concat(List.of("id", "createdAt", "lastUpdatedAt", "class",
-                "portalEnvironmentId", "studyEnvironmentId").stream(), getAdditionalPublishIgnoreProps().stream()).toList();
-    }
-
-    default List<String> getAdditionalPublishIgnoreProps() {
-        return List.of();
+        return List.of(
+                "id", "createdAt", "lastUpdatedAt", "class",
+                "portalEnvironmentId", "studyEnvironmentId",
+                "surveyId", "survey", "versionedEntity",
+                "exportOptions", "exportOptionsId", "destinationUrl"
+        );
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/study/StudyEnvironmentSurveyService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/study/StudyEnvironmentSurveyService.java
@@ -138,9 +138,4 @@ public class StudyEnvironmentSurveyService extends CrudService<StudyEnvironmentS
             }
         }
     }
-
-    @Override
-    public List<String> getAdditionalPublishIgnoreProps() {
-        return List.of( "surveyId", "survey", "versionedEntity");
-    }
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

This has been quite a journey to reproduce:

The overview of the issue is that the diff endpoint is returning the `survey` and `surveyId` fields for `StudyEnvironmentSurvey`s, despite them being explicitly ignored in `getAdditionalIgnoreProps`. Since these 2 properties are returned and displayed in the frontend, when the user submits the publish, these properties are also added to the JSON payload, which the backend rejects. Single-survey publishing doesn't do a diff, so that explains why it works.

Initially I assumed it was something related to the portal/study config in gVasc. So I extracted that and tried to reproduce locally. No luck.

Then I noticed that the issue was reproducible in HeartHive on demo, so I hoped that maybe it was a data issue. I dumped the _entire_ Postgres database to a bucket, and restored that into my local Postgres. I was unable to reproduce it locally, even with the same data.

After chatting with Devon a bit, it seems like _could_ be due to how the classes are initialized, and since there's a bunch of inheritance going on here, that seems plausible. It's hard to pin down though.

This proposed fix just adds these properties to the default ignore method in the `StudyEnvPublishable` interface.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Difficult to test, so you'll want to just regression test publish instead.
