### PR TITLE
[JN-1411] Allow participants to delete unused documents

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/file/ParticipantFileDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/file/ParticipantFileDao.java
@@ -53,6 +53,17 @@ public class ParticipantFileDao extends BaseJdbiDao<ParticipantFile> {
         return participantFiles;
     }
 
+    public Optional<ParticipantFile> findWithAnswers(UUID id) {
+        Optional<ParticipantFile> participantFile = find(id);
+        participantFile.ifPresent(file -> {
+            List<Answer> answers = answerDao.findByEnrolleeIdAndAnswerFormat(file.getEnrolleeId(), AnswerFormat.FILE_NAME);
+            Map<String, List<Answer>> answersByFileName = answers.stream().collect(Collectors.groupingBy(Answer::getStringValue));
+            List<Answer> answersForFile = answersByFileName.getOrDefault(file.getFileName(), new ArrayList<>());
+            file.setAssociatedAnswers(answersForFile);
+        });
+        return participantFile;
+    }
+
     public List<ParticipantFile> findByEnrolleeId(UUID enrolleeId) {
         return findAllByProperty("enrollee_id", enrolleeId);
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/file/ParticipantFileService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/ParticipantFileService.java
@@ -5,7 +5,9 @@ import bio.terra.pearl.core.model.BaseEntity;
 import bio.terra.pearl.core.model.file.ParticipantFile;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
+import bio.terra.pearl.core.service.CascadeProperty;
 import bio.terra.pearl.core.service.ImmutableEntityService;
+import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackend;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackendProvider;
 import bio.terra.pearl.core.service.survey.SurveyResponseService;
@@ -17,6 +19,7 @@ import org.springframework.stereotype.Service;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 @Service
@@ -50,5 +53,14 @@ public class ParticipantFileService extends ImmutableEntityService<ParticipantFi
 
     public Optional<ParticipantFile> findByEnrolleeIdAndFileName(UUID enrolleeId, String fileName) {
         return dao.findByEnrolleeIdAndFileName(enrolleeId, fileName);
+    }
+
+    @Override
+    public void delete(UUID id, Set<CascadeProperty> cascade) {
+        ParticipantFile participantFile = dao.find(id).orElseThrow(() -> new NotFoundException("File not found"));
+        if(!participantFile.getAssociatedAnswers().isEmpty()) {
+            throw new IllegalArgumentException("This file is being used in a survey response and cannot be deleted. Please remove the file from the survey response first.");
+        }
+        dao.delete(id);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/file/ParticipantFileService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/ParticipantFileService.java
@@ -57,10 +57,10 @@ public class ParticipantFileService extends ImmutableEntityService<ParticipantFi
 
     @Override
     public void delete(UUID id, Set<CascadeProperty> cascade) {
-        ParticipantFile participantFile = dao.find(id).orElseThrow(() -> new NotFoundException("File not found"));
+        ParticipantFile participantFile = dao.findWithAnswers(id).orElseThrow(() -> new NotFoundException("File not found"));
         if(!participantFile.getAssociatedAnswers().isEmpty()) {
             throw new IllegalArgumentException("This file is being used in a survey response and cannot be deleted. Please remove the file from the survey response first.");
         }
-        dao.delete(id);
+        super.delete(id, cascade);
     }
 }

--- a/ui-participant/src/hub/documents/DocumentLibrary.test.tsx
+++ b/ui-participant/src/hub/documents/DocumentLibrary.test.tsx
@@ -1,7 +1,7 @@
 import { asMockedFn, MockI18nProvider, setupRouterTest, mockParticipantFile } from '@juniper/ui-core'
 import { usePortalEnv } from 'providers/PortalProvider'
-import { mockUsePortalEnv } from 'test-utils/test-portal-factory'
-import { render, screen, waitFor } from '@testing-library/react'
+import { mockPortal, mockUsePortalEnv } from 'test-utils/test-portal-factory'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import React from 'react'
 import DocumentLibrary from './DocumentLibrary'
 import { useActiveUser } from 'providers/ActiveUserProvider'
@@ -16,7 +16,8 @@ jest.mock('providers/ActiveUserProvider', () => ({
 }))
 
 jest.mock('api/api', () => ({
-  listParticipantFiles: jest.fn()
+  listParticipantFiles: jest.fn(),
+  getPortal: jest.fn()
 }))
 
 beforeEach(() => {
@@ -58,10 +59,15 @@ describe('DocumentLibrary', () => {
       expect(screen.getByText('file1.pdf')).toBeInTheDocument()
     })
 
+    await act(async () => {
+      screen.getByText('Options').click()
+    })
+
+    expect(screen.getByText('Delete')).toBeInTheDocument()
     expect(screen.getByText('{documentDownloadButton}')).toBeInTheDocument()
   })
 
-  it('renders no associated tasks message', async () => {
+  it('does not render any associated tasks', async () => {
     asMockedFn(Api.listParticipantFiles).mockResolvedValue([
       mockParticipantFile('file1.pdf', [])
     ])
@@ -72,7 +78,7 @@ describe('DocumentLibrary', () => {
       expect(screen.getByText('file1.pdf')).toBeInTheDocument()
     })
 
-    expect(screen.getByText('not associated with any tasks')).toBeInTheDocument()
+    expect(screen.queryByText('shared in response to')).not.toBeInTheDocument()
   })
 
   it('renders associated tasks', async () => {
@@ -105,5 +111,73 @@ describe('DocumentLibrary', () => {
 
     //note: this is looking at the i18n key for the task name
     expect(screen.getByText('{researchSurvey1:1}')).toBeInTheDocument()
+  })
+
+
+  it('allows deleting documents that dont have any associated answers', async () => {
+    asMockedFn(Api.listParticipantFiles).mockResolvedValue([
+      mockParticipantFile('file1.pdf')
+    ])
+
+    asMockedFn(Api.getPortal).mockResolvedValue(mockPortal())
+
+    const { RoutedComponent } = setupRouterTest(
+      <MockI18nProvider><DocumentLibrary/></MockI18nProvider>
+    )
+    render(RoutedComponent)
+
+    await waitFor(() => {
+      expect(screen.getByText('file1.pdf')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      screen.getByText('Options').click()
+    })
+
+    await act(async () => {
+      screen.getByText('Delete').click()
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByText('Are you sure you want to delete this document?', { exact: false })).toBeInTheDocument()
+    })
+  })
+
+  it('shows a warning message when trying to delete a document that has associated answers', async () => {
+    asMockedFn(Api.listParticipantFiles).mockResolvedValue([
+      mockParticipantFile('file1.pdf', [{
+        format: 'FILE_NAME',
+        surveyVersion: 1,
+        stringValue: 'file1.pdf',
+        questionStableId: 'question1',
+        surveyResponseId: 'taskId1'
+      }])
+    ])
+
+    asMockedFn(Api.getPortal).mockResolvedValue(mockPortal())
+
+    const { RoutedComponent } = setupRouterTest(
+      <MockI18nProvider><DocumentLibrary/></MockI18nProvider>
+    )
+    render(RoutedComponent)
+
+    await waitFor(() => {
+      expect(screen.getByText('file1.pdf')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      screen.getByText('Options').click()
+    })
+
+    await act(async () => {
+      screen.getByText('Delete').click()
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByText('' +
+          'This document is currently shared in response to at least one survey. ' +
+          'Please remove it from the survey response(s) before deleting it.')
+      ).toBeInTheDocument()
+    })
   })
 })

--- a/ui-participant/src/hub/documents/DocumentLibrary.test.tsx
+++ b/ui-participant/src/hub/documents/DocumentLibrary.test.tsx
@@ -143,7 +143,7 @@ describe('DocumentLibrary', () => {
     })
   })
 
-  it('shows a warning message when trying to delete a document that has associated answers', async () => {
+  it('shows warning modal when trying to delete a document that has associated answers', async () => {
     asMockedFn(Api.listParticipantFiles).mockResolvedValue([
       mockParticipantFile('file1.pdf', [{
         format: 'FILE_NAME',

--- a/ui-participant/src/hub/documents/DocumentLibrary.tsx
+++ b/ui-participant/src/hub/documents/DocumentLibrary.tsx
@@ -209,7 +209,11 @@ const FileOptionsDropdown = ({ studyEnvParams, participantFile, enrollee, loadDo
       </Modal.Header>
       <Modal.Body>
         {participantFile.associatedAnswers.length === 0 ?
-          <p className="m-0">Are you sure you want to delete this document? This cannot be undone.</p> :
+          <p className="m-0">
+            Are you sure you want to delete this document? This cannot be undone. Please note that if a member
+            of the study staff has already downloaded this document, it will still be accessible to them. Please
+            contact a member of the study staff if you would like to have the document fully removed from all records.
+          </p> :
           <p className="m-0">This document is currently shared in response to at least one survey. Please remove it
                   from the survey response(s) before deleting it.</p>
         }

--- a/ui-participant/src/hub/documents/DocumentLibrary.tsx
+++ b/ui-participant/src/hub/documents/DocumentLibrary.tsx
@@ -3,8 +3,7 @@ import {
   EnvironmentName,
   I18nOptions,
   instantToDateString,
-  ParticipantFile, ParticipantTask,
-  saveBlobAsDownload,
+  ParticipantFile, ParticipantTask, saveBlobAsDownload,
   StudyEnvParams,
   useI18n
 } from '@juniper/ui-core'
@@ -12,10 +11,12 @@ import React, { useEffect, useState } from 'react'
 import { useActiveUser } from 'providers/ActiveUserProvider'
 import Api from 'api/api'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faDownload, faFile, faFileImage, faFileLines, faFilePdf } from '@fortawesome/free-solid-svg-icons'
+import { faFile, faFileImage, faFileLines, faFilePdf } from '@fortawesome/free-solid-svg-icons'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { Link } from 'react-router-dom'
 import { getTaskPath } from '../task/taskUtils'
+import Modal from 'react-bootstrap/Modal'
+import ThemedModal from 'components/ThemedModal'
 
 export default function DocumentLibrary() {
   const { i18n } = useI18n()
@@ -106,16 +107,11 @@ const DocumentsList = ({ studyName, studyEnvParams, enrollee }: {
               </td>
               <td className="align-middle">
                 <div className={'d-flex justify-content-end'}>
-                  <button className="btn btn-outline-primary" onClick={async () => {
-                    const response = await Api.downloadParticipantFile({
-                      studyEnvParams, enrolleeShortcode: enrollee.shortcode, fileName: participantFile.fileName
-                    })
-                    saveBlobAsDownload(await response.blob(), participantFile.fileName)
-                  }}>
-                    <span className="d-flex align-items-center">
-                      <FontAwesomeIcon className="pe-1" icon={faDownload}/>{i18n('documentDownloadButton')}
-                    </span>
-                  </button>
+                  <FileOptionsDropdown
+                    studyEnvParams={studyEnvParams}
+                    loadDocuments={loadDocuments}
+                    participantFile={participantFile}
+                    enrollee={enrollee}/>
                 </div>
               </td>
             </tr>
@@ -138,7 +134,7 @@ const surveyResponseIdsToTaskNames = (
   }).filter((task): task is ParticipantTask => task !== undefined)
 
   if (associatedTasks.length === 0) {
-    return <div className={'mt-2 fst-italic text-muted'}>not associated with any tasks</div>
+    return null
   }
 
   return (
@@ -169,4 +165,75 @@ const fileTypeToIcon = (fileType: string) => {
     default:
       return <FontAwesomeIcon className="me-2" icon={faFile}/>
   }
+}
+
+const FileOptionsDropdown = ({ studyEnvParams, participantFile, enrollee, loadDocuments }: {
+  studyEnvParams: StudyEnvParams, participantFile: ParticipantFile, enrollee: Enrollee, loadDocuments: () => void
+}) => {
+  const [showConfirmDelete, setShowConfirmDelete] = useState(false)
+  const { i18n } = useI18n()
+  return (<>
+    <li className="nav-item dropdown d-flex flex-column">
+      <button className="btn btn-outline-primary dropdown-toggle" id="fileOptionsDropdown"
+        data-bs-toggle="dropdown" aria-expanded="false">
+            Options
+      </button>
+      <ul className="dropdown-menu" aria-labelledby="fileOptionsDropdown">
+        <li>
+          <a role={'button'} className="dropdown-item"
+            onClick={() => setShowConfirmDelete(true)}
+          >
+                Delete
+          </a>
+        </li>
+        <li>
+          <a className="dropdown-item" role={'button'} onClick={async () => {
+            const response = await Api.downloadParticipantFile({
+              studyEnvParams, enrolleeShortcode: enrollee.shortcode, fileName: participantFile.fileName
+            })
+            saveBlobAsDownload(await response.blob(), participantFile.fileName)
+          }}>
+            {i18n('documentDownloadButton')}
+          </a>
+        </li>
+      </ul>
+    </li>
+    {showConfirmDelete && <ThemedModal show={true}
+      onHide={() => setShowConfirmDelete(false)} size={'lg'} animation={true}>
+      <Modal.Header>
+        <Modal.Title>
+          <h2 className="fw-bold pb-0 mb-0">
+            {participantFile.associatedAnswers.length === 0 ? 'Are you sure?' : 'This document is in use'}
+          </h2>
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {participantFile.associatedAnswers.length === 0 ?
+          <p className="m-0">Are you sure you want to delete this document? This cannot be undone.</p> :
+          <p className="m-0">This document is currently shared in response to at least one survey. Please remove it
+                  from the survey response(s) before deleting it.</p>
+        }
+      </Modal.Body>
+      <Modal.Footer>
+        <div className={'d-flex w-100'}>
+          <button className={'btn btn-primary m-2'}
+            disabled={participantFile.associatedAnswers.length > 0}
+            onClick={async () => {
+              await Api.deleteParticipantFile({
+                studyEnvParams, enrolleeShortcode: enrollee.shortcode, fileName: participantFile.fileName
+              })
+              loadDocuments()
+              setShowConfirmDelete(false)
+            }}>
+                Delete
+          </button>
+          <button className={'btn btn-outline-secondary m-2'}
+            onClick={() => setShowConfirmDelete(false)}>
+            {i18n('cancel')}
+          </button>
+        </div>
+      </Modal.Footer>
+    </ThemedModal> }
+  </>
+  )
 }

--- a/ui-participant/src/hub/documents/DocumentLibrary.tsx
+++ b/ui-participant/src/hub/documents/DocumentLibrary.tsx
@@ -212,7 +212,7 @@ const FileOptionsDropdown = ({ studyEnvParams, participantFile, enrollee, loadDo
           <p className="m-0">
             Are you sure you want to delete this document? This cannot be undone. Please note that if a member
             of the study staff has already downloaded this document, it will still be accessible to them. Please
-            contact a member of the study staff if you would like to have the document fully removed from all records.
+            contact the study staff if you would like to have the document fully removed from all records.
           </p> :
           <p className="m-0">This document is currently shared in response to at least one survey. Please remove it
                   from the survey response(s) before deleting it.</p>

--- a/ui-participant/src/test-utils/test-portal-factory.tsx
+++ b/ui-participant/src/test-utils/test-portal-factory.tsx
@@ -108,7 +108,8 @@ export const mockLocalSiteContent = (): LocalSiteContent => {
     landingPage: mockHtmlPage(),
     navLogoCleanFileName: 'navLogo.png',
     navLogoVersion: 1,
-    languageTextOverrides: []
+    languageTextOverrides: [],
+    primaryBrandColor: '#000000'
   }
 }
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

![screencapture-sandbox-demo-localhost-3001-hub-documents-2025-02-12-13_59_37](https://github.com/user-attachments/assets/4a3683f4-e433-49a8-ad56-d3d91d88dc5f)


<img width="310" alt="Screenshot 2025-02-12 at 1 59 45 PM" src="https://github.com/user-attachments/assets/40c66834-7035-4700-947e-bd81a6052fa4" />
<img width="862" alt="Screenshot 2025-02-12 at 2 03 21 PM" src="https://github.com/user-attachments/assets/acf84e18-1de4-4cce-bb66-88939bf54f5e" />
<img width="890" alt="Screenshot 2025-02-12 at 1 59 49 PM" src="https://github.com/user-attachments/assets/da8ac12e-b74f-47e9-86e9-bf645e6d72af" />

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Log into heart demo as jsalk@test.com
Go to Document library
Try to delete a document with no associated responses, confirm it works
Try to delete a document with an associated response, confirm you see a warning modal