### PR TITLE
[JN-1619] Create new response and task for user if response was considered stale

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/survey/Survey.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/Survey.java
@@ -54,6 +54,7 @@ public class Survey extends BaseEntity implements Versioned, PortalAttached {
     private boolean allowParticipantReedit = true; // whether participants can change answers after submission
     @Builder.Default
     private boolean prepopulate = false; // whether to bring forward answers from prior completions (if recurrence type is LONGITUDINAL)
+    private Integer createNewResponseAfterDays; // how many days after the last completion to create a separate new response if edits are made (if recurrence type is LONGITUDINAL)
     @Builder.Default
     private boolean autoAssign = true; // whether to assign the survey to enrollees automatically once they meet the eligibility criteria
     @Builder.Default

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -141,13 +141,13 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
     }
 
     //if the cutoff time has passed, create a new task and response
-    private boolean shouldCreateNewLongtitudinalTaskAndResponse(Integer createNewResponseAfterDays, ParticipantTask task) {
+    private boolean shouldCreateNewLongitudinalTaskAndResponse(Integer createNewResponseAfterDays, Instant surveyResponseLastUpdatedAt) {
         if(createNewResponseAfterDays == null) {
             return false;
         }
         Instant cutoffTime = ZonedDateTime.now(ZoneOffset.UTC)
-                .minusSeconds(createNewResponseAfterDays).toInstant(); //todo change back to minusDays
-        return task.getLastUpdatedAt().isBefore(cutoffTime);
+                .minusDays(createNewResponseAfterDays).toInstant();
+        return surveyResponseLastUpdatedAt.isBefore(cutoffTime);
     }
 
     /**
@@ -167,11 +167,14 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         validateResponse(survey, task, responseDto.getAnswers());
 
 
+        SurveyResponse priorResponse = dao.findOneWithAnswers(task.getSurveyResponseId()).orElse(null);
         SurveyResponse response;
         //if the survey is longitudinal and we're past the cutoff point for updating an existing response, we need to create a new response and task
-        if (survey.getRecurrenceType() == RecurrenceType.LONGITUDINAL && shouldCreateNewLongtitudinalTaskAndResponse(survey.getCreateNewResponseAfterDays(), task)) {
+        if (survey.getRecurrenceType() == RecurrenceType.LONGITUDINAL && priorResponse != null && shouldCreateNewLongitudinalTaskAndResponse(survey.getCreateNewResponseAfterDays(), priorResponse.getLastUpdatedAt())) {
             ParticipantTask newTask = participantTaskService.cleanForCopying(task);
-            SurveyResponse priorResponse = dao.findOneWithAnswers(task.getSurveyResponseId()).orElseThrow(() -> new NotFoundException("No response found for task %s".formatted(taskId)));
+            if(newTask.getCompletedAt() != null) {
+                newTask.setCompletedAt(Instant.now());
+            }
             priorResponse.getAnswers().forEach(a -> a.setSurveyResponseId(null));
             response = surveyTaskDispatcher.createPrepopulatedSurveyResponse(priorResponse);
             newTask.setSurveyResponseId(response.getId());

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -7,10 +7,7 @@ import bio.terra.pearl.core.model.audit.ResponsibleEntity;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.PortalParticipantUser;
 import bio.terra.pearl.core.model.survey.*;
-import bio.terra.pearl.core.model.workflow.HubResponse;
-import bio.terra.pearl.core.model.workflow.ParticipantTask;
-import bio.terra.pearl.core.model.workflow.TaskStatus;
-import bio.terra.pearl.core.model.workflow.TaskType;
+import bio.terra.pearl.core.model.workflow.*;
 import bio.terra.pearl.core.service.CascadeProperty;
 import bio.terra.pearl.core.service.CrudService;
 import bio.terra.pearl.core.service.exception.NotFoundException;
@@ -21,10 +18,15 @@ import bio.terra.pearl.core.service.survey.event.EnrolleeSurveyEvent;
 import bio.terra.pearl.core.service.workflow.EventService;
 import bio.terra.pearl.core.service.workflow.ParticipantDataChangeService;
 import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 public class SurveyResponseService extends CrudService<SurveyResponse, SurveyResponseDao> {
@@ -34,6 +36,7 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
     private final StudyEnvironmentSurveyService studyEnvironmentSurveyService;
     private final AnswerProcessingService answerProcessingService;
     private final ParticipantDataChangeService participantDataChangeService;
+    private final SurveyTaskDispatcher surveyTaskDispatcher;
     private final EventService eventService;
     private final EnrolleeContextService enrolleeContextService;
     public static final String CONSENTED_ANSWER_STABLE_ID = "consented";
@@ -44,8 +47,8 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
                                  ParticipantTaskService participantTaskService,
                                  StudyEnvironmentSurveyService studyEnvironmentSurveyService,
                                  AnswerProcessingService answerProcessingService,
-                                 ParticipantDataChangeService participantDataChangeService,
-                                 EventService eventService, EnrolleeContextService enrolleeContextService) {
+                                 EnrolleeContextService enrolleeContextService,
+                                 ParticipantDataChangeService participantDataChangeService, @Lazy SurveyTaskDispatcher surveyTaskDispatcher, EventService eventService) {
         super(dao);
         this.answerService = answerService;
         this.surveyService = surveyService;
@@ -53,6 +56,7 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         this.studyEnvironmentSurveyService = studyEnvironmentSurveyService;
         this.answerProcessingService = answerProcessingService;
         this.participantDataChangeService = participantDataChangeService;
+        this.surveyTaskDispatcher = surveyTaskDispatcher;
         this.eventService = eventService;
         this.enrolleeContextService = enrolleeContextService;
     }
@@ -136,6 +140,16 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         return answers;
     }
 
+    //if the cutoff time has passed, create a new task and response
+    private boolean shouldCreateNewLongtitudinalTaskAndResponse(Integer createNewResponseAfterDays, ParticipantTask task) {
+        if(createNewResponseAfterDays == null) {
+            return false;
+        }
+        Instant cutoffTime = ZonedDateTime.now(ZoneOffset.UTC)
+                .minusSeconds(createNewResponseAfterDays).toInstant(); //todo change back to minusDays
+        return task.getLastUpdatedAt().isBefore(cutoffTime);
+    }
+
     /**
      * Creates a survey response and fires appropriate downstream events.
      */
@@ -152,8 +166,20 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
                 task.getTargetAssignedVersion(), portalId).get();
         validateResponse(survey, task, responseDto.getAnswers());
 
-        // find or create the SurveyResponse object to attach the snapshot
-        SurveyResponse response = findOrCreateResponse(task, enrollee, enrollee.getParticipantUserId(), responseDto, portalId, operator);
+
+        SurveyResponse response;
+        //if the survey is longitudinal and we're past the cutoff point for updating an existing response, we need to create a new response and task
+        if (survey.getRecurrenceType() == RecurrenceType.LONGITUDINAL && shouldCreateNewLongtitudinalTaskAndResponse(survey.getCreateNewResponseAfterDays(), task)) {
+            ParticipantTask newTask = participantTaskService.cleanForCopying(task);
+            SurveyResponse priorResponse = dao.findOneWithAnswers(task.getSurveyResponseId()).orElseThrow(() -> new NotFoundException("No response found for task %s".formatted(taskId)));
+            priorResponse.getAnswers().forEach(a -> a.setSurveyResponseId(null));
+            response = surveyTaskDispatcher.createPrepopulatedSurveyResponse(priorResponse);
+            newTask.setSurveyResponseId(response.getId());
+            task = participantTaskService.create(newTask, null);
+        } else {
+            // find or create the SurveyResponse object to attach the snapshot
+            response = findOrCreateResponse(task, enrollee, enrollee.getParticipantUserId(), responseDto, portalId, operator);
+        }
 
         List<Answer> updatedAnswers = createOrUpdateAnswers(responseDto.getAnswers(), response, justification, survey, ppUser, operator);
         List<Answer> allAnswers = new ArrayList<>(response.getAnswers());

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -218,6 +218,8 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
             EnrolleeSurveyEvent event = eventService.publishEnrolleeSurveyEvent(enrollee, response, ppUser, task);
             enrolleeContext = event.getEnrolleeContext();
         } else {
+            enrollee.getParticipantTasks().clear();
+            enrollee.getParticipantTasks().addAll(participantTaskService.findByEnrolleeId(enrollee.getId()));
             enrolleeContext = enrolleeContextService.fetchData(enrollee);
         }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
@@ -158,7 +158,7 @@ public class SurveyTaskDispatcher extends TaskDispatcher<SurveyTaskConfigDto> {
 
     // creates a new survey response with the same answers as priorResponse
     // for use with longitudinal recurring surveys
-    private SurveyResponse createPrepopulatedSurveyResponse(SurveyResponse priorResponse) {
+    protected SurveyResponse createPrepopulatedSurveyResponse(SurveyResponse priorResponse) {
         List<Answer> answers = priorResponse.getAnswers().stream()
                 .map(a -> (Answer) a.cleanForCopying())
                 .collect(Collectors.toList());

--- a/core/src/main/resources/db/changelog/changesets/2025_02_13_create_new_survey_response_days.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2025_02_13_create_new_survey_response_days.yaml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: "create_new_survey_response_days"
+      author: mbemis
+      changes:
+        - addColumn:
+            tableName: survey
+            columns:
+              - column: { name: create_new_response_after_days, type: integer }

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -396,8 +396,12 @@ databaseChangeLog:
       file: changesets/2025_01_27_prenroll_type.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2025_02_13_create_new_survey_response_days.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2025_02_14_trigger_admin_email_filter.yaml
       relativeToChangelogFile: true
+
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements
 # are atomic. When they are grouped in a changeset and one fails the changeset cannot be

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/lifestyle.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/lifestyle.json
@@ -5,6 +5,7 @@
   "footer": "Resources used for this survey:\n * Tobacco Use Supplement to the Current Population Survey (TUS&#8209;CPS)\n * American Thoracic Society Division of Lung Disease questionnaire (ATS&nbsp;&#8209;&nbsp;DLD&nbsp;&#8209;&nbsp;78)\n * Million Veterans Program\n * Prostate, Lung, Colorectal, and Ovarian (PLCO) Cancer Screening Trial\n * Population Assessment of Tobacco and Health (PATH)\n * National Epidemiologic Survey on Alcohol and Related Conditions (NESARC)\n * Alcohol Use Disorders Identification Test (AUDIT&#8209;C)\n * NM ASSIST (NIDA-Modified Alcohol, Smoking, and Substance Involvement Screening Test)",
   "recurrenceIntervalDays": 7,
   "recurrenceType": "LONGITUDINAL",
+  "createNewResponseAfterDays": 1,
   "jsonContent": {
     "title": {
       "en": "Lifestyle",

--- a/ui-admin/src/study/participants/survey/SurveyResponseEditor.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyResponseEditor.tsx
@@ -19,7 +19,7 @@ export default function SurveyResponseEditor({
   updateResponseMap: (stableId: string, response: SurveyResponse) => void, justification?: string
 }) {
   const { defaultLanguage } = usePortalLanguage()
-  const { taskId } = useTaskIdParam()
+  const { taskId, setTaskId } = useTaskIdParam()
   if (!taskId) {
     return <span>Task Id must be specified</span>
   }
@@ -57,6 +57,7 @@ export default function SurveyResponseEditor({
         updateProfile={() => { /*no-op for admins*/ }}
         updateEnrollee={() => { /*no-op for admins*/ }}
         taskId={taskId}
+        setTaskId={setTaskId}
         justification={justification}
         showHeaders={false}/>
     </div>

--- a/ui-admin/src/study/surveys/FormOptionsModal.tsx
+++ b/ui-admin/src/study/surveys/FormOptionsModal.tsx
@@ -200,8 +200,8 @@ export const FormOptions = ({ studyEnvContext, initialWorkingForm, updateWorking
                   createNewResponseAfterDays: parseInt(val)
                 })}
               /> days <InfoPopup placement="right" content={<div>
-                      If this value is set, a new response will be created for the participant if the make an edit to
-                      their response after this many days
+                      If this value is set, a new task and response will be created for the participant
+                      if they make an edit to their response after this many days
               </div>}/>
             </label>
             </>}

--- a/ui-admin/src/study/surveys/FormOptionsModal.tsx
+++ b/ui-admin/src/study/surveys/FormOptionsModal.tsx
@@ -180,16 +180,31 @@ export const FormOptions = ({ studyEnvContext, initialWorkingForm, updateWorking
                 /> days
               </label>
             </div>
-            {workingForm.recurrenceType === 'LONGITUDINAL' &&  <label className="form-label d-block">
+            {workingForm.recurrenceType === 'LONGITUDINAL' && <><label className="form-label d-block">
               <input type="checkbox" checked={workingForm.prepopulate}
                 onChange={e => updateWorkingForm({
                   ...workingForm, prepopulate: e.target.checked
                 })}
               /> Prepopulate answers <InfoPopup placement="right" content={<div>
-                    For longitudinal surveys, enabling this will automatically
-                    prepopulate answers from the previous survey response
+                  For longitudinal surveys, enabling this will automatically
+                  prepopulate answers from the previous survey response
               </div>}/>
-            </label> }
+            </label>
+            <label className="d-flex align-items-center">
+                      Create a new response after
+              <TextInput value={workingForm.createNewResponseAfterDays} type="number" min={1} max={9999}
+                className="mx-2"
+                style={{ maxWidth: '100px' }}
+                onChange={val => updateWorkingForm({
+                  ...workingForm,
+                  createNewResponseAfterDays: parseInt(val)
+                })}
+              /> days <InfoPopup placement="right" content={<div>
+                      If this value is set, a new response will be created for the participant if the make an edit to
+                      their response after this many days
+              </div>}/>
+            </label>
+            </>}
             <h3 className="h6 mt-4">Eligibility Rule</h3>
             <div className="mb-2">
               <LazySearchQueryBuilder

--- a/ui-admin/src/study/surveys/SurveyView.tsx
+++ b/ui-admin/src/study/surveys/SurveyView.tsx
@@ -26,6 +26,7 @@ export type SaveableFormProps = {
   rule?: string
   recurrenceType: RecurrenceType
   prepopulate: boolean
+  createNewResponseAfterDays?: number
   recurrenceIntervalDays?: number
   daysAfterEligible?: number
   allowAdminEdit?: boolean

--- a/ui-core/src/components/forms/PagedSurveyView.test.tsx
+++ b/ui-core/src/components/forms/PagedSurveyView.test.tsx
@@ -468,7 +468,7 @@ const setupSurveyTest = (survey: Survey, profile?: Profile, referencedAnswers?: 
         <PagedSurveyView enrollee={enrollee} form={configuredSurvey.survey} response={mockHubResponse().response}
           studyEnvParams={{ studyShortcode: 'study', portalShortcode: 'portal', envName: 'sandbox' }}
           updateResponseMap={jest.fn()} referencedAnswers={referencedAnswers || []}
-          selectedLanguage={'en'} updateProfile={jest.fn()} setAutosaveStatus={jest.fn()}
+          selectedLanguage={'en'} updateProfile={jest.fn()} setAutosaveStatus={jest.fn()} setTaskId={jest.fn()}
           taskId={'guid34'} adminUserId={null} updateEnrollee={jest.fn()} onFailure={jest.fn()} onSuccess={jest.fn()}/>
       </MockI18nProvider>
     </ApiProvider>)

--- a/ui-core/src/components/forms/PagedSurveyView.tsx
+++ b/ui-core/src/components/forms/PagedSurveyView.tsx
@@ -21,7 +21,7 @@ import { SurveyAutoCompleteButton } from './SurveyAutoCompleteButton'
 import { SurveyReviewModeButton } from './ReviewModeButton'
 import { StudyEnvParams } from 'src/types/study'
 import {
-  Enrollee,
+  Enrollee, HubResponse,
   Profile
 } from 'src/types/user'
 import classNames from 'classnames'
@@ -40,6 +40,7 @@ export function PagedSurveyView({
   updateEnrollee,
   updateProfile,
   taskId,
+  setTaskId,
   selectedLanguage,
   justification,
   setAutosaveStatus, enrollee, proxyProfile, adminUserId, onSuccess, onFailure, showHeaders = true
@@ -53,7 +54,9 @@ export function PagedSurveyView({
     updateProfile: (profile: Profile, updateWithoutRerender?: boolean) => void,
     proxyProfile?: Profile,
     justification?: string,
-    taskId: string, adminUserId: string | null, enrollee: Enrollee, showHeaders?: boolean,
+    taskId: string,
+    setTaskId: (taskId: string) => void,
+    adminUserId: string | null, enrollee: Enrollee, showHeaders?: boolean,
 }) {
   const resumableData = makeSurveyJsData(response?.resumeData, response?.answers, enrollee.participantUserId)
   const pager = useRoutablePageNumber()
@@ -102,6 +105,7 @@ export function PagedSurveyView({
         participantTasks: response.tasks,
         profile: response.profile
       }
+      updateTaskId(response)
       /**
        * CAREFUL -- we're updating the enrollee object so that if they navigate back to the dashboard, they'll
        * see this survey as 'in progress' and capture any profile changes.
@@ -121,6 +125,15 @@ export function PagedSurveyView({
       prevSave.current = prevPrevSave
       lastAutoSaveErrored.current = true
     })
+  }
+
+  const updateTaskId = (response: HubResponse) => {
+    //TODO: can we trust that the first task returned is the newest? hmmm
+    const newestTask = response.tasks[0]
+    //set url params to the newest task id
+    if (newestTask && taskId !== newestTask.id) {
+      setTaskId(newestTask.id)
+    }
   }
 
   const cancelAutosave = useAutosaveEffect(saveDiff, AUTO_SAVE_INTERVAL)

--- a/ui-core/src/components/forms/PagedSurveyView.tsx
+++ b/ui-core/src/components/forms/PagedSurveyView.tsx
@@ -127,12 +127,12 @@ export function PagedSurveyView({
     })
   }
 
-  const updateTaskId = (response: HubResponse) => {
-    //TODO: can we trust that the first task returned is the newest? hmmm
-    const newestTask = response.tasks[0]
+  const updateTaskId = (hubResponse: HubResponse) => {
+    const surveyResponseId = hubResponse.response.id
+    const taskForResponse = hubResponse.tasks.find(task => task.surveyResponseId === surveyResponseId)
     //set url params to the newest task id
-    if (newestTask && taskId !== newestTask.id) {
-      setTaskId(newestTask.id)
+    if (taskForResponse && taskId !== taskForResponse.id) {
+      setTaskId(taskForResponse.id)
     }
   }
 

--- a/ui-core/src/components/forms/PagedSurveyView.tsx
+++ b/ui-core/src/components/forms/PagedSurveyView.tsx
@@ -105,6 +105,7 @@ export function PagedSurveyView({
         participantTasks: response.tasks,
         profile: response.profile
       }
+      // update the taskId in case this is an update to a longitudinal survey which will create a new task & response
       updateTaskId(response)
       /**
        * CAREFUL -- we're updating the enrollee object so that if they navigate back to the dashboard, they'll

--- a/ui-core/src/types/forms.ts
+++ b/ui-core/src/types/forms.ts
@@ -47,6 +47,7 @@ export type Survey = VersionedForm & {
   allowParticipantStart: boolean
   allowParticipantReedit: boolean
   prepopulate: boolean
+  createNewResponseAfterDays?: number
   eligibilityRule?: string
 }
 

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -59,7 +59,7 @@ function SurveyView({ showHeaders = true }: { showHeaders?: boolean }) {
     ?.profile : undefined
 
   const { i18n, selectedLanguage } = useI18n()
-  const { taskId } = useTaskIdParam() ?? ''
+  const { taskId, setTaskId } = useTaskIdParam()
   const navigate = useNavigate()
 
   if (!stableId || !version || !studyShortcode) {
@@ -130,7 +130,8 @@ function SurveyView({ showHeaders = true }: { showHeaders?: boolean }) {
         onFailure={onFailure}
         updateEnrollee={updateEnrollee}
         updateProfile={updateProfile}
-        taskId={taskId}
+        taskId={taskId || ''}
+        setTaskId={setTaskId}
         showHeaders={showHeaders}
       />
     </ApiProvider>


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds the option for study staff to configure a longitudinal survey to create a new response and task if a response is edited after X days

Admin UX:
<img width="814" alt="Screenshot 2025-02-14 at 2 16 35 PM" src="https://github.com/user-attachments/assets/dd702041-9dfd-48ee-a6df-c47ce6888424" />


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Restart admin and participant API apps
Repopulate demo
Log in as jsalk@test.com
Edit the response to the lifestyle survey
Since the survey is configured to create a new response if the last edit was >1 day ago, you should see a new task and response created with the new changes
Continue editing and confirm that the new edits are saved to the just-now-created task/response