### PR TITLE
[JN-1621] fix chinese surveyjs localization

### DIFF
--- a/ui-core/src/surveyjs/index.ts
+++ b/ui-core/src/surveyjs/index.ts
@@ -10,3 +10,4 @@ import './address-validation-modal-question'
 import './medications-question'
 
 import './surveyJsStyle.scss'
+import './localization'

--- a/ui-core/src/surveyjs/localization.ts
+++ b/ui-core/src/surveyjs/localization.ts
@@ -1,0 +1,9 @@
+import 'survey-core/survey.i18n'
+import { surveyLocalization } from 'survey-core'
+
+surveyLocalization.setupLocale(
+  'zh',   // A short code used as a locale identifier (for example, "en", "de", "fr")
+  surveyLocalization.getLocaleStrings('zh-cn'), // An array with custom translations,
+  '中文',
+  'Chinese')
+


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

`zh` isn't a supported language key - but `zh-cn` for simplified chinese is. Since it would be very annoying to port all our system texts and all of A-T's content to use `zh-cn`, I instead just copied `zh-cn` to the `zh` locale.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Populate A-T
- Observe next/previous buttons are in chinese when selected
- Observe all other languages work as expected