### PR TITLE
[JN-1594] fix printing + consolidate surveyjs variables

### DIFF
--- a/ui-admin/src/forms/FormPreview.tsx
+++ b/ui-admin/src/forms/FormPreview.tsx
@@ -4,9 +4,11 @@ import 'survey-core/survey.i18n'
 
 import {
   applyMarkdown,
+  applySurveyJsVariables,
   createAddressValidator,
   FormContent,
   PortalEnvironmentLanguage,
+  Profile,
   surveyJSModelFromFormContent,
   useForceUpdate,
   useI18n
@@ -34,9 +36,17 @@ export const FormPreview = (props: FormPreviewProps) => {
     // as the pages not being url-routable
     const model = surveyJSModelFromFormContent(formContent)
     model.setVariable('portalEnvironmentName', 'sandbox')
-    model.setVariable('profile', { })
-    model.setVariable('proxyProfile', { })
-    model.setVariable('isGovernedUser', false)
+    applySurveyJsVariables(model, {
+      profile: {} as Profile,
+      studyEnvParams: {
+        studyShortcode: 'TEST_STUDY',
+        envName: 'sandbox',
+        portalShortcode: 'TEST_PORTAL'
+      },
+      enrolleeShortcode: '',
+      referencedAnswers: [],
+      extraVariables: {}
+    })
     model.ignoreValidation = true
     model.locale = currentLanguage.languageCode
     model.onTextMarkdown.add(applyMarkdown)

--- a/ui-admin/src/forms/FormPreview.tsx
+++ b/ui-admin/src/forms/FormPreview.tsx
@@ -17,6 +17,7 @@ import {
 import { FormPreviewOptions } from './FormPreviewOptions'
 import Api from 'api/api'
 import useUpdateEffect from '../util/useUpdateEffect'
+import { useStudyEnvParamsFromPath } from 'study/StudyEnvironmentRouter'
 
 type FormPreviewProps = {
   formContent: FormContent
@@ -35,14 +36,9 @@ export const FormPreview = (props: FormPreviewProps) => {
     // note that this roughly mimics surveyUtils.newSurveyJSModel but with key differences, such
     // as the pages not being url-routable
     const model = surveyJSModelFromFormContent(formContent)
-    model.setVariable('portalEnvironmentName', 'sandbox')
     applySurveyJsVariables(model, {
       profile: {} as Profile,
-      studyEnvParams: {
-        studyShortcode: 'TEST_STUDY',
-        envName: 'sandbox',
-        portalShortcode: 'TEST_PORTAL'
-      },
+      studyEnvParams: useStudyEnvParamsFromPath(),
       enrolleeShortcode: '',
       referencedAnswers: [],
       extraVariables: {}

--- a/ui-core/src/components/forms/PagedSurveyView.tsx
+++ b/ui-core/src/components/forms/PagedSurveyView.tsx
@@ -167,8 +167,14 @@ export function PagedSurveyView({
   }
 
   const { surveyModel, refreshSurvey } = useSurveyJSModel(
-    form, resumableData, onComplete, pager, studyEnvParams,
-    enrollee.shortcode, enrollee.profile, proxyProfile, referencedAnswers
+    form, resumableData, onComplete, pager, {
+      studyEnvParams,
+      enrolleeShortcode: enrollee.shortcode,
+      profile: enrollee.profile,
+      proxyProfile,
+      referencedAnswers,
+      extraVariables: {}
+    }
   )
 
   surveyModel.locale = selectedLanguage

--- a/ui-core/src/surveyUtils.tsx
+++ b/ui-core/src/surveyUtils.tsx
@@ -14,7 +14,8 @@ import {
 } from 'survey-core'
 
 import {
-  Answer, AnswerFormat,
+  Answer,
+  AnswerFormat,
   FormContent,
   FormElement,
   Survey,
@@ -91,6 +92,40 @@ export const surveyJSModelFromFormContent = (formContent: FormContent): SurveyMo
   const model = new SurveyModel(formContentClone)
   applyDefaultSurveyConfig(model)
   return model
+}
+
+export type SurveyJsVariableContext = {
+  profile?: Profile,
+  proxyProfile?: Profile,
+  studyEnvParams?: StudyEnvParams,
+  environmentName?: string,
+  enrolleeShortcode?: string,
+  referencedAnswers?: Answer[],
+  extraVariables?: Record<string, unknown>
+}
+
+export const applySurveyJsVariables = (surveyModel: SurveyModel, varContext: SurveyJsVariableContext) => {
+  const {
+    profile, proxyProfile, studyEnvParams, enrolleeShortcode, extraVariables, referencedAnswers, environmentName
+  } = varContext
+
+  // if you add any new variables that are objects (e.g. {profile.givenName}), make sure you add
+  // them to the list of non-survey object variables in SurveyParseUtils
+  surveyModel.setVariable('profile', profile)
+  surveyModel.setVariable('proxyProfile', proxyProfile)
+  surveyModel.setVariable('isGovernedUser', !isNil(proxyProfile))
+  surveyModel.setVariable('studyEnvParams', studyEnvParams)
+  surveyModel.setVariable('enrolleeShortcode', enrolleeShortcode)
+  surveyModel.setVariable('portalEnvironmentName', environmentName || studyEnvParams?.envName)
+  referencedAnswers?.forEach(answer => {
+    surveyModel.setVariable(`${answer.surveyStableId}.${answer.questionStableId}`,
+      answer.stringValue ?? answer.numberValue ?? answer.booleanValue ?? answer.objectValue)
+  })
+  if (!isNil(extraVariables)) {
+    Object.keys(extraVariables).forEach(key => {
+      surveyModel.setVariable(key, extraVariables[key])
+    })
+  }
 }
 
 /** Get a VersionedForm's form content. */
@@ -312,7 +347,6 @@ export function useRoutablePageNumber(): PageNumberControl {
 
 type UseSurveyJsModelOpts = {
   extraCssClasses?: Record<string, string>,
-  extraVariables?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 /**
@@ -329,11 +363,7 @@ type UseSurveyJsModelOpts = {
  * survey on completion and display a completion banner.  To continue displaying the form, use the
  * `refreshSurvey` function
  * @param pager the control object for paging the survey
- * @param studyEnvParams
- * @param enrolleeShortcode
- * @param profile
- * @param proxyProfile
- * @param referencedAnswers
+ * @param varContext context for variables to be used in the survey
  * @param opts optional configuration for the survey
  * @param opts.extraCssClasses mapping of element to CSS classes to add to that element. See
  * https://surveyjs.io/form-library/examples/survey-customcss/reactjs#content-docs for a list of available elements.
@@ -343,16 +373,11 @@ export function useSurveyJSModel(
   resumeData: SurveyJsResumeData | null,
   onComplete: () => void,
   pager: PageNumberControl,
-  studyEnvParams: StudyEnvParams,
-  enrolleeShortcode: string,
-  profile?: Profile,
-  proxyProfile?: Profile,
-  referencedAnswers: Answer[] = [],
+  varContext: SurveyJsVariableContext,
   opts: UseSurveyJsModelOpts = {}
 ) {
   const {
-    extraCssClasses = {},
-    extraVariables = {}
+    extraCssClasses = {}
   } = opts
 
   const Api = useApiContext()
@@ -390,21 +415,8 @@ export function useSurveyJSModel(
     }
     newSurveyModel.currentPageNo = pageNumber
 
-    // if you add any new variables that are objects (e.g. {profile.givenName}), make sure you add
-    // them to the list of non-survey object variables in SurveyParseUtils
-    newSurveyModel.setVariable('profile', profile)
-    newSurveyModel.setVariable('proxyProfile', proxyProfile)
-    newSurveyModel.setVariable('isGovernedUser', !isNil(proxyProfile))
-    newSurveyModel.setVariable('studyEnvParams', studyEnvParams)
-    newSurveyModel.setVariable('enrolleeShortcode', enrolleeShortcode)
-    newSurveyModel.setVariable('portalEnvironmentName', studyEnvParams.envName)
-    referencedAnswers.forEach(answer => {
-      newSurveyModel.setVariable(`${answer.surveyStableId}.${answer.questionStableId}`,
-        answer.stringValue ?? answer.numberValue ?? answer.booleanValue ?? answer.objectValue)
-    })
-    Object.keys(extraVariables).forEach(key => {
-      newSurveyModel.setVariable(key, extraVariables[key])
-    })
+    applySurveyJsVariables(newSurveyModel, varContext)
+
     newSurveyModel.onComplete.add(onComplete)
     newSurveyModel.onCurrentPageChanged.add(handlePageChanged)
     newSurveyModel.onTextMarkdown.add(applyMarkdown)

--- a/ui-core/src/surveyUtils.tsx
+++ b/ui-core/src/surveyUtils.tsx
@@ -36,7 +36,7 @@ import { Markdown } from './participant/landing/Markdown'
 import { useI18n } from './participant/I18nProvider'
 import { createAddressValidator } from './surveyjs/address-validator'
 import { useApiContext } from './participant/ApiProvider'
-import { StudyEnvParams } from './types/study'
+import { OptionalStudyEnvParams } from './types/study'
 import { Profile } from 'src/types/user'
 import { DefaultLight } from 'survey-core/themes'
 
@@ -97,7 +97,7 @@ export const surveyJSModelFromFormContent = (formContent: FormContent): SurveyMo
 export type SurveyJsVariableContext = {
   profile?: Profile,
   proxyProfile?: Profile,
-  studyEnvParams?: StudyEnvParams,
+  studyEnvParams?: OptionalStudyEnvParams,
   environmentName?: string,
   enrolleeShortcode?: string,
   referencedAnswers?: Answer[],

--- a/ui-participant/src/hub/survey/PrintSurveyView.tsx
+++ b/ui-participant/src/hub/survey/PrintSurveyView.tsx
@@ -13,6 +13,7 @@ import {
   applySurveyJsVariables,
   configureModelForPrint,
   Enrollee,
+  EnvironmentName,
   makeSurveyJsData,
   surveyJSModelFromForm,
   useTaskIdParam,
@@ -25,6 +26,7 @@ import { useUser } from 'providers/UserProvider'
 import { DocumentTitle } from 'util/DocumentTitle'
 import { PageLoadingIndicator } from 'util/LoadingSpinner'
 import { enrolleeForStudy } from './SurveyView'
+import { useActiveUser } from 'providers/ActiveUserProvider'
 
 
 type UsePrintableConsentArgs = {
@@ -42,8 +44,11 @@ const usePrintableSurvey = (args: UsePrintableConsentArgs) => {
 
   const {
     user,
-    enrollees
+    enrollees: allEnrollees
   } = useUser()
+
+  const { ppUser } = useActiveUser()
+
 
   const [loading, setLoading] = useState(true)
   const [surveyModel, setSurveyModel] = useState<Model | null>(null)
@@ -70,14 +75,16 @@ const usePrintableSurvey = (args: UsePrintableConsentArgs) => {
       configureModelForPrint(surveyModel)
       surveyModel.setVariable('portalEnvironmentName', portalEnv.environmentName)
 
+      const proxyProfile = ppUser?.participantUserId != user?.id ? allEnrollees
+        .find(enrollee => enrollee.participantUserId === user?.id && enrollee.profile)
+        ?.profile : undefined
+
       applySurveyJsVariables(surveyModel, {
         profile: enrollee.profile,
-        proxyProfile: enrollee.participantUserId !== user?.id
-          ? enrollees.find(enrollee => enrollee.participantUserId === user?.id)?.profile
-          : undefined,
+        proxyProfile,
         studyEnvParams: {
           studyShortcode,
-          environmentName: portalEnv.environmentName,
+          environmentName: portalEnv.environmentName as EnvironmentName,
           portalShortcode: portal.shortcode
         },
         enrolleeShortcode: enrollee.shortcode,

--- a/ui-participant/src/hub/survey/PrintSurveyView.tsx
+++ b/ui-participant/src/hub/survey/PrintSurveyView.tsx
@@ -1,13 +1,21 @@
-import React, { useEffect, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import React, {
+  useEffect,
+  useState
+} from 'react'
+import {
+  useNavigate,
+  useParams
+} from 'react-router-dom'
 import { Model } from 'survey-core'
 import { Survey as SurveyComponent } from 'survey-react-ui'
 
 import {
+  applySurveyJsVariables,
   configureModelForPrint,
   Enrollee,
   makeSurveyJsData,
-  surveyJSModelFromForm, useTaskIdParam,
+  surveyJSModelFromForm,
+  useTaskIdParam,
   waitForImages
 } from '@juniper/ui-core'
 
@@ -30,7 +38,12 @@ type UsePrintableConsentArgs = {
 const usePrintableSurvey = (args: UsePrintableConsentArgs) => {
   const { studyShortcode, enrollee, stableId, version } = args
 
-  const { portalEnv } = usePortalEnv()
+  const { portalEnv, portal } = usePortalEnv()
+
+  const {
+    user,
+    enrollees
+  } = useUser()
 
   const [loading, setLoading] = useState(true)
   const [surveyModel, setSurveyModel] = useState<Model | null>(null)
@@ -56,6 +69,21 @@ const usePrintableSurvey = (args: UsePrintableConsentArgs) => {
       surveyModel.data = resumableData?.data
       configureModelForPrint(surveyModel)
       surveyModel.setVariable('portalEnvironmentName', portalEnv.environmentName)
+
+      applySurveyJsVariables(surveyModel, {
+        profile: enrollee.profile,
+        proxyProfile: enrollee.participantUserId !== user?.id
+          ? enrollees.find(enrollee => enrollee.participantUserId === user?.id)?.profile
+          : undefined,
+        studyEnvParams: {
+          studyShortcode,
+          environmentName: portalEnv.environmentName,
+          portalShortcode: portal.shortcode
+        },
+        enrolleeShortcode: enrollee.shortcode,
+        referencedAnswers: [],
+        extraVariables: {}
+      })
 
       return surveyModel
     }

--- a/ui-participant/src/hub/survey/PrintSurveyView.tsx
+++ b/ui-participant/src/hub/survey/PrintSurveyView.tsx
@@ -73,7 +73,6 @@ const usePrintableSurvey = (args: UsePrintableConsentArgs) => {
       surveyModel.title = form.name
       surveyModel.data = resumableData?.data
       configureModelForPrint(surveyModel)
-      surveyModel.setVariable('portalEnvironmentName', portalEnv.environmentName)
 
       const proxyProfile = ppUser?.participantUserId != user?.id ? allEnrollees
         .find(enrollee => enrollee.participantUserId === user?.id && enrollee.profile)

--- a/ui-participant/src/hub/survey/PrintSurveyView.tsx
+++ b/ui-participant/src/hub/survey/PrintSurveyView.tsx
@@ -84,7 +84,7 @@ const usePrintableSurvey = (args: UsePrintableConsentArgs) => {
         proxyProfile,
         studyEnvParams: {
           studyShortcode,
-          environmentName: portalEnv.environmentName as EnvironmentName,
+          envName: portalEnv.environmentName as EnvironmentName,
           portalShortcode: portal.shortcode
         },
         enrolleeShortcode: enrollee.shortcode,

--- a/ui-participant/src/landing/registration/Preregistration.tsx
+++ b/ui-participant/src/landing/registration/Preregistration.tsx
@@ -1,8 +1,16 @@
 import React from 'react'
-import Api, { PreregistrationResponse, Survey } from 'api/api'
+import Api, {
+  PreregistrationResponse,
+  Survey
+} from 'api/api'
 import { RegistrationContextT } from './PortalRegistrationRouter'
 import { useNavigate } from 'react-router-dom'
-import { EnvironmentName, getResumeData, getSurveyJsAnswerList, useI18n, useSurveyJSModel } from '@juniper/ui-core'
+import {
+  getResumeData,
+  getSurveyJsAnswerList,
+  useI18n,
+  useSurveyJSModel
+} from '@juniper/ui-core'
 import { usePortalEnv } from 'providers/PortalProvider'
 
 /** Renders a preregistration form, and handles submitting the user-inputted response */
@@ -15,7 +23,9 @@ export default function PreRegistration({ registrationContext }: { registrationC
   // for now, we assume all pre-screeners are a single page
   const pager = { pageNumber: 0, updatePageNumber: () => 0 }
   const { surveyModel, refreshSurvey, SurveyComponent } =
-    useSurveyJSModel(survey, null, handleComplete, pager, portalEnv.environmentName as EnvironmentName)
+    useSurveyJSModel(survey, null, handleComplete, pager, {
+      environmentName: portalEnv.environmentName
+    })
 
   surveyModel.locale = selectedLanguage || 'default'
 

--- a/ui-participant/src/landing/registration/RegistrationUnauthed.tsx
+++ b/ui-participant/src/landing/registration/RegistrationUnauthed.tsx
@@ -64,7 +64,8 @@ export default function RegistrationUnauthed({ registrationContext, returnTo }: 
   const { portalEnv } = usePortalEnv()
   // for now, assume registration surveys are a single page
   const pager = { pageNumber: 0, updatePageNumber: () => 0 }
-  const { surveyModel, refreshSurvey } = useSurveyJSModel(registrationSurveyModel, null, onComplete, pager, portalEnv.environmentName as EnvironmentName)
+  const { surveyModel, refreshSurvey } = useSurveyJSModel(registrationSurveyModel, null, onComplete, pager,
+    { environmentName: portalEnv.environmentName as EnvironmentName })
   const { loginUser } = useUser()
   const { selectedLanguage } = useI18n()
   const navigate = useNavigate()

--- a/ui-participant/src/studies/enroll/PreEnroll.tsx
+++ b/ui-participant/src/studies/enroll/PreEnroll.tsx
@@ -7,7 +7,8 @@ import { useNavigate } from 'react-router-dom'
 import { StudyEnrollContext } from './StudyEnrollRouter'
 import {
   getResumeData,
-  getSurveyJsAnswerList, makeSurveyJsData,
+  getSurveyJsAnswerList,
+  makeSurveyJsData,
   SurveyAutoCompleteButton,
   SurveyReviewModeButton,
   useI18n,
@@ -35,9 +36,13 @@ export default function PreEnrollView({ enrollContext, survey }:
     portalShortcode
   } = enrollContext
   const { selectedLanguage } = useI18n()
-  const { profile } = useActiveUser()
-  const { user, enrollees } = useUser()
-  const proxyProfile = enrollees.find(enrollee => enrollee.participantUserId === user?.id && enrollee.profile)?.profile
+  const { profile, enrollees: activeEnrollees } = useActiveUser()
+  const { user, enrollees: allEnrollees } = useUser()
+
+  const enrollee = activeEnrollees
+    .find(enrollee => enrollee.studyEnvironmentId === studyEnv.id)
+  const proxyProfile = allEnrollees
+    .find(enrollee => enrollee.participantUserId === user?.id && enrollee.profile)?.profile
   const navigate = useNavigate()
   // for now, we assume all pre-screeners are a single page
   const pager = { pageNumber: 0, updatePageNumber: () => 0 }
@@ -50,12 +55,15 @@ export default function PreEnrollView({ enrollContext, survey }:
     resumeData,
     handleComplete,
     pager,
-    { envName: studyEnv.environmentName, studyShortcode, portalShortcode },
-    '',
-    profile || undefined,
-    proxyProfile,
-    [],
-    { extraCssClasses: { container: 'my-0' }, extraVariables: { isProxyEnrollment, isSubjectEnrollment } }
+    {
+      profile: profile || undefined,
+      proxyProfile,
+      studyEnvParams: { envName: studyEnv.environmentName, studyShortcode, portalShortcode },
+      enrolleeShortcode: enrollee?.shortcode || '',
+      referencedAnswers: [],
+      extraVariables: { isProxyEnrollment, isSubjectEnrollment }
+    },
+    { extraCssClasses: { container: 'my-0' } }
   )
 
   surveyModel.locale = selectedLanguage || 'default'

--- a/ui-participant/src/util/surveyJsUtils.test.tsx
+++ b/ui-participant/src/util/surveyJsUtils.test.tsx
@@ -1,15 +1,25 @@
 import React from 'react'
 
-import { act, render, screen } from '@testing-library/react'
+import {
+  act,
+  render,
+  screen
+} from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { Survey } from 'api/api'
 
 import { Survey as SurveyComponent } from 'survey-react-ui'
-import { generateSurvey, generateThreePageSurvey } from '../test-utils/test-survey-factory'
+import {
+  generateSurvey,
+  generateThreePageSurvey
+} from '../test-utils/test-survey-factory'
 import { Model } from 'survey-core'
 import { usePortalEnv } from 'providers/PortalProvider'
 import {
-  asMockedFn, EnvironmentName, getSurveyJsAnswerList, getUpdatedAnswers,
+  asMockedFn,
+  EnvironmentName,
+  getSurveyJsAnswerList,
+  getUpdatedAnswers,
   MockI18nProvider,
   Profile,
   setupRouterTest,
@@ -18,9 +28,15 @@ import {
 } from '@juniper/ui-core'
 import { mockUsePortalEnv } from '../test-utils/test-portal-factory'
 import { useUser } from '../providers/UserProvider'
-import { mockUseActiveUser, mockUseUser } from '../test-utils/user-mocking-utils'
+import {
+  mockUseActiveUser,
+  mockUseUser
+} from '../test-utils/user-mocking-utils'
 import { useActiveUser } from '../providers/ActiveUserProvider'
-import { mockEnrollee, mockProfile } from '../test-utils/test-participant-factory'
+import {
+  mockEnrollee,
+  mockProfile
+} from '../test-utils/test-participant-factory'
 
 jest.mock('providers/PortalProvider', () => ({ usePortalEnv: jest.fn() }))
 jest.mock('providers/UserProvider')
@@ -39,9 +55,7 @@ function PlainSurveyComponent({ formModel, profile }: { formModel: Survey, profi
     null,
     () => 1,
     pager,
-    mockStudyEnvParams,
-    mockEnrollee().shortcode,
-    profile)
+    { profile, enrolleeShortcode: mockEnrollee().shortcode, studyEnvParams: mockStudyEnvParams })
 
   return <div>
     {surveyModel && <SurveyComponent model={surveyModel}/>}
@@ -230,96 +244,102 @@ test('gets checkbox answers from survey model', () => {
 })
 
 test('testGetUpdatedAnswersEmpty', () => {
-  expect(getUpdatedAnswers(null, {}, {})).toEqual([])
+  expect(getUpdatedAnswers(null as unknown as Model, {}, {})).toEqual([])
 })
 
 test('testGetUpdatedAnswersRemovedValue', () => {
-  const updatedAnswers = getUpdatedAnswers(null, { 'foo': 'bar' }, {})
+  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': 'bar' }, {})
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo' }])
 })
 
 test('testGetUpdatedAnswersStringNew', () => {
-  const updatedAnswers = getUpdatedAnswers(null, {}, { 'foo': 'bar' })
+  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, {}, { 'foo': 'bar' })
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo', stringValue: 'bar' }])
 })
 
 
 test('testGetUpdatedAnswersStringUnchanged', () => {
-  const updatedAnswers = getUpdatedAnswers(null, { 'foo': 'bar' }, { 'foo': 'bar' })
+  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': 'bar' }, { 'foo': 'bar' })
   expect(updatedAnswers).toEqual([])
 })
 
 
 test('testGetUpdatedAnswersStringUpdated', () => {
-  const updatedAnswers = getUpdatedAnswers(null, { 'foo': 'bar' }, { 'foo': 'baz' })
+  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': 'bar' }, { 'foo': 'baz' })
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo', stringValue: 'baz' }])
 })
 
 test('testGetUpdatedAnswersOtherAdded', () => {
-  const updatedAnswers = getUpdatedAnswers(null, { 'foo': 'bar' }, { 'foo': 'baz', 'foo-Comment': 'blah' })
+  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': 'bar' }, {
+    'foo': 'baz',
+    'foo-Comment': 'blah'
+  })
   expect(updatedAnswers).toEqual([
     { format: 'NONE', questionStableId: 'foo', stringValue: 'baz', otherDescription: 'blah' }
   ])
 })
 
 test('testGetUpdatedAnswersOtherRemoved', () => {
-  const updatedAnswers = getUpdatedAnswers(null, { 'foo': 'bar', 'foo-Comment': 'blah' }, { 'foo': 'baz' })
+  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, {
+    'foo': 'bar',
+    'foo-Comment': 'blah'
+  }, { 'foo': 'baz' })
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo', stringValue: 'baz' }])
 })
 
 test('testGetUpdatedAnswersOtherChanged', () => {
-  const updatedAnswers = getUpdatedAnswers(null, { 'foo': 'bar', 'foo-Comment': 'blah' },
+  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': 'bar', 'foo-Comment': 'blah' },
     { 'foo': 'baz', 'foo-Comment': 'blah2' })
   expect(updatedAnswers).toEqual(
     [{ format: 'NONE', questionStableId: 'foo', stringValue: 'baz', otherDescription: 'blah2' }])
 })
 
 test('testGetUpdatedAnswersBooleanNew', () => {
-  const updatedAnswers = getUpdatedAnswers(null, {}, { 'foo': false })
+  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, {}, { 'foo': false })
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo', booleanValue: false }])
 })
 
 test('testGetUpdatedAnswersBooleanUnchanged', () => {
-  const updatedAnswers = getUpdatedAnswers(null, { 'foo': false }, { 'foo': false })
+  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': false }, { 'foo': false })
   expect(updatedAnswers).toEqual([])
 })
 
 test('testGetUpdatedAnswersBooleanChanged', () => {
-  const updatedAnswers = getUpdatedAnswers(null, { 'foo': true }, { 'foo': false })
+  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': true }, { 'foo': false })
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo', booleanValue: false }])
 })
 
 test('testGetUpdatedAnswersObjectNew', () => {
-  const updatedAnswers = getUpdatedAnswers(null, {}, { 'foo': ['bleck'] })
+  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, {}, { 'foo': ['bleck'] })
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo', objectValue: JSON.stringify(['bleck']) }])
 })
 
 test('testGetUpdatedAnswersObjectChanged', () => {
-  const updatedAnswers = getUpdatedAnswers(null, { 'foo': ['blah'] }, { 'foo': ['bleck'] })
+  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': ['blah'] }, { 'foo': ['bleck'] })
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo', objectValue: JSON.stringify(['bleck']) }])
 })
 
 test('testGetUpdatedAnswersObjectUnchanged', () => {
-  const updatedAnswers = getUpdatedAnswers(null, { 'foo': ['blah'] }, { 'foo': ['blah'] })
+  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': ['blah'] }, { 'foo': ['blah'] })
   expect(updatedAnswers).toEqual([])
 })
 
 test('testGetUpdatedAnswersNumberNew', () => {
-  const updatedAnswers = getUpdatedAnswers(null, {}, { 'foo': 2 })
+  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, {}, { 'foo': 2 })
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo', numberValue: 2 }])
 })
 
 test('testGetUpdatedAnswersNumberNewZero', () => {
-  const updatedAnswers = getUpdatedAnswers(null, {}, { 'foo': 0 })
+  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, {}, { 'foo': 0 })
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo', numberValue: 0 }])
 })
 
 test('testGetUpdatedAnswersNumberChanged', () => {
-  const updatedAnswers = getUpdatedAnswers(null, { 'foo': 2 }, { 'foo': 3 })
+  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': 2 }, { 'foo': 3 })
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo', numberValue: 3 }])
 })
 
 test('testGetUpdatedAnswersNumberUnchanged', () => {
-  const updatedAnswers = getUpdatedAnswers(null, { 'foo': 4 }, { 'foo': 4 })
+  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': 4 }, { 'foo': 4 })
   expect(updatedAnswers).toEqual([])
 })

--- a/ui-participant/src/util/surveyJsUtils.test.tsx
+++ b/ui-participant/src/util/surveyJsUtils.test.tsx
@@ -243,34 +243,35 @@ test('gets checkbox answers from survey model', () => {
   })
 })
 
+const nullModel: Model = null as unknown as Model
 test('testGetUpdatedAnswersEmpty', () => {
-  expect(getUpdatedAnswers(null as unknown as Model, {}, {})).toEqual([])
+  expect(getUpdatedAnswers(nullModel, {}, {})).toEqual([])
 })
 
 test('testGetUpdatedAnswersRemovedValue', () => {
-  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': 'bar' }, {})
+  const updatedAnswers = getUpdatedAnswers(nullModel, { 'foo': 'bar' }, {})
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo' }])
 })
 
 test('testGetUpdatedAnswersStringNew', () => {
-  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, {}, { 'foo': 'bar' })
+  const updatedAnswers = getUpdatedAnswers(nullModel, {}, { 'foo': 'bar' })
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo', stringValue: 'bar' }])
 })
 
 
 test('testGetUpdatedAnswersStringUnchanged', () => {
-  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': 'bar' }, { 'foo': 'bar' })
+  const updatedAnswers = getUpdatedAnswers(nullModel, { 'foo': 'bar' }, { 'foo': 'bar' })
   expect(updatedAnswers).toEqual([])
 })
 
 
 test('testGetUpdatedAnswersStringUpdated', () => {
-  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': 'bar' }, { 'foo': 'baz' })
+  const updatedAnswers = getUpdatedAnswers(nullModel, { 'foo': 'bar' }, { 'foo': 'baz' })
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo', stringValue: 'baz' }])
 })
 
 test('testGetUpdatedAnswersOtherAdded', () => {
-  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': 'bar' }, {
+  const updatedAnswers = getUpdatedAnswers(nullModel, { 'foo': 'bar' }, {
     'foo': 'baz',
     'foo-Comment': 'blah'
   })
@@ -280,7 +281,7 @@ test('testGetUpdatedAnswersOtherAdded', () => {
 })
 
 test('testGetUpdatedAnswersOtherRemoved', () => {
-  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, {
+  const updatedAnswers = getUpdatedAnswers(nullModel, {
     'foo': 'bar',
     'foo-Comment': 'blah'
   }, { 'foo': 'baz' })
@@ -288,58 +289,58 @@ test('testGetUpdatedAnswersOtherRemoved', () => {
 })
 
 test('testGetUpdatedAnswersOtherChanged', () => {
-  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': 'bar', 'foo-Comment': 'blah' },
+  const updatedAnswers = getUpdatedAnswers(nullModel, { 'foo': 'bar', 'foo-Comment': 'blah' },
     { 'foo': 'baz', 'foo-Comment': 'blah2' })
   expect(updatedAnswers).toEqual(
     [{ format: 'NONE', questionStableId: 'foo', stringValue: 'baz', otherDescription: 'blah2' }])
 })
 
 test('testGetUpdatedAnswersBooleanNew', () => {
-  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, {}, { 'foo': false })
+  const updatedAnswers = getUpdatedAnswers(nullModel, {}, { 'foo': false })
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo', booleanValue: false }])
 })
 
 test('testGetUpdatedAnswersBooleanUnchanged', () => {
-  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': false }, { 'foo': false })
+  const updatedAnswers = getUpdatedAnswers(nullModel, { 'foo': false }, { 'foo': false })
   expect(updatedAnswers).toEqual([])
 })
 
 test('testGetUpdatedAnswersBooleanChanged', () => {
-  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': true }, { 'foo': false })
+  const updatedAnswers = getUpdatedAnswers(nullModel, { 'foo': true }, { 'foo': false })
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo', booleanValue: false }])
 })
 
 test('testGetUpdatedAnswersObjectNew', () => {
-  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, {}, { 'foo': ['bleck'] })
+  const updatedAnswers = getUpdatedAnswers(nullModel, {}, { 'foo': ['bleck'] })
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo', objectValue: JSON.stringify(['bleck']) }])
 })
 
 test('testGetUpdatedAnswersObjectChanged', () => {
-  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': ['blah'] }, { 'foo': ['bleck'] })
+  const updatedAnswers = getUpdatedAnswers(nullModel, { 'foo': ['blah'] }, { 'foo': ['bleck'] })
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo', objectValue: JSON.stringify(['bleck']) }])
 })
 
 test('testGetUpdatedAnswersObjectUnchanged', () => {
-  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': ['blah'] }, { 'foo': ['blah'] })
+  const updatedAnswers = getUpdatedAnswers(nullModel, { 'foo': ['blah'] }, { 'foo': ['blah'] })
   expect(updatedAnswers).toEqual([])
 })
 
 test('testGetUpdatedAnswersNumberNew', () => {
-  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, {}, { 'foo': 2 })
+  const updatedAnswers = getUpdatedAnswers(nullModel, {}, { 'foo': 2 })
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo', numberValue: 2 }])
 })
 
 test('testGetUpdatedAnswersNumberNewZero', () => {
-  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, {}, { 'foo': 0 })
+  const updatedAnswers = getUpdatedAnswers(nullModel, {}, { 'foo': 0 })
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo', numberValue: 0 }])
 })
 
 test('testGetUpdatedAnswersNumberChanged', () => {
-  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': 2 }, { 'foo': 3 })
+  const updatedAnswers = getUpdatedAnswers(nullModel, { 'foo': 2 }, { 'foo': 3 })
   expect(updatedAnswers).toEqual([{ format: 'NONE', questionStableId: 'foo', numberValue: 3 }])
 })
 
 test('testGetUpdatedAnswersNumberUnchanged', () => {
-  const updatedAnswers = getUpdatedAnswers(null as unknown as Model, { 'foo': 4 }, { 'foo': 4 })
+  const updatedAnswers = getUpdatedAnswers(nullModel, { 'foo': 4 }, { 'foo': 4 })
   expect(updatedAnswers).toEqual([])
 })


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Not all variables were populated when printing which caused problems for trcc.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Populate trcc from prod
- Ensure existing survey variable functionality didn't break:
   - Try out editing surveys in admin tool
   - Edit normal surveys
   - Make sure referenced answers still work - e.g. go to Massachusetts survey
   - Test out form preview
- Print consent as a self-enrolled user - make sure content is there and language is correct
- Print consent as a proxy - make sure content is there and language says "I/my child" 