### PR TITLE
[JN-1640] Print surveys in selected language

### DIFF
--- a/ui-participant/src/hub/survey/PrintSurveyView.tsx
+++ b/ui-participant/src/hub/survey/PrintSurveyView.tsx
@@ -16,6 +16,7 @@ import {
   EnvironmentName,
   makeSurveyJsData,
   surveyJSModelFromForm,
+  useI18n,
   useTaskIdParam,
   waitForImages
 } from '@juniper/ui-core'
@@ -41,6 +42,7 @@ const usePrintableSurvey = (args: UsePrintableConsentArgs) => {
   const { studyShortcode, enrollee, stableId, version } = args
 
   const { portalEnv, portal } = usePortalEnv()
+  const { selectedLanguage } = useI18n()
 
   const {
     user,
@@ -72,6 +74,7 @@ const usePrintableSurvey = (args: UsePrintableConsentArgs) => {
       const surveyModel = surveyJSModelFromForm(form)
       surveyModel.title = form.name
       surveyModel.data = resumableData?.data
+      surveyModel.locale = selectedLanguage
       configureModelForPrint(surveyModel)
 
       const proxyProfile = ppUser?.participantUserId != user?.id ? allEnrollees


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Log into heart demo as jsalk@test.com
Select DEV or Spanish as the language
Print the consent form
Confirm it prints in the selected language
Switch back and forth between languages and confirm the pdf is correct each time