### PR TITLE
[JN-1600] customer-specific mixpanel export

### DIFF
--- a/api-admin/build.gradle
+++ b/api-admin/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter:3.3.2'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:3.4.1'
     implementation 'org.springframework.boot:spring-boot-starter-web:3.4.1'
+    implementation 'org.springframework.boot:spring-boot-starter-cache:3.4.1'
     implementation 'org.yaml:snakeyaml:2.3'
     implementation 'org.springframework.retry:spring-retry'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:4.0.0'

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/ApiAdminApp.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/ApiAdminApp.java
@@ -9,6 +9,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
@@ -43,6 +44,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableSchedulerLock(defaultLockAtMostFor = "60m")
 @EnableConfigurationProperties
 @EnableAspectJAutoProxy
+@EnableCaching
 public class ApiAdminApp {
   public static void main(String[] args) {
     new SpringApplicationBuilder(ApiAdminApp.class)

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ConfigExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/ConfigExtService.java
@@ -92,7 +92,7 @@ public class ConfigExtService {
             Map.of("authToken", maskSecret(airtableConfig.getAuthToken())),
             "mixpanel",
             Map.of(
-                "enabled", mixpanelConfig.getEnabled(),
+                "enabled", mixpanelConfig.getEnabled().toString(),
                 "token", mixpanelConfig.getToken()));
     return internalConfigMap;
   }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/portal/PortalExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/portal/PortalExtService.java
@@ -14,7 +14,6 @@ import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
 import bio.terra.pearl.core.service.portal.PortalService;
 import bio.terra.pearl.core.service.portal.exception.PortalConfigMissing;
 import java.util.List;
-
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
@@ -104,6 +103,4 @@ public class PortalExtService {
             authContext.getPortalEnvironment().getId(), languages);
     return updatedLangs;
   }
-
-  private setEmptyString
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/portal/PortalExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/portal/PortalExtService.java
@@ -14,6 +14,8 @@ import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
 import bio.terra.pearl.core.service.portal.PortalService;
 import bio.terra.pearl.core.service.portal.exception.PortalConfigMissing;
 import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 
@@ -64,6 +66,12 @@ public class PortalExtService {
             .find(authContext.getPortalEnvironment().getPortalEnvironmentConfigId())
             .orElseThrow(PortalConfigMissing::new);
     BeanUtils.copyProperties(newConfig, config, "id", "createdAt");
+    if (StringUtils.isBlank(config.getParticipantHostname())) {
+      config.setParticipantHostname(null);
+    }
+    if (StringUtils.isBlank(config.getMixpanelToken())) {
+      config.setMixpanelToken(null);
+    }
     config = portalEnvironmentConfigService.update(config);
     return config;
   }
@@ -96,4 +104,6 @@ public class PortalExtService {
             authContext.getPortalEnvironment().getId(), languages);
     return updatedLangs;
   }
+
+  private setEmptyString
 }

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/ConfigExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/ConfigExtServiceTests.java
@@ -123,7 +123,7 @@ public class ConfigExtServiceTests {
     assertThat(addressValidationConfigMap.get("smartyAuthId"), equalTo("sm_id"));
     assertThat(addressValidationConfigMap.get("smartyAuthToken"), equalTo("sm..."));
 
-    assertThat(testMixpanelConfig.getEnabled(), equalTo("true"));
+    assertThat(testMixpanelConfig.getEnabled(), equalTo(true));
     assertThat(testMixpanelConfig.getToken(), equalTo("mp_token"));
   }
 

--- a/api-participant/build.gradle
+++ b/api-participant/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter:3.3.2'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:3.4.1'
     implementation 'org.springframework.boot:spring-boot-starter-web:3.4.1'
+    implementation 'org.springframework.boot:spring-boot-starter-cache:3.4.1'
     implementation 'org.yaml:snakeyaml:2.3'
     implementation 'org.springframework.retry:spring-retry'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:4.0.0'

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/ApiParticipantApp.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/ApiParticipantApp.java
@@ -6,6 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.retry.annotation.EnableRetry;
@@ -31,6 +32,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableAsync(proxyTargetClass = true)
 @EnableTransactionManagement
 @EnableConfigurationProperties
+@EnableCaching
 public class ApiParticipantApp {
   public static void main(String[] args) {
     new SpringApplicationBuilder(ApiParticipantApp.class)

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc:3.4.1'
     implementation 'org.springframework.boot:spring-boot-starter-webflux:3.3.2'
     implementation 'org.springframework.boot:spring-boot-starter-validation:3.4.0'
+    implementation 'org.springframework.boot:spring-boot-starter-cache:3.4.1'
     implementation 'org.springframework.retry:spring-retry:2.0.10'
     implementation 'org.apache.commons:commons-text:1.12.0'
     implementation 'org.apache.commons:commons-csv:1.12.0'

--- a/core/src/main/java/bio/terra/pearl/core/CoreCliApp.java
+++ b/core/src/main/java/bio/terra/pearl/core/CoreCliApp.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 /**
  * Placeholder application to make spring and liquibase configuration and testing easier.
@@ -11,6 +12,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  */
 @SpringBootApplication
 @Slf4j
+@EnableCaching
 public class CoreCliApp
         implements CommandLineRunner {
 

--- a/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalEnvironmentConfigDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalEnvironmentConfigDao.java
@@ -1,7 +1,10 @@
 package bio.terra.pearl.core.dao.portal;
 
 import bio.terra.pearl.core.dao.BaseMutableJdbiDao;
+import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironmentConfig;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.jdbi.v3.core.Jdbi;
@@ -19,12 +22,24 @@ public class PortalEnvironmentConfigDao extends BaseMutableJdbiDao<PortalEnviron
 
     public Optional<PortalEnvironmentConfig> findByPortalEnvId(UUID portalEnvId) {
         return jdbi.withHandle(handle ->
-                handle.createQuery("select " + prefixedGetQueryColumns("a") + " from " + tableName
-                                + " a join portal_environment on portal_environment_config_id = a.id"
-                                + " where portal_environment.id = :portalEnvId")
+                handle.createQuery("""
+                                select a.* from %s a
+                                join portal_environment on portal_environment_config_id = a.id
+                                where portal_environment.id = :portalEnvId
+                                """.formatted(tableName))
                         .bind("portalEnvId", portalEnvId)
                         .mapTo(clazz)
                         .findOne()
+        );
+    }
+
+    public List<PortalEnvironmentConfig> findAllWithCustomDomain() {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("""
+                                select * from %s where participant_hostname is not null
+                                """.formatted(tableName))
+                        .mapTo(clazz)
+                        .list()
         );
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/portal/PortalEnvironmentConfig.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/portal/PortalEnvironmentConfig.java
@@ -33,4 +33,5 @@ public class PortalEnvironmentConfig extends BaseEntity {
     @Builder.Default
     private String defaultLanguage = "en";
     private String primaryStudy; // study shortcode of a study that all initial participants are enrolled in
+    private String mixpanelToken; // token for mixpanel tracking
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/logging/LoggingConfigCache.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/logging/LoggingConfigCache.java
@@ -1,0 +1,40 @@
+package bio.terra.pearl.core.service.logging;
+
+import bio.terra.pearl.core.model.portal.PortalEnvironmentConfig;
+import bio.terra.pearl.core.service.portal.PortalEnvironmentConfigService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+/**
+ * we don't want to have to go to the database every time an event is logged in our system to get the configs,
+ * and they change very rarely. So we cache them here
+ */
+@Service
+@Slf4j
+public class LoggingConfigCache {
+    private final PortalEnvironmentConfigService portalEnvironmentConfigService;
+
+    public static final String CONFIGS_WITH_DOMAIN_CACHE_KEY = "portalEnvironmentConfigsWithDomain";
+
+    public LoggingConfigCache(PortalEnvironmentConfigService portalEnvironmentConfigService) {
+        this.portalEnvironmentConfigService = portalEnvironmentConfigService;
+    }
+
+    @Cacheable(value = CONFIGS_WITH_DOMAIN_CACHE_KEY)
+    public Map<String, PortalEnvironmentConfig> getConfigsWithDomain() {
+        return portalEnvironmentConfigService.findAllMappedByCustomDomain();
+    }
+
+    /** since we run multiple instances of the app, we can't rely on cache invalidation on writes,
+     * so instead we just clear the cache every 10mins */
+    @CacheEvict(allEntries = true, value = CONFIGS_WITH_DOMAIN_CACHE_KEY)
+    @Scheduled(fixedDelay = 10 * 60 * 1000,  initialDelay = 10 * 60 * 1000)
+    public void configCacheEvict() {
+        log.info("Evicting cache for {}", CONFIGS_WITH_DOMAIN_CACHE_KEY);
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/logging/MixpanelService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/logging/MixpanelService.java
@@ -78,7 +78,7 @@ public class MixpanelService {
             if (eventDomain != null) {
                 customDelivery = customDelivery == null ? new ClientDelivery() : customDelivery;
                 Map<String, PortalEnvironmentConfig> configMap = loggingConfigCache.getConfigsWithDomain();
-                 PortalEnvironmentConfig matchedConfig = configMap.get(eventDomain);
+                PortalEnvironmentConfig matchedConfig = configMap.get(eventDomain);
                 if (matchedConfig != null && matchedConfig.getMixpanelToken() != null) {
                     JSONObject domainEvent = buildEvent(event, matchedConfig.getMixpanelToken());
                     customDelivery.addMessage(domainEvent);

--- a/core/src/main/java/bio/terra/pearl/core/service/logging/MixpanelService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/logging/MixpanelService.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.core.service.logging;
 
+import bio.terra.pearl.core.model.portal.PortalEnvironmentConfig;
 import com.mixpanel.mixpanelapi.ClientDelivery;
 import com.mixpanel.mixpanelapi.MessageBuilder;
 import com.mixpanel.mixpanelapi.MixpanelAPI;
@@ -13,16 +14,21 @@ import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
 @Service
 @Slf4j
 public class MixpanelService {
-    private final Environment env;
+    private static final String MIXPANEL_TOKEN_ENV_VAR = "env.mixpanel.token";
+    private static final String MIXPANEL_ENABLED_ENV_VAR = "env.mixpanel.enabled";
+    private final MixpanelConfig mixpanelConfig;
+    private final LoggingConfigCache loggingConfigCache;
 
-    public MixpanelService(Environment env) {
-        this.env = env;
+    public MixpanelService(MixpanelConfig mixpanelConfig, LoggingConfigCache loggingConfigCache) {
+        this.mixpanelConfig = mixpanelConfig;
+        this.loggingConfigCache = loggingConfigCache;
     }
 
     private Map<String, String> getRedactionPatterns() {
@@ -47,42 +53,57 @@ public class MixpanelService {
     }
 
     public void logEvent(String data) {
-        if(!Boolean.parseBoolean(env.getProperty("env.mixpanel.enabled"))) {
+        if(mixpanelConfig.enabled) {
             return;
         }
 
         // Filter all the incoming events in one pass, so we don't have
         // to unpack the JSONObject and repack it for each individual event
         String filteredData = filterEventData(data);
-        
+
         //Mixpanel sends event data as urlencoded form data, so we need to parse the event data as a JSON array
         JSONArray events = new JSONArray(filteredData);
 
         ClientDelivery delivery = new ClientDelivery();
 
         for (int i = 0; i < events.length(); i++) {
-            JSONObject mixpanelEvent = buildEvent(events.getJSONObject(i));
+            JSONObject event = events.getJSONObject(i);
+            JSONObject mixpanelEvent = buildEvent(event, mixpanelConfig.token);
             delivery.addMessage(mixpanelEvent);
+            String eventDomain = getEventCurrentDomain(event);
+
+            /** check if the event comes from a domain with a dedicated mixpanel token, if so, use that token to send the
+             * event to that token in addition to the global mixpanel domain */
+            if (eventDomain != null) {
+                Map<String, PortalEnvironmentConfig> configMap = loggingConfigCache.getConfigsWithDomain();
+                 PortalEnvironmentConfig matchedConfig = configMap.get(eventDomain);
+                if (matchedConfig != null && matchedConfig.getMixpanelToken() != null) {
+                    JSONObject domainEvent = buildEvent(event, matchedConfig.getMixpanelToken());
+                    delivery.addMessage(domainEvent);
+                }
+            }
         }
 
         deliverEvents(delivery);
     }
 
-    protected JSONObject buildEvent(JSONObject event) {
-        String MIXPANEL_TOKEN_ENV_VAR = "env.mixpanel.token";
-        MessageBuilder messageBuilder = new MessageBuilder(env.getProperty(MIXPANEL_TOKEN_ENV_VAR));
+    protected JSONObject buildEvent(JSONObject event, String apiToken) {
+
+        MessageBuilder messageBuilder = new MessageBuilder(apiToken);
 
         return messageBuilder.event(
                 null,
                 event.getString("event"),
                 event.getJSONObject("properties")
-                        .put("token", env.getProperty(MIXPANEL_TOKEN_ENV_VAR))
+                        .put("token", apiToken)
         );
     }
 
     protected void deliverEvents(ClientDelivery delivery) {
         MixpanelAPI mixpanel = new MixpanelAPI();
-
+        if(!mixpanelConfig.enabled) {
+            return;
+        }
         try {
             mixpanel.deliver(delivery);
         } catch (IOException e) {
@@ -90,16 +111,41 @@ public class MixpanelService {
         }
     }
 
+    protected String getEventCurrentDomain(JSONObject event) {
+        String domain = null;
+        if (event.has("properties")) {
+            JSONObject properties = event.getJSONObject("properties");
+            if (properties.has("$current_url")) {
+                String url = properties.getString("$current_url");
+                return getDomainName(url);
+            }
+        }
+        return domain;
+    }
+
+    public static String getDomainName(String url) {
+        try {
+            URI uri = new URI(url);
+            String domain = uri.getHost();
+            return domain.startsWith("www.") ? domain.substring(4) : domain;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
     @Component
     @Getter @Setter
     public static class MixpanelConfig {
         private String token;
-        private String enabled;
+        private Boolean enabled;
 
         public MixpanelConfig(Environment environment) {
             this.token = environment.getProperty("env.mixpanel.token");
-            this.enabled = environment.getProperty("env.mixpanel.enabled");
+            this.enabled = Boolean.parseBoolean(environment.getProperty("env.mixpanel.enabled"));
         }
     }
+
+
+
 
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/logging/MixpanelService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/logging/MixpanelService.java
@@ -53,7 +53,7 @@ public class MixpanelService {
     }
 
     public void logEvent(String data) {
-        if(mixpanelConfig.enabled) {
+        if(!mixpanelConfig.enabled) {
             return;
         }
 
@@ -65,6 +65,7 @@ public class MixpanelService {
         JSONArray events = new JSONArray(filteredData);
 
         ClientDelivery delivery = new ClientDelivery();
+        ClientDelivery customDelivery = null;
 
         for (int i = 0; i < events.length(); i++) {
             JSONObject event = events.getJSONObject(i);
@@ -75,16 +76,19 @@ public class MixpanelService {
             /** check if the event comes from a domain with a dedicated mixpanel token, if so, use that token to send the
              * event to that token in addition to the global mixpanel domain */
             if (eventDomain != null) {
+                customDelivery = customDelivery == null ? new ClientDelivery() : customDelivery;
                 Map<String, PortalEnvironmentConfig> configMap = loggingConfigCache.getConfigsWithDomain();
                  PortalEnvironmentConfig matchedConfig = configMap.get(eventDomain);
                 if (matchedConfig != null && matchedConfig.getMixpanelToken() != null) {
                     JSONObject domainEvent = buildEvent(event, matchedConfig.getMixpanelToken());
-                    delivery.addMessage(domainEvent);
+                    customDelivery.addMessage(domainEvent);
                 }
             }
         }
-
         deliverEvents(delivery);
+        if (customDelivery != null) {
+            deliverEvents(customDelivery);
+        }
     }
 
     protected JSONObject buildEvent(JSONObject event, String apiToken) {
@@ -101,9 +105,6 @@ public class MixpanelService {
 
     protected void deliverEvents(ClientDelivery delivery) {
         MixpanelAPI mixpanel = new MixpanelAPI();
-        if(!mixpanelConfig.enabled) {
-            return;
-        }
         try {
             mixpanel.deliver(delivery);
         } catch (IOException e) {

--- a/core/src/main/java/bio/terra/pearl/core/service/portal/PortalEnvironmentConfigService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/portal/PortalEnvironmentConfigService.java
@@ -8,23 +8,41 @@ import bio.terra.pearl.core.model.publishing.PortalEnvironmentChange;
 import bio.terra.pearl.core.service.CrudService;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import bio.terra.pearl.core.service.exception.internal.InternalServerException;
 import bio.terra.pearl.core.service.publishing.PortalEnvPublishable;
 import org.apache.commons.beanutils.PropertyUtils;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 @Service
 public class PortalEnvironmentConfigService extends CrudService<PortalEnvironmentConfig, PortalEnvironmentConfigDao> implements PortalEnvPublishable {
-
     public PortalEnvironmentConfigService(PortalEnvironmentConfigDao portalEnvironmentConfigDao) {
         super(portalEnvironmentConfigDao);
     }
 
     public Optional<PortalEnvironmentConfig> findByPortalEnvId(UUID portalEnvId) {
         return dao.findByPortalEnvId(portalEnvId);
+    }
+
+    public Map<String, PortalEnvironmentConfig> findAllMappedByCustomDomain() {
+        return dao.findAllWithCustomDomain().stream()
+                .collect(Collectors.toMap(PortalEnvironmentConfig::getParticipantHostname, Function.identity()));
+    }
+
+    public PortalEnvironmentConfig create(PortalEnvironmentConfig portalEnvironmentConfig) {
+        return super.create(portalEnvironmentConfig);
+    }
+
+    public PortalEnvironmentConfig update(PortalEnvironmentConfig portalEnvironmentConfig) {
+        return super.update(portalEnvironmentConfig);
     }
 
     @Override

--- a/core/src/main/resources/db/changelog/changesets/2025_01_30_custom_mixpanel_config.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2025_01_30_custom_mixpanel_config.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: "custom_mixpanel_config"
+      author: dbush
+      changes:
+        - addColumn:
+            tableName: portal_environment_config
+            columns:
+              - column: { name: mixpanel_token, type: text }

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -386,6 +386,9 @@ databaseChangeLog:
   - include:
       file: changesets/2025_01_24_kit_label_unique_constraint.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2025_01_30_custom_mixpanel_config.yaml
+      relativeToChangelogFile: true
 
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements

--- a/core/src/test/java/bio/terra/pearl/core/BaseSpringBootTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/BaseSpringBootTest.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.core;
 
 import bio.terra.pearl.core.model.audit.DataAuditInfo;
 import org.junit.jupiter.api.TestInfo;
+import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 

--- a/core/src/test/java/bio/terra/pearl/core/service/logging/MixpanelServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/logging/MixpanelServiceTests.java
@@ -1,18 +1,29 @@
 package bio.terra.pearl.core.service.logging;
 
 import bio.terra.pearl.core.BaseSpringBootTest;
+import bio.terra.pearl.core.factory.portal.PortalEnvironmentFactory;
+import bio.terra.pearl.core.model.portal.PortalEnvironment;
+import bio.terra.pearl.core.model.portal.PortalEnvironmentConfig;
+import bio.terra.pearl.core.service.portal.PortalEnvironmentConfigService;
 import org.json.JSONObject;
 import org.json.JSONArray;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
+import org.springframework.transaction.annotation.Transactional;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 public class MixpanelServiceTests extends BaseSpringBootTest {
     @Autowired private MixpanelService mixpanelService;
     @Autowired private Environment env;
+    @Autowired private PortalEnvironmentConfigService portalEnvironmentConfigService;
+    @Autowired private PortalEnvironmentFactory portalEnvironmentFactory;
 
     @Test
     public void testBuildEvent() {
@@ -24,9 +35,10 @@ public class MixpanelServiceTests extends BaseSpringBootTest {
 
         env = mock(Environment.class);
         when(env.getProperty("env.mixpanel.token")).thenReturn("test-token");
-        MixpanelService mockedMixpanelService = new MixpanelService(env);
+        MixpanelService.MixpanelConfig mixpanelConfig = new MixpanelService.MixpanelConfig(env);
+        MixpanelService mockedMixpanelService = new MixpanelService(mixpanelConfig, portalEnvironmentConfigService, cacheManager);
 
-        JSONObject result = mockedMixpanelService.buildEvent(event);
+        JSONObject result = mockedMixpanelService.buildEvent(event, "test-token");
 
         JSONObject message = result.getJSONObject("message");
 
@@ -44,17 +56,17 @@ public class MixpanelServiceTests extends BaseSpringBootTest {
         mockedMixpanelService.logEvent("[]");
 
         verify(mockedMixpanelService, never()).deliverEvents(any());
-        verify(mockedMixpanelService, never()).buildEvent(any());
+        verify(mockedMixpanelService, never()).buildEvent(any(), any());
     }
 
     @Test
     public void testEnableMixpanel() {
         Environment env = mock(Environment.class);
         when(env.getProperty("env.mixpanel.enabled")).thenReturn("true");
-        when(env.getProperty("mixpanel.token")).thenReturn("test-token");
-
+        when(env.getProperty("env.mixpanel.token")).thenReturn("test-token");
+        MixpanelService.MixpanelConfig mixpanelConfig = new MixpanelService.MixpanelConfig(env);
         // Create a spy on the MixpanelService instance
-        MixpanelService mixpanelService = new MixpanelService(env);
+        MixpanelService mixpanelService = new MixpanelService(mixpanelConfig, portalEnvironmentConfigService, cacheManager);
         MixpanelService spyMixpanelService = spy(mixpanelService);
 
         JSONObject event = new JSONObject();
@@ -75,8 +87,55 @@ public class MixpanelServiceTests extends BaseSpringBootTest {
 
         spyMixpanelService.logEvent(events.toString());
 
-        verify(spyMixpanelService, times(2)).buildEvent(any());
+        verify(spyMixpanelService, times(2)).buildEvent(any(), any());
         verify(spyMixpanelService, times(1)).deliverEvents(any());
+    }
+
+    @Test
+    @Transactional
+    public void testSendsToCustomProject(TestInfo info) {
+        Environment env = mock(Environment.class);
+        when(env.getProperty("env.mixpanel.enabled")).thenReturn("true");
+        when(env.getProperty("env.mixpanel.token")).thenReturn("test-token");
+        MixpanelService.MixpanelConfig mixpanelConfig = new MixpanelService.MixpanelConfig(env);
+        // Create a spy on the MixpanelService instance
+        MixpanelService mixpanelService = new MixpanelService(mixpanelConfig, portalEnvironmentConfigService, cacheManager);
+        MixpanelService spyMixpanelService = spy(mixpanelService);
+
+        PortalEnvironment portalEnv =  portalEnvironmentFactory.buildPersisted(getTestName(info));
+        PortalEnvironmentConfig envConfig = portalEnvironmentConfigService.find(portalEnv.getPortalEnvironmentConfigId()).get();
+        envConfig.setParticipantHostname("somedomain.org");
+        envConfig.setMixpanelToken("custom-token");
+        portalEnvironmentConfigService.update(envConfig);
+
+
+        JSONObject event = new JSONObject();
+        event.put("event", "test_event");
+        JSONObject properties = new JSONObject();
+        properties.put("key", "value");
+        properties.put("current_domain", "somedomain.org");
+        event.put("properties", properties);
+
+        JSONObject event2 = new JSONObject();
+        event2.put("event", "test_event2");
+        JSONObject properties2 = new JSONObject();
+        properties2.put("key", "value2");
+        properties2.put("current_domain", "anotherdomain.com");
+        event2.put("properties", properties2);
+
+        JSONArray events = new JSONArray();
+        events.put(event);
+        events.put(event2);
+
+        spyMixpanelService.logEvent(events.toString());
+        ArgumentCaptor<JSONObject> objCaptor = ArgumentCaptor.forClass(JSONObject.class);
+        ArgumentCaptor<String> tokenCaptor = ArgumentCaptor.forClass(String.class);
+        verify(spyMixpanelService, times(3)).buildEvent(objCaptor.capture(), tokenCaptor.capture());
+
+        assertThat(tokenCaptor.getAllValues(), contains("test-token", "custom-token", "test-token"));
+        assertThat(objCaptor.getAllValues().stream().map(obj ->
+                ((JSONObject) obj.get("properties")).get("current_domain")).toList(),
+                contains("somedomain.org", "somedomain.org", "anotherdomain.com"));
     }
 
     @Test

--- a/core/src/test/java/bio/terra/pearl/core/service/logging/MixpanelServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/logging/MixpanelServiceTests.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.*;
 
 public class MixpanelServiceTests extends BaseSpringBootTest {
     @Autowired private MixpanelService mixpanelService;
+    @Autowired private LoggingConfigCache loggingConfigCache;
     @Autowired private Environment env;
     @Autowired private PortalEnvironmentConfigService portalEnvironmentConfigService;
     @Autowired private PortalEnvironmentFactory portalEnvironmentFactory;
@@ -36,7 +37,7 @@ public class MixpanelServiceTests extends BaseSpringBootTest {
         env = mock(Environment.class);
         when(env.getProperty("env.mixpanel.token")).thenReturn("test-token");
         MixpanelService.MixpanelConfig mixpanelConfig = new MixpanelService.MixpanelConfig(env);
-        MixpanelService mockedMixpanelService = new MixpanelService(mixpanelConfig, portalEnvironmentConfigService, cacheManager);
+        MixpanelService mockedMixpanelService = new MixpanelService(mixpanelConfig, loggingConfigCache);
 
         JSONObject result = mockedMixpanelService.buildEvent(event, "test-token");
 
@@ -66,7 +67,7 @@ public class MixpanelServiceTests extends BaseSpringBootTest {
         when(env.getProperty("env.mixpanel.token")).thenReturn("test-token");
         MixpanelService.MixpanelConfig mixpanelConfig = new MixpanelService.MixpanelConfig(env);
         // Create a spy on the MixpanelService instance
-        MixpanelService mixpanelService = new MixpanelService(mixpanelConfig, portalEnvironmentConfigService, cacheManager);
+        MixpanelService mixpanelService = new MixpanelService(mixpanelConfig, loggingConfigCache);
         MixpanelService spyMixpanelService = spy(mixpanelService);
 
         JSONObject event = new JSONObject();
@@ -99,7 +100,7 @@ public class MixpanelServiceTests extends BaseSpringBootTest {
         when(env.getProperty("env.mixpanel.token")).thenReturn("test-token");
         MixpanelService.MixpanelConfig mixpanelConfig = new MixpanelService.MixpanelConfig(env);
         // Create a spy on the MixpanelService instance
-        MixpanelService mixpanelService = new MixpanelService(mixpanelConfig, portalEnvironmentConfigService, cacheManager);
+        MixpanelService mixpanelService = new MixpanelService(mixpanelConfig, loggingConfigCache);
         MixpanelService spyMixpanelService = spy(mixpanelService);
 
         PortalEnvironment portalEnv =  portalEnvironmentFactory.buildPersisted(getTestName(info));
@@ -107,20 +108,21 @@ public class MixpanelServiceTests extends BaseSpringBootTest {
         envConfig.setParticipantHostname("somedomain.org");
         envConfig.setMixpanelToken("custom-token");
         portalEnvironmentConfigService.update(envConfig);
+        loggingConfigCache.configCacheEvict();
 
 
         JSONObject event = new JSONObject();
         event.put("event", "test_event");
         JSONObject properties = new JSONObject();
         properties.put("key", "value");
-        properties.put("current_domain", "somedomain.org");
+        properties.put("$current_url", "https://somedomain.org/page");
         event.put("properties", properties);
 
         JSONObject event2 = new JSONObject();
         event2.put("event", "test_event2");
         JSONObject properties2 = new JSONObject();
         properties2.put("key", "value2");
-        properties2.put("current_domain", "anotherdomain.com");
+        properties2.put("$current_url", "https://anotherdomain.com");
         event2.put("properties", properties2);
 
         JSONArray events = new JSONArray();
@@ -134,8 +136,8 @@ public class MixpanelServiceTests extends BaseSpringBootTest {
 
         assertThat(tokenCaptor.getAllValues(), contains("test-token", "custom-token", "test-token"));
         assertThat(objCaptor.getAllValues().stream().map(obj ->
-                ((JSONObject) obj.get("properties")).get("current_domain")).toList(),
-                contains("somedomain.org", "somedomain.org", "anotherdomain.com"));
+                ((JSONObject) obj.get("properties")).get("$current_url")).toList(),
+                contains("https://somedomain.org/page", "https://somedomain.org/page", "https://anotherdomain.com"));
     }
 
     @Test

--- a/e2e-tests/src/pages/ourhealth/study-dashboard.ts
+++ b/e2e-tests/src/pages/ourhealth/study-dashboard.ts
@@ -5,7 +5,7 @@ export enum Activities
 {
   Consent = 'OurHealth Consent',
   Basics = 'The Basics',
-  CardiometabolicMedicalHistory = 'OurHealth Medical History',
+  CardiometabolicMedicalHistory = 'Cardiometabolic Medical History',
   OtherMedicalHistory = 'Other Medical History',
   FamilyHistory = 'Family History',
   Medications = 'Medications',

--- a/scripts/mixpanel/process_export_file.py
+++ b/scripts/mixpanel/process_export_file.py
@@ -1,0 +1,26 @@
+# takes as input a file of exported mixpanel events and formats it for import -- adding json array and splitting
+# into  subfiles with < 2000 events in each
+# usage: python3 process_export_file.py <input_file>
+import sys
+import subprocess
+import glob
+import os
+
+input_file = sys.argv[1]
+input_file_name = os.path.basename(input_file)
+input_base_name = input_file_name.split(".")[0] + "_split_"
+
+subprocess.run(["split", "-l", "1500", "-a", "2", input_file, input_base_name])
+new_files = glob.glob(input_base_name + "*")
+for new_file in new_files:
+    # add a json suffix
+    file_with_suffix = new_file + ".json"
+    subprocess.run(["mv", new_file, file_with_suffix])
+    # reformat the content as a json array (from a raw list of event objects)
+    with open(file_with_suffix, "r") as f:
+        lines = f.readlines()
+    with open(file_with_suffix, "w") as f:
+        f.write("[\n")
+        f.write(",".join(lines))
+        f.write("]\n")
+

--- a/ui-admin/src/study/settings/portal/WebsiteSettings.tsx
+++ b/ui-admin/src/study/settings/portal/WebsiteSettings.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { PortalEnvironmentConfig } from '@juniper/ui-core'
+import InfoPopup from 'components/forms/InfoPopup'
 
 export const WebsiteSettings = (
   {
@@ -13,29 +14,38 @@ export const WebsiteSettings = (
   return <div>
     <p>Configure the accessibility of the landing page shown to all visitors, and sitewide properties</p>
     <div>
-      <label className="form-label">
-        password protected <input type="checkbox" checked={config.passwordProtected}
+      <label className="form-label mt-2">
+        password protected <input type="checkbox" checked={config.passwordProtected} className="ms-2"
           onChange={e => updateConfig('passwordProtected', e.target.checked)}/>
       </label>
     </div>
     <div>
-      <label className="form-label">
+      <label className="form-label mt-2">
         password <input type="text" className="form-control" value={config.password ?? ''}
           onChange={e => updateConfig('password', e.target.value)}/>
       </label>
     </div>
     <div>
-      <label className="form-label">
+      <label className="form-label mt-2">
         accepting registration
-        <input type="checkbox" checked={config.acceptingRegistration}
+        <input type="checkbox" checked={config.acceptingRegistration} className="ms-2"
           onChange={e => updateConfig('acceptingRegistration', e.target.checked)}/>
       </label>
     </div>
     <div>
-      <label className="form-label">
+      <label className="form-label mt-2">
         participant hostname
         <input type="text" className="form-control" value={config.participantHostname ?? ''}
           onChange={e => updateConfig('participantHostname', e.target.value)}/>
+      </label>
+    </div>
+    <div>
+      <label className="form-label mt-2">
+        Mixpanel api token <InfoPopup content={<span>
+        If provided, events for participant interactions with the website will
+        be sent to the mixpanel project corresponding to the token</span>}/>
+        <input type="text" className="form-control" value={config.mixpanelToken ?? ''}
+          onChange={e => updateConfig('mixpanelToken', e.target.value)}/>
       </label>
     </div>
   </div>

--- a/ui-core/src/types/portal.ts
+++ b/ui-core/src/types/portal.ts
@@ -43,6 +43,7 @@ export type PortalEnvironmentConfig = {
   emailSourceAddress?: string
   defaultLanguage: string
   primaryStudy?: string
+  mixpanelToken?: string
 }
 
 export {}


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

This adds a mixpanel token to portal environment configs.  If set, and a custom domain is present, events in that domain will also be logged to the given token.

This also adds spring caching so that we don't have to load and assemble the config map every time an event is called.  this is probably overkill for our purposes, but I thought it was a good excuse to dip our toes into using spring caching.  Down the road, I could imagine us implementing a simple postgres-backed Spring cache manager so that we wouldn't have to do crude cache evictions based on timeouts.


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
This is tricky to test in dev...
1.  redeploy admin app, redeploy participantApiApp with MIXPANEL_ENABLED=true
3. go to https://localhost:3000/demo/studies/heartdemo/env/live/settings/website
4. set the participant hostname to "demo.localhost"
5. set the mixpanel token value to anything
6. save the configs
7. put a breakpoint in line 84 of MixpanelService
8. go to https://demo.localhost:3001/
9. after a few seconds, the breakpoint should be triggered, and you should see an event being created with your custom token