### PR TITLE
[JN-1639] i18n for idle status monitor

### DIFF
--- a/populate/src/main/resources/seed/i18n/de/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/de/languageTexts.json
@@ -143,6 +143,7 @@
   {"keyName": "documentsPageTitle", "text": "Unterlagen", "language": "de", "machineTranslated": true},
   {"keyName": "documentsPageUploadedDocumentsTitle", "text": "Hochgeladene Dokumente", "language": "de", "machineTranslated": true},
   {"keyName": "documentsPageMessage", "text": "Während Sie an einer Studie teilnehmen, werden Sie möglicherweise aufgefordert, im Rahmen eines Formulars oder einer Umfrage Dokumente hochzuladen. Unten können Sie die hochgeladenen Dokumente verwalten.", "language": "de", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "Unterlagen", "language": "de", "machineTranslated": true}
-
+  {"keyName": "navbarDocuments", "text": "Unterlagen", "language": "de", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeTitle", "text": "Ihre Sitzung läuft bald ab", "language": "de", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeMessage", "text": "Um die Sicherheit zu gewährleisten und Ihre Daten zu schützen, werden Sie in ${timeRemaining} abgemeldet.", "language": "de", "machineTranslated": true}
 ]

--- a/populate/src/main/resources/seed/i18n/dev/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/dev/languageTexts.json
@@ -144,5 +144,7 @@
   {"keyName": "documentsPageTitle", "text": "DEV_Documents", "language": "dev", "machineTranslated": true},
   {"keyName": "documentsPageUploadedDocumentsTitle", "text": "DEV_Uploaded documents", "language": "dev", "machineTranslated": true},
   {"keyName": "documentsPageMessage", "text": "DEV_While participating in a study, you may be asked to upload documents as part of a form or survey. Below, you can review the documents you have uploaded.", "language": "dev", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "DEV_Documents", "language": "dev", "machineTranslated": true}
+  {"keyName": "navbarDocuments", "text": "DEV_Documents", "language": "dev", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeTitle", "text": "DEV_Your session is about to expire", "language": "dev"},
+  {"keyName": "idleStatusNoticeMessage", "text": "DEV_To maintain security and protect your data, you will be logged out in ${timeRemaining}.", "language": "dev"}
 ]

--- a/populate/src/main/resources/seed/i18n/en/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/en/languageTexts.json
@@ -145,5 +145,7 @@
   {"keyName": "documentsPageUploadedDocumentsTitle", "text": "Uploaded documents", "language": "en"},
   {"keyName": "documentsPageMessage", "text": "While participating in a study, you may be asked to upload documents as part of a form or survey. Below, you can review the documents you have uploaded.", "language": "en"},
   {"keyName": "navbarDocuments", "text": "Documents", "language": "en"},
-  {"keyName": "taskTypeDocumentRequests", "text": "Document Requests", "language": "en"}
+  {"keyName": "taskTypeDocumentRequests", "text": "Document Requests", "language": "en"},
+  {"keyName": "idleStatusNoticeTitle", "text": "Your session is about to expire", "language": "en"},
+  {"keyName": "idleStatusNoticeMessage", "text": "To maintain security and protect your data, you will be logged out in ${timeRemaining}.", "language": "en"}
 ]

--- a/populate/src/main/resources/seed/i18n/es/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/es/languageTexts.json
@@ -143,5 +143,7 @@
   {"keyName": "documentsPageTitle", "text": "Documentos", "language": "es", "machineTranslated": true},
   {"keyName": "documentsPageUploadedDocumentsTitle", "text": "Documentos cargados", "language": "es", "machineTranslated": true},
   {"keyName": "documentsPageMessage", "text": "Mientras participa en un estudio, es posible que se le solicite que cargue documentos como parte de un formulario o encuesta. A continuación, puede administrar los documentos que ha cargado.", "language": "es", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "Documentos", "language": "es", "machineTranslated": true}
+  {"keyName": "navbarDocuments", "text": "Documentos", "language": "es", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeTitle", "text": "Su sesión está a punto de expirar", "language": "es", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeMessage", "text": "Para mantener la seguridad y proteger sus datos, se cerrará la sesión en ${timeRemaining}.", "language": "es", "machineTranslated": true}
 ]

--- a/populate/src/main/resources/seed/i18n/fr/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/fr/languageTexts.json
@@ -143,6 +143,7 @@
   {"keyName": "documentsPageTitle", "text": "Documents", "language": "fr", "machineTranslated": true},
   {"keyName": "documentsPageUploadedDocumentsTitle", "text": "Documents téléchargés", "language": "fr", "machineTranslated": true},
   {"keyName": "documentsPageMessage", "text": "Lors de votre participation à une étude, il peut vous être demandé de télécharger des documents dans le cadre d'un formulaire ou d'une enquête. Ci-dessous, vous pouvez gérer les documents que vous avez téléchargés.", "language": "fr", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "Documents", "language": "fr", "machineTranslated": true}
-
+  {"keyName": "navbarDocuments", "text": "Documents", "language": "fr", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeTitle", "text": "Votre session est sur le point d'expirer", "language": "fr", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeMessage", "text": "Pour maintenir la sécurité et protéger vos données, vous serez déconnecté dans ${timeRemaining}.", "language": "fr", "machineTranslated": true}
 ]

--- a/populate/src/main/resources/seed/i18n/hi/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/hi/languageTexts.json
@@ -143,6 +143,7 @@
   {"keyName": "documentsPageTitle", "text": "दस्तावेज़", "language": "hi", "machineTranslated": true},
   {"keyName": "documentsPageUploadedDocumentsTitle", "text": "अपलोड किए गए दस्तावेज़", "language": "hi", "machineTranslated": true},
   {"keyName": "documentsPageMessage", "text": "अध्ययन में भाग लेने के दौरान, आपसे किसी फ़ॉर्म या सर्वेक्षण के भाग के रूप में दस्तावेज़ अपलोड करने के लिए कहा जा सकता है। नीचे, आप अपने द्वारा अपलोड किए गए दस्तावेज़ों को प्रबंधित कर सकते हैं।", "language": "hi", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "दस्तावेज़", "language": "hi", "machineTranslated": true}
-
+  {"keyName": "navbarDocuments", "text": "दस्तावेज़", "language": "hi", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeTitle", "text": "आपका सत्र समाप्त होने वाला है", "language": "hi", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeMessage", "text": "सुरक्षा बनाए रखने और आपके डेटा की सुरक्षा के लिए, आपको ${timeRemaining} में लॉग आउट कर दिया जाएगा।", "language": "hi", "machineTranslated": true}
 ]

--- a/populate/src/main/resources/seed/i18n/it/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/it/languageTexts.json
@@ -143,6 +143,7 @@
   {"keyName": "documentsPageTitle", "text": "Documenti", "language": "it", "machineTranslated": true},
   {"keyName": "documentsPageUploadedDocumentsTitle", "text": "Documenti caricati", "language": "it", "machineTranslated": true},
   {"keyName": "documentsPageMessage", "text": "Durante la partecipazione a uno studio, potrebbe esserti chiesto di caricare documenti come parte di un modulo o di un sondaggio. Di seguito, puoi gestire i documenti che hai caricato.", "language": "it", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "Documenti", "language": "it", "machineTranslated": true}
-
+  {"keyName": "navbarDocuments", "text": "Documenti", "language": "it", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeTitle", "text": "La tua sessione sta per scadere", "language": "it", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeMessage", "text": "Per garantire la sicurezza e proteggere i tuoi dati, verrai disconnesso tra ${timeRemaining}.", "language": "it", "machineTranslated": true}
 ]

--- a/populate/src/main/resources/seed/i18n/ja/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/ja/languageTexts.json
@@ -143,6 +143,7 @@
   {"keyName": "documentsPageTitle", "text": "文書", "language": "ja", "machineTranslated": true},
   {"keyName": "documentsPageUploadedDocumentsTitle", "text": "アップロードされた文書", "language": "ja", "machineTranslated": true},
   {"keyName": "documentsPageMessage", "text": "調査に参加する際に、フォームまたはアンケートの一部としてドキュメントをアップロードするよう求められる場合があります。以下で、アップロードしたドキュメントを管理できます。", "language": "ja", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "文書", "language": "ja", "machineTranslated": true}
-
+  {"keyName": "navbarDocuments", "text": "文書", "language": "ja", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeTitle", "text": "セッションの有効期限が切れます", "language": "ja", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeMessage", "text": "セキュリティを維持し、データを保護するため、${timeRemaining} 後にログアウトされます。", "language": "ja", "machineTranslated": true}
 ]

--- a/populate/src/main/resources/seed/i18n/pl/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/pl/languageTexts.json
@@ -143,6 +143,7 @@
   {"keyName": "documentsPageTitle", "text": "Dokumenty", "language": "pl", "machineTranslated": true},
   {"keyName": "documentsPageUploadedDocumentsTitle", "text": "Przesłane dokumenty", "language": "pl", "machineTranslated": true},
   {"keyName": "documentsPageMessage", "text": "Wpodczas uczestnictwa w badaniu możesz zostać poproszony o przesłanie dokumentów jako części formularza lub ankiety. Poniżej możesz zarządzać przesłanymi dokumentami.", "language": "pl", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "Dokumenty", "language": "pl", "machineTranslated": true}
-
+  {"keyName": "navbarDocuments", "text": "Dokumenty", "language": "pl", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeTitle", "text": "Twoja sesja wkrótce wygaśnie", "language": "pl", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeMessage", "text": "Aby zachować bezpieczeństwo i chronić Twoje dane, zostaniesz wylogowany za ${timeRemaining}.", "language": "pl", "machineTranslated": true}
 ]

--- a/populate/src/main/resources/seed/i18n/pt/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/pt/languageTexts.json
@@ -143,6 +143,7 @@
   {"keyName": "documentsPageTitle", "text": "Documentos", "language": "pt", "machineTranslated": true},
   {"keyName": "documentsPageUploadedDocumentsTitle", "text": "Documentos enviados", "language": "pt", "machineTranslated": true},
   {"keyName": "documentsPageMessage", "text": "Ao participar num estudo, poderá ser-lhe pedido que envie documentos como parte de um formulário ou inquérito. Abaixo, pode gerir os documentos que enviou.", "language": "pt", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "Documentos", "language": "pt", "machineTranslated": true}
-
+  {"keyName": "navbarDocuments", "text": "Documentos", "language": "pt", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeTitle", "text": "Sua sessão está prestes a expirar", "language": "pt", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeMessage", "text": "Para manter a segurança e proteger seus dados, você será desconectado em ${timeRemaining}.", "language": "pt", "machineTranslated": true}
 ]

--- a/populate/src/main/resources/seed/i18n/ru/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/ru/languageTexts.json
@@ -143,6 +143,7 @@
   {"keyName": "documentsPageTitle", "text": "Документы", "language": "ru", "machineTranslated": true},
   {"keyName": "documentsPageUploadedDocumentsTitle", "text": "Загруженные документы", "language": "ru", "machineTranslated": true},
   {"keyName": "documentsPageMessage", "text": "При участии в исследовании вас могут попросить загрузить документы как часть формы или опроса. Ниже вы можете управлять загруженными вами документами.", "language": "ru", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "Документы", "language": "ru", "machineTranslated": true}
-
+  {"keyName": "navbarDocuments", "text": "Документы", "language": "ru", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeTitle", "text": "Ваш сеанс скоро истечет", "language": "ru", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeMessage", "text": "Для обеспечения безопасности и защиты ваших данных вы выйдете из системы через ${timeRemaining}.", "language": "ru", "machineTranslated": true}
 ]

--- a/populate/src/main/resources/seed/i18n/tr/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/tr/languageTexts.json
@@ -143,6 +143,7 @@
   {"keyName": "documentsPageTitle", "text": "Belgeler", "language": "tr", "machineTranslated": true},
   {"keyName": "documentsPageUploadedDocumentsTitle", "text": "Yüklenen belgeler", "language": "tr", "machineTranslated": true},
   {"keyName": "documentsPageMessage", "text": "Bir çalışmaya katılırken, bir form veya anketin parçası olarak belgeleri yüklemeniz istenebilir. Aşağıda, yüklediğiniz belgeleri yönetebilirsiniz.", "language": "tr", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "Belgeler", "language": "tr", "machineTranslated": true}
-
+  {"keyName": "navbarDocuments", "text": "Belgeler", "language": "tr", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeTitle", "text": "Oturumunuz sona ermek üzere", "language": "tr", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeMessage", "text": "Güvenliğinizi sağlamak ve verilerinizi korumak için ${timeRemaining} içinde oturumunuz kapatılacak.", "language": "tr", "machineTranslated": true}
 ]

--- a/populate/src/main/resources/seed/i18n/zh/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/zh/languageTexts.json
@@ -143,6 +143,7 @@
   {"keyName": "documentsPageTitle", "text": "文件", "language": "zh", "machineTranslated": true},
   {"keyName": "documentsPageUploadedDocumentsTitle", "text": "已上传文件", "language": "zh", "machineTranslated": true},
   {"keyName": "documentsPageMessage", "text": "在参与研究期间，您可能会被要求上传文件作为表格或调查的一部分。下面，您可以管理已上传的文件。", "language": "zh", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "文件", "language": "zh", "machineTranslated": true}
-
+  {"keyName": "navbarDocuments", "text": "文件", "language": "zh", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeTitle", "text": "您的会话即将过期", "language": "zh", "machineTranslated": true},
+  {"keyName": "idleStatusNoticeMessage", "text": "为了维护安全并保护您的数据，您将在 ${timeRemaining} 后退出。", "language": "zh", "machineTranslated": true}
 ]

--- a/ui-participant/src/login/IdleStatusMonitor.tsx
+++ b/ui-participant/src/login/IdleStatusMonitor.tsx
@@ -8,6 +8,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { Modal } from 'react-bootstrap'
 import _ from 'lodash'
 import { useUser } from 'providers/UserProvider'
+import { useI18n } from '@juniper/ui-core'
 
 /*
  * This code was copied from Terra UI and modified to:
@@ -87,15 +88,16 @@ const IdleWarningModal = ({ secondsUntilTimedOut, onDismiss }: {
   secondsUntilTimedOut: number,
   onDismiss: () => void
 }) => {
+  const { i18n } = useI18n()
   const minutes = Math.floor(secondsUntilTimedOut / 60)
   const seconds = secondsUntilTimedOut % 60
   const timeRemaining = `${minutes}:${seconds.toString().padStart(2, '0')}`
   return <Modal show={true} onHide={onDismiss}>
     <Modal.Header>
-      <Modal.Title>Your session is about to expire</Modal.Title>
+      <Modal.Title>{i18n('idleStatusNoticeTitle')}</Modal.Title>
     </Modal.Header>
     <Modal.Body>
-      <p>To maintain security and protect your data, you will be logged out in {timeRemaining}.</p>
+      <p>{i18n('idleStatusNoticeMessage', { substitutions: { timeRemaining } })}</p>
     </Modal.Body>
   </Modal>
 }
@@ -142,7 +144,7 @@ const InactivityTimer = ({ maxIdleSessionDuration, idleWarningDuration, doSignOu
 
   setNextUpdateDelay(millisecondsUntilNextUpdate)
 
-  return idleModalVisible
+  return !idleModalVisible
     ? <IdleWarningModal secondsUntilTimedOut={secondsUntilTimedOut} onDismiss={() => setIdleModalVisible(false)}/>
     : null
 }

--- a/ui-participant/src/login/IdleStatusMonitor.tsx
+++ b/ui-participant/src/login/IdleStatusMonitor.tsx
@@ -144,7 +144,7 @@ const InactivityTimer = ({ maxIdleSessionDuration, idleWarningDuration, doSignOu
 
   setNextUpdateDelay(millisecondsUntilNextUpdate)
 
-  return !idleModalVisible
+  return idleModalVisible
     ? <IdleWarningModal secondsUntilTimedOut={secondsUntilTimedOut} onDismiss={() => setIdleModalVisible(false)}/>
     : null
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Restart AdminApiApp
Go to the heart demo study and log in as jsalk@test.com
Select Spanish
Wait 30 minutes or edit this to always show the warning: https://github.com/broadinstitute/juniper/blob/development/ui-participant/src/login/IdleStatusMonitor.tsx#L147
Confirm you see the idle status notice in spanish