### PR TITLE
[JN-1593] dynamic column cleanup

### DIFF
--- a/ui-admin/src/util/participantSearchUtils.tsx
+++ b/ui-admin/src/util/participantSearchUtils.tsx
@@ -230,7 +230,7 @@ export const getFacets = (searchState: ParticipantSearchState, opts?: { includeK
         for (const task of value as { task: string, status: string }[]) {
           facets.push({ label: task.task, value: task.status })
         }
-      } else if (key === 'includeFacetKeys') {
+      } else if (['includeFacets', 'queryFacets', 'includeFacetKeys'].includes(key)) {
         // skip -- not shown directly to users
       } else {
         facets.push({

--- a/ui-admin/src/util/table/columnUtils.test.tsx
+++ b/ui-admin/src/util/table/columnUtils.test.tsx
@@ -1,0 +1,15 @@
+import { KeyedSearchValueTypeDefinition } from 'api/api'
+import { parseAnswerFacet } from './columnUtils'
+
+test('filters legacy prefixes from col names', async () => {
+  const facet: KeyedSearchValueTypeDefinition = {
+    key: 'answer.surveyA.oh_oh_question1',
+    type: 'STRING',
+    allowMultiple: false,
+    allowOtherDescription: false
+  }
+  const { surveyStableId, questionStableId, header } = parseAnswerFacet(facet)
+  expect(surveyStableId).toBe('surveyA')
+  expect(questionStableId).toBe('oh_oh_question1')
+  expect(header).toBe('Question 1')
+})

--- a/ui-admin/src/util/table/columnUtils.tsx
+++ b/ui-admin/src/util/table/columnUtils.tsx
@@ -153,10 +153,10 @@ export const getDynamicColumn = <T extends EnrolleeSearchExpressionResult, >(fac
     field = field.replace('user.', 'participantUser.')
   }
   if (field.startsWith('answer')) {
-    const [, surveyStableId, questionStableId] = field.split('.')
+    const { questionStableId, surveyStableId, header } = parseAnswerFacet(facet)
     return {
       id: field,
-      header: _startCase(questionStableId),
+      header,
       accessorFn: info => {
         const answer = info.answers.find(ans =>
           ans.surveyStableId === surveyStableId && ans.questionStableId === questionStableId)
@@ -178,4 +178,14 @@ export const getDynamicColumn = <T extends EnrolleeSearchExpressionResult, >(fac
       }
     }
   }
+}
+
+export function parseAnswerFacet(facet: KeyedSearchValueTypeDefinition) {
+  const field = facet.key
+  const [, surveyStableId, questionStableId] = field.split('.')
+  let header = _startCase(questionStableId)
+  if (questionStableId.match(/^[a-z]{2}_[a-z]{2}_/)) {
+    header = _startCase(questionStableId.slice(5))
+  }
+  return { surveyStableId, questionStableId, header }
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Removes some extra query bubbles that were appearing, and also cleans up column name presentation for OurHealth and HeartHive

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants?search=%7B%22includeFacetKeys%22%3A%5B%22answer.hd_hd_basicInfo.hd_hd_basic_firstName%22%5D%7D
2. confirm you don't see any "includeFacets" query bubbles above the column selector
3. confirm the column header is rendered as "Basic First Name" and not "Oh Oh Basic First Name"