### PR TITLE
[JN-1644] virus scanning backend

### DIFF
--- a/api-admin/src/main/resources/application.yml
+++ b/api-admin/src/main/resources/application.yml
@@ -48,7 +48,9 @@ env:
   fileUpload:
     backend: LocalFileStorageBackend
     localFileStoragePath: ${LOCAL_FILE_STORAGE_PATH:/tmp/juniper/fileupload}
-    gcsFileStorageBucketName: ${GCS_FILE_STORAGE_BUCKET_NAME:}
+    gcsStorageUnscannedBucketName: ${GCS_FILE_STORAGE_UNSCANNED_BUCKET_NAME:}
+    gcsStorageCleanBucketName: ${GCS_FILE_STORAGE_CLEAN_BUCKET_NAME:}
+    gcsStorageQuarantinedBucketName: ${GCS_FILE_STORAGE_QUARANTINED_BUCKET_NAME:}
     gcsFileStorageProjectId: ${GCS_FILE_STORAGE_PROJECT_ID:}
 
 # Below here is non-deployment-specific

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/service/file/ParticipantFileExtService.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/service/file/ParticipantFileExtService.java
@@ -3,6 +3,7 @@ package bio.terra.pearl.api.participant.service.file;
 import bio.terra.pearl.api.participant.service.AuthUtilService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.file.ParticipantFile;
+import bio.terra.pearl.core.model.file.ScannedParticipantFileDto;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.service.exception.NotFoundException;
@@ -10,14 +11,13 @@ import bio.terra.pearl.core.service.file.ParticipantFileService;
 import bio.terra.pearl.core.service.file.VirusScanResult;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackend;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackendProvider;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Slf4j
@@ -36,7 +36,7 @@ public class ParticipantFileExtService {
     this.fileStorageBackend = fileStorageBackendProvider.get();
   }
 
-  public ParticipantFile get(
+  public ScannedParticipantFileDto get(
       String portalShortcode,
       EnvironmentName envName,
       ParticipantUser participantUser,
@@ -46,11 +46,12 @@ public class ParticipantFileExtService {
     Enrollee enrollee =
         authUtilService.authParticipantUserToEnrollee(participantUser.getId(), enrolleeShortcode);
 
-    ParticipantFile file = participantFileService
+    ParticipantFile file =
+        participantFileService
             .findByEnrolleeIdAndFileName(enrollee.getId(), fileName)
             .orElseThrow(() -> new NotFoundException("Could not find file"));
 
-    return updateScanResult(file);
+    return participantFileService.attachVirusScanResult(file);
   }
 
   public InputStream downloadFile(
@@ -67,9 +68,10 @@ public class ParticipantFileExtService {
             .findByEnrolleeIdAndFileName(enrollee.getId(), fileName)
             .orElseThrow(() -> new NotFoundException("Could not find file"));
 
-    participantFile = updateScanResult(participantFile);
+    VirusScanResult virusScanResult =
+        participantFileService.getVirusScanResult(participantFile.getExternalFileId());
 
-    if (participantFile.getVirusScanResult() == VirusScanResult.QUARANTINED) {
+    if (virusScanResult == VirusScanResult.QUARANTINED) {
       throw new IllegalArgumentException("Virus detected in file");
     }
 
@@ -135,16 +137,5 @@ public class ParticipantFileExtService {
 
     participantFileService.delete(participantFile.getId(), Set.of());
     fileStorageBackend.deleteFile(participantFile.getExternalFileId());
-  }
-
-  private ParticipantFile updateScanResult(ParticipantFile participantFile) {
-    if (participantFile.getVirusScanResult() == VirusScanResult.CLEAN) {
-      return participantFile;
-    }
-
-    VirusScanResult scanResult = fileStorageBackend.scanResult(participantFile.getExternalFileId());
-
-    participantFile.setVirusScanResult(scanResult);
-    return participantFileService.update(participantFile);
   }
 }

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/service/file/ParticipantFileExtService.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/service/file/ParticipantFileExtService.java
@@ -7,15 +7,17 @@ import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.file.ParticipantFileService;
+import bio.terra.pearl.core.service.file.VirusScanResult;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackend;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackendProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Set;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @Slf4j
@@ -43,9 +45,12 @@ public class ParticipantFileExtService {
     authUtilService.authParticipantToPortal(participantUser.getId(), portalShortcode, envName);
     Enrollee enrollee =
         authUtilService.authParticipantUserToEnrollee(participantUser.getId(), enrolleeShortcode);
-    return participantFileService
-        .findByEnrolleeIdAndFileName(enrollee.getId(), fileName)
-        .orElseThrow(() -> new NotFoundException("Could not find file"));
+
+    ParticipantFile file = participantFileService
+            .findByEnrolleeIdAndFileName(enrollee.getId(), fileName)
+            .orElseThrow(() -> new NotFoundException("Could not find file"));
+
+    return updateScanResult(file);
   }
 
   public InputStream downloadFile(
@@ -61,6 +66,12 @@ public class ParticipantFileExtService {
         participantFileService
             .findByEnrolleeIdAndFileName(enrollee.getId(), fileName)
             .orElseThrow(() -> new NotFoundException("Could not find file"));
+
+    participantFile = updateScanResult(participantFile);
+
+    if (participantFile.getVirusScanResult() == VirusScanResult.QUARANTINED) {
+      throw new IllegalArgumentException("Virus detected in file");
+    }
 
     return fileStorageBackend.downloadFile(participantFile.getExternalFileId());
   }
@@ -124,5 +135,16 @@ public class ParticipantFileExtService {
 
     participantFileService.delete(participantFile.getId(), Set.of());
     fileStorageBackend.deleteFile(participantFile.getExternalFileId());
+  }
+
+  private ParticipantFile updateScanResult(ParticipantFile participantFile) {
+    if (participantFile.getVirusScanResult() == VirusScanResult.CLEAN) {
+      return participantFile;
+    }
+
+    VirusScanResult scanResult = fileStorageBackend.scanResult(participantFile.getExternalFileId());
+
+    participantFile.setVirusScanResult(scanResult);
+    return participantFileService.update(participantFile);
   }
 }

--- a/api-participant/src/main/resources/application.yml
+++ b/api-participant/src/main/resources/application.yml
@@ -36,7 +36,9 @@ env:
   fileUpload:
     backend: LocalFileStorageBackend
     localFileStoragePath: ${LOCAL_FILE_STORAGE_PATH:/tmp/juniper/fileupload}
-    gcsFileStorageBucketName: ${GCS_FILE_STORAGE_BUCKET_NAME:}
+    gcsStorageUnscannedBucketName: ${GCS_FILE_STORAGE_UNSCANNED_BUCKET_NAME:}
+    gcsStorageCleanBucketName: ${GCS_FILE_STORAGE_CLEAN_BUCKET_NAME:}
+    gcsStorageQuarantinedBucketName: ${GCS_FILE_STORAGE_QUARANTINED_BUCKET_NAME:}
     gcsFileStorageProjectId: ${GCS_FILE_STORAGE_PROJECT_ID:}
 # Below here is non-deployment-specific
 

--- a/core/src/main/java/bio/terra/pearl/core/dao/file/ParticipantFileDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/file/ParticipantFileDao.java
@@ -1,6 +1,6 @@
 package bio.terra.pearl.core.dao.file;
 
-import bio.terra.pearl.core.dao.BaseJdbiDao;
+import bio.terra.pearl.core.dao.BaseMutableJdbiDao;
 import bio.terra.pearl.core.dao.survey.AnswerDao;
 import bio.terra.pearl.core.model.file.ParticipantFile;
 import bio.terra.pearl.core.model.survey.Answer;
@@ -12,7 +12,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @Component
-public class ParticipantFileDao extends BaseJdbiDao<ParticipantFile> {
+public class ParticipantFileDao extends BaseMutableJdbiDao<ParticipantFile> {
     private final AnswerDao answerDao;
 
     public ParticipantFileDao(Jdbi jdbi, AnswerDao answerDao) {

--- a/core/src/main/java/bio/terra/pearl/core/model/file/ParticipantFile.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/file/ParticipantFile.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.core.model.file;
 
 import bio.terra.pearl.core.model.BaseEntity;
 import bio.terra.pearl.core.model.survey.Answer;
+import bio.terra.pearl.core.service.file.VirusScanResult;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,6 +33,8 @@ public class ParticipantFile extends BaseEntity {
     private UUID enrolleeId;
 
     private String notes;
+
+    public VirusScanResult virusScanResult;
 
     @Builder.Default
     private List<Answer> associatedAnswers = new ArrayList<>(); //list of answers that are associated with this file

--- a/core/src/main/java/bio/terra/pearl/core/model/file/ParticipantFile.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/file/ParticipantFile.java
@@ -2,7 +2,6 @@ package bio.terra.pearl.core.model.file;
 
 import bio.terra.pearl.core.model.BaseEntity;
 import bio.terra.pearl.core.model.survey.Answer;
-import bio.terra.pearl.core.service.file.VirusScanResult;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,8 +32,6 @@ public class ParticipantFile extends BaseEntity {
     private UUID enrolleeId;
 
     private String notes;
-
-    public VirusScanResult virusScanResult;
 
     @Builder.Default
     private List<Answer> associatedAnswers = new ArrayList<>(); //list of answers that are associated with this file

--- a/core/src/main/java/bio/terra/pearl/core/model/file/ScannedParticipantFileDto.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/file/ScannedParticipantFileDto.java
@@ -1,0 +1,18 @@
+package bio.terra.pearl.core.model.file;
+
+import bio.terra.pearl.core.service.file.VirusScanResult;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.beans.BeanUtils;
+
+@Getter
+@Setter
+public class ScannedParticipantFileDto extends ParticipantFile {
+    private VirusScanResult virusScanResult;
+
+    public ScannedParticipantFileDto(ParticipantFile participantFile, VirusScanResult virusScanResult) {
+        BeanUtils.copyProperties(participantFile, this);
+
+        this.virusScanResult = virusScanResult;
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/file/FileStorageConfig.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/FileStorageConfig.java
@@ -13,13 +13,17 @@ import org.springframework.core.env.Environment;
 public class FileStorageConfig {
     private String defaultBackend;
     private String localFileStoragePath;
-    private String gcsStorageBucketName;
+    private String gcsStorageUnscannedBucketName;
+    private String gcsStorageCleanBucketName;
+    private String gcsStorageQuarantinedBucketName;
     private Storage gcsStorageConfig;
 
     public FileStorageConfig(Environment environment) {
         this.defaultBackend = environment.getProperty("env.fileUpload.backend", "LocalFileStorageBackend");
         this.localFileStoragePath = environment.getProperty("env.fileUpload.localFileStoragePath");
-        this.gcsStorageBucketName = environment.getProperty("env.fileUpload.gcsFileStorageBucketName");
+        this.gcsStorageUnscannedBucketName = environment.getProperty("env.fileUpload.gcsStorageUnscannedBucketName");
+        this.gcsStorageCleanBucketName = environment.getProperty("env.fileUpload.gcsStorageCleanBucketName");
+        this.gcsStorageQuarantinedBucketName = environment.getProperty("env.fileUpload.gcsStorageQuarantinedBucketName");
         this.gcsStorageConfig = StorageOptions.newBuilder().setProjectId(environment.getProperty("env.fileUpload.gcsFileStorageProjectId")).build().getService();
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/file/ParticipantFileService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/ParticipantFileService.java
@@ -6,6 +6,7 @@ import bio.terra.pearl.core.model.file.ParticipantFile;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
 import bio.terra.pearl.core.service.CascadeProperty;
+import bio.terra.pearl.core.service.CrudService;
 import bio.terra.pearl.core.service.ImmutableEntityService;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackend;
@@ -24,7 +25,7 @@ import java.util.UUID;
 
 @Service
 @Slf4j
-public class ParticipantFileService extends ImmutableEntityService<ParticipantFile, ParticipantFileDao> {
+public class ParticipantFileService extends CrudService<ParticipantFile, ParticipantFileDao> {
     private final FileStorageBackend fileStorageBackend;
 
     public ParticipantFileService(ParticipantFileDao dao, FileStorageBackendProvider fileStorageBackendProvider) {

--- a/core/src/main/java/bio/terra/pearl/core/service/file/ParticipantFileService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/ParticipantFileService.java
@@ -1,20 +1,14 @@
 package bio.terra.pearl.core.service.file;
 
 import bio.terra.pearl.core.dao.file.ParticipantFileDao;
-import bio.terra.pearl.core.model.BaseEntity;
 import bio.terra.pearl.core.model.file.ParticipantFile;
-import bio.terra.pearl.core.model.participant.Enrollee;
-import bio.terra.pearl.core.model.survey.SurveyResponse;
+import bio.terra.pearl.core.model.file.ScannedParticipantFileDto;
 import bio.terra.pearl.core.service.CascadeProperty;
 import bio.terra.pearl.core.service.CrudService;
-import bio.terra.pearl.core.service.ImmutableEntityService;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackend;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackendProvider;
-import bio.terra.pearl.core.service.survey.SurveyResponseService;
-import bio.terra.pearl.core.service.survey.SurveyService;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import java.io.InputStream;
@@ -63,5 +57,15 @@ public class ParticipantFileService extends CrudService<ParticipantFile, Partici
             throw new IllegalArgumentException("This file is being used in a survey response and cannot be deleted. Please remove the file from the survey response first.");
         }
         super.delete(id, cascade);
+    }
+
+    public ScannedParticipantFileDto attachVirusScanResult(ParticipantFile participantFile) {
+        VirusScanResult scanResult = fileStorageBackend.scanResult(participantFile.getExternalFileId());
+
+        return new ScannedParticipantFileDto(participantFile, scanResult);
+    }
+
+    public VirusScanResult getVirusScanResult(UUID fileId) {
+        return fileStorageBackend.scanResult(fileId);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/file/ScannedFile.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/ScannedFile.java
@@ -1,0 +1,6 @@
+package bio.terra.pearl.core.service.file;
+
+import java.io.InputStream;
+
+public record ScannedFile(InputStream file, VirusScanResult scanResult) {
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/file/VirusScanResult.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/VirusScanResult.java
@@ -1,0 +1,7 @@
+package bio.terra.pearl.core.service.file;
+
+public enum VirusScanResult {
+    UNSCANNED,
+    CLEAN,
+    QUARANTINED
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/file/backends/FileStorageBackend.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/backends/FileStorageBackend.java
@@ -1,5 +1,7 @@
 package bio.terra.pearl.core.service.file.backends;
 
+import bio.terra.pearl.core.service.file.VirusScanResult;
+
 import java.io.InputStream;
 import java.util.UUID;
 
@@ -15,6 +17,8 @@ public interface FileStorageBackend {
      * Download file from backend.
      */
     InputStream downloadFile(UUID uploadedFileId);
+
+    VirusScanResult scanResult(UUID uploadedFileId);
 
     /**
      * Delete file from backend.

--- a/core/src/main/java/bio/terra/pearl/core/service/file/backends/GCSFileStorageBackend.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/backends/GCSFileStorageBackend.java
@@ -1,10 +1,12 @@
 package bio.terra.pearl.core.service.file.backends;
 
+import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.file.FileStorageConfig;
+import bio.terra.pearl.core.service.file.VirusScanResult;
+import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageOptions;
 import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayInputStream;
@@ -14,19 +16,21 @@ import java.util.UUID;
 @Service
 public class GCSFileStorageBackend implements FileStorageBackend {
 
-    private final String bucketName;
+    private final String unscannedBucketName;
+    private final String cleanBucketName;
+    private final String quarantinedBucketName;
     private final Storage storage;
 
     public GCSFileStorageBackend(FileStorageConfig storageConfig) {
         this.storage = storageConfig.getGcsStorageConfig();
-        this.bucketName = storageConfig.getGcsStorageBucketName();
+        this.unscannedBucketName = storageConfig.getGcsStorageBucketName();
     }
 
     @Override
     public UUID uploadFile(InputStream data) {
         UUID fileId = UUID.randomUUID();
 
-        BlobId blobId = BlobId.of(bucketName, fileId.toString());
+        BlobId blobId = BlobId.of(unscannedBucketName, fileId.toString());
         BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
 
         try {
@@ -40,10 +44,19 @@ public class GCSFileStorageBackend implements FileStorageBackend {
 
     @Override
     public InputStream downloadFile(UUID uploadedFileId) {
-        BlobId blobId = BlobId.of(bucketName, uploadedFileId.toString());
-
+        BlobId cleanBlobId = BlobId.of(cleanBucketName, uploadedFileId.toString());
         try {
-            byte[] gcsBytes = storage.get(blobId).getContent();
+            Blob blob = storage.get(cleanBlobId);
+
+            if (blob == null) {
+                blob = storage.get(BlobId.of(unscannedBucketName, uploadedFileId.toString()));
+            }
+
+            if (blob == null) {
+                throw new NotFoundException("File not found in GCS");
+            }
+
+            byte[] gcsBytes = blob.getContent();
             return new ByteArrayInputStream(gcsBytes);
         } catch (Exception e) {
             throw new RuntimeException("Failed to download file from GCS", e);
@@ -51,8 +64,29 @@ public class GCSFileStorageBackend implements FileStorageBackend {
     }
 
     @Override
+    public VirusScanResult scanResult(UUID uploadedFileId) {
+        BlobId cleanBlobId = BlobId.of(cleanBucketName, uploadedFileId.toString());
+        BlobId unscannedBlobId = BlobId.of(unscannedBucketName, uploadedFileId.toString());
+        BlobId quarantinedBlobId = BlobId.of(quarantinedBucketName, uploadedFileId.toString());
+
+        if (storage.get(cleanBlobId) != null) {
+            return VirusScanResult.CLEAN;
+        } else if (storage.get(unscannedBlobId) != null) {
+            return VirusScanResult.UNSCANNED;
+        } else if (storage.get(quarantinedBlobId) != null) {
+            return VirusScanResult.QUARANTINED;
+        }
+
+        throw new NotFoundException("File not found in GCS");
+    }
+
+    @Override
     public void deleteFile(UUID uploadedFileId) {
-        BlobId blobId = BlobId.of(bucketName, uploadedFileId.toString());
+        BlobId blobId = BlobId.of(cleanBucketName, uploadedFileId.toString());
+
+        if (storage.get(blobId) == null) {
+            blobId = BlobId.of(unscannedBucketName, uploadedFileId.toString());
+        }
 
         try {
             storage.delete(blobId);

--- a/core/src/main/java/bio/terra/pearl/core/service/file/backends/GCSFileStorageBackend.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/backends/GCSFileStorageBackend.java
@@ -87,7 +87,6 @@ public class GCSFileStorageBackend implements FileStorageBackend {
         BlobId blobId = BlobId.of(cleanBucketName, uploadedFileId.toString());
 
         if (storage.get(blobId) == null) {
-            System.out.println("File not found in clean bucket, checking unscanned bucket");
             blobId = BlobId.of(unscannedBucketName, uploadedFileId.toString());
         }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/file/backends/GCSFileStorageBackend.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/backends/GCSFileStorageBackend.java
@@ -23,7 +23,9 @@ public class GCSFileStorageBackend implements FileStorageBackend {
 
     public GCSFileStorageBackend(FileStorageConfig storageConfig) {
         this.storage = storageConfig.getGcsStorageConfig();
-        this.unscannedBucketName = storageConfig.getGcsStorageBucketName();
+        this.unscannedBucketName = storageConfig.getGcsStorageUnscannedBucketName();
+        this.cleanBucketName = storageConfig.getGcsStorageCleanBucketName();
+        this.quarantinedBucketName = storageConfig.getGcsStorageQuarantinedBucketName();
     }
 
     @Override
@@ -85,6 +87,7 @@ public class GCSFileStorageBackend implements FileStorageBackend {
         BlobId blobId = BlobId.of(cleanBucketName, uploadedFileId.toString());
 
         if (storage.get(blobId) == null) {
+            System.out.println("File not found in clean bucket, checking unscanned bucket");
             blobId = BlobId.of(unscannedBucketName, uploadedFileId.toString());
         }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/file/backends/LocalFileStorageBackend.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/backends/LocalFileStorageBackend.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.service.file.backends;
 
 import bio.terra.pearl.core.service.file.FileStorageConfig;
+import bio.terra.pearl.core.service.file.VirusScanResult;
 import org.apache.commons.io.FileUtils;
 import org.springframework.stereotype.Service;
 
@@ -43,6 +44,11 @@ public class LocalFileStorageBackend implements FileStorageBackend {
             }
         }
         return null;
+    }
+
+    @Override
+    public VirusScanResult scanResult(UUID uploadedFileId) {
+        return VirusScanResult.CLEAN;
     }
 
     @Override

--- a/core/src/test/java/bio/terra/pearl/core/service/file/backends/GCSFileStorageBackendTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/file/backends/GCSFileStorageBackendTest.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.service.file.backends;
 
 import bio.terra.pearl.core.service.file.FileStorageConfig;
+import bio.terra.pearl.core.service.file.VirusScanResult;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
@@ -10,7 +11,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 
 import java.io.ByteArrayInputStream;
@@ -18,9 +18,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.UUID;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -40,7 +37,9 @@ public class GCSFileStorageBackendTest {
         MockitoAnnotations.openMocks(this);
 
         when(fileStorageConfig.getGcsStorageConfig()).thenReturn(storage);
-        when(fileStorageConfig.getGcsStorageBucketName()).thenReturn("test-bucket");
+        when(fileStorageConfig.getGcsStorageCleanBucketName()).thenReturn("test-bucket-clean");
+        when(fileStorageConfig.getGcsStorageUnscannedBucketName()).thenReturn("test-bucket-unscanned");
+        when(fileStorageConfig.getGcsStorageQuarantinedBucketName()).thenReturn("test-bucket-quarantined");
 
         gcsFileStorageBackend = new GCSFileStorageBackend(fileStorageConfig);
     }
@@ -64,7 +63,8 @@ public class GCSFileStorageBackendTest {
 
         Blob blob = mock(Blob.class);
         when(blob.getContent()).thenReturn(fileContent);
-        when(storage.get(any(BlobId.class))).thenReturn(blob);
+        when(storage.get(BlobId.of("test-bucket-clean", fileId.toString()))).thenReturn(blob);
+        when(storage.get(BlobId.of("test-bucket-unscanned", fileId.toString()))).thenReturn(null);
 
         InputStream result = gcsFileStorageBackend.downloadFile(fileId);
 
@@ -72,20 +72,104 @@ public class GCSFileStorageBackendTest {
         byte[] resultBytes = result.readAllBytes();
         Assertions.assertArrayEquals(fileContent, resultBytes);
 
-        BlobId expectBlobId = BlobId.of("test-bucket", fileId.toString());
-        verify(storage, times(1)).get(expectBlobId);
+        // only attempt clean bucket; since it's found, don't attempt unscanned
+        BlobId cleanBlobId = BlobId.of("test-bucket-clean", fileId.toString());
+        BlobId unscannedBlobId = BlobId.of("test-bucket-unscanned", fileId.toString());
+        verify(storage, times(1)).get(cleanBlobId);
+        verify(storage, times(0)).get(unscannedBlobId);
+    }
+
+    @Test
+    void testDownloadUnscannedFile() throws IOException {
+        UUID fileId = UUID.fromString("906c11cd-5e92-487b-a386-ac300e980861");
+        byte[] fileContent = "test data".getBytes();
+
+        Blob blob = mock(Blob.class);
+        when(blob.getContent()).thenReturn(fileContent);
+        when(storage.get(BlobId.of("test-bucket-clean", fileId.toString()))).thenReturn(null);
+        when(storage.get(BlobId.of("test-bucket-unscanned", fileId.toString()))).thenReturn(blob);
+
+        InputStream result = gcsFileStorageBackend.downloadFile(fileId);
+
+        Assertions.assertNotNull(result);
+        byte[] resultBytes = result.readAllBytes();
+        Assertions.assertArrayEquals(fileContent, resultBytes);
+
+        // attempts to download from both clean and unscanned buckets
+        BlobId cleanBlobId = BlobId.of("test-bucket-clean", fileId.toString());
+        BlobId unscannedBlobId = BlobId.of("test-bucket-unscanned", fileId.toString());
+        verify(storage, times(1)).get(cleanBlobId);
+        verify(storage, times(1)).get(unscannedBlobId);
     }
 
     @Test
     void testDeleteFile() {
         UUID fileId = UUID.fromString("906c11cd-5e92-487b-a386-ac300e980861");
 
+        when(storage.get(BlobId.of("test-bucket-clean", fileId.toString()))).thenReturn(mock(Blob.class));
         when(storage.delete(any(BlobId.class))).thenReturn(true);
 
         gcsFileStorageBackend.deleteFile(fileId);
 
-        BlobId expectedBlobId = BlobId.of("test-bucket", fileId.toString());
+        BlobId expectedBlobId = BlobId.of("test-bucket-clean", fileId.toString());
         verify(storage, times(1)).delete(expectedBlobId);
+    }
+
+    @Test
+    void testDeleteFileAlsoSearchesUnscanned() {
+        UUID fileId = UUID.fromString("906c11cd-5e92-487b-a386-ac300e980861");
+
+        when(storage.get(BlobId.of("test-bucket-clean", fileId.toString()))).thenReturn(null);
+        when(storage.get(BlobId.of("test-bucket-unscanned", fileId.toString()))).thenReturn(mock(Blob.class));
+
+        when(storage.delete(any(BlobId.class))).thenReturn(true);
+
+        gcsFileStorageBackend.deleteFile(fileId);
+
+        BlobId expectedBlobId = BlobId.of("test-bucket-unscanned", fileId.toString());
+        verify(storage, times(1)).delete(expectedBlobId);
+    }
+
+    @Test
+    void testVirusScanClean() {
+        UUID fileId = UUID.fromString("906c11cd-5e92-487b-a386-ac300e980861");
+
+        BlobId cleanBlobId = BlobId.of("test-bucket-clean", fileId.toString());
+        BlobId unscannedBlobId = BlobId.of("test-bucket-unscanned", fileId.toString());
+        BlobId quarantinedBlobId = BlobId.of("test-bucket-quarantined", fileId.toString());
+        when(storage.get(cleanBlobId)).thenReturn(mock(Blob.class));
+        when(storage.get(unscannedBlobId)).thenReturn(null);
+        when(storage.get(quarantinedBlobId)).thenReturn(null);
+
+        Assertions.assertEquals(gcsFileStorageBackend.scanResult(fileId), VirusScanResult.CLEAN);
+    }
+
+    @Test
+    void testVirusScanUnscanned() {
+        UUID fileId = UUID.fromString("906c11cd-5e92-487b-a386-ac300e980861");
+
+        BlobId cleanBlobId = BlobId.of("test-bucket-clean", fileId.toString());
+        BlobId unscannedBlobId = BlobId.of("test-bucket-unscanned", fileId.toString());
+        BlobId quarantinedBlobId = BlobId.of("test-bucket-quarantined", fileId.toString());
+        when(storage.get(cleanBlobId)).thenReturn(null);
+        when(storage.get(unscannedBlobId)).thenReturn(mock(Blob.class));
+        when(storage.get(quarantinedBlobId)).thenReturn(null);
+
+        Assertions.assertEquals(gcsFileStorageBackend.scanResult(fileId), VirusScanResult.UNSCANNED);
+    }
+
+    @Test
+    void testVirusScanQuarantined() {
+        UUID fileId = UUID.fromString("906c11cd-5e92-487b-a386-ac300e980861");
+
+        BlobId cleanBlobId = BlobId.of("test-bucket-clean", fileId.toString());
+        BlobId unscannedBlobId = BlobId.of("test-bucket-unscanned", fileId.toString());
+        BlobId quarantinedBlobId = BlobId.of("test-bucket-quarantined", fileId.toString());
+        when(storage.get(cleanBlobId)).thenReturn(null);
+        when(storage.get(unscannedBlobId)).thenReturn(null);
+        when(storage.get(quarantinedBlobId)).thenReturn(mock(Blob.class));
+
+        Assertions.assertEquals(gcsFileStorageBackend.scanResult(fileId), VirusScanResult.QUARANTINED);
     }
 
 }

--- a/terraform/gcp/k8s/environments/dev.yaml
+++ b/terraform/gcp/k8s/environments/dev.yaml
@@ -61,3 +61,7 @@ b2c:
       clientId: does-not-exist
       policyName: does-not-exist
       tenantName: does-not-exist
+gcsFileStorageBuckets:
+  unscanned: juniper-participant-documents-dev-unscanned
+  clean: juniper-participant-documents-dev-clean
+  quarantined: juniper-participant-documents-dev-quarantined

--- a/terraform/gcp/k8s/templates/admin-deployment.yml
+++ b/terraform/gcp/k8s/templates/admin-deployment.yml
@@ -145,8 +145,12 @@ spec:
               value: 'true'
             - name: AIRTABLE_AUTH_TOKEN_SECRET_ID
               value: airtable-auth-token
-            - name: GCS_FILE_STORAGE_BUCKET_NAME
-              value: {{ .Values.gcsFileStorageBucketName }}
+            - name: GCS_FILE_STORAGE_UNSCANNED_BUCKET_NAME
+              value: {{ .Values.gcsFileStorageBuckets.unscanned }}
+            - name: GCS_FILE_STORAGE_CLEAN_BUCKET_NAME
+              value: {{ .Values.gcsFileStorageBuckets.clean }}
+            - name: GCS_FILE_STORAGE_QUARANTINED_BUCKET_NAME
+              value: {{ .Values.gcsFileStorageBuckets.quarantined }}
             - name: GCS_FILE_STORAGE_PROJECT_ID
               value: {{ .Values.gcpProject }}
           resources:

--- a/terraform/gcp/k8s/templates/participant-deployment.yml
+++ b/terraform/gcp/k8s/templates/participant-deployment.yml
@@ -143,6 +143,14 @@ spec:
               value: 'true'
             - name: LIQUIBASE_ANALYTICS_ENABLED
               value: 'false'
+            - name: GCS_FILE_STORAGE_UNSCANNED_BUCKET_NAME
+              value: {{ .Values.gcsFileStorageBuckets.unscanned }}
+            - name: GCS_FILE_STORAGE_CLEAN_BUCKET_NAME
+              value: {{ .Values.gcsFileStorageBuckets.clean }}
+            - name: GCS_FILE_STORAGE_QUARANTINED_BUCKET_NAME
+              value: {{ .Values.gcsFileStorageBuckets.quarantined }}
+            - name: GCS_FILE_STORAGE_PROJECT_ID
+              value: {{ .Values.gcpProject }}
           resources:
             requests:
               memory: "2Gi"

--- a/terraform/gcp/k8s/values.yaml
+++ b/terraform/gcp/k8s/values.yaml
@@ -20,4 +20,7 @@ b2c:
 enableMaintenanceMode: false
 dsmUrl: https://dsm-dev.datadonationplatform.org/dsm
 dsmIssuer: admin-d2p.ddp-dev.envs.broadinstitute.org
-gcsFileStorageBucketName: ""
+gcsFileStorageBuckets:
+  unscanned: ""
+  clean: ""
+  quarantined: ""


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)



#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
Add these environment variables
```
GCS_FILE_STORAGE_UNSCANNED_BUCKET_NAME=juniper-participant-documents-dev-unscanned
GCS_FILE_STORAGE_CLEAN_BUCKET_NAME=juniper-participant-documents-dev-clean
GCS_FILE_STORAGE_QUARANTINED_BUCKET_NAME=juniper-participant-documents-dev-quarantined
GCS_FILE_STORAGE_PROJECT_ID=broad-juniper-dev
```
Change admin and participant application.yml file storage backend to `GCSFileStorageBackend`
Populate demo
Make sure everything still works
Check out the buckets and make sure all files with UUIDs end up in the clean bucket 
Also check out the malware scanner [logs](https://console.cloud.google.com/run/detail/us-central1/juniper-malware-scanner/logs?inv=1&invt=AbsdMA&project=broad-juniper-dev) to see it picking the files up, scanning them, then moving them
