### PR TITLE
[JN-1604] sex at birth admin UX

### DIFF
--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeProfile.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeProfile.tsx
@@ -116,6 +116,7 @@ function ReadOnlyProfile(
                    `${profile.givenName || ''} ${profile.familyName || ''}`.trim()
       ]}/>
     <InfoCardValue title={'Birthdate'} values={[dateToDefaultString(profile.birthDate)]}/>
+    <InfoCardValue title={'Sex at Birth'} values={[profile.sexAtBirth || '']}/>
     <ReadOnlyMailingAddress title={'Primary Address'} mailingAddress={mailingAddress}/>
     <InfoCardValue title={'Email'} values={[profile.contactEmail || '']}/>
     <InfoCardValue title={'Phone'} values={[profile.phoneNumber || '']}/>

--- a/ui-admin/src/study/participants/participantList/facets/EnrolleeSearchFacets.tsx
+++ b/ui-admin/src/study/participants/participantList/facets/EnrolleeSearchFacets.tsx
@@ -167,7 +167,8 @@ const SexAssignedAtBirthFacet = ({ searchState, updateSearchState }: {
       isMulti={true}
       options={[
         { label: 'female', value: 'female' },
-        { label: 'male', value: 'male' }
+        { label: 'male', value: 'male' },
+        { label: 'intersex', value: 'intersex' }
       ]}
       value={searchState.sexAtBirth.map(s => ({ label: s, value: s }))}
       onChange={selectedOptions => {

--- a/ui-admin/src/util/table/columnUtils.tsx
+++ b/ui-admin/src/util/table/columnUtils.tsx
@@ -168,15 +168,18 @@ export const getDynamicColumn = <T extends EnrolleeSearchExpressionResult, >(fac
       }
     }
   } else {
-    return {
+    const colDef: ColumnDef<T> = {
       id: field,
       header: _startCase(field.replace('.', ' ')),
       accessorKey: field,
-      cell: cellFn,
       meta: {
         columnType
       }
     }
+    if (cellFn) {
+      colDef.cell = cellFn
+    }
+    return colDef
   }
 }
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Some cleanups related to sex at birth in the admin tool.  This fixes it as a search column display, and adds it to the readonly profile view.  It is not editable, since that's a field assumed to be driven by surveys.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants?search=%7B%22includeFacetKeys%22%3A%5B%22profile.sexAtBirth%22%5D%7D.  Confirm you see some values in the "Sex at birth" column
2.  go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants/HDSALK/profile , confirm the sex at birth for Jonas Salk appears