### PR TITLE
[JN-1626] clean up pre-enroll task creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@types/react-dropzone": "^5.1.0",
         "@yudiel/react-qr-scanner": "^2.0.8",
         "mixpanel-browser": "^2.54.0",
-        "papaparse": "^5.5.2",
         "react-dropzone": "^14.3.5",
         "react-qr-code": "^2.0.15"
       },

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/preEnroll.json
@@ -3,6 +3,8 @@
   "version": 1,
   "name": "Pre-enroll",
   "surveyType": "PRE_ENROLL",
+  "assignToAllNewEnrollees": false,
+  "autoAssign": false,
   "answerMappings": [
     {
       "questionStableId": "proxy_enrollment",

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -55,6 +55,7 @@ const CreateSurveyModal = ({ studyEnvContext, onDismiss, type }:
     allowParticipantStart: type !== 'ADMIN',
     allowAdminEdit: type !== 'CONSENT',
     required: type === 'CONSENT',
+    autoAssign: type !== 'PRE_ENROLL',
     stableId: '',
     name: '',
     surveyType: type,


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Defaults to not auto assign for pre-enrolls. Also fixes demo pre-enroll.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- create new pre-enroll - observe defaults to auto assign off
- sign up participant - observe that the pre-enroll task isn't assigned in your dashboard