### PR TITLE
[JN-1615] enable all previous responses on export

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyResponseDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyResponseDao.java
@@ -45,7 +45,10 @@ public class SurveyResponseDao extends BaseMutableJdbiDao<SurveyResponse> {
                                 left join participant_task task on task.survey_response_id = sr.id
                                 where sr.enrollee_id in (<enrolleeIds>)
                                 and task.status is distinct from 'REMOVED'
-                                """.formatted(tableName))
+                                """
+                                .formatted(
+                                        tableName
+                                ))
                         .bindList("enrolleeIds", enrolleeIds)
                         .mapTo(clazz)
                         .stream().collect(Collectors.groupingBy(SurveyResponse::getEnrolleeId, Collectors.toList()))

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
@@ -213,14 +213,14 @@ public class EnrolleeExportService {
         Map<UUID, ParticipantUser> participantUsers = participantUserService.findByParticipantUserIds(participantUserIds);
         Map<UUID, List<Answer>> answers = answerDao.findByEnrolleeIds(enrolleeIds);
         Map<UUID, List<ParticipantTask>> tasks = participantTaskService.findByEnrolleeIds(enrolleeIds);
-        Map<UUID, List<SurveyResponseWithTaskDto>> surveyResponses =
+        Map<UUID, List<SurveyResponseWithTaskDto>> allSurveyResponses =
                 attachTasksToSurveyResponses(
                         tasks,
                         surveyResponseService.findByEnrolleeIdsNotRemoved(
                                 enrolleeIds));
-        if (exportOptions.isOnlyIncludeMostRecent()) {
-            surveyResponses = filterToMostRecentSurveyResponses(surveyResponses);
-        }
+        Map<UUID, List<SurveyResponseWithTaskDto>> surveyResponses = exportOptions.isOnlyIncludeMostRecent()
+                ? filterToMostRecentSurveyResponses(allSurveyResponses)
+                : allSurveyResponses;
 
         Map<UUID, List<KitRequestDto>> kitRequests = kitRequestService.findByEnrollees(enrollees);
 

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
@@ -7,7 +7,6 @@ import bio.terra.pearl.core.model.export.ExportOptions;
 import bio.terra.pearl.core.model.participant.*;
 import bio.terra.pearl.core.model.search.EnrolleeSearchExpressionResult;
 import bio.terra.pearl.core.model.study.Study;
-import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.study.StudyEnvironmentConfig;
 import bio.terra.pearl.core.model.survey.*;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
@@ -217,7 +216,12 @@ public class EnrolleeExportService {
         Map<UUID, List<SurveyResponseWithTaskDto>> surveyResponses =
                 attachTasksToSurveyResponses(
                         tasks,
-                        surveyResponseService.findByEnrolleeIdsNotRemoved(enrolleeIds));
+                        surveyResponseService.findByEnrolleeIdsNotRemoved(
+                                enrolleeIds));
+        if (exportOptions.isOnlyIncludeMostRecent()) {
+            surveyResponses = filterToMostRecentSurveyResponses(surveyResponses);
+        }
+
         Map<UUID, List<KitRequestDto>> kitRequests = kitRequestService.findByEnrollees(enrollees);
 
         return enrollees.stream()
@@ -243,7 +247,8 @@ public class EnrolleeExportService {
                 surveyResponses
                         .getOrDefault(enrollee.getId(), Collections.emptyList())
                         .stream()
-                        .sorted(Comparator.comparing(SurveyResponse::getCreatedAt).reversed()).toList(),
+                        .sorted(Comparator.comparing(SurveyResponse::getCreatedAt).reversed())
+                        .toList(),
                 kitRequests.getOrDefault(enrollee.getId(), Collections.emptyList()),
                 enrolleeRelations,
                 config.isEnableFamilyLinkage() ? familyService.findByEnrolleeIdWithProband(enrollee.getId()) : Collections.emptyList(),
@@ -312,6 +317,28 @@ public class EnrolleeExportService {
         }
 
         return surveyResponseWithTaskMap;
+    }
+
+    private Map<UUID, List<SurveyResponseWithTaskDto>> filterToMostRecentSurveyResponses(Map<UUID, List<SurveyResponseWithTaskDto>> surveyResponseWithTaskMap) {
+        return surveyResponseWithTaskMap.entrySet()
+                .stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> filterToMostRecentSurveyResponses(entry.getValue())
+                ));
+    }
+
+    private List<SurveyResponseWithTaskDto> filterToMostRecentSurveyResponses(List<SurveyResponseWithTaskDto> surveyResponses) {
+        return surveyResponses
+                .stream()
+                .collect(Collectors.groupingBy(sr -> sr.getTask().getTargetStableId()))
+                .values()
+                .stream()
+                .map(surveyResponsesForTask -> surveyResponsesForTask
+                        .stream()
+                        .max(Comparator.comparing(sr -> sr.getTask().getCreatedAt()))
+                        .orElseThrow())
+                .toList();
     }
 
 

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -61,6 +61,7 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         return dao.findByEnrolleeIdsNotRemoved(enrolleeIds);
     }
 
+
     public Optional<SurveyResponse> findOneWithAnswers(UUID responseId) {
         return dao.findOneWithAnswers(responseId);
     }

--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeExportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeExportServiceTests.java
@@ -843,12 +843,12 @@ public class EnrolleeExportServiceTests extends BaseSpringBootTest {
         List<Map<String, String>> exportMapsLatestCompletions = enrolleeExportService.generateExportMaps(exportDataLatestCompletions, exportModuleInfoLatestCompletions);
 
         assertThat(exportMapsLatestCompletions, hasSize(1));
-        Map<String, String> exportMapLatestCompletions = exportMapsAllCompletions.get(0);
+        Map<String, String> exportMapLatestCompletions = exportMapsLatestCompletions.get(0);
         assertThat(exportMapLatestCompletions.get("enrollee.shortcode"), equalTo(enrolleeBundle.enrollee().getShortcode()));
         assertThat(exportMapLatestCompletions.get("enrollee.subject"), equalTo("true"));
         assertThat(exportMapLatestCompletions.containsKey("socialHealth[2].hd_hd_socialHealth_neighborhoodSharesValues"), equalTo(false));
         assertThat(exportMapLatestCompletions.containsKey("socialHealth[2].hd_hd_socialHealth_neighborhoodIsWalkable"), equalTo(false));
-        assertThat(exportMapLatestCompletions.get("socialHealth.hd_hd_socialHealth_neighborhoodSharesValues"), equalTo("Agree"));
-        assertThat(exportMapLatestCompletions.get("socialHealth.hd_hd_socialHealth_neighborhoodIsWalkable"), equalTo("Agree"));
+        assertThat(exportMapLatestCompletions.get("socialHealth.hd_hd_socialHealth_neighborhoodSharesValues"), equalTo("Disagree"));
+        assertThat(exportMapLatestCompletions.get("socialHealth.hd_hd_socialHealth_neighborhoodIsWalkable"), equalTo("Disagree"));
     }
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeExportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeExportServiceTests.java
@@ -17,8 +17,12 @@ import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.study.StudyEnvironmentConfig;
 import bio.terra.pearl.core.model.survey.Survey;
+import bio.terra.pearl.core.model.survey.SurveyResponse;
 import bio.terra.pearl.core.model.survey.SurveyResponseWithTaskDto;
 import bio.terra.pearl.core.model.survey.SurveyType;
+import bio.terra.pearl.core.model.workflow.ParticipantTask;
+import bio.terra.pearl.core.model.workflow.TaskStatus;
+import bio.terra.pearl.core.model.workflow.TaskType;
 import bio.terra.pearl.core.service.export.formatters.ExportFormatUtils;
 import bio.terra.pearl.core.service.export.formatters.item.AnswerItemFormatter;
 import bio.terra.pearl.core.service.export.formatters.item.ItemFormatter;
@@ -32,6 +36,7 @@ import bio.terra.pearl.core.service.participant.ParticipantUserService;
 import bio.terra.pearl.core.service.search.EnrolleeSearchExpressionParser;
 import bio.terra.pearl.core.service.study.StudyEnvironmentConfigService;
 import bio.terra.pearl.core.service.survey.SurveyService;
+import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -84,6 +89,8 @@ public class EnrolleeExportServiceTests extends BaseSpringBootTest {
     private SurveyResponseFactory surveyResponseFactory;
     @Autowired
     private ParticipantTaskFactory participantTaskFactory;
+    @Autowired
+    private ParticipantTaskService participantTaskService;
 
     @Test
     @Transactional
@@ -155,7 +162,7 @@ public class EnrolleeExportServiceTests extends BaseSpringBootTest {
 
         ExportOptionsWithExpression opts = ExportOptionsWithExpression.builder()
                 .fileFormat(ExportFileFormat.TSV)
-                .includeFields(List.of("profile.familyName", "enrollee.shortcode", "account.username" )).build();
+                .includeFields(List.of("profile.familyName", "enrollee.shortcode", "account.username")).build();
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         enrolleeExportService.export(opts, studyEnvBundle.getStudyEnv().getId(), stream);
 
@@ -374,7 +381,7 @@ public class EnrolleeExportServiceTests extends BaseSpringBootTest {
                         "type": "radiogroup",
                         "title": "My neighborhood is walkable.",
                         "choices": [
-                          {"text": "Disagre", "value": "disagree"},
+                          {"text": "Disagree", "value": "disagree"},
                           {"text": "Agree", "value": "agree"}
                         ]
                       }
@@ -409,8 +416,8 @@ public class EnrolleeExportServiceTests extends BaseSpringBootTest {
         assertThat(socialHealthModule.getItemFormatters(), hasSize(7));
         // module should contain both the response properties and question items
         assertThat(socialHealthModule.getItemFormatters().stream()
-                .filter(itemFormatter -> itemFormatter instanceof PropertyItemFormatter)
-                .map(itemFormatter -> ((PropertyItemFormatter) itemFormatter).getPropertyName()).toList(),
+                        .filter(itemFormatter -> itemFormatter instanceof PropertyItemFormatter)
+                        .map(itemFormatter -> ((PropertyItemFormatter) itemFormatter).getPropertyName()).toList(),
                 hasItems("lastUpdatedAt", "complete", "responseMetadata"));
         assertThat(socialHealthModule.getItemFormatters().stream()
                         .filter(itemFormatter -> itemFormatter instanceof AnswerItemFormatter)
@@ -744,5 +751,104 @@ public class EnrolleeExportServiceTests extends BaseSpringBootTest {
         export = baos.toString();
         assertThat(export, containsString(",enrollee.createdAt"));
         assertThat(export, containsString(",Created At"));
+    }
+
+    @Test
+    @Transactional
+    public void testExportAllCompletions(TestInfo testInfo) {
+
+        String testName = getTestName(testInfo);
+        StudyEnvironmentBundle bundle = studyEnvironmentFactory.buildBundle(testName, EnvironmentName.sandbox);
+        StudyEnvironment studyEnv = bundle.getStudyEnv();
+
+        Survey survey = surveyService.create(
+                surveyFactory
+                        .builder(getTestName(testInfo))
+                        .portalId(bundle.getPortal().getId())
+                        .content(SOCIAL_HEALTH_EXCERPT)
+                        .name("Social Health")
+                        .stableId("socialHealth")
+                        .surveyType(SurveyType.RESEARCH)
+                        .autoAssign(false)
+                        .version(1)
+                        .build());
+        surveyFactory.attachToEnv(survey, studyEnv.getId(), true);
+
+        EnrolleeBundle enrolleeBundle = enrolleeFactory.buildWithPortalUser(testName, bundle.getPortalEnv(), studyEnv, new Profile());
+
+        ParticipantTask task1 = participantTaskFactory.buildPersisted(
+                enrolleeBundle,
+                survey.getStableId(),
+                TaskStatus.COMPLETE,
+                TaskType.SURVEY
+        );
+
+        ParticipantTask task2 = participantTaskFactory.buildPersisted(
+                enrolleeBundle,
+                survey.getStableId(),
+                TaskStatus.COMPLETE,
+                TaskType.SURVEY
+        );
+
+        SurveyResponse responseTask1 = surveyResponseFactory.buildWithAnswers(
+                enrolleeBundle.enrollee(),
+                survey,
+                Map.of(
+                        "hd_hd_socialHealth_neighborhoodSharesValues", "agree",
+                        "hd_hd_socialHealth_neighborhoodIsWalkable", "agree"
+                )
+        );
+
+        SurveyResponse responseTask2 = surveyResponseFactory.buildWithAnswers(
+                enrolleeBundle.enrollee(),
+                survey,
+                Map.of(
+                        "hd_hd_socialHealth_neighborhoodSharesValues", "disagree",
+                        "hd_hd_socialHealth_neighborhoodIsWalkable", "disagree"
+                )
+        );
+
+        task1.setSurveyResponseId(responseTask1.getId());
+        participantTaskService.update(task1, getAuditInfo(testInfo));
+
+        task2.setSurveyResponseId(responseTask2.getId());
+        participantTaskService.update(task2, getAuditInfo(testInfo));
+
+
+        ExportOptionsWithExpression optionsAllCompletions = ExportOptionsWithExpression
+                .builder()
+                .onlyIncludeMostRecent(false)
+                .build();
+        List<EnrolleeExportData> exportDataAllCompletions = enrolleeExportService.loadEnrolleeExportData(studyEnv.getId(), optionsAllCompletions);
+        List<ModuleFormatter> exportModuleInfoAllCompletions = enrolleeExportService.generateModuleInfos(optionsAllCompletions, studyEnv.getId(), exportDataAllCompletions);
+
+        List<Map<String, String>> exportMapsAllCompletions = enrolleeExportService.generateExportMaps(exportDataAllCompletions, exportModuleInfoAllCompletions);
+
+        assertThat(exportMapsAllCompletions, hasSize(1));
+        Map<String, String> exportMapAllCompletions = exportMapsAllCompletions.get(0);
+        assertThat(exportMapAllCompletions.get("enrollee.shortcode"), equalTo(enrolleeBundle.enrollee().getShortcode()));
+        assertThat(exportMapAllCompletions.get("enrollee.subject"), equalTo("true"));
+        assertThat(exportMapAllCompletions.get("socialHealth[2].hd_hd_socialHealth_neighborhoodSharesValues"), equalTo("Agree"));
+        assertThat(exportMapAllCompletions.get("socialHealth[2].hd_hd_socialHealth_neighborhoodIsWalkable"), equalTo("Agree"));
+        assertThat(exportMapAllCompletions.get("socialHealth.hd_hd_socialHealth_neighborhoodSharesValues"), equalTo("Disagree"));
+        assertThat(exportMapAllCompletions.get("socialHealth.hd_hd_socialHealth_neighborhoodIsWalkable"), equalTo("Disagree"));
+
+        ExportOptionsWithExpression optionsLatestCompletions = ExportOptionsWithExpression
+                .builder()
+                .onlyIncludeMostRecent(true)
+                .build();
+        List<EnrolleeExportData> exportDataLatestCompletions = enrolleeExportService.loadEnrolleeExportData(studyEnv.getId(), optionsLatestCompletions);
+        List<ModuleFormatter> exportModuleInfoLatestCompletions = enrolleeExportService.generateModuleInfos(optionsLatestCompletions, studyEnv.getId(), exportDataLatestCompletions);
+
+        List<Map<String, String>> exportMapsLatestCompletions = enrolleeExportService.generateExportMaps(exportDataLatestCompletions, exportModuleInfoLatestCompletions);
+
+        assertThat(exportMapsLatestCompletions, hasSize(1));
+        Map<String, String> exportMapLatestCompletions = exportMapsAllCompletions.get(0);
+        assertThat(exportMapLatestCompletions.get("enrollee.shortcode"), equalTo(enrolleeBundle.enrollee().getShortcode()));
+        assertThat(exportMapLatestCompletions.get("enrollee.subject"), equalTo("true"));
+        assertThat(exportMapLatestCompletions.containsKey("socialHealth[2].hd_hd_socialHealth_neighborhoodSharesValues"), equalTo(false));
+        assertThat(exportMapLatestCompletions.containsKey("socialHealth[2].hd_hd_socialHealth_neighborhoodIsWalkable"), equalTo(false));
+        assertThat(exportMapLatestCompletions.get("socialHealth.hd_hd_socialHealth_neighborhoodSharesValues"), equalTo("Agree"));
+        assertThat(exportMapLatestCompletions.get("socialHealth.hd_hd_socialHealth_neighborhoodIsWalkable"), equalTo("Agree"));
     }
 }

--- a/ui-admin/src/study/export/ExportOptionsForm.tsx
+++ b/ui-admin/src/study/export/ExportOptionsForm.tsx
@@ -3,11 +3,17 @@ import { ExportOptions } from 'api/api'
 import { buildFilter } from 'util/exportUtils'
 import { Button } from 'components/forms/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons'
+import {
+  faChevronDown,
+  faChevronUp
+} from '@fortawesome/free-solid-svg-icons'
 import Select from 'react-select'
 import { useReactMultiSelect } from 'util/react-select-utils'
 import InfoPopup from 'components/forms/InfoPopup'
-import { DocsKey, ZendeskLink } from 'util/zendeskUtils'
+import {
+  DocsKey,
+  ZendeskLink
+} from 'util/zendeskUtils'
 
 export const FILE_FORMATS = [{
   label: 'Tab-delimited (.tsv)',
@@ -94,13 +100,13 @@ function ExportOptionsForm({ exportOptions, setExportOptions }:
         <label className="form-control border-0">
           <input type="radio" name="onlyIncludeMostRecent" value="true" checked={exportOptions.onlyIncludeMostRecent}
             onChange={() => setExportOptions({ ...exportOptions, onlyIncludeMostRecent: true })}
-            className="me-1" disabled={true}/>
+            className="me-1"/>
           Only include most recent
         </label>
         <label className="form-control border-0">
           <input type="radio" name="onlyIncludeMostRecent" value="false" checked={!exportOptions.onlyIncludeMostRecent}
             onChange={() => setExportOptions({ ...exportOptions, onlyIncludeMostRecent: false })}
-            className="me-1" disabled={true}/>
+            className="me-1"/>
           Include all completions
         </label>
       </div>


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Idk if this is really something we even want to do. It was always returning all results, no matter what the setting was. This might be preferred. This PR fixes it but might make things more complicated than their worth. I'd also be down to just unsurface this option since nobody cares about it except for A-T and A-T always wants all responses.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Export default - observe latest `lifestyle` entry for jsalk
- Export with all previous - observe 2 lifestyle entries for jsalk