### PR TITLE
[JN-1631] Clean referralSource and related enrollment params from URL after load

### DIFF
--- a/ui-participant/src/studies/enroll/useEnrollmentParams.tsx
+++ b/ui-participant/src/studies/enroll/useEnrollmentParams.tsx
@@ -60,6 +60,13 @@ export function useEnrollmentParams() {
     captureEnrollmentParams()
   }, [searchParams])
 
+  // Removes referral parameters from the URL for a cleaner participant experience
+  const newUrl = new URL(window.location.href)
+  newUrl.searchParams.delete('skipPreEnroll')
+  newUrl.searchParams.delete('referralSource')
+  newUrl.searchParams.delete('preFilledAnswers')
+  window.history.replaceState({}, '', newUrl.toString())
+
   return {
     skipPreEnroll, referralSource, isProxyEnrollment, ppUserId, preFilledAnswers,
     captureEnrollmentParams, clearStoredEnrollmentParams


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

From some tRCC feedback: they're going to be using the referralSource param functionality to direct users from joincountmein.org and other sites, and after the site loads and the information has been captured in session storage, there's really no reason to preserve that information in the URL bar anymore. This cleans up the participant experience a bit.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Go to `https://sandbox.demo.localhost:3001/?referralSource={%22referringSite%22:%22http://google.com%22,%22referringPerson%22:%22Hello%20World%22}`
Confirm the referringSite was written to *session* storage, and the URL bar was cleaned up after the page loaded.