### PR TITLE
[JN-1630] Only dispatch survey events if survey is complete

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -14,6 +14,8 @@ import bio.terra.pearl.core.model.workflow.TaskType;
 import bio.terra.pearl.core.service.CascadeProperty;
 import bio.terra.pearl.core.service.CrudService;
 import bio.terra.pearl.core.service.exception.NotFoundException;
+import bio.terra.pearl.core.service.rule.EnrolleeContext;
+import bio.terra.pearl.core.service.rule.EnrolleeContextService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
 import bio.terra.pearl.core.service.survey.event.EnrolleeSurveyEvent;
 import bio.terra.pearl.core.service.workflow.EventService;
@@ -33,6 +35,7 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
     private final AnswerProcessingService answerProcessingService;
     private final ParticipantDataChangeService participantDataChangeService;
     private final EventService eventService;
+    private final EnrolleeContextService enrolleeContextService;
     public static final String CONSENTED_ANSWER_STABLE_ID = "consented";
 
     public SurveyResponseService(SurveyResponseDao dao,
@@ -41,7 +44,8 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
                                  ParticipantTaskService participantTaskService,
                                  StudyEnvironmentSurveyService studyEnvironmentSurveyService,
                                  AnswerProcessingService answerProcessingService,
-                                 ParticipantDataChangeService participantDataChangeService, EventService eventService) {
+                                 ParticipantDataChangeService participantDataChangeService,
+                                 EventService eventService, EnrolleeContextService enrolleeContextService) {
         super(dao);
         this.answerService = answerService;
         this.surveyService = surveyService;
@@ -50,6 +54,7 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         this.answerProcessingService = answerProcessingService;
         this.participantDataChangeService = participantDataChangeService;
         this.eventService = eventService;
+        this.enrolleeContextService = enrolleeContextService;
     }
 
     public List<SurveyResponse> findByEnrolleeId(UUID enrolleeId) {
@@ -175,10 +180,20 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
 
         // now update the task status and response id
         task = updateTaskToResponse(task, response, updatedAnswers, auditInfo);
-        EnrolleeSurveyEvent event = eventService.publishEnrolleeSurveyEvent(enrollee, response, ppUser, task);
+
+        // we only want to publish the event if the survey is complete
+        // eventually, we may add other types of events like SURVEY_RESPONSE_UPDATED, or something
+        // but for now we only care about eventing on completions or re-completions
+        EnrolleeContext enrolleeContext;
+        if(response.isComplete()) {
+            EnrolleeSurveyEvent event = eventService.publishEnrolleeSurveyEvent(enrollee, response, ppUser, task);
+            enrolleeContext = event.getEnrolleeContext();
+        } else {
+            enrolleeContext = enrolleeContextService.fetchData(enrollee);
+        }
 
         logger.info("SurveyResponse received -- enrollee: {}, surveyStabledId: {}", enrollee.getShortcode(), survey.getStableId());
-        HubResponse<SurveyResponse> hubResponse = eventService.buildHubResponse(event, response);
+        HubResponse<SurveyResponse> hubResponse = eventService.buildHubResponse(enrollee, enrolleeContext, response);
         return hubResponse;
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/event/EnrolleeSurveyEvent.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/event/EnrolleeSurveyEvent.java
@@ -16,6 +16,7 @@ import lombok.experimental.SuperBuilder;
 public class EnrolleeSurveyEvent extends EnrolleeEvent {
     private SurveyResponse surveyResponse;
     private ParticipantTask participantTask; // the task corresponding to the response
+    private boolean isComplete; // whether the survey is complete, to help differentiate between completing and updating for email notifs
 
     @Override
     public String getTargetStableId() {

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/event/EnrolleeSurveyEvent.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/event/EnrolleeSurveyEvent.java
@@ -16,7 +16,6 @@ import lombok.experimental.SuperBuilder;
 public class EnrolleeSurveyEvent extends EnrolleeEvent {
     private SurveyResponse surveyResponse;
     private ParticipantTask participantTask; // the task corresponding to the response
-    private boolean isComplete; // whether the survey is complete, to help differentiate between completing and updating for email notifs
 
     @Override
     public String getTargetStableId() {

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
@@ -99,6 +99,7 @@ public class EventService extends ImmutableEntityService<Event, EventDao> {
                 .enrollee(enrollee)
                 .portalParticipantUser(ppUser)
                 .participantTask(task)
+                .isComplete(response.isComplete())
                 .build();
         populateEvent(event);
         log.info("survey event for enrollee {}, studyEnv {} - formId {}, completed {}",

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
@@ -194,15 +194,18 @@ public class EventService extends ImmutableEntityService<Event, EventDao> {
      * response reflects the latest task list and profile
      */
     public <T extends BaseEntity> HubResponse<T> buildHubResponse(EnrolleeEvent event, T response) {
+        return buildHubResponse(event.getEnrollee(), event.getEnrolleeContext(), response);
+    }
+
+    public <T extends BaseEntity> HubResponse<T> buildHubResponse(Enrollee enrollee, EnrolleeContext enrolleeContext, T response) {
         HubResponse hubResponse = HubResponse.builder()
                 .response(response)
-                .tasks(event.getEnrollee().getParticipantTasks().stream().toList())
-                .enrollee(event.getEnrollee())
-                .profile(event.getEnrolleeContext().getProfile())
+                .tasks(enrollee.getParticipantTasks().stream().toList())
+                .enrollee(enrollee)
+                .profile(enrolleeContext.getProfile())
                 .build();
         return hubResponse;
     }
-
 
     @Autowired
     private ApplicationEventPublisher applicationEventPublisher;

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
@@ -99,7 +99,6 @@ public class EventService extends ImmutableEntityService<Event, EventDao> {
                 .enrollee(enrollee)
                 .portalParticipantUser(ppUser)
                 .participantTask(task)
-                .isComplete(response.isComplete())
                 .build();
         populateEvent(event);
         log.info("survey event for enrollee {}, studyEnv {} - formId {}, completed {}",

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/TriggerActionService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/TriggerActionService.java
@@ -72,7 +72,7 @@ public class TriggerActionService {
                 //if event is EnrolleeSurveyEvent, we need to check if the event was a survey
                 //completion or not to determine if we should send the notification
                 if (event instanceof EnrolleeSurveyEvent surveyEvent) {
-                    if (surveyEvent.isComplete()) {
+                    if (surveyEvent.getSurveyResponse().isComplete()) {
                         notificationDispatcher.dispatchNotificationAsync(trigger, event.getEnrolleeContext(),
                                 event.getPortalParticipantUser().getPortalEnvironmentId());
                     }

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/TriggerActionService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/TriggerActionService.java
@@ -69,17 +69,8 @@ public class TriggerActionService {
 
         for (Trigger trigger: applicableTriggers) {
             if (TriggerActionType.NOTIFICATION.equals(trigger.getActionType())) {
-                //if event is EnrolleeSurveyEvent, we need to check if the event was a survey
-                //completion or not to determine if we should send the notification
-                if (event instanceof EnrolleeSurveyEvent surveyEvent) {
-                    if (surveyEvent.getSurveyResponse().isComplete()) {
-                        notificationDispatcher.dispatchNotificationAsync(trigger, event.getEnrolleeContext(),
-                                event.getPortalParticipantUser().getPortalEnvironmentId());
-                    }
-                } else {
-                    notificationDispatcher.dispatchNotificationAsync(trigger, event.getEnrolleeContext(),
-                            event.getPortalParticipantUser().getPortalEnvironmentId());
-                }
+                notificationDispatcher.dispatchNotificationAsync(trigger, event.getEnrolleeContext(),
+                        event.getPortalParticipantUser().getPortalEnvironmentId());
             } else if (TriggerActionType.ADMIN_NOTIFICATION.equals(trigger.getActionType())) {
                 try {
                     adminEmailService.sendEmailFromTrigger(trigger, event);

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/TriggerActionService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/TriggerActionService.java
@@ -13,6 +13,7 @@ import bio.terra.pearl.core.service.notification.email.AdminEmailService;
 import bio.terra.pearl.core.service.notification.email.EmailTemplateService;
 import bio.terra.pearl.core.service.portal.PortalService;
 import bio.terra.pearl.core.service.rule.EnrolleeRuleEvaluator;
+import bio.terra.pearl.core.service.survey.event.EnrolleeSurveyEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
@@ -68,8 +69,17 @@ public class TriggerActionService {
 
         for (Trigger trigger: applicableTriggers) {
             if (TriggerActionType.NOTIFICATION.equals(trigger.getActionType())) {
-                notificationDispatcher.dispatchNotificationAsync(trigger, event.getEnrolleeContext(),
-                        event.getPortalParticipantUser().getPortalEnvironmentId());
+                //if event is EnrolleeSurveyEvent, we need to check if the event was a survey
+                //completion or not to determine if we should send the notification
+                if (event instanceof EnrolleeSurveyEvent surveyEvent) {
+                    if (surveyEvent.isComplete()) {
+                        notificationDispatcher.dispatchNotificationAsync(trigger, event.getEnrolleeContext(),
+                                event.getPortalParticipantUser().getPortalEnvironmentId());
+                    }
+                } else {
+                    notificationDispatcher.dispatchNotificationAsync(trigger, event.getEnrolleeContext(),
+                            event.getPortalParticipantUser().getPortalEnvironmentId());
+                }
             } else if (TriggerActionType.ADMIN_NOTIFICATION.equals(trigger.getActionType())) {
                 try {
                     adminEmailService.sendEmailFromTrigger(trigger, event);

--- a/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentWorkflowTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentWorkflowTests.java
@@ -156,7 +156,7 @@ public class EnrollmentWorkflowTests extends BaseSpringBootTest {
         surveyResponseService.updateResponse(consentResponse, new ResponsibleEntity(userBundle.user()), null, userBundle.ppUser(),
                 enrollee, consentTask.getId(), consent.getPortalId());
         assertThat(getEventsByType(enrollee.getId()).get(EventClass.ENROLLEE_CONSENT_EVENT), hasSize(1));
-        assertThat(getEventsByType(enrollee.getId()).get(EventClass.ENROLLEE_SURVEY_EVENT), hasSize(2));
+        assertThat(getEventsByType(enrollee.getId()).get(EventClass.ENROLLEE_SURVEY_EVENT), hasSize(1));
 
         Enrollee refreshedEnrollee = enrolleeService.find(enrollee.getId()).get();
         assertThat(refreshedEnrollee.isConsented(), equalTo(true));


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Survey completion notifications would be sent on every autosave, not just completions. Now this only sends an email if the survey has been completed.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Repopulate demo
Log in as jsalk@test.com
Go to the Other Medical History survey
Fill out some answers - make sure an autosave is triggered
Confirm you don't get an email
Autofill and submit the rest of the survey
Confirm you _do_ get an email