### PR TITLE
[JN-1597] increase load balancer timeout

### DIFF
--- a/terraform/gcp/k8s/templates/backend_config.yml
+++ b/terraform/gcp/k8s/templates/backend_config.yml
@@ -8,3 +8,4 @@ spec:
   customResponseHeaders:
     headers:
       - "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload"
+  timeoutSec: 300


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

[See docs](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-configuration#timeout). The default was 30 seconds. Very sneaky...

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- after merge, on demo server, try to extract and repopulate A-T