### PR TITLE
[JN-1625] Document upload bucket terraform

### DIFF
--- a/terraform/gcp/buckets.tf
+++ b/terraform/gcp/buckets.tf
@@ -1,0 +1,8 @@
+resource "google_storage_bucket" "participant_documents" {
+  name     = var.documents_bucket_name
+  location = var.region
+
+  versioning {
+    enabled = true
+  }
+}

--- a/terraform/gcp/buckets.tf
+++ b/terraform/gcp/buckets.tf
@@ -1,7 +1,11 @@
 resource "google_storage_bucket" "participant_documents" {
   name     = var.documents_bucket_name
   location = var.region
+  # no public access allowed
+  public_access_prevention    = "enforced"
 
+  # only allow access if you have iam perms
+  uniform_bucket_level_access = true
   versioning {
     enabled = true
   }

--- a/terraform/gcp/envs/dev.tfvars
+++ b/terraform/gcp/envs/dev.tfvars
@@ -8,7 +8,7 @@ environment = "dev"
 # note: automatically creates DNS records for these portals under the admin domain
 portals = ["demo", "atcp", "ourhealth", "hearthive", "rgp", "cmi"]
 k8s_namespace = "juniper-dev"
-documents_bucket_name = "participant-documents-dev"
+documents_bucket_name = "juniper-participant-documents-dev"
 
 # creates DNS records for these customer URLs
 customer_urls = {

--- a/terraform/gcp/envs/dev.tfvars
+++ b/terraform/gcp/envs/dev.tfvars
@@ -8,6 +8,7 @@ environment = "dev"
 # note: automatically creates DNS records for these portals under the admin domain
 portals = ["demo", "atcp", "ourhealth", "hearthive", "rgp", "cmi"]
 k8s_namespace = "juniper-dev"
+documents_bucket_name = "participant-documents-dev"
 
 # creates DNS records for these customer URLs
 customer_urls = {

--- a/terraform/gcp/envs/prod.tfvars
+++ b/terraform/gcp/envs/prod.tfvars
@@ -6,7 +6,7 @@ db_availability_type = "REGIONAL" # makes database highly available by replicati
 dns_ttl = 300
 admin_url = "juniper-cmi.org"
 environment = "prod"
-documents_bucket_name = "participant-documents-prod"
+documents_bucket_name = "juniper-participant-documents-prod"
 # note: automatically creates DNS records for these portals under the admin domain
 
 portals = ["demo", "atcp", "ourhealth", "hearthive", "rgp", "cmi", "trccproject", "gvasc"]

--- a/terraform/gcp/envs/prod.tfvars
+++ b/terraform/gcp/envs/prod.tfvars
@@ -6,6 +6,7 @@ db_availability_type = "REGIONAL" # makes database highly available by replicati
 dns_ttl = 300
 admin_url = "juniper-cmi.org"
 environment = "prod"
+documents_bucket_name = "participant-documents-prod"
 # note: automatically creates DNS records for these portals under the admin domain
 
 portals = ["demo", "atcp", "ourhealth", "hearthive", "rgp", "cmi", "trccproject", "gvasc"]

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -93,3 +93,8 @@ variable "slack_notification_channel" {
   default = ""
   description = "Slack notification channel"
 }
+
+variable "documents_bucket_name" {
+  type = string
+  description = "The name of the GCP bucket for storing participant documents"
+}


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds new terraform resources for the participant document upload buckets.

tf plan for dev:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # google_compute_subnetwork.juniper_subnetwork will be updated in-place
  ~ resource "google_compute_subnetwork" "juniper_subnetwork" {
        id                         = "projects/broad-juniper-dev/regions/us-central1/subnetworks/juniper-cluster-subnetwork"
        name                       = "juniper-cluster-subnetwork"
      ~ private_ipv6_google_access = "DISABLE_GOOGLE_ACCESS" -> "ENABLE_GOOGLE_ACCESS"
        # (18 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

  # google_storage_bucket.participant_documents will be created
  + resource "google_storage_bucket" "participant_documents" {
      + effective_labels            = {
          + "goog-terraform-provisioned" = "true"
        }
      + force_destroy               = false
      + id                          = (known after apply)
      + location                    = "US-CENTRAL1"
      + name                        = "participant-documents-dev"
      + project                     = (known after apply)
      + project_number              = (known after apply)
      + public_access_prevention    = (known after apply)
      + rpo                         = (known after apply)
      + self_link                   = (known after apply)
      + storage_class               = "STANDARD"
      + terraform_labels            = {
          + "goog-terraform-provisioned" = "true"
        }
      + uniform_bucket_level_access = (known after apply)
      + url                         = (known after apply)

      + soft_delete_policy (known after apply)

      + versioning {
          + enabled = true
        }

      + website (known after apply)
    }

Plan: 1 to add, 1 to change, 0 to destroy.
```

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

