### PR TITLE
[JN-1596] adding bidirectional links for viewing proxy relations

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeRelationController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/enrollee/EnrolleeRelationController.java
@@ -35,11 +35,11 @@ public class EnrolleeRelationController implements EnrolleeRelationApi {
   }
 
   @Override
-  public ResponseEntity<Object> findRelationsForTargetEnrollee(
+  public ResponseEntity<Object> findRelationsForEnrollee(
       String portalShortcode, String studyShortcode, String envName, String enrolleeShortcode) {
     AdminUser adminUser = authUtilService.requireAdminUser(request);
     List<EnrolleeRelation> relations =
-        enrolleeRelationExtService.findRelationsForTargetEnrollee(
+        enrolleeRelationExtService.findRelationsForEnrollee(
             PortalStudyEnvAuthContext.of(
                 adminUser,
                 portalShortcode,

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeRelationExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeRelationExtService.java
@@ -31,7 +31,7 @@ public class EnrolleeRelationExtService {
   }
 
   @EnforcePortalStudyEnvPermission(permission = "participant_data_view")
-  public List<EnrolleeRelation> findRelationsForTargetEnrollee(
+  public List<EnrolleeRelation> findRelationsForEnrollee(
       PortalStudyEnvAuthContext authContext, String enrolleeShortcode) {
 
     Enrollee enrollee =
@@ -41,7 +41,7 @@ public class EnrolleeRelationExtService {
                 authContext.getStudyShortcode(),
                 authContext.getEnvironmentName())
             .orElseThrow(() -> new NotFoundException("Enrollee not found"));
-    return enrolleeRelationService.findByTargetEnrolleeIdWithEnrolleesAndFamily(enrollee.getId());
+    return enrolleeRelationService.findByEnrolleeIdWithEnrolleesAndFamily(enrollee.getId());
   }
 
   @EnforcePortalStudyEnvPermission(permission = "participant_data_edit")

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -764,11 +764,11 @@ paths:
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
-  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/enrolleeRelations/byTarget/{enrolleeShortcode}:
+  /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/env/{envName}/enrolleeRelations/{enrolleeShortcode}:
     get:
-      summary: Finds all of the relations that the given enrollee is a target of. Includes the full enrollee objects.
+      summary: Finds all of the relations that the given enrollee is a target or subject of. Includes the full enrollee objects.
       tags: [ enrolleeRelation ]
-      operationId: findRelationsForTargetEnrollee
+      operationId: findRelationsForEnrollee
       parameters:
         - *portalShortcodeParam
         - *studyShortcodeParam

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeRelationExtServiceTest.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeRelationExtServiceTest.java
@@ -60,7 +60,7 @@ class EnrolleeRelationExtServiceTest extends BaseSpringBootTest {
         studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.sandbox);
 
     List<EnrolleeRelation> relations =
-        enrolleeRelationExtService.findRelationsForTargetEnrollee(
+        enrolleeRelationExtService.findRelationsForEnrollee(
             PortalStudyEnvAuthContext.of(
                 operator,
                 studyEnvBundle.getPortal().getShortcode(),
@@ -73,7 +73,7 @@ class EnrolleeRelationExtServiceTest extends BaseSpringBootTest {
     assertThrows(
         NotFoundException.class,
         () ->
-            enrolleeRelationExtService.findRelationsForTargetEnrollee(
+            enrolleeRelationExtService.findRelationsForEnrollee(
                 PortalStudyEnvAuthContext.of(
                     operator,
                     otherStudyEnv.getPortal().getShortcode(),
@@ -84,7 +84,7 @@ class EnrolleeRelationExtServiceTest extends BaseSpringBootTest {
     assertThrows(
         NotFoundException.class,
         () ->
-            enrolleeRelationExtService.findRelationsForTargetEnrollee(
+            enrolleeRelationExtService.findRelationsForEnrollee(
                 PortalStudyEnvAuthContext.of(
                     operator,
                     studyEnvBundle.getPortal().getShortcode(),

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeRelationExtServiceTest.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/enrollee/EnrolleeRelationExtServiceTest.java
@@ -40,7 +40,7 @@ class EnrolleeRelationExtServiceTest extends BaseSpringBootTest {
     AuthTestUtils.assertAllMethodsAnnotated(
         enrolleeRelationExtService,
         Map.of(
-            "findRelationsForTargetEnrollee",
+            "findRelationsForEnrollee",
                 AuthAnnotationSpec.withPortalStudyEnvPerm("participant_data_view"),
             "create", AuthAnnotationSpec.withPortalStudyEnvPerm("participant_data_edit"),
             "delete", AuthAnnotationSpec.withPortalStudyEnvPerm("participant_data_edit")));

--- a/core/src/main/java/bio/terra/pearl/core/model/participant/RelationshipType.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/participant/RelationshipType.java
@@ -2,7 +2,7 @@ package bio.terra.pearl.core.model.participant;
 
 public enum RelationshipType{
     PROXY, FAMILY;
-    public boolean isProxy(RelationshipType type) {
+    public static boolean isProxy(RelationshipType type) {
         return PROXY.equals(type);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
@@ -244,7 +244,7 @@ public class EnrolleeExportService {
                                                   Map<UUID, List<SurveyResponseWithTaskDto>> surveyResponses, Map<UUID, List<KitRequestDto>> kitRequests) {
 
         List<EnrolleeRelation> enrolleeRelations = loadRelations(config, enrollee);
-        List<ParticipantUser> proxies = loadProxyUsers(config, enrolleeRelations);
+        List<ParticipantUser> proxies = loadProxyUsers(config, enrolleeRelations, enrollee);
 
         return new EnrolleeExportData(
                 study,
@@ -264,10 +264,10 @@ public class EnrolleeExportService {
         );
     }
 
-    private List<ParticipantUser> loadProxyUsers(StudyEnvironmentConfig config, List<EnrolleeRelation> relations) {
+    private List<ParticipantUser> loadProxyUsers(StudyEnvironmentConfig config, List<EnrolleeRelation> relations, Enrollee enrollee) {
         if (config.isAcceptingProxyEnrollment()) {
             return relations.stream()
-                    .filter(relation -> relation.getRelationshipType().equals(RelationshipType.PROXY))
+                    .filter(relation -> relation.getRelationshipType().equals(RelationshipType.PROXY) && relation.getTargetEnrolleeId().equals(enrollee.getId()))
                     .map(relation -> participantUserService.findByEnrolleeId(relation.getEnrolleeId()).orElseThrow())
                     .toList();
         }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
@@ -277,10 +277,10 @@ public class EnrolleeExportService {
 
     private List<EnrolleeRelation> loadRelations(StudyEnvironmentConfig config, Enrollee enrollee) {
         if (config.isEnableFamilyLinkage()) {
-            return enrolleeRelationService.findByTargetEnrolleeIdWithEnrolleesAndFamily(enrollee.getId());
+            return enrolleeRelationService.findByEnrolleeIdWithEnrolleesAndFamily(enrollee.getId());
         }
         if (config.isAcceptingProxyEnrollment()) {
-            return enrolleeRelationService.findByTargetEnrolleeIdWithEnrollees(enrollee.getId());
+            return enrolleeRelationService.findByEnrolleeIdWithEnrollees(enrollee.getId());
         }
 
         // for performance reasons, we should grab nothing unless the study environment is configured to use

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeRelationFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeRelationFormatter.java
@@ -2,12 +2,12 @@ package bio.terra.pearl.core.service.export.formatters.module;
 
 import bio.terra.pearl.core.model.export.ExportOptions;
 import bio.terra.pearl.core.model.participant.EnrolleeRelation;
+import bio.terra.pearl.core.model.participant.RelationshipType;
 import bio.terra.pearl.core.service.export.EnrolleeExportData;
 import bio.terra.pearl.core.service.export.formatters.item.PropertyItemFormatter;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.experimental.SuperBuilder;
 import org.springframework.beans.BeanUtils;
 
 import java.util.Comparator;
@@ -17,7 +17,7 @@ import java.util.UUID;
 
 public class EnrolleeRelationFormatter extends BeanListModuleFormatter<EnrolleeRelationFormatter.EnrolleeRelationExport> {
     private static final List<String> INCLUDED_PROPERTIES =
-            List.of("otherEnrolleeShortcode", "isTarget", "relationshipType", "beginDate", "endDate", "familyRelationship", "family.shortcode");
+            List.of("otherEnrolleeShortcode", "relationship", "beginDate", "endDate", "familyRelationship", "family.shortcode");
 
     public EnrolleeRelationFormatter(ExportOptions exportOptions) {
         super(exportOptions, "relation",  "Relations");
@@ -36,7 +36,7 @@ public class EnrolleeRelationFormatter extends BeanListModuleFormatter<EnrolleeR
                     EnrolleeRelationExport relationExport = new EnrolleeRelationExport();
                     BeanUtils.copyProperties(relation, relationExport);
                     relationExport.setExportingEnrolleeId(enrolleeExportData.getEnrollee().getId());
-                    return relationExport
+                    return relationExport;
                 }).toList();
     }
 
@@ -52,17 +52,20 @@ public class EnrolleeRelationFormatter extends BeanListModuleFormatter<EnrolleeR
      */
     @Getter
     @Setter
-    @SuperBuilder
     @NoArgsConstructor
-    public class EnrolleeRelationExport extends EnrolleeRelation {
+    public static class EnrolleeRelationExport extends EnrolleeRelation {
         private UUID exportingEnrolleeId; // the enrollee corresponding to the current export row
         /** the shortcode of the enrollee in the relation who is not the exporting enrollee row */
         public String getOtherEnrolleeShortcode() {
             return exportingEnrolleeId.equals(getEnrolleeId()) ? getTargetEnrollee().getShortcode() : getEnrollee().getShortcode();
         }
 
-        public boolean isTarget() {
-            return exportingEnrolleeId.equals(getTargetEnrolleeId());
+        /** gets the type, but with description indicating directionality where appropriate */
+        public String getRelationship() {
+            if (RelationshipType.isProxy(getRelationshipType())) {
+                return exportingEnrolleeId.equals(getTargetEnrolleeId() ) ? "PROXY" : "PROXY_FOR";
+            }
+            return getRelationshipType().toString();
         }
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeRelationFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/EnrolleeRelationFormatter.java
@@ -4,33 +4,65 @@ import bio.terra.pearl.core.model.export.ExportOptions;
 import bio.terra.pearl.core.model.participant.EnrolleeRelation;
 import bio.terra.pearl.core.service.export.EnrolleeExportData;
 import bio.terra.pearl.core.service.export.formatters.item.PropertyItemFormatter;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.springframework.beans.BeanUtils;
 
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.UUID;
 
-public class EnrolleeRelationFormatter extends BeanListModuleFormatter<EnrolleeRelation> {
+public class EnrolleeRelationFormatter extends BeanListModuleFormatter<EnrolleeRelationFormatter.EnrolleeRelationExport> {
     private static final List<String> INCLUDED_PROPERTIES =
-            List.of("enrollee.shortcode", "relationshipType", "beginDate", "endDate", "familyRelationship", "family.shortcode");
+            List.of("otherEnrolleeShortcode", "isTarget", "relationshipType", "beginDate", "endDate", "familyRelationship", "family.shortcode");
 
     public EnrolleeRelationFormatter(ExportOptions exportOptions) {
         super(exportOptions, "relation",  "Relations");
     }
 
     @Override
-    protected List<PropertyItemFormatter<EnrolleeRelation>> generateItemFormatters(ExportOptions options) {
+    protected List<PropertyItemFormatter<EnrolleeRelationExport>> generateItemFormatters(ExportOptions options) {
         return INCLUDED_PROPERTIES.stream()
-                .map(propName -> new PropertyItemFormatter<>(propName, EnrolleeRelation.class, options.getZoneId()))
+                .map(propName -> new PropertyItemFormatter<>(propName, EnrolleeRelationExport.class, options.getZoneId()))
                 .collect(Collectors.toList());
     }
 
     @Override
-    public List<EnrolleeRelation> getBeans(EnrolleeExportData enrolleeExportData) {
-        return enrolleeExportData.getEnrolleeRelations();
+    public List<EnrolleeRelationExport> getBeans(EnrolleeExportData enrolleeExportData) {
+        return enrolleeExportData.getEnrolleeRelations().stream().map(relation -> {
+                    EnrolleeRelationExport relationExport = new EnrolleeRelationExport();
+                    BeanUtils.copyProperties(relation, relationExport);
+                    relationExport.setExportingEnrolleeId(enrolleeExportData.getEnrollee().getId());
+                    return relationExport
+                }).toList();
     }
 
     @Override
-    public Comparator<EnrolleeRelation> getComparator() {
+    public Comparator<EnrolleeRelationExport> getComparator() {
         return Comparator.comparing(EnrolleeRelation::getCreatedAt);
+    }
+
+
+    /**
+     * helper class for exporting relations so that columns can be formatted depending on whether the
+     * enrollee is the source or target of the relation
+     */
+    @Getter
+    @Setter
+    @SuperBuilder
+    @NoArgsConstructor
+    public class EnrolleeRelationExport extends EnrolleeRelation {
+        private UUID exportingEnrolleeId; // the enrollee corresponding to the current export row
+        /** the shortcode of the enrollee in the relation who is not the exporting enrollee row */
+        public String getOtherEnrolleeShortcode() {
+            return exportingEnrolleeId.equals(getEnrolleeId()) ? getTargetEnrollee().getShortcode() : getEnrollee().getShortcode();
+        }
+
+        public boolean isTarget() {
+            return exportingEnrolleeId.equals(getTargetEnrolleeId());
+        }
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeRelationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeRelationService.java
@@ -6,7 +6,6 @@ import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.EnrolleeRelation;
 import bio.terra.pearl.core.model.participant.Family;
 import bio.terra.pearl.core.model.participant.RelationshipType;
-import bio.terra.pearl.core.service.DataAuditedService;
 import bio.terra.pearl.core.service.ParticipantDataAuditedService;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.workflow.ParticipantDataChangeService;
@@ -60,8 +59,13 @@ public class EnrolleeRelationService extends ParticipantDataAuditedService<Enrol
         return filterValid(dao.findAllByEnrolleeId(enrolleeId));
     }
 
-    public List<EnrolleeRelation> findByTargetEnrolleeIdWithEnrolleesAndFamily(UUID enrolleeId) {
-        List<EnrolleeRelation> relations = this.findByTargetEnrolleeIdWithEnrollees(enrolleeId);
+    public <T extends EnrolleeRelation> List<T> findByEnrolleeIdWithEnrolleesAndFamily(UUID enrolleeId, Class<T> mappingClass) {
+        List<EnrolleeRelation> relations = this.findByEnrolleeIdWithEnrolleesAndFamily(enrolleeId, EnrolleeRelation.class);
+        return relations.stream().map(relation -> objectMapper.convertValue(relation, clazz)).toList();
+    }
+
+    public List<EnrolleeRelation> findByEnrolleeIdWithEnrolleesAndFamily(UUID enrolleeId) {
+        List<EnrolleeRelation> relations = this.findByEnrolleeIdWithEnrollees(enrolleeId);
         List<UUID> familyIds = relations
                 .stream()
                 .map(EnrolleeRelation::getFamilyId)
@@ -87,21 +91,24 @@ public class EnrolleeRelationService extends ParticipantDataAuditedService<Enrol
         return filterValid(dao.findAllByEnrolleeOrTargetId(enrolleeId));
     }
 
-    public List<EnrolleeRelation> findByTargetEnrolleeIdWithEnrollees(UUID enrolleeId) {
+    public List<EnrolleeRelation> findByEnrolleeIdWithEnrollees(UUID enrolleeId) {
         Enrollee target = this.enrolleeService.find(enrolleeId).orElseThrow(() -> new NotFoundException("Enrollee not found"));
         profileService
                 .loadWithMailingAddress(target.getProfileId())
                 .ifPresent(target::setProfile);
 
-        List<EnrolleeRelation> relations = findByTargetEnrolleeId(enrolleeId);
+        List<EnrolleeRelation> relations = findAllByEnrolleeId(enrolleeId);
 
         return relations.stream().map(relation -> {
-            relation.setTargetEnrollee(target);
-            relation.setEnrollee(this.enrolleeService.find(relation.getEnrolleeId()).orElse(null));
+            boolean enrolleeIsTarget = enrolleeId.equals(relation.getTargetEnrolleeId());
+            Enrollee relatedEnrollee = enrolleeIsTarget ?
+                    this.enrolleeService.find(relation.getEnrolleeId()).orElse(null) :
+                    this.enrolleeService.find(relation.getTargetEnrolleeId()).orElse(null);
             profileService
-                    .loadWithMailingAddress(relation.getEnrollee().getProfileId())
-                    .ifPresent(relation.getEnrollee()::setProfile);
-
+                    .loadWithMailingAddress(relatedEnrollee.getProfileId())
+                    .ifPresent(relatedEnrollee::setProfile);
+            relation.setTargetEnrollee(enrolleeIsTarget ? target : relatedEnrollee);
+            relation.setEnrollee(enrolleeIsTarget ? relatedEnrollee : target);
             return relation;
         }).toList();
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeRelationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeRelationService.java
@@ -59,11 +59,6 @@ public class EnrolleeRelationService extends ParticipantDataAuditedService<Enrol
         return filterValid(dao.findAllByEnrolleeId(enrolleeId));
     }
 
-    public <T extends EnrolleeRelation> List<T> findByEnrolleeIdWithEnrolleesAndFamily(UUID enrolleeId, Class<T> mappingClass) {
-        List<EnrolleeRelation> relations = this.findByEnrolleeIdWithEnrolleesAndFamily(enrolleeId, EnrolleeRelation.class);
-        return relations.stream().map(relation -> objectMapper.convertValue(relation, clazz)).toList();
-    }
-
     public List<EnrolleeRelation> findByEnrolleeIdWithEnrolleesAndFamily(UUID enrolleeId) {
         List<EnrolleeRelation> relations = this.findByEnrolleeIdWithEnrollees(enrolleeId);
         List<UUID> familyIds = relations
@@ -97,7 +92,7 @@ public class EnrolleeRelationService extends ParticipantDataAuditedService<Enrol
                 .loadWithMailingAddress(target.getProfileId())
                 .ifPresent(target::setProfile);
 
-        List<EnrolleeRelation> relations = findAllByEnrolleeId(enrolleeId);
+        List<EnrolleeRelation> relations = findAllByEnrolleeOrTargetId(enrolleeId);
 
         return relations.stream().map(relation -> {
             boolean enrolleeIsTarget = enrolleeId.equals(relation.getTargetEnrolleeId());

--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeExportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeExportServiceTests.java
@@ -282,7 +282,7 @@ public class EnrolleeExportServiceTests extends BaseSpringBootTest {
 
         // should export relation but not family data
         assertThat(exportMaps, hasSize(2));
-        assertThat(exportMaps.get(0).get("relation.relationshipType"), equalTo("PROXY"));
+        assertThat(exportMaps.get(0).get("relation.relationship"), equalTo("PROXY"));
         assertThat(exportMaps.get(0).containsKey("family.shortcode"), equalTo(false));
         assertThat(exportMaps.get(0).containsKey("family.shortcode"), equalTo(false));
     }
@@ -327,7 +327,7 @@ public class EnrolleeExportServiceTests extends BaseSpringBootTest {
         // no family or relation data should be exported because the study env config has neither enabled
         assertThat(exportMaps, hasSize(2));
         assertThat(exportMaps.get(0).containsKey("family.shortcode"), equalTo(false));
-        assertThat(exportMaps.get(0).containsKey("relation.relationshipType"), equalTo(false));
+        assertThat(exportMaps.get(0).containsKey("relation.relationship"), equalTo(false));
 
         // enable family data
         StudyEnvironmentConfig config = studyEnvironmentConfigService.findByStudyEnvironmentId(studyEnvId);
@@ -347,7 +347,7 @@ public class EnrolleeExportServiceTests extends BaseSpringBootTest {
         assertThat(exportMaps.get(1).get("family.shortcode"), equalTo(family.getShortcode()));
 
         Map<String, String> targetExportMap = exportMaps.stream().filter(map -> map.get("enrollee.shortcode").equals(enrollee2.getShortcode())).findFirst().get();
-        assertThat(targetExportMap.get("relation.relationshipType"), equalTo("FAMILY"));
+        assertThat(targetExportMap.get("relation.relationship"), equalTo("FAMILY"));
         assertThat(targetExportMap.get("relation.familyRelationship"), equalTo("father"));
         assertThat(targetExportMap.get("relation.family.shortcode"), equalTo("FAMILY1"));
 

--- a/core/src/test/java/bio/terra/pearl/core/service/participant/EnrolleeRelationServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/participant/EnrolleeRelationServiceTest.java
@@ -262,7 +262,7 @@ class EnrolleeRelationServiceTest extends BaseSpringBootTest {
         Enrollee proxyEnrollee = hubResponse.proxy();
         Enrollee governedEnrollee = hubResponse.governedEnrollee();
 
-        List<EnrolleeRelation> enrolleeRelations = enrolleeRelationService.findByTargetEnrolleeIdWithEnrolleesAndFamily(governedEnrollee.getId());
+        List<EnrolleeRelation> enrolleeRelations = enrolleeRelationService.findByEnrolleeIdWithEnrolleesAndFamily(governedEnrollee.getId());
 
         assertEquals(1, enrolleeRelations.size());
 

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -1034,13 +1034,13 @@ export default {
     return await this.processJsonResponse(response)
   },
 
-  async findRelationsByTargetShortcode(
+  async findRelationsByShortcode(
     portalShortcode: string,
     studyShortcode: string,
     envName: EnvironmentName,
     enrolleeShortcode: string): Promise<EnrolleeRelation[]> {
     const url = (
-        `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/enrolleeRelations/byTarget/${enrolleeShortcode}`
+        `${baseStudyEnvUrl(portalShortcode, studyShortcode, envName)}/enrolleeRelations/${enrolleeShortcode}`
     )
     const response = await fetch(url, this.getGetInit())
     return await this.processJsonResponse(response)

--- a/ui-admin/src/components/InfoCard.tsx
+++ b/ui-admin/src/components/InfoCard.tsx
@@ -108,7 +108,7 @@ export function InfoCardRow(
 export function InfoCardValue(
   { title, values, condensed }: {
         title: string,
-        values: string[],
+        values: React.ReactNode[],
         condensed?: boolean
     }
 ) {

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeOverview.test.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeOverview.test.tsx
@@ -11,7 +11,7 @@ import {
 import EnrolleeOverview from './EnrolleeOverview'
 
 test('renders enrollee participantUser info', async () => {
-  jest.spyOn(Api, 'findRelationsByTargetShortcode').mockResolvedValue([])
+  jest.spyOn(Api, 'findRelationsByShortcode').mockResolvedValue([])
   jest.spyOn(Api, 'fetchParticipantUser').mockResolvedValue({
     ...mockParticipantUser(),
     username: 'someone',

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeOverview.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeOverview.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import Api from 'api/api'
-import { StudyEnvContextT } from '../../StudyEnvironmentRouter'
+import { paramsFromContext, StudyEnvContextT } from '../../StudyEnvironmentRouter'
 import ParticipantNotesView from './ParticipantNotesView'
 import {
   dateToDefaultString,
@@ -19,6 +19,10 @@ import {
 import { useLoadingEffect } from 'api/api-utils'
 import LoadingSpinner from 'util/LoadingSpinner'
 import Families from 'study/participants/Families'
+import { studyEnvParticipantPath } from '../ParticipantsRouter'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faLink } from '@fortawesome/free-solid-svg-icons'
+import { Link } from 'react-router-dom'
 
 /** Shows minimal identifying information, and then kits and notes */
 export default function EnrolleeOverview({ enrollee, studyEnvContext, onUpdate }:
@@ -27,7 +31,7 @@ export default function EnrolleeOverview({ enrollee, studyEnvContext, onUpdate }
   const [participantUser, setParticipantUser] = React.useState<ParticipantUser>()
   const { isLoading: isLoadingRelations } = useLoadingEffect(async () => {
     const [relations, participantUser] = await Promise.all([
-      Api.findRelationsByTargetShortcode(
+      Api.findRelationsByShortcode(
         studyEnvContext.portal.shortcode,
         studyEnvContext.study.shortcode,
         studyEnvContext.currentEnv.environmentName,
@@ -37,7 +41,7 @@ export default function EnrolleeOverview({ enrollee, studyEnvContext, onUpdate }
     ])
     setRelations(relations)
     setParticipantUser(participantUser)
-  })
+  }, [enrollee.shortcode])
 
   const familyLinkageEnabled = studyEnvContext.currentEnv.studyEnvironmentConfig.enableFamilyLinkage
 
@@ -83,7 +87,9 @@ export default function EnrolleeOverview({ enrollee, studyEnvContext, onUpdate }
               <InfoCardValue
                 title={'Name'}
                 values={
-                  [formatName(relation.enrollee?.profile)]
+                  [<Link to={studyEnvParticipantPath(paramsFromContext(studyEnvContext), relation.enrolleeId)}>
+                    {formatName(relation.enrollee?.profile)} <FontAwesomeIcon icon={faLink} className="ms-3" />
+                  </Link>]
                 }
               />
               <InfoCardValue

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeOverview.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeOverview.tsx
@@ -20,8 +20,6 @@ import { useLoadingEffect } from 'api/api-utils'
 import LoadingSpinner from 'util/LoadingSpinner'
 import Families from 'study/participants/Families'
 import { studyEnvParticipantPath } from '../ParticipantsRouter'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faLink } from '@fortawesome/free-solid-svg-icons'
 import { Link } from 'react-router-dom'
 
 /** Shows minimal identifying information, and then kits and notes */
@@ -44,7 +42,10 @@ export default function EnrolleeOverview({ enrollee, studyEnvContext, onUpdate }
   }, [enrollee.shortcode])
 
   const familyLinkageEnabled = studyEnvContext.currentEnv.studyEnvironmentConfig.enableFamilyLinkage
-
+  const proxyForRelations = relations.filter(relation =>
+    relation.relationshipType === 'PROXY' && relation.enrolleeId === enrollee.id)
+  const proxyRelations = relations.filter(relation =>
+    relation.relationshipType === 'PROXY' && relation.enrolleeId !== enrollee.id)
   return <>
     <InfoCard>
       <InfoCardHeader>
@@ -75,31 +76,41 @@ export default function EnrolleeOverview({ enrollee, studyEnvContext, onUpdate }
     </InfoCard>
 
     {isLoadingRelations && <LoadingSpinner/>}
-    {
-      relations
-        .filter(relation => relation.relationshipType === 'PROXY')
-        .map(relation => {
-          return <InfoCard key={relation.id}>
-            <InfoCardHeader>
-              <InfoCardTitle title={'Proxy'}/>
-            </InfoCardHeader>
-            <InfoCardBody>
-              <InfoCardValue
-                title={'Name'}
-                values={
-                  [<Link to={studyEnvParticipantPath(paramsFromContext(studyEnvContext), relation.enrolleeId)}>
-                    {formatName(relation.enrollee?.profile)} <FontAwesomeIcon icon={faLink} className="ms-3" />
-                  </Link>]
-                }
-              />
-              <InfoCardValue
-                title={'Contact Email'}
-                values={[relation.enrollee?.profile?.contactEmail || '']}
-              />
-            </InfoCardBody>
-          </InfoCard>
-        })}
-
+    { proxyRelations.length > 0 && <InfoCard>
+      <InfoCardHeader>
+        <InfoCardTitle title={'Proxies'}/>
+      </InfoCardHeader>
+      <InfoCardBody>
+        <ul>
+          {proxyRelations.map(relation => <li className="mt-2" key={relation.id}>
+            <span className="fw-bold me-3">{formatName(relation.enrollee!.profile) }</span>
+            <span className="me-3">{relation.enrollee?.profile?.contactEmail}</span>
+              (<Link to={studyEnvParticipantPath(paramsFromContext(studyEnvContext), relation.enrolleeId)}>
+              {relation.enrollee!.shortcode}
+            </Link>)
+          </li>
+          )}
+        </ul>
+      </InfoCardBody>
+    </InfoCard>
+    }
+    { proxyForRelations.length > 0 && <InfoCard>
+      <InfoCardHeader>
+        <InfoCardTitle title={'Proxy for'}/>
+      </InfoCardHeader>
+      <InfoCardBody>
+        <ul>
+          {proxyForRelations.map(relation => <li className="mt-2" key={relation.id}>
+            <span className="fw-bold me-3">{formatName(relation.targetEnrollee!.profile) }</span>
+              (<Link to={studyEnvParticipantPath(paramsFromContext(studyEnvContext), relation.targetEnrolleeId)}>
+              {relation.targetEnrollee!.shortcode}
+            </Link>)
+          </li>
+          )}
+        </ul>
+      </InfoCardBody>
+    </InfoCard>
+    }
     <div>
       <ParticipantNotesView notes={enrollee.participantNotes} enrollee={enrollee}
         studyEnvContext={studyEnvContext} onUpdate={onUpdate}/>
@@ -116,9 +127,9 @@ export default function EnrolleeOverview({ enrollee, studyEnvContext, onUpdate }
   </>
 }
 
-const formatName = (profile: Profile | undefined) => {
-  if (!profile) {
-    return ''
+const formatName = (profile: Profile | undefined): React.ReactNode => {
+  if (!profile || (!profile.givenName && !profile.familyName)) {
+    return <span className="text-muted fst-italic">name not provided</span>
   }
   return `${profile.givenName || ''} ${profile.familyName || ''}`.trim()
 }

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeOverview.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeOverview.tsx
@@ -102,7 +102,8 @@ export default function EnrolleeOverview({ enrollee, studyEnvContext, onUpdate }
         <ul>
           {proxyForRelations.map(relation => <li className="mt-2" key={relation.id}>
             <span className="fw-bold me-3">{formatName(relation.targetEnrollee!.profile) }</span>
-              (<Link to={studyEnvParticipantPath(paramsFromContext(studyEnvContext), relation.targetEnrolleeId)}>
+              (<Link to={studyEnvParticipantPath(paramsFromContext(studyEnvContext),
+                  relation.targetEnrollee!.shortcode)}>
               {relation.targetEnrollee!.shortcode}
             </Link>)
           </li>
@@ -129,7 +130,7 @@ export default function EnrolleeOverview({ enrollee, studyEnvContext, onUpdate }
 
 const formatName = (profile: Profile | undefined): React.ReactNode => {
   if (!profile || (!profile.givenName && !profile.familyName)) {
-    return <span className="text-muted fst-italic">name not provided</span>
+    return <span className="text-muted fst-italic">(name not provided)</span>
   }
   return `${profile.givenName || ''} ${profile.familyName || ''}`.trim()
 }

--- a/ui-admin/src/study/participants/enrolleeView/useRoutedEnrollee.ts
+++ b/ui-admin/src/study/participants/enrolleeView/useRoutedEnrollee.ts
@@ -27,7 +27,7 @@ export default function useRoutedEnrollee(studyEnvContext: StudyEnvContextT) {
       enrollee = await Api.getEnrollee(portal.shortcode, study.shortcode,
         currentEnv.environmentName, enrolleeShortcodeOrId)
     } else {
-      // if we have, clear the state so the enrollee will be reloaded if the page is refreshed
+      // if we have data, clear the state so the enrollee will be reloaded if the page is refreshed
       window.history.replaceState({}, '')
     }
     if (enrollee.shortcode != enrolleeShortcodeOrId) {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds links for navigating to/from proxy relations

<img width="637" alt="image" src="https://github.com/user-attachments/assets/b1f4762f-b894-4e69-ac2b-055896b0a142" />

<img width="450" alt="image" src="https://github.com/user-attachments/assets/3a754c16-1975-4870-a0eb-8338eb58499b" />

Also, updates the enrollee export so that source and target relations will be included for each enrollee.


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy apiAdminApp
2. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants/HDPRXA
3. confirm you see the links to the two proxied enrollees
4. clikc them, confirm you have links back to the proxy
