### PR TITLE
[JN-1637] allow overriding translations for study & portal names

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/i18n/LanguageTextDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/i18n/LanguageTextDao.java
@@ -76,4 +76,20 @@ public class LanguageTextDao extends BaseMutableJdbiDao<LanguageText> {
     public List<LanguageText> findByLocalSiteId(UUID id) {
         return findAllByProperty("localized_site_content_id", id);
     }
+
+    public Optional<LanguageText> findBySiteContentLanguageAndKey(UUID siteContentId, String language, String key) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("""
+                                select lt.* from language_text lt
+                                 inner join localized_site_content lsc on lt.localized_site_content_id = lsc.id
+                                 inner join site_content sc on lsc.site_content_id = sc.id
+                                 where sc.id = :siteContentId and lsc.language = :language and lt.language = :language and lt.key_name = :key
+                                """)
+                        .bind("siteContentId", siteContentId)
+                        .bind("language", language)
+                        .bind("key", key)
+                        .mapTo(clazz)
+                        .findOne()
+        );
+    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/i18n/LanguageTextService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/i18n/LanguageTextService.java
@@ -40,4 +40,8 @@ public class LanguageTextService extends CrudService<LanguageText, LanguageTextD
     public void deleteByLocalSite(UUID localSiteId, Set<CascadeProperty> cascades) {
         languageTextDao.deleteByLocalSite(localSiteId);
     }
+
+    public Optional<LanguageText> findBySiteContentLanguageAndKey(UUID siteContentId, String language, String key) {
+        return languageTextDao.findBySiteContentLanguageAndKey(siteContentId, language, key);
+    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/i18n/LanguageTextService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/i18n/LanguageTextService.java
@@ -44,4 +44,12 @@ public class LanguageTextService extends CrudService<LanguageText, LanguageTextD
     public Optional<LanguageText> findBySiteContentLanguageAndKey(UUID siteContentId, String language, String key) {
         return languageTextDao.findBySiteContentLanguageAndKey(siteContentId, language, key);
     }
+
+    public static String formatStudyNameTranslationKey(String portalShortcode, String studyShortcode) {
+        return String.format("study:%s.%s", portalShortcode, studyShortcode);
+    }
+
+    public static String formatPortalNameTranslationKey(String portalShortcode) {
+        return String.format("portal:%s", portalShortcode);
+    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
@@ -141,7 +141,7 @@ public class EnrolleeEmailService implements NotificationSender {
                     .findBySiteContentLanguageAndKey(
                             contextInfo.portalEnv().getSiteContentId(),
                             preferredLanguage,
-                            "study:" + contextInfo.portal().getShortcode() + "." + contextInfo.study().getShortcode())
+                            LanguageTextService.formatStudyNameTranslationKey(contextInfo.portal().getShortcode(), contextInfo.study().getShortcode()))
                     .ifPresent(studyNameText -> contextInfo.study().setName(studyNameText.getText()));
         }
 
@@ -151,7 +151,7 @@ public class EnrolleeEmailService implements NotificationSender {
                     .findBySiteContentLanguageAndKey(
                             contextInfo.portalEnv().getSiteContentId(),
                             preferredLanguage,
-                            "portal:" + contextInfo.portal().getShortcode())
+                            LanguageTextService.formatPortalNameTranslationKey(contextInfo.portal().getShortcode()))
                     .ifPresent(portalNameText -> contextInfo.portal().setName(portalNameText.getText()));
         }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
@@ -5,6 +5,7 @@ import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.model.workflow.TaskType;
+import bio.terra.pearl.core.service.i18n.LanguageTextService;
 import bio.terra.pearl.core.service.notification.NotificationContextInfo;
 import bio.terra.pearl.core.service.notification.NotificationSender;
 import bio.terra.pearl.core.service.notification.NotificationService;
@@ -35,11 +36,12 @@ public class EnrolleeEmailService implements NotificationSender {
     private final EmailTemplateService emailTemplateService;
     private final ApplicationRoutingPaths routingPaths;
     private final SendgridClient sendgridClient;
+    private final LanguageTextService languageTextService;
 
     public EnrolleeEmailService(NotificationService notificationService,
                                 PortalEnvironmentService portalEnvService, PortalService portalService,
                                 StudyService studyService, EmailTemplateService emailTemplateService,
-                                ApplicationRoutingPaths routingPaths, SendgridClient sendgridClient) {
+                                ApplicationRoutingPaths routingPaths, SendgridClient sendgridClient, LanguageTextService languageTextService) {
         this.notificationService = notificationService;
         this.portalEnvService = portalEnvService;
         this.portalService = portalService;
@@ -47,6 +49,7 @@ public class EnrolleeEmailService implements NotificationSender {
         this.emailTemplateService = emailTemplateService;
         this.routingPaths = routingPaths;
         this.sendgridClient = sendgridClient;
+        this.languageTextService = languageTextService;
     }
 
     @Async
@@ -138,6 +141,17 @@ public class EnrolleeEmailService implements NotificationSender {
 
         if (!contextInfo.portalEnv().getEnvironmentName().isLive()) {
             fromName += " (%s)".formatted(contextInfo.portalEnv().getEnvironmentName());
+        }
+
+
+        if (contextInfo.study() != null) {
+            // makes sure study.name returns the name of the study in the preferred language
+            languageTextService
+                    .findBySiteContentLanguageAndKey(
+                            contextInfo.portalEnv().getSiteContentId(),
+                            preferredLanguage,
+                            contextInfo.portal().getShortcode() + "." + contextInfo.study().getShortcode())
+                    .ifPresent(studyNameText -> contextInfo.study().setName(studyNameText.getText()));
         }
 
         Mail mail = sendgridClient.buildEmail(

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailService.java
@@ -134,6 +134,28 @@ public class EnrolleeEmailService implements NotificationSender {
             // if this portal environment hasn't been configured with a specific email, just send from the support address
             fromAddress = routingPaths.getSupportEmailAddress();
         }
+
+        if (contextInfo.study() != null) {
+            // makes sure study.name returns the name of the study in the preferred language
+            languageTextService
+                    .findBySiteContentLanguageAndKey(
+                            contextInfo.portalEnv().getSiteContentId(),
+                            preferredLanguage,
+                            "study:" + contextInfo.portal().getShortcode() + "." + contextInfo.study().getShortcode())
+                    .ifPresent(studyNameText -> contextInfo.study().setName(studyNameText.getText()));
+        }
+
+        if (contextInfo.portal() != null) {
+            // makes sure portal.name returns the name of the portal in the preferred language
+            languageTextService
+                    .findBySiteContentLanguageAndKey(
+                            contextInfo.portalEnv().getSiteContentId(),
+                            preferredLanguage,
+                            "portal:" + contextInfo.portal().getShortcode())
+                    .ifPresent(portalNameText -> contextInfo.portal().setName(portalNameText.getText()));
+        }
+
+
         String fromName = "Juniper";
         if (contextInfo.portal().getName() != null) {
             fromName = contextInfo.portal().getName();
@@ -143,16 +165,6 @@ public class EnrolleeEmailService implements NotificationSender {
             fromName += " (%s)".formatted(contextInfo.portalEnv().getEnvironmentName());
         }
 
-
-        if (contextInfo.study() != null) {
-            // makes sure study.name returns the name of the study in the preferred language
-            languageTextService
-                    .findBySiteContentLanguageAndKey(
-                            contextInfo.portalEnv().getSiteContentId(),
-                            preferredLanguage,
-                            contextInfo.portal().getShortcode() + "." + contextInfo.study().getShortcode())
-                    .ifPresent(studyNameText -> contextInfo.study().setName(studyNameText.getText()));
-        }
 
         Mail mail = sendgridClient.buildEmail(
                 localizedEmailTemplate,

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
@@ -32,8 +32,10 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
     private NotificationContextInfo contextInfo;
     private final ApplicationRoutingPaths routingPaths;
 
-    protected EnrolleeEmailSubstitutor(EnrolleeContext ruleData, NotificationContextInfo contextInfo,
-                                       ApplicationRoutingPaths routingPaths, Map<String, String> messages) {
+    protected EnrolleeEmailSubstitutor(EnrolleeContext ruleData,
+                                       NotificationContextInfo contextInfo,
+                                       ApplicationRoutingPaths routingPaths,
+                                       Map<String, String> messages) {
         this.enrolleeContext = ruleData;
         this.contextInfo = contextInfo;
         this.routingPaths = routingPaths;

--- a/core/src/test/java/bio/terra/pearl/core/service/i18n/LanguageTextServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/i18n/LanguageTextServiceTests.java
@@ -3,8 +3,12 @@ package bio.terra.pearl.core.service.i18n;
 import bio.terra.pearl.core.BaseSpringBootTest;
 import bio.terra.pearl.core.factory.i18n.LanguageTextFactory;
 import bio.terra.pearl.core.factory.portal.PortalFactory;
+import bio.terra.pearl.core.factory.site.SiteContentFactory;
 import bio.terra.pearl.core.model.i18n.LanguageText;
 import bio.terra.pearl.core.model.portal.Portal;
+import bio.terra.pearl.core.model.site.LocalizedSiteContent;
+import bio.terra.pearl.core.model.site.SiteContent;
+import bio.terra.pearl.core.service.site.LocalizedSiteContentService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +30,12 @@ public class LanguageTextServiceTests extends BaseSpringBootTest  {
 
     @Autowired
     private PortalFactory portalFactory;
+
+    @Autowired
+    private SiteContentFactory siteContentFactory;
+
+    @Autowired
+    private LocalizedSiteContentService localizedSiteContentService;
 
     @Test
     @Transactional
@@ -70,6 +80,59 @@ public class LanguageTextServiceTests extends BaseSpringBootTest  {
             testName + "login", testName + " text",
             testName + "logout", testName + " text"
         )));
+    }
+
+    @Test
+    @Transactional
+    public void testGetLanguageTextBySiteContent(TestInfo info) {
+
+        SiteContent content1 = siteContentFactory.buildPersisted(getTestName(info));
+
+        LocalizedSiteContent localizedContent1Es = LocalizedSiteContent
+                .builder()
+                .siteContentId(content1.getId())
+                .language("es")
+                .build();
+
+        LocalizedSiteContent localizedContent1Dev = LocalizedSiteContent
+                .builder()
+                .siteContentId(content1.getId())
+                .language("dev")
+                .build();
+
+
+        localizedContent1Es = localizedSiteContentService.create(localizedContent1Es);
+        localizedContent1Dev = localizedSiteContentService.create(localizedContent1Dev);
+
+        SiteContent content2 = siteContentFactory.buildPersisted(getTestName(info));
+
+        LocalizedSiteContent localizedContent2Es = LocalizedSiteContent
+                .builder()
+                .siteContentId(content2.getId())
+                .language("es")
+                .build();
+
+
+        localizedContent2Es = localizedSiteContentService.create(localizedContent2Es);
+        
+        LanguageText languageTextEs = languageTextFactory.buildPersisted(getTestName(info), "testkey", "es", localizedContent1Es.getId());
+        LanguageText languageTextDev = languageTextFactory.buildPersisted(getTestName(info), "testkey", "dev", localizedContent1Dev.getId());
+
+
+        Optional<LanguageText> foundText = languageTextService.findBySiteContentLanguageAndKey(content1.getId(), "es", languageTextEs.getKeyName());
+        assertThat(foundText.isPresent(), equalTo(true));
+        assertThat(foundText.get().getText(), equalTo(languageTextEs.getText()));
+        assertThat(foundText.get().getId(), equalTo(languageTextEs.getId()));
+
+
+        foundText = languageTextService.findBySiteContentLanguageAndKey(content1.getId(), "dev", languageTextDev.getKeyName());
+        assertThat(foundText.isPresent(), equalTo(true));
+        assertThat(foundText.get().getText(), equalTo(languageTextDev.getText()));
+        assertThat(foundText.get().getId(), equalTo(languageTextDev.getId()));
+
+        foundText = languageTextService.findBySiteContentLanguageAndKey(content2.getId(), "es", languageTextEs.getKeyName());
+        assertThat(foundText.isPresent(), equalTo(false));
+
     }
 
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailServiceTests.java
@@ -204,6 +204,14 @@ public class EnrolleeEmailServiceTests extends BaseSpringBootTest {
                 .localizedSiteContentId(localizedSiteContentEs.getId())
                 .build());
 
+        LanguageText esPortalNameLanguageText = languageTextService.create(LanguageText
+                .builder()
+                .keyName("portal1")
+                .language("es")
+                .text("MiPortal")
+                .localizedSiteContentId(localizedSiteContentEs.getId())
+                .build());
+
 
         PortalEnvironmentConfig portalEnvConfig = PortalEnvironmentConfig.builder()
                 .emailSourceAddress("info@portal.org").build();
@@ -237,7 +245,7 @@ public class EnrolleeEmailServiceTests extends BaseSpringBootTest {
         assertThat(email.personalization.get(0).getTos().get(0).getEmail(), equalTo("test@test.com"));
         assertThat(email.content.get(0).getValue(), equalTo("estudio " + esStudyNameLanguageText.getText()));
         assertThat(email.from.getEmail(), equalTo("info@portal.org"));
-        assertThat(email.from.getName(), equalTo("MyPortal (irb) (local)"));
+        assertThat(email.from.getName(), equalTo("MiPortal (irb) (local)"));
         assertThat(email.getSubject(), equalTo("test"));
     }
 

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailServiceTests.java
@@ -198,7 +198,7 @@ public class EnrolleeEmailServiceTests extends BaseSpringBootTest {
 
         LanguageText esStudyNameLanguageText = languageTextService.create(LanguageText
                 .builder()
-                .keyName("portal1.study1")
+                .keyName("study:portal1.study1")
                 .language("es")
                 .text("spanish study name")
                 .localizedSiteContentId(localizedSiteContentEs.getId())
@@ -206,7 +206,7 @@ public class EnrolleeEmailServiceTests extends BaseSpringBootTest {
 
         LanguageText esPortalNameLanguageText = languageTextService.create(LanguageText
                 .builder()
-                .keyName("portal1")
+                .keyName("portal:portal1")
                 .language("es")
                 .text("MiPortal")
                 .localizedSiteContentId(localizedSiteContentEs.getId())

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailServiceTests.java
@@ -6,17 +6,24 @@ import bio.terra.pearl.core.factory.notification.NotificationFactory;
 import bio.terra.pearl.core.factory.notification.TriggerFactory;
 import bio.terra.pearl.core.factory.participant.EnrolleeBundle;
 import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
+import bio.terra.pearl.core.factory.site.SiteContentFactory;
 import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.i18n.LanguageText;
 import bio.terra.pearl.core.model.notification.*;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.Profile;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.portal.PortalEnvironmentConfig;
+import bio.terra.pearl.core.model.site.LocalizedSiteContent;
+import bio.terra.pearl.core.model.site.SiteContent;
+import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.model.workflow.TaskType;
+import bio.terra.pearl.core.service.i18n.LanguageTextService;
 import bio.terra.pearl.core.service.notification.NotificationContextInfo;
 import bio.terra.pearl.core.service.notification.NotificationService;
 import bio.terra.pearl.core.service.rule.EnrolleeContext;
+import bio.terra.pearl.core.service.site.LocalizedSiteContentService;
 import bio.terra.pearl.core.service.study.StudyService;
 import bio.terra.pearl.core.shared.ApplicationRoutingPaths;
 import com.sendgrid.helpers.mail.Mail;
@@ -49,6 +56,12 @@ public class EnrolleeEmailServiceTests extends BaseSpringBootTest {
     private SendgridClient sendgridClient;
     @Autowired
     private EnrolleeEmailService enrolleeEmailService;
+    @Autowired
+    private SiteContentFactory siteContentFactory;
+    @Autowired
+    private LocalizedSiteContentService localizedSiteContentService;
+    @Autowired
+    private LanguageTextService languageTextService;
 
 
     @Test
@@ -151,6 +164,81 @@ public class EnrolleeEmailServiceTests extends BaseSpringBootTest {
         assertThat(email.from.getEmail(), equalTo("info@portal.org"));
         assertThat(email.from.getName(), equalTo("MyPortal (irb) (local)"));
         assertThat(email.getSubject(), equalTo("Welcome given"));
+    }
+
+    @Test
+    @Transactional
+    public void testEmailBuildingLocalizesStudyName(TestInfo info) {
+        Profile profileEs = Profile.builder()
+                .familyName("tester")
+                .givenName("given")
+                .contactEmail("test@test.com")
+                .preferredLanguage("es")
+                .build();
+        Profile profileEn = Profile.builder()
+                .familyName("tester")
+                .givenName("given")
+                .contactEmail("test@test.com")
+                .preferredLanguage("en")
+                .build();
+        Enrollee enrollee = Enrollee.builder().build();
+
+        EnrolleeContext ruleDataEs = new EnrolleeContext(enrollee, profileEs, null, null);
+        EnrolleeContext ruleDataEn = new EnrolleeContext(enrollee, profileEn, null, null);
+
+        SiteContent siteContent = siteContentFactory.buildPersisted(getTestName(info));
+
+        LocalizedSiteContent localizedSiteContentEs = LocalizedSiteContent.builder()
+                .siteContentId(siteContent.getId())
+                .language("es")
+                .build();
+
+        localizedSiteContentEs = localizedSiteContentService.create(localizedSiteContentEs);
+
+
+        LanguageText esStudyNameLanguageText = languageTextService.create(LanguageText
+                .builder()
+                .keyName("portal1.study1")
+                .language("es")
+                .text("spanish study name")
+                .localizedSiteContentId(localizedSiteContentEs.getId())
+                .build());
+
+
+        PortalEnvironmentConfig portalEnvConfig = PortalEnvironmentConfig.builder()
+                .emailSourceAddress("info@portal.org").build();
+        PortalEnvironment portalEnv = PortalEnvironment.builder()
+                .siteContentId(siteContent.getId())
+                .environmentName(EnvironmentName.irb).portalEnvironmentConfig(portalEnvConfig).build();
+        Portal portal = Portal.builder().shortcode("portal1").name("MyPortal").build();
+        Study study = Study.builder().shortcode("study1").name("default study name").build();
+
+        LocalizedEmailTemplate englishTemplate = LocalizedEmailTemplate.builder()
+                .body("study ${study.name}")
+                .language("en")
+                .subject("test").build();
+        LocalizedEmailTemplate spanishTemplate = LocalizedEmailTemplate.builder()
+                .body("estudio ${study.name}")
+                .language("es")
+                .subject("test").build();
+        EmailTemplate emailTemplate = EmailTemplate.builder()
+                .localizedEmailTemplates(List.of(englishTemplate, spanishTemplate)).build();
+
+        NotificationContextInfo contextInfo = new NotificationContextInfo(portal, portalEnv, portalEnvConfig, study, emailTemplate);
+        Mail email = enrolleeEmailService.buildEmail(contextInfo, ruleDataEn, new Notification());
+        assertThat(email.personalization.get(0).getTos().get(0).getEmail(), equalTo("test@test.com"));
+        assertThat(email.content.get(0).getValue(), equalTo("study default study name"));
+        assertThat(email.from.getEmail(), equalTo("info@portal.org"));
+        assertThat(email.from.getName(), equalTo("MyPortal (irb) (local)"));
+        assertThat(email.getSubject(), equalTo("test"));
+
+        email = enrolleeEmailService.buildEmail(contextInfo, ruleDataEs, new Notification());
+
+        assertThat(email.personalization.get(0).getTos().get(0).getEmail(), equalTo("test@test.com"));
+        assertThat(email.content.get(0).getValue(), equalTo("estudio " + esStudyNameLanguageText.getText()));
+        assertThat(email.from.getEmail(), equalTo("info@portal.org"));
+        assertThat(email.from.getName(), equalTo("MyPortal (irb) (local)"));
+        assertThat(email.getSubject(), equalTo("test"));
     }
 
     @Test

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/siteContent.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/siteContent.json
@@ -37,7 +37,10 @@
     "languageTextOverrides": [
       {
         "text": "Estudio de Demostración",
-        "keyName": "demo.heartdemo"
+        "keyName": "study:demo.heartdemo"
+      }, {
+        "text": "Juniper Demostración",
+        "keyName": "portal:demo"
       }
     ]
   },{
@@ -59,7 +62,10 @@
         "keyName": "navbarJoin"
       }, {
         "text": "DEV_Heart Demo",
-        "keyName": "demo.heartdemo"
+        "keyName": "study:demo.heartdemo"
+      }, {
+        "text": "DEV_Juniper Heart Demo",
+        "keyName": "portal:demo"
       }
     ]
   }]

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/siteContent.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/siteContent.json
@@ -33,7 +33,13 @@
       "populateFileName": "es/participation.json"
     }, {
       "populateFileName": "es/learnMore.json"
-    }]
+    }],
+    "languageTextOverrides": [
+      {
+        "text": "Estudio de Demostración",
+        "keyName": "demo.heartdemo"
+      }
+    ]
   },{
     "language": "dev",
     "navLogoCleanFileName": "juniper-demo-logo.png",
@@ -51,6 +57,9 @@
       {
         "text": "DEV_Join Us",
         "keyName": "navbarJoin"
+      }, {
+        "text": "DEV_Heart Demo",
+        "keyName": "demo.heartdemo"
       }
     ]
   }]

--- a/ui-admin/src/portal/siteContent/LanguageTextOverridesEditor.tsx
+++ b/ui-admin/src/portal/siteContent/LanguageTextOverridesEditor.tsx
@@ -34,11 +34,11 @@ import {
 import { basicTableLayout } from 'util/table/tableUtils'
 import { faTrashCan } from '@fortawesome/free-solid-svg-icons/faTrashCan'
 import { TextInput } from 'components/forms/TextInput'
-import Select from 'react-select'
 import Api from 'api/api'
 import { useLoadingEffect } from 'api/api-utils'
 import LoadingSpinner from 'util/LoadingSpinner'
 import { PortalEnvContext } from 'portal/PortalRouter'
+import Creatable from 'react-select/creatable'
 
 
 type EditableLanguageText = Partial<LanguageText> & { isEditing: boolean }
@@ -124,6 +124,8 @@ export default function LanguageTextOverridesEditor(
   const onChangeNewOverrideKey = (key: string) => {
     if (languageKeys.includes(key)) {
       setNewOverride({ ...newOverride, keyName: key, text: languageTexts[key] })
+    } else {
+      setNewOverride({ ...newOverride, keyName: key, text: '' })
     }
   }
 
@@ -142,7 +144,7 @@ export default function LanguageTextOverridesEditor(
       cell: ({ row }) => {
         const value = row.original.keyName
         if (isEditable(row.original)) {
-          return row.original.isEditing && <Select
+          return row.original.isEditing && <Creatable
             aria-label={'New language text override key'}
             options={languageKeys.map(key => {
               return {

--- a/ui-core/src/i18nUtils.ts
+++ b/ui-core/src/i18nUtils.ts
@@ -67,5 +67,12 @@ export const getTranslatedStudyName = (
   portalShortcode: string,
   studyShortcode: string,
   studyName: string) => {
-  return i18n(`${portalShortcode}.${studyShortcode}`, { defaultValue: studyName })
+  return i18n(`study:${portalShortcode}.${studyShortcode}`, { defaultValue: studyName })
+}
+
+export const getTranslatedPortalName = (
+  i18n: I18nFn,
+  portalShortcode: string,
+  studyName: string) => {
+  return i18n(`portal:${portalShortcode}`, { defaultValue: studyName })
 }

--- a/ui-core/src/i18nUtils.ts
+++ b/ui-core/src/i18nUtils.ts
@@ -1,4 +1,9 @@
-import { isNil, sortBy, uniqBy } from 'lodash'
+import {
+  isNil,
+  sortBy,
+  uniqBy
+} from 'lodash'
+import { I18nFn } from 'src/participant/I18nProvider'
 
 /**
  * Turns a list of 2-alpha country codes (e.g. US, MX, CA) to their
@@ -54,4 +59,13 @@ export const getAllCountries = (lang = 'en') : { code: string, name: string }[] 
   // ensure no duplicates (some countries seem to have multiple codes)
   // and sort
   return sortBy(uniqBy(out, val => val.name), val => val.name)
+}
+
+
+export const getTranslatedStudyName = (
+  i18n: I18nFn,
+  portalShortcode: string,
+  studyShortcode: string,
+  studyName: string) => {
+  return i18n(`${portalShortcode}.${studyShortcode}`, { defaultValue: studyName })
 }

--- a/ui-core/src/participant/I18nProvider.tsx
+++ b/ui-core/src/participant/I18nProvider.tsx
@@ -15,9 +15,11 @@ export type I18nOptions = {
   defaultValue?: string
 }
 
+export type I18nFn = (key: string, options?: I18nOptions) => string
+
 export type I18nContextT = {
   languageTexts: Record<string, string>
-  i18n: (key: string, options?: I18nOptions) => string,
+  i18n: I18nFn,
   selectedLanguage: string,
   changeLanguage: (language: string) => void
 }

--- a/ui-core/src/participant/i18n-testing-utils.tsx
+++ b/ui-core/src/participant/i18n-testing-utils.tsx
@@ -1,20 +1,34 @@
 import React from 'react'
-import { I18nContext, I18nContextT } from './I18nProvider'
+import {
+  I18nContext,
+  I18nContextT,
+  I18nOptions
+} from './I18nProvider'
 
 export const mockTextsDefault: Record<string, string> = { taskTypeConsent: 'Consent', start: 'Start' }
 
 /**
  * Returns a MockI18nProvider. Used to test components that need an I18nContext
  */
-export const MockI18nProvider = ({ children, mockTexts = {}, selectedLanguage = 'en' }: {
-    children: React.ReactNode, mockTexts?: Record<string, string>, selectedLanguage?: string
+export const MockI18nProvider = ({ children, mockTexts = {}, selectedLanguage = 'en', useDefaultTexts = false }: {
+  children: React.ReactNode, mockTexts?: Record<string, string>, selectedLanguage?: string, useDefaultTexts?: boolean
 }) => {
   const fakeI18nContext: I18nContextT = {
     languageTexts: mockTexts,
     selectedLanguage,
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     changeLanguage: () => {},
-    i18n: (key: string) => (Object.hasOwn(mockTexts, key) ? mockTexts[key] : `{${key}}`)
+    i18n: (key: string, opts?: I18nOptions) => {
+      if (Object.hasOwn(mockTexts, key)) {
+        return mockTexts[key]
+      }
+
+      if (useDefaultTexts && opts?.defaultValue) {
+        return opts.defaultValue
+      }
+
+      return `{${key}}`
+    }
   }
   return <I18nContext.Provider value={fakeI18nContext}>
     {children}

--- a/ui-participant/src/App.tsx
+++ b/ui-participant/src/App.tsx
@@ -124,7 +124,6 @@ function App() {
   return (
     <ApiProvider api={Api}>
       <EnvironmentAlert portalEnvironment={portal.portalEnvironments[0]}/>
-      <DocumentTitle />
       <PortalPasswordGate portal={portal}>
         <div
           className="App d-flex flex-column min-vh-100 bg-white"
@@ -145,6 +144,8 @@ function App() {
                             defaultLanguage={portalEnv.portalEnvironmentConfig.defaultLanguage}
                             portalShortcode={portal.shortcode}
                             environmentName={portalEnv.environmentName as EnvironmentName}>
+                            <DocumentTitle/>
+
                             <Suspense fallback={<PageLoadingIndicator/>}>
                               <IdleStatusMonitor
                                 maxIdleSessionDuration={30 * 60 * 1000} idleWarningDuration={5 * 60 * 1000}/>

--- a/ui-participant/src/hub/HubPage.test.tsx
+++ b/ui-participant/src/hub/HubPage.test.tsx
@@ -84,7 +84,7 @@ jest.mock('../providers/ActiveUserProvider', () => {
 describe('HubPage', () => {
   it('is rendered with the study name', () => {
     const { RoutedComponent } = setupRouterTest(
-      <MockI18nProvider>
+      <MockI18nProvider useDefaultTexts={true}>
         <HubPage/>
       </MockI18nProvider>)
     render(RoutedComponent)

--- a/ui-participant/src/hub/HubPage.tsx
+++ b/ui-participant/src/hub/HubPage.tsx
@@ -18,6 +18,7 @@ import {
 import {
   Enrollee,
   getJoinLink,
+  getTranslatedStudyName,
   ParticipantDashboardAlert,
   useI18n
 } from '@juniper/ui-core'
@@ -143,7 +144,9 @@ const StudySection = (props: StudySectionProps) => {
 
   return (
     <>
-      <h1 className="mb-4">{matchedStudy.name}</h1>
+      <h1 className="mb-4">
+        {getTranslatedStudyName(i18n, portal.shortcode, matchedStudy.shortcode, matchedStudy.name)}
+      </h1>
       {enrollee.kitRequests.length > 0 && <KitBanner kitRequests={enrollee.kitRequests}/>}
       {enrollee.subject
         ? <StudyResearchTasks enrollee={enrollee} studyShortcode={matchedStudy.shortcode}

--- a/ui-participant/src/hub/HubPageWithProxies.test.tsx
+++ b/ui-participant/src/hub/HubPageWithProxies.test.tsx
@@ -73,7 +73,7 @@ describe('HubPage with proxies', () => {
     expect(screen.queryByText('{test-demographics-survey:0}')).toBeInTheDocument()
     expect(screen.queryByText('{test-consent-survey:0}')).toBeNull()
     selectParticipant('Jonas Salk {youInParens}')
-    await waitFor(() => expect(screen.getByText('{TESTPORTAL.STUDYSHORTCODE}')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText('{study:TESTPORTAL.STUDYSHORTCODE}')).toBeInTheDocument())
     expect(await screen.findByLabelText('{selectParticipant}')).toHaveTextContent('Jonas Salk {youInParens}')
     expect(screen.queryByText('{test-demographics-survey:0}')).toBeNull()
     expect(screen.queryByText('{test-consent-survey:0}')).toBeNull()

--- a/ui-participant/src/hub/HubPageWithProxies.test.tsx
+++ b/ui-participant/src/hub/HubPageWithProxies.test.tsx
@@ -40,7 +40,7 @@ describe('HubPage with proxies', () => {
         user={mockUser}
         portal={mockPortal}
       >
-        <MockI18nProvider>
+        <MockI18nProvider useDefaultTexts={true}>
           <HubPage/>
         </MockI18nProvider>
       </ProvideFullTestUserContext>
@@ -73,7 +73,7 @@ describe('HubPage with proxies', () => {
     expect(screen.queryByText('{test-demographics-survey:0}')).toBeInTheDocument()
     expect(screen.queryByText('{test-consent-survey:0}')).toBeNull()
     selectParticipant('Jonas Salk {youInParens}')
-    await waitFor(() => expect(screen.getByText('Test Study')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText('{TESTPORTAL.STUDYSHORTCODE}')).toBeInTheDocument())
     expect(await screen.findByLabelText('{selectParticipant}')).toHaveTextContent('Jonas Salk {youInParens}')
     expect(screen.queryByText('{test-demographics-survey:0}')).toBeNull()
     expect(screen.queryByText('{test-consent-survey:0}')).toBeNull()

--- a/ui-participant/src/hub/documents/DocumentLibrary.tsx
+++ b/ui-participant/src/hub/documents/DocumentLibrary.tsx
@@ -1,17 +1,28 @@
 import {
   Enrollee,
   EnvironmentName,
+  getTranslatedStudyName,
   I18nOptions,
   instantToDateString,
-  ParticipantFile, ParticipantTask, saveBlobAsDownload,
+  ParticipantFile,
+  ParticipantTask,
+  saveBlobAsDownload,
   StudyEnvParams,
   useI18n
 } from '@juniper/ui-core'
-import React, { useEffect, useState } from 'react'
+import React, {
+  useEffect,
+  useState
+} from 'react'
 import { useActiveUser } from 'providers/ActiveUserProvider'
 import Api from 'api/api'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faFile, faFileImage, faFileLines, faFilePdf } from '@fortawesome/free-solid-svg-icons'
+import {
+  faFile,
+  faFileImage,
+  faFileLines,
+  faFilePdf
+} from '@fortawesome/free-solid-svg-icons'
 import { usePortalEnv } from 'providers/PortalProvider'
 import { Link } from 'react-router-dom'
 import { getTaskPath } from '../task/taskUtils'
@@ -80,7 +91,11 @@ const DocumentsList = ({ studyName, studyEnvParams, enrollee }: {
   }, [])
 
   return <>
-    <h5 className={'mt-3'}>{studyName} ({participantFiles.length})</h5>
+    <h5
+      className={'mt-3'}>
+      {getTranslatedStudyName(
+        i18n, studyEnvParams.portalShortcode, studyEnvParams.studyShortcode, studyName
+      )} ({participantFiles.length})</h5>
     <div className="d-flex flex-column">
       {participantFiles.length > 0 && <table className="table">
         <thead>

--- a/ui-participant/src/landing/HtmlPageView.test.tsx
+++ b/ui-participant/src/landing/HtmlPageView.test.tsx
@@ -1,12 +1,16 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import {
+  render,
+  screen
+} from '@testing-library/react'
 import HtmlPageView from './HtmlPageView'
 import { HtmlPage } from 'api/api'
 import { usePortalEnv } from 'providers/PortalProvider'
-import { asMockedFn } from '@juniper/ui-core'
 import {
-  mockUsePortalEnv
-} from '../test-utils/test-portal-factory'
+  asMockedFn,
+  MockI18nProvider
+} from '@juniper/ui-core'
+import { mockUsePortalEnv } from '../test-utils/test-portal-factory'
 
 jest.mock('providers/PortalProvider', () => {
   return {
@@ -27,7 +31,7 @@ describe('HTMLPageView', () => {
       title: 'Page title',
       path: ''
     }
-    const { container } = render(<HtmlPageView page={simplePage}/>)
+    const { container } = render(<MockI18nProvider><HtmlPageView page={simplePage}/></MockI18nProvider>)
     expect(container).toBeEmptyDOMElement()
   })
 
@@ -43,7 +47,7 @@ describe('HTMLPageView', () => {
       title: 'Page title',
       path: ''
     }
-    render(<HtmlPageView page={simplePage}/>)
+    render(<MockI18nProvider><HtmlPageView page={simplePage}/></MockI18nProvider>)
     expect(screen.getByText('Hellllo')).toBeInTheDocument()
   })
 })

--- a/ui-participant/src/login/RedirectFromOAuth.tsx
+++ b/ui-participant/src/login/RedirectFromOAuth.tsx
@@ -94,7 +94,11 @@ export const RedirectFromOAuth = () => {
               const hubResponse = await enrollCurrentUserInStudy(
                 defaultEnrollStudy.shortcode, preEnrollResponseId, refreshLoginState)
 
-              handleNewStudyEnroll(hubResponse, defaultEnrollStudy.shortcode, navigate, i18n, defaultEnrollStudy.name)
+              handleNewStudyEnroll(hubResponse,
+                defaultEnrollStudy.shortcode,
+                navigate,
+                i18n,
+                i18n(`${portal.shortcode}.${defaultEnrollStudy.shortcode}`, { defaultValue: defaultEnrollStudy.name }))
             } else {
               navigate('/hub', { replace: true })
             }

--- a/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
+++ b/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
@@ -7,7 +7,8 @@ import {
   Route,
   Routes,
   useNavigate,
-  useParams, useSearchParams
+  useParams,
+  useSearchParams
 } from 'react-router-dom'
 import { usePortalEnv } from 'providers/PortalProvider'
 import Api, {
@@ -27,7 +28,9 @@ import {
 
 import { StudyEnrollPasswordGate } from './StudyEnrollPasswordGate'
 import {
+  getTranslatedStudyName,
   HubResponse,
+  I18nFn,
   ParticipantUser,
   useI18n
 } from '@juniper/ui-core'
@@ -36,7 +39,10 @@ import {
   enrollProxyUserInStudy
 } from 'util/enrolleeUtils'
 import { logError } from 'util/loggingUtils'
-import { getNextConsentTask, getTaskPath } from 'hub/task/taskUtils'
+import {
+  getNextConsentTask,
+  getTaskPath
+} from 'hub/task/taskUtils'
 import { useEnrollmentParams } from './useEnrollmentParams'
 
 export type StudyEnrollContext = {
@@ -126,6 +132,8 @@ function StudyEnrollOutletMatched(props: StudyEnrollOutletMatchedProps) {
 
   const matchedEnrollee = enrolleesForUser.find(rollee => rollee.studyEnvironmentId === studyEnv.id)
 
+  const translatedStudyName = getTranslatedStudyName(i18n, portal.shortcode, studyShortcode, studyName)
+
   /** route to a page depending on where in the pre-enroll/registration process the user is */
   const determineNextRoute = async () => {
     // if the user is a proxy, they still can enroll in the study
@@ -135,8 +143,8 @@ function StudyEnrollOutletMatched(props: StudyEnrollOutletMatchedProps) {
       const hubUpdate: HubUpdate = {
         message: {
           title: isProxyEnrollment
-            ? i18n('hubUpdateGovernedUserAlreadyEnrolledTitle', { substitutions: { studyName } })
-            : i18n('hubUpdateAlreadyEnrolledTitle', { substitutions: { studyName } }),
+            ? i18n('hubUpdateGovernedUserAlreadyEnrolledTitle', { substitutions: { studyName: translatedStudyName } })
+            : i18n('hubUpdateAlreadyEnrolledTitle', { substitutions: { studyName: translatedStudyName } }),
           type: 'INFO'
         }
       }
@@ -160,7 +168,12 @@ function StudyEnrollOutletMatched(props: StudyEnrollOutletMatchedProps) {
               studyShortcode, preEnrollResponseId, refreshLoginState
             )
 
-          handleNewStudyEnroll(hubResponse, studyShortcode, navigate, i18n, studyName)
+          handleNewStudyEnroll(
+            hubResponse,
+            studyShortcode,
+            navigate,
+            i18n,
+            translatedStudyName)
         } catch (e) {
           logError({ message: 'Error on StudyEnroll' }, (e as ErrorEvent)?.error?.stack)
           navigate('/hub', { replace: true })
@@ -221,7 +234,7 @@ export function handleNewStudyEnroll(
   hubResponse: HubResponse,
   studyShortcode: string,
   navigate: (path: string, options?: { replace?: boolean, state?: object }) => void,
-  i18n: (key: string, options?: { substitutions?: { [key: string]: string } }) => string,
+  i18n: I18nFn,
   studyName: string
 ) {
   const nextConsentTask = getNextConsentTask(hubResponse)

--- a/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
+++ b/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
@@ -61,6 +61,8 @@ export default function StudyEnrollRouter() {
   const studyShortcode = useParams().studyShortcode
 
   const { portal } = usePortalEnv()
+  const { i18n } = useI18n()
+
   const matchedStudy = portal.portalStudies.find(pStudy => pStudy.study.shortcode === studyShortcode)?.study
   const studyEnv = matchedStudy?.studyEnvironments[0]
   if (!studyEnv || !studyShortcode) {
@@ -70,7 +72,7 @@ export default function StudyEnrollRouter() {
     <StudyEnrollOutletMatched
       portal={portal}
       studyEnv={studyEnv}
-      studyName={matchedStudy.name}
+      studyName={getTranslatedStudyName(i18n, portal.shortcode, studyShortcode, matchedStudy.name)}
       studyShortcode={studyShortcode}
     />
   )

--- a/ui-participant/src/studies/enroll/StudyIneligible.tsx
+++ b/ui-participant/src/studies/enroll/StudyIneligible.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 
 import { Portal } from 'api/api'
 import {
+  getTranslatedPortalName,
   MailingListForm,
   useI18n
 } from '@juniper/ui-core'
@@ -35,7 +36,11 @@ export default function StudyIneligible(props: StudyIneligibleProps) {
         </div>
         <p className="text-center mt-3">
           <Link to="/">
-            {i18n('backToPortalHomepage', { substitutions: { portalName: portal.name } })}
+            {i18n('backToPortalHomepage', {
+              substitutions: {
+                portalName: getTranslatedPortalName(i18n, portal.shortcode, portal.name)
+              }
+            })}
           </Link>
         </p>
       </div>

--- a/ui-participant/src/util/DocumentTitle.tsx
+++ b/ui-participant/src/util/DocumentTitle.tsx
@@ -1,6 +1,10 @@
 import { useEffect } from 'react'
 
 import { usePortalEnv } from 'providers/PortalProvider'
+import {
+  getTranslatedPortalName,
+  useI18n
+} from '@juniper/ui-core'
 
 type DocumentTitleProps = {
   title?: string
@@ -10,7 +14,11 @@ export const DocumentTitle = (props: DocumentTitleProps) => {
   const { title } = props
   const { portal } = usePortalEnv()
 
-  const fullTitle = title ? `${title} | ${portal.name}` : portal.name
+  const { i18n } = useI18n()
+
+  const portalName = getTranslatedPortalName(i18n, portal.shortcode, portal.name)
+
+  const fullTitle = title ? `${title} | ${portalName}` : portalName
   useEffect(() => {
     const previousTitle = document.title
     document.title = fullTitle


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds the ability to override translations for study.name and portal.name. Does not add any new fields or anything to SQL. Instead, uses language text overrides to accomplish this in a simple/publishable way.

The frontend looks to see if any i18n override keys with the format `study:<portalshortcode>.<studyshortcode>` exist and uses that key instead of `study.name`, if it exists. Otherwise just take whatever's in `study.name` as the default. Same for portal, with `portal:<portalshortcode>` replacing `portal.name`.

Also uses the translation for all usages of  `{study.name}` in enrollee email substitutor. The portal name used in the `sender` field will also appropriately reflect the translation override.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Sign up a user in spanish
- Observe that the name of the study is in spanish on your dashboard
- Send the ad-hoc invitation email to this enrollee
- Observe the email they receive also uses the spanish name of the study & the sender is in spanish
