### PR TITLE
[JN-1634] Fix flaky testImportEnrolleeMultipleKitRequests assertion

### DIFF
--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
@@ -46,6 +46,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static java.util.Comparator.comparing;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -1025,9 +1026,12 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
     }
 
     private void verifyKitRequests(ImportItem importItem, List<KitRequestDto> expectedKitRequests) {
-
         List<KitRequestDto> kitRequestDtos = kitRequestService.findByEnrollee(enrolleeService.find(importItem.getCreatedEnrolleeId()).get());
         assertThat(kitRequestDtos.size(), equalTo(expectedKitRequests.size()));
+
+        kitRequestDtos.sort(comparing(KitRequestDto::getTrackingNumber));
+        expectedKitRequests.sort(comparing(KitRequestDto::getTrackingNumber));
+
         for (int i = 0; i < expectedKitRequests.size(); i++) {
             KitRequestDto kitRequestDto = kitRequestDtos.get(i);
             KitRequestDto expectedKit = expectedKitRequests.get(i);


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

This test was failing a bunch, it assumed the order of the kits would always be the same across the 2 collections.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Verify tests pass