### PR TITLE
[JN-1613] allow reassigning task

### DIFF
--- a/ui-admin/src/study/participants/survey/SurveyResponseView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyResponseView.tsx
@@ -137,6 +137,7 @@ export function RawEnrolleeSurveyView({
   const [view, setView] = useState<SurveyView>(configSurvey.survey.surveyType === 'ADMIN' ? 'editing' : 'viewing')
   const [autosaveStatus, setAutosaveStatus] = useState<AutosaveStatus | undefined>()
   const [showJustificationModal, setShowJustificationModal] = useState(false)
+  const [showReassignModal, setShowReassignModal] = useState(false)
   const [justification, setJustification] = useState<string>('')
   const [showTaskModal, setShowTaskModal] = useState(false)
 
@@ -153,6 +154,14 @@ export function RawEnrolleeSurveyView({
             </Button>
           </div>
           {surveyTaskStatus(task, response)}
+          <div className="ms-2">
+            <Button
+              variant="secondary"
+              onClick={() => setShowReassignModal(true)}
+              tooltip="Assign new instance of the task. Previous responses will still be visible.">
+              Re-assign
+            </Button>
+          </div>
         </div>
 
         <div className="d-flex align-items-center">
@@ -250,6 +259,13 @@ export function RawEnrolleeSurveyView({
         onDismiss={() => setShowJustificationModal(false)}
         changes={[]}
         confirmText={'Continue to edit'}
+      />}
+      {showReassignModal && <SurveyAssignModal
+        studyEnvParams={paramsFromContext(studyEnvContext)}
+        enrollee={enrollee}
+        survey={configSurvey.survey}
+        onDismiss={() => setShowReassignModal(false)}
+        onSubmit={onUpdate}
       />}
       {view === 'printing' && <PrintFormView answers={response?.answers || []} survey={configSurvey.survey}/>}
     </div>


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

I have decided I really love the "participantassigndto" code path we made. It's awesome and it just works!

I considered adding a "copy answers" option - but guess what! This utilizes the _same_ codepath that is used for automatic participant assignment so the prepopulate option will be triggered here. 

![image](https://github.com/user-attachments/assets/4bda874b-b3a6-4f98-a3da-59d978c1354d)

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Go to jsalk lifestyle survey
- Reassign
- Log in as jsalk - observe newly assigned survey