### PR TITLE
[JN-1581] Speculative fix for DSM connection errors

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClient.java
@@ -15,12 +15,17 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.env.Environment;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 import jakarta.validation.Validator;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
+
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
@@ -43,9 +48,19 @@ public class LivePepperDSMClient implements PepperDSMClient {
                                ObjectMapper objectMapper,
                                Validator validator) {
         this.pepperDSMConfig = pepperDSMConfig;
-        this.webClient = webClientBuilder.build();
         this.objectMapper = objectMapper;
         this.validator = validator;
+
+        ConnectionProvider provider = ConnectionProvider.builder("dsm-connection-provider")
+                .maxConnections(500)
+                .maxIdleTime(Duration.ofSeconds(20))
+                .maxLifeTime(Duration.ofSeconds(500)) //lifetime for both active and idle connections, so let's keep it high
+                .pendingAcquireTimeout(Duration.ofSeconds(60))
+                .evictInBackground(Duration.ofSeconds(120)).build();
+
+        this.webClient = webClientBuilder
+                .clientConnector(new ReactorClientHttpConnector(HttpClient.create(provider)))
+                .build();
     }
 
     @Override

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClient.java
@@ -51,6 +51,7 @@ public class LivePepperDSMClient implements PepperDSMClient {
         this.objectMapper = objectMapper;
         this.validator = validator;
 
+        //this is a workaround for dsm connection issues, per https://github.com/reactor/reactor-netty/issues/1774
         ConnectionProvider provider = ConnectionProvider.builder("dsm-connection-provider")
                 .maxConnections(500)
                 .maxIdleTime(Duration.ofSeconds(20))


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

This is a speculative fixe based on discussion in https://github.com/reactor/reactor-netty/issues/1774

Unless there are objections to the actual code changes, I'd like to merge this ASAP because it's not possible to test if this actually fixes the problem locally, so we need to try it out on demo (and even then, it's difficult to predictably reproduce- but we can at least have some degree of confidence). This also gives us more than enough time to test before pushing to prod during next week's release.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Configure local OurHealth to use live DSM
Try sending a kit
Confirm it succeeds and there aren't any regressions requesting kits from DSM
Check DSM to be doubly-sure: https://dsm-dev.datadonationplatform.org/juniper-ourheart/shippingUploaded