### PR TITLE
[JN-1543] launch notifs

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/notification/EnrolleeReminderService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/EnrolleeReminderService.java
@@ -1,9 +1,7 @@
 package bio.terra.pearl.core.service.notification;
 
-import bio.terra.pearl.core.dao.kit.KitRequestDao;
 import bio.terra.pearl.core.dao.kit.KitTypeDao;
 import bio.terra.pearl.core.dao.workflow.ParticipantTaskDao;
-import bio.terra.pearl.core.model.kit.KitType;
 import bio.terra.pearl.core.model.notification.Trigger;
 import bio.terra.pearl.core.model.notification.TriggerType;
 import bio.terra.pearl.core.model.participant.EnrolleeSourceType;
@@ -12,14 +10,16 @@ import bio.terra.pearl.core.model.workflow.TaskType;
 import bio.terra.pearl.core.service.kit.KitRequestService;
 import bio.terra.pearl.core.service.rule.EnrolleeContext;
 import bio.terra.pearl.core.service.rule.EnrolleeContextService;
+import bio.terra.pearl.core.service.search.EnrolleeSearchContext;
+import bio.terra.pearl.core.service.search.EnrolleeSearchExpression;
+import bio.terra.pearl.core.service.search.EnrolleeSearchExpressionParser;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
-import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 
 @Service
 @Slf4j
@@ -31,6 +31,7 @@ public class EnrolleeReminderService {
     private final NotificationDispatcher notificationDispatcher;
     private final KitTypeDao kitTypeDao;
     private final KitRequestService kitRequestService;
+    private final EnrolleeSearchExpressionParser enrolleeSearchExpressionParser;
 
     public EnrolleeReminderService(ParticipantTaskQueryService participantTaskQueryService,
                                    StudyEnvironmentService studyEnvironmentService,
@@ -38,7 +39,7 @@ public class EnrolleeReminderService {
                                    EnrolleeContextService enrolleeContextService,
                                    NotificationDispatcher notificationDispatcher,
                                    KitTypeDao kitTypeDao,
-                                   KitRequestService kitRequestService) {
+                                   KitRequestService kitRequestService, EnrolleeSearchExpressionParser enrolleeSearchExpressionParser) {
         this.participantTaskQueryService = participantTaskQueryService;
         this.studyEnvironmentService = studyEnvironmentService;
         this.triggerService = triggerService;
@@ -46,6 +47,7 @@ public class EnrolleeReminderService {
         this.notificationDispatcher = notificationDispatcher;
         this.kitTypeDao = kitTypeDao;
         this.kitRequestService = kitRequestService;
+        this.enrolleeSearchExpressionParser = enrolleeSearchExpressionParser;
     }
 
     public void sendTaskReminders() {
@@ -108,6 +110,14 @@ public class EnrolleeReminderService {
                  enrolleeContext.getParticipantUser().getLastLogin() == null) {
             return false;
         }
+
+        if (!StringUtils.isEmpty(trigger.getRule())) {
+            EnrolleeSearchExpression searchExpression = enrolleeSearchExpressionParser.parseRule(trigger.getRule());
+
+            EnrolleeSearchContext searchContext = new EnrolleeSearchContext(enrolleeContext.getEnrollee(), enrolleeContext.getProfile());
+            return searchExpression.evaluate(searchContext);
+        }
+
         return true;
     }
 }

--- a/ui-admin/jest.config.ts
+++ b/ui-admin/jest.config.ts
@@ -1,3 +1,5 @@
+process.env.TZ = 'EST'
+
 export default {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'jsdom',

--- a/ui-admin/src/search/SearchQueryBuilder.tsx
+++ b/ui-admin/src/search/SearchQueryBuilder.tsx
@@ -82,7 +82,7 @@ export const SearchQueryBuilder = ({
       if (isEmpty(searchExpression)) {
         return true
       }
-      toReactQueryBuilderState(parseExpression(searchExpression))
+      toReactQueryBuilderState(parseExpression(searchExpression), {})
       return true
     } catch (_) {
       setAdvancedMode(true)
@@ -200,23 +200,17 @@ const BasicQueryBuilder = ({
   onSearchExpressionChange: (searchExpression: string) => void,
   searchExpression: string
 }) => {
-  const tryParseExpression = (expression: string): RuleGroupType | undefined => {
+  const tryParseExpression = (expression: string, facets: ExpressionSearchFacets): RuleGroupType | undefined => {
     try {
-      return toReactQueryBuilderState(parseExpression(expression))
+      return toReactQueryBuilderState(parseExpression(expression), facets)
     } catch (_) {
       return undefined
     }
   }
 
-  const initialQuery = useMemo(() => !isEmpty(searchExpression) ? tryParseExpression(searchExpression) : {
-    combinator: 'and',
-    rules: []
-  }, [])
-
-  const [query, setQuery] = useState<RuleGroupTypeAny | undefined>(initialQuery)
-
-
+  const [query, setQuery] = useState<RuleGroupTypeAny | undefined>()
   const [facets, setFacets] = React.useState<ExpressionSearchFacets>({})
+
 
   const { isLoading } = useLoadingEffect(async () => {
     const loadedFacets = await Api.getExpressionSearchFacets(
@@ -226,6 +220,8 @@ const BasicQueryBuilder = ({
 
 
     setFacets(loadedFacets)
+
+    setQuery(tryParseExpression(searchExpression, loadedFacets))
   }, [], 'Failed to load cohort criteria options')
 
   const ruleProcessor = useMemo(() => createEnrolleeSearchExpressionRuleProcessor(facets), [facets])

--- a/ui-admin/src/study/workflow/WorkflowView.tsx
+++ b/ui-admin/src/study/workflow/WorkflowView.tsx
@@ -1,29 +1,53 @@
-import React, { useEffect, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import React, {
+  useEffect,
+  useState
+} from 'react'
+import {
+  Link,
+  useNavigate
+} from 'react-router-dom'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus'
 import {
   paramsFromContext,
-  StudyEnvContextT, studyEnvFormsParamsPath,
-  studyEnvPreEnrollPath, studyEnvSurveyPath,
-  studyEnvTriggerPath, studyEnvWorkflowPath,
+  StudyEnvContextT,
+  studyEnvFormsParamsPath,
+  studyEnvPreEnrollPath,
+  studyEnvSurveyPath,
+  studyEnvTriggerPath,
+  studyEnvWorkflowPath,
   triggerPath
 } from '../StudyEnvironmentRouter'
 import { renderPageHeader } from 'util/pageUtils'
 import { LoadedPortalContextT } from '../../portal/PortalProvider'
-import { StudyEnvironmentSurvey, StudyEnvParams, Survey, Trigger } from '@juniper/ui-core'
+import {
+  StudyEnvironmentSurvey,
+  StudyEnvParams,
+  Survey,
+  Trigger
+} from '@juniper/ui-core'
 import Api from 'api/api'
 import { useLoadingEffect } from 'api/api-utils'
 import LoadingSpinner from 'util/LoadingSpinner'
 import CreateTriggerModal from '../notifications/CreateTriggerModal'
 import {
-  faAsterisk, faEdit, faFilter,
+  faAsterisk,
+  faEdit,
+  faFilter,
   faTasks
 } from '@fortawesome/free-solid-svg-icons'
-import { faCalendarAlt, faClipboard, faEnvelope,   faCheckSquare } from '@fortawesome/free-regular-svg-icons'
+import {
+  faCalendarAlt,
+  faCheckSquare,
+  faClipboard,
+  faEnvelope
+} from '@fortawesome/free-regular-svg-icons'
 import InfoPopup from 'components/forms/InfoPopup'
 import _sortBy from 'lodash/sortBy'
-import { minutesToDayString, triggerName } from './workflowUtils'
+import {
+  minutesToDayString,
+  triggerName
+} from './workflowUtils'
 import { EllipsisDropdownButton } from 'components/forms/Button'
 
 /** shows configuration of notifications for a study */
@@ -248,6 +272,23 @@ const AddTriggerMenu = ({ triggerOpts, setTriggerOpts, setShowCreateModal }:
             Add reminder
           </button>
         </li> }
+        {triggerOpts.taskType && <li>
+          <button className="dropdown-item"
+            onClick={() => {
+              setTriggerOpts({
+                ...triggerOpts,
+                triggerType: 'TASK_REMINDER',
+                eventType: undefined,
+                maxNumReminders: 1,
+                afterMinutesIncomplete: 0,
+                reminderIntervalMinutes: 0,
+                rule: `{enrollee.createdAt} < '${new Date().toISOString()}'`
+              })
+              setShowCreateModal(true)
+            }}>
+                Add launch notification
+          </button>
+        </li>}
         {triggerOpts.eventType && <li>
           <button className="dropdown-item"
             onClick={() => {

--- a/ui-admin/src/util/searchExpressionUtils.test.tsx
+++ b/ui-admin/src/util/searchExpressionUtils.test.tsx
@@ -1,11 +1,13 @@
 import { parseExpression } from './searchExpressionParser'
 import { toReactQueryBuilderState } from './searchExpressionUtils'
 
+const noFacets = {}
+
 describe('to react query builder', () => {
   it('converts basic expression', () => {
     const expression = parseExpression(`{profile.name} = 'John' and {age} > 30 or {age} < 20`)
 
-    const result = toReactQueryBuilderState(expression)
+    const result = toReactQueryBuilderState(expression, noFacets)
 
     expect(result).toEqual({
       'combinator': 'and',
@@ -44,7 +46,7 @@ describe('to react query builder', () => {
       `{profile.name} = 'John' and {age} > 30 and {age} < 40 and {age} > 20 or {age} < 20`
     )
 
-    const result = toReactQueryBuilderState(expression)
+    const result = toReactQueryBuilderState(expression, noFacets)
 
     expect(result).toEqual({
       'combinator': 'and',
@@ -94,7 +96,7 @@ describe('to react query builder', () => {
       `({profile.name} = 'John' and {age} > 30) or {age} < 20 or ({age} > 30 and {age} < 40)`
     )
 
-    expect(toReactQueryBuilderState(expression)).toEqual({
+    expect(toReactQueryBuilderState(expression, noFacets)).toEqual({
       'combinator': 'and',
       'id': '1',
       'rules': [
@@ -140,5 +142,28 @@ describe('to react query builder', () => {
         }
       ]
     })
+  })
+})
+
+
+it('reformats instants', () => {
+  const expression = parseExpression(`{instant} > '2021-01-01T12:00:00Z'`)
+
+  expect(toReactQueryBuilderState(expression, {
+    instant: {
+      type: 'INSTANT',
+      allowMultiple: false,
+      allowOtherDescription: false
+    }
+  })).toEqual({
+    'combinator': 'and',
+    'id': '1',
+    'rules': [
+      {
+        'field': 'instant',
+        'operator': '>',
+        'value': '2021-01-01T07:00' // in local timezone
+      }
+    ]
   })
 })

--- a/ui-admin/src/util/searchExpressionUtils.tsx
+++ b/ui-admin/src/util/searchExpressionUtils.tsx
@@ -14,7 +14,11 @@ import {
   RuleGroupType
 } from 'react-querybuilder'
 import { isEmpty } from 'lodash/fp'
-import { ExpressionSearchFacets } from 'api/api'
+import {
+  ExpressionSearchFacets,
+  SearchValueTypeDefinition
+} from 'api/api'
+import { isNil } from 'lodash'
 
 /**
  * Concatenates search expressions with an 'and' by default.
@@ -43,7 +47,10 @@ export const toReactQueryBuilderState = (
  * Returns an array of rules - these are combined with either 'and' or 'or' depending on the operator
  * parameter. Each element could either be a facet comparison or new group of rules.
  */
-const _toReactQueryBuilderState = (operator: BooleanOperator, expression: SearchExpression, facets: ExpressionSearchFacets): RuleGroupArray => {
+const _toReactQueryBuilderState = (
+  operator: BooleanOperator,
+  expression: SearchExpression,
+  facets: ExpressionSearchFacets): RuleGroupArray => {
   if (isBooleanSearchExpression(expression)) {
     // only create a new group if the operator changes
     if (expression.booleanOperator !== operator) {
@@ -66,9 +73,13 @@ const _toReactQueryBuilderState = (operator: BooleanOperator, expression: Search
   }
 
   if (isComparisonSearchFacet(expression)) {
+    const field = termToString(expression.left, undefined)?.toString() || ''
+
+    const typeDefinition = facets[field]
+
     return [{
-      field: termToString(expression.left)?.toString() || '',
-      value: termToString(expression.right),
+      field,
+      value: termToString(expression.right, typeDefinition),
       operator: expression.comparisonOperator
     }]
   }
@@ -76,7 +87,9 @@ const _toReactQueryBuilderState = (operator: BooleanOperator, expression: Search
 }
 
 // Converts a Term object into a string representation.
-const termToString = (term: Term): string | number | boolean | null => {
+const termToString = (
+  term: Term,
+  typeDef: SearchValueTypeDefinition | undefined): string | number | boolean | null => {
   if (isSearchVariable(term)) {
     if (term.field.length === 0) {
       return term.model
@@ -87,5 +100,37 @@ const termToString = (term: Term): string | number | boolean | null => {
     throw new Error('Function terms are not supported')
   }
 
+  if (!isNil(typeDef) && typeDef.type === 'INSTANT') {
+    const parsedDate = Date.parse(term?.toString() || '')
+    if (isNaN(parsedDate)) {
+      return term // return the original term just to be safe
+    }
+
+    const date = new Date(parsedDate)
+
+    return formatDate(date)
+  }
+
   return term
+}
+
+
+// react query builder needs dates with format: 2025-01-21T14:15
+const formatDate = (date: Date): string => {
+  // we can't use toISOString because it returns the date in UTC and we need it in local time
+  return `${
+    date.getFullYear()
+  }-${
+    zeroPad(date.getMonth() + 1)
+  }-${
+    zeroPad(date.getDate())
+  }T${
+    zeroPad(date.getHours())
+  }:${
+    zeroPad(date.getMinutes())
+  }`
+}
+
+const zeroPad = (num: number): string => {
+  return num.toString().padStart(2, '0')
 }

--- a/ui-admin/src/util/searchExpressionUtils.tsx
+++ b/ui-admin/src/util/searchExpressionUtils.tsx
@@ -14,6 +14,7 @@ import {
   RuleGroupType
 } from 'react-querybuilder'
 import { isEmpty } from 'lodash/fp'
+import { ExpressionSearchFacets } from 'api/api'
 
 /**
  * Concatenates search expressions with an 'and' by default.
@@ -27,11 +28,13 @@ export const concatSearchExpressions =
  * Converts a SearchExpression object into a RuleGroupType object,
  * which can be used by the react-querybuilder component.
  */
-export const toReactQueryBuilderState = (searchExpression: SearchExpression): RuleGroupType => {
+export const toReactQueryBuilderState = (
+  searchExpression: SearchExpression,
+  facets: ExpressionSearchFacets): RuleGroupType => {
   return {
     id: '1',
     combinator: 'and',
-    rules: _toReactQueryBuilderState('and', searchExpression)
+    rules: _toReactQueryBuilderState('and', searchExpression, facets)
   }
 }
 
@@ -40,18 +43,18 @@ export const toReactQueryBuilderState = (searchExpression: SearchExpression): Ru
  * Returns an array of rules - these are combined with either 'and' or 'or' depending on the operator
  * parameter. Each element could either be a facet comparison or new group of rules.
  */
-const _toReactQueryBuilderState = (operator: BooleanOperator, expression: SearchExpression): RuleGroupArray => {
+const _toReactQueryBuilderState = (operator: BooleanOperator, expression: SearchExpression, facets: ExpressionSearchFacets): RuleGroupArray => {
   if (isBooleanSearchExpression(expression)) {
     // only create a new group if the operator changes
     if (expression.booleanOperator !== operator) {
       return [{
         combinator: expression.booleanOperator,
-        rules: _toReactQueryBuilderState(expression.booleanOperator, expression.left)
-          .concat(_toReactQueryBuilderState(expression.booleanOperator, expression.right))
+        rules: _toReactQueryBuilderState(expression.booleanOperator, expression.left, facets)
+          .concat(_toReactQueryBuilderState(expression.booleanOperator, expression.right, facets))
       }]
     }
-    return _toReactQueryBuilderState(operator, expression.left)
-      .concat(_toReactQueryBuilderState(operator, expression.right))
+    return _toReactQueryBuilderState(operator, expression.left, facets)
+      .concat(_toReactQueryBuilderState(operator, expression.right, facets))
   }
 
   if (isNotExpression(expression)) {
@@ -83,5 +86,6 @@ const termToString = (term: Term): string | number | boolean | null => {
   if (isFunctionTerm(term)) {
     throw new Error('Function terms are not supported')
   }
+
   return term
 }

--- a/ui-core/jest.config.ts
+++ b/ui-core/jest.config.ts
@@ -1,3 +1,5 @@
+process.env.TZ = 'EST'
+
 export default {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'jsdom',

--- a/ui-participant/jest.config.ts
+++ b/ui-participant/jest.config.ts
@@ -1,3 +1,5 @@
+process.env.TZ = 'EST'
+
 export default {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'jsdom',


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

From the workload view, you can now create a launch notification. Reminders now also can work with rules.

While my previous improvements of date handling corrected query builder -> backend communication, if you gave react query builder a properly formatted instant it wouldn't work. This was annoying for this PR because the rule wouldn't show up properly. So I went ahead and fixed that.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- sign up a user
- create launch notification for some random survey
- sign up another user
- wait up to 10 minutes for reminder service to run
- confirm you only get one email (for the user who signed up prior to creating the launch notifiaction)