### PR TITLE
[JN-1632] GCS backend for document upload

### DIFF
--- a/api-admin/build.gradle
+++ b/api-admin/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation 'com.auth0:java-jwt:4.5.0'
     implementation 'org.liquibase:liquibase-core:4.31.0'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    implementation 'com.google.guava:guava:33.4.0-jre'
 
     implementation 'net.javacrumbs.shedlock:shedlock-spring:6.2.0'
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.2.0'

--- a/api-admin/src/main/resources/application-gcp.yml
+++ b/api-admin/src/main/resources/application-gcp.yml
@@ -20,6 +20,8 @@ env:
     token: ${sm://${MIXPANEL_TOKEN_SECRET_ID}}
   airtable:
     authToken: ${sm://${AIRTABLE_AUTH_TOKEN_SECRET_ID}}
+  fileUpload:
+    backend: GCSFileStorageBackend
 spring:
   cloud:
     gcp:

--- a/api-admin/src/main/resources/application.yml
+++ b/api-admin/src/main/resources/application.yml
@@ -46,7 +46,7 @@ env:
   airtable:
     authToken: ${AIRTABLE_AUTH_TOKEN:foobar}
   fileUpload:
-    backend: LocalFileStorageBackend
+    backend: GCSFileStorageBackend
     localFileStoragePath: ${LOCAL_FILE_STORAGE_PATH:/tmp/juniper/fileupload}
 
 # Below here is non-deployment-specific

--- a/api-admin/src/main/resources/application.yml
+++ b/api-admin/src/main/resources/application.yml
@@ -48,7 +48,9 @@ env:
   fileUpload:
     backend: LocalFileStorageBackend
     localFileStoragePath: ${LOCAL_FILE_STORAGE_PATH:/tmp/juniper/fileupload}
-    gcsFileStorageBucketName: ${GCS_FILE_STORAGE_BUCKET_NAME:}
+    gcsStorageUnscannedBucketName: ${GCS_FILE_STORAGE_UNSCANNED_BUCKET_NAME:}
+    gcsStorageCleanBucketName: ${GCS_FILE_STORAGE_CLEAN_BUCKET_NAME:}
+    gcsStorageQuarantinedBucketName: ${GCS_FILE_STORAGE_QUARANTINED_BUCKET_NAME:}
     gcsFileStorageProjectId: ${GCS_FILE_STORAGE_PROJECT_ID:}
 
 # Below here is non-deployment-specific

--- a/api-admin/src/main/resources/application.yml
+++ b/api-admin/src/main/resources/application.yml
@@ -46,7 +46,7 @@ env:
   airtable:
     authToken: ${AIRTABLE_AUTH_TOKEN:foobar}
   fileUpload:
-    backend: GCSFileStorageBackend
+    backend: LocalFileStorageBackend
     localFileStoragePath: ${LOCAL_FILE_STORAGE_PATH:/tmp/juniper/fileupload}
 
 # Below here is non-deployment-specific

--- a/api-admin/src/main/resources/application.yml
+++ b/api-admin/src/main/resources/application.yml
@@ -48,6 +48,8 @@ env:
   fileUpload:
     backend: LocalFileStorageBackend
     localFileStoragePath: ${LOCAL_FILE_STORAGE_PATH:/tmp/juniper/fileupload}
+    gcsFileStorageBucketName: ${GCS_FILE_STORAGE_BUCKET_NAME:}
+    gcsFileStorageProjectId: ${GCS_FILE_STORAGE_PROJECT_ID:}
 
 # Below here is non-deployment-specific
 

--- a/api-admin/src/test/resources/application.yml
+++ b/api-admin/src/test/resources/application.yml
@@ -18,6 +18,15 @@ env:
   email:
     sendgridApiKey: ${SENDGRID_API_KEY:}
 
+otel:
+  sdk:
+    disabled: true
+  instrumentation:
+    spring-webflux:
+      enabled: false
+    spring-web:
+      enabled: false
+
 # Below here is non-deployment-specific
 
 # When the target is 'local' the write-config.sh script will generate this properties file. It

--- a/api-participant/build.gradle
+++ b/api-participant/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'com.sendgrid:sendgrid-java:4.10.3'
     implementation 'org.liquibase:liquibase-core:4.31.0'
     implementation 'com.auth0:java-jwt:4.5.0'
+    implementation 'com.google.guava:guava:33.4.0-jre'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6',

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/service/file/ParticipantFileExtService.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/service/file/ParticipantFileExtService.java
@@ -3,10 +3,12 @@ package bio.terra.pearl.api.participant.service.file;
 import bio.terra.pearl.api.participant.service.AuthUtilService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.file.ParticipantFile;
+import bio.terra.pearl.core.model.file.ScannedParticipantFileDto;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.file.ParticipantFileService;
+import bio.terra.pearl.core.service.file.VirusScanResult;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackend;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackendProvider;
 import java.io.IOException;
@@ -34,7 +36,7 @@ public class ParticipantFileExtService {
     this.fileStorageBackend = fileStorageBackendProvider.get();
   }
 
-  public ParticipantFile get(
+  public ScannedParticipantFileDto get(
       String portalShortcode,
       EnvironmentName envName,
       ParticipantUser participantUser,
@@ -43,9 +45,13 @@ public class ParticipantFileExtService {
     authUtilService.authParticipantToPortal(participantUser.getId(), portalShortcode, envName);
     Enrollee enrollee =
         authUtilService.authParticipantUserToEnrollee(participantUser.getId(), enrolleeShortcode);
-    return participantFileService
-        .findByEnrolleeIdAndFileName(enrollee.getId(), fileName)
-        .orElseThrow(() -> new NotFoundException("Could not find file"));
+
+    ParticipantFile file =
+        participantFileService
+            .findByEnrolleeIdAndFileName(enrollee.getId(), fileName)
+            .orElseThrow(() -> new NotFoundException("Could not find file"));
+
+    return participantFileService.attachVirusScanResult(file);
   }
 
   public InputStream downloadFile(
@@ -61,6 +67,13 @@ public class ParticipantFileExtService {
         participantFileService
             .findByEnrolleeIdAndFileName(enrollee.getId(), fileName)
             .orElseThrow(() -> new NotFoundException("Could not find file"));
+
+    VirusScanResult virusScanResult =
+        participantFileService.getVirusScanResult(participantFile.getExternalFileId());
+
+    if (virusScanResult == VirusScanResult.QUARANTINED) {
+      throw new IllegalArgumentException("Virus detected in file");
+    }
 
     return fileStorageBackend.downloadFile(participantFile.getExternalFileId());
   }

--- a/api-participant/src/main/resources/application-gcp.yml
+++ b/api-participant/src/main/resources/application-gcp.yml
@@ -18,6 +18,8 @@ env:
     smartyAuthToken: ${sm://${SMARTY_AUTH_TOKEN_SECRET_ID}}
   mixpanel:
     token: ${sm://${MIXPANEL_TOKEN_SECRET_ID}}
+  fileUpload:
+    backend: GCSFileStorageBackend
 spring:
   cloud:
     gcp:

--- a/api-participant/src/main/resources/application.yml
+++ b/api-participant/src/main/resources/application.yml
@@ -36,7 +36,9 @@ env:
   fileUpload:
     backend: LocalFileStorageBackend
     localFileStoragePath: ${LOCAL_FILE_STORAGE_PATH:/tmp/juniper/fileupload}
-    gcsFileStorageBucketName: ${GCS_FILE_STORAGE_BUCKET_NAME:}
+    gcsStorageUnscannedBucketName: ${GCS_FILE_STORAGE_UNSCANNED_BUCKET_NAME:}
+    gcsStorageCleanBucketName: ${GCS_FILE_STORAGE_CLEAN_BUCKET_NAME:}
+    gcsStorageQuarantinedBucketName: ${GCS_FILE_STORAGE_QUARANTINED_BUCKET_NAME:}
     gcsFileStorageProjectId: ${GCS_FILE_STORAGE_PROJECT_ID:}
 # Below here is non-deployment-specific
 

--- a/api-participant/src/main/resources/application.yml
+++ b/api-participant/src/main/resources/application.yml
@@ -34,7 +34,7 @@ env:
     enabled: ${MIXPANEL_ENABLED:false}
     token: ${MIXPANEL_TOKEN:}
   fileUpload:
-    backend: LocalFileStorageBackend
+    backend: GCSFileStorageBackend2
     localFileStoragePath: ${LOCAL_FILE_STORAGE_PATH:/tmp/juniper/fileupload}
 # Below here is non-deployment-specific
 

--- a/api-participant/src/main/resources/application.yml
+++ b/api-participant/src/main/resources/application.yml
@@ -34,7 +34,7 @@ env:
     enabled: ${MIXPANEL_ENABLED:false}
     token: ${MIXPANEL_TOKEN:}
   fileUpload:
-    backend: GCSFileStorageBackend2
+    backend: GCSFileStorageBackend
     localFileStoragePath: ${LOCAL_FILE_STORAGE_PATH:/tmp/juniper/fileupload}
 # Below here is non-deployment-specific
 

--- a/api-participant/src/main/resources/application.yml
+++ b/api-participant/src/main/resources/application.yml
@@ -34,7 +34,7 @@ env:
     enabled: ${MIXPANEL_ENABLED:false}
     token: ${MIXPANEL_TOKEN:}
   fileUpload:
-    backend: GCSFileStorageBackend
+    backend: LocalFileStorageBackend
     localFileStoragePath: ${LOCAL_FILE_STORAGE_PATH:/tmp/juniper/fileupload}
 # Below here is non-deployment-specific
 

--- a/api-participant/src/main/resources/application.yml
+++ b/api-participant/src/main/resources/application.yml
@@ -36,6 +36,8 @@ env:
   fileUpload:
     backend: LocalFileStorageBackend
     localFileStoragePath: ${LOCAL_FILE_STORAGE_PATH:/tmp/juniper/fileupload}
+    gcsFileStorageBucketName: ${GCS_FILE_STORAGE_BUCKET_NAME:}
+    gcsFileStorageProjectId: ${GCS_FILE_STORAGE_PROJECT_ID:}
 # Below here is non-deployment-specific
 
 # When the target is 'local' the write-config.sh script will generate this properties file. It

--- a/api-participant/src/test/resources/application.yml
+++ b/api-participant/src/test/resources/application.yml
@@ -18,6 +18,15 @@ env:
   email:
     sendgridApiKey: ${SENDGRID_API_KEY:}
 
+otel:
+  sdk:
+    disabled: true
+  instrumentation:
+    spring-webflux:
+      enabled: false
+    spring-web:
+      enabled: false
+
 # Below here is non-deployment-specific
 
 # When the target is 'local' the write-config.sh script will generate this properties file. It

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation 'org.jooq:jooq:3.19.18'
     implementation 'com.mixpanel:mixpanel-java:1.5.3'
     implementation platform('com.google.cloud:libraries-bom:26.54.0')
-    implementation 'com.google.cloud:google-cloud-storage:2.43.2'
+    implementation 'com.google.cloud:google-cloud-storage:2.48.1'
 
     implementation 'com.google.cloud:spring-cloud-gcp-starter-secretmanager:6.0.0'
     implementation 'com.google.cloud:spring-cloud-gcp-starter:6.0.0'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -50,6 +50,8 @@ dependencies {
     implementation 'com.smartystreets.api:smartystreets-java-sdk:3.16.1'
     implementation 'org.jooq:jooq:3.19.18'
     implementation 'com.mixpanel:mixpanel-java:1.5.3'
+    implementation platform('com.google.cloud:libraries-bom:26.54.0')
+    implementation 'com.google.cloud:google-cloud-storage'
 
     implementation 'com.google.cloud:spring-cloud-gcp-starter-secretmanager:6.0.0'
     implementation 'com.google.cloud:spring-cloud-gcp-starter:6.0.0'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation 'org.jooq:jooq:3.19.18'
     implementation 'com.mixpanel:mixpanel-java:1.5.3'
     implementation platform('com.google.cloud:libraries-bom:26.54.0')
-    implementation 'com.google.cloud:google-cloud-storage'
+    implementation 'com.google.cloud:google-cloud-storage:2.43.2'
 
     implementation 'com.google.cloud:spring-cloud-gcp-starter-secretmanager:6.0.0'
     implementation 'com.google.cloud:spring-cloud-gcp-starter:6.0.0'

--- a/core/src/main/java/bio/terra/pearl/core/dao/file/ParticipantFileDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/file/ParticipantFileDao.java
@@ -1,6 +1,6 @@
 package bio.terra.pearl.core.dao.file;
 
-import bio.terra.pearl.core.dao.BaseJdbiDao;
+import bio.terra.pearl.core.dao.BaseMutableJdbiDao;
 import bio.terra.pearl.core.dao.survey.AnswerDao;
 import bio.terra.pearl.core.model.file.ParticipantFile;
 import bio.terra.pearl.core.model.survey.Answer;
@@ -12,7 +12,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @Component
-public class ParticipantFileDao extends BaseJdbiDao<ParticipantFile> {
+public class ParticipantFileDao extends BaseMutableJdbiDao<ParticipantFile> {
     private final AnswerDao answerDao;
 
     public ParticipantFileDao(Jdbi jdbi, AnswerDao answerDao) {

--- a/core/src/main/java/bio/terra/pearl/core/model/file/ScannedParticipantFileDto.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/file/ScannedParticipantFileDto.java
@@ -1,0 +1,18 @@
+package bio.terra.pearl.core.model.file;
+
+import bio.terra.pearl.core.service.file.VirusScanResult;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.beans.BeanUtils;
+
+@Getter
+@Setter
+public class ScannedParticipantFileDto extends ParticipantFile {
+    private VirusScanResult virusScanResult;
+
+    public ScannedParticipantFileDto(ParticipantFile participantFile, VirusScanResult virusScanResult) {
+        BeanUtils.copyProperties(participantFile, this);
+
+        this.virusScanResult = virusScanResult;
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/file/FileStorageConfig.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/FileStorageConfig.java
@@ -13,13 +13,17 @@ import org.springframework.core.env.Environment;
 public class FileStorageConfig {
     private String defaultBackend;
     private String localFileStoragePath;
-    private String gcsStorageBucketName;
+    private String gcsStorageUnscannedBucketName;
+    private String gcsStorageCleanBucketName;
+    private String gcsStorageQuarantinedBucketName;
     private Storage gcsStorageConfig;
 
     public FileStorageConfig(Environment environment) {
         this.defaultBackend = environment.getProperty("env.fileUpload.backend", "LocalFileStorageBackend");
         this.localFileStoragePath = environment.getProperty("env.fileUpload.localFileStoragePath");
-        this.gcsStorageBucketName = environment.getProperty("env.fileUpload.gcsFileStorageBucketName");
+        this.gcsStorageUnscannedBucketName = environment.getProperty("env.fileUpload.gcsStorageUnscannedBucketName");
+        this.gcsStorageCleanBucketName = environment.getProperty("env.fileUpload.gcsStorageCleanBucketName");
+        this.gcsStorageQuarantinedBucketName = environment.getProperty("env.fileUpload.gcsStorageQuarantinedBucketName");
         this.gcsStorageConfig = StorageOptions.newBuilder().setProjectId(environment.getProperty("env.fileUpload.gcsFileStorageProjectId")).build().getService();
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/file/FileStorageConfig.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/FileStorageConfig.java
@@ -1,5 +1,7 @@
 package bio.terra.pearl.core.service.file;
 
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.context.annotation.Configuration;
@@ -11,9 +13,13 @@ import org.springframework.core.env.Environment;
 public class FileStorageConfig {
     private String defaultBackend;
     private String localFileStoragePath;
+    private String gcsStorageBucketName;
+    private Storage gcsStorageConfig;
 
     public FileStorageConfig(Environment environment) {
         this.defaultBackend = environment.getProperty("env.fileUpload.backend", "LocalFileStorageBackend");
         this.localFileStoragePath = environment.getProperty("env.fileUpload.localFileStoragePath");
+        this.gcsStorageBucketName = "mb-test-juniper-upload-bucket";
+        this.gcsStorageConfig = StorageOptions.newBuilder().setProjectId("broad-juniper-dev").build().getService();
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/file/FileStorageConfig.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/FileStorageConfig.java
@@ -20,6 +20,6 @@ public class FileStorageConfig {
         this.defaultBackend = environment.getProperty("env.fileUpload.backend", "LocalFileStorageBackend");
         this.localFileStoragePath = environment.getProperty("env.fileUpload.localFileStoragePath");
         this.gcsStorageBucketName = environment.getProperty("env.fileUpload.gcsFileStorageBucketName");
-        this.gcsStorageConfig = StorageOptions.newBuilder().setProjectId("broad-juniper-dev").build().getService();
+        this.gcsStorageConfig = StorageOptions.newBuilder().setProjectId(environment.getProperty("env.fileUpload.gcsFileStorageProjectId")).build().getService();
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/file/FileStorageConfig.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/FileStorageConfig.java
@@ -19,7 +19,7 @@ public class FileStorageConfig {
     public FileStorageConfig(Environment environment) {
         this.defaultBackend = environment.getProperty("env.fileUpload.backend", "LocalFileStorageBackend");
         this.localFileStoragePath = environment.getProperty("env.fileUpload.localFileStoragePath");
-        this.gcsStorageBucketName = "mb-test-juniper-upload-bucket";
+        this.gcsStorageBucketName = environment.getProperty("env.fileUpload.gcsFileStorageBucketName");
         this.gcsStorageConfig = StorageOptions.newBuilder().setProjectId("broad-juniper-dev").build().getService();
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/file/ParticipantFileService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/ParticipantFileService.java
@@ -1,19 +1,14 @@
 package bio.terra.pearl.core.service.file;
 
 import bio.terra.pearl.core.dao.file.ParticipantFileDao;
-import bio.terra.pearl.core.model.BaseEntity;
 import bio.terra.pearl.core.model.file.ParticipantFile;
-import bio.terra.pearl.core.model.participant.Enrollee;
-import bio.terra.pearl.core.model.survey.SurveyResponse;
+import bio.terra.pearl.core.model.file.ScannedParticipantFileDto;
 import bio.terra.pearl.core.service.CascadeProperty;
-import bio.terra.pearl.core.service.ImmutableEntityService;
+import bio.terra.pearl.core.service.CrudService;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackend;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackendProvider;
-import bio.terra.pearl.core.service.survey.SurveyResponseService;
-import bio.terra.pearl.core.service.survey.SurveyService;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import java.io.InputStream;
@@ -24,7 +19,7 @@ import java.util.UUID;
 
 @Service
 @Slf4j
-public class ParticipantFileService extends ImmutableEntityService<ParticipantFile, ParticipantFileDao> {
+public class ParticipantFileService extends CrudService<ParticipantFile, ParticipantFileDao> {
     private final FileStorageBackend fileStorageBackend;
 
     public ParticipantFileService(ParticipantFileDao dao, FileStorageBackendProvider fileStorageBackendProvider) {
@@ -62,5 +57,15 @@ public class ParticipantFileService extends ImmutableEntityService<ParticipantFi
             throw new IllegalArgumentException("This file is being used in a survey response and cannot be deleted. Please remove the file from the survey response first.");
         }
         super.delete(id, cascade);
+    }
+
+    public ScannedParticipantFileDto attachVirusScanResult(ParticipantFile participantFile) {
+        VirusScanResult scanResult = fileStorageBackend.scanResult(participantFile.getExternalFileId());
+
+        return new ScannedParticipantFileDto(participantFile, scanResult);
+    }
+
+    public VirusScanResult getVirusScanResult(UUID fileId) {
+        return fileStorageBackend.scanResult(fileId);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/file/ScannedFile.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/ScannedFile.java
@@ -1,0 +1,6 @@
+package bio.terra.pearl.core.service.file;
+
+import java.io.InputStream;
+
+public record ScannedFile(InputStream file, VirusScanResult scanResult) {
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/file/VirusScanResult.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/VirusScanResult.java
@@ -1,0 +1,7 @@
+package bio.terra.pearl.core.service.file;
+
+public enum VirusScanResult {
+    UNSCANNED,
+    CLEAN,
+    QUARANTINED
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/file/backends/FileStorageBackend.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/backends/FileStorageBackend.java
@@ -1,5 +1,7 @@
 package bio.terra.pearl.core.service.file.backends;
 
+import bio.terra.pearl.core.service.file.VirusScanResult;
+
 import java.io.InputStream;
 import java.util.UUID;
 
@@ -15,6 +17,8 @@ public interface FileStorageBackend {
      * Download file from backend.
      */
     InputStream downloadFile(UUID uploadedFileId);
+
+    VirusScanResult scanResult(UUID uploadedFileId);
 
     /**
      * Delete file from backend.

--- a/core/src/main/java/bio/terra/pearl/core/service/file/backends/FileStorageBackendProvider.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/backends/FileStorageBackendProvider.java
@@ -14,9 +14,11 @@ public class FileStorageBackendProvider {
 
     public FileStorageBackendProvider(
             FileStorageConfig fileStorageConfig,
-            LocalFileStorageBackend localFileStorageBackend) {
+            LocalFileStorageBackend localFileStorageBackend,
+            GCSFileStorageBackend gcsFileStorageBackend) {
         defaultBackend = fileStorageConfig.getDefaultBackend();
         backendMap.put("LocalFileStorageBackend", localFileStorageBackend);
+        backendMap.put("GCSFileStorageBackend", gcsFileStorageBackend);
     }
 
     public FileStorageBackend get() {

--- a/core/src/main/java/bio/terra/pearl/core/service/file/backends/GCSFileStorageBackend.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/backends/GCSFileStorageBackend.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.core.service.file.backends;
 
+import bio.terra.pearl.core.service.file.FileStorageConfig;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
@@ -13,15 +14,19 @@ import java.util.UUID;
 @Service
 public class GCSFileStorageBackend implements FileStorageBackend {
 
-    private final String BUCKET_NAME = "mb-test-juniper-upload-bucket";
-    private final String PROJECT_NAME = "broad-juniper-dev";
+    private final String bucketName;
+    private final Storage storage;
+
+    public GCSFileStorageBackend(FileStorageConfig storageConfig) {
+        this.storage = storageConfig.getGcsStorageConfig();
+        this.bucketName = storageConfig.getGcsStorageBucketName();
+    }
 
     @Override
     public UUID uploadFile(InputStream data) {
         UUID fileId = UUID.randomUUID();
 
-        Storage storage = StorageOptions.newBuilder().setProjectId(PROJECT_NAME).build().getService();
-        BlobId blobId = BlobId.of(BUCKET_NAME, fileId.toString());
+        BlobId blobId = BlobId.of(bucketName, fileId.toString());
         BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
 
         try {
@@ -35,8 +40,7 @@ public class GCSFileStorageBackend implements FileStorageBackend {
 
     @Override
     public InputStream downloadFile(UUID uploadedFileId) {
-        Storage storage = StorageOptions.newBuilder().setProjectId(PROJECT_NAME).build().getService();
-        BlobId blobId = BlobId.of(BUCKET_NAME, uploadedFileId.toString());
+        BlobId blobId = BlobId.of(bucketName, uploadedFileId.toString());
 
         try {
             byte[] gcsBytes = storage.get(blobId).getContent();
@@ -48,8 +52,7 @@ public class GCSFileStorageBackend implements FileStorageBackend {
 
     @Override
     public void deleteFile(UUID uploadedFileId) {
-        Storage storage = StorageOptions.newBuilder().setProjectId(PROJECT_NAME).build().getService();
-        BlobId blobId = BlobId.of(BUCKET_NAME, uploadedFileId.toString());
+        BlobId blobId = BlobId.of(bucketName, uploadedFileId.toString());
 
         try {
             storage.delete(blobId);

--- a/core/src/main/java/bio/terra/pearl/core/service/file/backends/GCSFileStorageBackend.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/backends/GCSFileStorageBackend.java
@@ -1,0 +1,60 @@
+package bio.terra.pearl.core.service.file.backends;
+
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.UUID;
+
+@Service
+public class GCSFileStorageBackend implements FileStorageBackend {
+
+    private final String BUCKET_NAME = "mb-test-juniper-upload-bucket";
+    private final String PROJECT_NAME = "broad-juniper-dev";
+
+    @Override
+    public UUID uploadFile(InputStream data) {
+        UUID fileId = UUID.randomUUID();
+
+        Storage storage = StorageOptions.newBuilder().setProjectId(PROJECT_NAME).build().getService();
+        BlobId blobId = BlobId.of(BUCKET_NAME, fileId.toString());
+        BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
+
+        try {
+            storage.createFrom(blobInfo, data);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to upload file to GCS", e);
+        }
+
+        return fileId;
+    }
+
+    @Override
+    public InputStream downloadFile(UUID uploadedFileId) {
+        Storage storage = StorageOptions.newBuilder().setProjectId(PROJECT_NAME).build().getService();
+        BlobId blobId = BlobId.of(BUCKET_NAME, uploadedFileId.toString());
+
+        try {
+            byte[] gcsBytes = storage.get(blobId).getContent();
+            return new ByteArrayInputStream(gcsBytes);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to download file from GCS", e);
+        }
+    }
+
+    @Override
+    public void deleteFile(UUID uploadedFileId) {
+        Storage storage = StorageOptions.newBuilder().setProjectId(PROJECT_NAME).build().getService();
+        BlobId blobId = BlobId.of(BUCKET_NAME, uploadedFileId.toString());
+
+        try {
+            storage.delete(blobId);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to delete file from GCS", e);
+        }
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/file/backends/GCSFileStorageBackend.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/backends/GCSFileStorageBackend.java
@@ -1,10 +1,12 @@
 package bio.terra.pearl.core.service.file.backends;
 
+import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.file.FileStorageConfig;
+import bio.terra.pearl.core.service.file.VirusScanResult;
+import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageOptions;
 import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayInputStream;
@@ -14,19 +16,23 @@ import java.util.UUID;
 @Service
 public class GCSFileStorageBackend implements FileStorageBackend {
 
-    private final String bucketName;
+    private final String unscannedBucketName;
+    private final String cleanBucketName;
+    private final String quarantinedBucketName;
     private final Storage storage;
 
     public GCSFileStorageBackend(FileStorageConfig storageConfig) {
         this.storage = storageConfig.getGcsStorageConfig();
-        this.bucketName = storageConfig.getGcsStorageBucketName();
+        this.unscannedBucketName = storageConfig.getGcsStorageUnscannedBucketName();
+        this.cleanBucketName = storageConfig.getGcsStorageCleanBucketName();
+        this.quarantinedBucketName = storageConfig.getGcsStorageQuarantinedBucketName();
     }
 
     @Override
     public UUID uploadFile(InputStream data) {
         UUID fileId = UUID.randomUUID();
 
-        BlobId blobId = BlobId.of(bucketName, fileId.toString());
+        BlobId blobId = BlobId.of(unscannedBucketName, fileId.toString());
         BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
 
         try {
@@ -40,10 +46,19 @@ public class GCSFileStorageBackend implements FileStorageBackend {
 
     @Override
     public InputStream downloadFile(UUID uploadedFileId) {
-        BlobId blobId = BlobId.of(bucketName, uploadedFileId.toString());
-
+        BlobId cleanBlobId = BlobId.of(cleanBucketName, uploadedFileId.toString());
         try {
-            byte[] gcsBytes = storage.get(blobId).getContent();
+            Blob blob = storage.get(cleanBlobId);
+
+            if (blob == null) {
+                blob = storage.get(BlobId.of(unscannedBucketName, uploadedFileId.toString()));
+            }
+
+            if (blob == null) {
+                throw new NotFoundException("File not found in GCS");
+            }
+
+            byte[] gcsBytes = blob.getContent();
             return new ByteArrayInputStream(gcsBytes);
         } catch (Exception e) {
             throw new RuntimeException("Failed to download file from GCS", e);
@@ -51,8 +66,29 @@ public class GCSFileStorageBackend implements FileStorageBackend {
     }
 
     @Override
+    public VirusScanResult scanResult(UUID uploadedFileId) {
+        BlobId cleanBlobId = BlobId.of(cleanBucketName, uploadedFileId.toString());
+        BlobId unscannedBlobId = BlobId.of(unscannedBucketName, uploadedFileId.toString());
+        BlobId quarantinedBlobId = BlobId.of(quarantinedBucketName, uploadedFileId.toString());
+
+        if (storage.get(cleanBlobId) != null) {
+            return VirusScanResult.CLEAN;
+        } else if (storage.get(unscannedBlobId) != null) {
+            return VirusScanResult.UNSCANNED;
+        } else if (storage.get(quarantinedBlobId) != null) {
+            return VirusScanResult.QUARANTINED;
+        }
+
+        throw new NotFoundException("File not found in GCS");
+    }
+
+    @Override
     public void deleteFile(UUID uploadedFileId) {
-        BlobId blobId = BlobId.of(bucketName, uploadedFileId.toString());
+        BlobId blobId = BlobId.of(cleanBucketName, uploadedFileId.toString());
+
+        if (storage.get(blobId) == null) {
+            blobId = BlobId.of(unscannedBucketName, uploadedFileId.toString());
+        }
 
         try {
             storage.delete(blobId);

--- a/core/src/main/java/bio/terra/pearl/core/service/file/backends/LocalFileStorageBackend.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/backends/LocalFileStorageBackend.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.service.file.backends;
 
 import bio.terra.pearl.core.service.file.FileStorageConfig;
+import bio.terra.pearl.core.service.file.VirusScanResult;
 import org.apache.commons.io.FileUtils;
 import org.springframework.stereotype.Service;
 
@@ -43,6 +44,11 @@ public class LocalFileStorageBackend implements FileStorageBackend {
             }
         }
         return null;
+    }
+
+    @Override
+    public VirusScanResult scanResult(UUID uploadedFileId) {
+        return VirusScanResult.CLEAN;
     }
 
     @Override

--- a/core/src/test/java/bio/terra/pearl/core/service/file/backends/GCSFileStorageBackendTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/file/backends/GCSFileStorageBackendTest.java
@@ -1,0 +1,91 @@
+package bio.terra.pearl.core.service.file.backends;
+
+import bio.terra.pearl.core.service.file.FileStorageConfig;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class GCSFileStorageBackendTest {
+
+    @Mock
+    private Storage storage;
+
+    @Mock
+    private FileStorageConfig fileStorageConfig;
+
+    @InjectMocks
+    private GCSFileStorageBackend gcsFileStorageBackend;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        when(fileStorageConfig.getGcsStorageConfig()).thenReturn(storage);
+        when(fileStorageConfig.getGcsStorageBucketName()).thenReturn("test-bucket");
+
+        gcsFileStorageBackend = new GCSFileStorageBackend(fileStorageConfig);
+    }
+
+    @Test
+    void testUploadFile() throws IOException {
+        UUID fileId = UUID.fromString("906c11cd-5e92-487b-a386-ac300e980861");
+        InputStream data = new ByteArrayInputStream("test data".getBytes());
+
+        MockedStatic<UUID> mocked = mockStatic(UUID.class);
+        mocked.when(UUID::randomUUID).thenReturn(fileId);
+        when(storage.createFrom(any(BlobInfo.class), any(InputStream.class))).thenReturn(null);
+
+        UUID result = gcsFileStorageBackend.uploadFile(data);
+
+        assertEquals(fileId,result);
+        verify(storage, times(1)).createFrom(any(BlobInfo.class), any(InputStream.class));
+    }
+
+    @Test
+    void testDownloadFile() throws IOException {
+        UUID fileId = UUID.fromString("906c11cd-5e92-487b-a386-ac300e980861");
+        byte[] fileContent = "test data".getBytes();
+
+        Blob blob = mock(Blob.class);
+        when(blob.getContent()).thenReturn(fileContent);
+        when(storage.get(any(BlobId.class))).thenReturn(blob);
+
+        InputStream result = gcsFileStorageBackend.downloadFile(fileId);
+
+        assertNotNull(result);
+        byte[] resultBytes = result.readAllBytes();
+        assertArrayEquals(fileContent, resultBytes);
+
+        verify(storage, times(1)).get(any(BlobId.class));
+    }
+
+    @Test
+    void testDeleteFile() {
+        UUID fileId = UUID.fromString("906c11cd-5e92-487b-a386-ac300e980861");
+
+        when(storage.delete(any(BlobId.class))).thenReturn(true);
+
+        gcsFileStorageBackend.deleteFile(fileId);
+
+        verify(storage, times(1)).delete(any(BlobId.class));
+    }
+
+}

--- a/core/src/test/java/bio/terra/pearl/core/service/file/backends/GCSFileStorageBackendTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/file/backends/GCSFileStorageBackendTest.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.service.file.backends;
 
 import bio.terra.pearl.core.service.file.FileStorageConfig;
+import bio.terra.pearl.core.service.file.VirusScanResult;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
@@ -10,7 +11,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 
 import java.io.ByteArrayInputStream;
@@ -18,9 +18,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.UUID;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -40,7 +37,9 @@ public class GCSFileStorageBackendTest {
         MockitoAnnotations.openMocks(this);
 
         when(fileStorageConfig.getGcsStorageConfig()).thenReturn(storage);
-        when(fileStorageConfig.getGcsStorageBucketName()).thenReturn("test-bucket");
+        when(fileStorageConfig.getGcsStorageCleanBucketName()).thenReturn("test-bucket-clean");
+        when(fileStorageConfig.getGcsStorageUnscannedBucketName()).thenReturn("test-bucket-unscanned");
+        when(fileStorageConfig.getGcsStorageQuarantinedBucketName()).thenReturn("test-bucket-quarantined");
 
         gcsFileStorageBackend = new GCSFileStorageBackend(fileStorageConfig);
     }
@@ -64,7 +63,8 @@ public class GCSFileStorageBackendTest {
 
         Blob blob = mock(Blob.class);
         when(blob.getContent()).thenReturn(fileContent);
-        when(storage.get(any(BlobId.class))).thenReturn(blob);
+        when(storage.get(BlobId.of("test-bucket-clean", fileId.toString()))).thenReturn(blob);
+        when(storage.get(BlobId.of("test-bucket-unscanned", fileId.toString()))).thenReturn(null);
 
         InputStream result = gcsFileStorageBackend.downloadFile(fileId);
 
@@ -72,20 +72,104 @@ public class GCSFileStorageBackendTest {
         byte[] resultBytes = result.readAllBytes();
         Assertions.assertArrayEquals(fileContent, resultBytes);
 
-        BlobId expectBlobId = BlobId.of("test-bucket", fileId.toString());
-        verify(storage, times(1)).get(expectBlobId);
+        // only attempt clean bucket; since it's found, don't attempt unscanned
+        BlobId cleanBlobId = BlobId.of("test-bucket-clean", fileId.toString());
+        BlobId unscannedBlobId = BlobId.of("test-bucket-unscanned", fileId.toString());
+        verify(storage, times(1)).get(cleanBlobId);
+        verify(storage, times(0)).get(unscannedBlobId);
+    }
+
+    @Test
+    void testDownloadUnscannedFile() throws IOException {
+        UUID fileId = UUID.fromString("906c11cd-5e92-487b-a386-ac300e980861");
+        byte[] fileContent = "test data".getBytes();
+
+        Blob blob = mock(Blob.class);
+        when(blob.getContent()).thenReturn(fileContent);
+        when(storage.get(BlobId.of("test-bucket-clean", fileId.toString()))).thenReturn(null);
+        when(storage.get(BlobId.of("test-bucket-unscanned", fileId.toString()))).thenReturn(blob);
+
+        InputStream result = gcsFileStorageBackend.downloadFile(fileId);
+
+        Assertions.assertNotNull(result);
+        byte[] resultBytes = result.readAllBytes();
+        Assertions.assertArrayEquals(fileContent, resultBytes);
+
+        // attempts to download from both clean and unscanned buckets
+        BlobId cleanBlobId = BlobId.of("test-bucket-clean", fileId.toString());
+        BlobId unscannedBlobId = BlobId.of("test-bucket-unscanned", fileId.toString());
+        verify(storage, times(1)).get(cleanBlobId);
+        verify(storage, times(1)).get(unscannedBlobId);
     }
 
     @Test
     void testDeleteFile() {
         UUID fileId = UUID.fromString("906c11cd-5e92-487b-a386-ac300e980861");
 
+        when(storage.get(BlobId.of("test-bucket-clean", fileId.toString()))).thenReturn(mock(Blob.class));
         when(storage.delete(any(BlobId.class))).thenReturn(true);
 
         gcsFileStorageBackend.deleteFile(fileId);
 
-        BlobId expectedBlobId = BlobId.of("test-bucket", fileId.toString());
+        BlobId expectedBlobId = BlobId.of("test-bucket-clean", fileId.toString());
         verify(storage, times(1)).delete(expectedBlobId);
+    }
+
+    @Test
+    void testDeleteFileAlsoSearchesUnscanned() {
+        UUID fileId = UUID.fromString("906c11cd-5e92-487b-a386-ac300e980861");
+
+        when(storage.get(BlobId.of("test-bucket-clean", fileId.toString()))).thenReturn(null);
+        when(storage.get(BlobId.of("test-bucket-unscanned", fileId.toString()))).thenReturn(mock(Blob.class));
+
+        when(storage.delete(any(BlobId.class))).thenReturn(true);
+
+        gcsFileStorageBackend.deleteFile(fileId);
+
+        BlobId expectedBlobId = BlobId.of("test-bucket-unscanned", fileId.toString());
+        verify(storage, times(1)).delete(expectedBlobId);
+    }
+
+    @Test
+    void testVirusScanClean() {
+        UUID fileId = UUID.fromString("906c11cd-5e92-487b-a386-ac300e980861");
+
+        BlobId cleanBlobId = BlobId.of("test-bucket-clean", fileId.toString());
+        BlobId unscannedBlobId = BlobId.of("test-bucket-unscanned", fileId.toString());
+        BlobId quarantinedBlobId = BlobId.of("test-bucket-quarantined", fileId.toString());
+        when(storage.get(cleanBlobId)).thenReturn(mock(Blob.class));
+        when(storage.get(unscannedBlobId)).thenReturn(null);
+        when(storage.get(quarantinedBlobId)).thenReturn(null);
+
+        Assertions.assertEquals(gcsFileStorageBackend.scanResult(fileId), VirusScanResult.CLEAN);
+    }
+
+    @Test
+    void testVirusScanUnscanned() {
+        UUID fileId = UUID.fromString("906c11cd-5e92-487b-a386-ac300e980861");
+
+        BlobId cleanBlobId = BlobId.of("test-bucket-clean", fileId.toString());
+        BlobId unscannedBlobId = BlobId.of("test-bucket-unscanned", fileId.toString());
+        BlobId quarantinedBlobId = BlobId.of("test-bucket-quarantined", fileId.toString());
+        when(storage.get(cleanBlobId)).thenReturn(null);
+        when(storage.get(unscannedBlobId)).thenReturn(mock(Blob.class));
+        when(storage.get(quarantinedBlobId)).thenReturn(null);
+
+        Assertions.assertEquals(gcsFileStorageBackend.scanResult(fileId), VirusScanResult.UNSCANNED);
+    }
+
+    @Test
+    void testVirusScanQuarantined() {
+        UUID fileId = UUID.fromString("906c11cd-5e92-487b-a386-ac300e980861");
+
+        BlobId cleanBlobId = BlobId.of("test-bucket-clean", fileId.toString());
+        BlobId unscannedBlobId = BlobId.of("test-bucket-unscanned", fileId.toString());
+        BlobId quarantinedBlobId = BlobId.of("test-bucket-quarantined", fileId.toString());
+        when(storage.get(cleanBlobId)).thenReturn(null);
+        when(storage.get(unscannedBlobId)).thenReturn(null);
+        when(storage.get(quarantinedBlobId)).thenReturn(mock(Blob.class));
+
+        Assertions.assertEquals(gcsFileStorageBackend.scanResult(fileId), VirusScanResult.QUARANTINED);
     }
 
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/file/backends/GCSFileStorageBackendTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/file/backends/GCSFileStorageBackendTest.java
@@ -5,6 +5,7 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -46,16 +47,13 @@ public class GCSFileStorageBackendTest {
 
     @Test
     void testUploadFile() throws IOException {
-        UUID fileId = UUID.fromString("906c11cd-5e92-487b-a386-ac300e980861");
         InputStream data = new ByteArrayInputStream("test data".getBytes());
 
-        MockedStatic<UUID> mocked = mockStatic(UUID.class);
-        mocked.when(UUID::randomUUID).thenReturn(fileId);
         when(storage.createFrom(any(BlobInfo.class), any(InputStream.class))).thenReturn(null);
 
         UUID result = gcsFileStorageBackend.uploadFile(data);
 
-        assertEquals(fileId,result);
+        Assertions.assertNotNull(result);
         verify(storage, times(1)).createFrom(any(BlobInfo.class), any(InputStream.class));
     }
 
@@ -70,11 +68,12 @@ public class GCSFileStorageBackendTest {
 
         InputStream result = gcsFileStorageBackend.downloadFile(fileId);
 
-        assertNotNull(result);
+        Assertions.assertNotNull(result);
         byte[] resultBytes = result.readAllBytes();
-        assertArrayEquals(fileContent, resultBytes);
+        Assertions.assertArrayEquals(fileContent, resultBytes);
 
-        verify(storage, times(1)).get(any(BlobId.class));
+        BlobId expectBlobId = BlobId.of("test-bucket", fileId.toString());
+        verify(storage, times(1)).get(expectBlobId);
     }
 
     @Test
@@ -85,7 +84,8 @@ public class GCSFileStorageBackendTest {
 
         gcsFileStorageBackend.deleteFile(fileId);
 
-        verify(storage, times(1)).delete(any(BlobId.class));
+        BlobId expectedBlobId = BlobId.of("test-bucket", fileId.toString());
+        verify(storage, times(1)).delete(expectedBlobId);
     }
 
 }

--- a/terraform/gcp/k8s/environments/dev.yaml
+++ b/terraform/gcp/k8s/environments/dev.yaml
@@ -5,6 +5,7 @@ deploymentZone: dev
 replicas: 1
 dsmUrl: https://dsm-dev.datadonationplatform.org/dsm
 dsmIssuer: admin-d2p.ddp-dev.envs.broadinstitute.org
+gcsFileStorageBucketName: juniper-participant-documents-dev
 # "portals" adds certificates for each portal - both for the juniper-cmi.dev subdomains and the custom domain
 portals:
   - name: demo

--- a/terraform/gcp/k8s/environments/dev.yaml
+++ b/terraform/gcp/k8s/environments/dev.yaml
@@ -61,3 +61,7 @@ b2c:
       clientId: does-not-exist
       policyName: does-not-exist
       tenantName: does-not-exist
+gcsFileStorageBuckets:
+  unscanned: juniper-participant-documents-dev-unscanned
+  clean: juniper-participant-documents-dev-clean
+  quarantined: juniper-participant-documents-dev-quarantined

--- a/terraform/gcp/k8s/environments/prod.yaml
+++ b/terraform/gcp/k8s/environments/prod.yaml
@@ -5,6 +5,7 @@ deploymentZone: prod
 replicas: 3
 dsmUrl: https://dsm.datadonationplatform.org/dsm
 dsmIssuer: juniper.terra.bio
+gcsFileStorageBucketName: juniper-participant-documents-prod
 # "portals" adds certificates for each portal - both for the admin subdomains and the custom domain
 portals:
   - name: demo

--- a/terraform/gcp/k8s/templates/admin-deployment.yml
+++ b/terraform/gcp/k8s/templates/admin-deployment.yml
@@ -145,6 +145,10 @@ spec:
               value: 'true'
             - name: AIRTABLE_AUTH_TOKEN_SECRET_ID
               value: airtable-auth-token
+            - name: GCS_FILE_STORAGE_BUCKET_NAME
+              value: {{ .Values.gcsFileStorageBucketName }}
+            - name: GCS_FILE_STORAGE_PROJECT_ID
+              value: {{ .Values.gcpProject }}
           resources:
             requests:
               # The proxy's memory use scales linearly with the number of active

--- a/terraform/gcp/k8s/templates/admin-deployment.yml
+++ b/terraform/gcp/k8s/templates/admin-deployment.yml
@@ -145,8 +145,12 @@ spec:
               value: 'true'
             - name: AIRTABLE_AUTH_TOKEN_SECRET_ID
               value: airtable-auth-token
-            - name: GCS_FILE_STORAGE_BUCKET_NAME
-              value: {{ .Values.gcsFileStorageBucketName }}
+            - name: GCS_FILE_STORAGE_UNSCANNED_BUCKET_NAME
+              value: {{ .Values.gcsFileStorageBuckets.unscanned }}
+            - name: GCS_FILE_STORAGE_CLEAN_BUCKET_NAME
+              value: {{ .Values.gcsFileStorageBuckets.clean }}
+            - name: GCS_FILE_STORAGE_QUARANTINED_BUCKET_NAME
+              value: {{ .Values.gcsFileStorageBuckets.quarantined }}
             - name: GCS_FILE_STORAGE_PROJECT_ID
               value: {{ .Values.gcpProject }}
           resources:

--- a/terraform/gcp/k8s/templates/participant-deployment.yml
+++ b/terraform/gcp/k8s/templates/participant-deployment.yml
@@ -143,6 +143,14 @@ spec:
               value: 'true'
             - name: LIQUIBASE_ANALYTICS_ENABLED
               value: 'false'
+            - name: GCS_FILE_STORAGE_UNSCANNED_BUCKET_NAME
+              value: {{ .Values.gcsFileStorageBuckets.unscanned }}
+            - name: GCS_FILE_STORAGE_CLEAN_BUCKET_NAME
+              value: {{ .Values.gcsFileStorageBuckets.clean }}
+            - name: GCS_FILE_STORAGE_QUARANTINED_BUCKET_NAME
+              value: {{ .Values.gcsFileStorageBuckets.quarantined }}
+            - name: GCS_FILE_STORAGE_PROJECT_ID
+              value: {{ .Values.gcpProject }}
           resources:
             requests:
               memory: "2Gi"

--- a/terraform/gcp/k8s/values.yaml
+++ b/terraform/gcp/k8s/values.yaml
@@ -20,4 +20,7 @@ b2c:
 enableMaintenanceMode: false
 dsmUrl: https://dsm-dev.datadonationplatform.org/dsm
 dsmIssuer: admin-d2p.ddp-dev.envs.broadinstitute.org
-gcsFileStorageBucketName: ""
+gcsFileStorageBuckets:
+  unscanned: ""
+  clean: ""
+  quarantined: ""

--- a/terraform/gcp/k8s/values.yaml
+++ b/terraform/gcp/k8s/values.yaml
@@ -20,3 +20,4 @@ b2c:
 enableMaintenanceMode: false
 dsmUrl: https://dsm-dev.datadonationplatform.org/dsm
 dsmIssuer: admin-d2p.ddp-dev.envs.broadinstitute.org
+gcsFileStorageBucketName: ""


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds a GCS file backend for document uploads.

In general, local development should still use the tmp file storage, but I've included instructions for how to test this locally.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1) Update application.yml for participant and admin APIs to use `GCSFileStorageBackend`
2) Add two new environment variables to admin and participant run configurations:

```
GCS_FILE_STORAGE_BUCKET_NAME=mb-test-juniper-upload-bucket;GCS_FILE_STORAGE_PROJECT_ID=broad-juniper-dev
```
(the above uses a test bucket I made- not the real bucket for demo)

3) Repopulate demo
4) Confirm you can see the 3 new objects created and uploaded as part of the populate process: https://console.cloud.google.com/storage/browser/mb-test-juniper-upload-bucket;tab=permissions?forceOnBucketsSortingFiltering=true&project=broad-juniper-dev&prefix=&forceOnObjectsSortingFiltering=false&inv=1&invt=Abqnsg
5) Log in to Heart Demo as jsalk, go to the Documents page and confirm download and delete still work
6) Confirm you can upload a new document and the file can be found in the bucket

Also note testing note's in Connor's PR for virus scanning: https://github.com/broadinstitute/juniper/pull/1548