### PR TITLE
[JN-1648] answer mapping works with yes

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
@@ -24,8 +24,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.function.BiFunction;
 
-import static java.lang.Boolean.parseBoolean;
-
 /**
  * Handles mapping ParsedSnapshots (typically received from the frontend) into objects.  This is done with stableIdMaps
  * which map question stableIds to the object properties they should be assigned to.
@@ -168,6 +166,10 @@ public class AnswerProcessingService {
                     mapToDate(answer.getStringValue(), mapping),
             AnswerMappingMapType.STRING_TO_BOOLEAN, (Answer answer, AnswerMapping mapping) -> parseBoolean(answer.getStringValue())
     );
+
+    private static Boolean parseBoolean(String value) {
+        return Boolean.parseBoolean(value) || value.equalsIgnoreCase("yes");
+    }
 
     public static LocalDate mapToDate(String dateString, AnswerMapping mapping) {
         try {

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/AnswerProcessingServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/AnswerProcessingServiceTests.java
@@ -16,11 +16,7 @@ import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.model.participant.Profile;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
-import bio.terra.pearl.core.model.survey.Answer;
-import bio.terra.pearl.core.model.survey.AnswerMapping;
-import bio.terra.pearl.core.model.survey.AnswerMappingMapType;
-import bio.terra.pearl.core.model.survey.AnswerMappingTargetType;
-import bio.terra.pearl.core.model.survey.Survey;
+import bio.terra.pearl.core.model.survey.*;
 import bio.terra.pearl.core.model.workflow.ObjectWithChangeLog;
 import bio.terra.pearl.core.service.participant.ParticipantUserService;
 import bio.terra.pearl.core.service.participant.ProfileService;
@@ -37,9 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 
 public class AnswerProcessingServiceTests extends BaseSpringBootTest {
     @Autowired
@@ -128,6 +122,10 @@ public class AnswerProcessingServiceTests extends BaseSpringBootTest {
         AnswerMapping mapping = new AnswerMapping();
         Object result = AnswerProcessingService.JSON_MAPPERS.get(AnswerMappingMapType.STRING_TO_BOOLEAN)
                 .apply(Answer.builder().stringValue("true").build(), mapping);
+        assertThat((Boolean) result, equalTo(true));
+
+        result = AnswerProcessingService.JSON_MAPPERS.get(AnswerMappingMapType.STRING_TO_BOOLEAN)
+                .apply(Answer.builder().stringValue("Yes").build(), mapping);
         assertThat((Boolean) result, equalTo(true));
 
         result = AnswerProcessingService.JSON_MAPPERS.get(AnswerMappingMapType.STRING_TO_BOOLEAN)


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

For legacy Pepper reasons, all AT boolean fields use "Yes" and "No". We need to map on one of these fields.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- n/a