### PR TITLE
[JN-1607] add filter to study staff emails

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/notification/Trigger.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/notification/Trigger.java
@@ -6,16 +6,16 @@ import bio.terra.pearl.core.model.publishing.VersionedEntityConfig;
 import bio.terra.pearl.core.model.study.StudyEnvAttached;
 import bio.terra.pearl.core.model.workflow.TaskStatus;
 import bio.terra.pearl.core.model.workflow.TaskType;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 /**
  * configuration for notifications.
@@ -53,6 +53,11 @@ public class Trigger extends BaseEntity implements VersionedEntityConfig, StudyE
     private UUID emailTemplateId;
     private EmailTemplate emailTemplate;
     private String rule;
+
+    // for admin notifications, comma separated list of email addresses.
+    // will verify that the email address is valid before sending.
+    // if blank, all admins will be notified
+    private String adminEmailFilter;
     /**
      * notificationTypes of TASK_REMINDER, if specified, will limit to one type of task.  if null,
      * will apply to all tasks.

--- a/core/src/main/java/bio/terra/pearl/core/model/notification/Trigger.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/notification/Trigger.java
@@ -54,9 +54,9 @@ public class Trigger extends BaseEntity implements VersionedEntityConfig, StudyE
     private EmailTemplate emailTemplate;
     private String rule;
 
-    // for admin notifications, comma separated list of email addresses.
-    // will verify that the email address is valid before sending.
-    // if blank, all admins will be notified
+    // for admin notifications, comma separated list of admin emails.
+    // will not send if the email does not have an associated admin account
+    // if blank, no admins will be notified
     private String adminEmailFilter;
     /**
      * notificationTypes of TASK_REMINDER, if specified, will limit to one type of task.  if null,

--- a/core/src/main/java/bio/terra/pearl/core/model/notification/Trigger.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/notification/Trigger.java
@@ -57,7 +57,7 @@ public class Trigger extends BaseEntity implements VersionedEntityConfig, StudyE
     // for admin notifications, comma separated list of admin emails.
     // will not send if the email does not have an associated admin account
     // if blank, no admins will be notified
-    private String adminEmailFilter;
+    private String targetEmails;
     /**
      * notificationTypes of TASK_REMINDER, if specified, will limit to one type of task.  if null,
      * will apply to all tasks.

--- a/core/src/main/java/bio/terra/pearl/core/service/admin/AdminUserService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/admin/AdminUserService.java
@@ -4,14 +4,13 @@ import bio.terra.pearl.core.dao.admin.AdminUserDao;
 import bio.terra.pearl.core.model.admin.*;
 import bio.terra.pearl.core.model.audit.DataAuditInfo;
 import bio.terra.pearl.core.service.CascadeProperty;
-
-import java.util.*;
-
 import bio.terra.pearl.core.service.publishing.PortalEnvironmentChangeRecordService;
 import bio.terra.pearl.core.service.workflow.ParticipantDataChangeService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
 
 @Service
 public class AdminUserService extends AdminDataAuditedService<AdminUser, AdminUserDao> {

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/email/AdminEmailService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/email/AdminEmailService.java
@@ -21,11 +21,12 @@ import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import bio.terra.pearl.core.service.study.StudyService;
 import bio.terra.pearl.core.service.workflow.EnrolleeEvent;
 import bio.terra.pearl.core.shared.ApplicationRoutingPaths;
+import com.sendgrid.helpers.mail.Mail;
+import io.micrometer.common.util.StringUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.text.StringSubstitutor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import com.sendgrid.helpers.mail.Mail;
 
 import java.util.List;
 import java.util.UUID;
@@ -111,6 +112,14 @@ public class AdminEmailService {
             .findByPortalEnvironmentId(event.getPortalParticipantUser().getPortalEnvironmentId())
             .orElseThrow(() -> new IllegalStateException("Portal not found"));
     List<AdminUser> adminUsers = adminUserService.findAllWithRolesByPortal(portal.getId());
+
+    if (StringUtils.isNotBlank(trigger.getAdminEmailFilter())) {
+      List<String> emails = List.of(trigger.getAdminEmailFilter().split(",")).stream().map(String::trim).toList();
+
+      adminUsers = adminUsers.stream()
+              .filter(adminUser -> emails.contains(adminUser.getUsername()))
+              .toList();
+    }
 
     EmailTemplate emailTemplate = emailTemplateService.find(trigger.getEmailTemplateId())
             .orElseThrow(() -> new NotFoundException("Email template not found"));

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/email/AdminEmailService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/email/AdminEmailService.java
@@ -113,7 +113,7 @@ public class AdminEmailService {
     List<AdminUser> adminUsers = adminUserService.findAllWithRolesByPortal(portal.getId());
 
 
-    String emailFilter = trigger.getAdminEmailFilter();
+    String emailFilter = trigger.getTargetEmails();
     if (emailFilter == null) {
       emailFilter = "";
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/email/AdminEmailService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/email/AdminEmailService.java
@@ -22,7 +22,6 @@ import bio.terra.pearl.core.service.study.StudyService;
 import bio.terra.pearl.core.service.workflow.EnrolleeEvent;
 import bio.terra.pearl.core.shared.ApplicationRoutingPaths;
 import com.sendgrid.helpers.mail.Mail;
-import io.micrometer.common.util.StringUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.text.StringSubstitutor;
 import org.springframework.scheduling.annotation.Async;
@@ -113,13 +112,18 @@ public class AdminEmailService {
             .orElseThrow(() -> new IllegalStateException("Portal not found"));
     List<AdminUser> adminUsers = adminUserService.findAllWithRolesByPortal(portal.getId());
 
-    if (StringUtils.isNotBlank(trigger.getAdminEmailFilter())) {
-      List<String> emails = List.of(trigger.getAdminEmailFilter().split(",")).stream().map(String::trim).toList();
 
-      adminUsers = adminUsers.stream()
-              .filter(adminUser -> emails.contains(adminUser.getUsername()))
-              .toList();
+    String emailFilter = trigger.getAdminEmailFilter();
+    if (emailFilter == null) {
+      emailFilter = "";
     }
+
+    List<String> emails = List.of(emailFilter.split(",")).stream().map(String::trim).toList();
+
+    adminUsers = adminUsers.stream()
+            .filter(adminUser -> emails.contains(adminUser.getUsername()))
+            .toList();
+
 
     EmailTemplate emailTemplate = emailTemplateService.find(trigger.getEmailTemplateId())
             .orElseThrow(() -> new NotFoundException("Email template not found"));

--- a/core/src/main/resources/db/changelog/changesets/2025_02_14_trigger_admin_email_filter.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2025_02_14_trigger_admin_email_filter.yaml
@@ -1,11 +1,11 @@
 databaseChangeLog:
   - changeSet:
-      id: "trigger_admin_email_filter"
+      id: "trigger_target_emails"
       author: connorlbark
       changes:
         - addColumn:
             tableName: trigger
             columns:
               - column:
-                  name: admin_email_filter
+                  name: target_emails
                   type: text

--- a/core/src/main/resources/db/changelog/changesets/2025_02_14_trigger_admin_email_filter.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2025_02_14_trigger_admin_email_filter.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: "trigger_admin_email_filter"
+      author: connorlbark
+      changes:
+        - addColumn:
+            tableName: trigger
+            columns:
+              - column:
+                  name: admin_email_filter
+                  type: text

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -395,7 +395,9 @@ databaseChangeLog:
   - include:
       file: changesets/2025_01_27_prenroll_type.yaml
       relativeToChangelogFile: true
-
+  - include:
+      file: changesets/2025_02_14_trigger_admin_email_filter.yaml
+      relativeToChangelogFile: true
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements
 # are atomic. When they are grouped in a changeset and one fails the changeset cannot be

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/email/AdminEmailServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/email/AdminEmailServiceTest.java
@@ -22,8 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class AdminEmailServiceTest extends BaseSpringBootTest {
     @Autowired
@@ -54,20 +53,25 @@ class AdminEmailServiceTest extends BaseSpringBootTest {
         EmailTemplate emailTemplate = emailTemplateFactory.buildPersisted(getTestName(info), bundle.getPortal().getId());
         localizedEmailTemplateService.create(LocalizedEmailTemplate.builder().emailTemplateId(emailTemplate.getId()).language("en").subject("subject").body("body").build());
 
+
+        AdminUserBundle adminUserBundle1 = portalAdminUserFactory.buildPersistedWithPortals(getTestName(info), List.of(bundle.getPortal()));
+        AdminUserBundle adminUserBundle2 = portalAdminUserFactory.buildPersistedWithPortals(getTestName(info), List.of(bundle.getPortal()));
+        AdminUserBundle adminUserBundle3 = portalAdminUserFactory.buildPersistedWithPortals(getTestName(info), List.of(bundle.getPortal()));
+
         Trigger trigger = triggerFactory.buildPersisted(
                 Trigger.builder()
                         .emailTemplateId(emailTemplate.getId())
                         .deliveryType(NotificationDeliveryType.EMAIL)
                         .actionType(TriggerActionType.ADMIN_NOTIFICATION)
+                        .adminEmailFilter(
+                                adminUserBundle1.user().getUsername() + "," + adminUserBundle2.user().getUsername()
+                        )
                         .triggerType(TriggerType.EVENT),
                 bundle.getStudyEnv().getId(),
                 bundle.getPortalEnv().getId());
 
         EnrolleeBundle enrolleeBundle = enrolleeFactory.buildWithPortalUser(getTestName(info), bundle.getPortalEnv(), bundle.getStudyEnv());
 
-
-        AdminUserBundle adminUserBundle1 = portalAdminUserFactory.buildPersistedWithPortals(getTestName(info), List.of(bundle.getPortal()));
-        AdminUserBundle adminUserBundle2 = portalAdminUserFactory.buildPersistedWithPortals(getTestName(info), List.of(bundle.getPortal()));
 
         List<Notification> notificationsBefore = notificationService.findAllByConfigId(trigger.getId(), false);
 
@@ -99,6 +103,7 @@ class AdminEmailServiceTest extends BaseSpringBootTest {
         assertEquals(NotificationType.ADMIN, notification.getNotificationType());
         assertTrue(notification.getSentTo().contains(adminUserBundle1.user().getUsername()));
         assertTrue(notification.getSentTo().contains(adminUserBundle2.user().getUsername()));
+        assertFalse(notification.getSentTo().contains(adminUserBundle3.user().getUsername()));
 
     }
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/email/AdminEmailServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/email/AdminEmailServiceTest.java
@@ -63,7 +63,7 @@ class AdminEmailServiceTest extends BaseSpringBootTest {
                         .emailTemplateId(emailTemplate.getId())
                         .deliveryType(NotificationDeliveryType.EMAIL)
                         .actionType(TriggerActionType.ADMIN_NOTIFICATION)
-                        .adminEmailFilter(
+                        .targetEmails(
                                 adminUserBundle1.user().getUsername() + "," + adminUserBundle2.user().getUsername()
                         )
                         .triggerType(TriggerType.EVENT),

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
@@ -126,6 +126,7 @@
         "eventType": "STUDY_ENROLLMENT",
         "actionType": "ADMIN_NOTIFICATION",
         "rule": "{profile.doNotEmailSolicit} = true",
+        "adminEmailFilter": "heartdemostaff@gmail.com",
         "populateFileName": "emails/adminNotificationTest.json"
       }],
       "enrolleeFiles": [

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
@@ -126,7 +126,7 @@
         "eventType": "STUDY_ENROLLMENT",
         "actionType": "ADMIN_NOTIFICATION",
         "rule": "{profile.doNotEmailSolicit} = true",
-        "adminEmailFilter": "heartdemostaff@gmail.com",
+        "targetEmails": "heartdemostaff@gmail.com",
         "populateFileName": "emails/adminNotificationTest.json"
       }],
       "enrolleeFiles": [

--- a/ui-admin/src/study/notifications/TriggerDesignerEditor.tsx
+++ b/ui-admin/src/study/notifications/TriggerDesignerEditor.tsx
@@ -30,6 +30,7 @@ import { Checkbox } from 'components/forms/Checkbox'
 import { LazySearchQueryBuilder } from 'search/LazySearchQueryBuilder'
 import { useLoadingEffect } from 'api/api-utils'
 import Api from 'api/api'
+import LoadingSpinner from 'util/LoadingSpinner'
 
 
 export const TriggerDesignerEditor = (
@@ -400,7 +401,7 @@ const NotificationEditor = (
     {
       trigger.actionType === 'ADMIN_NOTIFICATION'
       && <div className='w-50 mb-2'>
-        <AdminEmailFilterEditor
+        <TargetEmailEditor
           studyEnvContext={studyEnvContext}
           trigger={trigger}
           updateTrigger={updateTrigger}/>
@@ -440,7 +441,7 @@ const NotificationEditor = (
   </>
 }
 
-const AdminEmailFilterEditor = (
+const TargetEmailEditor = (
   {
     studyEnvContext,
     trigger,
@@ -460,22 +461,22 @@ const AdminEmailFilterEditor = (
 
 
   if (isLoading) {
-    return <div>Loading...</div>
+    return <LoadingSpinner/>
   }
 
   return <div>
-    <label className="form-label" htmlFor="adminEmailFilter">
+    <label className="form-label" htmlFor="targetEmailEditor">
       Send notification to
     </label>
 
     <Select
       options={adminUsers.map(username => ({ label: username, value: username }))}
-      inputId="adminEmailFilter"
+      inputId="targetEmailEditor"
       value={adminUsers
-        .filter(username => trigger.adminEmailFilter?.includes(username))
+        .filter(username => trigger.targetEmails?.includes(username))
         .map(username => ({ label: username, value: username }))}
       isMulti={true}
-      onChange={options => updateTrigger('adminEmailFilter', options.map(opt => opt!.value).join(','))}
+      onChange={options => updateTrigger('targetEmails', options.map(opt => opt!.value).join(','))}
     />
   </div>
 }

--- a/ui-admin/src/study/notifications/TriggerDesignerEditor.tsx
+++ b/ui-admin/src/study/notifications/TriggerDesignerEditor.tsx
@@ -1,12 +1,16 @@
 import {
-  ParticipantTaskStatus, StudyEnvParams,
+  ParticipantTaskStatus,
+  StudyEnvParams,
   Trigger,
   TriggerActionType,
   TriggerDeliveryType,
   TriggerScope,
   TriggerType
 } from '@juniper/ui-core'
-import React, { useId, useState } from 'react'
+import React, {
+  useId,
+  useState
+} from 'react'
 import Select from 'react-select'
 import useReactSingleSelect from 'util/react-select-utils'
 import {
@@ -16,7 +20,10 @@ import {
   InfoCardTitle
 } from 'components/InfoCard'
 import EmailTemplateEditor from 'study/notifications/EmailTemplateEditor'
-import { paramsFromContext, StudyEnvContextT } from 'study/StudyEnvironmentRouter'
+import {
+  paramsFromContext,
+  StudyEnvContextT
+} from 'study/StudyEnvironmentRouter'
 import InfoPopup from 'components/forms/InfoPopup'
 import { NavLink } from 'react-router-dom'
 import { Checkbox } from 'components/forms/Checkbox'
@@ -390,6 +397,15 @@ const NotificationEditor = (
     <div className="float-end position-relative">
       <NavLink to='notifications'>View sent notifications</NavLink>
     </div>
+    {
+      trigger.actionType === 'ADMIN_NOTIFICATION'
+      && <div className='w-50 mb-2'>
+        <AdminEmailFilterEditor
+          studyEnvContext={studyEnvContext}
+          trigger={trigger}
+          updateTrigger={updateTrigger}/>
+      </div>
+    }
     <label className="form-label">
       Notification Type <InfoPopup content={'Juniper only supports reminders via email.'}/>
       <Select options={deliveryTypeOptions} isDisabled={true}
@@ -422,6 +438,46 @@ const NotificationEditor = (
           </div>}
         </>}
   </>
+}
+
+const AdminEmailFilterEditor = (
+  {
+    studyEnvContext,
+    trigger,
+    updateTrigger
+  }: {
+    studyEnvContext: StudyEnvContextT,
+    trigger: Trigger;
+    updateTrigger: (string: keyof Trigger, value: unknown) => void;
+  }
+) => {
+  const [adminUsers, setAdminUsers] = useState<string[]>([])
+
+  const { isLoading } = useLoadingEffect(async () => {
+    const adminUsers = await Api.fetchAdminUsersByPortal(studyEnvContext.portal.shortcode)
+    setAdminUsers(adminUsers.map(user => user.username))
+  }, [])
+
+
+  if (isLoading) {
+    return <div>Loading...</div>
+  }
+
+  return <div>
+    <label className="form-label" htmlFor="adminEmailFilter">
+      Send notification to <span className='fst-italic'>(leave blank to send to all study staff)</span>
+    </label>
+
+    <Select
+      options={adminUsers.map(username => ({ label: username, value: username }))}
+      inputId="adminEmailFilter"
+      value={adminUsers
+        .filter(username => trigger.adminEmailFilter?.includes(username))
+        .map(username => ({ label: username, value: username }))}
+      isMulti={true}
+      onChange={options => updateTrigger('adminEmailFilter', options.map(opt => opt!.value).join(','))}
+    />
+  </div>
 }
 
 const statusOptions: { label: string, value: ParticipantTaskStatus }[] = [

--- a/ui-admin/src/study/notifications/TriggerDesignerEditor.tsx
+++ b/ui-admin/src/study/notifications/TriggerDesignerEditor.tsx
@@ -465,7 +465,7 @@ const AdminEmailFilterEditor = (
 
   return <div>
     <label className="form-label" htmlFor="adminEmailFilter">
-      Send notification to <span className='fst-italic'>(leave blank to send to all study staff)</span>
+      Send notification to
     </label>
 
     <Select

--- a/ui-core/src/types/study.ts
+++ b/ui-core/src/types/study.ts
@@ -86,6 +86,7 @@ export type Trigger = {
   maxNumReminders: number
   emailTemplateId: string
   emailTemplate: EmailTemplate
+  adminEmailFilter?: string
 }
 
 export type EmailTemplate = {

--- a/ui-core/src/types/study.ts
+++ b/ui-core/src/types/study.ts
@@ -86,7 +86,7 @@ export type Trigger = {
   maxNumReminders: number
   emailTemplateId: string
   emailTemplate: EmailTemplate
-  adminEmailFilter?: string
+  targetEmails?: string
 }
 
 export type EmailTemplate = {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds the ability to filter which emails to send to.

I couldn't figure out how to slice it to easily mute during enrollee import. But this way, if you remove all the emails, it just won't send. So we can temporarily "mute" it by removing all the emails while importing. Then add the emails afterwards.

The other thing mentioned on the ticket was (I believe) to link to the enrollee on sent notifications, which it already does.

![image](https://github.com/user-attachments/assets/d5fdcc74-1564-4f81-abfd-ee151f47ee6b)

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Sign up a user in demo and say "no" to receiving emails
- Go to sent notifications for the admin notif trigger
- Notice it only sent an email to heartdemostaff and not power user
- Click on the enrollee to go to your new enrollee's page