### PR TITLE
[JN-1595] outreach tasks for proxies

### DIFF
--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/task/ParticipantTaskController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/task/ParticipantTaskController.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.api.participant.controller.task;
 
 import bio.terra.pearl.api.participant.api.ParticipantTaskApi;
+import bio.terra.pearl.api.participant.service.AuthUtilService;
 import bio.terra.pearl.api.participant.service.ParticipantTaskExtService;
 import bio.terra.pearl.api.participant.service.RequestUtilService;
 import bio.terra.pearl.core.model.EnvironmentName;
@@ -9,38 +10,46 @@ import bio.terra.pearl.core.model.workflow.TaskType;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 @Controller
 public class ParticipantTaskController implements ParticipantTaskApi {
-  private EnrolleeService enrolleeService;
-  private ParticipantTaskExtService participantTaskExtService;
-  private RequestUtilService requestUtilService;
-  private HttpServletRequest request;
+  private final EnrolleeService enrolleeService;
+  private final ParticipantTaskExtService participantTaskExtService;
+  private final RequestUtilService requestUtilService;
+  private final AuthUtilService authUtilService;
+  private final HttpServletRequest request;
 
   @Autowired
   public ParticipantTaskController(
       EnrolleeService enrolleeService,
       ParticipantTaskExtService participantTaskExtService,
       RequestUtilService requestUtilService,
+      AuthUtilService authUtilService,
       HttpServletRequest request) {
     this.enrolleeService = enrolleeService;
     this.participantTaskExtService = participantTaskExtService;
     this.requestUtilService = requestUtilService;
+    this.authUtilService = authUtilService;
     this.request = request;
   }
 
   @Override
   public ResponseEntity<Object> listTasksWithSurveys(
-      String portalShortcode, String envName, String taskType) {
+      String portalShortcode, String envName, String taskType, UUID participantUserId) {
     ParticipantUser user = requestUtilService.requireUser(request);
     EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
+    if (participantUserId == null) {
+      // default is a user getting their own tasks
+      participantUserId = user.getId();
+    }
     TaskType taskTypeEnum = taskType != null ? TaskType.valueOf(taskType.toUpperCase()) : null;
     List<ParticipantTaskExtService.TaskAndSurvey> outreachSurveys =
         participantTaskExtService.listSurveyTasks(
-            user, portalShortcode, environmentName, taskTypeEnum);
+            user, portalShortcode, environmentName, taskTypeEnum, participantUserId);
     return ResponseEntity.ok(outreachSurveys);
   }
 }

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/service/ParticipantTaskExtService.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/service/ParticipantTaskExtService.java
@@ -13,6 +13,7 @@ import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.IntStream;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -38,9 +39,22 @@ public class ParticipantTaskExtService {
 
   // Loads all outreach activities for the logged-in PortalParticipantUser
   public List<TaskAndSurvey> listSurveyTasks(
-      ParticipantUser user, String portalShortcode, EnvironmentName envName, TaskType taskType) {
+      ParticipantUser operator,
+      String portalShortcode,
+      EnvironmentName envName,
+      TaskType taskType,
+      UUID participantUserId) {
     PortalWithPortalUser portalUser =
-        authUtilService.authParticipantToPortal(user.getId(), portalShortcode, envName);
+        authUtilService.authParticipantToPortal(operator.getId(), portalShortcode, envName);
+
+    if (participantUserId != operator.getId()) {
+      // this is a proxy getting tasks for a governed participant
+      portalUser =
+          authUtilService.authParticipantToPortal(participantUserId, portalShortcode, envName);
+      authUtilService.authParticipantUserToPortalParticipantUser(
+          operator.getId(), portalUser.ppUser().getId());
+    }
+
     List<Enrollee> participantEnrollees =
         enrolleeService.findByPortalParticipantUser(portalUser.ppUser());
 

--- a/api-participant/src/main/resources/api/openapi.yml
+++ b/api-participant/src/main/resources/api/openapi.yml
@@ -379,6 +379,7 @@ paths:
         - { name: portalShortcode, in: path, required: true, schema: { type: string } }
         - { name: envName, in: path, required: true, schema: { type: string } }
         - { name: taskType, in: query, required: false, schema: { type: string } }
+        - { name: participantUserId, in: query, required: false, schema: { type: string, format: uuid } }
       responses:
         '200':
           description: list of outreach activities

--- a/api-participant/src/test/java/bio/terra/pearl/api/participant/service/ParticipantTaskExtServiceTests.java
+++ b/api-participant/src/test/java/bio/terra/pearl/api/participant/service/ParticipantTaskExtServiceTests.java
@@ -1,0 +1,106 @@
+package bio.terra.pearl.api.participant.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+import bio.terra.pearl.api.participant.BaseSpringBootTest;
+import bio.terra.pearl.core.factory.StudyEnvironmentBundle;
+import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
+import bio.terra.pearl.core.factory.participant.EnrolleeBundle;
+import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
+import bio.terra.pearl.core.factory.participant.ParticipantTaskFactory;
+import bio.terra.pearl.core.factory.survey.SurveyFactory;
+import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.audit.DataAuditInfo;
+import bio.terra.pearl.core.model.participant.EnrolleeRelation;
+import bio.terra.pearl.core.model.participant.RelationshipType;
+import bio.terra.pearl.core.model.survey.Survey;
+import bio.terra.pearl.core.model.workflow.ParticipantTask;
+import bio.terra.pearl.core.model.workflow.TaskType;
+import bio.terra.pearl.core.service.exception.NotFoundException;
+import bio.terra.pearl.core.service.participant.EnrolleeRelationService;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+public class ParticipantTaskExtServiceTests extends BaseSpringBootTest {
+  @Autowired private StudyEnvironmentFactory studyEnvironmentFactory;
+  @Autowired private EnrolleeFactory enrolleeFactory;
+  @Autowired private SurveyFactory surveyFactory;
+  @Autowired private ParticipantTaskFactory participantTaskFactory;
+  @Autowired private ParticipantTaskExtService participantTaskExtService;
+  @Autowired private EnrolleeRelationService enrolleeRelationService;
+
+  @Test
+  @Transactional
+  public void testListSurveyTasks(TestInfo info) {
+    StudyEnvironmentBundle bundle =
+        studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.sandbox);
+    EnrolleeBundle enrollee1 =
+        enrolleeFactory.buildWithPortalUser(
+            getTestName(info), bundle.getPortalEnv(), bundle.getStudyEnv());
+    EnrolleeBundle enrollee2 =
+        enrolleeFactory.buildWithPortalUser(
+            getTestName(info), bundle.getPortalEnv(), bundle.getStudyEnv());
+    Survey survey = surveyFactory.buildPersisted(getTestName(info), bundle.getPortal().getId());
+    ParticipantTask task1 =
+        participantTaskFactory.buildPersisted(
+            enrollee1,
+            ParticipantTaskFactory.DEFAULT_BUILDER
+                .targetStableId(survey.getStableId())
+                .targetAssignedVersion(survey.getVersion())
+                .taskType(TaskType.OUTREACH));
+    ParticipantTask task2 =
+        participantTaskFactory.buildPersisted(
+            enrollee2,
+            ParticipantTaskFactory.DEFAULT_BUILDER
+                .targetStableId(survey.getStableId())
+                .targetAssignedVersion(survey.getVersion())
+                .taskType(TaskType.OUTREACH));
+
+    // enrollee can fetch their own tasks
+    List<ParticipantTaskExtService.TaskAndSurvey> tasks =
+        participantTaskExtService.listSurveyTasks(
+            enrollee1.participantUser(),
+            bundle.getPortal().getShortcode(),
+            EnvironmentName.sandbox,
+            TaskType.OUTREACH,
+            enrollee1.participantUser().getId());
+    assertThat(tasks, hasSize(1));
+    assertThat(tasks.get(0).task().getId(), equalTo(task1.getId()));
+
+    // enrollee can't fetch other enrollee's tasks
+    Assertions.assertThrows(
+        NotFoundException.class,
+        () -> {
+          participantTaskExtService.listSurveyTasks(
+              enrollee1.participantUser(),
+              bundle.getPortal().getShortcode(),
+              EnvironmentName.sandbox,
+              TaskType.OUTREACH,
+              enrollee2.participantUser().getId());
+        });
+
+    // enrollee can fetch a proxy's tasks
+    enrolleeRelationService.create(
+        EnrolleeRelation.builder()
+            .enrolleeId(enrollee1.enrollee().getId())
+            .targetEnrolleeId(enrollee2.enrollee().getId())
+            .relationshipType(RelationshipType.PROXY)
+            .build(),
+        DataAuditInfo.builder().systemProcess("test").build());
+    tasks =
+        participantTaskExtService.listSurveyTasks(
+            enrollee1.participantUser(),
+            bundle.getPortal().getShortcode(),
+            EnvironmentName.sandbox,
+            TaskType.OUTREACH,
+            enrollee2.participantUser().getId());
+    assertThat(tasks, hasSize(1));
+    assertThat(tasks.get(0).task().getId(), equalTo(task2.getId()));
+  }
+}

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -178,9 +178,11 @@ export default {
     return await this.processJsonResponse(response)
   },
 
-  async listOutreachActivities(
-  ): Promise<TaskWithSurvey[]> {
-    const url = `${baseEnvUrl(false)}/tasks?taskType=outreach`
+  async listOutreachActivities(participantUserId?: string): Promise<TaskWithSurvey[]> {
+    const url = `${baseEnvUrl(false)}/tasks?${queryString.stringify({
+      taskType: 'OUTREACH',
+      participantUserId
+    })}`
     const response = await fetch(url, this.getGetInit())
     return await this.processJsonResponse(response)
   },

--- a/ui-participant/src/hub/OutreachTasks.tsx
+++ b/ui-participant/src/hub/OutreachTasks.tsx
@@ -63,7 +63,8 @@ export default function OutreachTasks({ enrollees, studies }: {enrollees: Enroll
   }
 
   const loadOutreachActivities = async () => {
-    const outreachActivities = await Api.listOutreachActivities()
+    const participantUserId = enrollees[0]?.participantUserId
+    const outreachActivities = await Api.listOutreachActivities(participantUserId)
     setOutreachActivities(outreachActivities)
   }
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Previously, outreach tasks were only fetched for the logged in user.  This upgrades the endpoint to fetch tasks for a requested participant user id.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy apiParticipantApp
2. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants/HDGVAA/surveys/depressionOutreach
3. assign the task to the enrollee (you will have to override eligibility criteria)
4. goto https://sandbox.demo.localhost:3001
5. sign in as proxyFamily2@test.com
6. confirm the outreach task "Depression sleep study"  appears in the "Your Dependent" user dashboard, but not the dashboard for "You" or "child 2 family 2"