### PR TITLE
[JN-1526] Add option to prepopulate longitudinal survey responses with previous answers

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/scheduled/ScheduledAssignmentService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/scheduled/ScheduledAssignmentService.java
@@ -4,7 +4,6 @@ import bio.terra.pearl.api.admin.service.system.CheckDisableScheduledTask;
 import bio.terra.pearl.core.service.workflow.TaskDispatcher;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -20,10 +19,10 @@ public class ScheduledAssignmentService {
   @Scheduled(
       fixedDelay = 60 * 60 * 1000,
       initialDelay = 5 * 1000) // wait an hour between executions, start after 5 seconds
-  @SchedulerLock(
-      name = "ScheduledSurveyAssignmentService.assignScheduledSurveys",
-      lockAtMostFor = "500s",
-      lockAtLeastFor = "60s")
+  //  @SchedulerLock(
+  //      name = "ScheduledSurveyAssignmentService.assignScheduledSurveys",
+  //      lockAtMostFor = "500s",
+  //      lockAtLeastFor = "60s")
   @CheckDisableScheduledTask
   public void assignScheduledSurveys() {
     log.info("Scheduled task processing beginning");

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/scheduled/ScheduledAssignmentService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/scheduled/ScheduledAssignmentService.java
@@ -4,6 +4,7 @@ import bio.terra.pearl.api.admin.service.system.CheckDisableScheduledTask;
 import bio.terra.pearl.core.service.workflow.TaskDispatcher;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -19,10 +20,10 @@ public class ScheduledAssignmentService {
   @Scheduled(
       fixedDelay = 60 * 60 * 1000,
       initialDelay = 5 * 1000) // wait an hour between executions, start after 5 seconds
-  //  @SchedulerLock(
-  //      name = "ScheduledSurveyAssignmentService.assignScheduledSurveys",
-  //      lockAtMostFor = "500s",
-  //      lockAtLeastFor = "60s")
+  @SchedulerLock(
+      name = "ScheduledSurveyAssignmentService.assignScheduledSurveys",
+      lockAtMostFor = "500s",
+      lockAtLeastFor = "60s")
   @CheckDisableScheduledTask
   public void assignScheduledSurveys() {
     log.info("Scheduled task processing beginning");

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/Survey.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/Survey.java
@@ -53,7 +53,7 @@ public class Survey extends BaseEntity implements Versioned, PortalAttached {
     @Builder.Default
     private boolean allowParticipantReedit = true; // whether participants can change answers after submission
     @Builder.Default
-    private boolean prepopulate = false; // whether to bring forward answers from prior completions (if recur is true)
+    private boolean prepopulate = false; // whether to bring forward answers from prior completions (if recurrence type is LONGITUDINAL)
     @Builder.Default
     private boolean autoAssign = true; // whether to assign the survey to enrollees automatically once they meet the eligibility criteria
     @Builder.Default

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
@@ -139,29 +139,33 @@ public class SurveyTaskDispatcher extends TaskDispatcher<SurveyTaskConfigDto> {
     public void copyTaskData(ParticipantTask newTask, ParticipantTask oldTask, SurveyTaskConfigDto taskDispatchConfig) {
         super.copyTaskData(newTask, oldTask, taskDispatchConfig);
 
-        //todo check if task config is set to prepopulate
-        Optional<SurveyResponse> priorResponse = surveyResponseService.findOneWithAnswers(oldTask.getSurveyResponseId());
+        // if the survey is set to prepopulate, copy the answers from the old task to the new task
+        // we need to also create a new survey response for the new task and attach it to that task
+        if(taskDispatchConfig.getSurvey().isPrepopulate()) {
+            Optional<SurveyResponse> priorResponse = surveyResponseService.findOneWithAnswers(oldTask.getSurveyResponseId());
 
-        //todo check if task config is set to prepopulate
-        if(priorResponse.isPresent()) {
-            //pulls answers off of priorResponse and sets answer ids all to null
-            List<Answer> answers = priorResponse.get().getAnswers().stream()
-                    .map(foo -> (Answer) foo.cleanForCopying())
-                    .collect(Collectors.toList());
-
-
-
-            SurveyResponse newResponse = SurveyResponse.builder()
-                    .surveyId(priorResponse.get().getSurveyId())
-                    .enrolleeId(priorResponse.get().getEnrolleeId())
-                    .answers(answers)
-                    .participantFiles(priorResponse.get().getParticipantFiles())
-                    .build();
-
-            SurveyResponse createdResponse = surveyResponseService.create(newResponse);
-
-            newTask.setStatus(TaskStatus.NEW);
-            newTask.setSurveyResponseId(createdResponse.getId());
+            if (priorResponse.isPresent() && taskDispatchConfig.getSurvey().isPrepopulate()) {
+                SurveyResponse createdResponse = createPrepopulatedSurveyResponse(priorResponse.get());
+                newTask.setStatus(TaskStatus.NEW);
+                newTask.setSurveyResponseId(createdResponse.getId());
+            }
         }
+    }
+
+    // creates a new survey response with the same answers as priorResponse
+    // for use with longitudinal recurring surveys
+    private SurveyResponse createPrepopulatedSurveyResponse(SurveyResponse priorResponse) {
+        List<Answer> answers = priorResponse.getAnswers().stream()
+                .map(a -> (Answer) a.cleanForCopying())
+                .collect(Collectors.toList());
+
+        SurveyResponse newResponse = SurveyResponse.builder()
+                .surveyId(priorResponse.getSurveyId())
+                .enrolleeId(priorResponse.getEnrolleeId())
+                .answers(answers)
+                .participantFiles(priorResponse.getParticipantFiles())
+                .build();
+
+        return surveyResponseService.create(newResponse);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
@@ -1,9 +1,8 @@
 package bio.terra.pearl.core.service.survey;
 
-import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
-import bio.terra.pearl.core.model.survey.Survey;
-import bio.terra.pearl.core.model.survey.SurveyTaskConfigDto;
-import bio.terra.pearl.core.model.survey.SurveyType;
+import bio.terra.pearl.core.model.survey.*;
+import bio.terra.pearl.core.model.workflow.ParticipantTask;
+import bio.terra.pearl.core.model.workflow.TaskStatus;
 import bio.terra.pearl.core.model.workflow.TaskType;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
@@ -16,6 +15,7 @@ import bio.terra.pearl.core.service.survey.event.EnrolleeSurveyEvent;
 import bio.terra.pearl.core.service.survey.event.SurveyPublishedEvent;
 import bio.terra.pearl.core.service.workflow.*;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.formula.functions.T;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /** listens for events and updates enrollee survey tasks accordingly */
 @Service
@@ -31,6 +32,7 @@ import java.util.UUID;
 public class SurveyTaskDispatcher extends TaskDispatcher<SurveyTaskConfigDto> {
     private final StudyEnvironmentSurveyService studyEnvironmentSurveyService;
     private final SurveyService surveyService;
+    private final SurveyResponseService surveyResponseService;
 
 
     public SurveyTaskDispatcher(StudyEnvironmentSurveyService studyEnvironmentSurveyService,
@@ -38,10 +40,11 @@ public class SurveyTaskDispatcher extends TaskDispatcher<SurveyTaskConfigDto> {
                                 EnrolleeService enrolleeService,
                                 PortalParticipantUserService portalParticipantUserService,
                                 EnrolleeContextService enrolleeContextService,
-                                EnrolleeSearchExpressionParser enrolleeSearchExpressionParser, SurveyService surveyService) {
+                                EnrolleeSearchExpressionParser enrolleeSearchExpressionParser, SurveyService surveyService, SurveyResponseService surveyResponseService) {
         super(studyEnvironmentService, participantTaskService, enrolleeService, enrolleeSearchExpressionParser, enrolleeContextService, portalParticipantUserService);
         this.studyEnvironmentSurveyService = studyEnvironmentSurveyService;
         this.surveyService = surveyService;
+        this.surveyResponseService = surveyResponseService;
     }
 
     @EventListener
@@ -130,5 +133,35 @@ public class SurveyTaskDispatcher extends TaskDispatcher<SurveyTaskConfigDto> {
         }
 
         return Optional.of(new SurveyTaskConfigDto(sesOpt.get(), surveyOpt.get()));
+    }
+
+    @Override
+    public void copyTaskData(ParticipantTask newTask, ParticipantTask oldTask, SurveyTaskConfigDto taskDispatchConfig) {
+        super.copyTaskData(newTask, oldTask, taskDispatchConfig);
+
+        //todo check if task config is set to prepopulate
+        Optional<SurveyResponse> priorResponse = surveyResponseService.findOneWithAnswers(oldTask.getSurveyResponseId());
+
+        //todo check if task config is set to prepopulate
+        if(priorResponse.isPresent()) {
+            //pulls answers off of priorResponse and sets answer ids all to null
+            List<Answer> answers = priorResponse.get().getAnswers().stream()
+                    .map(foo -> (Answer) foo.cleanForCopying())
+                    .collect(Collectors.toList());
+
+
+
+            SurveyResponse newResponse = SurveyResponse.builder()
+                    .surveyId(priorResponse.get().getSurveyId())
+                    .enrolleeId(priorResponse.get().getEnrolleeId())
+                    .answers(answers)
+                    .participantFiles(priorResponse.get().getParticipantFiles())
+                    .build();
+
+            SurveyResponse createdResponse = surveyResponseService.create(newResponse);
+
+            newTask.setStatus(TaskStatus.NEW);
+            newTask.setSurveyResponseId(createdResponse.getId());
+        }
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
@@ -167,7 +167,7 @@ public class SurveyTaskDispatcher extends TaskDispatcher<SurveyTaskConfigDto> {
                 .surveyId(priorResponse.getSurveyId())
                 .enrolleeId(priorResponse.getEnrolleeId())
                 .createdAt(Instant.now())
-                .lastUpdatedAt(null)
+                .lastUpdatedAt(Instant.now())
                 .answers(answers)
                 .participantFiles(priorResponse.getParticipantFiles())
                 .build();

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
@@ -15,7 +15,6 @@ import bio.terra.pearl.core.service.survey.event.EnrolleeSurveyEvent;
 import bio.terra.pearl.core.service.survey.event.SurveyPublishedEvent;
 import bio.terra.pearl.core.service.workflow.*;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.poi.ss.formula.functions.T;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
@@ -15,10 +15,12 @@ import bio.terra.pearl.core.service.survey.event.EnrolleeSurveyEvent;
 import bio.terra.pearl.core.service.survey.event.SurveyPublishedEvent;
 import bio.terra.pearl.core.service.workflow.*;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.BeanUtils;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -138,6 +140,9 @@ public class SurveyTaskDispatcher extends TaskDispatcher<SurveyTaskConfigDto> {
     public void copyTaskData(ParticipantTask newTask, ParticipantTask oldTask, SurveyTaskConfigDto taskDispatchConfig) {
         super.copyTaskData(newTask, oldTask, taskDispatchConfig);
 
+        newTask.setSurveyResponseId(null);
+        newTask.setCompletedAt(null);
+
         // if the survey is set to prepopulate, copy the answers from the old task to the new task
         // we need to also create a new survey response for the new task and attach it to that task
         if(taskDispatchConfig.getSurvey().isPrepopulate()) {
@@ -161,6 +166,8 @@ public class SurveyTaskDispatcher extends TaskDispatcher<SurveyTaskConfigDto> {
         SurveyResponse newResponse = SurveyResponse.builder()
                 .surveyId(priorResponse.getSurveyId())
                 .enrolleeId(priorResponse.getEnrolleeId())
+                .createdAt(Instant.now())
+                .lastUpdatedAt(null)
                 .answers(answers)
                 .participantFiles(priorResponse.getParticipantFiles())
                 .build();

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/TaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/TaskDispatcher.java
@@ -196,7 +196,7 @@ public abstract class TaskDispatcher<T extends TaskConfig> {
         List<Enrollee> enrollees = enrolleeService.findWithTaskInPast(
                 taskConfig.getStudyEnvironmentId(),
                 taskConfig.getStableId(),
-                Duration.of(taskConfig.getRecurrenceIntervalDays(), ChronoUnit.SECONDS));
+                Duration.of(taskConfig.getRecurrenceIntervalDays(), ChronoUnit.DAYS));
         assign(enrollees, taskConfig, false, "scheduled",
                 new ResponsibleEntity(DataAuditInfo.systemProcessName(getClass(), "assignRecurringSurvey")));
     }
@@ -334,10 +334,9 @@ public abstract class TaskDispatcher<T extends TaskConfig> {
         if (taskDispatchConfig.getRecurrenceType() == RecurrenceType.NONE) {
             return false;
         }
-        //TODO switch this back after testing
         Instant pastCutoffTime = ZonedDateTime.now(ZoneOffset.UTC)
                 .minusDays(taskDispatchConfig.getRecurrenceIntervalDays()).toInstant();
-        return true;
+        return pastTask.getCreatedAt().isBefore(pastCutoffTime);
     }
 
     protected void copyTaskData(ParticipantTask newTask, ParticipantTask oldTask, T taskDispatchConfig) {

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/TaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/TaskDispatcher.java
@@ -83,6 +83,7 @@ public abstract class TaskDispatcher<T extends TaskConfig> {
         return assign(enrollees, taskConfigOpt.get(), assignDto.overrideEligibility(), assignDto.justification(), operator);
     }
 
+    //this is the one
     public List<ParticipantTask> assign(List<Enrollee> enrollees,
                                         T taskDispatchConfig,
                                         boolean overrideEligibility,
@@ -196,7 +197,7 @@ public abstract class TaskDispatcher<T extends TaskConfig> {
         List<Enrollee> enrollees = enrolleeService.findWithTaskInPast(
                 taskConfig.getStudyEnvironmentId(),
                 taskConfig.getStableId(),
-                Duration.of(taskConfig.getRecurrenceIntervalDays(), ChronoUnit.DAYS));
+                Duration.of(taskConfig.getRecurrenceIntervalDays(), ChronoUnit.SECONDS));
         assign(enrollees, taskConfig, false, "scheduled",
                 new ResponsibleEntity(DataAuditInfo.systemProcessName(getClass(), "assignRecurringSurvey")));
     }
@@ -276,6 +277,14 @@ public abstract class TaskDispatcher<T extends TaskConfig> {
                     .max(Comparator.comparing(ParticipantTask::getCreatedAt));
             existingTask.ifPresent(participantTask -> copyTaskData(task, participantTask, taskDispatchConfig));
         }
+        else if(taskDispatchConfig.getRecurrenceType().equals(RecurrenceType.LONGITUDINAL)) {
+            Optional<ParticipantTask> existingTask = existingTasks.stream()
+                    .filter(t -> t.getTargetStableId() != null)
+                    .filter(t -> t.getTargetStableId().equals(task.getTargetStableId()))
+                    .max(Comparator.comparing(ParticipantTask::getCreatedAt));
+            System.out.println("existingTask: " + existingTask);
+            existingTask.ifPresent(participantTask -> copyTaskData(task, participantTask, taskDispatchConfig));
+        }
     }
 
     private boolean isEligible(T taskDispatchConfig, EnrolleeContext enrolleeContext) {
@@ -328,11 +337,11 @@ public abstract class TaskDispatcher<T extends TaskConfig> {
             return false;
         }
         Instant pastCutoffTime = ZonedDateTime.now(ZoneOffset.UTC)
-                .minusDays(taskDispatchConfig.getRecurrenceIntervalDays()).toInstant();
-        return pastTask.getCreatedAt().isBefore(pastCutoffTime);
+                .minusSeconds(taskDispatchConfig.getRecurrenceIntervalDays()).toInstant();
+        return true;
     }
 
-    private void copyTaskData(ParticipantTask newTask, ParticipantTask oldTask, T taskDispatchConfig) {
+    protected void copyTaskData(ParticipantTask newTask, ParticipantTask oldTask, T taskDispatchConfig) {
         BeanUtils.copyProperties(
                 oldTask,
                 newTask,

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/TaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/TaskDispatcher.java
@@ -83,7 +83,6 @@ public abstract class TaskDispatcher<T extends TaskConfig> {
         return assign(enrollees, taskConfigOpt.get(), assignDto.overrideEligibility(), assignDto.justification(), operator);
     }
 
-    //this is the one
     public List<ParticipantTask> assign(List<Enrollee> enrollees,
                                         T taskDispatchConfig,
                                         boolean overrideEligibility,
@@ -282,7 +281,6 @@ public abstract class TaskDispatcher<T extends TaskConfig> {
                     .filter(t -> t.getTargetStableId() != null)
                     .filter(t -> t.getTargetStableId().equals(task.getTargetStableId()))
                     .max(Comparator.comparing(ParticipantTask::getCreatedAt));
-            System.out.println("existingTask: " + existingTask);
             existingTask.ifPresent(participantTask -> copyTaskData(task, participantTask, taskDispatchConfig));
         }
     }
@@ -336,8 +334,9 @@ public abstract class TaskDispatcher<T extends TaskConfig> {
         if (taskDispatchConfig.getRecurrenceType() == RecurrenceType.NONE) {
             return false;
         }
+        //TODO switch this back after testing
         Instant pastCutoffTime = ZonedDateTime.now(ZoneOffset.UTC)
-                .minusSeconds(taskDispatchConfig.getRecurrenceIntervalDays()).toInstant();
+                .minusDays(taskDispatchConfig.getRecurrenceIntervalDays()).toInstant();
         return true;
     }
 

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.core.service.survey;
 
 import bio.terra.pearl.core.BaseSpringBootTest;
 import bio.terra.pearl.core.dao.dataimport.TimeShiftDao;
+import bio.terra.pearl.core.dao.survey.SurveyResponseDao;
 import bio.terra.pearl.core.factory.StudyEnvironmentBundle;
 import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
 import bio.terra.pearl.core.factory.admin.AdminUserFactory;
@@ -15,10 +16,9 @@ import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.audit.DataAuditInfo;
 import bio.terra.pearl.core.model.audit.ResponsibleEntity;
+import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.Profile;
-import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
-import bio.terra.pearl.core.model.survey.Survey;
-import bio.terra.pearl.core.model.survey.SurveyTaskConfigDto;
+import bio.terra.pearl.core.model.survey.*;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
 import bio.terra.pearl.core.model.workflow.RecurrenceType;
 import bio.terra.pearl.core.model.workflow.TaskStatus;
@@ -59,6 +59,8 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
     private SurveyResponseFactory surveyResponseFactory;
     @Autowired
     private TimeShiftDao timeShiftDao;
+    @Autowired
+    private SurveyResponseDao surveyResponseDao;
 
 
     @Test
@@ -365,5 +367,58 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
         assertThat(participantTaskService.findByEnrolleeId(sandbox1.enrollee().getId()), hasSize(0));
         assertThat(participantTaskService.findByEnrolleeId(sandbox2.enrollee().getId()), hasSize(2));
         assertThat(participantTaskService.findByEnrolleeId(sandbox3.enrollee().getId()), hasSize(1));
+    }
+
+    @Test
+    @Transactional
+    public void testLongitudinalPrepopulate(TestInfo testInfo) {
+        StudyEnvironmentBundle sandboxBundle = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.sandbox);
+        AdminUser operator = adminUserFactory.buildPersisted(getTestName(testInfo), true);
+        EnrolleeBundle enrollee = enrolleeFactory.buildWithPortalUser(getTestName(testInfo), sandboxBundle.getPortalEnv(), sandboxBundle.getStudyEnv());
+        Survey survey = surveyFactory.buildPersisted(Survey.builder()
+                .portalId(sandboxBundle.getPortal().getId())
+                .stableId("lifestyle")
+                .content("{\"pages\":[{\"elements\":[{\"type\":\"text\",\"name\":\"diagnosis\",\"title\":\"What is your diagnosis?\"}]}]}")
+                .surveyType(SurveyType.RESEARCH)
+                .name("Lifestyle Survey")
+                .recurrenceType(RecurrenceType.LONGITUDINAL)
+                .recurrenceIntervalDays(7)
+                .prepopulate(true));
+        surveyFactory.attachToEnv(survey, sandboxBundle.getStudyEnv().getId(), true);
+        ParticipantTaskAssignDto assignDto = new ParticipantTaskAssignDto(TaskType.SURVEY, survey.getStableId(), survey.getVersion(), null, true, true, "reason" );
+        surveyTaskDispatcher.assign(assignDto, sandboxBundle.getStudyEnv().getId(), new ResponsibleEntity(operator));
+        List<ParticipantTask> initialParticipantTasks = participantTaskService.findByEnrolleeId(enrollee.enrollee().getId());
+
+        // confirm the task was assigned
+        assertThat(initialParticipantTasks, hasSize(1));
+        ParticipantTask initialTask = initialParticipantTasks.getFirst();
+
+        // submit an answer to the survey
+        surveyResponseFactory.submitStringAnswer(
+                initialTask,
+                "diagnosis",
+                "sick",
+                false,
+                enrollee);
+
+        // change the task time to 8 days ago, so it can be re-assigned during the next scheduled task assignment
+        timeShiftDao.changeTaskCreationTime(initialTask.getId(), Instant.now().minus(8, ChronoUnit.DAYS));
+
+        // test that task is re-assigned and answer was prepopulated in the new response
+        surveyTaskDispatcher.assignScheduledTasks();
+
+        // confirm the task was re-assigned
+        List<ParticipantTask> latestParticipantTasks = participantTaskService.findByEnrolleeId(enrollee.enrollee().getId());
+        assertThat(latestParticipantTasks, hasSize(2));
+
+        ParticipantTask reassignedTask = latestParticipantTasks.get(1);
+        SurveyResponse reassignedResponse = surveyResponseDao.findOneWithAnswers(reassignedTask.getSurveyResponseId()).get();
+
+        //confirm diagnosis answer was prepopulated in the new response
+        assertThat(reassignedResponse.getAnswers().getFirst().getStringValue(), equalTo("sick"));
+
+        assertThat(reassignedTask.getCreatedAt(), not(equalTo(initialTask.getCreatedAt())));
+        assertThat(reassignedTask.getLastUpdatedAt(), not(equalTo(initialTask.getLastUpdatedAt())));
+        assertThat(reassignedTask.getStatus(), equalTo(TaskStatus.NEW));
     }
 }

--- a/ui-admin/src/study/surveys/FormOptionsModal.tsx
+++ b/ui-admin/src/study/surveys/FormOptionsModal.tsx
@@ -84,7 +84,8 @@ export const FormOptions = ({ studyEnvContext, initialWorkingForm, updateWorking
     (val: RecurrenceType) => updateWorkingForm({
       ...workingForm,
       recurrenceType: val,
-      recurrenceIntervalDays: val === 'NONE' ? undefined : workingForm.recurrenceIntervalDays || 365
+      recurrenceIntervalDays: val === 'NONE' ? undefined : workingForm.recurrenceIntervalDays || 365,
+      prepopulate: workingForm.recurrenceType === 'LONGITUDINAL' ? workingForm.prepopulate : false
     }),
     workingForm.recurrenceType || 'NONE')
   return <>
@@ -179,6 +180,16 @@ export const FormOptions = ({ studyEnvContext, initialWorkingForm, updateWorking
                 /> days
               </label>
             </div>
+            {workingForm.recurrenceType === 'LONGITUDINAL' &&  <label className="form-label d-block">
+              <input type="checkbox" checked={workingForm.prepopulate}
+                onChange={e => updateWorkingForm({
+                  ...workingForm, prepopulate: e.target.checked
+                })}
+              /> Prepopulate answers <InfoPopup placement="right" content={<div>
+                    For longitudinal surveys, enabling this will automatically
+                    prepopulate answers from the previous survey response
+              </div>}/>
+            </label> }
             <h3 className="h6 mt-4">Eligibility Rule</h3>
             <div className="mb-2">
               <LazySearchQueryBuilder


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Surfaces the prepopulate option on surveys if the recurrence type is longitudinal.

<img width="816" alt="Screenshot 2025-02-11 at 12 17 58 PM" src="https://github.com/user-attachments/assets/aa4d118a-bd07-4e62-b553-c4479f7e50a8" />

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

