### PR TITLE
[JN-1636] Don't sync deactivated kits

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
@@ -407,7 +407,14 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
             // if the kit has been deactivated in Juniper, we no longer need to update the status
             // based on what DSM thinks. this allows us to independently deactivate kits in Juniper
             // without having to worry about DSM status updates.
-            log.info("Skipping status update for deactivated kit request %s".formatted(kitRequest.getId()));
+            if(!PepperKitStatus.mapToKitRequestStatus(pepperKit.getCurrentStatus()).equals(priorStatus)) {
+                // if the statuses don't match, log a warning so we know about the inconsistency
+                // this case is expected if a kit has been deactivated in Juniper but not DSM
+                log.warn((
+                    "Skipped status update for deactivated kit request %s, " +
+                    "and statuses did not match. Juniper status: %s, DSM status: %s"
+                ).formatted(kitRequest.getId(), priorStatus, pepperKit.getCurrentStatus()));
+            }
             return;
         }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
@@ -402,6 +402,15 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
      */
     private void saveKitStatus(KitRequest kitRequest, PepperKit pepperKit, Instant pepperStatusFetchedAt) {
         KitRequestStatus priorStatus = kitRequest.getStatus();
+
+        if(priorStatus.equals(KitRequestStatus.DEACTIVATED)) {
+            // if the kit has been deactivated in Juniper, we no longer need to update the status
+            // based on what DSM thinks. this allows us to independently deactivate kits in Juniper
+            // without having to worry about DSM status updates.
+            log.info("Skipping status update for deactivated kit request %s".formatted(kitRequest.getId()));
+            return;
+        }
+
         try {
             kitRequest.setExternalKit(objectMapper.writeValueAsString(pepperKit));
             kitRequest.setExternalKitFetchedAt(pepperStatusFetchedAt);

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
@@ -208,6 +208,31 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
 
     @Transactional
     @Test
+    public void testSkipStatusUpdateForDeactivatedKit(TestInfo testInfo) throws Exception {
+        String testName = getTestName(testInfo);
+        AdminUser adminUser = adminUserFactory.buildPersisted(testName);
+        EnrolleeBundle enrolleeBundle = enrolleeFactory.buildWithPortalUser(testName);
+        Enrollee enrollee = enrolleeBundle.enrollee();
+        KitType kitType = kitTypeFactory.buildPersisted(testName);
+        KitRequest kitRequest = kitRequestFactory.buildPersisted(testName,
+                enrollee, PepperKitStatus.DEACTIVATED, kitType.getId(), adminUser.getId());
+
+        PepperKit pepperKit = PepperKit.builder()
+                .juniperKitId(kitRequest.getId().toString())
+                .currentStatus(PepperKitStatus.SENT.pepperString)
+                .build();
+        when(mockPepperDSMClient.fetchKitStatus(any(), eq(kitRequest.getId()))).thenReturn(pepperKit);
+
+        kitRequestService.syncKitStatusFromPepper(kitRequest.getId());
+
+        // Verify that the status was not updated
+        KitRequest savedKit = kitRequestDao.find(kitRequest.getId()).get();
+        assertThat(savedKit.getStatus(), equalTo(KitRequestStatus.DEACTIVATED));
+        verify(mockPepperDSMClient).fetchKitStatus(any(), eq(kitRequest.getId()));
+    }
+
+    @Transactional
+    @Test
     public void testGetKitsByStudyEnvironment(TestInfo testInfo) throws Exception {
         // Arrange:
         //   2 kits, one with bogus status JSON


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Once a kit is deactivated in Juniper, we don't want to keep updating the statuses for those kits.

Motivation: gVasc has a bunch of kits that they accidentally sent out. Participants returned completed kits back to GP, but gVasc wants to exclude these kits from sequencing (presumably to save $). Things have already been handled on the GP-side, and we set these kits to Deactivated in Juniper, but because we sync statuses with DSM nightly, the statuses keep getting reset to "Received". This is confusing for gVasc and has generated a decent amount of support chatter.

One downside of this is that we could have statuses that differ between DSM and Juniper, but I think that's okay if it means we don't have to have someone go into both Juniper _and_ DSM to deactivate kits.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

