### PR TITLE
[JN-1608][member's choice] editable sidebars

### DIFF
--- a/ui-admin/src/App.css
+++ b/ui-admin/src/App.css
@@ -110,3 +110,11 @@ a {
 .hover-opacity-50 {
   opacity: 0.5;
 }
+
+.pointer-none {
+  pointer-events: none;
+}
+
+.pointer-auto {
+  pointer-events: auto;
+}

--- a/ui-admin/src/App.css
+++ b/ui-admin/src/App.css
@@ -102,3 +102,11 @@ a {
 .nav-icon:hover {
   color: #858D9A;
 }
+
+.hover-opacity-50:hover {
+  opacity: 1.0;
+}
+
+.hover-opacity-50 {
+  opacity: 0.5;
+}

--- a/ui-admin/src/navbar/AdminSidebar.tsx
+++ b/ui-admin/src/navbar/AdminSidebar.tsx
@@ -9,7 +9,11 @@ import {
   useParams
 } from 'react-router-dom'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCaretRight } from '@fortawesome/free-solid-svg-icons'
+import {
+  faCaretRight,
+  faPencil,
+  faSave
+} from '@fortawesome/free-solid-svg-icons'
 import { Study } from '@juniper/ui-core'
 import { studyShortcodeFromPath } from 'study/StudyRouter'
 import { useNavContext } from './NavContextProvider'
@@ -26,6 +30,22 @@ const ZONE_COLORS: { [index: string]: string } = {
 }
 
 export const sidebarNavLinkClasses = 'text-white p-1 rounded w-100 d-block sidebar-nav-link'
+
+export type StudySidebarConfig = {
+  hidden: string[]
+}
+
+export type SidebarConfig = {
+  studyConfig?: { [studyShortcode: string]: StudySidebarConfig }
+}
+
+const parseSidebarConfigState = (data: string): SidebarConfig => {
+  try {
+    return JSON.parse(data)
+  } catch (e) {
+    return {}
+  }
+}
 
 /** renders the left navbar of admin tool */
 const AdminSidebar = ({ config }: { config: Config }) => {
@@ -46,6 +66,50 @@ const AdminSidebar = ({ config }: { config: Config }) => {
   const currentStudy = studyList.find(study => study.shortcode === studyShortcode)
   const color = ZONE_COLORS[config.deploymentZone] || ZONE_COLORS['prod']
 
+
+  const sidebarConfig: SidebarConfig = parseSidebarConfigState(localStorage.getItem('sidebarConfig') || '{}')
+
+  const [isEditingSidebarConfig, setIsEditingSidebarConfig] = React.useState(false)
+
+  const getStudyConfig = (studyShortcode: string): StudySidebarConfig => {
+    if (!sidebarConfig.studyConfig) {
+      sidebarConfig.studyConfig = {}
+      localStorage.setItem('sidebarConfig', JSON.stringify(sidebarConfig))
+    }
+
+    if (!sidebarConfig.studyConfig[studyShortcode]) {
+      sidebarConfig.studyConfig[studyShortcode] = { hidden: [] }
+      localStorage.setItem('sidebarConfig', JSON.stringify(sidebarConfig))
+    }
+
+
+    return sidebarConfig.studyConfig[studyShortcode]
+  }
+
+  const setStudyConfig = (studyShortcode: string, studyConfig: StudySidebarConfig) => {
+    if (!sidebarConfig.studyConfig) {
+      sidebarConfig.studyConfig = {}
+    }
+
+    sidebarConfig.studyConfig[studyShortcode] = studyConfig
+    localStorage.setItem('sidebarConfig', JSON.stringify(sidebarConfig))
+  }
+
+  const toggleHiddenItem = (key: string) => {
+    if (!currentStudy) {
+      return
+    }
+
+    const studyConfig = getStudyConfig(currentStudy.shortcode)
+    const hiddenItems = studyConfig.hidden
+    if (hiddenItems.includes(key)) {
+      studyConfig.hidden = hiddenItems.filter(item => item !== key)
+    } else {
+      studyConfig.hidden = [...hiddenItems, key]
+    }
+    setStudyConfig(currentStudy.shortcode, studyConfig)
+  }
+
   // automatically collapse the sidebar for mobile-first routes
   useEffect(() => {
     if (isMobileFirstRoute()) {
@@ -58,8 +122,8 @@ const AdminSidebar = ({ config }: { config: Config }) => {
   }
 
   return <div style={{ backgroundColor: color, minHeight: '100vh', minWidth: open ? '250px' : '50px' }}
-    className="p-2 pt-3">
-    <>
+    className="p-2 pt-3 d-flex flex-column">
+    <div style={{ minHeight: '100vh', height: '100%' }}>
       <div className="d-flex justify-content-between align-items-center">
         { open && <Link to="/" className="text-white fs-4 px-2 rounded-1 sidebar-nav-link flex-grow-1">Juniper</Link> }
         <Button variant="secondary" className="m-1 text-light" tooltipPlacement={'right'}
@@ -73,7 +137,12 @@ const AdminSidebar = ({ config }: { config: Config }) => {
         </Button>
       </div>
       { open && <>
-        { currentStudy && <StudySidebar study={currentStudy} portalList={portalList}
+        {currentStudy && <StudySidebar
+          study={currentStudy}
+          isEditingSidebarConfig={isEditingSidebarConfig}
+          toggleHiddenItem={toggleHiddenItem}
+          studySidebarConfig={getStudyConfig(currentStudy.shortcode)}
+          portalList={portalList}
           portalShortcode={portalShortcode!}/> }
 
         {user?.superuser && <CollapsableMenu header={'Superuser Functions'} content={
@@ -95,7 +164,18 @@ const AdminSidebar = ({ config }: { config: Config }) => {
             </li>
           </ul>}/>}
       </>}
-    </>
+    </div>
+    {currentStudy && <div className="sticky-bottom w-100 d-flex justify-content-end p-1 pointer-none">
+      <button
+        className="btn btn-secondary btn-sm text-white hover-opacity-50 pointer-auto"
+        onClick={() => setIsEditingSidebarConfig(!isEditingSidebarConfig)}
+        aria-label={isEditingSidebarConfig ? 'Save sidebar config' : 'Edit sidebar config'}
+      >
+        {isEditingSidebarConfig
+          ? <FontAwesomeIcon icon={faSave}/>
+          : <FontAwesomeIcon icon={faPencil}/>}
+      </button>
+    </div>}
   </div>
 }
 

--- a/ui-admin/src/navbar/SidebarSection.tsx
+++ b/ui-admin/src/navbar/SidebarSection.tsx
@@ -1,0 +1,71 @@
+import { NavLink } from 'react-router-dom'
+import React from 'react'
+import { sidebarNavLinkClasses } from 'navbar/AdminSidebar'
+import CollapsableMenu from 'navbar/CollapsableMenu'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import {
+  faEye,
+  faEyeSlash
+} from '@fortawesome/free-solid-svg-icons'
+
+export type SidebarItemT = {
+  key: string
+  label: string
+  link: string
+}
+
+export type SidebarSectionT = {
+  key: string
+  label: string
+  items: SidebarItemT[]
+}
+
+const navStyleFunc = ({ isActive }: { isActive: boolean }) => {
+  return isActive ? { background: 'rgba(255, 255, 255, 0.3)' } : {}
+}
+
+export const SidebarSection = ({
+  section, isEditing, hiddenItems, toggleHiddenItem
+}: {
+  section: SidebarSectionT, isEditing: boolean, hiddenItems: string[], toggleHiddenItem: (key: string) => void
+}) => {
+  const shownItems = isEditing
+    ? section.items // show all items when editing
+    : section.items.filter(item => !hiddenItems.includes(item.key)) || []
+
+  if (shownItems.length === 0) {
+    return <></>
+  }
+
+  return <CollapsableMenu header={section.label} content={<ul className="list-unstyled">
+    {shownItems
+      .map(item => <SidebarItem
+        key={item.key}
+        item={item}
+        isEditing={isEditing}
+        hiddenItems={hiddenItems}
+        toggleHiddenItem={toggleHiddenItem}
+      />)}
+  </ul>}/>
+}
+
+export const SidebarItem = ({
+  item, isEditing, hiddenItems, toggleHiddenItem
+}: { item: SidebarItemT, isEditing: boolean, hiddenItems: string[], toggleHiddenItem: (key: string) => void }) => {
+  return <>
+    <li className="mb-2 d-flex">
+      <NavLink
+        to={item.link}
+        className={sidebarNavLinkClasses}
+        style={navStyleFunc}>{item.label}</NavLink>
+      {isEditing && <>
+        <button
+          className="btn btn-secondary btn-sm text-white hover-opacity-50"
+          onClick={() => toggleHiddenItem(item.key)}
+        >
+          {hiddenItems.includes(item.key) ? <FontAwesomeIcon icon={faEyeSlash} /> : <FontAwesomeIcon icon={faEye}/>}
+        </button>
+      </>}
+    </li>
+  </>
+}

--- a/ui-admin/src/navbar/SidebarSection.tsx
+++ b/ui-admin/src/navbar/SidebarSection.tsx
@@ -62,6 +62,7 @@ export const SidebarItem = ({
         <button
           className="btn btn-secondary btn-sm text-white hover-opacity-50"
           onClick={() => toggleHiddenItem(item.key)}
+          aria-label={`Toggle visibility for ${item.label}`}
         >
           {hiddenItems.includes(item.key) ? <FontAwesomeIcon icon={faEyeSlash} /> : <FontAwesomeIcon icon={faEye}/>}
         </button>

--- a/ui-admin/src/navbar/StudySidebar.test.tsx
+++ b/ui-admin/src/navbar/StudySidebar.test.tsx
@@ -1,10 +1,20 @@
 import React from 'react'
 
-import { mockAdminUser, MockUserProvider } from 'test-utils/user-mocking-utils'
-import { render, screen } from '@testing-library/react'
+import {
+  mockAdminUser,
+  MockUserProvider
+} from 'test-utils/user-mocking-utils'
+import {
+  render,
+  screen
+} from '@testing-library/react'
 import { StudySidebar } from './StudySidebar'
-import { mockPortal, mockStudyEnvContext } from '../test-utils/mocking-utils'
+import {
+  mockPortal,
+  mockStudyEnvContext
+} from '../test-utils/mocking-utils'
 import { setupRouterTest } from '@juniper/ui-core'
+import { act } from 'react-dom/test-utils'
 
 test('renders the study selector and sub menus', async () => {
   const { study } = mockStudyEnvContext()
@@ -15,11 +25,80 @@ test('renders the study selector and sub menus', async () => {
   })
   const { RoutedComponent } = setupRouterTest(
     <MockUserProvider user={mockAdminUser(true)}>
-      <StudySidebar study={study} portalList={[portal]} portalShortcode={portal.shortcode}/>
+      <StudySidebar
+        study={study}
+        portalList={[portal]}
+        portalShortcode={portal.shortcode}
+        studySidebarConfig={{ hidden: [] }}
+        isEditingSidebarConfig={false}
+        toggleHiddenItem={() => {
+        }}
+      />
     </MockUserProvider>)
   render(RoutedComponent)
   expect(screen.getByText(study.name)).toBeInTheDocument()
   expect(screen.getByText('Research Coordination')).toBeVisible()
   expect(screen.getByText('Participants')).toBeVisible()
   expect(screen.getByText('Study Trends')).toBeVisible()
+
+  expect(screen.queryByText('Toggle visibility for Participants')).not.toBeInTheDocument()
+})
+
+
+test('hides hidden items', async () => {
+  const { study } = mockStudyEnvContext()
+  const portal = mockPortal()
+  portal.portalStudies.push({
+    createdAt: 0,
+    study
+  })
+  const { RoutedComponent } = setupRouterTest(
+    <MockUserProvider user={mockAdminUser(true)}>
+      <StudySidebar
+        study={study}
+        portalList={[portal]}
+        portalShortcode={portal.shortcode}
+        studySidebarConfig={{ hidden: ['participants'] }}
+        isEditingSidebarConfig={false}
+        toggleHiddenItem={() => {
+        }}
+      />
+    </MockUserProvider>)
+  render(RoutedComponent)
+  expect(screen.getByText(study.name)).toBeInTheDocument()
+  expect(screen.getByText('Research Coordination')).toBeVisible()
+  expect(screen.queryByText('Participants')).not.toBeInTheDocument()
+  expect(screen.getByText('Study Trends')).toBeVisible()
+})
+
+test('toggles hidden items', async () => {
+  const { study } = mockStudyEnvContext()
+  const portal = mockPortal()
+  portal.portalStudies.push({
+    createdAt: 0,
+    study
+  })
+
+  const toggleHiddenItem = jest.fn()
+
+  const { RoutedComponent } = setupRouterTest(
+    <MockUserProvider user={mockAdminUser(true)}>
+      <StudySidebar
+        study={study}
+        portalList={[portal]}
+        portalShortcode={portal.shortcode}
+        studySidebarConfig={{ hidden: [] }}
+        isEditingSidebarConfig={true}
+        toggleHiddenItem={toggleHiddenItem}
+      />
+    </MockUserProvider>)
+  render(RoutedComponent)
+  expect(screen.getByText(study.name)).toBeInTheDocument()
+  expect(screen.queryByText('Participants')).toBeVisible()
+
+  expect(toggleHiddenItem).not.toHaveBeenCalled()
+
+  act(() => screen.getByLabelText('Toggle visibility for Participants').click())
+
+  expect(toggleHiddenItem).toHaveBeenCalledWith('participants')
 })

--- a/ui-admin/src/navbar/StudySidebar.tsx
+++ b/ui-admin/src/navbar/StudySidebar.tsx
@@ -2,40 +2,48 @@ import {
   Portal,
   Study
 } from '@juniper/ui-core'
-import {
-  NavLink,
-  useNavigate
-} from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import {
   studyKitsPath,
   studyParticipantsPath
 } from 'portal/PortalRouter'
 import StudySelector from './StudySelector'
-import React from 'react'
+import React, { useEffect } from 'react'
 import {
-  adminTasksPath, studyEnvMailingListPath, studyEnvSiteContentPath,
+  adminTasksPath,
   studyEnvDataBrowserPath,
   studyEnvDatasetListViewPath,
   studyEnvExportIntegrationsPath,
   studyEnvFormsPath,
   studyEnvImportPath,
+  studyEnvMailingListPath,
   studyEnvMetricsPath,
-  studyEnvTriggersPath, studyEnvWorkflowPath,
-  studyEnvSiteSettingsPath
+  studyEnvSiteContentPath,
+  studyEnvSiteSettingsPath,
+  studyEnvTriggersPath,
+  studyEnvWorkflowPath
 } from 'study/StudyEnvironmentRouter'
-
-
-import CollapsableMenu from './CollapsableMenu'
 import {
   userHasPermission,
   useUser
 } from 'user/UserProvider'
+import { studyPublishingPath } from 'study/StudyRouter'
+import { portalUsersPath } from 'user/AdminUserRouter'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
-  studyPublishingPath
-} from 'study/StudyRouter'
-import { sidebarNavLinkClasses } from './AdminSidebar'
-import { portalUsersPath } from '../user/AdminUserRouter'
+  faCheck,
+  faPencil
+} from '@fortawesome/free-solid-svg-icons'
+import {
+  SidebarSection,
+  SidebarSectionT
+} from 'navbar/SidebarSection'
 
+type SidebarConfig = {
+  hidden: string[]
+}
+
+type SidebarConfigState = { [key: string]: SidebarConfig }
 
 /** shows menu options related to the current study */
 export const StudySidebar = ({ study, portalList, portalShortcode }:
@@ -44,102 +52,225 @@ export const StudySidebar = ({ study, portalList, portalShortcode }:
   const user = useUser()
   const portalId = portalList.find(p => p.shortcode === portalShortcode)?.id
 
+  const sidebarConfigState: SidebarConfigState = parseSidebarConfigState(localStorage.getItem('sidebarConfig') || '{}')
+
+  const sidebarConfig: SidebarConfig = sidebarConfigState[study.shortcode] || { hidden: [] }
+  const [hiddenItems, setHiddenItems] = React.useState(sidebarConfig.hidden)
+  useEffect(() => {
+    setHiddenItems(sidebarConfig.hidden)
+  }, [sidebarConfig])
+
+  const [isEditing, setIsEditing] = React.useState(false)
+
+  const toggleHiddenItem = (key: string) => {
+    if (hiddenItems.includes(key)) {
+      sidebarConfig.hidden = hiddenItems.filter(item => item !== key)
+    } else {
+      sidebarConfig.hidden = [...hiddenItems, key]
+    }
+    sidebarConfigState[study.shortcode] = sidebarConfig
+    localStorage.setItem('sidebarConfig', JSON.stringify(sidebarConfigState))
+    setHiddenItems(sidebarConfig.hidden)
+  }
+
   /** updates the selected study -- routes to that study's homepage */
   const setSelectedStudy = (portalShortcode: string, studyShortcode: string) => {
     navigate(studyParticipantsPath(portalShortcode, studyShortcode, 'live'))
   }
-  const navStyleFunc = ({ isActive }: { isActive: boolean }) => {
-    return isActive ? { background: 'rgba(255, 255, 255, 0.3)' } : {}
+
+  const userHasPermissionInPortal = (permission: string) => {
+    if (!portalId) {
+      return false
+    }
+    return userHasPermission(user.user, portalId, permission)
   }
 
-  const studyParams = {
+  const sections: SidebarSectionT[] = buildStudySidebarSections(userHasPermissionInPortal,
     portalShortcode,
-    studyShortcode: study.shortcode
-  }
+    study.shortcode)
 
   return <div className="pt-3">
-    <StudySelector portalList={portalList} selectedShortcode={study.shortcode} setSelectedStudy={setSelectedStudy}/>
-    <div className="text-white">
-      <CollapsableMenu header={'Research Coordination'} content={<ul className="list-unstyled">
-        <li className="mb-2">
-          <NavLink to={studyParticipantsPath(portalShortcode, study.shortcode, 'live')}
-            className={sidebarNavLinkClasses} style={navStyleFunc}>Participants</NavLink>
-        </li>
-        <li className="mb-2">
-          <NavLink to={studyKitsPath(portalShortcode, study.shortcode, 'live')}
-            className={sidebarNavLinkClasses} style={navStyleFunc}>Kits</NavLink>
-        </li>
-        <li className="mb-2">
-          <NavLink to={adminTasksPath(portalShortcode, study.shortcode, 'live')}
-            className={sidebarNavLinkClasses} style={navStyleFunc}>Tasks</NavLink>
-        </li>
-        <li className="mb-2">
-          <NavLink to={studyEnvImportPath(portalShortcode, study.shortcode, 'sandbox')}
-            className={sidebarNavLinkClasses} style={navStyleFunc}>Import Participants</NavLink>
-        </li>
-        <li className="mb-2">
-          <NavLink to={studyEnvMailingListPath({ ...studyParams, envName: 'live' })}
-            className={sidebarNavLinkClasses} style={navStyleFunc}>Mailing List</NavLink>
-        </li>
-      </ul>}/>
-      <CollapsableMenu header={'Analytics & Data'} content={<ul className="list-unstyled">
-        <li className="mb-2">
-          <NavLink to={studyEnvMetricsPath(portalShortcode, study.shortcode, 'live')}
-            className={sidebarNavLinkClasses} style={navStyleFunc}>Study Trends</NavLink>
-        </li>
-        <li className="mb-2">
-          <NavLink to={studyEnvDataBrowserPath(portalShortcode, study.shortcode, 'live')}
-            className={sidebarNavLinkClasses} style={navStyleFunc}>Data Export</NavLink>
-        </li>
-        { portalId && userHasPermission(user.user, portalId, 'export_integration') && <li className="mb-2">
-          <NavLink to={studyEnvExportIntegrationsPath({ ...studyParams, envName: 'live' })}
-            className={sidebarNavLinkClasses} style={navStyleFunc}>Export Integrations</NavLink>
-        </li>
-        }
-        { portalId && userHasPermission(user.user, portalId, 'tdr_export') && <li>
-          <NavLink to={studyEnvDatasetListViewPath(portalShortcode, study.shortcode, 'live')}
-            className={sidebarNavLinkClasses} style={navStyleFunc}>Terra Data Repo</NavLink>
-        </li>
-        }
-      </ul>}/>
-      <CollapsableMenu header={'Design & Build'} content={<ul className="list-unstyled">
-        <li className="mb-2">
-          <NavLink to={studyEnvSiteContentPath({ ...studyParams, envName: 'sandbox' })}
-            className={sidebarNavLinkClasses} style={navStyleFunc}>Website</NavLink>
-        </li>
-        <li className="mb-2">
-          <NavLink to={studyEnvWorkflowPath({
-            portalShortcode, studyShortcode: study.shortcode, envName: 'sandbox'
-          })}
-          className={sidebarNavLinkClasses} style={navStyleFunc}>Participant Flow</NavLink>
-        </li>
-        <li className="mb-2">
-          <NavLink to={studyEnvFormsPath(portalShortcode, study.shortcode, 'sandbox')}
-            className={sidebarNavLinkClasses} style={navStyleFunc}>Forms &amp; Surveys</NavLink>
-        </li>
-        <li className="mb-2">
-          <NavLink to={studyEnvTriggersPath({
-            portalShortcode, studyShortcode: study.shortcode, envName: 'sandbox'
-          })}
-          className={sidebarNavLinkClasses} style={navStyleFunc}>Emails &amp; Automation</NavLink>
-        </li>
-      </ul>}/>
-      <CollapsableMenu header={'Publish'} content={<ul className="list-unstyled">
-        <li className="mb-2">
-          <NavLink to={studyPublishingPath(portalShortcode, study.shortcode)}
-            className={sidebarNavLinkClasses} style={navStyleFunc}>Publish Content</NavLink>
-        </li>
-        <li>
-          <NavLink to={studyEnvSiteSettingsPath(portalShortcode, study.shortcode, 'live')}
-            className={sidebarNavLinkClasses} style={navStyleFunc}>Site Settings</NavLink>
-        </li>
-      </ul>}/>
-      <CollapsableMenu header={'Manage'} content={<ul className="list-unstyled">
-        <li className="mb-2">
-          <NavLink to={portalUsersPath({ portalShortcode, studyShortcode: study.shortcode, envName: 'live' })}
-            className={sidebarNavLinkClasses} style={navStyleFunc}>Team Members</NavLink>
-        </li>
-      </ul>}/>
+    <div className="d-flex w-100 align-items-baseline">
+      <div className="flex-grow-1">
+        <StudySelector
+          portalList={portalList}
+          selectedShortcode={study.shortcode}
+          setSelectedStudy={setSelectedStudy}/>
+
+      </div>
+      <button
+        className="btn btn-secondary btn-sm text-white m-0 ms-2 hover-opacity-50"
+        onClick={() => setIsEditing(!isEditing)}
+      >
+        {isEditing ? <FontAwesomeIcon icon={faCheck}/> : <FontAwesomeIcon icon={faPencil}/>}
+      </button>
     </div>
+    {sections.map(section => <SidebarSection
+      key={section.key}
+      section={section}
+      isEditing={isEditing}
+      hiddenItems={hiddenItems}
+      toggleHiddenItem={toggleHiddenItem}/>)}
   </div>
+}
+
+const parseSidebarConfigState = (data: string): SidebarConfigState => {
+  try {
+    return JSON.parse(data)
+  } catch (e) {
+    return {}
+  }
+}
+
+const buildStudySidebarSections = (
+  userHasPermissionInPortal: (permission: string) => boolean,
+  portalShortcode: string,
+  studyShortcode: string): SidebarSectionT[] => {
+  const sections: SidebarSectionT[] = [
+    {
+      key: 'research',
+      label: 'Research Coordination',
+      items: [
+        {
+          key: 'participants',
+          label: 'Participants',
+          link: studyParticipantsPath(portalShortcode, studyShortcode, 'live')
+        },
+        {
+          key: 'kits',
+          label: 'Kits',
+          link: studyKitsPath(portalShortcode, studyShortcode, 'live')
+        },
+        {
+          key: 'tasks',
+          label: 'Tasks',
+          link: adminTasksPath(portalShortcode, studyShortcode, 'live')
+        },
+        {
+          key: 'import',
+          label: 'Import Participants',
+          link: studyEnvImportPath(portalShortcode, studyShortcode, 'sandbox')
+        },
+        {
+          key: 'mailingList',
+          label: 'Mailing List',
+          link: studyEnvMailingListPath({
+            portalShortcode,
+            studyShortcode,
+            envName: 'live'
+          })
+        }
+      ]
+    }
+  ]
+
+  const analyticsDataSection: SidebarSectionT = {
+    key: 'analytics',
+    label: 'Analytics & Data',
+    items: [
+      {
+        key: 'metrics',
+        label: 'Study Trends',
+        link: studyEnvMetricsPath(portalShortcode, studyShortcode, 'live')
+      },
+      {
+        key: 'dataBrowser',
+        label: 'Data Export',
+        link: studyEnvDataBrowserPath(portalShortcode, studyShortcode, 'live')
+      }
+    ]
+  }
+
+  if (userHasPermissionInPortal('export_integration')) {
+    analyticsDataSection.items.push({
+      key: 'exportIntegrations',
+      label: 'Export Integrations',
+      link: studyEnvExportIntegrationsPath({
+        portalShortcode,
+        studyShortcode,
+        envName: 'live'
+      })
+    })
+  }
+
+  if (userHasPermissionInPortal('tdr_export')) {
+    analyticsDataSection.items.push({
+      key: 'terraDataRepo',
+      label: 'Terra Data Repo',
+      link: studyEnvDatasetListViewPath(portalShortcode, studyShortcode, 'live')
+    })
+  }
+
+  sections.push(analyticsDataSection,
+    {
+      key: 'design',
+      label: 'Design & Build',
+      items: [
+        {
+          key: 'siteContent',
+          label: 'Website',
+          link: studyEnvSiteContentPath({
+            portalShortcode,
+            studyShortcode,
+            envName: 'sandbox'
+          })
+        },
+        {
+          key: 'workflow',
+          label: 'Participant Flow',
+          link: studyEnvWorkflowPath({
+            portalShortcode,
+            studyShortcode,
+            envName: 'sandbox'
+          })
+        },
+        {
+          key: 'forms',
+          label: 'Forms & Surveys',
+          link: studyEnvFormsPath(portalShortcode, studyShortcode, 'sandbox')
+        },
+        {
+          key: 'triggers',
+          label: 'Emails & Automation',
+          link: studyEnvTriggersPath({
+            portalShortcode,
+            studyShortcode,
+            envName: 'sandbox'
+          })
+        }
+      ]
+    },
+    {
+      key: 'publish',
+      label: 'Publish',
+      items: [
+        {
+          key: 'publishContent',
+          label: 'Publish Content',
+          link: studyPublishingPath(portalShortcode, studyShortcode)
+        },
+        {
+          key: 'siteSettings',
+          label: 'Site Settings',
+          link: studyEnvSiteSettingsPath(portalShortcode, studyShortcode, 'live')
+        }
+      ]
+    },
+    {
+      key: 'manage',
+      label: 'Manage',
+      items: [
+        {
+          key: 'teamMembers',
+          label: 'Team Members',
+          link: portalUsersPath({
+            portalShortcode,
+            studyShortcode,
+            envName: 'live'
+          })
+        }
+      ]
+    })
+
+  return sections
 }

--- a/ui-admin/src/navbar/StudySidebar.tsx
+++ b/ui-admin/src/navbar/StudySidebar.tsx
@@ -8,7 +8,7 @@ import {
   studyParticipantsPath
 } from 'portal/PortalRouter'
 import StudySelector from './StudySelector'
-import React, { useEffect } from 'react'
+import React from 'react'
 import {
   adminTasksPath,
   studyEnvDataBrowserPath,
@@ -29,48 +29,44 @@ import {
 } from 'user/UserProvider'
 import { studyPublishingPath } from 'study/StudyRouter'
 import { portalUsersPath } from 'user/AdminUserRouter'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import {
-  faCheck,
-  faPencil
-} from '@fortawesome/free-solid-svg-icons'
 import {
   SidebarSection,
   SidebarSectionT
 } from 'navbar/SidebarSection'
-
-type SidebarConfig = {
-  hidden: string[]
-}
-
-type SidebarConfigState = { [key: string]: SidebarConfig }
+import { StudySidebarConfig } from 'navbar/AdminSidebar'
 
 /** shows menu options related to the current study */
-export const StudySidebar = ({ study, portalList, portalShortcode }:
-                               { study: Study, portalList: Portal[], portalShortcode: string }) => {
+export const StudySidebar = ({
+  study,
+  portalList,
+  portalShortcode,
+  studySidebarConfig,
+  isEditingSidebarConfig,
+  toggleHiddenItem
+}: {
+  study: Study,
+  portalList: Portal[],
+  portalShortcode: string,
+  studySidebarConfig: StudySidebarConfig,
+  isEditingSidebarConfig: boolean,
+  toggleHiddenItem: (key: string) => void
+}) => {
   const navigate = useNavigate()
   const user = useUser()
   const portalId = portalList.find(p => p.shortcode === portalShortcode)?.id
 
-  const sidebarConfigState: SidebarConfigState = parseSidebarConfigState(localStorage.getItem('sidebarConfig') || '{}')
 
-  const sidebarConfig: SidebarConfig = sidebarConfigState[study.shortcode] || { hidden: [] }
-  const [hiddenItems, setHiddenItems] = React.useState(sidebarConfig.hidden)
-  useEffect(() => {
-    setHiddenItems(sidebarConfig.hidden)
-  }, [sidebarConfig])
+  const [hiddenItems, setHiddenItems] = React.useState<string[]>(studySidebarConfig.hidden)
+  React.useEffect(() => {
+    setHiddenItems(studySidebarConfig.hidden)
+  }, [studySidebarConfig])
 
-  const [isEditing, setIsEditing] = React.useState(false)
-
-  const toggleHiddenItem = (key: string) => {
+  const onToggleHiddenItem = (key: string) => {
     if (hiddenItems.includes(key)) {
-      sidebarConfig.hidden = hiddenItems.filter(item => item !== key)
+      setHiddenItems(hiddenItems.filter(i => i !== key))
     } else {
-      sidebarConfig.hidden = [...hiddenItems, key]
+      setHiddenItems([...hiddenItems, key])
     }
-    sidebarConfigState[study.shortcode] = sidebarConfig
-    localStorage.setItem('sidebarConfig', JSON.stringify(sidebarConfigState))
-    setHiddenItems(sidebarConfig.hidden)
   }
 
   /** updates the selected study -- routes to that study's homepage */
@@ -90,36 +86,21 @@ export const StudySidebar = ({ study, portalList, portalShortcode }:
     study.shortcode)
 
   return <div className="pt-3">
-    <div className="d-flex w-100 align-items-baseline">
-      <div className="flex-grow-1">
-        <StudySelector
-          portalList={portalList}
-          selectedShortcode={study.shortcode}
-          setSelectedStudy={setSelectedStudy}/>
+    <StudySelector
+      portalList={portalList}
+      selectedShortcode={study.shortcode}
+      setSelectedStudy={setSelectedStudy}/>
 
-      </div>
-      <button
-        className="btn btn-secondary btn-sm text-white m-0 ms-2 hover-opacity-50"
-        onClick={() => setIsEditing(!isEditing)}
-      >
-        {isEditing ? <FontAwesomeIcon icon={faCheck}/> : <FontAwesomeIcon icon={faPencil}/>}
-      </button>
-    </div>
     {sections.map(section => <SidebarSection
       key={section.key}
       section={section}
-      isEditing={isEditing}
+      isEditing={isEditingSidebarConfig}
       hiddenItems={hiddenItems}
-      toggleHiddenItem={toggleHiddenItem}/>)}
+      toggleHiddenItem={key => {
+        toggleHiddenItem(key)
+        onToggleHiddenItem(key)
+      }}/>)}
   </div>
-}
-
-const parseSidebarConfigState = (data: string): SidebarConfigState => {
-  try {
-    return JSON.parse(data)
-  } catch (e) {
-    return {}
-  }
 }
 
 const buildStudySidebarSections = (


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds ability to customize what you see on your sidebar. Could be cool to also be able to drag n drop reorder but that's definitely a lot harder (but possible!)

Right now, this is just stored in local storage. However, I could imagine a world where this is sent to the backend as part of the user's settings just as a json blob that gets refreshed upon logging in.

<img width="356" alt="Screenshot 2025-02-03 at 2 36 01 PM" src="https://github.com/user-attachments/assets/bbe50264-a467-40f9-8bc3-90e3115fb6c7" />

<img width="356" alt="Screenshot 2025-02-03 at 2 36 04 PM" src="https://github.com/user-attachments/assets/0bd7989c-fb57-4be1-ba7f-fe43ebe8ec6e" />


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- populate at least 2 studies
- edit sidebar (i.e. hide some stuff) in one study
- go to another study, observe stuff isn't hidden then
- hide some other stuff in the other study
- switch between them and observe that state is study-specific
- refresh, exit chrome, etc., ensure it remembers state