### PR TITLE
[JN-1650] redirect user back to pre-enroll if enrollment fails

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyDao.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.core.dao.survey;
 
 import bio.terra.pearl.core.dao.BaseVersionedJdbiDao;
 import bio.terra.pearl.core.model.survey.Survey;
+import bio.terra.pearl.core.model.survey.SurveyType;
 import org.jdbi.v3.core.Jdbi;
 import org.springframework.stereotype.Component;
 
@@ -142,6 +143,20 @@ public class SurveyDao extends BaseVersionedJdbiDao<Survey> {
                                 where s.portal_id = :portalId and s.id = se.pre_enroll_survey_id
                                 """)
                         .bind("portalId", portalId)
+                        .mapTo(clazz)
+                        .list()
+        );
+    }
+
+    public List<Survey> findActiveInStudyEnvWithType(UUID studyEnvId, SurveyType type) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("""
+                                select s.* from survey s
+                                inner join study_environment_survey ses on s.id = ses.survey_id and ses.active = true
+                                where ses.study_environment_id = :studyEnvId and s.survey_type = :type
+                                """)
+                        .bind("studyEnvId", studyEnvId)
+                        .bind("type", type)
                         .mapTo(clazz)
                         .list()
         );

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyService.java
@@ -9,6 +9,7 @@ import bio.terra.pearl.core.model.i18n.LanguageText;
 import bio.terra.pearl.core.model.survey.AnswerMapping;
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.model.survey.SurveyQuestionDefinition;
+import bio.terra.pearl.core.model.survey.SurveyType;
 import bio.terra.pearl.core.service.CascadeProperty;
 import bio.terra.pearl.core.service.VersionedEntityService;
 import bio.terra.pearl.core.service.exception.NotFoundException;
@@ -227,5 +228,9 @@ public class SurveyService extends VersionedEntityService<Survey, SurveyDao> {
         surveys.addAll(dao.findActivePreEnrolleeSurveysByPortalId(portalId));
 
         return surveys;
+    }
+
+    public List<Survey> findActiveInStudyEnvWithType(UUID studyEnvId, SurveyType type) {
+        return dao.findActiveInStudyEnvWithType(studyEnvId, type);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
@@ -148,6 +148,10 @@ public class EnrollmentService {
         if (!studyEnvConfig.isAcceptingEnrollment()) {
             throw new IllegalArgumentException("study %s is not accepting enrollment".formatted(studyShortcode));
         }
+        if (preEnrollResponseId == null && hasRequiredPreEnroll(studyEnv.getId())) {
+            throw new IllegalArgumentException("user did not complete required pre-enrollment survey");
+        }
+
         PreEnrollmentResponse preEnrollResponse = validatePreEnrollResponse(operator, studyEnv, preEnrollResponseId, user.getId(), isSubject);
 
         // if the user is signed up, but not a subject, we can just return the existing enrollee,
@@ -161,8 +165,6 @@ public class EnrollmentService {
 
             // backfill the enrollee with the pre-enrollment response data
             this.backfillPreEnrollResponse(operator, enrollee, preEnrollResponse);
-        } else if (hasRequiredPreEnroll(studyEnv.getId())) {
-            throw new IllegalArgumentException("user did not complete required pre-enrollment survey");
         }
 
         EnrolleeEvent event = eventService.publishEnrolleeCreationEvent(enrollee, ppUser);

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
@@ -161,6 +161,8 @@ public class EnrollmentService {
 
             // backfill the enrollee with the pre-enrollment response data
             this.backfillPreEnrollResponse(operator, enrollee, preEnrollResponse);
+        } else if (hasRequiredPreEnroll(studyEnv.getId())) {
+            throw new IllegalArgumentException("user did not complete required pre-enrollment survey");
         }
 
         EnrolleeEvent event = eventService.publishEnrolleeCreationEvent(enrollee, ppUser);
@@ -168,6 +170,12 @@ public class EnrollmentService {
                 user.getId(), studyShortcode, enrollee.getShortcode(), enrollee.getParticipantTasks().size());
         HubResponse hubResponse = eventService.buildHubResponse(event, enrollee);
         return hubResponse;
+    }
+
+    private boolean hasRequiredPreEnroll(UUID studyEnvId) {
+        // should be a single pre-enroll survey, but we'll check all of them
+        List<Survey> preEnrolls = surveyService.findActiveInStudyEnvWithType(studyEnvId, SurveyType.PRE_ENROLL);
+        return preEnrolls.stream().anyMatch(Survey::isRequired);
     }
 
     private Enrollee findOrCreateEnrolleeForEnrollment(ParticipantUser user, PortalParticipantUser ppUser, StudyEnvironment studyEnv,

--- a/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentServiceTests.java
@@ -26,7 +26,6 @@ import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import bio.terra.pearl.core.service.study.StudyService;
 import bio.terra.pearl.core.service.survey.SurveyResponseService;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +36,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class EnrollmentServiceTests extends BaseSpringBootTest {
     @Autowired
@@ -136,6 +136,30 @@ public class EnrollmentServiceTests extends BaseSpringBootTest {
 
     @Test
     @Transactional
+    public void testEnrollRequiresPreEnrollIfSurveyRequired(TestInfo testInfo) {
+        PortalEnvironment portalEnv = portalEnvironmentFactory.buildPersisted(getTestName(testInfo));
+        StudyEnvironment studyEnv = studyEnvironmentFactory.buildPersisted(portalEnv, getTestName(testInfo));
+        Survey survey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(testInfo))
+                .surveyType(SurveyType.PRE_ENROLL)
+                .required(true)
+                .portalId(portalEnv.getPortalId()));
+        surveyFactory.attachToEnv(survey, studyEnv.getId(), true);
+        ParticipantUserFactory.ParticipantUserAndPortalUser userBundle = participantUserFactory.buildPersisted(portalEnv,
+                getTestName(testInfo));
+        String studyShortcode = studyService.find(studyEnv.getStudyId()).get().getShortcode();
+
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                    enrollmentService.enroll(userBundle.ppUser(), studyEnv.getEnvironmentName(), studyShortcode,
+                            userBundle.user(), userBundle.ppUser(), null, false);
+                });
+
+    }
+
+    @Test
+    @Transactional
     public void testEnrollChecksConfigAllowsEnrollment(TestInfo testInfo) {
         PortalEnvironment portalEnv = portalEnvironmentFactory.buildPersisted(getTestName(testInfo));
         StudyEnvironment studyEnv = studyEnvironmentFactory.buildPersisted(portalEnv, getTestName(testInfo));
@@ -148,7 +172,7 @@ public class EnrollmentServiceTests extends BaseSpringBootTest {
                 getTestName(testInfo));
         String studyShortcode = studyService.find(studyEnv.getStudyId()).get().getShortcode();
         String portalShortcode = portalService.find(portalEnv.getPortalId()).get().getShortcode();
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(IllegalArgumentException.class, () -> {
             enrollmentService.enroll(userBundle.ppUser(), studyEnv.getEnvironmentName(), studyShortcode, userBundle.user(), userBundle.ppUser(),
                     null, false);
         });

--- a/populate/src/main/resources/seed/i18n/de/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/de/languageTexts.json
@@ -1,163 +1,836 @@
 [
-  {"keyName": "navbarDashboard", "text": "Dashboard", "language": "de"},
-  {"keyName": "navbarChangePassword", "text": "Passwort ändern", "language": "de"},
-  {"keyName": "navbarLogout", "text": "Abmelden", "language": "de"},
-  {"keyName": "profile", "text": "Profil", "language": "de"},
-  {"keyName": "navbarLogin", "text": "Anmelden", "language": "de"},
-  {"keyName": "navbarJoin", "text": "Registrieren", "language": "de"},
-  {"keyName": "taskComplete", "text": "Abgeschlossen", "language": "de"},
-  {"keyName": "taskInProgress", "text": "Wird durchgeführt", "language": "de"},
-  {"keyName": "taskNotStarted", "text": "Nicht gestartet", "language": "de"},
-  {"keyName": "taskDeclined", "text": "Abgelehnt", "language": "de"},
-  {"keyName": "taskLocked", "text": "Gesperrt", "language": "de"},
-  {"keyName": "tasksNoneForStudy", "text": "Keine Aufgaben für diese Studie", "language": "de"},
-  {"keyName": "taskHistory", "text": "Verlauf", "language": "de"},
-  {"keyName": "taskNew", "text": "NEU", "language": "de"},
-  {"keyName": "surveysSomeLocked", "text": "Einige Erhebungen sind gesperrt, bis andere erforderliche Aufgaben abgeschlossen sind.", "language": "de"},
-  {"keyName": "taskTypeSurvey", "text": "Erhebung", "language": "de"},
-  {"keyName": "taskTypeSurveys", "text": "Erhebungen", "language": "de"},
-  {"keyName": "taskTypeConsent", "text": "Einwilligung", "language": "de"},
-  {"keyName": "taskTypeForms", "text": "Formulare", "language": "de"},
-  {"keyName": "start", "text": "Start", "language": "de"},
-  {"keyName": "continue", "text": "Weiter", "language": "de"},
-  {"keyName": "save", "text": "Speichern", "language": "de"},
-  {"keyName": "outreachLearnMore", "text": "Mehr Info", "language": "de"},
-  {"keyName": "cancel", "text": "Abbrechen", "language": "de"},
-  {"keyName": "goBack", "text": "Zurück", "language": "de"},
-  {"keyName": "name", "text": "Name", "language": "de"},
-  {"keyName": "givenName", "text": "Vorname", "language": "de"},
-  {"keyName": "familyName", "text": "Nachname", "language": "de"},
-  {"keyName": "editName", "text": "Name bearbeiten", "language": "de"},
-  {"keyName": "editBirthDate", "text": "Geburtstag bearbeiten", "language": "de"},
-  {"keyName": "birthDate", "text": "Geburtstag", "language": "de"},
-  {"keyName": "mailingAddress", "text": "Postanschrift", "language": "de"},
-  {"keyName": "editMailingAddress", "text": "Postanschrift bearbeiten", "language": "de"},
-  {"keyName": "primaryAddress", "text": "Primäre Anschrift", "language": "de"},
-  {"keyName": "editPrimaryAddress", "text": "Primäre Anschrift bearbeiten", "language": "de"},
-  {"keyName": "street1", "text": "Straße 1", "language": "de"},
-  {"keyName": "street2", "text": "Straße 2", "language": "de"},
-  {"keyName": "city", "text": "Stadt", "language": "de"},
-  {"keyName": "state", "text": "Bundesstaat\/Provinz", "language": "de"},
-  {"keyName": "postalCode", "text": "Postleitzahl", "language": "de"},
-  {"keyName": "country", "text": "Land", "language": "de"},
-  {"keyName": "communicationPreferences", "text": "Kommunikationseinstellungen", "language": "de"},
-  {"keyName": "editCommunicationPreferences", "text": "Kommunikationseinstellungen bearbeiten", "language": "de"},
-  {"keyName": "contactEmail", "text": "Kontakt-E-Mail", "language": "de"},
-  {"keyName": "editContactEmail", "text": "Kontakt-E-Mail bearbeiten", "language": "de"},
-  {"keyName": "phoneNumber", "text": "Telefonnummer", "language": "de"},
-  {"keyName": "editPhoneNumber", "text": "Telefonnummer bearbeiten", "language": "de"},
-  {"keyName": "doNotSolicit", "text": "Keine Werbung", "language": "de"},
-  {"keyName": "doNotContact", "text": "Kein Kontakt", "language": "de"},
-  {"keyName": "editDoNotSolicit", "text": "Keine Werbung bearbeiten", "language": "de"},
-  {"keyName": "editNotifications", "text": "Benachrichtigungen bearbeiten", "language": "de"},
-  {"keyName": "notifications", "text": "Benachrichtigungen", "language": "de"},
-  {"keyName": "on", "text": "Ein", "language": "de"},
-  {"keyName": "off", "text": "Aus", "language": "de"},
-  {"keyName": "notProvided", "text": "Keine Angabe", "language": "de"},
-  {"keyName": "editProfileContactEmailWarning", "text": "Klicken Sie auf „Speichern“, um die für die Kommunikation verwendete E-Mail zu aktualisieren. Beachten Sie, dass sich Ihre Anmeldedaten nicht ändern.", "language": "de"},
-  {"keyName": "privacyPolicy", "text": "Datenschutzrichtlinie", "language": "de"},
-  {"keyName": "termsOfUse", "text": "Nutzungsbedingungen", "language": "de"},
-  {"keyName": "addressInvalidPostalCode", "text": "Die Postleitzahl konnte nicht verifiziert werden.", "language": "de"},
-  {"keyName": "addressInvalidCountry", "text": "Das Land konnte nicht verifiziert werden.", "language": "de"},
-  {"keyName": "addressInvalidState", "text": "Der Bundesstaat\/die Provinz konnte nicht verifiziert werden.", "language": "de"},
-  {"keyName": "addressInvalidCity", "text": "Die Stadt konnte nicht verifiziert werden.", "language": "de"},
-  {"keyName": "addressInvalidHouseNumber", "text": "Die Hausnummer konnte nicht verifiziert werden.", "language": "de"},
-  {"keyName": "addressInvalidStreetName", "text": "Der Straßenname konnte nicht verifiziert werden.", "language": "de"},
-  {"keyName": "addressInvalidStreetType", "text": "Der Straßentyp konnte nicht verifiziert werden.", "language": "de"},
-  {"keyName": "addressNeedsSubpremise", "text": "Bitte geben Sie die Nummer einer Wohnung\/Suite an.", "language": "de"},
-  {"keyName": "addressFailedToValidate", "text": "Die Anschrift konnte nicht validiert werden.", "language": "de"},
-  {"keyName": "suggestBetterAddressHeader", "text": "Ist die Anschrift korrekt?", "language": "de"},
-  {"keyName": "suggestBetterAddressBody", "text": "Wir konnten eine ähnliche Anschrift verifizieren. Bitte wählen Sie aus, welche Sie verwenden möchten.", "language": "de"},
-  {"keyName": "newAddress", "text": "Neue Anschrift", "language": "de"},
-  {"keyName": "oldAddress", "text": "Alte Anschrift", "language": "de"},
-  {"keyName": "you", "text": "Sie", "language": "de"},
-  {"keyName": "yourDependent", "text": "Ihr\/ Angehörige\/r", "language": "de"},
-  {"keyName": "youInParens", "text": "(Sie)", "language": "de"},
-  {"keyName": "allProfiles", "text": "Alle Profile", "language": "de"},
-  {"keyName": "manageProfiles", "text": "Profile verwalten", "language": "de"},
-  {"keyName": "addNewParticipant", "text": "Neue\/n Teilnehmende\/n hinzufügen", "language": "de"},
-  {"keyName": "dashboard", "text": "Dashboard", "language": "de"},
-  {"keyName": "selectParticipant", "text": "Teilnehmende\/n auswählen", "language": "de"},
-  {"keyName": "hubUpdateFormSubmittedTitle", "text": "${formName} abgeschlossen", "language": "de"},
-  {"keyName": "hubUpdateNoActivitiesTitle", "text": "Alle Aktivitäten abgeschlossen", "language": "de"},
-  {"keyName": "hubUpdateNoActivitiesDetail", "text": "Sie haben alle Aktivitäten für diese Studie abgeschlossen. Wir benachrichtigen Sie, sobald neue Aktivitäten verfügbar sind. Vielen Dank für Ihre Teilnahme!", "language": "de"},
-  {"keyName": "hubUpdateWelcomeToStudyTitle", "text": "Willkommen bei ${studyName}", "language": "de"},
-  {"keyName": "hubUpdateWelcomeToStudyDetail", "text": "Bitte lesen und unterschreiben Sie die untenstehende Einwilligungserklärung, um fortzufahren.", "language": "de"},
-  {"keyName": "hubUpdateAlreadyEnrolledTitle", "text": "Sie wurden bereits in ${studyName} aufgenommen.", "language": "de"},
-  {"keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle", "text": "Dieser Nutzer wurde bereits in ${studyName} aufgenommen.", "language": "de"},
-  {"keyName": "cookieAlertTitle", "text": "Cookies", "language": "de"},
-  {"keyName": "cookieAlertDetail", "text": "Diese Website verwendet Internet-Token, sogenannte „Cookies“, um die ordnungsgemäße Funktion und Sicherheit unserer Website zu gewährleisten und Ihr Nutzererlebnis zu verbessern. Alle von uns verwendeten Cookies sind absolut erforderliche Cookies. Diese Art von Cookie erfasst keine personenbezogenen Daten über Sie und zeichnet Ihre Surfgewohnheiten nicht auf. Um mehr zu erfahren, [lesen Sie unsere Datenschutzrichtlinie](\/privacy).", "language": "de"},
-  {"keyName": "joinStudy", "text": "An der Studie teilnehmen", "language": "de"},
-  {"keyName": "ineligibleThankYou", "text": "Vielen Dank für Ihr Interesse an ${studyName}", "language": "de" },
-  {"keyName": "ineligibleDescription", "text": "Leider erfüllen Sie derzeit nicht die Teilnahmekriterien für ${studyName}.", "language": "de"},
-  {"keyName": "ineligibleProvideYourEmail", "text": "Wenn Sie unten Ihre E-Mail-Adresse hinterlassen, halten wir Sie über die Entwicklungen auf dem Laufenden. Sie können sich jederzeit abmelden.", "language":  "de"},
-  {"keyName": "ineligibleStayInformed", "text": "Auf dem Laufenden bleiben", "language": "de"},
-  {"keyName": "backToPortalHomepage", "text": "Zurück zur Startseite von ${portalName}", "language": "de"},
-  {"keyName": "joinMailingList", "text": "Für Mailingliste anmelden", "language": "de"},
-  {"keyName": "mailingFormStayUpdated", "text":  "Über Neuigkeiten zur Studie auf dem Laufenden bleiben", "language": "de"},
-  {"keyName": "yourName", "text": "Ihr Name", "language": "de"},
-  {"keyName": "yourEmail", "text": "Ihre E-Mail", "language": "de"},
-  {"keyName": "join", "text":  "Teilnehmen", "language": "de"},
-  {"keyName": "thanksForJoining", "text": "Vielen Dank für die Anmeldung!", "language": "de"},
-  {"keyName": "pageNotFoundTitle", "text": "Seite nicht gefunden", "language": "de"},
-  {"keyName": "pageNotFoundMessage", "text": "Wenn Sie glauben, dass es sich hierbei um einen Fehler handelt, wenden Sie sich bitte an ${studyContactEmail}", "language": "de"},
-  {"keyName": "pageNotFoundReturnHome", "text": "Zurück zur Startseite", "language": "de"},
-  {"keyName": "authErrorPageTitle", "text": "Etwas ist schiefgelaufen", "language": "de"},
-  {"keyName": "authErrorPageMessage", "text": "Es gab ein Problem mit unserem Authentifizierungsdienst. Bitte versuchen Sie es erneut. Wenn das Problem weiterhin besteht, wenden Sie sich bitte an ${studyContactEmail}.", "language": "de"},
-  {"keyName": "navbarSampleKits", "text":  "Probenkits", "language": "de"},
-  {"keyName": "kitsPageTitle", "text": "Probenentnahme-Kits", "language": "de"},
-  {"keyName": "kitsPageDescription", "text": "Probenentnahme-Kits sind ein wichtiger Teil des Studienprozesses und können Forschenden dabei helfen, wichtige Erkenntnisse zu gewinnen. Nachfolgend finden Sie den Status aller Kits, die Ihnen zur Verfügung gestellt wurden.", "language": "de"},
-  {"keyName": "kitsPageInPersonTitle", "text": "Eine Probe persönlich abgeben", "language": "de"},
-  {"keyName": "kitsPageInPersonDescription", "text": "Diese Studie bietet derzeit die Möglichkeit, ein Probenentnahme-Kit selbst anzuwenden.", "language": "de"},
-  {"keyName": "kitsPageInPersonCompleteButton", "text": "Ein Kit selbst anwenden", "language": "de"},
-  {"keyName": "kitsPageYourKitsTitle", "text": "Ihre Kits", "language": "de"},
-  {"keyName": "kitsPageStatusPreparing", "text": "Vorbereitung", "language": "de"},
-  {"keyName": "kitsPageStatusShipped", "text": "Versendet", "language": "de"},
-  {"keyName": "kitsPageStatusReturned", "text": "Zurückgesendet", "language": "de"},
-  {"keyName": "kitsPageStatusCreated", "text": "Erstellt", "language": "de"},
-  {"keyName": "kitsPageStatusCollected", "text": "Abgenommen", "language": "de"},
-  {"keyName": "kitsPageNoKits", "text": "Sie haben derzeit keine Probenentnahme-Kits.", "language": "de"},
-  {"keyName": "kitsInPersonTitle", "text": "Anleitung zur Anwendung des Probenkits", "language": "de"},
-  {"keyName": "kitsInPersonDescription", "text": "Wenn Sie ein Probenentnahme-Kit selbst anwenden, befolgen Sie bitte die Anweisungen, die Sie von einem Mitglied des Studienteams erhalten haben. Eventuelle weitere Angaben, die Sie benötigen, wie beispielsweise Ihre eindeutige Teilnehmerkennung, finden Sie weiter unten.", "language": "de"},
-  {"keyName": "kitsInPersonSubDescription", "text": "Wenn Sie Fragen haben, wenden Sie sich bitte an ein Mitglied des Studienteams.", "language": "de"},
-  {"keyName": "kitsInPersonYourKitTitle", "text": "Ihr Probenentnahme-Kit", "language": "de"},
-  {"keyName": "kitsInPersonYourKitDescription", "text": "Ein Teammitglied hat Ihnen ein Probenentnahme-Kit ausgehändigt. Dieses Probenkit ist mit Ihrem Nutzerkonto verbunden. Wenn Sie jemand anderem bei der Anwendung des Probenentnahme-Kits helfen, stellen Sie bitte sicher, dass jede\/r Teilnehmende das ihm\/ihr jeweils zugewiesene Probenentnahme-Kit verwendet.", "language": "de"},
-  {"keyName": "kitsInPersonYourKitIdentifier", "text": "Ihre Kit-Kennung", "language": "de"},
-  {"keyName": "kitsInPersonReturnToDashboard", "text": "Zurück zum Dashboard", "language": "de"},
-  {"keyName": "kitsInPersonRefreshPage", "text": "Aktualisieren", "language": "de"},
-  {"keyName": "kitsInPersonConsentRequiredTitle", "text": "Einwilligung erforderlich", "language": "de"},
-  {"keyName": "kitsInPersonConsentRequiredDescription", "text": "Vor der Anwendung eines Probenentnahme-Kits müssen Sie zunächst in die Studie aufgenommen werden. Bei Interesse können Sie über den untenstehenden Link die Einwilligungserklärung aufrufen und unterschreiben.", "language": "de"},
-  {"keyName": "kitsInPersonStartConsent", "text": "Vorgang zur Erteilung der Einwilligung starten", "language": "de"},
-  {"keyName": "kitsInPersonError", "text": "Beim Laden Ihrer Kit-Informationen ist ein Fehler aufgetreten. Bitte wenden Sie sich an ein Mitglied des Studienteams.", "language": "de"},
-  {"keyName": "kitsInPersonCreatedInstructions", "text": "Nachdem Sie das Probenentnahme-Kit angewendet haben, geben Sie es bitte an ein Mitglied des Studienteams zurück und lassen Sie Ihren Teilnahmecode unten scannen.", "language": "de"},
-  {"keyName": "kitsInPersonNoKitInstructions", "text": "Um ein Probenentnahme-Kit zu erhalten, scannt ein Mitglied des Studienteams Ihren unten stehenden individuellen Teilnahmecode, um Ihrem Konto ein Probenentnahme-Kit zuzuordnen.", "language": "de"},
-  {"keyName": "kitsInPersonNoKitSubInstructions", "text": "Wenn Sie ein Kit erhalten haben, aktualisieren Sie bitte diese Seite, um Ihre Kit-Informationen anzuzeigen und weitere Anweisungen zu erhalten.", "language": "de"},
-  {"keyName": "kitsInPersonCollectedDescription", "text": "Ein Teammitglied hat Ihr Probenentnahme-Kit erhalten. Sie erhalten eine E-Mail-Benachrichtigung, wenn Ihre Probe verarbeitet wurde, und können den Status der Probe auf Ihrem Studien-Dashboard anzeigen.", "language": "de"},
-  {"keyName": "kitsInPersonCollectedThankYou", "text": "Vielen Dank für Ihre Teilnahme.", "language": "de"},
-  {"keyName": "kitTypeSaliva", "text": "Speichelkit", "language": "de"},
-  {"keyName": "kitTypeStool", "text": "Stuhlkit", "language": "de"},
-  {"keyName": "kitTypeBlood", "text": "Blutkit", "language": "de"},
-  {"keyName": "documentDownloadButton", "text": "Herunterladen", "language": "de", "machineTranslated": true},
-  {"keyName": "documentsListNone", "text": "Sie haben noch keine Dokumente hochgeladen", "language": "de", "machineTranslated": true},
-  {"keyName": "documentsListCreatedOn", "text": "Erstellt am", "language": "de", "machineTranslated": true},
-  {"keyName": "documentsPageTitle", "text": "Unterlagen", "language": "de", "machineTranslated": true},
-  {"keyName": "documentsPageUploadedDocumentsTitle", "text": "Hochgeladene Dokumente", "language": "de", "machineTranslated": true},
-  {"keyName": "documentsPageMessage", "text": "Während Sie an einer Studie teilnehmen, werden Sie möglicherweise aufgefordert, im Rahmen eines Formulars oder einer Umfrage Dokumente hochzuladen. Unten können Sie die hochgeladenen Dokumente verwalten.", "language": "de", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "Unterlagen", "language": "de", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureTitle", "text": "Bist du sicher?", "language": "de", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureMessage", "text": "Möchten Sie dieses Dokument wirklich löschen? Dies kann nicht rückgängig gemacht werden. Bitte beachten Sie, dass ein Studienmitarbeiter, der dieses Dokument bereits heruntergeladen hat, weiterhin darauf zugreifen kann. Wenden Sie sich bitte an den Studienmitarbeiter, wenn Sie das Dokument vollständig aus allen Aufzeichnungen entfernen lassen möchten.", "language": "de", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseTitle", "text": "Dieses Dokument wird verwendet", "language": "de", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseMessage", "text": "Dieses Dokument wird derzeit als Antwort auf mindestens eine Umfrage freigegeben. Entfernen Sie es vor dem Löschen aus den Umfrageantworten.", "language": "de", "machineTranslated": true},
-  {"keyName": "documentDeleteButton", "text": "Löschen", "language": "de", "machineTranslated": true},
-  {"keyName": "documentOptionsButton", "text": "Optionen", "language": "de", "machineTranslated": true},
-  {"keyName": "documentSharedInResponseTo", "text": "geteilt als Antwort auf", "language": "de", "machineTranslated": true},
-  {"keyName": "documentUploaderSelectedDocuments", "text": "Ausgewählte Dokumente", "language": "de", "machineTranslated": true},
-  {"keyName": "documentUploaderIncludedInResponse", "text": "Diese Dokumente sind in Ihrer Antwort enthalten", "language": "de", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocumentsSelected", "text": "Keine Dokumente ausgewählt. Bitte laden Sie unten ein neues Dokument hoch oder wählen Sie ein vorhandenes Dokument aus.", "language": "de", "machineTranslated": true},
-  {"keyName": "documentUploaderAvailableDocuments", "text": "Verfügbare Dokumente", "language": "de", "machineTranslated": true},
-  {"keyName": "documentUploaderNotIncludedInResponse", "text": "Diese Dokumente sind nicht in Ihrer Antwort enthalten", "language": "de", "machineTranslated": true},
-  {"keyName": "documentUploaderClickToUpload", "text": "Legen Sie die Dateien hier ab, oder klicken Sie zum Hochladen", "language": "de", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocuments", "text": "Keine Dokumente verfügbar", "language": "de", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeTitle", "text": "Ihre Sitzung läuft bald ab", "language": "de", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeMessage", "text": "Um die Sicherheit zu gewährleisten und Ihre Daten zu schützen, werden Sie in ${timeRemaining} abgemeldet.", "language": "de", "machineTranslated": true}
+  {
+    "keyName": "navbarDashboard",
+    "text": "Dashboard",
+    "language": "de"
+  },
+  {
+    "keyName": "navbarChangePassword",
+    "text": "Passwort ändern",
+    "language": "de"
+  },
+  {
+    "keyName": "navbarLogout",
+    "text": "Abmelden",
+    "language": "de"
+  },
+  {
+    "keyName": "profile",
+    "text": "Profil",
+    "language": "de"
+  },
+  {
+    "keyName": "navbarLogin",
+    "text": "Anmelden",
+    "language": "de"
+  },
+  {
+    "keyName": "navbarJoin",
+    "text": "Registrieren",
+    "language": "de"
+  },
+  {
+    "keyName": "taskComplete",
+    "text": "Abgeschlossen",
+    "language": "de"
+  },
+  {
+    "keyName": "taskInProgress",
+    "text": "Wird durchgeführt",
+    "language": "de"
+  },
+  {
+    "keyName": "taskNotStarted",
+    "text": "Nicht gestartet",
+    "language": "de"
+  },
+  {
+    "keyName": "taskDeclined",
+    "text": "Abgelehnt",
+    "language": "de"
+  },
+  {
+    "keyName": "taskLocked",
+    "text": "Gesperrt",
+    "language": "de"
+  },
+  {
+    "keyName": "tasksNoneForStudy",
+    "text": "Keine Aufgaben für diese Studie",
+    "language": "de"
+  },
+  {
+    "keyName": "taskHistory",
+    "text": "Verlauf",
+    "language": "de"
+  },
+  {
+    "keyName": "taskNew",
+    "text": "NEU",
+    "language": "de"
+  },
+  {
+    "keyName": "surveysSomeLocked",
+    "text": "Einige Erhebungen sind gesperrt, bis andere erforderliche Aufgaben abgeschlossen sind.",
+    "language": "de"
+  },
+  {
+    "keyName": "taskTypeSurvey",
+    "text": "Erhebung",
+    "language": "de"
+  },
+  {
+    "keyName": "taskTypeSurveys",
+    "text": "Erhebungen",
+    "language": "de"
+  },
+  {
+    "keyName": "taskTypeConsent",
+    "text": "Einwilligung",
+    "language": "de"
+  },
+  {
+    "keyName": "taskTypeForms",
+    "text": "Formulare",
+    "language": "de"
+  },
+  {
+    "keyName": "start",
+    "text": "Start",
+    "language": "de"
+  },
+  {
+    "keyName": "continue",
+    "text": "Weiter",
+    "language": "de"
+  },
+  {
+    "keyName": "save",
+    "text": "Speichern",
+    "language": "de"
+  },
+  {
+    "keyName": "outreachLearnMore",
+    "text": "Mehr Info",
+    "language": "de"
+  },
+  {
+    "keyName": "cancel",
+    "text": "Abbrechen",
+    "language": "de"
+  },
+  {
+    "keyName": "goBack",
+    "text": "Zurück",
+    "language": "de"
+  },
+  {
+    "keyName": "name",
+    "text": "Name",
+    "language": "de"
+  },
+  {
+    "keyName": "givenName",
+    "text": "Vorname",
+    "language": "de"
+  },
+  {
+    "keyName": "familyName",
+    "text": "Nachname",
+    "language": "de"
+  },
+  {
+    "keyName": "editName",
+    "text": "Name bearbeiten",
+    "language": "de"
+  },
+  {
+    "keyName": "editBirthDate",
+    "text": "Geburtstag bearbeiten",
+    "language": "de"
+  },
+  {
+    "keyName": "birthDate",
+    "text": "Geburtstag",
+    "language": "de"
+  },
+  {
+    "keyName": "mailingAddress",
+    "text": "Postanschrift",
+    "language": "de"
+  },
+  {
+    "keyName": "editMailingAddress",
+    "text": "Postanschrift bearbeiten",
+    "language": "de"
+  },
+  {
+    "keyName": "primaryAddress",
+    "text": "Primäre Anschrift",
+    "language": "de"
+  },
+  {
+    "keyName": "editPrimaryAddress",
+    "text": "Primäre Anschrift bearbeiten",
+    "language": "de"
+  },
+  {
+    "keyName": "street1",
+    "text": "Straße 1",
+    "language": "de"
+  },
+  {
+    "keyName": "street2",
+    "text": "Straße 2",
+    "language": "de"
+  },
+  {
+    "keyName": "city",
+    "text": "Stadt",
+    "language": "de"
+  },
+  {
+    "keyName": "state",
+    "text": "Bundesstaat/Provinz",
+    "language": "de"
+  },
+  {
+    "keyName": "postalCode",
+    "text": "Postleitzahl",
+    "language": "de"
+  },
+  {
+    "keyName": "country",
+    "text": "Land",
+    "language": "de"
+  },
+  {
+    "keyName": "communicationPreferences",
+    "text": "Kommunikationseinstellungen",
+    "language": "de"
+  },
+  {
+    "keyName": "editCommunicationPreferences",
+    "text": "Kommunikationseinstellungen bearbeiten",
+    "language": "de"
+  },
+  {
+    "keyName": "contactEmail",
+    "text": "Kontakt-E-Mail",
+    "language": "de"
+  },
+  {
+    "keyName": "editContactEmail",
+    "text": "Kontakt-E-Mail bearbeiten",
+    "language": "de"
+  },
+  {
+    "keyName": "phoneNumber",
+    "text": "Telefonnummer",
+    "language": "de"
+  },
+  {
+    "keyName": "editPhoneNumber",
+    "text": "Telefonnummer bearbeiten",
+    "language": "de"
+  },
+  {
+    "keyName": "doNotSolicit",
+    "text": "Keine Werbung",
+    "language": "de"
+  },
+  {
+    "keyName": "doNotContact",
+    "text": "Kein Kontakt",
+    "language": "de"
+  },
+  {
+    "keyName": "editDoNotSolicit",
+    "text": "Keine Werbung bearbeiten",
+    "language": "de"
+  },
+  {
+    "keyName": "editNotifications",
+    "text": "Benachrichtigungen bearbeiten",
+    "language": "de"
+  },
+  {
+    "keyName": "notifications",
+    "text": "Benachrichtigungen",
+    "language": "de"
+  },
+  {
+    "keyName": "on",
+    "text": "Ein",
+    "language": "de"
+  },
+  {
+    "keyName": "off",
+    "text": "Aus",
+    "language": "de"
+  },
+  {
+    "keyName": "notProvided",
+    "text": "Keine Angabe",
+    "language": "de"
+  },
+  {
+    "keyName": "editProfileContactEmailWarning",
+    "text": "Klicken Sie auf „Speichern“, um die für die Kommunikation verwendete E-Mail zu aktualisieren. Beachten Sie, dass sich Ihre Anmeldedaten nicht ändern.",
+    "language": "de"
+  },
+  {
+    "keyName": "privacyPolicy",
+    "text": "Datenschutzrichtlinie",
+    "language": "de"
+  },
+  {
+    "keyName": "termsOfUse",
+    "text": "Nutzungsbedingungen",
+    "language": "de"
+  },
+  {
+    "keyName": "addressInvalidPostalCode",
+    "text": "Die Postleitzahl konnte nicht verifiziert werden.",
+    "language": "de"
+  },
+  {
+    "keyName": "addressInvalidCountry",
+    "text": "Das Land konnte nicht verifiziert werden.",
+    "language": "de"
+  },
+  {
+    "keyName": "addressInvalidState",
+    "text": "Der Bundesstaat/die Provinz konnte nicht verifiziert werden.",
+    "language": "de"
+  },
+  {
+    "keyName": "addressInvalidCity",
+    "text": "Die Stadt konnte nicht verifiziert werden.",
+    "language": "de"
+  },
+  {
+    "keyName": "addressInvalidHouseNumber",
+    "text": "Die Hausnummer konnte nicht verifiziert werden.",
+    "language": "de"
+  },
+  {
+    "keyName": "addressInvalidStreetName",
+    "text": "Der Straßenname konnte nicht verifiziert werden.",
+    "language": "de"
+  },
+  {
+    "keyName": "addressInvalidStreetType",
+    "text": "Der Straßentyp konnte nicht verifiziert werden.",
+    "language": "de"
+  },
+  {
+    "keyName": "addressNeedsSubpremise",
+    "text": "Bitte geben Sie die Nummer einer Wohnung/Suite an.",
+    "language": "de"
+  },
+  {
+    "keyName": "addressFailedToValidate",
+    "text": "Die Anschrift konnte nicht validiert werden.",
+    "language": "de"
+  },
+  {
+    "keyName": "suggestBetterAddressHeader",
+    "text": "Ist die Anschrift korrekt?",
+    "language": "de"
+  },
+  {
+    "keyName": "suggestBetterAddressBody",
+    "text": "Wir konnten eine ähnliche Anschrift verifizieren. Bitte wählen Sie aus, welche Sie verwenden möchten.",
+    "language": "de"
+  },
+  {
+    "keyName": "newAddress",
+    "text": "Neue Anschrift",
+    "language": "de"
+  },
+  {
+    "keyName": "oldAddress",
+    "text": "Alte Anschrift",
+    "language": "de"
+  },
+  {
+    "keyName": "you",
+    "text": "Sie",
+    "language": "de"
+  },
+  {
+    "keyName": "yourDependent",
+    "text": "Ihr/ Angehörige/r",
+    "language": "de"
+  },
+  {
+    "keyName": "youInParens",
+    "text": "(Sie)",
+    "language": "de"
+  },
+  {
+    "keyName": "allProfiles",
+    "text": "Alle Profile",
+    "language": "de"
+  },
+  {
+    "keyName": "manageProfiles",
+    "text": "Profile verwalten",
+    "language": "de"
+  },
+  {
+    "keyName": "addNewParticipant",
+    "text": "Neue/n Teilnehmende/n hinzufügen",
+    "language": "de"
+  },
+  {
+    "keyName": "dashboard",
+    "text": "Dashboard",
+    "language": "de"
+  },
+  {
+    "keyName": "selectParticipant",
+    "text": "Teilnehmende/n auswählen",
+    "language": "de"
+  },
+  {
+    "keyName": "hubUpdateFormSubmittedTitle",
+    "text": "${formName} abgeschlossen",
+    "language": "de"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesTitle",
+    "text": "Alle Aktivitäten abgeschlossen",
+    "language": "de"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesDetail",
+    "text": "Sie haben alle Aktivitäten für diese Studie abgeschlossen. Wir benachrichtigen Sie, sobald neue Aktivitäten verfügbar sind. Vielen Dank für Ihre Teilnahme!",
+    "language": "de"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyTitle",
+    "text": "Willkommen bei ${studyName}",
+    "language": "de"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyDetail",
+    "text": "Bitte lesen und unterschreiben Sie die untenstehende Einwilligungserklärung, um fortzufahren.",
+    "language": "de"
+  },
+  {
+    "keyName": "hubUpdateAlreadyEnrolledTitle",
+    "text": "Sie wurden bereits in ${studyName} aufgenommen.",
+    "language": "de"
+  },
+  {
+    "keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle",
+    "text": "Dieser Nutzer wurde bereits in ${studyName} aufgenommen.",
+    "language": "de"
+  },
+  {
+    "keyName": "cookieAlertTitle",
+    "text": "Cookies",
+    "language": "de"
+  },
+  {
+    "keyName": "cookieAlertDetail",
+    "text": "Diese Website verwendet Internet-Token, sogenannte „Cookies“, um die ordnungsgemäße Funktion und Sicherheit unserer Website zu gewährleisten und Ihr Nutzererlebnis zu verbessern. Alle von uns verwendeten Cookies sind absolut erforderliche Cookies. Diese Art von Cookie erfasst keine personenbezogenen Daten über Sie und zeichnet Ihre Surfgewohnheiten nicht auf. Um mehr zu erfahren, [lesen Sie unsere Datenschutzrichtlinie](/privacy).",
+    "language": "de"
+  },
+  {
+    "keyName": "joinStudy",
+    "text": "An der Studie teilnehmen",
+    "language": "de"
+  },
+  {
+    "keyName": "ineligibleThankYou",
+    "text": "Vielen Dank für Ihr Interesse an ${studyName}",
+    "language": "de"
+  },
+  {
+    "keyName": "ineligibleDescription",
+    "text": "Leider erfüllen Sie derzeit nicht die Teilnahmekriterien für ${studyName}.",
+    "language": "de"
+  },
+  {
+    "keyName": "ineligibleProvideYourEmail",
+    "text": "Wenn Sie unten Ihre E-Mail-Adresse hinterlassen, halten wir Sie über die Entwicklungen auf dem Laufenden. Sie können sich jederzeit abmelden.",
+    "language": "de"
+  },
+  {
+    "keyName": "ineligibleStayInformed",
+    "text": "Auf dem Laufenden bleiben",
+    "language": "de"
+  },
+  {
+    "keyName": "backToPortalHomepage",
+    "text": "Zurück zur Startseite von ${portalName}",
+    "language": "de"
+  },
+  {
+    "keyName": "joinMailingList",
+    "text": "Für Mailingliste anmelden",
+    "language": "de"
+  },
+  {
+    "keyName": "mailingFormStayUpdated",
+    "text": "Über Neuigkeiten zur Studie auf dem Laufenden bleiben",
+    "language": "de"
+  },
+  {
+    "keyName": "yourName",
+    "text": "Ihr Name",
+    "language": "de"
+  },
+  {
+    "keyName": "yourEmail",
+    "text": "Ihre E-Mail",
+    "language": "de"
+  },
+  {
+    "keyName": "join",
+    "text": "Teilnehmen",
+    "language": "de"
+  },
+  {
+    "keyName": "thanksForJoining",
+    "text": "Vielen Dank für die Anmeldung!",
+    "language": "de"
+  },
+  {
+    "keyName": "pageNotFoundTitle",
+    "text": "Seite nicht gefunden",
+    "language": "de"
+  },
+  {
+    "keyName": "pageNotFoundMessage",
+    "text": "Wenn Sie glauben, dass es sich hierbei um einen Fehler handelt, wenden Sie sich bitte an ${studyContactEmail}",
+    "language": "de"
+  },
+  {
+    "keyName": "pageNotFoundReturnHome",
+    "text": "Zurück zur Startseite",
+    "language": "de"
+  },
+  {
+    "keyName": "authErrorPageTitle",
+    "text": "Etwas ist schiefgelaufen",
+    "language": "de"
+  },
+  {
+    "keyName": "authErrorPageMessage",
+    "text": "Es gab ein Problem mit unserem Authentifizierungsdienst. Bitte versuchen Sie es erneut. Wenn das Problem weiterhin besteht, wenden Sie sich bitte an ${studyContactEmail}.",
+    "language": "de"
+  },
+  {
+    "keyName": "navbarSampleKits",
+    "text": "Probenkits",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsPageTitle",
+    "text": "Probenentnahme-Kits",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsPageDescription",
+    "text": "Probenentnahme-Kits sind ein wichtiger Teil des Studienprozesses und können Forschenden dabei helfen, wichtige Erkenntnisse zu gewinnen. Nachfolgend finden Sie den Status aller Kits, die Ihnen zur Verfügung gestellt wurden.",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsPageInPersonTitle",
+    "text": "Eine Probe persönlich abgeben",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsPageInPersonDescription",
+    "text": "Diese Studie bietet derzeit die Möglichkeit, ein Probenentnahme-Kit selbst anzuwenden.",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsPageInPersonCompleteButton",
+    "text": "Ein Kit selbst anwenden",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsPageYourKitsTitle",
+    "text": "Ihre Kits",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsPageStatusPreparing",
+    "text": "Vorbereitung",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsPageStatusShipped",
+    "text": "Versendet",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsPageStatusReturned",
+    "text": "Zurückgesendet",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsPageStatusCreated",
+    "text": "Erstellt",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsPageStatusCollected",
+    "text": "Abgenommen",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsPageNoKits",
+    "text": "Sie haben derzeit keine Probenentnahme-Kits.",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsInPersonTitle",
+    "text": "Anleitung zur Anwendung des Probenkits",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsInPersonDescription",
+    "text": "Wenn Sie ein Probenentnahme-Kit selbst anwenden, befolgen Sie bitte die Anweisungen, die Sie von einem Mitglied des Studienteams erhalten haben. Eventuelle weitere Angaben, die Sie benötigen, wie beispielsweise Ihre eindeutige Teilnehmerkennung, finden Sie weiter unten.",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsInPersonSubDescription",
+    "text": "Wenn Sie Fragen haben, wenden Sie sich bitte an ein Mitglied des Studienteams.",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsInPersonYourKitTitle",
+    "text": "Ihr Probenentnahme-Kit",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsInPersonYourKitDescription",
+    "text": "Ein Teammitglied hat Ihnen ein Probenentnahme-Kit ausgehändigt. Dieses Probenkit ist mit Ihrem Nutzerkonto verbunden. Wenn Sie jemand anderem bei der Anwendung des Probenentnahme-Kits helfen, stellen Sie bitte sicher, dass jede/r Teilnehmende das ihm/ihr jeweils zugewiesene Probenentnahme-Kit verwendet.",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsInPersonYourKitIdentifier",
+    "text": "Ihre Kit-Kennung",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsInPersonReturnToDashboard",
+    "text": "Zurück zum Dashboard",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsInPersonRefreshPage",
+    "text": "Aktualisieren",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredTitle",
+    "text": "Einwilligung erforderlich",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredDescription",
+    "text": "Vor der Anwendung eines Probenentnahme-Kits müssen Sie zunächst in die Studie aufgenommen werden. Bei Interesse können Sie über den untenstehenden Link die Einwilligungserklärung aufrufen und unterschreiben.",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsInPersonStartConsent",
+    "text": "Vorgang zur Erteilung der Einwilligung starten",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsInPersonError",
+    "text": "Beim Laden Ihrer Kit-Informationen ist ein Fehler aufgetreten. Bitte wenden Sie sich an ein Mitglied des Studienteams.",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsInPersonCreatedInstructions",
+    "text": "Nachdem Sie das Probenentnahme-Kit angewendet haben, geben Sie es bitte an ein Mitglied des Studienteams zurück und lassen Sie Ihren Teilnahmecode unten scannen.",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsInPersonNoKitInstructions",
+    "text": "Um ein Probenentnahme-Kit zu erhalten, scannt ein Mitglied des Studienteams Ihren unten stehenden individuellen Teilnahmecode, um Ihrem Konto ein Probenentnahme-Kit zuzuordnen.",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsInPersonNoKitSubInstructions",
+    "text": "Wenn Sie ein Kit erhalten haben, aktualisieren Sie bitte diese Seite, um Ihre Kit-Informationen anzuzeigen und weitere Anweisungen zu erhalten.",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsInPersonCollectedDescription",
+    "text": "Ein Teammitglied hat Ihr Probenentnahme-Kit erhalten. Sie erhalten eine E-Mail-Benachrichtigung, wenn Ihre Probe verarbeitet wurde, und können den Status der Probe auf Ihrem Studien-Dashboard anzeigen.",
+    "language": "de"
+  },
+  {
+    "keyName": "kitsInPersonCollectedThankYou",
+    "text": "Vielen Dank für Ihre Teilnahme.",
+    "language": "de"
+  },
+  {
+    "keyName": "kitTypeSaliva",
+    "text": "Speichelkit",
+    "language": "de"
+  },
+  {
+    "keyName": "kitTypeStool",
+    "text": "Stuhlkit",
+    "language": "de"
+  },
+  {
+    "keyName": "kitTypeBlood",
+    "text": "Blutkit",
+    "language": "de"
+  },
+  {
+    "keyName": "documentDownloadButton",
+    "text": "Herunterladen",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListNone",
+    "text": "Sie haben noch keine Dokumente hochgeladen",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListCreatedOn",
+    "text": "Erstellt am",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageTitle",
+    "text": "Unterlagen",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageUploadedDocumentsTitle",
+    "text": "Hochgeladene Dokumente",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageMessage",
+    "text": "Während Sie an einer Studie teilnehmen, werden Sie möglicherweise aufgefordert, im Rahmen eines Formulars oder einer Umfrage Dokumente hochzuladen. Unten können Sie die hochgeladenen Dokumente verwalten.",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "navbarDocuments",
+    "text": "Unterlagen",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureTitle",
+    "text": "Bist du sicher?",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureMessage",
+    "text": "Möchten Sie dieses Dokument wirklich löschen? Dies kann nicht rückgängig gemacht werden. Bitte beachten Sie, dass ein Studienmitarbeiter, der dieses Dokument bereits heruntergeladen hat, weiterhin darauf zugreifen kann. Wenden Sie sich bitte an den Studienmitarbeiter, wenn Sie das Dokument vollständig aus allen Aufzeichnungen entfernen lassen möchten.",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseTitle",
+    "text": "Dieses Dokument wird verwendet",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseMessage",
+    "text": "Dieses Dokument wird derzeit als Antwort auf mindestens eine Umfrage freigegeben. Entfernen Sie es vor dem Löschen aus den Umfrageantworten.",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteButton",
+    "text": "Löschen",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentOptionsButton",
+    "text": "Optionen",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentSharedInResponseTo",
+    "text": "geteilt als Antwort auf",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderSelectedDocuments",
+    "text": "Ausgewählte Dokumente",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderIncludedInResponse",
+    "text": "Diese Dokumente sind in Ihrer Antwort enthalten",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocumentsSelected",
+    "text": "Keine Dokumente ausgewählt. Bitte laden Sie unten ein neues Dokument hoch oder wählen Sie ein vorhandenes Dokument aus.",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderAvailableDocuments",
+    "text": "Verfügbare Dokumente",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNotIncludedInResponse",
+    "text": "Diese Dokumente sind nicht in Ihrer Antwort enthalten",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderClickToUpload",
+    "text": "Legen Sie die Dateien hier ab, oder klicken Sie zum Hochladen",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocuments",
+    "text": "Keine Dokumente verfügbar",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeTitle",
+    "text": "Ihre Sitzung läuft bald ab",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeMessage",
+    "text": "Um die Sicherheit zu gewährleisten und Ihre Daten zu schützen, werden Sie in ${timeRemaining} abgemeldet.",
+    "language": "de",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "failedToEnroll",
+    "language": "de",
+    "text": "Während des Registrierungsprozesses ging etwas schief. Bitte füllen Sie das Formular erneut aus.",
+    "machineTranslated": true
+  }
 ]

--- a/populate/src/main/resources/seed/i18n/dev/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/dev/languageTexts.json
@@ -1,166 +1,829 @@
 [
-  {"keyName": "navbarDashboard", "text": "DEV_Dashboard", "language": "dev"},
-  {"keyName": "navbarChangePassword", "text": "DEV_Change Password", "language": "dev"},
-  {"keyName": "navbarLogout", "text": "DEV_Log Out", "language": "dev"},
-  {"keyName": "profile", "text": "DEV_Profile", "language": "dev"},
-  {"keyName": "navbarLogin", "text": "DEV_Log In", "language": "dev"},
-  {"keyName": "navbarJoin", "text": "DEV_Register", "language": "dev"},
-  {"keyName": "taskComplete", "text": "DEV_Complete", "language": "dev"},
-  {"keyName": "taskInProgress", "text": "DEV_In Progress", "language": "dev"},
-  {"keyName": "taskNotStarted", "text": "DEV_Not Started", "language": "dev"},
-  {"keyName": "taskDeclined", "text": "DEV_Declined", "language": "dev"},
-  {"keyName": "taskRemoved", "text": "DEV_Removed", "language": "dev"},
-  {"keyName": "taskLocked", "text": "DEV_Locked", "language": "dev"},
-  {"keyName": "taskHistory", "text": "DEV_history", "language": "dev"},
-  {"keyName": "taskNew", "text": "DEV_NEW", "language": "dev"},
-  {"keyName": "tasksNoneForStudy", "text": "DEV_No tasks for this study", "language": "dev"},
-  {"keyName": "surveysSomeLocked", "text": "DEV_Some surveys are locked until other required tasks are completed.", "language": "dev"},
-  {"keyName": "taskTypeSurvey", "text": "DEV_Survey", "language": "dev"},
-  {"keyName": "taskTypeSurveys", "text": "DEV_Surveys", "language": "dev"},
-  {"keyName": "taskTypeConsent", "text": "DEV_Consent", "language": "dev"},
-  {"keyName": "taskTypeForms", "text": "DEV_Forms", "language": "dev"},
-  {"keyName": "start", "text": "DEV_Start", "language": "dev"},
-  {"keyName": "continue", "text": "DEV_Continue", "language": "dev"},
-  {"keyName": "save", "text": "DEV_Save", "language": "dev"},
-  {"keyName": "outreachLearnMore", "text": "DEV_Learn More", "language": "dev"},
-  {"keyName": "cancel", "text": "DEV_Cancel", "language": "dev"},
-  {"keyName": "goBack", "text": "DEV_Go Back", "language": "dev"},
-  {"keyName": "name", "text": "DEV_Name", "language": "dev"},
-  {"keyName": "givenName", "text": "DEV_Given Name", "language": "dev"},
-  {"keyName": "familyName", "text": "DEV_Family Name", "language": "dev"},
-  {"keyName": "editName", "text": "DEV_Edit Name", "language": "dev"},
-  {"keyName": "editBirthDate", "text": "DEV_Edit Birthday", "language": "dev"},
-  {"keyName": "birthDate", "text": "DEV_Birthday", "language": "dev"},
-  {"keyName": "mailingAddress", "text": "DEV_Mailing Address", "language": "dev"},
-  {"keyName": "editMailingAddress", "text": "DEV_Edit Mailing Address", "language": "dev"},
-  {"keyName": "primaryAddress", "text": "DEV_Primary Address", "language": "dev"},
-  {"keyName": "editPrimaryAddress", "text": "DEV_Edit Primary Address", "language": "dev"},
-  {"keyName": "street1", "text": "DEV_Street 1", "language": "dev"},
-  {"keyName": "street2", "text": "DEV_Street 2", "language": "dev"},
-  {"keyName": "city", "text": "DEV_City", "language": "dev"},
-  {"keyName": "state", "text": "DEV_State/Province", "language": "dev"},
-  {"keyName": "postalCode", "text": "DEV_Postal Code", "language": "dev"},
-  {"keyName": "country", "text": "DEV_Country", "language": "dev"},
-  {"keyName": "communicationPreferences", "text": "DEV_Communication Preferences", "language": "dev"},
-  {"keyName": "editCommunicationPreferences", "text": "DEV_Edit Communication Preferences", "language": "dev"},
-  {"keyName": "contactEmail", "text": "DEV_Contact Email", "language": "dev"},
-  {"keyName": "editContactEmail", "text": "DEV_Edit Contact Email", "language": "dev"},
-  {"keyName": "phoneNumber", "text": "DEV_Phone Number", "language": "dev"},
-  {"keyName": "editPhoneNumber", "text": "DEV_Edit Phone Number", "language": "dev"},
-  {"keyName": "doNotSolicit", "text": "DEV_Do Not Solicit", "language": "dev"},
-  {"keyName": "doNotContact", "text": "DEV_Do Not Contact", "language": "dev"},
-  {"keyName": "editDoNotSolicit", "text": "DEV_Edit Do Not Solicit", "language": "dev"},
-  {"keyName": "editNotifications", "text": "DEV_Edit Notifications", "language": "dev"},
-  {"keyName": "notifications", "text": "DEV_Notifications", "language": "dev"},
-  {"keyName": "on", "text": "DEV_On", "language": "dev"},
-  {"keyName": "off", "text": "DEV_Off", "language": "dev"},
-  {"keyName": "notProvided", "text": "DEV_Not Provided", "language": "dev"},
-  {"keyName": "editProfileContactEmailWarning", "text": "DEV_Press \"Save\"  to update the email used for communication. Note that your login information will not change.", "language": "dev"},
-  {"keyName": "privacyPolicy", "text": "DEV_Privacy Policy", "language": "dev"},
-  {"keyName": "termsOfUse", "text": "DEV_Terms of Use", "language": "dev"},
-  {"keyName": "addressInvalidPostalCode", "text": "DEV_The postal code could not be verified.", "language": "dev"},
-  {"keyName": "addressInvalidCountry", "text": "DEV_The country could not be verified.", "language": "dev"},
-  {"keyName": "addressInvalidState", "text": "DEV_The state/province could not be verified.", "language": "dev"},
-  {"keyName": "addressInvalidCity", "text": "DEV_The city could not be verified.", "language": "dev"},
-  {"keyName": "addressInvalidHouseNumber", "text": "DEV_The house number could not be verified.", "language": "dev"},
-  {"keyName": "addressInvalidStreetName", "text": "DEV_The street name could not be verified.", "language": "dev"},
-  {"keyName": "addressInvalidStreetType", "text": "DEV_The street type could not be verified.", "language": "dev"},
-  {"keyName": "addressNeedsSubpremise", "text": "DEV_Please provide a unit/suite number.", "language": "dev"},
-  {"keyName": "addressFailedToValidate", "text": "DEV_Address could not be validated.", "language": "dev"},
-  {"keyName": "suggestBetterAddressHeader", "text": "DEV_Is this the correct address?", "language": "dev"},
-  {"keyName": "suggestBetterAddressBody", "text": "DEV_We were able to verify a similar address. Please select which you would like to use.", "language": "dev"},
-  {"keyName": "newAddress", "text": "DEV_New Address", "language": "dev"},
-  {"keyName": "oldAddress", "text": "DEV_Old Address", "language": "dev"},
-  {"keyName": "you", "text": "DEV_You", "language": "dev"},
-  {"keyName": "yourDependent", "text": "DEV_Your Dependent", "language": "dev"},
-  {"keyName": "youInParens", "text": "DEV_(you)", "language": "dev"},
-  {"keyName": "allProfiles", "text": "DEV_All Profiles", "language": "dev"},
-  {"keyName": "manageProfiles", "text": "DEV_Manage Profiles", "language": "dev"},
-  {"keyName": "addNewParticipant", "text": "DEV_Add New Participant", "language": "dev"},
-  {"keyName": "dashboard", "text": "DEV_Dashboard", "language": "dev"},
-  {"keyName": "selectParticipant", "text": "DEV_Select Participant", "language": "dev"},
-  {"keyName": "hubUpdateFormSubmittedTitle", "text": "DEV_${formName} completed", "language": "dev"},
-  {"keyName": "hubUpdateNoActivitiesTitle", "text": "DEV_All activities complete", "language": "dev"},
-  {"keyName": "hubUpdateNoActivitiesDetail", "text": "DEV_You have completed all activities for this study. We will notify you as soon as new activities are available. Thank you for your participation!", "language": "dev"},
-  {"keyName": "hubUpdateWelcomeToStudyTitle", "text": "DEV_Welcome to ${studyName}", "language": "dev"},
-  {"keyName": "hubUpdateWelcomeToStudyDetail", "text": "DEV_Please read and sign the consent form below to continue.", "language": "dev"},
-  {"keyName": "hubUpdateAlreadyEnrolledTitle", "text": "DEV_You are already enrolled in ${studyName}.", "language": "dev"},
-  {"keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle", "text": "DEV_This user is already enrolled in ${studyName}.", "language": "dev"},
-  {"keyName": "cookieAlertTitle", "text": "DEV_Cookies", "language": "dev"},
-  {"keyName": "cookieAlertDetail", "text": "DEV_This site uses internet tokens called &quot;cookies&quot; to enable the proper functioning and security of our website, and to improve your experience while you use it. All of the cookies we use are strictly necessary cookies. This type of cookie does not collect any personally identifiable information about you and does not track your browsing habits. To learn more, [read our Privacy Policy](/privacy).", "language": "dev"},
-  {"keyName": "joinStudy", "text": "DEV_Join Study", "language": "dev"},
-  {"keyName": "ineligibleThankYou", "text": "DEV_Thank you for your interest in ${studyName}", "language": "dev" },
-  {"keyName": "ineligibleDescription", "text": "DEV_Unfortunately, you do not meet the eligibility criteria to participate in ${studyName} at this time.", "language": "dev"},
-  {"keyName": "ineligibleProvideYourEmail", "text": "DEV_Provide your email below and we’ll keep you up-to-date on developments. You can unsubscribe at any time.", "language": "dev"},
-  {"keyName": "ineligibleStayInformed", "text": "DEV_Stay informed", "language": "dev"},
-  {"keyName": "backToPortalHomepage", "text": "DEV_Back to ${portalName} homepage", "language": "dev"},
-  {"keyName": "joinMailingList", "text": "DEV_Join Mailing List", "language": "dev"},
-  {"keyName": "mailingFormStayUpdated", "text":  "DEV_Stay updated with news about the study", "language": "dev"},
-  {"keyName": "yourName", "text": "DEV_Your name", "language": "dev"},
-  {"keyName": "yourEmail", "text": "DEV_Your email", "language": "dev"},
-  {"keyName": "join", "text":  "DEV_Join", "language": "dev"},
-  {"keyName": "thanksForJoining", "text": "DEV_Thanks for joining!", "language": "dev"},
-  {"keyName": "pageNotFoundTitle", "text": "DEV_Page not found", "language": "dev"},
-  {"keyName": "pageNotFoundMessage", "text": "DEV_If you believe this is an error, please contact ${studyContactEmail}", "language": "dev"},
-  {"keyName": "pageNotFoundReturnHome", "text": "DEV_Return to the home page", "language": "dev"},
-  {"keyName": "authErrorPageTitle", "text": "DEV_Something went wrong", "language": "dev"},
-  {"keyName": "authErrorPageMessage", "text": "DEV_There was an issue with our authentication service. Please try again. If the problem persists, please contact ${studyContactEmail}.", "language": "dev"},
-  {"keyName": "navbarSampleKits", "text":  "DEV_Sample Kits", "language": "dev"},
-  {"keyName": "kitsPageTitle", "text": "DEV_Sample collection kits", "language": "dev"},
-  {"keyName": "kitsPageDescription", "text": "DEV_Sample collection kits are a valuable part of the study process and can help provide researchers with important insights. Below you will find the status of all kits that have been provided to you.", "language": "dev"},
-  {"keyName": "kitsPageInPersonTitle", "text": "DEV_Provide a sample in-person", "language": "dev"},
-  {"keyName": "kitsPageInPersonDescription", "text": "DEV_This study is currently offering the option to complete a sample collection kit in-person.", "language": "dev"},
-  {"keyName": "kitsPageInPersonCompleteButton", "text": "DEV_Complete a kit in-person", "language": "dev"},
-  {"keyName": "kitsPageYourKitsTitle", "text": "DEV_Your kits", "language": "dev"},
-  {"keyName": "kitsPageStatusPreparing", "text": "DEV_Preparing", "language": "dev"},
-  {"keyName": "kitsPageStatusShipped", "text": "DEV_Shipped", "language": "dev"},
-  {"keyName": "kitsPageStatusReturned", "text": "DEV_Returned", "language": "dev"},
-  {"keyName": "kitsPageStatusCreated", "text": "DEV_Created", "language": "dev"},
-  {"keyName": "kitsPageStatusCollected", "text": "DEV_Collected", "language": "dev"},
-  {"keyName": "kitsPageNoKits", "text": "DEV_You do not have any sample collection kits at this time.", "language": "dev"},
-  {"keyName": "kitsInPersonTitle", "text": "DEV_Sample kit instructions", "language": "dev"},
-  {"keyName": "kitsInPersonDescription", "text": "DEV_If you are completing a sample collection kit in-person, please follow the instructions provided by a member of the study team. Any additional information that you may need, such as your unique participant identifier, will be provided below.", "language": "dev"},
-  {"keyName": "kitsInPersonSubDescription", "text": "DEV_If you have any questions, please ask a member of the study team.", "language": "dev"},
-  {"keyName": "kitsInPersonYourKitTitle", "text": "DEV_Your sample collection kit", "language": "dev"},
-  {"keyName": "kitsInPersonYourKitDescription", "text": "DEV_A member of the team has provided you with a sample collection kit. This sample kit is associated with your account. If you are assisting someone else with their sample collection kit, please ensure that each participant completes the sample collection kit that was assigned to them.", "language": "dev"},
-  {"keyName": "kitsInPersonYourKitIdentifier", "text": "DEV_Your kit identifier", "language": "dev"},
-  {"keyName": "kitsInPersonReturnToDashboard", "text": "DEV_Return to dashboard", "language": "dev"},
-  {"keyName": "kitsInPersonRefreshPage", "text": "DEV_Refresh", "language": "dev"},
-  {"keyName": "kitsInPersonConsentRequiredTitle", "text": "DEV_Consent Required", "language": "dev"},
-  {"keyName": "kitsInPersonConsentRequiredDescription", "text": "DEV_Before completing a sample collection kit, you must first be enrolled in the study. If of interest, you may find and sign the consent form via the link below.", "language": "dev"},
-  {"keyName": "kitsInPersonStartConsent", "text": "DEV_Start Consent", "language": "dev"},
-  {"keyName": "kitsInPersonError", "text": "DEV_There was an error loading your kit information. Please contact a member of the study team for assistance.", "language": "dev"},
-  {"keyName": "kitsInPersonCreatedInstructions", "text": "DEV_After you have completed the sample collection kit, please return it to a member of the study team and allow them to scan your participation code below.", "language": "dev"},
-  {"keyName": "kitsInPersonNoKitInstructions", "text": "DEV_To receive a sample collection kit, a member of the study team will scan your unique participation code below to associate a sample kit with your account.", "language": "dev"},
-  {"keyName": "kitsInPersonNoKitSubInstructions", "text": "DEV_Once you have received a kit, please refresh this page to view your kit information and receive further instructions.", "language": "dev"},
-  {"keyName": "kitsInPersonCollectedDescription", "text": "DEV_A member of the study team has received your sample collection kit. You will receive an email notification when your sample has been processed, and you will be able to view the status of the sample on your study dashboard.", "language": "dev"},
-  {"keyName": "kitsInPersonCollectedThankYou", "text": "DEV_Thank you for your participation.", "language": "dev"},
-  {"keyName": "kitTypeSaliva", "text": "DEV_Saliva kit", "language": "dev"},
-  {"keyName": "kitTypeStool", "text": "DEV_Stool kit", "language": "dev"},
-  {"keyName": "kitTypeBlood", "text": "DEV_Blood kit", "language": "dev"},
-  {"keyName": "documentDownloadButton", "text": "DEV_Download", "language": "dev"},
-  {"keyName": "documentsListNone", "text": "DEV_You have not uploaded any documents yet", "language": "dev"},
-  {"keyName": "documentsListCreatedOn", "text": "DEV_Created on", "language": "dev"},
-  {"keyName": "documentsPageTitle", "text": "DEV_Documents", "language": "dev"},
-  {"keyName": "documentsPageUploadedDocumentsTitle", "text": "DEV_Uploaded documents", "language": "dev"},
-  {"keyName": "documentsPageMessage", "text": "DEV_While participating in a study, you may be asked to upload documents as part of a form or survey. Below, you can review the documents you have uploaded.", "language": "dev", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "DEV_Documents", "language": "dev"},
-  {"keyName": "taskTypeDocumentRequests", "text": "DEV_Document Requests", "language": "dev"},
-  {"keyName": "documentDeleteAreYouSureTitle", "text": "DEV_Are you sure?", "language": "dev"},
-  {"keyName": "documentDeleteAreYouSureMessage", "text": "DEV_Are you sure you want to delete this document? This cannot be undone. Please note that if a member of the study staff has already downloaded this document, it will still be accessible to them. Please contact the study staff if you would like to have the document fully removed from all records.", "language": "dev"},
-  {"keyName": "documentDeleteDocumentInUseTitle", "text": "DEV_This document is in use", "language": "dev"},
-  {"keyName": "documentDeleteDocumentInUseMessage", "text": "DEV_This document is currently shared in response to at least one survey. Please remove it from the survey response(s) before deleting it.", "language": "dev"},
-  {"keyName": "documentDeleteButton", "text": "DEV_Delete", "language": "dev"},
-  {"keyName": "documentOptionsButton", "text": "DEV_Options", "language": "dev"},
-  {"keyName": "documentSharedInResponseTo", "text": "DEV_shared in response to", "language": "dev"},
-  {"keyName": "documentUploaderSelectedDocuments", "text": "DEV_Selected documents", "language": "dev"},
-  {"keyName": "documentUploaderIncludedInResponse", "text": "DEV_These documents are included in your response", "language": "dev"},
-  {"keyName": "documentUploaderNoDocumentsSelected", "text": "DEV_No documents selected. Please upload a new document or select an existing document below.", "language": "dev"},
-  {"keyName": "documentUploaderAvailableDocuments", "text": "DEV_Available documents", "language": "dev"},
-  {"keyName": "documentUploaderNotIncludedInResponse", "text": "DEV_These documents are not included in your response", "language": "dev"},
-  {"keyName": "documentUploaderClickToUpload", "text": "DEV_Drop files here or click to upload", "language": "dev"},
-  {"keyName": "documentUploaderNoDocuments", "text": "DEV_No documents available", "language": "dev"},
-  {"keyName": "navbarDocuments", "text": "DEV_Documents", "language": "dev", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeTitle", "text": "DEV_Your session is about to expire", "language": "dev"},
-  {"keyName": "idleStatusNoticeMessage", "text": "DEV_To maintain security and protect your data, you will be logged out in ${timeRemaining}.", "language": "dev"}
+  {
+    "keyName": "navbarDashboard",
+    "text": "DEV_Dashboard",
+    "language": "dev"
+  },
+  {
+    "keyName": "navbarChangePassword",
+    "text": "DEV_Change Password",
+    "language": "dev"
+  },
+  {
+    "keyName": "navbarLogout",
+    "text": "DEV_Log Out",
+    "language": "dev"
+  },
+  {
+    "keyName": "profile",
+    "text": "DEV_Profile",
+    "language": "dev"
+  },
+  {
+    "keyName": "navbarLogin",
+    "text": "DEV_Log In",
+    "language": "dev"
+  },
+  {
+    "keyName": "navbarJoin",
+    "text": "DEV_Register",
+    "language": "dev"
+  },
+  {
+    "keyName": "taskComplete",
+    "text": "DEV_Complete",
+    "language": "dev"
+  },
+  {
+    "keyName": "taskInProgress",
+    "text": "DEV_In Progress",
+    "language": "dev"
+  },
+  {
+    "keyName": "taskNotStarted",
+    "text": "DEV_Not Started",
+    "language": "dev"
+  },
+  {
+    "keyName": "taskDeclined",
+    "text": "DEV_Declined",
+    "language": "dev"
+  },
+  {
+    "keyName": "taskRemoved",
+    "text": "DEV_Removed",
+    "language": "dev"
+  },
+  {
+    "keyName": "taskLocked",
+    "text": "DEV_Locked",
+    "language": "dev"
+  },
+  {
+    "keyName": "taskHistory",
+    "text": "DEV_history",
+    "language": "dev"
+  },
+  {
+    "keyName": "taskNew",
+    "text": "DEV_NEW",
+    "language": "dev"
+  },
+  {
+    "keyName": "tasksNoneForStudy",
+    "text": "DEV_No tasks for this study",
+    "language": "dev"
+  },
+  {
+    "keyName": "surveysSomeLocked",
+    "text": "DEV_Some surveys are locked until other required tasks are completed.",
+    "language": "dev"
+  },
+  {
+    "keyName": "taskTypeSurvey",
+    "text": "DEV_Survey",
+    "language": "dev"
+  },
+  {
+    "keyName": "taskTypeSurveys",
+    "text": "DEV_Surveys",
+    "language": "dev"
+  },
+  {
+    "keyName": "taskTypeConsent",
+    "text": "DEV_Consent",
+    "language": "dev"
+  },
+  {
+    "keyName": "taskTypeForms",
+    "text": "DEV_Forms",
+    "language": "dev"
+  },
+  {
+    "keyName": "start",
+    "text": "DEV_Start",
+    "language": "dev"
+  },
+  {
+    "keyName": "continue",
+    "text": "DEV_Continue",
+    "language": "dev"
+  },
+  {
+    "keyName": "save",
+    "text": "DEV_Save",
+    "language": "dev"
+  },
+  {
+    "keyName": "outreachLearnMore",
+    "text": "DEV_Learn More",
+    "language": "dev"
+  },
+  {
+    "keyName": "cancel",
+    "text": "DEV_Cancel",
+    "language": "dev"
+  },
+  {
+    "keyName": "goBack",
+    "text": "DEV_Go Back",
+    "language": "dev"
+  },
+  {
+    "keyName": "name",
+    "text": "DEV_Name",
+    "language": "dev"
+  },
+  {
+    "keyName": "givenName",
+    "text": "DEV_Given Name",
+    "language": "dev"
+  },
+  {
+    "keyName": "familyName",
+    "text": "DEV_Family Name",
+    "language": "dev"
+  },
+  {
+    "keyName": "editName",
+    "text": "DEV_Edit Name",
+    "language": "dev"
+  },
+  {
+    "keyName": "editBirthDate",
+    "text": "DEV_Edit Birthday",
+    "language": "dev"
+  },
+  {
+    "keyName": "birthDate",
+    "text": "DEV_Birthday",
+    "language": "dev"
+  },
+  {
+    "keyName": "mailingAddress",
+    "text": "DEV_Mailing Address",
+    "language": "dev"
+  },
+  {
+    "keyName": "editMailingAddress",
+    "text": "DEV_Edit Mailing Address",
+    "language": "dev"
+  },
+  {
+    "keyName": "primaryAddress",
+    "text": "DEV_Primary Address",
+    "language": "dev"
+  },
+  {
+    "keyName": "editPrimaryAddress",
+    "text": "DEV_Edit Primary Address",
+    "language": "dev"
+  },
+  {
+    "keyName": "street1",
+    "text": "DEV_Street 1",
+    "language": "dev"
+  },
+  {
+    "keyName": "street2",
+    "text": "DEV_Street 2",
+    "language": "dev"
+  },
+  {
+    "keyName": "city",
+    "text": "DEV_City",
+    "language": "dev"
+  },
+  {
+    "keyName": "state",
+    "text": "DEV_State/Province",
+    "language": "dev"
+  },
+  {
+    "keyName": "postalCode",
+    "text": "DEV_Postal Code",
+    "language": "dev"
+  },
+  {
+    "keyName": "country",
+    "text": "DEV_Country",
+    "language": "dev"
+  },
+  {
+    "keyName": "communicationPreferences",
+    "text": "DEV_Communication Preferences",
+    "language": "dev"
+  },
+  {
+    "keyName": "editCommunicationPreferences",
+    "text": "DEV_Edit Communication Preferences",
+    "language": "dev"
+  },
+  {
+    "keyName": "contactEmail",
+    "text": "DEV_Contact Email",
+    "language": "dev"
+  },
+  {
+    "keyName": "editContactEmail",
+    "text": "DEV_Edit Contact Email",
+    "language": "dev"
+  },
+  {
+    "keyName": "phoneNumber",
+    "text": "DEV_Phone Number",
+    "language": "dev"
+  },
+  {
+    "keyName": "editPhoneNumber",
+    "text": "DEV_Edit Phone Number",
+    "language": "dev"
+  },
+  {
+    "keyName": "doNotSolicit",
+    "text": "DEV_Do Not Solicit",
+    "language": "dev"
+  },
+  {
+    "keyName": "doNotContact",
+    "text": "DEV_Do Not Contact",
+    "language": "dev"
+  },
+  {
+    "keyName": "editDoNotSolicit",
+    "text": "DEV_Edit Do Not Solicit",
+    "language": "dev"
+  },
+  {
+    "keyName": "editNotifications",
+    "text": "DEV_Edit Notifications",
+    "language": "dev"
+  },
+  {
+    "keyName": "notifications",
+    "text": "DEV_Notifications",
+    "language": "dev"
+  },
+  {
+    "keyName": "on",
+    "text": "DEV_On",
+    "language": "dev"
+  },
+  {
+    "keyName": "off",
+    "text": "DEV_Off",
+    "language": "dev"
+  },
+  {
+    "keyName": "notProvided",
+    "text": "DEV_Not Provided",
+    "language": "dev"
+  },
+  {
+    "keyName": "editProfileContactEmailWarning",
+    "text": "DEV_Press \"Save\"  to update the email used for communication. Note that your login information will not change.",
+    "language": "dev"
+  },
+  {
+    "keyName": "privacyPolicy",
+    "text": "DEV_Privacy Policy",
+    "language": "dev"
+  },
+  {
+    "keyName": "termsOfUse",
+    "text": "DEV_Terms of Use",
+    "language": "dev"
+  },
+  {
+    "keyName": "addressInvalidPostalCode",
+    "text": "DEV_The postal code could not be verified.",
+    "language": "dev"
+  },
+  {
+    "keyName": "addressInvalidCountry",
+    "text": "DEV_The country could not be verified.",
+    "language": "dev"
+  },
+  {
+    "keyName": "addressInvalidState",
+    "text": "DEV_The state/province could not be verified.",
+    "language": "dev"
+  },
+  {
+    "keyName": "addressInvalidCity",
+    "text": "DEV_The city could not be verified.",
+    "language": "dev"
+  },
+  {
+    "keyName": "addressInvalidHouseNumber",
+    "text": "DEV_The house number could not be verified.",
+    "language": "dev"
+  },
+  {
+    "keyName": "addressInvalidStreetName",
+    "text": "DEV_The street name could not be verified.",
+    "language": "dev"
+  },
+  {
+    "keyName": "addressInvalidStreetType",
+    "text": "DEV_The street type could not be verified.",
+    "language": "dev"
+  },
+  {
+    "keyName": "addressNeedsSubpremise",
+    "text": "DEV_Please provide a unit/suite number.",
+    "language": "dev"
+  },
+  {
+    "keyName": "addressFailedToValidate",
+    "text": "DEV_Address could not be validated.",
+    "language": "dev"
+  },
+  {
+    "keyName": "suggestBetterAddressHeader",
+    "text": "DEV_Is this the correct address?",
+    "language": "dev"
+  },
+  {
+    "keyName": "suggestBetterAddressBody",
+    "text": "DEV_We were able to verify a similar address. Please select which you would like to use.",
+    "language": "dev"
+  },
+  {
+    "keyName": "newAddress",
+    "text": "DEV_New Address",
+    "language": "dev"
+  },
+  {
+    "keyName": "oldAddress",
+    "text": "DEV_Old Address",
+    "language": "dev"
+  },
+  {
+    "keyName": "you",
+    "text": "DEV_You",
+    "language": "dev"
+  },
+  {
+    "keyName": "yourDependent",
+    "text": "DEV_Your Dependent",
+    "language": "dev"
+  },
+  {
+    "keyName": "youInParens",
+    "text": "DEV_(you)",
+    "language": "dev"
+  },
+  {
+    "keyName": "allProfiles",
+    "text": "DEV_All Profiles",
+    "language": "dev"
+  },
+  {
+    "keyName": "manageProfiles",
+    "text": "DEV_Manage Profiles",
+    "language": "dev"
+  },
+  {
+    "keyName": "addNewParticipant",
+    "text": "DEV_Add New Participant",
+    "language": "dev"
+  },
+  {
+    "keyName": "dashboard",
+    "text": "DEV_Dashboard",
+    "language": "dev"
+  },
+  {
+    "keyName": "selectParticipant",
+    "text": "DEV_Select Participant",
+    "language": "dev"
+  },
+  {
+    "keyName": "hubUpdateFormSubmittedTitle",
+    "text": "DEV_${formName} completed",
+    "language": "dev"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesTitle",
+    "text": "DEV_All activities complete",
+    "language": "dev"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesDetail",
+    "text": "DEV_You have completed all activities for this study. We will notify you as soon as new activities are available. Thank you for your participation!",
+    "language": "dev"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyTitle",
+    "text": "DEV_Welcome to ${studyName}",
+    "language": "dev"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyDetail",
+    "text": "DEV_Please read and sign the consent form below to continue.",
+    "language": "dev"
+  },
+  {
+    "keyName": "hubUpdateAlreadyEnrolledTitle",
+    "text": "DEV_You are already enrolled in ${studyName}.",
+    "language": "dev"
+  },
+  {
+    "keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle",
+    "text": "DEV_This user is already enrolled in ${studyName}.",
+    "language": "dev"
+  },
+  {
+    "keyName": "cookieAlertTitle",
+    "text": "DEV_Cookies",
+    "language": "dev"
+  },
+  {
+    "keyName": "cookieAlertDetail",
+    "text": "DEV_This site uses internet tokens called &quot;cookies&quot; to enable the proper functioning and security of our website, and to improve your experience while you use it. All of the cookies we use are strictly necessary cookies. This type of cookie does not collect any personally identifiable information about you and does not track your browsing habits. To learn more, [read our Privacy Policy](/privacy).",
+    "language": "dev"
+  },
+  {
+    "keyName": "joinStudy",
+    "text": "DEV_Join Study",
+    "language": "dev"
+  },
+  {
+    "keyName": "ineligibleThankYou",
+    "text": "DEV_Thank you for your interest in ${studyName}",
+    "language": "dev"
+  },
+  {
+    "keyName": "ineligibleDescription",
+    "text": "DEV_Unfortunately, you do not meet the eligibility criteria to participate in ${studyName} at this time.",
+    "language": "dev"
+  },
+  {
+    "keyName": "ineligibleProvideYourEmail",
+    "text": "DEV_Provide your email below and we’ll keep you up-to-date on developments. You can unsubscribe at any time.",
+    "language": "dev"
+  },
+  {
+    "keyName": "ineligibleStayInformed",
+    "text": "DEV_Stay informed",
+    "language": "dev"
+  },
+  {
+    "keyName": "backToPortalHomepage",
+    "text": "DEV_Back to ${portalName} homepage",
+    "language": "dev"
+  },
+  {
+    "keyName": "joinMailingList",
+    "text": "DEV_Join Mailing List",
+    "language": "dev"
+  },
+  {
+    "keyName": "mailingFormStayUpdated",
+    "text": "DEV_Stay updated with news about the study",
+    "language": "dev"
+  },
+  {
+    "keyName": "yourName",
+    "text": "DEV_Your name",
+    "language": "dev"
+  },
+  {
+    "keyName": "yourEmail",
+    "text": "DEV_Your email",
+    "language": "dev"
+  },
+  {
+    "keyName": "join",
+    "text": "DEV_Join",
+    "language": "dev"
+  },
+  {
+    "keyName": "thanksForJoining",
+    "text": "DEV_Thanks for joining!",
+    "language": "dev"
+  },
+  {
+    "keyName": "pageNotFoundTitle",
+    "text": "DEV_Page not found",
+    "language": "dev"
+  },
+  {
+    "keyName": "pageNotFoundMessage",
+    "text": "DEV_If you believe this is an error, please contact ${studyContactEmail}",
+    "language": "dev"
+  },
+  {
+    "keyName": "pageNotFoundReturnHome",
+    "text": "DEV_Return to the home page",
+    "language": "dev"
+  },
+  {
+    "keyName": "authErrorPageTitle",
+    "text": "DEV_Something went wrong",
+    "language": "dev"
+  },
+  {
+    "keyName": "authErrorPageMessage",
+    "text": "DEV_There was an issue with our authentication service. Please try again. If the problem persists, please contact ${studyContactEmail}.",
+    "language": "dev"
+  },
+  {
+    "keyName": "navbarSampleKits",
+    "text": "DEV_Sample Kits",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsPageTitle",
+    "text": "DEV_Sample collection kits",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsPageDescription",
+    "text": "DEV_Sample collection kits are a valuable part of the study process and can help provide researchers with important insights. Below you will find the status of all kits that have been provided to you.",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsPageInPersonTitle",
+    "text": "DEV_Provide a sample in-person",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsPageInPersonDescription",
+    "text": "DEV_This study is currently offering the option to complete a sample collection kit in-person.",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsPageInPersonCompleteButton",
+    "text": "DEV_Complete a kit in-person",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsPageYourKitsTitle",
+    "text": "DEV_Your kits",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsPageStatusPreparing",
+    "text": "DEV_Preparing",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsPageStatusShipped",
+    "text": "DEV_Shipped",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsPageStatusReturned",
+    "text": "DEV_Returned",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsPageStatusCreated",
+    "text": "DEV_Created",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsPageStatusCollected",
+    "text": "DEV_Collected",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsPageNoKits",
+    "text": "DEV_You do not have any sample collection kits at this time.",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsInPersonTitle",
+    "text": "DEV_Sample kit instructions",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsInPersonDescription",
+    "text": "DEV_If you are completing a sample collection kit in-person, please follow the instructions provided by a member of the study team. Any additional information that you may need, such as your unique participant identifier, will be provided below.",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsInPersonSubDescription",
+    "text": "DEV_If you have any questions, please ask a member of the study team.",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsInPersonYourKitTitle",
+    "text": "DEV_Your sample collection kit",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsInPersonYourKitDescription",
+    "text": "DEV_A member of the team has provided you with a sample collection kit. This sample kit is associated with your account. If you are assisting someone else with their sample collection kit, please ensure that each participant completes the sample collection kit that was assigned to them.",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsInPersonYourKitIdentifier",
+    "text": "DEV_Your kit identifier",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsInPersonReturnToDashboard",
+    "text": "DEV_Return to dashboard",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsInPersonRefreshPage",
+    "text": "DEV_Refresh",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredTitle",
+    "text": "DEV_Consent Required",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredDescription",
+    "text": "DEV_Before completing a sample collection kit, you must first be enrolled in the study. If of interest, you may find and sign the consent form via the link below.",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsInPersonStartConsent",
+    "text": "DEV_Start Consent",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsInPersonError",
+    "text": "DEV_There was an error loading your kit information. Please contact a member of the study team for assistance.",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsInPersonCreatedInstructions",
+    "text": "DEV_After you have completed the sample collection kit, please return it to a member of the study team and allow them to scan your participation code below.",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsInPersonNoKitInstructions",
+    "text": "DEV_To receive a sample collection kit, a member of the study team will scan your unique participation code below to associate a sample kit with your account.",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsInPersonNoKitSubInstructions",
+    "text": "DEV_Once you have received a kit, please refresh this page to view your kit information and receive further instructions.",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsInPersonCollectedDescription",
+    "text": "DEV_A member of the study team has received your sample collection kit. You will receive an email notification when your sample has been processed, and you will be able to view the status of the sample on your study dashboard.",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitsInPersonCollectedThankYou",
+    "text": "DEV_Thank you for your participation.",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitTypeSaliva",
+    "text": "DEV_Saliva kit",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitTypeStool",
+    "text": "DEV_Stool kit",
+    "language": "dev"
+  },
+  {
+    "keyName": "kitTypeBlood",
+    "text": "DEV_Blood kit",
+    "language": "dev"
+  },
+  {
+    "keyName": "documentDownloadButton",
+    "text": "DEV_Download",
+    "language": "dev"
+  },
+  {
+    "keyName": "documentsListNone",
+    "text": "DEV_You have not uploaded any documents yet",
+    "language": "dev"
+  },
+  {
+    "keyName": "documentsListCreatedOn",
+    "text": "DEV_Created on",
+    "language": "dev"
+  },
+  {
+    "keyName": "documentsPageTitle",
+    "text": "DEV_Documents",
+    "language": "dev"
+  },
+  {
+    "keyName": "documentsPageUploadedDocumentsTitle",
+    "text": "DEV_Uploaded documents",
+    "language": "dev"
+  },
+  {
+    "keyName": "documentsPageMessage",
+    "text": "DEV_While participating in a study, you may be asked to upload documents as part of a form or survey. Below, you can review the documents you have uploaded.",
+    "language": "dev",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "navbarDocuments",
+    "text": "DEV_Documents",
+    "language": "dev"
+  },
+  {
+    "keyName": "taskTypeDocumentRequests",
+    "text": "DEV_Document Requests",
+    "language": "dev"
+  },
+  {
+    "keyName": "documentDeleteAreYouSureTitle",
+    "text": "DEV_Are you sure?",
+    "language": "dev"
+  },
+  {
+    "keyName": "documentDeleteAreYouSureMessage",
+    "text": "DEV_Are you sure you want to delete this document? This cannot be undone. Please note that if a member of the study staff has already downloaded this document, it will still be accessible to them. Please contact the study staff if you would like to have the document fully removed from all records.",
+    "language": "dev"
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseTitle",
+    "text": "DEV_This document is in use",
+    "language": "dev"
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseMessage",
+    "text": "DEV_This document is currently shared in response to at least one survey. Please remove it from the survey response(s) before deleting it.",
+    "language": "dev"
+  },
+  {
+    "keyName": "documentDeleteButton",
+    "text": "DEV_Delete",
+    "language": "dev"
+  },
+  {
+    "keyName": "documentOptionsButton",
+    "text": "DEV_Options",
+    "language": "dev"
+  },
+  {
+    "keyName": "documentSharedInResponseTo",
+    "text": "DEV_shared in response to",
+    "language": "dev"
+  },
+  {
+    "keyName": "documentUploaderSelectedDocuments",
+    "text": "DEV_Selected documents",
+    "language": "dev"
+  },
+  {
+    "keyName": "documentUploaderIncludedInResponse",
+    "text": "DEV_These documents are included in your response",
+    "language": "dev"
+  },
+  {
+    "keyName": "documentUploaderNoDocumentsSelected",
+    "text": "DEV_No documents selected. Please upload a new document or select an existing document below.",
+    "language": "dev"
+  },
+  {
+    "keyName": "documentUploaderAvailableDocuments",
+    "text": "DEV_Available documents",
+    "language": "dev"
+  },
+  {
+    "keyName": "documentUploaderNotIncludedInResponse",
+    "text": "DEV_These documents are not included in your response",
+    "language": "dev"
+  },
+  {
+    "keyName": "documentUploaderClickToUpload",
+    "text": "DEV_Drop files here or click to upload",
+    "language": "dev"
+  },
+  {
+    "keyName": "documentUploaderNoDocuments",
+    "text": "DEV_No documents available",
+    "language": "dev"
+  },
+  {
+    "keyName": "navbarDocuments",
+    "text": "DEV_Documents",
+    "language": "dev",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeTitle",
+    "text": "DEV_Your session is about to expire",
+    "language": "dev"
+  },
+  {
+    "keyName": "idleStatusNoticeMessage",
+    "text": "DEV_To maintain security and protect your data, you will be logged out in ${timeRemaining}.",
+    "language": "dev"
+  },
+  {
+    "keyName": "failedToEnroll",
+    "language": "dev",
+    "text": "dev_Something went wrong during the enrollment process. Please fill out the form again."
+  }
 ]

--- a/populate/src/main/resources/seed/i18n/en/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/en/languageTexts.json
@@ -1,165 +1,822 @@
 [
-  {"keyName": "navbarDashboard", "text": "Dashboard", "language": "en"},
-  {"keyName": "navbarChangePassword", "text": "Change Password", "language": "en"},
-  {"keyName": "navbarLogout", "text": "Log Out", "language": "en"},
-  {"keyName": "profile", "text": "Profile", "language": "en"},
-  {"keyName": "navbarLogin", "text": "Log In", "language": "en"},
-  {"keyName": "navbarJoin", "text": "Register", "language": "en"},
-  {"keyName": "taskComplete", "text": "Complete", "language": "en"},
-  {"keyName": "taskInProgress", "text": "In Progress", "language": "en"},
-  {"keyName": "taskNotStarted", "text": "Not Started", "language": "en"},
-  {"keyName": "taskDeclined", "text": "Declined", "language": "en"},
-  {"keyName": "taskRemoved", "text": "Removed", "language": "en"},
-  {"keyName": "taskLocked", "text": "Locked", "language": "en"},
-  {"keyName": "tasksNoneForStudy", "text": "No tasks for this study", "language": "en"},
-  {"keyName": "taskHistory", "text": "history", "language": "en"},
-  {"keyName": "taskNew", "text": "NEW", "language": "en"},
-  {"keyName": "surveysSomeLocked", "text": "Some surveys are locked until other required tasks are completed.", "language": "en"},
-  {"keyName": "taskTypeSurvey", "text": "Survey", "language": "en"},
-  {"keyName": "taskTypeSurveys", "text": "Surveys", "language": "en"},
-  {"keyName": "taskTypeConsent", "text": "Consent", "language": "en"},
-  {"keyName": "taskTypeForms", "text": "Forms", "language": "en"},
-  {"keyName": "start", "text": "Start", "language": "en"},
-  {"keyName": "continue", "text": "Continue", "language": "en"},
-  {"keyName": "save", "text": "Save", "language": "en"},
-  {"keyName": "outreachLearnMore", "text": "Learn More", "language": "en"},
-  {"keyName": "cancel", "text": "Cancel", "language": "en"},
-  {"keyName": "goBack", "text": "Go Back", "language": "en"},
-  {"keyName": "name", "text": "Name", "language": "en"},
-  {"keyName": "givenName", "text": "Given Name", "language": "en"},
-  {"keyName": "familyName", "text": "Family Name", "language": "en"},
-  {"keyName": "editName", "text": "Edit Name", "language": "en"},
-  {"keyName": "editBirthDate", "text": "Edit Birthday", "language": "en"},
-  {"keyName": "birthDate", "text": "Birthday", "language": "en"},
-  {"keyName": "mailingAddress", "text": "Mailing Address", "language": "en"},
-  {"keyName": "editMailingAddress", "text": "Edit Mailing Address", "language": "en"},
-  {"keyName": "primaryAddress", "text": "Primary Address", "language": "en"},
-  {"keyName": "editPrimaryAddress", "text": "Edit Primary Address", "language": "en"},
-  {"keyName": "street1", "text": "Street 1", "language": "en"},
-  {"keyName": "street2", "text": "Street 2", "language": "en"},
-  {"keyName": "city", "text": "City", "language": "en"},
-  {"keyName": "state", "text": "State/Province", "language": "en"},
-  {"keyName": "postalCode", "text": "Postal Code", "language": "en"},
-  {"keyName": "country", "text": "Country", "language": "en"},
-  {"keyName": "communicationPreferences", "text": "Communication Preferences", "language": "en"},
-  {"keyName": "editCommunicationPreferences", "text": "Edit Communication Preferences", "language": "en"},
-  {"keyName": "contactEmail", "text": "Contact Email", "language": "en"},
-  {"keyName": "editContactEmail", "text": "Edit Contact Email", "language": "en"},
-  {"keyName": "phoneNumber", "text": "Phone Number", "language": "en"},
-  {"keyName": "editPhoneNumber", "text": "Edit Phone Number", "language": "en"},
-  {"keyName": "doNotSolicit", "text": "Do Not Solicit", "language": "en"},
-  {"keyName": "doNotContact", "text": "Do Not Contact", "language": "en"},
-  {"keyName": "editDoNotSolicit", "text": "Edit Do Not Solicit", "language": "en"},
-  {"keyName": "editNotifications", "text": "Edit Notifications", "language": "en"},
-  {"keyName": "notifications", "text": "Notifications", "language": "en"},
-  {"keyName": "on", "text": "On", "language": "en"},
-  {"keyName": "off", "text": "Off", "language": "en"},
-  {"keyName": "notProvided", "text": "Not Provided", "language": "en"},
-  {"keyName": "editProfileContactEmailWarning", "text": "Press \"Save\"  to update the email used for communication. Note that your login information will not change.", "language": "en"},
-  {"keyName": "privacyPolicy", "text": "Privacy Policy", "language": "en"},
-  {"keyName": "termsOfUse", "text": "Terms of Use", "language": "en"},
-  {"keyName": "addressInvalidPostalCode", "text": "The postal code could not be verified.", "language": "en"},
-  {"keyName": "addressInvalidCountry", "text": "The country could not be verified.", "language": "en"},
-  {"keyName": "addressInvalidState", "text": "The state/province could not be verified.", "language": "en"},
-  {"keyName": "addressInvalidCity", "text": "The city could not be verified.", "language": "en"},
-  {"keyName": "addressInvalidHouseNumber", "text": "The house number could not be verified.", "language": "en"},
-  {"keyName": "addressInvalidStreetName", "text": "The street name could not be verified.", "language": "en"},
-  {"keyName": "addressInvalidStreetType", "text": "The street type could not be verified.", "language": "en"},
-  {"keyName": "addressNeedsSubpremise", "text": "Please provide a unit/suite number.", "language": "en"},
-  {"keyName": "addressFailedToValidate", "text": "Address could not be validated.", "language": "en"},
-  {"keyName": "suggestBetterAddressHeader", "text": "Is this the correct address?", "language": "en"},
-  {"keyName": "suggestBetterAddressBody", "text": "We were able to verify a similar address. Please select which you would like to use.", "language": "en"},
-  {"keyName": "newAddress", "text": "New Address", "language": "en"},
-  {"keyName": "oldAddress", "text": "Old Address", "language": "en"},
-  {"keyName": "you", "text": "You", "language": "en"},
-  {"keyName": "yourDependent", "text": "Your Dependent", "language": "en"},
-  {"keyName": "youInParens", "text": "(you)", "language": "en"},
-  {"keyName": "allProfiles", "text": "All Profiles", "language": "en"},
-  {"keyName": "manageProfiles", "text": "Manage Profiles", "language": "en"},
-  {"keyName": "addNewParticipant", "text": "Add New Participant", "language": "en"},
-  {"keyName": "dashboard", "text": "Dashboard", "language": "en"},
-  {"keyName": "selectParticipant", "text": "Select Participant", "language": "en"},
-  {"keyName": "hubUpdateFormSubmittedTitle", "text": "${formName} completed", "language": "en"},
-  {"keyName": "hubUpdateNoActivitiesTitle", "text": "All activities complete", "language": "en"},
-  {"keyName": "hubUpdateNoActivitiesDetail", "text": "You have completed all activities for this study. We will notify you as soon as new activities are available. Thank you for your participation!", "language": "en"},
-  {"keyName": "hubUpdateWelcomeToStudyTitle", "text": "Welcome to ${studyName}", "language": "en"},
-  {"keyName": "hubUpdateWelcomeToStudyDetail", "text": "Please read and sign the consent form below to continue.", "language": "en"},
-  {"keyName": "hubUpdateAlreadyEnrolledTitle", "text": "You are already enrolled in ${studyName}.", "language": "en"},
-  {"keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle", "text": "This user is already enrolled in ${studyName}.", "language": "en"},
-  {"keyName": "cookieAlertTitle", "text": "Cookies", "language": "en"},
-  {"keyName": "cookieAlertDetail", "text": "This site uses internet tokens called &quot;cookies&quot; to enable the proper functioning and security of our website, and to improve your experience while you use it. All of the cookies we use are strictly necessary cookies. This type of cookie does not collect any personally identifiable information about you and does not track your browsing habits. To learn more, [read our Privacy Policy](/privacy).", "language": "en"},
-  {"keyName": "joinStudy", "text": "Join Study", "language": "en"},
-  {"keyName": "ineligibleThankYou", "text": "Thank you for your interest in ${studyName}", "language": "en" },
-  {"keyName": "ineligibleDescription", "text": "Unfortunately, you do not meet the eligibility criteria to participate in ${studyName} at this time.", "language": "en"},
-  {"keyName": "ineligibleProvideYourEmail", "text": "Provide your email below and we’ll keep you up-to-date on developments. You can unsubscribe at any time.", "language":  "en"},
-  {"keyName": "ineligibleStayInformed", "text": "Stay informed", "language": "en"},
-  {"keyName": "backToPortalHomepage", "text": "Back to ${portalName} homepage", "language": "en"},
-  {"keyName": "joinMailingList", "text": "Join Mailing List", "language": "en"},
-  {"keyName": "mailingFormStayUpdated", "text":  "Stay updated with news about the study", "language": "en"},
-  {"keyName": "yourName", "text": "Your name", "language": "en"},
-  {"keyName": "yourEmail", "text": "Your email", "language": "en"},
-  {"keyName": "join", "text":  "Join", "language": "en"},
-  {"keyName": "thanksForJoining", "text": "Thanks for joining!", "language": "en"},
-  {"keyName": "pageNotFoundTitle", "text": "Page not found", "language": "en"},
-  {"keyName": "pageNotFoundMessage", "text": "If you believe this is an error, please contact ${studyContactEmail}", "language": "en"},
-  {"keyName": "pageNotFoundReturnHome", "text": "Return to the home page", "language": "en"},
-  {"keyName": "authErrorPageTitle", "text": "Something went wrong", "language": "en"},
-  {"keyName": "authErrorPageMessage", "text": "There was an issue with our authentication service. Please try again. If the problem persists, please contact ${studyContactEmail}.", "language": "en"},
-  {"keyName": "navbarSampleKits", "text":  "Sample Kits", "language": "en"},
-  {"keyName": "kitsPageTitle", "text": "Sample collection kits", "language": "en"},
-  {"keyName": "kitsPageDescription", "text": "Sample collection kits are a valuable part of the study process and can help provide researchers with important insights. Below you will find the status of all kits that have been provided to you.", "language": "en"},
-  {"keyName": "kitsPageInPersonTitle", "text": "Provide a sample in-person", "language": "en"},
-  {"keyName": "kitsPageInPersonDescription", "text": "This study is currently offering the option to complete a sample collection kit in-person.", "language": "en"},
-  {"keyName": "kitsPageInPersonCompleteButton", "text": "Complete a kit in-person", "language": "en"},
-  {"keyName": "kitsPageYourKitsTitle", "text": "Your kits", "language": "en"},
-  {"keyName": "kitsPageStatusPreparing", "text": "Preparing", "language": "en"},
-  {"keyName": "kitsPageStatusShipped", "text": "Shipped", "language": "en"},
-  {"keyName": "kitsPageStatusReturned", "text": "Returned", "language": "en"},
-  {"keyName": "kitsPageStatusCreated", "text": "Created", "language": "en"},
-  {"keyName": "kitsPageStatusCollected", "text": "Collected", "language": "en"},
-  {"keyName": "kitsPageNoKits", "text": "You do not have any sample collection kits at this time.", "language": "en"},
-  {"keyName": "kitsInPersonTitle", "text": "Sample kit instructions", "language": "en"},
-  {"keyName": "kitsInPersonDescription", "text": "If you are completing a sample collection kit in-person, please follow the instructions provided by a member of the study team. Any additional information that you may need, such as your unique participant identifier, will be provided below.", "language": "en"},
-  {"keyName": "kitsInPersonSubDescription", "text": "If you have any questions, please ask a member of the study team.", "language": "en"},
-  {"keyName": "kitsInPersonYourKitTitle", "text": "Your sample collection kit", "language": "en"},
-  {"keyName": "kitsInPersonYourKitDescription", "text": "A member of the team has provided you with a sample collection kit. This sample kit is associated with your account. If you are assisting someone else with their sample collection kit, please ensure that each participant completes the sample collection kit that was assigned to them.", "language": "en"},
-  {"keyName": "kitsInPersonYourKitIdentifier", "text": "Your kit identifier", "language": "en"},
-  {"keyName": "kitsInPersonReturnToDashboard", "text": "Return to dashboard", "language": "en"},
-  {"keyName": "kitsInPersonRefreshPage", "text": "Refresh", "language": "en"},
-  {"keyName": "kitsInPersonConsentRequiredTitle", "text": "Consent Required", "language": "en"},
-  {"keyName": "kitsInPersonConsentRequiredDescription", "text": "Before completing a sample collection kit, you must first be enrolled in the study. If of interest, you may find and sign the consent form via the link below.", "language": "en"},
-  {"keyName": "kitsInPersonStartConsent", "text": "Start Consent", "language": "en"},
-  {"keyName": "kitsInPersonError", "text": "There was an error loading your kit information. Please contact a member of the study team for assistance.", "language": "en"},
-  {"keyName": "kitsInPersonCreatedInstructions", "text": "After you have completed the sample collection kit, please return it to a member of the study team and allow them to scan your participation code below.", "language": "en"},
-  {"keyName": "kitsInPersonNoKitInstructions", "text": "To receive a sample collection kit, a member of the study team will scan your unique participation code below to associate a sample kit with your account.", "language": "en"},
-  {"keyName": "kitsInPersonNoKitSubInstructions", "text": "Once you have received a kit, please refresh this page to view your kit information and receive further instructions.", "language": "en"},
-  {"keyName": "kitsInPersonCollectedDescription", "text": "A member of the study team has received your sample collection kit. You will receive an email notification when your sample has been processed, and you will be able to view the status of the sample on your study dashboard.", "language": "en"},
-  {"keyName": "kitsInPersonCollectedThankYou", "text": "Thank you for your participation.", "language": "en"},
-  {"keyName": "kitTypeSaliva", "text": "Saliva kit", "language": "en"},
-  {"keyName": "kitTypeStool", "text": "Stool kit", "language": "en"},
-  {"keyName": "kitTypeBlood", "text": "Blood kit", "language": "en"},
-  {"keyName": "documentDownloadButton", "text": "Download", "language": "en"},
-  {"keyName": "documentsListNone", "text": "You have not uploaded any documents yet", "language": "en"},
-  {"keyName": "documentsListCreatedOn", "text": "Created on", "language": "en"},
-  {"keyName": "documentsPageTitle", "text": "Documents", "language": "en"},
-  {"keyName": "documentsPageUploadedDocumentsTitle", "text": "Uploaded documents", "language": "en"},
-  {"keyName": "documentsPageMessage", "text": "While participating in a study, you may be asked to upload documents as part of a form or survey. Below, you can review the documents you have uploaded.", "language": "en"},
-  {"keyName": "navbarDocuments", "text": "Documents", "language": "en"},
-  {"keyName": "taskTypeDocumentRequests", "text": "Document Requests", "language": "en"},
-  {"keyName": "documentDeleteAreYouSureTitle", "text": "Are you sure?", "language": "en"},
-  {"keyName": "documentDeleteAreYouSureMessage", "text": "Are you sure you want to delete this document? This cannot be undone. Please note that if a member of the study staff has already downloaded this document, it will still be accessible to them. Please contact the study staff if you would like to have the document fully removed from all records.", "language": "en"},
-  {"keyName": "documentDeleteDocumentInUseTitle", "text": "This document is in use", "language": "en"},
-  {"keyName": "documentDeleteDocumentInUseMessage", "text": "This document is currently shared in response to at least one survey. Please remove it from the survey response(s) before deleting it.", "language": "en"},
-  {"keyName": "documentDeleteButton", "text": "Delete", "language": "en"},
-  {"keyName": "documentOptionsButton", "text": "Options", "language": "en"},
-  {"keyName": "documentSharedInResponseTo", "text": "shared in response to", "language": "en"},
-  {"keyName": "documentUploaderSelectedDocuments", "text": "Selected documents", "language": "en"},
-  {"keyName": "documentUploaderIncludedInResponse", "text": "These documents are included in your response", "language": "en"},
-  {"keyName": "documentUploaderNoDocumentsSelected", "text": "No documents selected. Please upload a new document or select an existing document below.", "language": "en"},
-  {"keyName": "documentUploaderAvailableDocuments", "text": "Available documents", "language": "en"},
-  {"keyName": "documentUploaderNotIncludedInResponse", "text": "These documents are not included in your response", "language": "en"},
-  {"keyName": "documentUploaderClickToUpload", "text": "Drop files here or click to upload", "language": "en"},
-  {"keyName": "documentUploaderNoDocuments", "text": "No documents available", "language": "en"},
-  {"keyName": "idleStatusNoticeTitle", "text": "Your session is about to expire", "language": "en"},
-  {"keyName": "idleStatusNoticeMessage", "text": "To maintain security and protect your data, you will be logged out in ${timeRemaining}.", "language": "en"}
+  {
+    "keyName": "navbarDashboard",
+    "text": "Dashboard",
+    "language": "en"
+  },
+  {
+    "keyName": "navbarChangePassword",
+    "text": "Change Password",
+    "language": "en"
+  },
+  {
+    "keyName": "navbarLogout",
+    "text": "Log Out",
+    "language": "en"
+  },
+  {
+    "keyName": "profile",
+    "text": "Profile",
+    "language": "en"
+  },
+  {
+    "keyName": "navbarLogin",
+    "text": "Log In",
+    "language": "en"
+  },
+  {
+    "keyName": "navbarJoin",
+    "text": "Register",
+    "language": "en"
+  },
+  {
+    "keyName": "taskComplete",
+    "text": "Complete",
+    "language": "en"
+  },
+  {
+    "keyName": "taskInProgress",
+    "text": "In Progress",
+    "language": "en"
+  },
+  {
+    "keyName": "taskNotStarted",
+    "text": "Not Started",
+    "language": "en"
+  },
+  {
+    "keyName": "taskDeclined",
+    "text": "Declined",
+    "language": "en"
+  },
+  {
+    "keyName": "taskRemoved",
+    "text": "Removed",
+    "language": "en"
+  },
+  {
+    "keyName": "taskLocked",
+    "text": "Locked",
+    "language": "en"
+  },
+  {
+    "keyName": "tasksNoneForStudy",
+    "text": "No tasks for this study",
+    "language": "en"
+  },
+  {
+    "keyName": "taskHistory",
+    "text": "history",
+    "language": "en"
+  },
+  {
+    "keyName": "taskNew",
+    "text": "NEW",
+    "language": "en"
+  },
+  {
+    "keyName": "surveysSomeLocked",
+    "text": "Some surveys are locked until other required tasks are completed.",
+    "language": "en"
+  },
+  {
+    "keyName": "taskTypeSurvey",
+    "text": "Survey",
+    "language": "en"
+  },
+  {
+    "keyName": "taskTypeSurveys",
+    "text": "Surveys",
+    "language": "en"
+  },
+  {
+    "keyName": "taskTypeConsent",
+    "text": "Consent",
+    "language": "en"
+  },
+  {
+    "keyName": "taskTypeForms",
+    "text": "Forms",
+    "language": "en"
+  },
+  {
+    "keyName": "start",
+    "text": "Start",
+    "language": "en"
+  },
+  {
+    "keyName": "continue",
+    "text": "Continue",
+    "language": "en"
+  },
+  {
+    "keyName": "save",
+    "text": "Save",
+    "language": "en"
+  },
+  {
+    "keyName": "outreachLearnMore",
+    "text": "Learn More",
+    "language": "en"
+  },
+  {
+    "keyName": "cancel",
+    "text": "Cancel",
+    "language": "en"
+  },
+  {
+    "keyName": "goBack",
+    "text": "Go Back",
+    "language": "en"
+  },
+  {
+    "keyName": "name",
+    "text": "Name",
+    "language": "en"
+  },
+  {
+    "keyName": "givenName",
+    "text": "Given Name",
+    "language": "en"
+  },
+  {
+    "keyName": "familyName",
+    "text": "Family Name",
+    "language": "en"
+  },
+  {
+    "keyName": "editName",
+    "text": "Edit Name",
+    "language": "en"
+  },
+  {
+    "keyName": "editBirthDate",
+    "text": "Edit Birthday",
+    "language": "en"
+  },
+  {
+    "keyName": "birthDate",
+    "text": "Birthday",
+    "language": "en"
+  },
+  {
+    "keyName": "mailingAddress",
+    "text": "Mailing Address",
+    "language": "en"
+  },
+  {
+    "keyName": "editMailingAddress",
+    "text": "Edit Mailing Address",
+    "language": "en"
+  },
+  {
+    "keyName": "primaryAddress",
+    "text": "Primary Address",
+    "language": "en"
+  },
+  {
+    "keyName": "editPrimaryAddress",
+    "text": "Edit Primary Address",
+    "language": "en"
+  },
+  {
+    "keyName": "street1",
+    "text": "Street 1",
+    "language": "en"
+  },
+  {
+    "keyName": "street2",
+    "text": "Street 2",
+    "language": "en"
+  },
+  {
+    "keyName": "city",
+    "text": "City",
+    "language": "en"
+  },
+  {
+    "keyName": "state",
+    "text": "State/Province",
+    "language": "en"
+  },
+  {
+    "keyName": "postalCode",
+    "text": "Postal Code",
+    "language": "en"
+  },
+  {
+    "keyName": "country",
+    "text": "Country",
+    "language": "en"
+  },
+  {
+    "keyName": "communicationPreferences",
+    "text": "Communication Preferences",
+    "language": "en"
+  },
+  {
+    "keyName": "editCommunicationPreferences",
+    "text": "Edit Communication Preferences",
+    "language": "en"
+  },
+  {
+    "keyName": "contactEmail",
+    "text": "Contact Email",
+    "language": "en"
+  },
+  {
+    "keyName": "editContactEmail",
+    "text": "Edit Contact Email",
+    "language": "en"
+  },
+  {
+    "keyName": "phoneNumber",
+    "text": "Phone Number",
+    "language": "en"
+  },
+  {
+    "keyName": "editPhoneNumber",
+    "text": "Edit Phone Number",
+    "language": "en"
+  },
+  {
+    "keyName": "doNotSolicit",
+    "text": "Do Not Solicit",
+    "language": "en"
+  },
+  {
+    "keyName": "doNotContact",
+    "text": "Do Not Contact",
+    "language": "en"
+  },
+  {
+    "keyName": "editDoNotSolicit",
+    "text": "Edit Do Not Solicit",
+    "language": "en"
+  },
+  {
+    "keyName": "editNotifications",
+    "text": "Edit Notifications",
+    "language": "en"
+  },
+  {
+    "keyName": "notifications",
+    "text": "Notifications",
+    "language": "en"
+  },
+  {
+    "keyName": "on",
+    "text": "On",
+    "language": "en"
+  },
+  {
+    "keyName": "off",
+    "text": "Off",
+    "language": "en"
+  },
+  {
+    "keyName": "notProvided",
+    "text": "Not Provided",
+    "language": "en"
+  },
+  {
+    "keyName": "editProfileContactEmailWarning",
+    "text": "Press \"Save\"  to update the email used for communication. Note that your login information will not change.",
+    "language": "en"
+  },
+  {
+    "keyName": "privacyPolicy",
+    "text": "Privacy Policy",
+    "language": "en"
+  },
+  {
+    "keyName": "termsOfUse",
+    "text": "Terms of Use",
+    "language": "en"
+  },
+  {
+    "keyName": "addressInvalidPostalCode",
+    "text": "The postal code could not be verified.",
+    "language": "en"
+  },
+  {
+    "keyName": "addressInvalidCountry",
+    "text": "The country could not be verified.",
+    "language": "en"
+  },
+  {
+    "keyName": "addressInvalidState",
+    "text": "The state/province could not be verified.",
+    "language": "en"
+  },
+  {
+    "keyName": "addressInvalidCity",
+    "text": "The city could not be verified.",
+    "language": "en"
+  },
+  {
+    "keyName": "addressInvalidHouseNumber",
+    "text": "The house number could not be verified.",
+    "language": "en"
+  },
+  {
+    "keyName": "addressInvalidStreetName",
+    "text": "The street name could not be verified.",
+    "language": "en"
+  },
+  {
+    "keyName": "addressInvalidStreetType",
+    "text": "The street type could not be verified.",
+    "language": "en"
+  },
+  {
+    "keyName": "addressNeedsSubpremise",
+    "text": "Please provide a unit/suite number.",
+    "language": "en"
+  },
+  {
+    "keyName": "addressFailedToValidate",
+    "text": "Address could not be validated.",
+    "language": "en"
+  },
+  {
+    "keyName": "suggestBetterAddressHeader",
+    "text": "Is this the correct address?",
+    "language": "en"
+  },
+  {
+    "keyName": "suggestBetterAddressBody",
+    "text": "We were able to verify a similar address. Please select which you would like to use.",
+    "language": "en"
+  },
+  {
+    "keyName": "newAddress",
+    "text": "New Address",
+    "language": "en"
+  },
+  {
+    "keyName": "oldAddress",
+    "text": "Old Address",
+    "language": "en"
+  },
+  {
+    "keyName": "you",
+    "text": "You",
+    "language": "en"
+  },
+  {
+    "keyName": "yourDependent",
+    "text": "Your Dependent",
+    "language": "en"
+  },
+  {
+    "keyName": "youInParens",
+    "text": "(you)",
+    "language": "en"
+  },
+  {
+    "keyName": "allProfiles",
+    "text": "All Profiles",
+    "language": "en"
+  },
+  {
+    "keyName": "manageProfiles",
+    "text": "Manage Profiles",
+    "language": "en"
+  },
+  {
+    "keyName": "addNewParticipant",
+    "text": "Add New Participant",
+    "language": "en"
+  },
+  {
+    "keyName": "dashboard",
+    "text": "Dashboard",
+    "language": "en"
+  },
+  {
+    "keyName": "selectParticipant",
+    "text": "Select Participant",
+    "language": "en"
+  },
+  {
+    "keyName": "hubUpdateFormSubmittedTitle",
+    "text": "${formName} completed",
+    "language": "en"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesTitle",
+    "text": "All activities complete",
+    "language": "en"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesDetail",
+    "text": "You have completed all activities for this study. We will notify you as soon as new activities are available. Thank you for your participation!",
+    "language": "en"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyTitle",
+    "text": "Welcome to ${studyName}",
+    "language": "en"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyDetail",
+    "text": "Please read and sign the consent form below to continue.",
+    "language": "en"
+  },
+  {
+    "keyName": "hubUpdateAlreadyEnrolledTitle",
+    "text": "You are already enrolled in ${studyName}.",
+    "language": "en"
+  },
+  {
+    "keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle",
+    "text": "This user is already enrolled in ${studyName}.",
+    "language": "en"
+  },
+  {
+    "keyName": "cookieAlertTitle",
+    "text": "Cookies",
+    "language": "en"
+  },
+  {
+    "keyName": "cookieAlertDetail",
+    "text": "This site uses internet tokens called &quot;cookies&quot; to enable the proper functioning and security of our website, and to improve your experience while you use it. All of the cookies we use are strictly necessary cookies. This type of cookie does not collect any personally identifiable information about you and does not track your browsing habits. To learn more, [read our Privacy Policy](/privacy).",
+    "language": "en"
+  },
+  {
+    "keyName": "joinStudy",
+    "text": "Join Study",
+    "language": "en"
+  },
+  {
+    "keyName": "ineligibleThankYou",
+    "text": "Thank you for your interest in ${studyName}",
+    "language": "en"
+  },
+  {
+    "keyName": "ineligibleDescription",
+    "text": "Unfortunately, you do not meet the eligibility criteria to participate in ${studyName} at this time.",
+    "language": "en"
+  },
+  {
+    "keyName": "ineligibleProvideYourEmail",
+    "text": "Provide your email below and we’ll keep you up-to-date on developments. You can unsubscribe at any time.",
+    "language": "en"
+  },
+  {
+    "keyName": "ineligibleStayInformed",
+    "text": "Stay informed",
+    "language": "en"
+  },
+  {
+    "keyName": "backToPortalHomepage",
+    "text": "Back to ${portalName} homepage",
+    "language": "en"
+  },
+  {
+    "keyName": "joinMailingList",
+    "text": "Join Mailing List",
+    "language": "en"
+  },
+  {
+    "keyName": "mailingFormStayUpdated",
+    "text": "Stay updated with news about the study",
+    "language": "en"
+  },
+  {
+    "keyName": "yourName",
+    "text": "Your name",
+    "language": "en"
+  },
+  {
+    "keyName": "yourEmail",
+    "text": "Your email",
+    "language": "en"
+  },
+  {
+    "keyName": "join",
+    "text": "Join",
+    "language": "en"
+  },
+  {
+    "keyName": "thanksForJoining",
+    "text": "Thanks for joining!",
+    "language": "en"
+  },
+  {
+    "keyName": "pageNotFoundTitle",
+    "text": "Page not found",
+    "language": "en"
+  },
+  {
+    "keyName": "pageNotFoundMessage",
+    "text": "If you believe this is an error, please contact ${studyContactEmail}",
+    "language": "en"
+  },
+  {
+    "keyName": "pageNotFoundReturnHome",
+    "text": "Return to the home page",
+    "language": "en"
+  },
+  {
+    "keyName": "authErrorPageTitle",
+    "text": "Something went wrong",
+    "language": "en"
+  },
+  {
+    "keyName": "authErrorPageMessage",
+    "text": "There was an issue with our authentication service. Please try again. If the problem persists, please contact ${studyContactEmail}.",
+    "language": "en"
+  },
+  {
+    "keyName": "navbarSampleKits",
+    "text": "Sample Kits",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsPageTitle",
+    "text": "Sample collection kits",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsPageDescription",
+    "text": "Sample collection kits are a valuable part of the study process and can help provide researchers with important insights. Below you will find the status of all kits that have been provided to you.",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsPageInPersonTitle",
+    "text": "Provide a sample in-person",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsPageInPersonDescription",
+    "text": "This study is currently offering the option to complete a sample collection kit in-person.",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsPageInPersonCompleteButton",
+    "text": "Complete a kit in-person",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsPageYourKitsTitle",
+    "text": "Your kits",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsPageStatusPreparing",
+    "text": "Preparing",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsPageStatusShipped",
+    "text": "Shipped",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsPageStatusReturned",
+    "text": "Returned",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsPageStatusCreated",
+    "text": "Created",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsPageStatusCollected",
+    "text": "Collected",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsPageNoKits",
+    "text": "You do not have any sample collection kits at this time.",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsInPersonTitle",
+    "text": "Sample kit instructions",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsInPersonDescription",
+    "text": "If you are completing a sample collection kit in-person, please follow the instructions provided by a member of the study team. Any additional information that you may need, such as your unique participant identifier, will be provided below.",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsInPersonSubDescription",
+    "text": "If you have any questions, please ask a member of the study team.",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsInPersonYourKitTitle",
+    "text": "Your sample collection kit",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsInPersonYourKitDescription",
+    "text": "A member of the team has provided you with a sample collection kit. This sample kit is associated with your account. If you are assisting someone else with their sample collection kit, please ensure that each participant completes the sample collection kit that was assigned to them.",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsInPersonYourKitIdentifier",
+    "text": "Your kit identifier",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsInPersonReturnToDashboard",
+    "text": "Return to dashboard",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsInPersonRefreshPage",
+    "text": "Refresh",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredTitle",
+    "text": "Consent Required",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredDescription",
+    "text": "Before completing a sample collection kit, you must first be enrolled in the study. If of interest, you may find and sign the consent form via the link below.",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsInPersonStartConsent",
+    "text": "Start Consent",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsInPersonError",
+    "text": "There was an error loading your kit information. Please contact a member of the study team for assistance.",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsInPersonCreatedInstructions",
+    "text": "After you have completed the sample collection kit, please return it to a member of the study team and allow them to scan your participation code below.",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsInPersonNoKitInstructions",
+    "text": "To receive a sample collection kit, a member of the study team will scan your unique participation code below to associate a sample kit with your account.",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsInPersonNoKitSubInstructions",
+    "text": "Once you have received a kit, please refresh this page to view your kit information and receive further instructions.",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsInPersonCollectedDescription",
+    "text": "A member of the study team has received your sample collection kit. You will receive an email notification when your sample has been processed, and you will be able to view the status of the sample on your study dashboard.",
+    "language": "en"
+  },
+  {
+    "keyName": "kitsInPersonCollectedThankYou",
+    "text": "Thank you for your participation.",
+    "language": "en"
+  },
+  {
+    "keyName": "kitTypeSaliva",
+    "text": "Saliva kit",
+    "language": "en"
+  },
+  {
+    "keyName": "kitTypeStool",
+    "text": "Stool kit",
+    "language": "en"
+  },
+  {
+    "keyName": "kitTypeBlood",
+    "text": "Blood kit",
+    "language": "en"
+  },
+  {
+    "keyName": "documentDownloadButton",
+    "text": "Download",
+    "language": "en"
+  },
+  {
+    "keyName": "documentsListNone",
+    "text": "You have not uploaded any documents yet",
+    "language": "en"
+  },
+  {
+    "keyName": "documentsListCreatedOn",
+    "text": "Created on",
+    "language": "en"
+  },
+  {
+    "keyName": "documentsPageTitle",
+    "text": "Documents",
+    "language": "en"
+  },
+  {
+    "keyName": "documentsPageUploadedDocumentsTitle",
+    "text": "Uploaded documents",
+    "language": "en"
+  },
+  {
+    "keyName": "documentsPageMessage",
+    "text": "While participating in a study, you may be asked to upload documents as part of a form or survey. Below, you can review the documents you have uploaded.",
+    "language": "en"
+  },
+  {
+    "keyName": "navbarDocuments",
+    "text": "Documents",
+    "language": "en"
+  },
+  {
+    "keyName": "taskTypeDocumentRequests",
+    "text": "Document Requests",
+    "language": "en"
+  },
+  {
+    "keyName": "documentDeleteAreYouSureTitle",
+    "text": "Are you sure?",
+    "language": "en"
+  },
+  {
+    "keyName": "documentDeleteAreYouSureMessage",
+    "text": "Are you sure you want to delete this document? This cannot be undone. Please note that if a member of the study staff has already downloaded this document, it will still be accessible to them. Please contact the study staff if you would like to have the document fully removed from all records.",
+    "language": "en"
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseTitle",
+    "text": "This document is in use",
+    "language": "en"
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseMessage",
+    "text": "This document is currently shared in response to at least one survey. Please remove it from the survey response(s) before deleting it.",
+    "language": "en"
+  },
+  {
+    "keyName": "documentDeleteButton",
+    "text": "Delete",
+    "language": "en"
+  },
+  {
+    "keyName": "documentOptionsButton",
+    "text": "Options",
+    "language": "en"
+  },
+  {
+    "keyName": "documentSharedInResponseTo",
+    "text": "shared in response to",
+    "language": "en"
+  },
+  {
+    "keyName": "documentUploaderSelectedDocuments",
+    "text": "Selected documents",
+    "language": "en"
+  },
+  {
+    "keyName": "documentUploaderIncludedInResponse",
+    "text": "These documents are included in your response",
+    "language": "en"
+  },
+  {
+    "keyName": "documentUploaderNoDocumentsSelected",
+    "text": "No documents selected. Please upload a new document or select an existing document below.",
+    "language": "en"
+  },
+  {
+    "keyName": "documentUploaderAvailableDocuments",
+    "text": "Available documents",
+    "language": "en"
+  },
+  {
+    "keyName": "documentUploaderNotIncludedInResponse",
+    "text": "These documents are not included in your response",
+    "language": "en"
+  },
+  {
+    "keyName": "documentUploaderClickToUpload",
+    "text": "Drop files here or click to upload",
+    "language": "en"
+  },
+  {
+    "keyName": "documentUploaderNoDocuments",
+    "text": "No documents available",
+    "language": "en"
+  },
+  {
+    "keyName": "idleStatusNoticeTitle",
+    "text": "Your session is about to expire",
+    "language": "en"
+  },
+  {
+    "keyName": "idleStatusNoticeMessage",
+    "text": "To maintain security and protect your data, you will be logged out in ${timeRemaining}.",
+    "language": "en"
+  },
+  {
+    "keyName": "failedToEnroll",
+    "language": "en",
+    "text": "Something went wrong during the enrollment process. Please fill out the form again."
+  }
 ]

--- a/populate/src/main/resources/seed/i18n/es/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/es/languageTexts.json
@@ -1,163 +1,836 @@
 [
-  {"keyName": "navbarDashboard", "text": "Panel de control", "language": "es"},
-  {"keyName": "navbarChangePassword", "text": "Cambiar contraseña", "language": "es"},
-  {"keyName": "navbarLogout", "text": "Cerrar sesión", "language": "es"},
-  {"keyName": "profile", "text": "Perfil", "language": "es"},
-  {"keyName": "navbarLogin", "text": "Iniciar sesión", "language": "es"},
-  {"keyName": "navbarJoin", "text": "Registrarse", "language": "es"},
-  {"keyName": "taskComplete", "text": "Completo", "language": "es"},
-  {"keyName": "taskInProgress", "text": "En curso", "language": "es"},
-  {"keyName": "taskNotStarted", "text": "No iniciado", "language": "es"},
-  {"keyName": "taskDeclined", "text": "Rechazado", "language": "es"},
-  {"keyName": "taskLocked", "text": "Bloqueado", "language": "es"},
-  {"keyName": "tasksNoneForStudy", "text": "No hay tareas para este estudio", "language": "es"},
-  {"keyName": "taskHistory", "text": "historia", "language": "es"},
-  {"keyName": "taskNew", "text": "NUEVO", "language": "es"},
-  {"keyName": "surveysSomeLocked", "text": "Algunas encuestas permanecen bloqueadas hasta que se completen otras tareas necesarias.", "language": "es"},
-  {"keyName": "taskTypeSurvey", "text": "Encuesta", "language": "es"},
-  {"keyName": "taskTypeSurveys", "text": "Encuestas", "language": "es"},
-  {"keyName": "taskTypeConsent", "text": "Consentimiento", "language": "es"},
-  {"keyName": "taskTypeForms", "text": "Formularios", "language": "es"},
-  {"keyName": "start", "text": "Empezar", "language": "es"},
-  {"keyName": "continue", "text": "Continuar", "language": "es"},
-  {"keyName": "save", "text": "Guardar", "language": "es"},
-  {"keyName": "outreachLearnMore", "text": "Más información", "language": "es"},
-  {"keyName": "cancel", "text": "Cancelar", "language": "es"},
-  {"keyName": "goBack", "text": "Volver", "language": "es"},
-  {"keyName": "name", "text": "Nombre", "language": "es"},
-  {"keyName": "givenName", "text": "Nombre", "language": "es"},
-  {"keyName": "familyName", "text": "Apellido", "language": "es"},
-  {"keyName": "editName", "text": "Editar nombre", "language": "es"},
-  {"keyName": "editBirthDate", "text": "Editar fecha de nacimiento", "language": "es"},
-  {"keyName": "birthDate", "text": "Fecha de nacimiento", "language": "es"},
-  {"keyName": "mailingAddress", "text": "Dirección postal", "language": "es"},
-  {"keyName": "editMailingAddress", "text": "Editar dirección postal", "language": "es"},
-  {"keyName": "primaryAddress", "text": "Dirección principal", "language": "es"},
-  {"keyName": "editPrimaryAddress", "text": "Editar dirección principal", "language": "es"},
-  {"keyName": "street1", "text": "Línea de dirección 1", "language": "es"},
-  {"keyName": "street2", "text": "Línea de dirección 2", "language": "es"},
-  {"keyName": "city", "text": "Ciudad", "language": "es"},
-  {"keyName": "state", "text": "Estado\/Provincia", "language": "es"},
-  {"keyName": "postalCode", "text": "Código postal", "language": "es"},
-  {"keyName": "country", "text": "País", "language": "es"},
-  {"keyName": "communicationPreferences", "text": "Preferencias de comunicación", "language": "es"},
-  {"keyName": "editCommunicationPreferences", "text": "Editar preferencias de comunicación", "language": "es"},
-  {"keyName": "contactEmail", "text": "Correo electrónico de contacto", "language": "es"},
-  {"keyName": "editContactEmail", "text": "Editar correo electrónico de contacto", "language": "es"},
-  {"keyName": "phoneNumber", "text": "Número de teléfono", "language": "es"},
-  {"keyName": "editPhoneNumber", "text": "Editar número de teléfono", "language": "es"},
-  {"keyName": "doNotSolicit", "text": "No solicitar", "language": "es"},
-  {"keyName": "doNotContact", "text": "No contactar", "language": "es"},
-  {"keyName": "editDoNotSolicit", "text": "Editar no solicitar", "language": "es"},
-  {"keyName": "editNotifications", "text": "Editar notificaciones", "language": "es"},
-  {"keyName": "notifications", "text": "Notificaciones", "language": "es"},
-  {"keyName": "on", "text": "Activado", "language": "es"},
-  {"keyName": "off", "text": "Desactivado", "language": "es"},
-  {"keyName": "notProvided", "text": "No proporcionado", "language": "es"},
-  {"keyName": "editProfileContactEmailWarning", "text": "Pulse \"Guardar\" para actualizar el correo electrónico usado para las comunicaciones. Sus datos de inicio de sesión no cambiarán.", "language": "es"},
-  {"keyName": "privacyPolicy", "text": "Política de Privacidad", "language": "es"},
-  {"keyName": "termsOfUse", "text": "Condiciones de uso", "language": "es"},
-  {"keyName": "addressInvalidPostalCode", "text": "No se ha podido verificar el código postal.", "language": "es"},
-  {"keyName": "addressInvalidCountry", "text": "No se ha podido verificar el país.", "language": "es"},
-  {"keyName": "addressInvalidState", "text": "No se ha podido verificar la provincia\/el estado.", "language": "es"},
-  {"keyName": "addressInvalidCity", "text": "No se ha podido verificar la ciudad.", "language": "es"},
-  {"keyName": "addressInvalidHouseNumber", "text": "No se ha podido verificar el número de la casa.", "language": "es"},
-  {"keyName": "addressInvalidStreetName", "text": "No se ha podido verificar el nombre de la calle.", "language": "es"},
-  {"keyName": "addressInvalidStreetType", "text": "No se ha podido verificar el tipo de calle.", "language": "es"},
-  {"keyName": "addressNeedsSubpremise", "text": "Indique el número de puerta\/local.", "language": "es"},
-  {"keyName": "addressFailedToValidate", "text": "No se ha podido verificar la dirección.", "language": "es"},
-  {"keyName": "suggestBetterAddressHeader", "text": "¿Es esta la dirección correcta?", "language": "es"},
-  {"keyName": "suggestBetterAddressBody", "text": "Se ha podido verificar una dirección similar. Seleccione la que desea usar.", "language": "es"},
-  {"keyName": "newAddress", "text": "Nueva dirección", "language": "es"},
-  {"keyName": "oldAddress", "text": "Dirección anterior", "language": "es"},
-  {"keyName": "you", "text": "Usted", "language": "es"},
-  {"keyName": "yourDependent", "text": "Su dependiente", "language": "es"},
-  {"keyName": "youInParens", "text": "(usted)", "language": "es"},
-  {"keyName": "allProfiles", "text": "Todos los perfiles", "language": "es"},
-  {"keyName": "manageProfiles", "text": "Gestionar perfiles", "language": "es"},
-  {"keyName": "addNewParticipant", "text": "Añadir nuevo participante", "language": "es"},
-  {"keyName": "dashboard", "text": "Panel de control", "language": "es"},
-  {"keyName": "selectParticipant", "text": "Seleccionar participante", "language": "es"},
-  {"keyName": "hubUpdateFormSubmittedTitle", "text": "${formName} completado", "language": "es"},
-  {"keyName": "hubUpdateNoActivitiesTitle", "text": "Todas las actividades completadas", "language": "es"},
-  {"keyName": "hubUpdateNoActivitiesDetail", "text": "Ha completado todas las actividades de este estudio. Le avisaremos cuando haya nuevas actividades disponibles. ¡Gracias por su participación!", "language": "es"},
-  {"keyName": "hubUpdateWelcomeToStudyTitle", "text": "Bienvenido a ${studyName}", "language": "es"},
-  {"keyName": "hubUpdateWelcomeToStudyDetail", "text": "Por favor, lea y firme el siguiente formulario de consentimiento para continuar.", "language": "es"},
-  {"keyName": "hubUpdateAlreadyEnrolledTitle", "text": "Ya está inscrito en ${studyName}.", "language": "es"},
-  {"keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle", "text": "Este usuario ya está inscrito en ${studyName}.", "language": "es"},
-  {"keyName": "cookieAlertTitle", "text": "Cookies", "language": "es"},
-  {"keyName": "cookieAlertDetail", "text": "Este sitio utiliza tokens de Internet denominados &quot;cookies&quot; para un funcionamiento correcto y para garantizar la seguridad de nuestro sitio web, además de mejorar su experiencia mientras lo usa. Todas las cookies que usamos son estrictamente necesarias. Este tipo de cookie no recoge ninguna información de identificación personal sobre usted ni hace un seguimiento de sus hábitos de navegación. Para obtener más información, [lea nuestra Política de Privacidad](\/privacidad).", "language": "es"},
-  {"keyName": "joinStudy", "text": "Participar en el estudio", "language": "es"},
-  {"keyName": "ineligibleThankYou", "text": "Gracias por su interés en ${studyName}", "language": "es" },
-  {"keyName": "ineligibleDescription", "text": "Lamentamos comunicarle que en este momento no cumple los criterios de inclusión para participar en ${studyName}.", "language": "es"},
-  {"keyName": "ineligibleProvideYourEmail", "text": "Puede facilitarnos su correo electrónico a continuación para que le mantengamos informado de las novedades. Puede darse de baja en cualquier momento.", "language":  "es"},
-  {"keyName": "ineligibleStayInformed", "text": "Mantenerme informado", "language": "es"},
-  {"keyName": "backToPortalHomepage", "text": "Volver a la página de inicio ${portalName}", "language": "es"},
-  {"keyName": "joinMailingList", "text": "Suscribirme a la lista de correo", "language": "es"},
-  {"keyName": "mailingFormStayUpdated", "text":  "Mantenerme informado de las novedades del estudio", "language": "es"},
-  {"keyName": "yourName", "text": "Su nombre", "language": "es"},
-  {"keyName": "yourEmail", "text": "Su correo electrónico", "language": "es"},
-  {"keyName": "join", "text":  "Suscribirme", "language": "es"},
-  {"keyName": "thanksForJoining", "text": "¡Gracias por suscribirse!", "language": "es"},
-  {"keyName": "pageNotFoundTitle", "text": "Página no encontrada", "language": "es"},
-  {"keyName": "pageNotFoundMessage", "text": "Si cree que se trata de un error, diríjase a ${studyContactEmail}", "language": "es"},
-  {"keyName": "pageNotFoundReturnHome", "text": "Volver a la página de inicio", "language": "es"},
-  {"keyName": "authErrorPageTitle", "text": "Se ha producido un error", "language": "es"},
-  {"keyName": "authErrorPageMessage", "text": "Ha habido un problema con nuestro servicio de autenticación. Por favor, vuelva a intentarlo. Si el problema persiste, póngase en contacto con ${studyContactEmail}.", "language": "es"},
-  {"keyName": "navbarSampleKits", "text":  "Kits para muestras", "language": "es"},
-  {"keyName": "kitsPageTitle", "text": "Kits de toma de muestras", "language": "es"},
-  {"keyName": "kitsPageDescription", "text": "Los kits de toma de muestras son una parte importante del proceso de estudio y pueden proporcionar información importante a los investigadores. A continuación puede consultar el estado de todos los kits que se le han proporcionado.", "language": "es"},
-  {"keyName": "kitsPageInPersonTitle", "text": "Entregar una muestra en persona", "language": "es"},
-  {"keyName": "kitsPageInPersonDescription", "text": "Este estudio ofrece actualmente la opción de realizar el kit de toma de muestras en persona.", "language": "es"},
-  {"keyName": "kitsPageInPersonCompleteButton", "text": "Realizar un kit en persona", "language": "es"},
-  {"keyName": "kitsPageYourKitsTitle", "text": "Sus kits", "language": "es"},
-  {"keyName": "kitsPageStatusPreparing", "text": "En preparación", "language": "es"},
-  {"keyName": "kitsPageStatusShipped", "text": "Enviado", "language": "es"},
-  {"keyName": "kitsPageStatusReturned", "text": "Devuelto", "language": "es"},
-  {"keyName": "kitsPageStatusCreated", "text": "Creado", "language": "es"},
-  {"keyName": "kitsPageStatusCollected", "text": "Recogido", "language": "es"},
-  {"keyName": "kitsPageNoKits", "text": "En este momento no tiene ningún kit de toma de muestras.", "language": "es"},
-  {"keyName": "kitsInPersonTitle", "text": "Instrucciones del kit para muestras", "language": "es"},
-  {"keyName": "kitsInPersonDescription", "text": "Si está realizando un kit de toma de muestras en persona, le rogamos que siga las instrucciones facilitadas por un miembro del equipo del estudio. Toda la información adicional que pueda necesitar, como su identificador de participante único, se facilitará a continuación.", "language": "es"},
-  {"keyName": "kitsInPersonSubDescription", "text": "Si tiene alguna pregunta, póngase en contacto con un miembro del equipo del estudio.", "language": "es"},
-  {"keyName": "kitsInPersonYourKitTitle", "text": "Su kit de toma de muestras", "language": "es"},
-  {"keyName": "kitsInPersonYourKitDescription", "text": "Un miembro del equipo le ha entregado un kit de toma de muestras. Este kit para muestras está asociado a su cuenta. Si está ayudando a otras personas con sus kits de toma de muestras, asegúrese de que cada uno realiza el kit de toma de muestras que se le ha asignado.", "language": "es"},
-  {"keyName": "kitsInPersonYourKitIdentifier", "text": "Identificador de su kit", "language": "es"},
-  {"keyName": "kitsInPersonReturnToDashboard", "text": "Volver al panel del control", "language": "es"},
-  {"keyName": "kitsInPersonRefreshPage", "text": "Actualizar", "language": "es"},
-  {"keyName": "kitsInPersonConsentRequiredTitle", "text": "Se necesita consentimiento", "language": "es"},
-  {"keyName": "kitsInPersonConsentRequiredDescription", "text": "Antes de realizar un kit de toma de muestras, debe estar inscrito en el estudio. Si está interesado, puede firmar el formulario de consentimiento que encontrará en el siguiente enlace.", "language": "es"},
-  {"keyName": "kitsInPersonStartConsent", "text": "Iniciar consentimiento", "language": "es"},
-  {"keyName": "kitsInPersonError", "text": "Se ha producido un error al cargar la información de su kit. Le rogamos que se ponga en contacto con un miembro del equipo del estudio para recibir asistencia.", "language": "es"},
-  {"keyName": "kitsInPersonCreatedInstructions", "text": "Una vez completado el kit de toma de muestras, por favor, devuélvaselo al miembro del equipo del estudio y permita que escanee su código de participación que figura a continuación.", "language": "es"},
-  {"keyName": "kitsInPersonNoKitInstructions", "text": "Para recibir un kit de toma de muestras, un miembro del equipo del estudio escaneará su código de participación que figura a continuación para asociar el kit a su cuenta.", "language": "es"},
-  {"keyName": "kitsInPersonNoKitSubInstructions", "text": "Después de recibir un kit, actualice esta página para ver la información de su kit y obtener más instrucciones.", "language": "es"},
-  {"keyName": "kitsInPersonCollectedDescription", "text": "Un miembro del equipo del estudio ha recibido su kit de toma de muestras. Recibirá una notificación por correo electrónico cuando se haya procesado su muestra, y podrá ver el estado de la misma en el panel de control del estudio.", "language": "es"},
-  {"keyName": "kitsInPersonCollectedThankYou", "text": "Gracias por su participación.", "language": "es"},
-  {"keyName": "kitTypeSaliva", "text": "Kit para saliva", "language": "es"},
-  {"keyName": "kitTypeStool", "text": "Kit para heces", "language": "es"},
-  {"keyName": "kitTypeBlood", "text": "Kit para sangre", "language": "es"},
-  {"keyName": "documentDownloadButton", "text": "Descargar", "language": "es", "machineTranslated": true},
-  {"keyName": "documentsListNone", "text": "Aún no has subido ningún documento", "language": "es", "machineTranslated": true},
-  {"keyName": "documentsListCreatedOn", "text": "Creado el", "language": "es", "machineTranslated": true},
-  {"keyName": "documentsPageTitle", "text": "Documentos", "language": "es", "machineTranslated": true},
-  {"keyName": "documentsPageUploadedDocumentsTitle", "text": "Documentos cargados", "language": "es", "machineTranslated": true},
-  {"keyName": "documentsPageMessage", "text": "Mientras participa en un estudio, es posible que se le solicite que cargue documentos como parte de un formulario o encuesta. A continuación, puede administrar los documentos que ha cargado.", "language": "es", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "Documentos", "language": "es", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureTitle", "text": "Estas segura", "language": "es", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureMessage", "text": "¿Está seguro de que desea eliminar este documento? No es posible deshacer esta acción. Tenga en cuenta que si un miembro del personal del estudio ya ha descargado este documento, seguirá teniendo acceso a él. Póngase en contacto con el personal del estudio si desea que el documento se elimine por completo de todos los registros.", "language": "es", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseTitle", "text": "Este documento está en uso", "language": "es", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseMessage", "text": "Este documento se comparte actualmente en respuesta a al menos una encuesta. Elimínelo de las respuestas de la encuesta antes de eliminarlo.", "language": "es", "machineTranslated": true},
-  {"keyName": "documentDeleteButton", "text": "Borrar", "language": "es", "machineTranslated": true},
-  {"keyName": "documentOptionsButton", "text": "Opciones", "language": "es", "machineTranslated": true},
-  {"keyName": "documentSharedInResponseTo", "text": "compartido en respuesta a", "language": "es", "machineTranslated": true},
-  {"keyName": "documentUploaderSelectedDocuments", "text": "Documentos seleccionados", "language": "es", "machineTranslated": true},
-  {"keyName": "documentUploaderIncludedInResponse", "text": "Estos documentos están incluidos en su respuesta.", "language": "es", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocumentsSelected", "text": "No se han seleccionado documentos. Cargue un nuevo documento o seleccione uno existente a continuación.", "language": "es", "machineTranslated": true},
-  {"keyName": "documentUploaderAvailableDocuments", "text": "Documentos disponibles", "language": "es", "machineTranslated": true},
-  {"keyName": "documentUploaderNotIncludedInResponse", "text": "Estos documentos no están incluidos en su respuesta.", "language": "es", "machineTranslated": true},
-  {"keyName": "documentUploaderClickToUpload", "text": "Suelte los archivos aquí o haga clic para cargarlos", "language": "es", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocuments", "text": "No hay documentos disponibles", "language": "es", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeTitle", "text": "Su sesión está a punto de expirar", "language": "es", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeMessage", "text": "Para mantener la seguridad y proteger sus datos, se cerrará la sesión en ${timeRemaining}.", "language": "es", "machineTranslated": true}
+  {
+    "keyName": "navbarDashboard",
+    "text": "Panel de control",
+    "language": "es"
+  },
+  {
+    "keyName": "navbarChangePassword",
+    "text": "Cambiar contraseña",
+    "language": "es"
+  },
+  {
+    "keyName": "navbarLogout",
+    "text": "Cerrar sesión",
+    "language": "es"
+  },
+  {
+    "keyName": "profile",
+    "text": "Perfil",
+    "language": "es"
+  },
+  {
+    "keyName": "navbarLogin",
+    "text": "Iniciar sesión",
+    "language": "es"
+  },
+  {
+    "keyName": "navbarJoin",
+    "text": "Registrarse",
+    "language": "es"
+  },
+  {
+    "keyName": "taskComplete",
+    "text": "Completo",
+    "language": "es"
+  },
+  {
+    "keyName": "taskInProgress",
+    "text": "En curso",
+    "language": "es"
+  },
+  {
+    "keyName": "taskNotStarted",
+    "text": "No iniciado",
+    "language": "es"
+  },
+  {
+    "keyName": "taskDeclined",
+    "text": "Rechazado",
+    "language": "es"
+  },
+  {
+    "keyName": "taskLocked",
+    "text": "Bloqueado",
+    "language": "es"
+  },
+  {
+    "keyName": "tasksNoneForStudy",
+    "text": "No hay tareas para este estudio",
+    "language": "es"
+  },
+  {
+    "keyName": "taskHistory",
+    "text": "historia",
+    "language": "es"
+  },
+  {
+    "keyName": "taskNew",
+    "text": "NUEVO",
+    "language": "es"
+  },
+  {
+    "keyName": "surveysSomeLocked",
+    "text": "Algunas encuestas permanecen bloqueadas hasta que se completen otras tareas necesarias.",
+    "language": "es"
+  },
+  {
+    "keyName": "taskTypeSurvey",
+    "text": "Encuesta",
+    "language": "es"
+  },
+  {
+    "keyName": "taskTypeSurveys",
+    "text": "Encuestas",
+    "language": "es"
+  },
+  {
+    "keyName": "taskTypeConsent",
+    "text": "Consentimiento",
+    "language": "es"
+  },
+  {
+    "keyName": "taskTypeForms",
+    "text": "Formularios",
+    "language": "es"
+  },
+  {
+    "keyName": "start",
+    "text": "Empezar",
+    "language": "es"
+  },
+  {
+    "keyName": "continue",
+    "text": "Continuar",
+    "language": "es"
+  },
+  {
+    "keyName": "save",
+    "text": "Guardar",
+    "language": "es"
+  },
+  {
+    "keyName": "outreachLearnMore",
+    "text": "Más información",
+    "language": "es"
+  },
+  {
+    "keyName": "cancel",
+    "text": "Cancelar",
+    "language": "es"
+  },
+  {
+    "keyName": "goBack",
+    "text": "Volver",
+    "language": "es"
+  },
+  {
+    "keyName": "name",
+    "text": "Nombre",
+    "language": "es"
+  },
+  {
+    "keyName": "givenName",
+    "text": "Nombre",
+    "language": "es"
+  },
+  {
+    "keyName": "familyName",
+    "text": "Apellido",
+    "language": "es"
+  },
+  {
+    "keyName": "editName",
+    "text": "Editar nombre",
+    "language": "es"
+  },
+  {
+    "keyName": "editBirthDate",
+    "text": "Editar fecha de nacimiento",
+    "language": "es"
+  },
+  {
+    "keyName": "birthDate",
+    "text": "Fecha de nacimiento",
+    "language": "es"
+  },
+  {
+    "keyName": "mailingAddress",
+    "text": "Dirección postal",
+    "language": "es"
+  },
+  {
+    "keyName": "editMailingAddress",
+    "text": "Editar dirección postal",
+    "language": "es"
+  },
+  {
+    "keyName": "primaryAddress",
+    "text": "Dirección principal",
+    "language": "es"
+  },
+  {
+    "keyName": "editPrimaryAddress",
+    "text": "Editar dirección principal",
+    "language": "es"
+  },
+  {
+    "keyName": "street1",
+    "text": "Línea de dirección 1",
+    "language": "es"
+  },
+  {
+    "keyName": "street2",
+    "text": "Línea de dirección 2",
+    "language": "es"
+  },
+  {
+    "keyName": "city",
+    "text": "Ciudad",
+    "language": "es"
+  },
+  {
+    "keyName": "state",
+    "text": "Estado/Provincia",
+    "language": "es"
+  },
+  {
+    "keyName": "postalCode",
+    "text": "Código postal",
+    "language": "es"
+  },
+  {
+    "keyName": "country",
+    "text": "País",
+    "language": "es"
+  },
+  {
+    "keyName": "communicationPreferences",
+    "text": "Preferencias de comunicación",
+    "language": "es"
+  },
+  {
+    "keyName": "editCommunicationPreferences",
+    "text": "Editar preferencias de comunicación",
+    "language": "es"
+  },
+  {
+    "keyName": "contactEmail",
+    "text": "Correo electrónico de contacto",
+    "language": "es"
+  },
+  {
+    "keyName": "editContactEmail",
+    "text": "Editar correo electrónico de contacto",
+    "language": "es"
+  },
+  {
+    "keyName": "phoneNumber",
+    "text": "Número de teléfono",
+    "language": "es"
+  },
+  {
+    "keyName": "editPhoneNumber",
+    "text": "Editar número de teléfono",
+    "language": "es"
+  },
+  {
+    "keyName": "doNotSolicit",
+    "text": "No solicitar",
+    "language": "es"
+  },
+  {
+    "keyName": "doNotContact",
+    "text": "No contactar",
+    "language": "es"
+  },
+  {
+    "keyName": "editDoNotSolicit",
+    "text": "Editar no solicitar",
+    "language": "es"
+  },
+  {
+    "keyName": "editNotifications",
+    "text": "Editar notificaciones",
+    "language": "es"
+  },
+  {
+    "keyName": "notifications",
+    "text": "Notificaciones",
+    "language": "es"
+  },
+  {
+    "keyName": "on",
+    "text": "Activado",
+    "language": "es"
+  },
+  {
+    "keyName": "off",
+    "text": "Desactivado",
+    "language": "es"
+  },
+  {
+    "keyName": "notProvided",
+    "text": "No proporcionado",
+    "language": "es"
+  },
+  {
+    "keyName": "editProfileContactEmailWarning",
+    "text": "Pulse \"Guardar\" para actualizar el correo electrónico usado para las comunicaciones. Sus datos de inicio de sesión no cambiarán.",
+    "language": "es"
+  },
+  {
+    "keyName": "privacyPolicy",
+    "text": "Política de Privacidad",
+    "language": "es"
+  },
+  {
+    "keyName": "termsOfUse",
+    "text": "Condiciones de uso",
+    "language": "es"
+  },
+  {
+    "keyName": "addressInvalidPostalCode",
+    "text": "No se ha podido verificar el código postal.",
+    "language": "es"
+  },
+  {
+    "keyName": "addressInvalidCountry",
+    "text": "No se ha podido verificar el país.",
+    "language": "es"
+  },
+  {
+    "keyName": "addressInvalidState",
+    "text": "No se ha podido verificar la provincia/el estado.",
+    "language": "es"
+  },
+  {
+    "keyName": "addressInvalidCity",
+    "text": "No se ha podido verificar la ciudad.",
+    "language": "es"
+  },
+  {
+    "keyName": "addressInvalidHouseNumber",
+    "text": "No se ha podido verificar el número de la casa.",
+    "language": "es"
+  },
+  {
+    "keyName": "addressInvalidStreetName",
+    "text": "No se ha podido verificar el nombre de la calle.",
+    "language": "es"
+  },
+  {
+    "keyName": "addressInvalidStreetType",
+    "text": "No se ha podido verificar el tipo de calle.",
+    "language": "es"
+  },
+  {
+    "keyName": "addressNeedsSubpremise",
+    "text": "Indique el número de puerta/local.",
+    "language": "es"
+  },
+  {
+    "keyName": "addressFailedToValidate",
+    "text": "No se ha podido verificar la dirección.",
+    "language": "es"
+  },
+  {
+    "keyName": "suggestBetterAddressHeader",
+    "text": "¿Es esta la dirección correcta?",
+    "language": "es"
+  },
+  {
+    "keyName": "suggestBetterAddressBody",
+    "text": "Se ha podido verificar una dirección similar. Seleccione la que desea usar.",
+    "language": "es"
+  },
+  {
+    "keyName": "newAddress",
+    "text": "Nueva dirección",
+    "language": "es"
+  },
+  {
+    "keyName": "oldAddress",
+    "text": "Dirección anterior",
+    "language": "es"
+  },
+  {
+    "keyName": "you",
+    "text": "Usted",
+    "language": "es"
+  },
+  {
+    "keyName": "yourDependent",
+    "text": "Su dependiente",
+    "language": "es"
+  },
+  {
+    "keyName": "youInParens",
+    "text": "(usted)",
+    "language": "es"
+  },
+  {
+    "keyName": "allProfiles",
+    "text": "Todos los perfiles",
+    "language": "es"
+  },
+  {
+    "keyName": "manageProfiles",
+    "text": "Gestionar perfiles",
+    "language": "es"
+  },
+  {
+    "keyName": "addNewParticipant",
+    "text": "Añadir nuevo participante",
+    "language": "es"
+  },
+  {
+    "keyName": "dashboard",
+    "text": "Panel de control",
+    "language": "es"
+  },
+  {
+    "keyName": "selectParticipant",
+    "text": "Seleccionar participante",
+    "language": "es"
+  },
+  {
+    "keyName": "hubUpdateFormSubmittedTitle",
+    "text": "${formName} completado",
+    "language": "es"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesTitle",
+    "text": "Todas las actividades completadas",
+    "language": "es"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesDetail",
+    "text": "Ha completado todas las actividades de este estudio. Le avisaremos cuando haya nuevas actividades disponibles. ¡Gracias por su participación!",
+    "language": "es"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyTitle",
+    "text": "Bienvenido a ${studyName}",
+    "language": "es"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyDetail",
+    "text": "Por favor, lea y firme el siguiente formulario de consentimiento para continuar.",
+    "language": "es"
+  },
+  {
+    "keyName": "hubUpdateAlreadyEnrolledTitle",
+    "text": "Ya está inscrito en ${studyName}.",
+    "language": "es"
+  },
+  {
+    "keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle",
+    "text": "Este usuario ya está inscrito en ${studyName}.",
+    "language": "es"
+  },
+  {
+    "keyName": "cookieAlertTitle",
+    "text": "Cookies",
+    "language": "es"
+  },
+  {
+    "keyName": "cookieAlertDetail",
+    "text": "Este sitio utiliza tokens de Internet denominados &quot;cookies&quot; para un funcionamiento correcto y para garantizar la seguridad de nuestro sitio web, además de mejorar su experiencia mientras lo usa. Todas las cookies que usamos son estrictamente necesarias. Este tipo de cookie no recoge ninguna información de identificación personal sobre usted ni hace un seguimiento de sus hábitos de navegación. Para obtener más información, [lea nuestra Política de Privacidad](/privacidad).",
+    "language": "es"
+  },
+  {
+    "keyName": "joinStudy",
+    "text": "Participar en el estudio",
+    "language": "es"
+  },
+  {
+    "keyName": "ineligibleThankYou",
+    "text": "Gracias por su interés en ${studyName}",
+    "language": "es"
+  },
+  {
+    "keyName": "ineligibleDescription",
+    "text": "Lamentamos comunicarle que en este momento no cumple los criterios de inclusión para participar en ${studyName}.",
+    "language": "es"
+  },
+  {
+    "keyName": "ineligibleProvideYourEmail",
+    "text": "Puede facilitarnos su correo electrónico a continuación para que le mantengamos informado de las novedades. Puede darse de baja en cualquier momento.",
+    "language": "es"
+  },
+  {
+    "keyName": "ineligibleStayInformed",
+    "text": "Mantenerme informado",
+    "language": "es"
+  },
+  {
+    "keyName": "backToPortalHomepage",
+    "text": "Volver a la página de inicio ${portalName}",
+    "language": "es"
+  },
+  {
+    "keyName": "joinMailingList",
+    "text": "Suscribirme a la lista de correo",
+    "language": "es"
+  },
+  {
+    "keyName": "mailingFormStayUpdated",
+    "text": "Mantenerme informado de las novedades del estudio",
+    "language": "es"
+  },
+  {
+    "keyName": "yourName",
+    "text": "Su nombre",
+    "language": "es"
+  },
+  {
+    "keyName": "yourEmail",
+    "text": "Su correo electrónico",
+    "language": "es"
+  },
+  {
+    "keyName": "join",
+    "text": "Suscribirme",
+    "language": "es"
+  },
+  {
+    "keyName": "thanksForJoining",
+    "text": "¡Gracias por suscribirse!",
+    "language": "es"
+  },
+  {
+    "keyName": "pageNotFoundTitle",
+    "text": "Página no encontrada",
+    "language": "es"
+  },
+  {
+    "keyName": "pageNotFoundMessage",
+    "text": "Si cree que se trata de un error, diríjase a ${studyContactEmail}",
+    "language": "es"
+  },
+  {
+    "keyName": "pageNotFoundReturnHome",
+    "text": "Volver a la página de inicio",
+    "language": "es"
+  },
+  {
+    "keyName": "authErrorPageTitle",
+    "text": "Se ha producido un error",
+    "language": "es"
+  },
+  {
+    "keyName": "authErrorPageMessage",
+    "text": "Ha habido un problema con nuestro servicio de autenticación. Por favor, vuelva a intentarlo. Si el problema persiste, póngase en contacto con ${studyContactEmail}.",
+    "language": "es"
+  },
+  {
+    "keyName": "navbarSampleKits",
+    "text": "Kits para muestras",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsPageTitle",
+    "text": "Kits de toma de muestras",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsPageDescription",
+    "text": "Los kits de toma de muestras son una parte importante del proceso de estudio y pueden proporcionar información importante a los investigadores. A continuación puede consultar el estado de todos los kits que se le han proporcionado.",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsPageInPersonTitle",
+    "text": "Entregar una muestra en persona",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsPageInPersonDescription",
+    "text": "Este estudio ofrece actualmente la opción de realizar el kit de toma de muestras en persona.",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsPageInPersonCompleteButton",
+    "text": "Realizar un kit en persona",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsPageYourKitsTitle",
+    "text": "Sus kits",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsPageStatusPreparing",
+    "text": "En preparación",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsPageStatusShipped",
+    "text": "Enviado",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsPageStatusReturned",
+    "text": "Devuelto",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsPageStatusCreated",
+    "text": "Creado",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsPageStatusCollected",
+    "text": "Recogido",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsPageNoKits",
+    "text": "En este momento no tiene ningún kit de toma de muestras.",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsInPersonTitle",
+    "text": "Instrucciones del kit para muestras",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsInPersonDescription",
+    "text": "Si está realizando un kit de toma de muestras en persona, le rogamos que siga las instrucciones facilitadas por un miembro del equipo del estudio. Toda la información adicional que pueda necesitar, como su identificador de participante único, se facilitará a continuación.",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsInPersonSubDescription",
+    "text": "Si tiene alguna pregunta, póngase en contacto con un miembro del equipo del estudio.",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsInPersonYourKitTitle",
+    "text": "Su kit de toma de muestras",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsInPersonYourKitDescription",
+    "text": "Un miembro del equipo le ha entregado un kit de toma de muestras. Este kit para muestras está asociado a su cuenta. Si está ayudando a otras personas con sus kits de toma de muestras, asegúrese de que cada uno realiza el kit de toma de muestras que se le ha asignado.",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsInPersonYourKitIdentifier",
+    "text": "Identificador de su kit",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsInPersonReturnToDashboard",
+    "text": "Volver al panel del control",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsInPersonRefreshPage",
+    "text": "Actualizar",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredTitle",
+    "text": "Se necesita consentimiento",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredDescription",
+    "text": "Antes de realizar un kit de toma de muestras, debe estar inscrito en el estudio. Si está interesado, puede firmar el formulario de consentimiento que encontrará en el siguiente enlace.",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsInPersonStartConsent",
+    "text": "Iniciar consentimiento",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsInPersonError",
+    "text": "Se ha producido un error al cargar la información de su kit. Le rogamos que se ponga en contacto con un miembro del equipo del estudio para recibir asistencia.",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsInPersonCreatedInstructions",
+    "text": "Una vez completado el kit de toma de muestras, por favor, devuélvaselo al miembro del equipo del estudio y permita que escanee su código de participación que figura a continuación.",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsInPersonNoKitInstructions",
+    "text": "Para recibir un kit de toma de muestras, un miembro del equipo del estudio escaneará su código de participación que figura a continuación para asociar el kit a su cuenta.",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsInPersonNoKitSubInstructions",
+    "text": "Después de recibir un kit, actualice esta página para ver la información de su kit y obtener más instrucciones.",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsInPersonCollectedDescription",
+    "text": "Un miembro del equipo del estudio ha recibido su kit de toma de muestras. Recibirá una notificación por correo electrónico cuando se haya procesado su muestra, y podrá ver el estado de la misma en el panel de control del estudio.",
+    "language": "es"
+  },
+  {
+    "keyName": "kitsInPersonCollectedThankYou",
+    "text": "Gracias por su participación.",
+    "language": "es"
+  },
+  {
+    "keyName": "kitTypeSaliva",
+    "text": "Kit para saliva",
+    "language": "es"
+  },
+  {
+    "keyName": "kitTypeStool",
+    "text": "Kit para heces",
+    "language": "es"
+  },
+  {
+    "keyName": "kitTypeBlood",
+    "text": "Kit para sangre",
+    "language": "es"
+  },
+  {
+    "keyName": "documentDownloadButton",
+    "text": "Descargar",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListNone",
+    "text": "Aún no has subido ningún documento",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListCreatedOn",
+    "text": "Creado el",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageTitle",
+    "text": "Documentos",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageUploadedDocumentsTitle",
+    "text": "Documentos cargados",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageMessage",
+    "text": "Mientras participa en un estudio, es posible que se le solicite que cargue documentos como parte de un formulario o encuesta. A continuación, puede administrar los documentos que ha cargado.",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "navbarDocuments",
+    "text": "Documentos",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureTitle",
+    "text": "Estas segura",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureMessage",
+    "text": "¿Está seguro de que desea eliminar este documento? No es posible deshacer esta acción. Tenga en cuenta que si un miembro del personal del estudio ya ha descargado este documento, seguirá teniendo acceso a él. Póngase en contacto con el personal del estudio si desea que el documento se elimine por completo de todos los registros.",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseTitle",
+    "text": "Este documento está en uso",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseMessage",
+    "text": "Este documento se comparte actualmente en respuesta a al menos una encuesta. Elimínelo de las respuestas de la encuesta antes de eliminarlo.",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteButton",
+    "text": "Borrar",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentOptionsButton",
+    "text": "Opciones",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentSharedInResponseTo",
+    "text": "compartido en respuesta a",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderSelectedDocuments",
+    "text": "Documentos seleccionados",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderIncludedInResponse",
+    "text": "Estos documentos están incluidos en su respuesta.",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocumentsSelected",
+    "text": "No se han seleccionado documentos. Cargue un nuevo documento o seleccione uno existente a continuación.",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderAvailableDocuments",
+    "text": "Documentos disponibles",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNotIncludedInResponse",
+    "text": "Estos documentos no están incluidos en su respuesta.",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderClickToUpload",
+    "text": "Suelte los archivos aquí o haga clic para cargarlos",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocuments",
+    "text": "No hay documentos disponibles",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeTitle",
+    "text": "Su sesión está a punto de expirar",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeMessage",
+    "text": "Para mantener la seguridad y proteger sus datos, se cerrará la sesión en ${timeRemaining}.",
+    "language": "es",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "failedToEnroll",
+    "language": "es",
+    "text": "Algo salió mal durante el proceso de inscripción. Por favor, complete el formulario nuevamente.",
+    "machineTranslated": true
+  }
 ]

--- a/populate/src/main/resources/seed/i18n/fr/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/fr/languageTexts.json
@@ -1,163 +1,836 @@
 [
-  {"keyName": "navbarDashboard", "text": "Tableau de bord", "language": "fr"},
-  {"keyName": "navbarChangePassword", "text": "Modifier le mot de passe", "language": "fr"},
-  {"keyName": "navbarLogout", "text": "Déconnexion", "language": "fr"},
-  {"keyName": "profile", "text": "Profil", "language": "fr"},
-  {"keyName": "navbarLogin", "text": "Connexion", "language": "fr"},
-  {"keyName": "navbarJoin", "text": "Inscription", "language": "fr"},
-  {"keyName": "taskComplete", "text": "Terminé", "language": "fr"},
-  {"keyName": "taskInProgress", "text": "En cours", "language": "fr"},
-  {"keyName": "taskNotStarted", "text": "Non commencé", "language": "fr"},
-  {"keyName": "taskDeclined", "text": "Refusé", "language": "fr"},
-  {"keyName": "taskLocked", "text": "Verrouillé", "language": "fr"},
-  {"keyName": "tasksNoneForStudy", "text": "Aucune tâche pour cette étude", "language": "fr"},
-  {"keyName": "taskHistory", "text": "Historique", "language": "fr"},
-  {"keyName": "taskNew", "text": "Nouveau", "language": "fr"},
-  {"keyName": "surveysSomeLocked", "text": "Certaines enquêtes sont verrouillées en attendant l’exécution d’autres tâches obligatoires.", "language": "fr"},
-  {"keyName": "taskTypeSurvey", "text": "Enquête", "language": "fr"},
-  {"keyName": "taskTypeSurveys", "text": "Enquêtes", "language": "fr"},
-  {"keyName": "taskTypeConsent", "text": "Consentement", "language": "fr"},
-  {"keyName": "taskTypeForms", "text": "Formulaires", "language": "fr"},
-  {"keyName": "start", "text": "Démarrer", "language": "fr"},
-  {"keyName": "continue", "text": "Poursuivre", "language": "fr"},
-  {"keyName": "save", "text": "Enregistrer", "language": "fr"},
-  {"keyName": "outreachLearnMore", "text": "En savoir plus", "language": "fr"},
-  {"keyName": "cancel", "text": "Annuler", "language": "fr"},
-  {"keyName": "goBack", "text": "Revenir en arrière", "language": "fr"},
-  {"keyName": "name", "text": "Nom", "language": "fr"},
-  {"keyName": "givenName", "text": "Prénom", "language": "fr"},
-  {"keyName": "familyName", "text": "Nom de famille", "language": "fr"},
-  {"keyName": "editName", "text": "Modifier le nom", "language": "fr"},
-  {"keyName": "editBirthDate", "text": "Modifier la date d’anniversaire", "language": "fr"},
-  {"keyName": "birthDate", "text": "Anniversaire", "language": "fr"},
-  {"keyName": "mailingAddress", "text": "Adresse postale", "language": "fr"},
-  {"keyName": "editMailingAddress", "text": "Modifier l’adresse postale", "language": "fr"},
-  {"keyName": "primaryAddress", "text": "Adresse principale", "language": "fr"},
-  {"keyName": "editPrimaryAddress", "text": "Modifier l’adresse principale", "language": "fr"},
-  {"keyName": "street1", "text": "Rue 1", "language": "fr"},
-  {"keyName": "street2", "text": "Rue 2", "language": "fr"},
-  {"keyName": "city", "text": "Ville", "language": "fr"},
-  {"keyName": "state", "text": "État\/province", "language": "fr"},
-  {"keyName": "postalCode", "text": "Code postal", "language": "fr"},
-  {"keyName": "country", "text": "Pays", "language": "fr"},
-  {"keyName": "communicationPreferences", "text": "Préférences en matière de communication", "language": "fr"},
-  {"keyName": "editCommunicationPreferences", "text": "Modifier les préférences en matière de communication", "language": "fr"},
-  {"keyName": "contactEmail", "text": "E-mail de contact", "language": "fr"},
-  {"keyName": "editContactEmail", "text": "Modifier l’e-mail de contact", "language": "fr"},
-  {"keyName": "phoneNumber", "text": "Numéro de téléphone", "language": "fr"},
-  {"keyName": "editPhoneNumber", "text": "Modifier le numéro de téléphone", "language": "fr"},
-  {"keyName": "doNotSolicit", "text": "Ne pas solliciter", "language": "fr"},
-  {"keyName": "doNotContact", "text": "Ne pas contacter", "language": "fr"},
-  {"keyName": "editDoNotSolicit", "text": "Modifier « Ne pas solliciter »", "language": "fr"},
-  {"keyName": "editNotifications", "text": "Modifier « Notifications »", "language": "fr"},
-  {"keyName": "notifications", "text": "Notifications", "language": "fr"},
-  {"keyName": "on", "text": "Activées", "language": "fr"},
-  {"keyName": "off", "text": "Désactivées", "language": "fr"},
-  {"keyName": "notProvided", "text": "Non fournies", "language": "fr"},
-  {"keyName": "editProfileContactEmailWarning", "text": "Appuyez sur « Save » (Sauvegarder) pour actualiser l’adresse e-mail utilisée pour les communications. Notez que cela ne modifiera pas vos informations de connexion.", "language": "fr"},
-  {"keyName": "privacyPolicy", "text": "Politique de confidentialité", "language": "fr"},
-  {"keyName": "termsOfUse", "text": "Conditions générales", "language": "fr"},
-  {"keyName": "addressInvalidPostalCode", "text": "Nous n’avons pas pu vérifier le code postal.", "language": "fr"},
-  {"keyName": "addressInvalidCountry", "text": "Nous n’avons pas pu vérifier le pays.", "language": "fr"},
-  {"keyName": "addressInvalidState", "text": "Nous n’avons pas pu vérifier l’État\/la province.", "language": "fr"},
-  {"keyName": "addressInvalidCity", "text": "Nous n’avons pas pu vérifier la ville.", "language": "fr"},
-  {"keyName": "addressInvalidHouseNumber", "text": "Nous n’avons pas pu vérifier le numéro du bâtiment.", "language": "fr"},
-  {"keyName": "addressInvalidStreetName", "text": "Nous n’avons pas pu vérifier le nom de la rue.", "language": "fr"},
-  {"keyName": "addressInvalidStreetType", "text": "Nous n’avons pas pu vérifier le type de rue.", "language": "fr"},
-  {"keyName": "addressNeedsSubpremise", "text": "Veuillez indiquer un numéro d’appartement.", "language": "fr"},
-  {"keyName": "addressFailedToValidate", "text": "Nous n’avons pas pu valider votre adresse.", "language": "fr"},
-  {"keyName": "suggestBetterAddressHeader", "text": "Est-ce l’adresse correcte ?", "language": "fr"},
-  {"keyName": "suggestBetterAddressBody", "text": "Nous avons pu vérifier une adresse similaire. Veuillez sélectionner celle que vous souhaitez utiliser.", "language": "fr"},
-  {"keyName": "newAddress", "text": "Nouvelle adresse", "language": "fr"},
-  {"keyName": "oldAddress", "text": "Ancienne adresse", "language": "fr"},
-  {"keyName": "you", "text": "Vous", "language": "fr"},
-  {"keyName": "yourDependent", "text": "La personne à votre charge", "language": "fr"},
-  {"keyName": "youInParens", "text": "(vous)", "language": "fr"},
-  {"keyName": "allProfiles", "text": "Tous les profils", "language": "fr"},
-  {"keyName": "manageProfiles", "text": "Gérer les profils", "language": "fr"},
-  {"keyName": "addNewParticipant", "text": "Ajouter un nouveau participant", "language": "fr"},
-  {"keyName": "dashboard", "text": "Tableau de bord", "language": "fr"},
-  {"keyName": "selectParticipant", "text": "Sélectionner un participant", "language": "fr"},
-  {"keyName": "hubUpdateFormSubmittedTitle", "text": "${formName} rempli", "language": "fr"},
-  {"keyName": "hubUpdateNoActivitiesTitle", "text": "Toutes les activités sont terminées", "language": "fr"},
-  {"keyName": "hubUpdateNoActivitiesDetail", "text": "Vous avez terminé toutes les activités pour cette étude. Nous vous avertirons dès que de nouvelles activités seront disponibles. Nous vous remercions pour votre participation !", "language": "fr"},
-  {"keyName": "hubUpdateWelcomeToStudyTitle", "text": "Bienvenue dans ${studyName}", "language": "fr"},
-  {"keyName": "hubUpdateWelcomeToStudyDetail", "text": "Veuillez lire et signer le formulaire de consentement ci-dessous pour pouvoir continuer.", "language": "fr"},
-  {"keyName": "hubUpdateAlreadyEnrolledTitle", "text": "Vous participez déjà à ${studyName}.", "language": "fr"},
-  {"keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle", "text": "Cet utilisateur participe déjà à ${studyName}.", "language": "fr"},
-  {"keyName": "cookieAlertTitle", "text": "Cookies", "language": "fr"},
-  {"keyName": "cookieAlertDetail", "text": "Ce site utilise des jetons Web appelés « cookies » pour améliorer le fonctionnement et la sécurité de notre site Internet ainsi que votre expérience utilisateur. Tous les cookies que nous utilisons sont des cookies strictement nécessaires. Ce type de cookies ne collecte pas d’informations qui permettent de vous identifier personnellement et n’enregistre pas de renseignements sur vos habitudes de navigation. Pour en savoir plus, [veuillez consulter notre politique de confidentialité](\/confidentialité).", "language": "fr"},
-  {"keyName": "joinStudy", "text": "Rejoindre l’étude", "language": "fr"},
-  {"keyName": "ineligibleThankYou", "text": "Nous vous remercions de votre intérêt pour ${studyName}", "language": "fr" },
-  {"keyName": "ineligibleDescription", "text": "Malheureusement, pour l’instant, vous ne répondez pas aux critères d’éligibilité pour participer à ${studyName}.", "language": "fr"},
-  {"keyName": "ineligibleProvideYourEmail", "text": "Veuillez indiquer ci-dessous votre adresse e-mail, ce qui nous permettra de vous informer des futurs événements. Vous pourrez vous désinscrire à tout moment.", "language":  "fr"},
-  {"keyName": "ineligibleStayInformed", "text": "Rester informé", "language": "fr"},
-  {"keyName": "backToPortalHomepage", "text": "Retour à la page d’accueil ${portalName}", "language": "fr"},
-  {"keyName": "joinMailingList", "text": "S’inscrire sur la liste de diffusion", "language": "fr"},
-  {"keyName": "mailingFormStayUpdated", "text":  "Rester informé des actualités de l’étude", "language": "fr"},
-  {"keyName": "yourName", "text": "Votre nom", "language": "fr"},
-  {"keyName": "yourEmail", "text": "Votre adresse e-mail", "language": "fr"},
-  {"keyName": "join", "text":  "Nous rejoindre", "language": "fr"},
-  {"keyName": "thanksForJoining", "text": "Merci de nous avoir rejoints !", "language": "fr"},
-  {"keyName": "pageNotFoundTitle", "text": "Page introuvable", "language": "fr"},
-  {"keyName": "pageNotFoundMessage", "text": "Si vous pensez qu’il s’agit d’une erreur, veuillez contacter ${studyContactEmail}", "language": "fr"},
-  {"keyName": "pageNotFoundReturnHome", "text": "Retour à la page d’accueil", "language": "fr"},
-  {"keyName": "authErrorPageTitle", "text": "Une erreur est survenue.", "language": "fr"},
-  {"keyName": "authErrorPageMessage", "text": "Une erreur est survenue avec notre service d’authentification. Veuillez réessayer. Si le problème persiste, veuillez contacter ${studyContactEmail}", "language": "fr"},
-  {"keyName": "navbarSampleKits", "text":  "Kits d’échantillons", "language": "fr"},
-  {"keyName": "kitsPageTitle", "text": "Kits de prélèvement d’échantillons", "language": "fr"},
-  {"keyName": "kitsPageDescription", "text": "Les kits de prélèvement d’échantillons représentent une partie importante du déroulement de l’étude et peuvent fournir des renseignements précieux aux chercheurs. Vous trouverez ci-dessous le statut de l’ensemble des kits qui vous ont été fournis.", "language": "fr"},
-  {"keyName": "kitsPageInPersonTitle", "text": "Fournir un échantillon en personne", "language": "fr"},
-  {"keyName": "kitsPageInPersonDescription", "text": "Cette étude propose actuellement la possibilité d’utiliser un kit de prélèvement d’échantillons en personne.", "language": "fr"},
-  {"keyName": "kitsPageInPersonCompleteButton", "text": "Utiliser un kit en personne", "language": "fr"},
-  {"keyName": "kitsPageYourKitsTitle", "text": "Vos kits", "language": "fr"},
-  {"keyName": "kitsPageStatusPreparing", "text": "En cours de préparation", "language": "fr"},
-  {"keyName": "kitsPageStatusShipped", "text": "Expédiés", "language": "fr"},
-  {"keyName": "kitsPageStatusReturned", "text": "Retournés", "language": "fr"},
-  {"keyName": "kitsPageStatusCreated", "text": "Créés", "language": "fr"},
-  {"keyName": "kitsPageStatusCollected", "text": "Recueillis", "language": "fr"},
-  {"keyName": "kitsPageNoKits", "text": "Actuellement, vous ne possédez aucun kit de prélèvement d’échantillons.", "language": "fr"},
-  {"keyName": "kitsInPersonTitle", "text": "Instruction pour le kit d’échantillons", "language": "fr"},
-  {"keyName": "kitsInPersonDescription", "text": "Si vous utilisez un kit de prélèvement d’échantillons en personne, veuillez suivre les instructions fournies par un membre de l’équipe de l’étude. Les informations complémentaires qui pourraient vous être utiles telles que votre identifiant unique de participation sont fournies ci-dessous.", "language": "fr"},
-  {"keyName": "kitsInPersonSubDescription", "text": "Pour toute question, veuillez vous adresser à un membre de l’équipe de l’étude.", "language": "fr"},
-  {"keyName": "kitsInPersonYourKitTitle", "text": "Votre kit de prélèvement d’échantillons", "language": "fr"},
-  {"keyName": "kitsInPersonYourKitDescription", "text": "Un membre de l’équipe vous a fourni un kit de prélèvement d’échantillons. Ce kit d’échantillon est associé à votre compte. Si vous aidez une autre personne à utiliser son kit de prélèvement d’échantillons, veuillez vous assurer que chaque participant utilise le kit de prélèvement d’échantillons qui lui a été attribué.", "language": "fr"},
-  {"keyName": "kitsInPersonYourKitIdentifier", "text": "L’identifiant de votre kit", "language": "fr"},
-  {"keyName": "kitsInPersonReturnToDashboard", "text": "Retour au tableau de bord", "language": "fr"},
-  {"keyName": "kitsInPersonRefreshPage", "text": "Rafraîchir la page", "language": "fr"},
-  {"keyName": "kitsInPersonConsentRequiredTitle", "text": "Consentement nécessaire", "language": "fr"},
-  {"keyName": "kitsInPersonConsentRequiredDescription", "text": "Vous devez être recruté(e) dans l’étude avant d’utiliser un kit de prélèvement d’échantillons. Si cette étude vous intéresse, vous pourrez trouver et signer le formulaire de consentement en cliquant sur le lien ci-dessous.", "language": "fr"},
-  {"keyName": "kitsInPersonStartConsent", "text": "Commencer à remplir le consentement", "language": "fr"},
-  {"keyName": "kitsInPersonError", "text": "Une erreur s’est produite pendant le chargement des informations relatives à votre kit. Veuillez contacter un membre de l’équipe de l’étude pour recevoir l’assistance nécessaire.", "language": "fr"},
-  {"keyName": "kitsInPersonCreatedInstructions", "text": "Après avoir terminé l’utilisation du kit de prélèvement d’échantillons, veuillez le rapporter à un membre de l’équipe de l’étude pour qu’il scanne votre code de participation ci-dessous.", "language": "fr"},
-  {"keyName": "kitsInPersonNoKitInstructions", "text": "Pour pouvoir recevoir un kit de prélèvement d’échantillons, un membre de l’équipe de l’étude doit scanner votre code unique de participation ci-dessous afin d’associer un kit d’échantillons à votre compte.", "language": "fr"},
-  {"keyName": "kitsInPersonNoKitSubInstructions", "text": "Une fois le kit reçu, veuillez rafraîchir cette page pour afficher les informations relatives à votre kit et recevoir de nouvelles instructions.", "language": "fr"},
-  {"keyName": "kitsInPersonCollectedDescription", "text": "Un membre de l’équipe de l’étude a reçu votre kit de prélèvement d’échantillons. Vous recevrez une notification par e-mail lorsque votre échantillon aura été analysé et vous pourrez voir le statut de l’échantillon sur le tableau de bord de votre étude.", "language": "fr"},
-  {"keyName": "kitsInPersonCollectedThankYou", "text": "Nous vous remercions pour votre participation.", "language": "fr"},
-  {"keyName": "kitTypeSaliva", "text": "Kit pour la salive", "language": "fr"},
-  {"keyName": "kitTypeStool", "text": "Kit pour les fèces", "language": "fr"},
-  {"keyName": "kitTypeBlood", "text": "Kit pour le sang", "language": "fr"},
-  {"keyName": "documentDownloadButton", "text": "Télécharger", "language": "fr", "machineTranslated": true},
-  {"keyName": "documentsListNone", "text": "Vous n'avez pas encore téléchargé de documents", "language": "fr", "machineTranslated": true},
-  {"keyName": "documentsListCreatedOn", "text": "Créé le", "language": "fr", "machineTranslated": true},
-  {"keyName": "documentsPageTitle", "text": "Documents", "language": "fr", "machineTranslated": true},
-  {"keyName": "documentsPageUploadedDocumentsTitle", "text": "Documents téléchargés", "language": "fr", "machineTranslated": true},
-  {"keyName": "documentsPageMessage", "text": "Lors de votre participation à une étude, il peut vous être demandé de télécharger des documents dans le cadre d'un formulaire ou d'une enquête. Ci-dessous, vous pouvez gérer les documents que vous avez téléchargés.", "language": "fr", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "Documents", "language": "fr", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureTitle", "text": "Es-tu sûr?", "language": "fr", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureMessage", "text": "Êtes-vous sûr de vouloir supprimer ce document ? Cette opération est irréversible. Veuillez noter que si un membre du personnel de l'étude a déjà téléchargé ce document, il pourra toujours y avoir accès. Veuillez contacter le personnel de l'étude si vous souhaitez que le document soit entièrement supprimé de tous les dossiers.", "language": "fr", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseTitle", "text": "Ce document est en cours d'utilisation", "language": "fr", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseMessage", "text": "Ce document est actuellement partagé en réponse à au moins une enquête. Veuillez le supprimer des réponses à l'enquête avant de le supprimer.", "language": "fr", "machineTranslated": true},
-  {"keyName": "documentDeleteButton", "text": "Supprimer", "language": "fr", "machineTranslated": true},
-  {"keyName": "documentOptionsButton", "text": "Options", "language": "fr", "machineTranslated": true},
-  {"keyName": "documentSharedInResponseTo", "text": "partagé en réponse à", "language": "fr", "machineTranslated": true},
-  {"keyName": "documentUploaderSelectedDocuments", "text": "Documents sélectionnés", "language": "fr", "machineTranslated": true},
-  {"keyName": "documentUploaderIncludedInResponse", "text": "Ces documents sont inclus dans votre réponse", "language": "fr", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocumentsSelected", "text": "Aucun document sélectionné. Veuillez télécharger un nouveau document ou sélectionner un document existant ci-dessous.", "language": "fr", "machineTranslated": true},
-  {"keyName": "documentUploaderAvailableDocuments", "text": "Documents disponibles", "language": "fr", "machineTranslated": true},
-  {"keyName": "documentUploaderNotIncludedInResponse", "text": "Ces documents ne sont pas inclus dans votre réponse", "language": "fr", "machineTranslated": true},
-  {"keyName": "documentUploaderClickToUpload", "text": "Déposez les fichiers ici ou cliquez pour télécharger", "language": "fr", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocuments", "text": "Aucun document disponible", "language": "fr", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeTitle", "text": "Votre session est sur le point d'expirer", "language": "fr", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeMessage", "text": "Pour maintenir la sécurité et protéger vos données, vous serez déconnecté dans ${timeRemaining}.", "language": "fr", "machineTranslated": true}
+  {
+    "keyName": "navbarDashboard",
+    "text": "Tableau de bord",
+    "language": "fr"
+  },
+  {
+    "keyName": "navbarChangePassword",
+    "text": "Modifier le mot de passe",
+    "language": "fr"
+  },
+  {
+    "keyName": "navbarLogout",
+    "text": "Déconnexion",
+    "language": "fr"
+  },
+  {
+    "keyName": "profile",
+    "text": "Profil",
+    "language": "fr"
+  },
+  {
+    "keyName": "navbarLogin",
+    "text": "Connexion",
+    "language": "fr"
+  },
+  {
+    "keyName": "navbarJoin",
+    "text": "Inscription",
+    "language": "fr"
+  },
+  {
+    "keyName": "taskComplete",
+    "text": "Terminé",
+    "language": "fr"
+  },
+  {
+    "keyName": "taskInProgress",
+    "text": "En cours",
+    "language": "fr"
+  },
+  {
+    "keyName": "taskNotStarted",
+    "text": "Non commencé",
+    "language": "fr"
+  },
+  {
+    "keyName": "taskDeclined",
+    "text": "Refusé",
+    "language": "fr"
+  },
+  {
+    "keyName": "taskLocked",
+    "text": "Verrouillé",
+    "language": "fr"
+  },
+  {
+    "keyName": "tasksNoneForStudy",
+    "text": "Aucune tâche pour cette étude",
+    "language": "fr"
+  },
+  {
+    "keyName": "taskHistory",
+    "text": "Historique",
+    "language": "fr"
+  },
+  {
+    "keyName": "taskNew",
+    "text": "Nouveau",
+    "language": "fr"
+  },
+  {
+    "keyName": "surveysSomeLocked",
+    "text": "Certaines enquêtes sont verrouillées en attendant l’exécution d’autres tâches obligatoires.",
+    "language": "fr"
+  },
+  {
+    "keyName": "taskTypeSurvey",
+    "text": "Enquête",
+    "language": "fr"
+  },
+  {
+    "keyName": "taskTypeSurveys",
+    "text": "Enquêtes",
+    "language": "fr"
+  },
+  {
+    "keyName": "taskTypeConsent",
+    "text": "Consentement",
+    "language": "fr"
+  },
+  {
+    "keyName": "taskTypeForms",
+    "text": "Formulaires",
+    "language": "fr"
+  },
+  {
+    "keyName": "start",
+    "text": "Démarrer",
+    "language": "fr"
+  },
+  {
+    "keyName": "continue",
+    "text": "Poursuivre",
+    "language": "fr"
+  },
+  {
+    "keyName": "save",
+    "text": "Enregistrer",
+    "language": "fr"
+  },
+  {
+    "keyName": "outreachLearnMore",
+    "text": "En savoir plus",
+    "language": "fr"
+  },
+  {
+    "keyName": "cancel",
+    "text": "Annuler",
+    "language": "fr"
+  },
+  {
+    "keyName": "goBack",
+    "text": "Revenir en arrière",
+    "language": "fr"
+  },
+  {
+    "keyName": "name",
+    "text": "Nom",
+    "language": "fr"
+  },
+  {
+    "keyName": "givenName",
+    "text": "Prénom",
+    "language": "fr"
+  },
+  {
+    "keyName": "familyName",
+    "text": "Nom de famille",
+    "language": "fr"
+  },
+  {
+    "keyName": "editName",
+    "text": "Modifier le nom",
+    "language": "fr"
+  },
+  {
+    "keyName": "editBirthDate",
+    "text": "Modifier la date d’anniversaire",
+    "language": "fr"
+  },
+  {
+    "keyName": "birthDate",
+    "text": "Anniversaire",
+    "language": "fr"
+  },
+  {
+    "keyName": "mailingAddress",
+    "text": "Adresse postale",
+    "language": "fr"
+  },
+  {
+    "keyName": "editMailingAddress",
+    "text": "Modifier l’adresse postale",
+    "language": "fr"
+  },
+  {
+    "keyName": "primaryAddress",
+    "text": "Adresse principale",
+    "language": "fr"
+  },
+  {
+    "keyName": "editPrimaryAddress",
+    "text": "Modifier l’adresse principale",
+    "language": "fr"
+  },
+  {
+    "keyName": "street1",
+    "text": "Rue 1",
+    "language": "fr"
+  },
+  {
+    "keyName": "street2",
+    "text": "Rue 2",
+    "language": "fr"
+  },
+  {
+    "keyName": "city",
+    "text": "Ville",
+    "language": "fr"
+  },
+  {
+    "keyName": "state",
+    "text": "État/province",
+    "language": "fr"
+  },
+  {
+    "keyName": "postalCode",
+    "text": "Code postal",
+    "language": "fr"
+  },
+  {
+    "keyName": "country",
+    "text": "Pays",
+    "language": "fr"
+  },
+  {
+    "keyName": "communicationPreferences",
+    "text": "Préférences en matière de communication",
+    "language": "fr"
+  },
+  {
+    "keyName": "editCommunicationPreferences",
+    "text": "Modifier les préférences en matière de communication",
+    "language": "fr"
+  },
+  {
+    "keyName": "contactEmail",
+    "text": "E-mail de contact",
+    "language": "fr"
+  },
+  {
+    "keyName": "editContactEmail",
+    "text": "Modifier l’e-mail de contact",
+    "language": "fr"
+  },
+  {
+    "keyName": "phoneNumber",
+    "text": "Numéro de téléphone",
+    "language": "fr"
+  },
+  {
+    "keyName": "editPhoneNumber",
+    "text": "Modifier le numéro de téléphone",
+    "language": "fr"
+  },
+  {
+    "keyName": "doNotSolicit",
+    "text": "Ne pas solliciter",
+    "language": "fr"
+  },
+  {
+    "keyName": "doNotContact",
+    "text": "Ne pas contacter",
+    "language": "fr"
+  },
+  {
+    "keyName": "editDoNotSolicit",
+    "text": "Modifier « Ne pas solliciter »",
+    "language": "fr"
+  },
+  {
+    "keyName": "editNotifications",
+    "text": "Modifier « Notifications »",
+    "language": "fr"
+  },
+  {
+    "keyName": "notifications",
+    "text": "Notifications",
+    "language": "fr"
+  },
+  {
+    "keyName": "on",
+    "text": "Activées",
+    "language": "fr"
+  },
+  {
+    "keyName": "off",
+    "text": "Désactivées",
+    "language": "fr"
+  },
+  {
+    "keyName": "notProvided",
+    "text": "Non fournies",
+    "language": "fr"
+  },
+  {
+    "keyName": "editProfileContactEmailWarning",
+    "text": "Appuyez sur « Save » (Sauvegarder) pour actualiser l’adresse e-mail utilisée pour les communications. Notez que cela ne modifiera pas vos informations de connexion.",
+    "language": "fr"
+  },
+  {
+    "keyName": "privacyPolicy",
+    "text": "Politique de confidentialité",
+    "language": "fr"
+  },
+  {
+    "keyName": "termsOfUse",
+    "text": "Conditions générales",
+    "language": "fr"
+  },
+  {
+    "keyName": "addressInvalidPostalCode",
+    "text": "Nous n’avons pas pu vérifier le code postal.",
+    "language": "fr"
+  },
+  {
+    "keyName": "addressInvalidCountry",
+    "text": "Nous n’avons pas pu vérifier le pays.",
+    "language": "fr"
+  },
+  {
+    "keyName": "addressInvalidState",
+    "text": "Nous n’avons pas pu vérifier l’État/la province.",
+    "language": "fr"
+  },
+  {
+    "keyName": "addressInvalidCity",
+    "text": "Nous n’avons pas pu vérifier la ville.",
+    "language": "fr"
+  },
+  {
+    "keyName": "addressInvalidHouseNumber",
+    "text": "Nous n’avons pas pu vérifier le numéro du bâtiment.",
+    "language": "fr"
+  },
+  {
+    "keyName": "addressInvalidStreetName",
+    "text": "Nous n’avons pas pu vérifier le nom de la rue.",
+    "language": "fr"
+  },
+  {
+    "keyName": "addressInvalidStreetType",
+    "text": "Nous n’avons pas pu vérifier le type de rue.",
+    "language": "fr"
+  },
+  {
+    "keyName": "addressNeedsSubpremise",
+    "text": "Veuillez indiquer un numéro d’appartement.",
+    "language": "fr"
+  },
+  {
+    "keyName": "addressFailedToValidate",
+    "text": "Nous n’avons pas pu valider votre adresse.",
+    "language": "fr"
+  },
+  {
+    "keyName": "suggestBetterAddressHeader",
+    "text": "Est-ce l’adresse correcte ?",
+    "language": "fr"
+  },
+  {
+    "keyName": "suggestBetterAddressBody",
+    "text": "Nous avons pu vérifier une adresse similaire. Veuillez sélectionner celle que vous souhaitez utiliser.",
+    "language": "fr"
+  },
+  {
+    "keyName": "newAddress",
+    "text": "Nouvelle adresse",
+    "language": "fr"
+  },
+  {
+    "keyName": "oldAddress",
+    "text": "Ancienne adresse",
+    "language": "fr"
+  },
+  {
+    "keyName": "you",
+    "text": "Vous",
+    "language": "fr"
+  },
+  {
+    "keyName": "yourDependent",
+    "text": "La personne à votre charge",
+    "language": "fr"
+  },
+  {
+    "keyName": "youInParens",
+    "text": "(vous)",
+    "language": "fr"
+  },
+  {
+    "keyName": "allProfiles",
+    "text": "Tous les profils",
+    "language": "fr"
+  },
+  {
+    "keyName": "manageProfiles",
+    "text": "Gérer les profils",
+    "language": "fr"
+  },
+  {
+    "keyName": "addNewParticipant",
+    "text": "Ajouter un nouveau participant",
+    "language": "fr"
+  },
+  {
+    "keyName": "dashboard",
+    "text": "Tableau de bord",
+    "language": "fr"
+  },
+  {
+    "keyName": "selectParticipant",
+    "text": "Sélectionner un participant",
+    "language": "fr"
+  },
+  {
+    "keyName": "hubUpdateFormSubmittedTitle",
+    "text": "${formName} rempli",
+    "language": "fr"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesTitle",
+    "text": "Toutes les activités sont terminées",
+    "language": "fr"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesDetail",
+    "text": "Vous avez terminé toutes les activités pour cette étude. Nous vous avertirons dès que de nouvelles activités seront disponibles. Nous vous remercions pour votre participation !",
+    "language": "fr"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyTitle",
+    "text": "Bienvenue dans ${studyName}",
+    "language": "fr"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyDetail",
+    "text": "Veuillez lire et signer le formulaire de consentement ci-dessous pour pouvoir continuer.",
+    "language": "fr"
+  },
+  {
+    "keyName": "hubUpdateAlreadyEnrolledTitle",
+    "text": "Vous participez déjà à ${studyName}.",
+    "language": "fr"
+  },
+  {
+    "keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle",
+    "text": "Cet utilisateur participe déjà à ${studyName}.",
+    "language": "fr"
+  },
+  {
+    "keyName": "cookieAlertTitle",
+    "text": "Cookies",
+    "language": "fr"
+  },
+  {
+    "keyName": "cookieAlertDetail",
+    "text": "Ce site utilise des jetons Web appelés « cookies » pour améliorer le fonctionnement et la sécurité de notre site Internet ainsi que votre expérience utilisateur. Tous les cookies que nous utilisons sont des cookies strictement nécessaires. Ce type de cookies ne collecte pas d’informations qui permettent de vous identifier personnellement et n’enregistre pas de renseignements sur vos habitudes de navigation. Pour en savoir plus, [veuillez consulter notre politique de confidentialité](/confidentialité).",
+    "language": "fr"
+  },
+  {
+    "keyName": "joinStudy",
+    "text": "Rejoindre l’étude",
+    "language": "fr"
+  },
+  {
+    "keyName": "ineligibleThankYou",
+    "text": "Nous vous remercions de votre intérêt pour ${studyName}",
+    "language": "fr"
+  },
+  {
+    "keyName": "ineligibleDescription",
+    "text": "Malheureusement, pour l’instant, vous ne répondez pas aux critères d’éligibilité pour participer à ${studyName}.",
+    "language": "fr"
+  },
+  {
+    "keyName": "ineligibleProvideYourEmail",
+    "text": "Veuillez indiquer ci-dessous votre adresse e-mail, ce qui nous permettra de vous informer des futurs événements. Vous pourrez vous désinscrire à tout moment.",
+    "language": "fr"
+  },
+  {
+    "keyName": "ineligibleStayInformed",
+    "text": "Rester informé",
+    "language": "fr"
+  },
+  {
+    "keyName": "backToPortalHomepage",
+    "text": "Retour à la page d’accueil ${portalName}",
+    "language": "fr"
+  },
+  {
+    "keyName": "joinMailingList",
+    "text": "S’inscrire sur la liste de diffusion",
+    "language": "fr"
+  },
+  {
+    "keyName": "mailingFormStayUpdated",
+    "text": "Rester informé des actualités de l’étude",
+    "language": "fr"
+  },
+  {
+    "keyName": "yourName",
+    "text": "Votre nom",
+    "language": "fr"
+  },
+  {
+    "keyName": "yourEmail",
+    "text": "Votre adresse e-mail",
+    "language": "fr"
+  },
+  {
+    "keyName": "join",
+    "text": "Nous rejoindre",
+    "language": "fr"
+  },
+  {
+    "keyName": "thanksForJoining",
+    "text": "Merci de nous avoir rejoints !",
+    "language": "fr"
+  },
+  {
+    "keyName": "pageNotFoundTitle",
+    "text": "Page introuvable",
+    "language": "fr"
+  },
+  {
+    "keyName": "pageNotFoundMessage",
+    "text": "Si vous pensez qu’il s’agit d’une erreur, veuillez contacter ${studyContactEmail}",
+    "language": "fr"
+  },
+  {
+    "keyName": "pageNotFoundReturnHome",
+    "text": "Retour à la page d’accueil",
+    "language": "fr"
+  },
+  {
+    "keyName": "authErrorPageTitle",
+    "text": "Une erreur est survenue.",
+    "language": "fr"
+  },
+  {
+    "keyName": "authErrorPageMessage",
+    "text": "Une erreur est survenue avec notre service d’authentification. Veuillez réessayer. Si le problème persiste, veuillez contacter ${studyContactEmail}",
+    "language": "fr"
+  },
+  {
+    "keyName": "navbarSampleKits",
+    "text": "Kits d’échantillons",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsPageTitle",
+    "text": "Kits de prélèvement d’échantillons",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsPageDescription",
+    "text": "Les kits de prélèvement d’échantillons représentent une partie importante du déroulement de l’étude et peuvent fournir des renseignements précieux aux chercheurs. Vous trouverez ci-dessous le statut de l’ensemble des kits qui vous ont été fournis.",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsPageInPersonTitle",
+    "text": "Fournir un échantillon en personne",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsPageInPersonDescription",
+    "text": "Cette étude propose actuellement la possibilité d’utiliser un kit de prélèvement d’échantillons en personne.",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsPageInPersonCompleteButton",
+    "text": "Utiliser un kit en personne",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsPageYourKitsTitle",
+    "text": "Vos kits",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsPageStatusPreparing",
+    "text": "En cours de préparation",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsPageStatusShipped",
+    "text": "Expédiés",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsPageStatusReturned",
+    "text": "Retournés",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsPageStatusCreated",
+    "text": "Créés",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsPageStatusCollected",
+    "text": "Recueillis",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsPageNoKits",
+    "text": "Actuellement, vous ne possédez aucun kit de prélèvement d’échantillons.",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsInPersonTitle",
+    "text": "Instruction pour le kit d’échantillons",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsInPersonDescription",
+    "text": "Si vous utilisez un kit de prélèvement d’échantillons en personne, veuillez suivre les instructions fournies par un membre de l’équipe de l’étude. Les informations complémentaires qui pourraient vous être utiles telles que votre identifiant unique de participation sont fournies ci-dessous.",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsInPersonSubDescription",
+    "text": "Pour toute question, veuillez vous adresser à un membre de l’équipe de l’étude.",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsInPersonYourKitTitle",
+    "text": "Votre kit de prélèvement d’échantillons",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsInPersonYourKitDescription",
+    "text": "Un membre de l’équipe vous a fourni un kit de prélèvement d’échantillons. Ce kit d’échantillon est associé à votre compte. Si vous aidez une autre personne à utiliser son kit de prélèvement d’échantillons, veuillez vous assurer que chaque participant utilise le kit de prélèvement d’échantillons qui lui a été attribué.",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsInPersonYourKitIdentifier",
+    "text": "L’identifiant de votre kit",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsInPersonReturnToDashboard",
+    "text": "Retour au tableau de bord",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsInPersonRefreshPage",
+    "text": "Rafraîchir la page",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredTitle",
+    "text": "Consentement nécessaire",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredDescription",
+    "text": "Vous devez être recruté(e) dans l’étude avant d’utiliser un kit de prélèvement d’échantillons. Si cette étude vous intéresse, vous pourrez trouver et signer le formulaire de consentement en cliquant sur le lien ci-dessous.",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsInPersonStartConsent",
+    "text": "Commencer à remplir le consentement",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsInPersonError",
+    "text": "Une erreur s’est produite pendant le chargement des informations relatives à votre kit. Veuillez contacter un membre de l’équipe de l’étude pour recevoir l’assistance nécessaire.",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsInPersonCreatedInstructions",
+    "text": "Après avoir terminé l’utilisation du kit de prélèvement d’échantillons, veuillez le rapporter à un membre de l’équipe de l’étude pour qu’il scanne votre code de participation ci-dessous.",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsInPersonNoKitInstructions",
+    "text": "Pour pouvoir recevoir un kit de prélèvement d’échantillons, un membre de l’équipe de l’étude doit scanner votre code unique de participation ci-dessous afin d’associer un kit d’échantillons à votre compte.",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsInPersonNoKitSubInstructions",
+    "text": "Une fois le kit reçu, veuillez rafraîchir cette page pour afficher les informations relatives à votre kit et recevoir de nouvelles instructions.",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsInPersonCollectedDescription",
+    "text": "Un membre de l’équipe de l’étude a reçu votre kit de prélèvement d’échantillons. Vous recevrez une notification par e-mail lorsque votre échantillon aura été analysé et vous pourrez voir le statut de l’échantillon sur le tableau de bord de votre étude.",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitsInPersonCollectedThankYou",
+    "text": "Nous vous remercions pour votre participation.",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitTypeSaliva",
+    "text": "Kit pour la salive",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitTypeStool",
+    "text": "Kit pour les fèces",
+    "language": "fr"
+  },
+  {
+    "keyName": "kitTypeBlood",
+    "text": "Kit pour le sang",
+    "language": "fr"
+  },
+  {
+    "keyName": "documentDownloadButton",
+    "text": "Télécharger",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListNone",
+    "text": "Vous n'avez pas encore téléchargé de documents",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListCreatedOn",
+    "text": "Créé le",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageTitle",
+    "text": "Documents",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageUploadedDocumentsTitle",
+    "text": "Documents téléchargés",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageMessage",
+    "text": "Lors de votre participation à une étude, il peut vous être demandé de télécharger des documents dans le cadre d'un formulaire ou d'une enquête. Ci-dessous, vous pouvez gérer les documents que vous avez téléchargés.",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "navbarDocuments",
+    "text": "Documents",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureTitle",
+    "text": "Es-tu sûr?",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureMessage",
+    "text": "Êtes-vous sûr de vouloir supprimer ce document ? Cette opération est irréversible. Veuillez noter que si un membre du personnel de l'étude a déjà téléchargé ce document, il pourra toujours y avoir accès. Veuillez contacter le personnel de l'étude si vous souhaitez que le document soit entièrement supprimé de tous les dossiers.",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseTitle",
+    "text": "Ce document est en cours d'utilisation",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseMessage",
+    "text": "Ce document est actuellement partagé en réponse à au moins une enquête. Veuillez le supprimer des réponses à l'enquête avant de le supprimer.",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteButton",
+    "text": "Supprimer",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentOptionsButton",
+    "text": "Options",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentSharedInResponseTo",
+    "text": "partagé en réponse à",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderSelectedDocuments",
+    "text": "Documents sélectionnés",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderIncludedInResponse",
+    "text": "Ces documents sont inclus dans votre réponse",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocumentsSelected",
+    "text": "Aucun document sélectionné. Veuillez télécharger un nouveau document ou sélectionner un document existant ci-dessous.",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderAvailableDocuments",
+    "text": "Documents disponibles",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNotIncludedInResponse",
+    "text": "Ces documents ne sont pas inclus dans votre réponse",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderClickToUpload",
+    "text": "Déposez les fichiers ici ou cliquez pour télécharger",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocuments",
+    "text": "Aucun document disponible",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeTitle",
+    "text": "Votre session est sur le point d'expirer",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeMessage",
+    "text": "Pour maintenir la sécurité et protéger vos données, vous serez déconnecté dans ${timeRemaining}.",
+    "language": "fr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "failedToEnroll",
+    "language": "fr",
+    "text": "Quelque chose s'est mal passé pendant le processus d'inscription. Veuillez remplir à nouveau le formulaire.",
+    "machineTranslated": true
+  }
 ]

--- a/populate/src/main/resources/seed/i18n/hi/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/hi/languageTexts.json
@@ -1,163 +1,836 @@
 [
-  {"keyName": "navbarDashboard", "text": "डैशबोर्ड", "language": "hi"},
-  {"keyName": "navbarChangePassword", "text": "पासवर्ड बदलें", "language": "hi"},
-  {"keyName": "navbarLogout", "text": "लॉग आउट करें", "language": "hi"},
-  {"keyName": "profile", "text": "प्रोफ़ाइल", "language": "hi"},
-  {"keyName": "navbarLogin", "text": "लॉग इन करें", "language": "hi"},
-  {"keyName": "navbarJoin", "text": "रजिस्टर करें", "language": "hi"},
-  {"keyName": "taskComplete", "text": "पूरा करें", "language": "hi"},
-  {"keyName": "taskInProgress", "text": "प्रगति में है", "language": "hi"},
-  {"keyName": "taskNotStarted", "text": "शुरू नहीं हुआ", "language": "hi"},
-  {"keyName": "taskDeclined", "text": "अस्वीकार किया गया", "language": "hi"},
-  {"keyName": "taskLocked", "text": "लॉक किया गया", "language": "hi"},
-  {"keyName": "tasksNoneForStudy", "text": "इस स्टडी के लिए कोई टास्क नहीं", "language": "hi"},
-  {"keyName": "taskHistory", "text": "इतिहास", "language": "hi"},
-  {"keyName": "taskNew", "text": "नया", "language": "hi"},
-  {"keyName": "surveysSomeLocked", "text": "कुछ सर्वेक्षण तब तक के लिए लॉक किए गए हैं, जब तक दूसरे आवश्यक टास्क पूरे नहीं हो जाते।", "language": "hi"},
-  {"keyName": "taskTypeSurvey", "text": "सर्वेक्षण", "language": "hi"},
-  {"keyName": "taskTypeSurveys", "text": "सर्वेक्षण", "language": "hi"},
-  {"keyName": "taskTypeConsent", "text": "सहमति", "language": "hi"},
-  {"keyName": "taskTypeForms", "text": "फ़ॉर्म", "language": "hi"},
-  {"keyName": "start", "text": "शुरू करें", "language": "hi"},
-  {"keyName": "continue", "text": "जारी रखें", "language": "hi"},
-  {"keyName": "save", "text": "सेव करें", "language": "hi"},
-  {"keyName": "outreachLearnMore", "text": "अधिक जानें", "language": "hi"},
-  {"keyName": "cancel", "text": "रद्द करें", "language": "hi"},
-  {"keyName": "goBack", "text": "वापस जाएँ", "language": "hi"},
-  {"keyName": "name", "text": "नाम", "language": "hi"},
-  {"keyName": "givenName", "text": "प्रथम नाम", "language": "hi"},
-  {"keyName": "familyName", "text": "कुलनाम", "language": "hi"},
-  {"keyName": "editName", "text": "नाम में बदलाव करें", "language": "hi"},
-  {"keyName": "editBirthDate", "text": "जन्मदिन में बदलाव करें", "language": "hi"},
-  {"keyName": "birthDate", "text": "जन्मदिन", "language": "hi"},
-  {"keyName": "mailingAddress", "text": "डाक पता", "language": "hi"},
-  {"keyName": "editMailingAddress", "text": "डाक पता में बदलाव करें", "language": "hi"},
-  {"keyName": "primaryAddress", "text": "मुख्य पता", "language": "hi"},
-  {"keyName": "editPrimaryAddress", "text": "मुख्य पते में बदलाव करें", "language": "hi"},
-  {"keyName": "street1", "text": "सड़क 1", "language": "hi"},
-  {"keyName": "street2", "text": "सड़क 2", "language": "hi"},
-  {"keyName": "city", "text": "शहर", "language": "hi"},
-  {"keyName": "state", "text": "राज्य\/प्रांत", "language": "hi"},
-  {"keyName": "postalCode", "text": "पिन कोड", "language": "hi"},
-  {"keyName": "country", "text": "देश", "language": "hi"},
-  {"keyName": "communicationPreferences", "text": "संचार की प्राथमिकताएँ", "language": "hi"},
-  {"keyName": "editCommunicationPreferences", "text": "संचार की प्राथमिकताएँ संपादित करें", "language": "hi"},
-  {"keyName": "contactEmail", "text": "संपर्क ईमेल", "language": "hi"},
-  {"keyName": "editContactEmail", "text": "संपर्क ईमेल में बदलाव करें", "language": "hi"},
-  {"keyName": "phoneNumber", "text": "फ़ोन नंबर", "language": "hi"},
-  {"keyName": "editPhoneNumber", "text": "फ़ोन नंबर में बदलाव करें", "language": "hi"},
-  {"keyName": "doNotSolicit", "text": "माँगें नहीं", "language": "hi"},
-  {"keyName": "doNotContact", "text": "संपर्क न करें", "language": "hi"},
-  {"keyName": "editDoNotSolicit", "text": "'माँगें नहीं' में बदलाव करें", "language": "hi"},
-  {"keyName": "editNotifications", "text": "नोटिफ़िकेशन में बदलाव करें", "language": "hi"},
-  {"keyName": "notifications", "text": "नोटिफ़िकेशन", "language": "hi"},
-  {"keyName": "on", "text": "चालू करें", "language": "hi"},
-  {"keyName": "off", "text": "बंद करें", "language": "hi"},
-  {"keyName": "notProvided", "text": "प्रदान नहीं किया गया", "language": "hi"},
-  {"keyName": "editProfileContactEmailWarning", "text": "संचार के लिए इस्तेमाल किए गए ईमेल को अपडेट करने के लिए \"सेव करें\" को दबाएँ। ध्यान दें कि आपकी लॉगइन जानकारी नहीं बदलेगी।", "language": "hi"},
-  {"keyName": "privacyPolicy", "text": "निजता नीति", "language": "hi"},
-  {"keyName": "termsOfUse", "text": "उपयोग की शर्तें", "language": "hi"},
-  {"keyName": "addressInvalidPostalCode", "text": "पिन कोड को सत्यापित नहीं किया जा सका।", "language": "hi"},
-  {"keyName": "addressInvalidCountry", "text": "देश को सत्यापित नहीं किया जा सका।", "language": "hi"},
-  {"keyName": "addressInvalidState", "text": "राज्य\/प्रांत को सत्यापित नहीं किया जा सका।", "language": "hi"},
-  {"keyName": "addressInvalidCity", "text": "शहर को सत्यापित नहीं किया जा सका।", "language": "hi"},
-  {"keyName": "addressInvalidHouseNumber", "text": "मकान नंबर को सत्यापित नहीं किया जा सका।", "language": "hi"},
-  {"keyName": "addressInvalidStreetName", "text": "सड़क के नाम को सत्यापित नहीं किया जा सका।", "language": "hi"},
-  {"keyName": "addressInvalidStreetType", "text": "सड़क के प्रकार को सत्यापित नहीं किया जा सका।", "language": "hi"},
-  {"keyName": "addressNeedsSubpremise", "text": "कृपया यूनिट\/स्वीट नंबर प्रदान करें।", "language": "hi"},
-  {"keyName": "addressFailedToValidate", "text": "पते की पुष्टि नहीं की जा सकी।", "language": "hi"},
-  {"keyName": "suggestBetterAddressHeader", "text": "क्या यह सही पता है?", "language": "hi"},
-  {"keyName": "suggestBetterAddressBody", "text": "हम एक मिलते-जुलते पते का सत्यापन कर पाए थे। कृपया चुनें कि आप किसका इस्तेमाल करना चाहेंगे।", "language": "hi"},
-  {"keyName": "newAddress", "text": "नया पता", "language": "hi"},
-  {"keyName": "oldAddress", "text": "पुराना पता", "language": "hi"},
-  {"keyName": "you", "text": "आप", "language": "hi"},
-  {"keyName": "yourDependent", "text": "आपका आश्रित", "language": "hi"},
-  {"keyName": "youInParens", "text": "(आप)", "language": "hi"},
-  {"keyName": "allProfiles", "text": "सभी प्रोफ़ाइलें", "language": "hi"},
-  {"keyName": "manageProfiles", "text": "प्रोफ़ाइलें प्रबंधित करें", "language": "hi"},
-  {"keyName": "addNewParticipant", "text": "नया प्रतिभागी जोड़ें", "language": "hi"},
-  {"keyName": "dashboard", "text": "डैशबोर्ड", "language": "hi"},
-  {"keyName": "selectParticipant", "text": "प्रतिभागी का चयन करें", "language": "hi"},
-  {"keyName": "hubUpdateFormSubmittedTitle", "text": "${formName} पूरा हुआ", "language": "hi"},
-  {"keyName": "hubUpdateNoActivitiesTitle", "text": "सभी गतिविधियाँ पूर्ण", "language": "hi"},
-  {"keyName": "hubUpdateNoActivitiesDetail", "text": "आपने इस स्टडी के लिए सभी गतिविधियाँ पूरी कर ली हैं। नई गतिविधियाँ उपलब्ध होते ही, हम आपको सूचना देंगे। आपकी भागीदारी के लिए धन्यवाद!", "language": "hi"},
-  {"keyName": "hubUpdateWelcomeToStudyTitle", "text": "${studyName} में आपका स्वागत है", "language": "hi"},
-  {"keyName": "hubUpdateWelcomeToStudyDetail", "text": "जारी रखने के लिए, कृपया नीचे दिए गए सहमति फ़ॉर्म को पढ़कर उस पर हस्ताक्षर करें।", "language": "hi"},
-  {"keyName": "hubUpdateAlreadyEnrolledTitle", "text": "आप पहले से ही ${studyName} में नामांकित हैं।", "language": "hi"},
-  {"keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle", "text": "यह उपयोगकर्ता पहले से ही ${studyName} में नामांकित है।", "language": "hi"},
-  {"keyName": "cookieAlertTitle", "text": "कुकीज़", "language": "hi"},
-  {"keyName": "cookieAlertDetail", "text": "यह साइट हमारी वेबसाइट के सही तरीके से काम करने और उसे सुरक्षित रखने के लिए, और आपके द्वारा उसका उपयोग किए जाने के दौरान आपका अनुभव बेहतर बनाने के लिए, \"कुकीज़\" नामक इंटरनेट टोकनों का इस्तेमाल करती है। हम जो कुकीज़ इस्तेमाल करते हैं वे सभी पूरी तरह से ज़रूरी कुकीज़ होती हैं। इस तरह की कुकी व्यक्तिगत रूप से पहचान योग्य कोई भी जानकारी आपके बारे में एकत्र नहीं करती है और ब्राउज़ करने की आपकी आदतों को ट्रैक नहीं करती है। अधिक जानने के लिए, [हमारी निजता नीति पढ़ें](\/privacy)।", "language": "hi"},
-  {"keyName": "joinStudy", "text": "स्टडी में शामिल हों", "language": "hi"},
-  {"keyName": "ineligibleThankYou", "text": "${studyName} में आपकी रुचि के लिए धन्यवाद", "language": "hi" },
-  {"keyName": "ineligibleDescription", "text": "खेद है कि आप अभी ${studyName} में भाग लेने की पात्रता के मानदंडों को पूरा नहीं करते हैं।", "language": "hi"},
-  {"keyName": "ineligibleProvideYourEmail", "text": "नीचे अपना ईमेल प्रदान करें और हम आपको घटनाक्रम के बारे में अपडेट देते रहेंगे। आप किसी भी समय अनसब्सक्राइब कर सकते हैं।", "language":  "hi"},
-  {"keyName": "ineligibleStayInformed", "text": "सूचना पाते रहें", "language": "hi"},
-  {"keyName": "backToPortalHomepage", "text": "${portalName} के होमपेज पर वापस जाएँ", "language": "hi"},
-  {"keyName": "joinMailingList", "text": "मेलिंग लिस्ट में शामिल हों", "language": "hi"},
-  {"keyName": "mailingFormStayUpdated", "text":  "स्टडी के बारे में समाचारों के अपडेट पाते रहें", "language": "hi"},
-  {"keyName": "yourName", "text": "आपका नाम", "language": "hi"},
-  {"keyName": "yourEmail", "text": "आपका ईमेल", "language": "hi"},
-  {"keyName": "join", "text":  "शामिल हों", "language": "hi"},
-  {"keyName": "thanksForJoining", "text": "शामिल होने के लिए धन्यवाद!", "language": "hi"},
-  {"keyName": "pageNotFoundTitle", "text": "पेज नहीं मिला", "language": "hi"},
-  {"keyName": "pageNotFoundMessage", "text": "अगर आपको लगता है कि यह गलती से हुआ है, तो कृपया ${studyContactEmail} से संपर्क करें", "language": "hi"},
-  {"keyName": "pageNotFoundReturnHome", "text": "होम पेज पर वापस जाएँ", "language": "hi"},
-  {"keyName": "authErrorPageTitle", "text": "कुछ गड़बड़ी हुई", "language": "hi"},
-  {"keyName": "authErrorPageMessage", "text": "हमारी प्रमाणीकरण सेवा में कोई समस्या पेश आई। कृपया फिर से कोशिश करें। अगर समस्या बनी रहती है, तो कृपया ${studyContactEmail} से संपर्क करें।", "language": "hi"},
-  {"keyName": "navbarSampleKits", "text":  "सैंपल किटें", "language": "hi"},
-  {"keyName": "kitsPageTitle", "text": "सैंपल एकत्रीकरण किटें", "language": "hi"},
-  {"keyName": "kitsPageDescription", "text": "सैंपल एकत्रीकरण किटें, स्टडी की प्रक्रिया का एक अहम हिस्सा हैं और इनकी मदद से शोधकर्ताओं को ज़रूरी गहन-जानकारी मिल सकती है। नीचे आपको उन सभी किटों की स्थिति के बारे में जानकारी मिलेगी जो आपको दी गईं थीं।", "language": "hi"},
-  {"keyName": "kitsPageInPersonTitle", "text": "साक्षात व्यक्तिगत रूप से सैंपल दें", "language": "hi"},
-  {"keyName": "kitsPageInPersonDescription", "text": "वर्तमान में यह स्टडी साक्षात व्यक्तिगत रूप से सैंपल एकत्रीकरण किट को पूरा करने का विकल्प दे रही है।", "language": "hi"},
-  {"keyName": "kitsPageInPersonCompleteButton", "text": "साक्षात व्यक्तिगत रूप से किट पूरी करें", "language": "hi"},
-  {"keyName": "kitsPageYourKitsTitle", "text": "आपकी किटें", "language": "hi"},
-  {"keyName": "kitsPageStatusPreparing", "text": "तैयार किया जा रहा है", "language": "hi"},
-  {"keyName": "kitsPageStatusShipped", "text": "शिप किया गया", "language": "hi"},
-  {"keyName": "kitsPageStatusReturned", "text": "वापस किया गया", "language": "hi"},
-  {"keyName": "kitsPageStatusCreated", "text": "बनाया गया", "language": "hi"},
-  {"keyName": "kitsPageStatusCollected", "text": "एकत्र किया गया", "language": "hi"},
-  {"keyName": "kitsPageNoKits", "text": "अभी आपके पास कोई सैंपल एकत्रीकरण किट नहीं है।", "language": "hi"},
-  {"keyName": "kitsInPersonTitle", "text": "सैंपल किट संबंधी निर्देश", "language": "hi"},
-  {"keyName": "kitsInPersonDescription", "text": "अगर आप साक्षात व्यक्तिगत रूप से सैंपल एकत्रीकरण किट पूरी कर रहे हैं, तो कृपया स्टडी टीम के सदस्य की ओर से दिए गए निर्देशों का पालन करें। ऐसी हर अतिरिक्त जानकारी नीचे दी गई है जिसकी आपको आवश्यकता पड़ सकती है, जैसे कि आपका अनन्य प्रतिभागी पहचानकर्ता।", "language": "hi"},
-  {"keyName": "kitsInPersonSubDescription", "text": "अगर आपके कोई सवाल हैं, तो कृपया स्टडी टीम के किसी सदस्य से पूछें।", "language": "hi"},
-  {"keyName": "kitsInPersonYourKitTitle", "text": "आपकी सैंपल एकत्रीकरण किट", "language": "hi"},
-  {"keyName": "kitsInPersonYourKitDescription", "text": "टीम के एक सदस्य ने आपको सैंपल एकत्रीकरण किट दी है। यह सैंपल किट आपके खाते से जुड़ी है। अगर आप किसी अन्य व्यक्ति की सैंपल एकत्रीकरण किट के लिए उसकी मदद कर रहे हैं, तो कृपया यह सुनिश्चित करें कि हर प्रतिभागी अपने लिए नियत की गई सैंपल एकत्रीकरण किट को पूरा कर ले।", "language": "hi"},
-  {"keyName": "kitsInPersonYourKitIdentifier", "text": "आपका किट पहचानकर्ता", "language": "hi"},
-  {"keyName": "kitsInPersonReturnToDashboard", "text": "डैशबोर्ड पर वापस जाएँ", "language": "hi"},
-  {"keyName": "kitsInPersonRefreshPage", "text": "रीफ़्रेश करें", "language": "hi"},
-  {"keyName": "kitsInPersonConsentRequiredTitle", "text": "सहमति की ज़रूरत है", "language": "hi"},
-  {"keyName": "kitsInPersonConsentRequiredDescription", "text": "सैंपल एकत्रीकरण किट पूरी करने से पहले, आपको स्टडी में नामांकित होना होगा। अगर दिलचस्पी हो, तो आपको नीचे दिए गए लिंक पर सहमति फ़ॉर्म मिल सकता है और आप उस पर हस्ताक्षर कर सकते हैं।", "language": "hi"},
-  {"keyName": "kitsInPersonStartConsent", "text": "सहमति शुरू करें", "language": "hi"},
-  {"keyName": "kitsInPersonError", "text": "आपकी किट की जानकारी को लोड होने में गड़बड़ी हुई। मदद के लिए, कृपया स्टडी टीम के किसी सदस्य से संपर्क करें।", "language": "hi"},
-  {"keyName": "kitsInPersonCreatedInstructions", "text": "जब आप सैंपल एकत्रीकरण किट को पूरा कर लें, तो कृपया उसे स्टडी टीम के किसी सदस्य को लौटा दें और उसे नीचे दिया गया अपना भागीदारी कोड स्कैन करने दें।", "language": "hi"},
-  {"keyName": "kitsInPersonNoKitInstructions", "text": "सैंपल एकत्रीकरण किट प्राप्त करने के लिए, स्टडी टीम का कोई सदस्य किसी सैंपल किट को आपके खाते से जोड़ने के उद्देश्य से, नीचे दिए गए आपके अनन्य भागीदारी कोड को स्कैन करेगा।", "language": "hi"},
-  {"keyName": "kitsInPersonNoKitSubInstructions", "text": "जब आपको किट प्राप्त हो जाए, तो कृपया इस पेज को रीफ़्रेश करके अपनी किट की जानकारी देखें और आगे के लिए निर्देश पाएँ।", "language": "hi"},
-  {"keyName": "kitsInPersonCollectedDescription", "text": "स्टडी टीम के एक सदस्य को आपकी सैंपल एकत्रीकरण किट प्राप्त हो गई है। जब आपका सैंपल संसाधित हो जाएगा, तब आपको एक ईमेल नोटिफ़िकेशन मिलेगा, और आप अपने स्टडी डैशबोर्ड पर सैंपल की स्थिति देख पाएँगे।", "language": "hi"},
-  {"keyName": "kitsInPersonCollectedThankYou", "text": "आपकी भागीदारी के लिए धन्यवाद।", "language": "hi"},
-  {"keyName": "kitTypeSaliva", "text": "लार किट", "language": "hi"},
-  {"keyName": "kitTypeStool", "text": "मल किट", "language": "hi"},
-  {"keyName": "kitTypeBlood", "text": "रक्त किट", "language": "hi"},
-  {"keyName": "documentDownloadButton", "text": "डाउनलोड करना", "language": "hi", "machineTranslated": true},
-  {"keyName": "documentsListNone", "text": "आपने अभी तक कोई दस्तावेज़ अपलोड नहीं किया है", "language": "hi", "machineTranslated": true},
-  {"keyName": "documentsListCreatedOn", "text": "पर बनाया", "language": "hi", "machineTranslated": true},
-  {"keyName": "documentsPageTitle", "text": "दस्तावेज़", "language": "hi", "machineTranslated": true},
-  {"keyName": "documentsPageUploadedDocumentsTitle", "text": "अपलोड किए गए दस्तावेज़", "language": "hi", "machineTranslated": true},
-  {"keyName": "documentsPageMessage", "text": "अध्ययन में भाग लेने के दौरान, आपसे किसी फ़ॉर्म या सर्वेक्षण के भाग के रूप में दस्तावेज़ अपलोड करने के लिए कहा जा सकता है। नीचे, आप अपने द्वारा अपलोड किए गए दस्तावेज़ों को प्रबंधित कर सकते हैं।", "language": "hi", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "दस्तावेज़", "language": "hi", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureTitle", "text": "क्या आपको यकीन है?", "language": "hi", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureMessage", "text": "क्या आप वाकई इस दस्तावेज़ को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता। कृपया ध्यान दें कि यदि अध्ययन स्टाफ़ के किसी सदस्य ने पहले ही इस दस्तावेज़ को डाउनलोड कर लिया है, तो भी यह उनके लिए सुलभ रहेगा। यदि आप दस्तावेज़ को सभी रिकॉर्ड से पूरी तरह से हटाना चाहते हैं, तो कृपया अध्ययन स्टाफ़ से संपर्क करें।", "language": "hi", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseTitle", "text": "यह दस्तावेज़ उपयोग में है", "language": "hi", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseMessage", "text": "यह दस्तावेज़ वर्तमान में कम से कम एक सर्वेक्षण के जवाब में साझा किया गया है। कृपया इसे हटाने से पहले सर्वेक्षण प्रतिक्रिया(ओं) से हटा दें।", "language": "hi", "machineTranslated": true},
-  {"keyName": "documentDeleteButton", "text": "मिटाना", "language": "hi", "machineTranslated": true},
-  {"keyName": "documentOptionsButton", "text": "विकल्प", "language": "hi", "machineTranslated": true},
-  {"keyName": "documentSharedInResponseTo", "text": "के जवाब में साझा किया गया", "language": "hi", "machineTranslated": true},
-  {"keyName": "documentUploaderSelectedDocuments", "text": "चयनित दस्तावेज़", "language": "hi", "machineTranslated": true},
-  {"keyName": "documentUploaderIncludedInResponse", "text": "ये दस्तावेज़ आपके उत्तर में शामिल हैं", "language": "hi", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocumentsSelected", "text": "कोई दस्तावेज़ चयनित नहीं है। कृपया एक नया दस्तावेज़ अपलोड करें या नीचे कोई मौजूदा दस्तावेज़ चुनें।", "language": "hi", "machineTranslated": true},
-  {"keyName": "documentUploaderAvailableDocuments", "text": "उपलब्ध दस्तावेज़", "language": "hi", "machineTranslated": true},
-  {"keyName": "documentUploaderNotIncludedInResponse", "text": "ये दस्तावेज़ आपके उत्तर में शामिल नहीं हैं", "language": "hi", "machineTranslated": true},
-  {"keyName": "documentUploaderClickToUpload", "text": "फ़ाइलें यहां डालें या अपलोड करने के लिए क्लिक करें", "language": "hi", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocuments", "text": "कोई दस्तावेज़ उपलब्ध नहीं है", "language": "hi", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeTitle", "text": "आपका सत्र समाप्त होने वाला है", "language": "hi", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeMessage", "text": "सुरक्षा बनाए रखने और आपके डेटा की सुरक्षा के लिए, आपको ${timeRemaining} में लॉग आउट कर दिया जाएगा।", "language": "hi", "machineTranslated": true}
+  {
+    "keyName": "navbarDashboard",
+    "text": "डैशबोर्ड",
+    "language": "hi"
+  },
+  {
+    "keyName": "navbarChangePassword",
+    "text": "पासवर्ड बदलें",
+    "language": "hi"
+  },
+  {
+    "keyName": "navbarLogout",
+    "text": "लॉग आउट करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "profile",
+    "text": "प्रोफ़ाइल",
+    "language": "hi"
+  },
+  {
+    "keyName": "navbarLogin",
+    "text": "लॉग इन करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "navbarJoin",
+    "text": "रजिस्टर करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "taskComplete",
+    "text": "पूरा करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "taskInProgress",
+    "text": "प्रगति में है",
+    "language": "hi"
+  },
+  {
+    "keyName": "taskNotStarted",
+    "text": "शुरू नहीं हुआ",
+    "language": "hi"
+  },
+  {
+    "keyName": "taskDeclined",
+    "text": "अस्वीकार किया गया",
+    "language": "hi"
+  },
+  {
+    "keyName": "taskLocked",
+    "text": "लॉक किया गया",
+    "language": "hi"
+  },
+  {
+    "keyName": "tasksNoneForStudy",
+    "text": "इस स्टडी के लिए कोई टास्क नहीं",
+    "language": "hi"
+  },
+  {
+    "keyName": "taskHistory",
+    "text": "इतिहास",
+    "language": "hi"
+  },
+  {
+    "keyName": "taskNew",
+    "text": "नया",
+    "language": "hi"
+  },
+  {
+    "keyName": "surveysSomeLocked",
+    "text": "कुछ सर्वेक्षण तब तक के लिए लॉक किए गए हैं, जब तक दूसरे आवश्यक टास्क पूरे नहीं हो जाते।",
+    "language": "hi"
+  },
+  {
+    "keyName": "taskTypeSurvey",
+    "text": "सर्वेक्षण",
+    "language": "hi"
+  },
+  {
+    "keyName": "taskTypeSurveys",
+    "text": "सर्वेक्षण",
+    "language": "hi"
+  },
+  {
+    "keyName": "taskTypeConsent",
+    "text": "सहमति",
+    "language": "hi"
+  },
+  {
+    "keyName": "taskTypeForms",
+    "text": "फ़ॉर्म",
+    "language": "hi"
+  },
+  {
+    "keyName": "start",
+    "text": "शुरू करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "continue",
+    "text": "जारी रखें",
+    "language": "hi"
+  },
+  {
+    "keyName": "save",
+    "text": "सेव करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "outreachLearnMore",
+    "text": "अधिक जानें",
+    "language": "hi"
+  },
+  {
+    "keyName": "cancel",
+    "text": "रद्द करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "goBack",
+    "text": "वापस जाएँ",
+    "language": "hi"
+  },
+  {
+    "keyName": "name",
+    "text": "नाम",
+    "language": "hi"
+  },
+  {
+    "keyName": "givenName",
+    "text": "प्रथम नाम",
+    "language": "hi"
+  },
+  {
+    "keyName": "familyName",
+    "text": "कुलनाम",
+    "language": "hi"
+  },
+  {
+    "keyName": "editName",
+    "text": "नाम में बदलाव करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "editBirthDate",
+    "text": "जन्मदिन में बदलाव करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "birthDate",
+    "text": "जन्मदिन",
+    "language": "hi"
+  },
+  {
+    "keyName": "mailingAddress",
+    "text": "डाक पता",
+    "language": "hi"
+  },
+  {
+    "keyName": "editMailingAddress",
+    "text": "डाक पता में बदलाव करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "primaryAddress",
+    "text": "मुख्य पता",
+    "language": "hi"
+  },
+  {
+    "keyName": "editPrimaryAddress",
+    "text": "मुख्य पते में बदलाव करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "street1",
+    "text": "सड़क 1",
+    "language": "hi"
+  },
+  {
+    "keyName": "street2",
+    "text": "सड़क 2",
+    "language": "hi"
+  },
+  {
+    "keyName": "city",
+    "text": "शहर",
+    "language": "hi"
+  },
+  {
+    "keyName": "state",
+    "text": "राज्य/प्रांत",
+    "language": "hi"
+  },
+  {
+    "keyName": "postalCode",
+    "text": "पिन कोड",
+    "language": "hi"
+  },
+  {
+    "keyName": "country",
+    "text": "देश",
+    "language": "hi"
+  },
+  {
+    "keyName": "communicationPreferences",
+    "text": "संचार की प्राथमिकताएँ",
+    "language": "hi"
+  },
+  {
+    "keyName": "editCommunicationPreferences",
+    "text": "संचार की प्राथमिकताएँ संपादित करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "contactEmail",
+    "text": "संपर्क ईमेल",
+    "language": "hi"
+  },
+  {
+    "keyName": "editContactEmail",
+    "text": "संपर्क ईमेल में बदलाव करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "phoneNumber",
+    "text": "फ़ोन नंबर",
+    "language": "hi"
+  },
+  {
+    "keyName": "editPhoneNumber",
+    "text": "फ़ोन नंबर में बदलाव करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "doNotSolicit",
+    "text": "माँगें नहीं",
+    "language": "hi"
+  },
+  {
+    "keyName": "doNotContact",
+    "text": "संपर्क न करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "editDoNotSolicit",
+    "text": "'माँगें नहीं' में बदलाव करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "editNotifications",
+    "text": "नोटिफ़िकेशन में बदलाव करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "notifications",
+    "text": "नोटिफ़िकेशन",
+    "language": "hi"
+  },
+  {
+    "keyName": "on",
+    "text": "चालू करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "off",
+    "text": "बंद करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "notProvided",
+    "text": "प्रदान नहीं किया गया",
+    "language": "hi"
+  },
+  {
+    "keyName": "editProfileContactEmailWarning",
+    "text": "संचार के लिए इस्तेमाल किए गए ईमेल को अपडेट करने के लिए \"सेव करें\" को दबाएँ। ध्यान दें कि आपकी लॉगइन जानकारी नहीं बदलेगी।",
+    "language": "hi"
+  },
+  {
+    "keyName": "privacyPolicy",
+    "text": "निजता नीति",
+    "language": "hi"
+  },
+  {
+    "keyName": "termsOfUse",
+    "text": "उपयोग की शर्तें",
+    "language": "hi"
+  },
+  {
+    "keyName": "addressInvalidPostalCode",
+    "text": "पिन कोड को सत्यापित नहीं किया जा सका।",
+    "language": "hi"
+  },
+  {
+    "keyName": "addressInvalidCountry",
+    "text": "देश को सत्यापित नहीं किया जा सका।",
+    "language": "hi"
+  },
+  {
+    "keyName": "addressInvalidState",
+    "text": "राज्य/प्रांत को सत्यापित नहीं किया जा सका।",
+    "language": "hi"
+  },
+  {
+    "keyName": "addressInvalidCity",
+    "text": "शहर को सत्यापित नहीं किया जा सका।",
+    "language": "hi"
+  },
+  {
+    "keyName": "addressInvalidHouseNumber",
+    "text": "मकान नंबर को सत्यापित नहीं किया जा सका।",
+    "language": "hi"
+  },
+  {
+    "keyName": "addressInvalidStreetName",
+    "text": "सड़क के नाम को सत्यापित नहीं किया जा सका।",
+    "language": "hi"
+  },
+  {
+    "keyName": "addressInvalidStreetType",
+    "text": "सड़क के प्रकार को सत्यापित नहीं किया जा सका।",
+    "language": "hi"
+  },
+  {
+    "keyName": "addressNeedsSubpremise",
+    "text": "कृपया यूनिट/स्वीट नंबर प्रदान करें।",
+    "language": "hi"
+  },
+  {
+    "keyName": "addressFailedToValidate",
+    "text": "पते की पुष्टि नहीं की जा सकी।",
+    "language": "hi"
+  },
+  {
+    "keyName": "suggestBetterAddressHeader",
+    "text": "क्या यह सही पता है?",
+    "language": "hi"
+  },
+  {
+    "keyName": "suggestBetterAddressBody",
+    "text": "हम एक मिलते-जुलते पते का सत्यापन कर पाए थे। कृपया चुनें कि आप किसका इस्तेमाल करना चाहेंगे।",
+    "language": "hi"
+  },
+  {
+    "keyName": "newAddress",
+    "text": "नया पता",
+    "language": "hi"
+  },
+  {
+    "keyName": "oldAddress",
+    "text": "पुराना पता",
+    "language": "hi"
+  },
+  {
+    "keyName": "you",
+    "text": "आप",
+    "language": "hi"
+  },
+  {
+    "keyName": "yourDependent",
+    "text": "आपका आश्रित",
+    "language": "hi"
+  },
+  {
+    "keyName": "youInParens",
+    "text": "(आप)",
+    "language": "hi"
+  },
+  {
+    "keyName": "allProfiles",
+    "text": "सभी प्रोफ़ाइलें",
+    "language": "hi"
+  },
+  {
+    "keyName": "manageProfiles",
+    "text": "प्रोफ़ाइलें प्रबंधित करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "addNewParticipant",
+    "text": "नया प्रतिभागी जोड़ें",
+    "language": "hi"
+  },
+  {
+    "keyName": "dashboard",
+    "text": "डैशबोर्ड",
+    "language": "hi"
+  },
+  {
+    "keyName": "selectParticipant",
+    "text": "प्रतिभागी का चयन करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "hubUpdateFormSubmittedTitle",
+    "text": "${formName} पूरा हुआ",
+    "language": "hi"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesTitle",
+    "text": "सभी गतिविधियाँ पूर्ण",
+    "language": "hi"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesDetail",
+    "text": "आपने इस स्टडी के लिए सभी गतिविधियाँ पूरी कर ली हैं। नई गतिविधियाँ उपलब्ध होते ही, हम आपको सूचना देंगे। आपकी भागीदारी के लिए धन्यवाद!",
+    "language": "hi"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyTitle",
+    "text": "${studyName} में आपका स्वागत है",
+    "language": "hi"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyDetail",
+    "text": "जारी रखने के लिए, कृपया नीचे दिए गए सहमति फ़ॉर्म को पढ़कर उस पर हस्ताक्षर करें।",
+    "language": "hi"
+  },
+  {
+    "keyName": "hubUpdateAlreadyEnrolledTitle",
+    "text": "आप पहले से ही ${studyName} में नामांकित हैं।",
+    "language": "hi"
+  },
+  {
+    "keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle",
+    "text": "यह उपयोगकर्ता पहले से ही ${studyName} में नामांकित है।",
+    "language": "hi"
+  },
+  {
+    "keyName": "cookieAlertTitle",
+    "text": "कुकीज़",
+    "language": "hi"
+  },
+  {
+    "keyName": "cookieAlertDetail",
+    "text": "यह साइट हमारी वेबसाइट के सही तरीके से काम करने और उसे सुरक्षित रखने के लिए, और आपके द्वारा उसका उपयोग किए जाने के दौरान आपका अनुभव बेहतर बनाने के लिए, \"कुकीज़\" नामक इंटरनेट टोकनों का इस्तेमाल करती है। हम जो कुकीज़ इस्तेमाल करते हैं वे सभी पूरी तरह से ज़रूरी कुकीज़ होती हैं। इस तरह की कुकी व्यक्तिगत रूप से पहचान योग्य कोई भी जानकारी आपके बारे में एकत्र नहीं करती है और ब्राउज़ करने की आपकी आदतों को ट्रैक नहीं करती है। अधिक जानने के लिए, [हमारी निजता नीति पढ़ें](/privacy)।",
+    "language": "hi"
+  },
+  {
+    "keyName": "joinStudy",
+    "text": "स्टडी में शामिल हों",
+    "language": "hi"
+  },
+  {
+    "keyName": "ineligibleThankYou",
+    "text": "${studyName} में आपकी रुचि के लिए धन्यवाद",
+    "language": "hi"
+  },
+  {
+    "keyName": "ineligibleDescription",
+    "text": "खेद है कि आप अभी ${studyName} में भाग लेने की पात्रता के मानदंडों को पूरा नहीं करते हैं।",
+    "language": "hi"
+  },
+  {
+    "keyName": "ineligibleProvideYourEmail",
+    "text": "नीचे अपना ईमेल प्रदान करें और हम आपको घटनाक्रम के बारे में अपडेट देते रहेंगे। आप किसी भी समय अनसब्सक्राइब कर सकते हैं।",
+    "language": "hi"
+  },
+  {
+    "keyName": "ineligibleStayInformed",
+    "text": "सूचना पाते रहें",
+    "language": "hi"
+  },
+  {
+    "keyName": "backToPortalHomepage",
+    "text": "${portalName} के होमपेज पर वापस जाएँ",
+    "language": "hi"
+  },
+  {
+    "keyName": "joinMailingList",
+    "text": "मेलिंग लिस्ट में शामिल हों",
+    "language": "hi"
+  },
+  {
+    "keyName": "mailingFormStayUpdated",
+    "text": "स्टडी के बारे में समाचारों के अपडेट पाते रहें",
+    "language": "hi"
+  },
+  {
+    "keyName": "yourName",
+    "text": "आपका नाम",
+    "language": "hi"
+  },
+  {
+    "keyName": "yourEmail",
+    "text": "आपका ईमेल",
+    "language": "hi"
+  },
+  {
+    "keyName": "join",
+    "text": "शामिल हों",
+    "language": "hi"
+  },
+  {
+    "keyName": "thanksForJoining",
+    "text": "शामिल होने के लिए धन्यवाद!",
+    "language": "hi"
+  },
+  {
+    "keyName": "pageNotFoundTitle",
+    "text": "पेज नहीं मिला",
+    "language": "hi"
+  },
+  {
+    "keyName": "pageNotFoundMessage",
+    "text": "अगर आपको लगता है कि यह गलती से हुआ है, तो कृपया ${studyContactEmail} से संपर्क करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "pageNotFoundReturnHome",
+    "text": "होम पेज पर वापस जाएँ",
+    "language": "hi"
+  },
+  {
+    "keyName": "authErrorPageTitle",
+    "text": "कुछ गड़बड़ी हुई",
+    "language": "hi"
+  },
+  {
+    "keyName": "authErrorPageMessage",
+    "text": "हमारी प्रमाणीकरण सेवा में कोई समस्या पेश आई। कृपया फिर से कोशिश करें। अगर समस्या बनी रहती है, तो कृपया ${studyContactEmail} से संपर्क करें।",
+    "language": "hi"
+  },
+  {
+    "keyName": "navbarSampleKits",
+    "text": "सैंपल किटें",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsPageTitle",
+    "text": "सैंपल एकत्रीकरण किटें",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsPageDescription",
+    "text": "सैंपल एकत्रीकरण किटें, स्टडी की प्रक्रिया का एक अहम हिस्सा हैं और इनकी मदद से शोधकर्ताओं को ज़रूरी गहन-जानकारी मिल सकती है। नीचे आपको उन सभी किटों की स्थिति के बारे में जानकारी मिलेगी जो आपको दी गईं थीं।",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsPageInPersonTitle",
+    "text": "साक्षात व्यक्तिगत रूप से सैंपल दें",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsPageInPersonDescription",
+    "text": "वर्तमान में यह स्टडी साक्षात व्यक्तिगत रूप से सैंपल एकत्रीकरण किट को पूरा करने का विकल्प दे रही है।",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsPageInPersonCompleteButton",
+    "text": "साक्षात व्यक्तिगत रूप से किट पूरी करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsPageYourKitsTitle",
+    "text": "आपकी किटें",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsPageStatusPreparing",
+    "text": "तैयार किया जा रहा है",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsPageStatusShipped",
+    "text": "शिप किया गया",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsPageStatusReturned",
+    "text": "वापस किया गया",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsPageStatusCreated",
+    "text": "बनाया गया",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsPageStatusCollected",
+    "text": "एकत्र किया गया",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsPageNoKits",
+    "text": "अभी आपके पास कोई सैंपल एकत्रीकरण किट नहीं है।",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsInPersonTitle",
+    "text": "सैंपल किट संबंधी निर्देश",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsInPersonDescription",
+    "text": "अगर आप साक्षात व्यक्तिगत रूप से सैंपल एकत्रीकरण किट पूरी कर रहे हैं, तो कृपया स्टडी टीम के सदस्य की ओर से दिए गए निर्देशों का पालन करें। ऐसी हर अतिरिक्त जानकारी नीचे दी गई है जिसकी आपको आवश्यकता पड़ सकती है, जैसे कि आपका अनन्य प्रतिभागी पहचानकर्ता।",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsInPersonSubDescription",
+    "text": "अगर आपके कोई सवाल हैं, तो कृपया स्टडी टीम के किसी सदस्य से पूछें।",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsInPersonYourKitTitle",
+    "text": "आपकी सैंपल एकत्रीकरण किट",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsInPersonYourKitDescription",
+    "text": "टीम के एक सदस्य ने आपको सैंपल एकत्रीकरण किट दी है। यह सैंपल किट आपके खाते से जुड़ी है। अगर आप किसी अन्य व्यक्ति की सैंपल एकत्रीकरण किट के लिए उसकी मदद कर रहे हैं, तो कृपया यह सुनिश्चित करें कि हर प्रतिभागी अपने लिए नियत की गई सैंपल एकत्रीकरण किट को पूरा कर ले।",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsInPersonYourKitIdentifier",
+    "text": "आपका किट पहचानकर्ता",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsInPersonReturnToDashboard",
+    "text": "डैशबोर्ड पर वापस जाएँ",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsInPersonRefreshPage",
+    "text": "रीफ़्रेश करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredTitle",
+    "text": "सहमति की ज़रूरत है",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredDescription",
+    "text": "सैंपल एकत्रीकरण किट पूरी करने से पहले, आपको स्टडी में नामांकित होना होगा। अगर दिलचस्पी हो, तो आपको नीचे दिए गए लिंक पर सहमति फ़ॉर्म मिल सकता है और आप उस पर हस्ताक्षर कर सकते हैं।",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsInPersonStartConsent",
+    "text": "सहमति शुरू करें",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsInPersonError",
+    "text": "आपकी किट की जानकारी को लोड होने में गड़बड़ी हुई। मदद के लिए, कृपया स्टडी टीम के किसी सदस्य से संपर्क करें।",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsInPersonCreatedInstructions",
+    "text": "जब आप सैंपल एकत्रीकरण किट को पूरा कर लें, तो कृपया उसे स्टडी टीम के किसी सदस्य को लौटा दें और उसे नीचे दिया गया अपना भागीदारी कोड स्कैन करने दें।",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsInPersonNoKitInstructions",
+    "text": "सैंपल एकत्रीकरण किट प्राप्त करने के लिए, स्टडी टीम का कोई सदस्य किसी सैंपल किट को आपके खाते से जोड़ने के उद्देश्य से, नीचे दिए गए आपके अनन्य भागीदारी कोड को स्कैन करेगा।",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsInPersonNoKitSubInstructions",
+    "text": "जब आपको किट प्राप्त हो जाए, तो कृपया इस पेज को रीफ़्रेश करके अपनी किट की जानकारी देखें और आगे के लिए निर्देश पाएँ।",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsInPersonCollectedDescription",
+    "text": "स्टडी टीम के एक सदस्य को आपकी सैंपल एकत्रीकरण किट प्राप्त हो गई है। जब आपका सैंपल संसाधित हो जाएगा, तब आपको एक ईमेल नोटिफ़िकेशन मिलेगा, और आप अपने स्टडी डैशबोर्ड पर सैंपल की स्थिति देख पाएँगे।",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitsInPersonCollectedThankYou",
+    "text": "आपकी भागीदारी के लिए धन्यवाद।",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitTypeSaliva",
+    "text": "लार किट",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitTypeStool",
+    "text": "मल किट",
+    "language": "hi"
+  },
+  {
+    "keyName": "kitTypeBlood",
+    "text": "रक्त किट",
+    "language": "hi"
+  },
+  {
+    "keyName": "documentDownloadButton",
+    "text": "डाउनलोड करना",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListNone",
+    "text": "आपने अभी तक कोई दस्तावेज़ अपलोड नहीं किया है",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListCreatedOn",
+    "text": "पर बनाया",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageTitle",
+    "text": "दस्तावेज़",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageUploadedDocumentsTitle",
+    "text": "अपलोड किए गए दस्तावेज़",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageMessage",
+    "text": "अध्ययन में भाग लेने के दौरान, आपसे किसी फ़ॉर्म या सर्वेक्षण के भाग के रूप में दस्तावेज़ अपलोड करने के लिए कहा जा सकता है। नीचे, आप अपने द्वारा अपलोड किए गए दस्तावेज़ों को प्रबंधित कर सकते हैं।",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "navbarDocuments",
+    "text": "दस्तावेज़",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureTitle",
+    "text": "क्या आपको यकीन है?",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureMessage",
+    "text": "क्या आप वाकई इस दस्तावेज़ को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता। कृपया ध्यान दें कि यदि अध्ययन स्टाफ़ के किसी सदस्य ने पहले ही इस दस्तावेज़ को डाउनलोड कर लिया है, तो भी यह उनके लिए सुलभ रहेगा। यदि आप दस्तावेज़ को सभी रिकॉर्ड से पूरी तरह से हटाना चाहते हैं, तो कृपया अध्ययन स्टाफ़ से संपर्क करें।",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseTitle",
+    "text": "यह दस्तावेज़ उपयोग में है",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseMessage",
+    "text": "यह दस्तावेज़ वर्तमान में कम से कम एक सर्वेक्षण के जवाब में साझा किया गया है। कृपया इसे हटाने से पहले सर्वेक्षण प्रतिक्रिया(ओं) से हटा दें।",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteButton",
+    "text": "मिटाना",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentOptionsButton",
+    "text": "विकल्प",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentSharedInResponseTo",
+    "text": "के जवाब में साझा किया गया",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderSelectedDocuments",
+    "text": "चयनित दस्तावेज़",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderIncludedInResponse",
+    "text": "ये दस्तावेज़ आपके उत्तर में शामिल हैं",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocumentsSelected",
+    "text": "कोई दस्तावेज़ चयनित नहीं है। कृपया एक नया दस्तावेज़ अपलोड करें या नीचे कोई मौजूदा दस्तावेज़ चुनें।",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderAvailableDocuments",
+    "text": "उपलब्ध दस्तावेज़",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNotIncludedInResponse",
+    "text": "ये दस्तावेज़ आपके उत्तर में शामिल नहीं हैं",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderClickToUpload",
+    "text": "फ़ाइलें यहां डालें या अपलोड करने के लिए क्लिक करें",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocuments",
+    "text": "कोई दस्तावेज़ उपलब्ध नहीं है",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeTitle",
+    "text": "आपका सत्र समाप्त होने वाला है",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeMessage",
+    "text": "सुरक्षा बनाए रखने और आपके डेटा की सुरक्षा के लिए, आपको ${timeRemaining} में लॉग आउट कर दिया जाएगा।",
+    "language": "hi",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "failedToEnroll",
+    "language": "hi",
+    "text": "नामांकन प्रक्रिया के दौरान कुछ गलत हो गया। कृपया फिर से फॉर्म भरें।",
+    "machineTranslated": true
+  }
 ]

--- a/populate/src/main/resources/seed/i18n/it/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/it/languageTexts.json
@@ -1,163 +1,836 @@
 [
-  {"keyName": "navbarDashboard", "text": "Dashboard", "language": "it"},
-  {"keyName": "navbarChangePassword", "text": "Modifica password", "language": "it"},
-  {"keyName": "navbarLogout", "text": "Esci", "language": "it"},
-  {"keyName": "profile", "text": "Profilo", "language": "it"},
-  {"keyName": "navbarLogin", "text": "Accedi", "language": "it"},
-  {"keyName": "navbarJoin", "text": "Registrati", "language": "it"},
-  {"keyName": "taskComplete", "text": "Completato", "language": "it"},
-  {"keyName": "taskInProgress", "text": "In corso", "language": "it"},
-  {"keyName": "taskNotStarted", "text": "Non iniziato", "language": "it"},
-  {"keyName": "taskDeclined", "text": "Rifiutato", "language": "it"},
-  {"keyName": "taskLocked", "text": "Bloccato", "language": "it"},
-  {"keyName": "tasksNoneForStudy", "text": "Nessun task per questo studio", "language": "it"},
-  {"keyName": "taskHistory", "text": "cronologia", "language": "it"},
-  {"keyName": "taskNew", "text": "NUOVO", "language": "it"},
-  {"keyName": "surveysSomeLocked", "text": "Alcuni sondaggi rimarranno bloccati fino al completamento degli altri task richiesti.", "language": "it"},
-  {"keyName": "taskTypeSurvey", "text": "Sondaggio", "language": "it"},
-  {"keyName": "taskTypeSurveys", "text": "Sondaggi", "language": "it"},
-  {"keyName": "taskTypeConsent", "text": "Moduli di", "language": "it"},
-  {"keyName": "taskTypeForms", "text": "consenso", "language": "it"},
-  {"keyName": "start", "text": "Inizia", "language": "it"},
-  {"keyName": "continue", "text": "Continua", "language": "it"},
-  {"keyName": "save", "text": "Salva", "language": "it"},
-  {"keyName": "outreachLearnMore", "text": "Scopri di più", "language": "it"},
-  {"keyName": "cancel", "text": "Annulla", "language": "it"},
-  {"keyName": "goBack", "text": "Indietro", "language": "it"},
-  {"keyName": "name", "text": "Nome completo", "language": "it"},
-  {"keyName": "givenName", "text": "Nome", "language": "it"},
-  {"keyName": "familyName", "text": "Cognome", "language": "it"},
-  {"keyName": "editName", "text": "Modifica nome completo", "language": "it"},
-  {"keyName": "editBirthDate", "text": "Modifica data di nascita", "language": "it"},
-  {"keyName": "birthDate", "text": "Data di nascita", "language": "it"},
-  {"keyName": "mailingAddress", "text": "Indirizzo per la corrispondenza", "language": "it"},
-  {"keyName": "editMailingAddress", "text": "Modifica l'indirizzo per la corrispondenza", "language": "it"},
-  {"keyName": "primaryAddress", "text": "Indirizzo principale", "language": "it"},
-  {"keyName": "editPrimaryAddress", "text": "Modifica l'indirizzo principale", "language": "it"},
-  {"keyName": "street1", "text": "Via 1", "language": "it"},
-  {"keyName": "street2", "text": "Via 2", "language": "it"},
-  {"keyName": "city", "text": "Città", "language": "it"},
-  {"keyName": "state", "text": "Stato\/Provincia", "language": "it"},
-  {"keyName": "postalCode", "text": "CAP", "language": "it"},
-  {"keyName": "country", "text": "Paese", "language": "it"},
-  {"keyName": "communicationPreferences", "text": "Preferenze per le comunicazioni", "language": "it"},
-  {"keyName": "editCommunicationPreferences", "text": "Modifica preferenze per le comunicazioni", "language": "it"},
-  {"keyName": "contactEmail", "text": "Email di contatto", "language": "it"},
-  {"keyName": "editContactEmail", "text": "Modifica email di contatto", "language": "it"},
-  {"keyName": "phoneNumber", "text": "Numero di telefono", "language": "it"},
-  {"keyName": "editPhoneNumber", "text": "Modifica numero di telefono", "language": "it"},
-  {"keyName": "doNotSolicit", "text": "Non inviare comunicazioni promozionali", "language": "it"},
-  {"keyName": "doNotContact", "text": "Non contattare", "language": "it"},
-  {"keyName": "editDoNotSolicit", "text": "Modifica Non inviare comunicazioni promozionali", "language": "it"},
-  {"keyName": "editNotifications", "text": "Modifica notifiche", "language": "it"},
-  {"keyName": "notifications", "text": "Notifiche", "language": "it"},
-  {"keyName": "on", "text": "Attive", "language": "it"},
-  {"keyName": "off", "text": "Non attive", "language": "it"},
-  {"keyName": "notProvided", "text": "Non rilasciato", "language": "it"},
-  {"keyName": "editProfileContactEmailWarning", "text": "Premi \"Salva\" per aggiornare l'indirizzo email da usare per le comunicazioni. Le credenziali di accesso rimarranno invariate.", "language": "it"},
-  {"keyName": "privacyPolicy", "text": "Informativa sulla privacy", "language": "it"},
-  {"keyName": "termsOfUse", "text": "Termini di utilizzo", "language": "it"},
-  {"keyName": "addressInvalidPostalCode", "text": "Non è stato possibile verificare il CAP.", "language": "it"},
-  {"keyName": "addressInvalidCountry", "text": "Non è stato possibile verificare il Paese.", "language": "it"},
-  {"keyName": "addressInvalidState", "text": "Non è stato possibile verificare lo stato\/la provincia.", "language": "it"},
-  {"keyName": "addressInvalidCity", "text": "Non è stato possibile verificare la città.", "language": "it"},
-  {"keyName": "addressInvalidHouseNumber", "text": "Non è stato possibile verificare il numero civico.", "language": "it"},
-  {"keyName": "addressInvalidStreetName", "text": "Non è stato possibile verificare il nome della via.", "language": "it"},
-  {"keyName": "addressInvalidStreetType", "text": "Non è stato possibile verificare il tipo di via.", "language": "it"},
-  {"keyName": "addressNeedsSubpremise", "text": "Indica il numero dell'unità\/interno.", "language": "it"},
-  {"keyName": "addressFailedToValidate", "text": "Non è stato possibile convalidare l'indirizzo.", "language": "it"},
-  {"keyName": "suggestBetterAddressHeader", "text": "L'indirizzo è corretto?", "language": "it"},
-  {"keyName": "suggestBetterAddressBody", "text": "Siamo riusciti a verificare un indirizzo simile. Seleziona quello che vorresti usare.", "language": "it"},
-  {"keyName": "newAddress", "text": "Indirizzo nuovo", "language": "it"},
-  {"keyName": "oldAddress", "text": "Indirizzo precedente", "language": "it"},
-  {"keyName": "you", "text": "Tu", "language": "it"},
-  {"keyName": "yourDependent", "text": "La persona a tuo carico", "language": "it"},
-  {"keyName": "youInParens", "text": "(tu)", "language": "it"},
-  {"keyName": "allProfiles", "text": "Tutti i profili", "language": "it"},
-  {"keyName": "manageProfiles", "text": "Gestisci i profili", "language": "it"},
-  {"keyName": "addNewParticipant", "text": "Aggiungi un nuovo partecipante", "language": "it"},
-  {"keyName": "dashboard", "text": "Dashboard", "language": "it"},
-  {"keyName": "selectParticipant", "text": "Seleziona partecipante", "language": "it"},
-  {"keyName": "hubUpdateFormSubmittedTitle", "text": "${formName} completato", "language": "it"},
-  {"keyName": "hubUpdateNoActivitiesTitle", "text": "Tutte le attività sono state completate", "language": "it"},
-  {"keyName": "hubUpdateNoActivitiesDetail", "text": "Hai completato tutte le attività per questo studio. Ti informeremo appena saranno disponibili nuove attività. Grazie della partecipazione!", "language": "it"},
-  {"keyName": "hubUpdateWelcomeToStudyTitle", "text": "Ti diamo il benvenuto nello studio ${studyName}", "language": "it"},
-  {"keyName": "hubUpdateWelcomeToStudyDetail", "text": "Leggi e firma il modulo di consenso in basso per proseguire.", "language": "it"},
-  {"keyName": "hubUpdateAlreadyEnrolledTitle", "text": "Partecipi già allo studio ${studyName}.", "language": "it"},
-  {"keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle", "text": "Questo utente partecipa già allo studio ${studyName}.", "language": "it"},
-  {"keyName": "cookieAlertTitle", "text": "Cookies", "language": "it"},
-  {"keyName": "cookieAlertDetail", "text": "Questo sito utilizza piccoli file di testo chiamati &quot;cookies&quot; per consentire il corretto funzionamento e la sicurezza del nostro sito web e per migliorare la tua esperienza di utilizzo. Utilizziamo solo i cookies strettamente necessari. Questo tipo di cookie non raccoglie dati personali e non traccia le tue abitudini di navigazione. Per maggiori informazioni, [leggi la nostra informativa sulla privacy](\/privacy).", "language": "it"},
-  {"keyName": "joinStudy", "text": "Partecipa allo studio", "language": "it"},
-  {"keyName": "ineligibleThankYou", "text": "Grazie dell'interesse che hai mostrato per lo studio ${studyName}", "language": "it" },
-  {"keyName": "ineligibleDescription", "text": "Purtroppo, al momento non soddisfi i criteri di idoneità per partecipare allo studio ${studyName}.", "language": "it"},
-  {"keyName": "ineligibleProvideYourEmail", "text": "Inserisci qui il tuo indirizzo email e ti aggiorneremo sugli sviluppi. Puoi cancellarti in qualsiasi momento.", "language":  "it"},
-  {"keyName": "ineligibleStayInformed", "text": "Ricevi le ultime notizie", "language": "it"},
-  {"keyName": "backToPortalHomepage", "text": "Torna alla pagina iniziale di ${portalName}", "language": "it"},
-  {"keyName": "joinMailingList", "text": "Iscriviti alla mailing list", "language": "it"},
-  {"keyName": "mailingFormStayUpdated", "text":  "Ricevi le ultime notizie su questo studio", "language": "it"},
-  {"keyName": "yourName", "text": "Nome", "language": "it"},
-  {"keyName": "yourEmail", "text": "Indirizzo email", "language": "it"},
-  {"keyName": "join", "text":  "Iscriviti", "language": "it"},
-  {"keyName": "thanksForJoining", "text": "Grazie dell'iscrizione!", "language": "it"},
-  {"keyName": "pageNotFoundTitle", "text": "Pagina non trovata", "language": "it"},
-  {"keyName": "pageNotFoundMessage", "text": "Se ritieni che ci sia stato un errore, contatta ${studyContactEmail}", "language": "it"},
-  {"keyName": "pageNotFoundReturnHome", "text": "Torna alla pagina iniziale", "language": "it"},
-  {"keyName": "authErrorPageTitle", "text": "Si è verificato un errore", "language": "it"},
-  {"keyName": "authErrorPageMessage", "text": "C'è stato un problema con il nostro servizio di autenticazione. Prova di nuovo. Se il problema persiste, contatta ${studyContactEmail}.", "language": "it"},
-  {"keyName": "navbarSampleKits", "text":  "Kit di raccolta", "language": "it"},
-  {"keyName": "kitsPageTitle", "text": "Kit di raccolta campioni", "language": "it"},
-  {"keyName": "kitsPageDescription", "text": "I kit di raccolta campioni sono una parte importante del processo di studio e possono fornire ai ricercatori informazioni utili. Di seguito puoi vedere lo stato di tutti i kit che ti sono stati forniti.", "language": "it"},
-  {"keyName": "kitsPageInPersonTitle", "text": "Fornisci un campione di persona", "language": "it"},
-  {"keyName": "kitsPageInPersonDescription", "text": "Questo studio offre la possibilità di effettuare la raccolta campioni di persona.", "language": "it"},
-  {"keyName": "kitsPageInPersonCompleteButton", "text": "Effettua la raccolta di persona", "language": "it"},
-  {"keyName": "kitsPageYourKitsTitle", "text": "I tuoi kit", "language": "it"},
-  {"keyName": "kitsPageStatusPreparing", "text": "In preparazione", "language": "it"},
-  {"keyName": "kitsPageStatusShipped", "text": "Spediti", "language": "it"},
-  {"keyName": "kitsPageStatusReturned", "text": "Restituiti", "language": "it"},
-  {"keyName": "kitsPageStatusCreated", "text": "Creati", "language": "it"},
-  {"keyName": "kitsPageStatusCollected", "text": "Raccolta effettuata", "language": "it"},
-  {"keyName": "kitsPageNoKits", "text": "Al momento non possiedi nessun kit di raccolta campioni.", "language": "it"},
-  {"keyName": "kitsInPersonTitle", "text": "Istruzioni per la raccolta dei campioni", "language": "it"},
-  {"keyName": "kitsInPersonDescription", "text": "Se stai effettuando la raccolta dei campioni di persona, segui le istruzioni fornite dai membri del team di studio. Le eventuali altre informazioni di cui potresti avere bisogno, come il tuo codice identificativo univoco, sono fornite di seguito.", "language": "it"},
-  {"keyName": "kitsInPersonSubDescription", "text": "Se hai domande, rivolgiti a un membro del team di studio.", "language": "it"},
-  {"keyName": "kitsInPersonYourKitTitle", "text": "Il tuo kit di raccolta campioni", "language": "it"},
-  {"keyName": "kitsInPersonYourKitDescription", "text": "Un membro del team ti ha fornito un kit di raccolta campioni. Questo kit è associato al tuo account. Se stai aiutando un'altra persona nella raccolta dei campioni, assicurati che ogni partecipante esegua la raccolta con il kit che gli è stato assegnato.", "language": "it"},
-  {"keyName": "kitsInPersonYourKitIdentifier", "text": "Codice identificativo del tuo kit", "language": "it"},
-  {"keyName": "kitsInPersonReturnToDashboard", "text": "Torna alla dashboard", "language": "it"},
-  {"keyName": "kitsInPersonRefreshPage", "text": "Aggiorna", "language": "it"},
-  {"keyName": "kitsInPersonConsentRequiredTitle", "text": "Consenso richiesto", "language": "it"},
-  {"keyName": "kitsInPersonConsentRequiredDescription", "text": "Per poter eseguire la raccolta dei campioni con il kit, devi prima essere stato\/a incluso\/a nello studio. Se ti interessa, puoi leggere e firmare il modulo di consenso tramite il link riportato di seguito.", "language": "it"},
-  {"keyName": "kitsInPersonStartConsent", "text": "Avvia consenso", "language": "it"},
-  {"keyName": "kitsInPersonError", "text": "Si è verificato un errore durante il caricamento delle informazioni sul tuo kit. Contatta un membro del team di studio per ricevere assistenza.", "language": "it"},
-  {"keyName": "kitsInPersonCreatedInstructions", "text": "Quando avrai completato la raccolta dei campioni, restituisci il kit a un membro del team di studio in modo che possa scansionare il tuo codice partecipante riportato di seguito.", "language": "it"},
-  {"keyName": "kitsInPersonNoKitInstructions", "text": "Per ricevere un kit di raccolta campioni, un membro del team di studio scansionerà il tuo codice di partecipazione univoco per associare il kit al tuo account.", "language": "it"},
-  {"keyName": "kitsInPersonNoKitSubInstructions", "text": "Quando avrai ricevuto il kit, aggiorna questa pagina per visualizzare le informazioni sul tuo kit e ottenere ulteriori istruzioni.", "language": "it"},
-  {"keyName": "kitsInPersonCollectedDescription", "text": "Un membro del team di studio ha ricevuto il tuo kit di raccolta campioni. Riceverai un'email di notifica non appena il campione sarà stato elaborato e potrai visualizzarne lo stato sulla tua dashboard dello studio.", "language": "it"},
-  {"keyName": "kitsInPersonCollectedThankYou", "text": "Grazie della partecipazione.", "language": "it"},
-  {"keyName": "kitTypeSaliva", "text": "Kit di raccolta saliva", "language": "it"},
-  {"keyName": "kitTypeStool", "text": "Kit di raccolta feci", "language": "it"},
-  {"keyName": "kitTypeBlood", "text": "Kit di raccolta sangue", "language": "it"},
-  {"keyName": "documentDownloadButton", "text": "Scaricamento", "language": "it", "machineTranslated": true},
-  {"keyName": "documentsListNone", "text": "Non hai ancora caricato alcun documento", "language": "it", "machineTranslated": true},
-  {"keyName": "documentsListCreatedOn", "text": "Creato il", "language": "it", "machineTranslated": true},
-  {"keyName": "documentsPageTitle", "text": "Documenti", "language": "it", "machineTranslated": true},
-  {"keyName": "documentsPageUploadedDocumentsTitle", "text": "Documenti caricati", "language": "it", "machineTranslated": true},
-  {"keyName": "documentsPageMessage", "text": "Durante la partecipazione a uno studio, potrebbe esserti chiesto di caricare documenti come parte di un modulo o di un sondaggio. Di seguito, puoi gestire i documenti che hai caricato.", "language": "it", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "Documenti", "language": "it", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureTitle", "text": "Sei sicuro?", "language": "it", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureMessage", "text": "Sei sicuro di voler eliminare questo documento? Questa operazione non può essere annullata. Nota che se un membro dello staff dello studio ha già scaricato questo documento, sarà comunque accessibile a lui. Contatta lo staff dello studio se desideri che il documento venga completamente rimosso da tutti i record.", "language": "it", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseTitle", "text": "Questo documento è in uso", "language": "it", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseMessage", "text": "Questo documento è attualmente condiviso in risposta ad almeno un sondaggio. Si prega di rimuoverlo dalle risposte al sondaggio prima di eliminarlo.", "language": "it", "machineTranslated": true},
-  {"keyName": "documentDeleteButton", "text": "Eliminare", "language": "it", "machineTranslated": true},
-  {"keyName": "documentOptionsButton", "text": "Opzioni", "language": "it", "machineTranslated": true},
-  {"keyName": "documentSharedInResponseTo", "text": "condiviso in risposta a", "language": "it", "machineTranslated": true},
-  {"keyName": "documentUploaderSelectedDocuments", "text": "Documenti selezionati", "language": "it", "machineTranslated": true},
-  {"keyName": "documentUploaderIncludedInResponse", "text": "Questi documenti sono inclusi nella tua risposta", "language": "it", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocumentsSelected", "text": "Nessun documento selezionato. Carica un nuovo documento o seleziona un documento esistente qui sotto.", "language": "it", "machineTranslated": true},
-  {"keyName": "documentUploaderAvailableDocuments", "text": "Documenti disponibili", "language": "it", "machineTranslated": true},
-  {"keyName": "documentUploaderNotIncludedInResponse", "text": "Questi documenti non sono inclusi nella tua risposta", "language": "it", "machineTranslated": true},
-  {"keyName": "documentUploaderClickToUpload", "text": "Trascina i file qui o clicca per caricarli", "language": "it", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocuments", "text": "Nessun documento disponibile", "language": "it", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeTitle", "text": "La tua sessione sta per scadere", "language": "it", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeMessage", "text": "Per garantire la sicurezza e proteggere i tuoi dati, verrai disconnesso tra ${timeRemaining}.", "language": "it", "machineTranslated": true}
+  {
+    "keyName": "navbarDashboard",
+    "text": "Dashboard",
+    "language": "it"
+  },
+  {
+    "keyName": "navbarChangePassword",
+    "text": "Modifica password",
+    "language": "it"
+  },
+  {
+    "keyName": "navbarLogout",
+    "text": "Esci",
+    "language": "it"
+  },
+  {
+    "keyName": "profile",
+    "text": "Profilo",
+    "language": "it"
+  },
+  {
+    "keyName": "navbarLogin",
+    "text": "Accedi",
+    "language": "it"
+  },
+  {
+    "keyName": "navbarJoin",
+    "text": "Registrati",
+    "language": "it"
+  },
+  {
+    "keyName": "taskComplete",
+    "text": "Completato",
+    "language": "it"
+  },
+  {
+    "keyName": "taskInProgress",
+    "text": "In corso",
+    "language": "it"
+  },
+  {
+    "keyName": "taskNotStarted",
+    "text": "Non iniziato",
+    "language": "it"
+  },
+  {
+    "keyName": "taskDeclined",
+    "text": "Rifiutato",
+    "language": "it"
+  },
+  {
+    "keyName": "taskLocked",
+    "text": "Bloccato",
+    "language": "it"
+  },
+  {
+    "keyName": "tasksNoneForStudy",
+    "text": "Nessun task per questo studio",
+    "language": "it"
+  },
+  {
+    "keyName": "taskHistory",
+    "text": "cronologia",
+    "language": "it"
+  },
+  {
+    "keyName": "taskNew",
+    "text": "NUOVO",
+    "language": "it"
+  },
+  {
+    "keyName": "surveysSomeLocked",
+    "text": "Alcuni sondaggi rimarranno bloccati fino al completamento degli altri task richiesti.",
+    "language": "it"
+  },
+  {
+    "keyName": "taskTypeSurvey",
+    "text": "Sondaggio",
+    "language": "it"
+  },
+  {
+    "keyName": "taskTypeSurveys",
+    "text": "Sondaggi",
+    "language": "it"
+  },
+  {
+    "keyName": "taskTypeConsent",
+    "text": "Moduli di",
+    "language": "it"
+  },
+  {
+    "keyName": "taskTypeForms",
+    "text": "consenso",
+    "language": "it"
+  },
+  {
+    "keyName": "start",
+    "text": "Inizia",
+    "language": "it"
+  },
+  {
+    "keyName": "continue",
+    "text": "Continua",
+    "language": "it"
+  },
+  {
+    "keyName": "save",
+    "text": "Salva",
+    "language": "it"
+  },
+  {
+    "keyName": "outreachLearnMore",
+    "text": "Scopri di più",
+    "language": "it"
+  },
+  {
+    "keyName": "cancel",
+    "text": "Annulla",
+    "language": "it"
+  },
+  {
+    "keyName": "goBack",
+    "text": "Indietro",
+    "language": "it"
+  },
+  {
+    "keyName": "name",
+    "text": "Nome completo",
+    "language": "it"
+  },
+  {
+    "keyName": "givenName",
+    "text": "Nome",
+    "language": "it"
+  },
+  {
+    "keyName": "familyName",
+    "text": "Cognome",
+    "language": "it"
+  },
+  {
+    "keyName": "editName",
+    "text": "Modifica nome completo",
+    "language": "it"
+  },
+  {
+    "keyName": "editBirthDate",
+    "text": "Modifica data di nascita",
+    "language": "it"
+  },
+  {
+    "keyName": "birthDate",
+    "text": "Data di nascita",
+    "language": "it"
+  },
+  {
+    "keyName": "mailingAddress",
+    "text": "Indirizzo per la corrispondenza",
+    "language": "it"
+  },
+  {
+    "keyName": "editMailingAddress",
+    "text": "Modifica l'indirizzo per la corrispondenza",
+    "language": "it"
+  },
+  {
+    "keyName": "primaryAddress",
+    "text": "Indirizzo principale",
+    "language": "it"
+  },
+  {
+    "keyName": "editPrimaryAddress",
+    "text": "Modifica l'indirizzo principale",
+    "language": "it"
+  },
+  {
+    "keyName": "street1",
+    "text": "Via 1",
+    "language": "it"
+  },
+  {
+    "keyName": "street2",
+    "text": "Via 2",
+    "language": "it"
+  },
+  {
+    "keyName": "city",
+    "text": "Città",
+    "language": "it"
+  },
+  {
+    "keyName": "state",
+    "text": "Stato/Provincia",
+    "language": "it"
+  },
+  {
+    "keyName": "postalCode",
+    "text": "CAP",
+    "language": "it"
+  },
+  {
+    "keyName": "country",
+    "text": "Paese",
+    "language": "it"
+  },
+  {
+    "keyName": "communicationPreferences",
+    "text": "Preferenze per le comunicazioni",
+    "language": "it"
+  },
+  {
+    "keyName": "editCommunicationPreferences",
+    "text": "Modifica preferenze per le comunicazioni",
+    "language": "it"
+  },
+  {
+    "keyName": "contactEmail",
+    "text": "Email di contatto",
+    "language": "it"
+  },
+  {
+    "keyName": "editContactEmail",
+    "text": "Modifica email di contatto",
+    "language": "it"
+  },
+  {
+    "keyName": "phoneNumber",
+    "text": "Numero di telefono",
+    "language": "it"
+  },
+  {
+    "keyName": "editPhoneNumber",
+    "text": "Modifica numero di telefono",
+    "language": "it"
+  },
+  {
+    "keyName": "doNotSolicit",
+    "text": "Non inviare comunicazioni promozionali",
+    "language": "it"
+  },
+  {
+    "keyName": "doNotContact",
+    "text": "Non contattare",
+    "language": "it"
+  },
+  {
+    "keyName": "editDoNotSolicit",
+    "text": "Modifica Non inviare comunicazioni promozionali",
+    "language": "it"
+  },
+  {
+    "keyName": "editNotifications",
+    "text": "Modifica notifiche",
+    "language": "it"
+  },
+  {
+    "keyName": "notifications",
+    "text": "Notifiche",
+    "language": "it"
+  },
+  {
+    "keyName": "on",
+    "text": "Attive",
+    "language": "it"
+  },
+  {
+    "keyName": "off",
+    "text": "Non attive",
+    "language": "it"
+  },
+  {
+    "keyName": "notProvided",
+    "text": "Non rilasciato",
+    "language": "it"
+  },
+  {
+    "keyName": "editProfileContactEmailWarning",
+    "text": "Premi \"Salva\" per aggiornare l'indirizzo email da usare per le comunicazioni. Le credenziali di accesso rimarranno invariate.",
+    "language": "it"
+  },
+  {
+    "keyName": "privacyPolicy",
+    "text": "Informativa sulla privacy",
+    "language": "it"
+  },
+  {
+    "keyName": "termsOfUse",
+    "text": "Termini di utilizzo",
+    "language": "it"
+  },
+  {
+    "keyName": "addressInvalidPostalCode",
+    "text": "Non è stato possibile verificare il CAP.",
+    "language": "it"
+  },
+  {
+    "keyName": "addressInvalidCountry",
+    "text": "Non è stato possibile verificare il Paese.",
+    "language": "it"
+  },
+  {
+    "keyName": "addressInvalidState",
+    "text": "Non è stato possibile verificare lo stato/la provincia.",
+    "language": "it"
+  },
+  {
+    "keyName": "addressInvalidCity",
+    "text": "Non è stato possibile verificare la città.",
+    "language": "it"
+  },
+  {
+    "keyName": "addressInvalidHouseNumber",
+    "text": "Non è stato possibile verificare il numero civico.",
+    "language": "it"
+  },
+  {
+    "keyName": "addressInvalidStreetName",
+    "text": "Non è stato possibile verificare il nome della via.",
+    "language": "it"
+  },
+  {
+    "keyName": "addressInvalidStreetType",
+    "text": "Non è stato possibile verificare il tipo di via.",
+    "language": "it"
+  },
+  {
+    "keyName": "addressNeedsSubpremise",
+    "text": "Indica il numero dell'unità/interno.",
+    "language": "it"
+  },
+  {
+    "keyName": "addressFailedToValidate",
+    "text": "Non è stato possibile convalidare l'indirizzo.",
+    "language": "it"
+  },
+  {
+    "keyName": "suggestBetterAddressHeader",
+    "text": "L'indirizzo è corretto?",
+    "language": "it"
+  },
+  {
+    "keyName": "suggestBetterAddressBody",
+    "text": "Siamo riusciti a verificare un indirizzo simile. Seleziona quello che vorresti usare.",
+    "language": "it"
+  },
+  {
+    "keyName": "newAddress",
+    "text": "Indirizzo nuovo",
+    "language": "it"
+  },
+  {
+    "keyName": "oldAddress",
+    "text": "Indirizzo precedente",
+    "language": "it"
+  },
+  {
+    "keyName": "you",
+    "text": "Tu",
+    "language": "it"
+  },
+  {
+    "keyName": "yourDependent",
+    "text": "La persona a tuo carico",
+    "language": "it"
+  },
+  {
+    "keyName": "youInParens",
+    "text": "(tu)",
+    "language": "it"
+  },
+  {
+    "keyName": "allProfiles",
+    "text": "Tutti i profili",
+    "language": "it"
+  },
+  {
+    "keyName": "manageProfiles",
+    "text": "Gestisci i profili",
+    "language": "it"
+  },
+  {
+    "keyName": "addNewParticipant",
+    "text": "Aggiungi un nuovo partecipante",
+    "language": "it"
+  },
+  {
+    "keyName": "dashboard",
+    "text": "Dashboard",
+    "language": "it"
+  },
+  {
+    "keyName": "selectParticipant",
+    "text": "Seleziona partecipante",
+    "language": "it"
+  },
+  {
+    "keyName": "hubUpdateFormSubmittedTitle",
+    "text": "${formName} completato",
+    "language": "it"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesTitle",
+    "text": "Tutte le attività sono state completate",
+    "language": "it"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesDetail",
+    "text": "Hai completato tutte le attività per questo studio. Ti informeremo appena saranno disponibili nuove attività. Grazie della partecipazione!",
+    "language": "it"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyTitle",
+    "text": "Ti diamo il benvenuto nello studio ${studyName}",
+    "language": "it"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyDetail",
+    "text": "Leggi e firma il modulo di consenso in basso per proseguire.",
+    "language": "it"
+  },
+  {
+    "keyName": "hubUpdateAlreadyEnrolledTitle",
+    "text": "Partecipi già allo studio ${studyName}.",
+    "language": "it"
+  },
+  {
+    "keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle",
+    "text": "Questo utente partecipa già allo studio ${studyName}.",
+    "language": "it"
+  },
+  {
+    "keyName": "cookieAlertTitle",
+    "text": "Cookies",
+    "language": "it"
+  },
+  {
+    "keyName": "cookieAlertDetail",
+    "text": "Questo sito utilizza piccoli file di testo chiamati &quot;cookies&quot; per consentire il corretto funzionamento e la sicurezza del nostro sito web e per migliorare la tua esperienza di utilizzo. Utilizziamo solo i cookies strettamente necessari. Questo tipo di cookie non raccoglie dati personali e non traccia le tue abitudini di navigazione. Per maggiori informazioni, [leggi la nostra informativa sulla privacy](/privacy).",
+    "language": "it"
+  },
+  {
+    "keyName": "joinStudy",
+    "text": "Partecipa allo studio",
+    "language": "it"
+  },
+  {
+    "keyName": "ineligibleThankYou",
+    "text": "Grazie dell'interesse che hai mostrato per lo studio ${studyName}",
+    "language": "it"
+  },
+  {
+    "keyName": "ineligibleDescription",
+    "text": "Purtroppo, al momento non soddisfi i criteri di idoneità per partecipare allo studio ${studyName}.",
+    "language": "it"
+  },
+  {
+    "keyName": "ineligibleProvideYourEmail",
+    "text": "Inserisci qui il tuo indirizzo email e ti aggiorneremo sugli sviluppi. Puoi cancellarti in qualsiasi momento.",
+    "language": "it"
+  },
+  {
+    "keyName": "ineligibleStayInformed",
+    "text": "Ricevi le ultime notizie",
+    "language": "it"
+  },
+  {
+    "keyName": "backToPortalHomepage",
+    "text": "Torna alla pagina iniziale di ${portalName}",
+    "language": "it"
+  },
+  {
+    "keyName": "joinMailingList",
+    "text": "Iscriviti alla mailing list",
+    "language": "it"
+  },
+  {
+    "keyName": "mailingFormStayUpdated",
+    "text": "Ricevi le ultime notizie su questo studio",
+    "language": "it"
+  },
+  {
+    "keyName": "yourName",
+    "text": "Nome",
+    "language": "it"
+  },
+  {
+    "keyName": "yourEmail",
+    "text": "Indirizzo email",
+    "language": "it"
+  },
+  {
+    "keyName": "join",
+    "text": "Iscriviti",
+    "language": "it"
+  },
+  {
+    "keyName": "thanksForJoining",
+    "text": "Grazie dell'iscrizione!",
+    "language": "it"
+  },
+  {
+    "keyName": "pageNotFoundTitle",
+    "text": "Pagina non trovata",
+    "language": "it"
+  },
+  {
+    "keyName": "pageNotFoundMessage",
+    "text": "Se ritieni che ci sia stato un errore, contatta ${studyContactEmail}",
+    "language": "it"
+  },
+  {
+    "keyName": "pageNotFoundReturnHome",
+    "text": "Torna alla pagina iniziale",
+    "language": "it"
+  },
+  {
+    "keyName": "authErrorPageTitle",
+    "text": "Si è verificato un errore",
+    "language": "it"
+  },
+  {
+    "keyName": "authErrorPageMessage",
+    "text": "C'è stato un problema con il nostro servizio di autenticazione. Prova di nuovo. Se il problema persiste, contatta ${studyContactEmail}.",
+    "language": "it"
+  },
+  {
+    "keyName": "navbarSampleKits",
+    "text": "Kit di raccolta",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsPageTitle",
+    "text": "Kit di raccolta campioni",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsPageDescription",
+    "text": "I kit di raccolta campioni sono una parte importante del processo di studio e possono fornire ai ricercatori informazioni utili. Di seguito puoi vedere lo stato di tutti i kit che ti sono stati forniti.",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsPageInPersonTitle",
+    "text": "Fornisci un campione di persona",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsPageInPersonDescription",
+    "text": "Questo studio offre la possibilità di effettuare la raccolta campioni di persona.",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsPageInPersonCompleteButton",
+    "text": "Effettua la raccolta di persona",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsPageYourKitsTitle",
+    "text": "I tuoi kit",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsPageStatusPreparing",
+    "text": "In preparazione",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsPageStatusShipped",
+    "text": "Spediti",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsPageStatusReturned",
+    "text": "Restituiti",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsPageStatusCreated",
+    "text": "Creati",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsPageStatusCollected",
+    "text": "Raccolta effettuata",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsPageNoKits",
+    "text": "Al momento non possiedi nessun kit di raccolta campioni.",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsInPersonTitle",
+    "text": "Istruzioni per la raccolta dei campioni",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsInPersonDescription",
+    "text": "Se stai effettuando la raccolta dei campioni di persona, segui le istruzioni fornite dai membri del team di studio. Le eventuali altre informazioni di cui potresti avere bisogno, come il tuo codice identificativo univoco, sono fornite di seguito.",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsInPersonSubDescription",
+    "text": "Se hai domande, rivolgiti a un membro del team di studio.",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsInPersonYourKitTitle",
+    "text": "Il tuo kit di raccolta campioni",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsInPersonYourKitDescription",
+    "text": "Un membro del team ti ha fornito un kit di raccolta campioni. Questo kit è associato al tuo account. Se stai aiutando un'altra persona nella raccolta dei campioni, assicurati che ogni partecipante esegua la raccolta con il kit che gli è stato assegnato.",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsInPersonYourKitIdentifier",
+    "text": "Codice identificativo del tuo kit",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsInPersonReturnToDashboard",
+    "text": "Torna alla dashboard",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsInPersonRefreshPage",
+    "text": "Aggiorna",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredTitle",
+    "text": "Consenso richiesto",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredDescription",
+    "text": "Per poter eseguire la raccolta dei campioni con il kit, devi prima essere stato/a incluso/a nello studio. Se ti interessa, puoi leggere e firmare il modulo di consenso tramite il link riportato di seguito.",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsInPersonStartConsent",
+    "text": "Avvia consenso",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsInPersonError",
+    "text": "Si è verificato un errore durante il caricamento delle informazioni sul tuo kit. Contatta un membro del team di studio per ricevere assistenza.",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsInPersonCreatedInstructions",
+    "text": "Quando avrai completato la raccolta dei campioni, restituisci il kit a un membro del team di studio in modo che possa scansionare il tuo codice partecipante riportato di seguito.",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsInPersonNoKitInstructions",
+    "text": "Per ricevere un kit di raccolta campioni, un membro del team di studio scansionerà il tuo codice di partecipazione univoco per associare il kit al tuo account.",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsInPersonNoKitSubInstructions",
+    "text": "Quando avrai ricevuto il kit, aggiorna questa pagina per visualizzare le informazioni sul tuo kit e ottenere ulteriori istruzioni.",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsInPersonCollectedDescription",
+    "text": "Un membro del team di studio ha ricevuto il tuo kit di raccolta campioni. Riceverai un'email di notifica non appena il campione sarà stato elaborato e potrai visualizzarne lo stato sulla tua dashboard dello studio.",
+    "language": "it"
+  },
+  {
+    "keyName": "kitsInPersonCollectedThankYou",
+    "text": "Grazie della partecipazione.",
+    "language": "it"
+  },
+  {
+    "keyName": "kitTypeSaliva",
+    "text": "Kit di raccolta saliva",
+    "language": "it"
+  },
+  {
+    "keyName": "kitTypeStool",
+    "text": "Kit di raccolta feci",
+    "language": "it"
+  },
+  {
+    "keyName": "kitTypeBlood",
+    "text": "Kit di raccolta sangue",
+    "language": "it"
+  },
+  {
+    "keyName": "documentDownloadButton",
+    "text": "Scaricamento",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListNone",
+    "text": "Non hai ancora caricato alcun documento",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListCreatedOn",
+    "text": "Creato il",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageTitle",
+    "text": "Documenti",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageUploadedDocumentsTitle",
+    "text": "Documenti caricati",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageMessage",
+    "text": "Durante la partecipazione a uno studio, potrebbe esserti chiesto di caricare documenti come parte di un modulo o di un sondaggio. Di seguito, puoi gestire i documenti che hai caricato.",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "navbarDocuments",
+    "text": "Documenti",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureTitle",
+    "text": "Sei sicuro?",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureMessage",
+    "text": "Sei sicuro di voler eliminare questo documento? Questa operazione non può essere annullata. Nota che se un membro dello staff dello studio ha già scaricato questo documento, sarà comunque accessibile a lui. Contatta lo staff dello studio se desideri che il documento venga completamente rimosso da tutti i record.",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseTitle",
+    "text": "Questo documento è in uso",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseMessage",
+    "text": "Questo documento è attualmente condiviso in risposta ad almeno un sondaggio. Si prega di rimuoverlo dalle risposte al sondaggio prima di eliminarlo.",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteButton",
+    "text": "Eliminare",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentOptionsButton",
+    "text": "Opzioni",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentSharedInResponseTo",
+    "text": "condiviso in risposta a",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderSelectedDocuments",
+    "text": "Documenti selezionati",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderIncludedInResponse",
+    "text": "Questi documenti sono inclusi nella tua risposta",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocumentsSelected",
+    "text": "Nessun documento selezionato. Carica un nuovo documento o seleziona un documento esistente qui sotto.",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderAvailableDocuments",
+    "text": "Documenti disponibili",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNotIncludedInResponse",
+    "text": "Questi documenti non sono inclusi nella tua risposta",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderClickToUpload",
+    "text": "Trascina i file qui o clicca per caricarli",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocuments",
+    "text": "Nessun documento disponibile",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeTitle",
+    "text": "La tua sessione sta per scadere",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeMessage",
+    "text": "Per garantire la sicurezza e proteggere i tuoi dati, verrai disconnesso tra ${timeRemaining}.",
+    "language": "it",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "failedToEnroll",
+    "language": "it",
+    "text": "Qualcosa è andato storto durante il processo di iscrizione. Si prega di compilare di nuovo il modulo.",
+    "machineTranslated": true
+  }
 ]

--- a/populate/src/main/resources/seed/i18n/ja/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/ja/languageTexts.json
@@ -1,163 +1,836 @@
 [
-  {"keyName": "navbarDashboard", "text": "ダッシュボード", "language": "ja"},
-  {"keyName": "navbarChangePassword", "text": "パスワードの変更", "language": "ja"},
-  {"keyName": "navbarLogout", "text": "ログアウト", "language": "ja"},
-  {"keyName": "profile", "text": "プロファイル", "language": "ja"},
-  {"keyName": "navbarLogin", "text": "ログイン", "language": "ja"},
-  {"keyName": "navbarJoin", "text": "登録", "language": "ja"},
-  {"keyName": "taskComplete", "text": "完了", "language": "ja"},
-  {"keyName": "taskInProgress", "text": "進行中", "language": "ja"},
-  {"keyName": "taskNotStarted", "text": "未開始", "language": "ja"},
-  {"keyName": "taskDeclined", "text": "拒否", "language": "ja"},
-  {"keyName": "taskLocked", "text": "ロック済み", "language": "ja"},
-  {"keyName": "tasksNoneForStudy", "text": "この治験にタスクはありません", "language": "ja"},
-  {"keyName": "taskHistory", "text": "履歴", "language": "ja"},
-  {"keyName": "taskNew", "text": "新規", "language": "ja"},
-  {"keyName": "surveysSomeLocked", "text": "一部の調査は必要なタスクが完了するまでロックされています。", "language": "ja"},
-  {"keyName": "taskTypeSurvey", "text": "調査", "language": "ja"},
-  {"keyName": "taskTypeSurveys", "text": "調査", "language": "ja"},
-  {"keyName": "taskTypeConsent", "text": "同意", "language": "ja"},
-  {"keyName": "taskTypeForms", "text": "文書", "language": "ja"},
-  {"keyName": "start", "text": "開始", "language": "ja"},
-  {"keyName": "continue", "text": "続行", "language": "ja"},
-  {"keyName": "save", "text": "保存", "language": "ja"},
-  {"keyName": "outreachLearnMore", "text": "詳細", "language": "ja"},
-  {"keyName": "cancel", "text": "キャンセル", "language": "ja"},
-  {"keyName": "goBack", "text": "戻る", "language": "ja"},
-  {"keyName": "name", "text": "名前", "language": "ja"},
-  {"keyName": "givenName", "text": "名", "language": "ja"},
-  {"keyName": "familyName", "text": "姓", "language": "ja"},
-  {"keyName": "editName", "text": "名前の編集", "language": "ja"},
-  {"keyName": "editBirthDate", "text": "生年月日の編集", "language": "ja"},
-  {"keyName": "birthDate", "text": "生年月日", "language": "ja"},
-  {"keyName": "mailingAddress", "text": "郵送先住所", "language": "ja"},
-  {"keyName": "editMailingAddress", "text": "郵送先住所の編集", "language": "ja"},
-  {"keyName": "primaryAddress", "text": "主な住所", "language": "ja"},
-  {"keyName": "editPrimaryAddress", "text": "主な住所の編集", "language": "ja"},
-  {"keyName": "street1", "text": "町名番地 1", "language": "ja"},
-  {"keyName": "street2", "text": "町名番地 2", "language": "ja"},
-  {"keyName": "city", "text": "市区町村", "language": "ja"},
-  {"keyName": "state", "text": "都道府県", "language": "ja"},
-  {"keyName": "postalCode", "text": "郵便番号", "language": "ja"},
-  {"keyName": "country", "text": "国", "language": "ja"},
-  {"keyName": "communicationPreferences", "text": "希望する連絡方法", "language": "ja"},
-  {"keyName": "editCommunicationPreferences", "text": "希望する連絡方法の編集", "language": "ja"},
-  {"keyName": "contactEmail", "text": "連絡先Eメール", "language": "ja"},
-  {"keyName": "editContactEmail", "text": "連絡先Eメールの編集", "language": "ja"},
-  {"keyName": "phoneNumber", "text": "電話番号", "language": "ja"},
-  {"keyName": "editPhoneNumber", "text": "電話番号の編集", "language": "ja"},
-  {"keyName": "doNotSolicit", "text": "勧誘拒否", "language": "ja"},
-  {"keyName": "doNotContact", "text": "連絡拒否", "language": "ja"},
-  {"keyName": "editDoNotSolicit", "text": "勧誘拒否の編集", "language": "ja"},
-  {"keyName": "editNotifications", "text": "通知の編集", "language": "ja"},
-  {"keyName": "notifications", "text": "通知", "language": "ja"},
-  {"keyName": "on", "text": "オン", "language": "ja"},
-  {"keyName": "off", "text": "オフ", "language": "ja"},
-  {"keyName": "notProvided", "text": "未入力", "language": "ja"},
-  {"keyName": "editProfileContactEmailWarning", "text": "「保存」をクリックして連絡に使用するEメールを更新してください。ただし、ログイン情報は変更されません。", "language": "ja"},
-  {"keyName": "privacyPolicy", "text": "プライバシーポリシー", "language": "ja"},
-  {"keyName": "termsOfUse", "text": "利用規定", "language": "ja"},
-  {"keyName": "addressInvalidPostalCode", "text": "郵便番号を確認できませんでした。", "language": "ja"},
-  {"keyName": "addressInvalidCountry", "text": "国を確認できませんでした。", "language": "ja"},
-  {"keyName": "addressInvalidState", "text": "都道府県を確認できませんでした。", "language": "ja"},
-  {"keyName": "addressInvalidCity", "text": "市区町村を確認できませんでした。", "language": "ja"},
-  {"keyName": "addressInvalidHouseNumber", "text": "番地を確認できませんでした。", "language": "ja"},
-  {"keyName": "addressInvalidStreetName", "text": "町名番地を確認できませんでした。", "language": "ja"},
-  {"keyName": "addressInvalidStreetType", "text": "町名を確認できませんでした。", "language": "ja"},
-  {"keyName": "addressNeedsSubpremise", "text": "建物名／部屋番号を入力してください。", "language": "ja"},
-  {"keyName": "addressFailedToValidate", "text": "住所を確認できませんでした。", "language": "ja"},
-  {"keyName": "suggestBetterAddressHeader", "text": "これは正しい住所ですか？", "language": "ja"},
-  {"keyName": "suggestBetterAddressBody", "text": "同じような住所を確認することができました。どちらの住所を使用するか選択してください。", "language": "ja"},
-  {"keyName": "newAddress", "text": "新住所", "language": "ja"},
-  {"keyName": "oldAddress", "text": "旧住所", "language": "ja"},
-  {"keyName": "you", "text": "あなた", "language": "ja"},
-  {"keyName": "yourDependent", "text": "あなたの扶養家族", "language": "ja"},
-  {"keyName": "youInParens", "text": "(あなた)", "language": "ja"},
-  {"keyName": "allProfiles", "text": "すべてのプロファイル", "language": "ja"},
-  {"keyName": "manageProfiles", "text": "プロファイルの管理", "language": "ja"},
-  {"keyName": "addNewParticipant", "text": "参加者の新規追加", "language": "ja"},
-  {"keyName": "dashboard", "text": "ダッシュボード", "language": "ja"},
-  {"keyName": "selectParticipant", "text": "参加者の選択", "language": "ja"},
-  {"keyName": "hubUpdateFormSubmittedTitle", "text": "${formName} は完了済み", "language": "ja"},
-  {"keyName": "hubUpdateNoActivitiesTitle", "text": "すべてのアクティビティが完了済み", "language": "ja"},
-  {"keyName": "hubUpdateNoActivitiesDetail", "text": "この治験のすべてのアクティビティが完了しています。新しいアクティビティが有効になり次第通知します。ご参加いただきありがとうございます！", "language": "ja"},
-  {"keyName": "hubUpdateWelcomeToStudyTitle", "text": "${studyName} へようこそ", "language": "ja"},
-  {"keyName": "hubUpdateWelcomeToStudyDetail", "text": "続行するには、以下の同意文書をお読みいただき、署名してください。", "language": "ja"},
-  {"keyName": "hubUpdateAlreadyEnrolledTitle", "text": "あなたは ${studyName} に登録済みです。", "language": "ja"},
-  {"keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle", "text": "このユーザーは ${studyName} に登録済みです。", "language": "ja"},
-  {"keyName": "cookieAlertTitle", "text": "Cookies（クッキー）", "language": "ja"},
-  {"keyName": "cookieAlertDetail", "text": "このサイトでは「クッキー」と呼ばれるインターネットのトークンを使用して、ウェブサイトの正常な機能とセキュリティを可能にし、ユーザー体験を向上しています。使用するクッキーはすべて厳密に必要なクッキーです。このタイプのクッキーは、あなたの個人識別情報を収集したり、あなたの閲覧行動を追跡したりしません。詳しくは [当社のプライバシーポリシーをご覧ください](\/privacy)。", "language": "ja"},
-  {"keyName": "joinStudy", "text": "治験に参加", "language": "ja"},
-  {"keyName": "ineligibleThankYou", "text": "${studyName} にご関心をお寄せいただき、ありがとうございます", "language": "ja" },
-  {"keyName": "ineligibleDescription", "text": "申し訳ございませんが、今回は ${studyName} の参加に必要な適格基準を満たしていらっしゃいません。", "language": "ja"},
-  {"keyName": "ineligibleProvideYourEmail", "text": "以下にEメールアドレスを入力してください。治験計画に関する最新情報をお届けします。いつでも登録を解除することができます。", "language":  "ja"},
-  {"keyName": "ineligibleStayInformed", "text": "最新情報の入手", "language": "ja"},
-  {"keyName": "backToPortalHomepage", "text": "${portalName} ホームページに戻る", "language": "ja"},
-  {"keyName": "joinMailingList", "text": "メーリングリストに参加", "language": "ja"},
-  {"keyName": "mailingFormStayUpdated", "text":  "治験に関する最新情報を希望", "language": "ja"},
-  {"keyName": "yourName", "text": "お名前", "language": "ja"},
-  {"keyName": "yourEmail", "text": "Eメール", "language": "ja"},
-  {"keyName": "join", "text":  "参加する", "language": "ja"},
-  {"keyName": "thanksForJoining", "text": "ご登録ありがとうございます！", "language": "ja"},
-  {"keyName": "pageNotFoundTitle", "text": "ページが見つかりません", "language": "ja"},
-  {"keyName": "pageNotFoundMessage", "text": "これがエラーだと思われる場合は、${studyContactEmail} までご連絡ください。", "language": "ja"},
-  {"keyName": "pageNotFoundReturnHome", "text": "ホームページに戻る", "language": "ja"},
-  {"keyName": "authErrorPageTitle", "text": "エラーが発生しました", "language": "ja"},
-  {"keyName": "authErrorPageMessage", "text": "認証サービスに問題が発生しました。もう一度お試しください。問題が解決しない場合は、${studyContactEmail} までご連絡ください。", "language": "ja"},
-  {"keyName": "navbarSampleKits", "text":  "検体キット", "language": "ja"},
-  {"keyName": "kitsPageTitle", "text": "検体採取キット", "language": "ja"},
-  {"keyName": "kitsPageDescription", "text": "検体採取キットは治験の重要な過程であり、研究者に重要な知見を提供するのに役立ちます。以下から、あなたに提供されたキットすべてのステータスを検索できます。", "language": "ja"},
-  {"keyName": "kitsPageInPersonTitle", "text": "検体を対面で提供", "language": "ja"},
-  {"keyName": "kitsPageInPersonDescription", "text": "この治験では現在、検体採取キットを対面で完了する選択肢を提供しています。", "language": "ja"},
-  {"keyName": "kitsPageInPersonCompleteButton", "text": "キットを対面で完了", "language": "ja"},
-  {"keyName": "kitsPageYourKitsTitle", "text": "あなたのキット", "language": "ja"},
-  {"keyName": "kitsPageStatusPreparing", "text": "準備中", "language": "ja"},
-  {"keyName": "kitsPageStatusShipped", "text": "発送済み", "language": "ja"},
-  {"keyName": "kitsPageStatusReturned", "text": "返却済み", "language": "ja"},
-  {"keyName": "kitsPageStatusCreated", "text": "作成済み", "language": "ja"},
-  {"keyName": "kitsPageStatusCollected", "text": "採取済み", "language": "ja"},
-  {"keyName": "kitsPageNoKits", "text": "現時点ではあなたの検体採取キットはありません。", "language": "ja"},
-  {"keyName": "kitsInPersonTitle", "text": "検体キットに関する指示", "language": "ja"},
-  {"keyName": "kitsInPersonDescription", "text": "検体採取キットを対面で完了する場合は、治験チームメンバーの指示に従ってください。あなた固有の参加者IDなど、必要になる追加情報はすべて以下に提供されます。", "language": "ja"},
-  {"keyName": "kitsInPersonSubDescription", "text": "ご質問がある場合は、治験チームのメンバーにお尋ねください。", "language": "ja"},
-  {"keyName": "kitsInPersonYourKitTitle", "text": "検体採取キット", "language": "ja"},
-  {"keyName": "kitsInPersonYourKitDescription", "text": "治験チームのメンバーが検体採取キットをあなたに提供しました。この検体キットはあなたのアカウントに関連付けられています。あなた以外の他の方の検体採取キットの使用を補助している場合は、各参加者が各自割り当てられた検体採取キットを完了することを確かめてください。", "language": "ja"},
-  {"keyName": "kitsInPersonYourKitIdentifier", "text": "あなたのキットID", "language": "ja"},
-  {"keyName": "kitsInPersonReturnToDashboard", "text": "ダッシュボードに戻る", "language": "ja"},
-  {"keyName": "kitsInPersonRefreshPage", "text": "表示の更新", "language": "ja"},
-  {"keyName": "kitsInPersonConsentRequiredTitle", "text": "同意が必要", "language": "ja"},
-  {"keyName": "kitsInPersonConsentRequiredDescription", "text": "検体採取キットを完了していただく前に、まず治験に登録する必要があります。ご関心をお持ちの場合は、以下のリンクから同意文書を取得して署名していただけます。", "language": "ja"},
-  {"keyName": "kitsInPersonStartConsent", "text": "同意の開始", "language": "ja"},
-  {"keyName": "kitsInPersonError", "text": "キット情報の検索中にエラーが発生しました。ヘルプが必要な場合は治験チームのメンバーに連絡してください。", "language": "ja"},
-  {"keyName": "kitsInPersonCreatedInstructions", "text": "検体採取キットを完了したら、治験チームのメンバーに返却し、以下の参加コードをスキャンしてもらってください。", "language": "ja"},
-  {"keyName": "kitsInPersonNoKitInstructions", "text": "検体採取キットを受領する際、治験チームのメンバーが以下のあなた固有の参加コードをスキャンして、検体キットをあなたのアカウントに関連付けます。", "language": "ja"},
-  {"keyName": "kitsInPersonNoKitSubInstructions", "text": "キットを受領した後、このページの表示を更新してください。あなたのキット情報が表示され、詳しい指示を確認することができます。", "language": "ja"},
-  {"keyName": "kitsInPersonCollectedDescription", "text": "治験チームのメンバーがあなたの検体採取キットを受領しました。あなたの検体が処理されるとEメールで通知が送信されます。また治験ダッシュボードで検体のステータスを確認することができるようになります。", "language": "ja"},
-  {"keyName": "kitsInPersonCollectedThankYou", "text": "ご参加いただきありがとうございます。", "language": "ja"},
-  {"keyName": "kitTypeSaliva", "text": "唾液キット", "language": "ja"},
-  {"keyName": "kitTypeStool", "text": "便キット", "language": "ja"},
-  {"keyName": "kitTypeBlood", "text": "血液キット", "language": "ja"},
-  {"keyName": "documentDownloadButton", "text": "ダウンロード", "language": "ja", "machineTranslated": true},
-  {"keyName": "documentsListNone", "text": "まだ書類をアップロードしていません", "language": "ja", "machineTranslated": true},
-  {"keyName": "documentsListCreatedOn", "text": "作成日", "language": "ja", "machineTranslated": true},
-  {"keyName": "documentsPageTitle", "text": "文書", "language": "ja", "machineTranslated": true},
-  {"keyName": "documentsPageUploadedDocumentsTitle", "text": "アップロードされた文書", "language": "ja", "machineTranslated": true},
-  {"keyName": "documentsPageMessage", "text": "調査に参加する際に、フォームまたはアンケートの一部としてドキュメントをアップロードするよう求められる場合があります。以下で、アップロードしたドキュメントを管理できます。", "language": "ja", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "文書", "language": "ja", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureTitle", "text": "本気ですか？", "language": "ja", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureMessage", "text": "この文書を削除してもよろしいですか? 元に戻すことはできません。研究スタッフのメンバーがすでにこの文書をダウンロードしている場合は、引き続きアクセスできます。すべての記録から文書を完全に削除したい場合は、研究スタッフに連絡してください。", "language": "ja", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseTitle", "text": "この文書は使用中です", "language": "ja", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseMessage", "text": "このドキュメントは現在、少なくとも 1 つのアンケートへの回答として共有されています。削除する前に、アンケートの回答から削除してください。", "language": "ja", "machineTranslated": true},
-  {"keyName": "documentDeleteButton", "text": "消去", "language": "ja", "machineTranslated": true},
-  {"keyName": "documentOptionsButton", "text": "オプション", "language": "ja", "machineTranslated": true},
-  {"keyName": "documentSharedInResponseTo", "text": "への返信として共有", "language": "ja", "machineTranslated": true},
-  {"keyName": "documentUploaderSelectedDocuments", "text": "選択された文書", "language": "ja", "machineTranslated": true},
-  {"keyName": "documentUploaderIncludedInResponse", "text": "これらの文書はあなたの回答に含まれています", "language": "ja", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocumentsSelected", "text": "ドキュメントが選択されていません。新しいドキュメントをアップロードするか、以下の既存のドキュメントを選択してください。", "language": "ja", "machineTranslated": true},
-  {"keyName": "documentUploaderAvailableDocuments", "text": "利用可能な文書", "language": "ja", "machineTranslated": true},
-  {"keyName": "documentUploaderNotIncludedInResponse", "text": "これらの文書は回答に含まれていません", "language": "ja", "machineTranslated": true},
-  {"keyName": "documentUploaderClickToUpload", "text": "ここにファイルをドロップするか、クリックしてアップロードしてください", "language": "ja", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocuments", "text": "利用可能な文書はありません", "language": "ja", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeTitle", "text": "セッションの有効期限が切れます", "language": "ja", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeMessage", "text": "セキュリティを維持し、データを保護するため、${timeRemaining} 後にログアウトされます。", "language": "ja", "machineTranslated": true}
+  {
+    "keyName": "navbarDashboard",
+    "text": "ダッシュボード",
+    "language": "ja"
+  },
+  {
+    "keyName": "navbarChangePassword",
+    "text": "パスワードの変更",
+    "language": "ja"
+  },
+  {
+    "keyName": "navbarLogout",
+    "text": "ログアウト",
+    "language": "ja"
+  },
+  {
+    "keyName": "profile",
+    "text": "プロファイル",
+    "language": "ja"
+  },
+  {
+    "keyName": "navbarLogin",
+    "text": "ログイン",
+    "language": "ja"
+  },
+  {
+    "keyName": "navbarJoin",
+    "text": "登録",
+    "language": "ja"
+  },
+  {
+    "keyName": "taskComplete",
+    "text": "完了",
+    "language": "ja"
+  },
+  {
+    "keyName": "taskInProgress",
+    "text": "進行中",
+    "language": "ja"
+  },
+  {
+    "keyName": "taskNotStarted",
+    "text": "未開始",
+    "language": "ja"
+  },
+  {
+    "keyName": "taskDeclined",
+    "text": "拒否",
+    "language": "ja"
+  },
+  {
+    "keyName": "taskLocked",
+    "text": "ロック済み",
+    "language": "ja"
+  },
+  {
+    "keyName": "tasksNoneForStudy",
+    "text": "この治験にタスクはありません",
+    "language": "ja"
+  },
+  {
+    "keyName": "taskHistory",
+    "text": "履歴",
+    "language": "ja"
+  },
+  {
+    "keyName": "taskNew",
+    "text": "新規",
+    "language": "ja"
+  },
+  {
+    "keyName": "surveysSomeLocked",
+    "text": "一部の調査は必要なタスクが完了するまでロックされています。",
+    "language": "ja"
+  },
+  {
+    "keyName": "taskTypeSurvey",
+    "text": "調査",
+    "language": "ja"
+  },
+  {
+    "keyName": "taskTypeSurveys",
+    "text": "調査",
+    "language": "ja"
+  },
+  {
+    "keyName": "taskTypeConsent",
+    "text": "同意",
+    "language": "ja"
+  },
+  {
+    "keyName": "taskTypeForms",
+    "text": "文書",
+    "language": "ja"
+  },
+  {
+    "keyName": "start",
+    "text": "開始",
+    "language": "ja"
+  },
+  {
+    "keyName": "continue",
+    "text": "続行",
+    "language": "ja"
+  },
+  {
+    "keyName": "save",
+    "text": "保存",
+    "language": "ja"
+  },
+  {
+    "keyName": "outreachLearnMore",
+    "text": "詳細",
+    "language": "ja"
+  },
+  {
+    "keyName": "cancel",
+    "text": "キャンセル",
+    "language": "ja"
+  },
+  {
+    "keyName": "goBack",
+    "text": "戻る",
+    "language": "ja"
+  },
+  {
+    "keyName": "name",
+    "text": "名前",
+    "language": "ja"
+  },
+  {
+    "keyName": "givenName",
+    "text": "名",
+    "language": "ja"
+  },
+  {
+    "keyName": "familyName",
+    "text": "姓",
+    "language": "ja"
+  },
+  {
+    "keyName": "editName",
+    "text": "名前の編集",
+    "language": "ja"
+  },
+  {
+    "keyName": "editBirthDate",
+    "text": "生年月日の編集",
+    "language": "ja"
+  },
+  {
+    "keyName": "birthDate",
+    "text": "生年月日",
+    "language": "ja"
+  },
+  {
+    "keyName": "mailingAddress",
+    "text": "郵送先住所",
+    "language": "ja"
+  },
+  {
+    "keyName": "editMailingAddress",
+    "text": "郵送先住所の編集",
+    "language": "ja"
+  },
+  {
+    "keyName": "primaryAddress",
+    "text": "主な住所",
+    "language": "ja"
+  },
+  {
+    "keyName": "editPrimaryAddress",
+    "text": "主な住所の編集",
+    "language": "ja"
+  },
+  {
+    "keyName": "street1",
+    "text": "町名番地 1",
+    "language": "ja"
+  },
+  {
+    "keyName": "street2",
+    "text": "町名番地 2",
+    "language": "ja"
+  },
+  {
+    "keyName": "city",
+    "text": "市区町村",
+    "language": "ja"
+  },
+  {
+    "keyName": "state",
+    "text": "都道府県",
+    "language": "ja"
+  },
+  {
+    "keyName": "postalCode",
+    "text": "郵便番号",
+    "language": "ja"
+  },
+  {
+    "keyName": "country",
+    "text": "国",
+    "language": "ja"
+  },
+  {
+    "keyName": "communicationPreferences",
+    "text": "希望する連絡方法",
+    "language": "ja"
+  },
+  {
+    "keyName": "editCommunicationPreferences",
+    "text": "希望する連絡方法の編集",
+    "language": "ja"
+  },
+  {
+    "keyName": "contactEmail",
+    "text": "連絡先Eメール",
+    "language": "ja"
+  },
+  {
+    "keyName": "editContactEmail",
+    "text": "連絡先Eメールの編集",
+    "language": "ja"
+  },
+  {
+    "keyName": "phoneNumber",
+    "text": "電話番号",
+    "language": "ja"
+  },
+  {
+    "keyName": "editPhoneNumber",
+    "text": "電話番号の編集",
+    "language": "ja"
+  },
+  {
+    "keyName": "doNotSolicit",
+    "text": "勧誘拒否",
+    "language": "ja"
+  },
+  {
+    "keyName": "doNotContact",
+    "text": "連絡拒否",
+    "language": "ja"
+  },
+  {
+    "keyName": "editDoNotSolicit",
+    "text": "勧誘拒否の編集",
+    "language": "ja"
+  },
+  {
+    "keyName": "editNotifications",
+    "text": "通知の編集",
+    "language": "ja"
+  },
+  {
+    "keyName": "notifications",
+    "text": "通知",
+    "language": "ja"
+  },
+  {
+    "keyName": "on",
+    "text": "オン",
+    "language": "ja"
+  },
+  {
+    "keyName": "off",
+    "text": "オフ",
+    "language": "ja"
+  },
+  {
+    "keyName": "notProvided",
+    "text": "未入力",
+    "language": "ja"
+  },
+  {
+    "keyName": "editProfileContactEmailWarning",
+    "text": "「保存」をクリックして連絡に使用するEメールを更新してください。ただし、ログイン情報は変更されません。",
+    "language": "ja"
+  },
+  {
+    "keyName": "privacyPolicy",
+    "text": "プライバシーポリシー",
+    "language": "ja"
+  },
+  {
+    "keyName": "termsOfUse",
+    "text": "利用規定",
+    "language": "ja"
+  },
+  {
+    "keyName": "addressInvalidPostalCode",
+    "text": "郵便番号を確認できませんでした。",
+    "language": "ja"
+  },
+  {
+    "keyName": "addressInvalidCountry",
+    "text": "国を確認できませんでした。",
+    "language": "ja"
+  },
+  {
+    "keyName": "addressInvalidState",
+    "text": "都道府県を確認できませんでした。",
+    "language": "ja"
+  },
+  {
+    "keyName": "addressInvalidCity",
+    "text": "市区町村を確認できませんでした。",
+    "language": "ja"
+  },
+  {
+    "keyName": "addressInvalidHouseNumber",
+    "text": "番地を確認できませんでした。",
+    "language": "ja"
+  },
+  {
+    "keyName": "addressInvalidStreetName",
+    "text": "町名番地を確認できませんでした。",
+    "language": "ja"
+  },
+  {
+    "keyName": "addressInvalidStreetType",
+    "text": "町名を確認できませんでした。",
+    "language": "ja"
+  },
+  {
+    "keyName": "addressNeedsSubpremise",
+    "text": "建物名／部屋番号を入力してください。",
+    "language": "ja"
+  },
+  {
+    "keyName": "addressFailedToValidate",
+    "text": "住所を確認できませんでした。",
+    "language": "ja"
+  },
+  {
+    "keyName": "suggestBetterAddressHeader",
+    "text": "これは正しい住所ですか？",
+    "language": "ja"
+  },
+  {
+    "keyName": "suggestBetterAddressBody",
+    "text": "同じような住所を確認することができました。どちらの住所を使用するか選択してください。",
+    "language": "ja"
+  },
+  {
+    "keyName": "newAddress",
+    "text": "新住所",
+    "language": "ja"
+  },
+  {
+    "keyName": "oldAddress",
+    "text": "旧住所",
+    "language": "ja"
+  },
+  {
+    "keyName": "you",
+    "text": "あなた",
+    "language": "ja"
+  },
+  {
+    "keyName": "yourDependent",
+    "text": "あなたの扶養家族",
+    "language": "ja"
+  },
+  {
+    "keyName": "youInParens",
+    "text": "(あなた)",
+    "language": "ja"
+  },
+  {
+    "keyName": "allProfiles",
+    "text": "すべてのプロファイル",
+    "language": "ja"
+  },
+  {
+    "keyName": "manageProfiles",
+    "text": "プロファイルの管理",
+    "language": "ja"
+  },
+  {
+    "keyName": "addNewParticipant",
+    "text": "参加者の新規追加",
+    "language": "ja"
+  },
+  {
+    "keyName": "dashboard",
+    "text": "ダッシュボード",
+    "language": "ja"
+  },
+  {
+    "keyName": "selectParticipant",
+    "text": "参加者の選択",
+    "language": "ja"
+  },
+  {
+    "keyName": "hubUpdateFormSubmittedTitle",
+    "text": "${formName} は完了済み",
+    "language": "ja"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesTitle",
+    "text": "すべてのアクティビティが完了済み",
+    "language": "ja"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesDetail",
+    "text": "この治験のすべてのアクティビティが完了しています。新しいアクティビティが有効になり次第通知します。ご参加いただきありがとうございます！",
+    "language": "ja"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyTitle",
+    "text": "${studyName} へようこそ",
+    "language": "ja"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyDetail",
+    "text": "続行するには、以下の同意文書をお読みいただき、署名してください。",
+    "language": "ja"
+  },
+  {
+    "keyName": "hubUpdateAlreadyEnrolledTitle",
+    "text": "あなたは ${studyName} に登録済みです。",
+    "language": "ja"
+  },
+  {
+    "keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle",
+    "text": "このユーザーは ${studyName} に登録済みです。",
+    "language": "ja"
+  },
+  {
+    "keyName": "cookieAlertTitle",
+    "text": "Cookies（クッキー）",
+    "language": "ja"
+  },
+  {
+    "keyName": "cookieAlertDetail",
+    "text": "このサイトでは「クッキー」と呼ばれるインターネットのトークンを使用して、ウェブサイトの正常な機能とセキュリティを可能にし、ユーザー体験を向上しています。使用するクッキーはすべて厳密に必要なクッキーです。このタイプのクッキーは、あなたの個人識別情報を収集したり、あなたの閲覧行動を追跡したりしません。詳しくは [当社のプライバシーポリシーをご覧ください](/privacy)。",
+    "language": "ja"
+  },
+  {
+    "keyName": "joinStudy",
+    "text": "治験に参加",
+    "language": "ja"
+  },
+  {
+    "keyName": "ineligibleThankYou",
+    "text": "${studyName} にご関心をお寄せいただき、ありがとうございます",
+    "language": "ja"
+  },
+  {
+    "keyName": "ineligibleDescription",
+    "text": "申し訳ございませんが、今回は ${studyName} の参加に必要な適格基準を満たしていらっしゃいません。",
+    "language": "ja"
+  },
+  {
+    "keyName": "ineligibleProvideYourEmail",
+    "text": "以下にEメールアドレスを入力してください。治験計画に関する最新情報をお届けします。いつでも登録を解除することができます。",
+    "language": "ja"
+  },
+  {
+    "keyName": "ineligibleStayInformed",
+    "text": "最新情報の入手",
+    "language": "ja"
+  },
+  {
+    "keyName": "backToPortalHomepage",
+    "text": "${portalName} ホームページに戻る",
+    "language": "ja"
+  },
+  {
+    "keyName": "joinMailingList",
+    "text": "メーリングリストに参加",
+    "language": "ja"
+  },
+  {
+    "keyName": "mailingFormStayUpdated",
+    "text": "治験に関する最新情報を希望",
+    "language": "ja"
+  },
+  {
+    "keyName": "yourName",
+    "text": "お名前",
+    "language": "ja"
+  },
+  {
+    "keyName": "yourEmail",
+    "text": "Eメール",
+    "language": "ja"
+  },
+  {
+    "keyName": "join",
+    "text": "参加する",
+    "language": "ja"
+  },
+  {
+    "keyName": "thanksForJoining",
+    "text": "ご登録ありがとうございます！",
+    "language": "ja"
+  },
+  {
+    "keyName": "pageNotFoundTitle",
+    "text": "ページが見つかりません",
+    "language": "ja"
+  },
+  {
+    "keyName": "pageNotFoundMessage",
+    "text": "これがエラーだと思われる場合は、${studyContactEmail} までご連絡ください。",
+    "language": "ja"
+  },
+  {
+    "keyName": "pageNotFoundReturnHome",
+    "text": "ホームページに戻る",
+    "language": "ja"
+  },
+  {
+    "keyName": "authErrorPageTitle",
+    "text": "エラーが発生しました",
+    "language": "ja"
+  },
+  {
+    "keyName": "authErrorPageMessage",
+    "text": "認証サービスに問題が発生しました。もう一度お試しください。問題が解決しない場合は、${studyContactEmail} までご連絡ください。",
+    "language": "ja"
+  },
+  {
+    "keyName": "navbarSampleKits",
+    "text": "検体キット",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsPageTitle",
+    "text": "検体採取キット",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsPageDescription",
+    "text": "検体採取キットは治験の重要な過程であり、研究者に重要な知見を提供するのに役立ちます。以下から、あなたに提供されたキットすべてのステータスを検索できます。",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsPageInPersonTitle",
+    "text": "検体を対面で提供",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsPageInPersonDescription",
+    "text": "この治験では現在、検体採取キットを対面で完了する選択肢を提供しています。",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsPageInPersonCompleteButton",
+    "text": "キットを対面で完了",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsPageYourKitsTitle",
+    "text": "あなたのキット",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsPageStatusPreparing",
+    "text": "準備中",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsPageStatusShipped",
+    "text": "発送済み",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsPageStatusReturned",
+    "text": "返却済み",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsPageStatusCreated",
+    "text": "作成済み",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsPageStatusCollected",
+    "text": "採取済み",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsPageNoKits",
+    "text": "現時点ではあなたの検体採取キットはありません。",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsInPersonTitle",
+    "text": "検体キットに関する指示",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsInPersonDescription",
+    "text": "検体採取キットを対面で完了する場合は、治験チームメンバーの指示に従ってください。あなた固有の参加者IDなど、必要になる追加情報はすべて以下に提供されます。",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsInPersonSubDescription",
+    "text": "ご質問がある場合は、治験チームのメンバーにお尋ねください。",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsInPersonYourKitTitle",
+    "text": "検体採取キット",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsInPersonYourKitDescription",
+    "text": "治験チームのメンバーが検体採取キットをあなたに提供しました。この検体キットはあなたのアカウントに関連付けられています。あなた以外の他の方の検体採取キットの使用を補助している場合は、各参加者が各自割り当てられた検体採取キットを完了することを確かめてください。",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsInPersonYourKitIdentifier",
+    "text": "あなたのキットID",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsInPersonReturnToDashboard",
+    "text": "ダッシュボードに戻る",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsInPersonRefreshPage",
+    "text": "表示の更新",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredTitle",
+    "text": "同意が必要",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredDescription",
+    "text": "検体採取キットを完了していただく前に、まず治験に登録する必要があります。ご関心をお持ちの場合は、以下のリンクから同意文書を取得して署名していただけます。",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsInPersonStartConsent",
+    "text": "同意の開始",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsInPersonError",
+    "text": "キット情報の検索中にエラーが発生しました。ヘルプが必要な場合は治験チームのメンバーに連絡してください。",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsInPersonCreatedInstructions",
+    "text": "検体採取キットを完了したら、治験チームのメンバーに返却し、以下の参加コードをスキャンしてもらってください。",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsInPersonNoKitInstructions",
+    "text": "検体採取キットを受領する際、治験チームのメンバーが以下のあなた固有の参加コードをスキャンして、検体キットをあなたのアカウントに関連付けます。",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsInPersonNoKitSubInstructions",
+    "text": "キットを受領した後、このページの表示を更新してください。あなたのキット情報が表示され、詳しい指示を確認することができます。",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsInPersonCollectedDescription",
+    "text": "治験チームのメンバーがあなたの検体採取キットを受領しました。あなたの検体が処理されるとEメールで通知が送信されます。また治験ダッシュボードで検体のステータスを確認することができるようになります。",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitsInPersonCollectedThankYou",
+    "text": "ご参加いただきありがとうございます。",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitTypeSaliva",
+    "text": "唾液キット",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitTypeStool",
+    "text": "便キット",
+    "language": "ja"
+  },
+  {
+    "keyName": "kitTypeBlood",
+    "text": "血液キット",
+    "language": "ja"
+  },
+  {
+    "keyName": "documentDownloadButton",
+    "text": "ダウンロード",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListNone",
+    "text": "まだ書類をアップロードしていません",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListCreatedOn",
+    "text": "作成日",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageTitle",
+    "text": "文書",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageUploadedDocumentsTitle",
+    "text": "アップロードされた文書",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageMessage",
+    "text": "調査に参加する際に、フォームまたはアンケートの一部としてドキュメントをアップロードするよう求められる場合があります。以下で、アップロードしたドキュメントを管理できます。",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "navbarDocuments",
+    "text": "文書",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureTitle",
+    "text": "本気ですか？",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureMessage",
+    "text": "この文書を削除してもよろしいですか? 元に戻すことはできません。研究スタッフのメンバーがすでにこの文書をダウンロードしている場合は、引き続きアクセスできます。すべての記録から文書を完全に削除したい場合は、研究スタッフに連絡してください。",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseTitle",
+    "text": "この文書は使用中です",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseMessage",
+    "text": "このドキュメントは現在、少なくとも 1 つのアンケートへの回答として共有されています。削除する前に、アンケートの回答から削除してください。",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteButton",
+    "text": "消去",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentOptionsButton",
+    "text": "オプション",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentSharedInResponseTo",
+    "text": "への返信として共有",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderSelectedDocuments",
+    "text": "選択された文書",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderIncludedInResponse",
+    "text": "これらの文書はあなたの回答に含まれています",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocumentsSelected",
+    "text": "ドキュメントが選択されていません。新しいドキュメントをアップロードするか、以下の既存のドキュメントを選択してください。",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderAvailableDocuments",
+    "text": "利用可能な文書",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNotIncludedInResponse",
+    "text": "これらの文書は回答に含まれていません",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderClickToUpload",
+    "text": "ここにファイルをドロップするか、クリックしてアップロードしてください",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocuments",
+    "text": "利用可能な文書はありません",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeTitle",
+    "text": "セッションの有効期限が切れます",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeMessage",
+    "text": "セキュリティを維持し、データを保護するため、${timeRemaining} 後にログアウトされます。",
+    "language": "ja",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "failedToEnroll",
+    "language": "ja",
+    "text": "登録プロセス中に何かがうまくいかなかった。もう一度フォームに記入してください。",
+    "machineTranslated": true
+  }
 ]

--- a/populate/src/main/resources/seed/i18n/pl/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/pl/languageTexts.json
@@ -1,163 +1,836 @@
 [
-  {"keyName": "navbarDashboard", "text": "Panel", "language": "pl"},
-  {"keyName": "navbarChangePassword", "text": "Zmień hasło", "language": "pl"},
-  {"keyName": "navbarLogout", "text": "Wyloguj się", "language": "pl"},
-  {"keyName": "profile", "text": "Profil", "language": "pl"},
-  {"keyName": "navbarLogin", "text": "Zaloguj się", "language": "pl"},
-  {"keyName": "navbarJoin", "text": "Rejestracja", "language": "pl"},
-  {"keyName": "taskComplete", "text": "Ukończ", "language": "pl"},
-  {"keyName": "taskInProgress", "text": "W trakcie", "language": "pl"},
-  {"keyName": "taskNotStarted", "text": "Nie rozpoczęto", "language": "pl"},
-  {"keyName": "taskDeclined", "text": "Odrzucono", "language": "pl"},
-  {"keyName": "taskLocked", "text": "Zablokowano", "language": "pl"},
-  {"keyName": "tasksNoneForStudy", "text": "Brak zadań dla tego badania", "language": "pl"},
-  {"keyName": "taskHistory", "text": "historia", "language": "pl"},
-  {"keyName": "taskNew", "text": "NOWE", "language": "pl"},
-  {"keyName": "surveysSomeLocked", "text": "Niektóre badania ankietowe są zablokowane do momentu ukończenia wymaganych zadań.", "language": "pl"},
-  {"keyName": "taskTypeSurvey", "text": "Badanie ankietowe", "language": "pl"},
-  {"keyName": "taskTypeSurveys", "text": "Badania ankietowe", "language": "pl"},
-  {"keyName": "taskTypeConsent", "text": "Zgoda", "language": "pl"},
-  {"keyName": "taskTypeForms", "text": "Formularze", "language": "pl"},
-  {"keyName": "start", "text": "Rozpocznij", "language": "pl"},
-  {"keyName": "continue", "text": "Kontynuuj", "language": "pl"},
-  {"keyName": "save", "text": "Zapisz", "language": "pl"},
-  {"keyName": "outreachLearnMore", "text": "Dowiedz się więcej", "language": "pl"},
-  {"keyName": "cancel", "text": "Anuluj", "language": "pl"},
-  {"keyName": "goBack", "text": "Wróć", "language": "pl"},
-  {"keyName": "name", "text": "Imię i nazwisko", "language": "pl"},
-  {"keyName": "givenName", "text": "Imię", "language": "pl"},
-  {"keyName": "familyName", "text": "Nazwisko", "language": "pl"},
-  {"keyName": "editName", "text": "Edytuj imię i nazwisko", "language": "pl"},
-  {"keyName": "editBirthDate", "text": "Edytuj datę urodzenia", "language": "pl"},
-  {"keyName": "birthDate", "text": "Data urodzenia", "language": "pl"},
-  {"keyName": "mailingAddress", "text": "Adres do korespondencji", "language": "pl"},
-  {"keyName": "editMailingAddress", "text": "Edytuj adres do korespondencji", "language": "pl"},
-  {"keyName": "primaryAddress", "text": "Adres główny", "language": "pl"},
-  {"keyName": "editPrimaryAddress", "text": "Edytuj adres główny", "language": "pl"},
-  {"keyName": "street1", "text": "Ulica, wiersz 1", "language": "pl"},
-  {"keyName": "street2", "text": "Ulica, wiersz 2", "language": "pl"},
-  {"keyName": "city", "text": "Miejscowość", "language": "pl"},
-  {"keyName": "state", "text": "Stan\/region", "language": "pl"},
-  {"keyName": "postalCode", "text": "Kod pocztowy", "language": "pl"},
-  {"keyName": "country", "text": "Kraj", "language": "pl"},
-  {"keyName": "communicationPreferences", "text": "Preferowany kanał komunikacji", "language": "pl"},
-  {"keyName": "editCommunicationPreferences", "text": "Edytuj preferowany kanał komunikacji", "language": "pl"},
-  {"keyName": "contactEmail", "text": "Kontaktowy adres e-mail", "language": "pl"},
-  {"keyName": "editContactEmail", "text": "Edytuj kontaktowy adres e-mail", "language": "pl"},
-  {"keyName": "phoneNumber", "text": "Numer telefonu", "language": "pl"},
-  {"keyName": "editPhoneNumber", "text": "Edytuj numer telefonu", "language": "pl"},
-  {"keyName": "doNotSolicit", "text": "Zakaz namawiania", "language": "pl"},
-  {"keyName": "doNotContact", "text": "Zakaz kontaktu", "language": "pl"},
-  {"keyName": "editDoNotSolicit", "text": "Edytuj zakaz namawiania", "language": "pl"},
-  {"keyName": "editNotifications", "text": "Edytuj powiadomienia", "language": "pl"},
-  {"keyName": "notifications", "text": "Powiadomienia", "language": "pl"},
-  {"keyName": "on", "text": "Wł.", "language": "pl"},
-  {"keyName": "off", "text": "Wył.", "language": "pl"},
-  {"keyName": "notProvided", "text": "Nie podano", "language": "pl"},
-  {"keyName": "editProfileContactEmailWarning", "text": "Naciśnij „Zapisz”, aby zaktualizować adres e-mail wykorzystywany do komunikacji. Pamiętaj, że dane logowania nie ulegną zmianie.", "language": "pl"},
-  {"keyName": "privacyPolicy", "text": "Polityka prywatności", "language": "pl"},
-  {"keyName": "termsOfUse", "text": "Warunki użytkowania", "language": "pl"},
-  {"keyName": "addressInvalidPostalCode", "text": "Nie udało się zweryfikować kodu pocztowego.", "language": "pl"},
-  {"keyName": "addressInvalidCountry", "text": "Nie udało się zweryfikować kraju.", "language": "pl"},
-  {"keyName": "addressInvalidState", "text": "Nie udało się zweryfikować stanu\/regionu.", "language": "pl"},
-  {"keyName": "addressInvalidCity", "text": "Nie udało się zweryfikować miejscowości.", "language": "pl"},
-  {"keyName": "addressInvalidHouseNumber", "text": "Nie udało się zweryfikować numeru budynku.", "language": "pl"},
-  {"keyName": "addressInvalidStreetName", "text": "Nie udało się zweryfikować nazwy ulicy.", "language": "pl"},
-  {"keyName": "addressInvalidStreetType", "text": "Nie udało się zweryfikować rodzaju ulicy.", "language": "pl"},
-  {"keyName": "addressNeedsSubpremise", "text": "Podaj numer jednostki\/mieszkania.", "language": "pl"},
-  {"keyName": "addressFailedToValidate", "text": "Nie udało się zweryfikować adresu.", "language": "pl"},
-  {"keyName": "suggestBetterAddressHeader", "text": "Czy to prawidłowy adres?", "language": "pl"},
-  {"keyName": "suggestBetterAddressBody", "text": "Udało nam się zweryfikować podobny adres. Wybierz ten, którego chcesz używać.", "language": "pl"},
-  {"keyName": "newAddress", "text": "Nowy adres", "language": "pl"},
-  {"keyName": "oldAddress", "text": "Stary adres", "language": "pl"},
-  {"keyName": "you", "text": "Ty", "language": "pl"},
-  {"keyName": "yourDependent", "text": "Twoje osoby zależne", "language": "pl"},
-  {"keyName": "youInParens", "text": "(Ty)", "language": "pl"},
-  {"keyName": "allProfiles", "text": "Wszystkie profile", "language": "pl"},
-  {"keyName": "manageProfiles", "text": "Zarządzaj profilami", "language": "pl"},
-  {"keyName": "addNewParticipant", "text": "Dodaj nowego uczestnika", "language": "pl"},
-  {"keyName": "dashboard", "text": "Panel", "language": "pl"},
-  {"keyName": "selectParticipant", "text": "Wybierz uczestnika", "language": "pl"},
-  {"keyName": "hubUpdateFormSubmittedTitle", "text": "Ukończono ${formName}", "language": "pl"},
-  {"keyName": "hubUpdateNoActivitiesTitle", "text": "Ukończono wszystkie działania", "language": "pl"},
-  {"keyName": "hubUpdateNoActivitiesDetail", "text": "Udało Ci się ukończyć wszystkie działania dla tego badania. Poinformujemy Cię, gdy tylko nowe działania będą dostępne. Dziękujemy za udział!", "language": "pl"},
-  {"keyName": "hubUpdateWelcomeToStudyTitle", "text": "Witamy w ${studyName}", "language": "pl"},
-  {"keyName": "hubUpdateWelcomeToStudyDetail", "text": "Zapoznaj się z formularzem zgody i podpisz go, aby kontynuować.", "language": "pl"},
-  {"keyName": "hubUpdateAlreadyEnrolledTitle", "text": "Jesteś już zapisany(-a) do badania ${studyName}.", "language": "pl"},
-  {"keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle", "text": "Użytkownik jest już zapisany(-a) do badania ${studyName}.", "language": "pl"},
-  {"keyName": "cookieAlertTitle", "text": "Pliki cookie", "language": "pl"},
-  {"keyName": "cookieAlertDetail", "text": "Niniejsza strona wykorzystuje tokeny zwane „ciasteczkami” albo plikami cookie w celu zapewnienia prawidłowego działania i bezpieczeństwa naszej strony, a także poprawienia komfortu użytkowania. Wszystkie wykorzystywane przez nas pliki cookie są niezbędnymi plikami cookie. Ten rodzaj plików cookie nie zbiera żadnych danych identyfikujących osobę na temat uzytkowników ani nie śledzi zwyczajów związanych z przeglądaniem. Jeśli chcesz dowiedzieć się więcej, [zapoznaj się z naszą Polityką prywatności](\/privacy).", "language": "pl"},
-  {"keyName": "joinStudy", "text": "Dołącz do badania", "language": "pl"},
-  {"keyName": "ineligibleThankYou", "text": "Dziękujemy za zainteresowanie badaniem ${studyName}", "language": "pl" },
-  {"keyName": "ineligibleDescription", "text": "Niestety nie spełniasz kryteriów kwalifikacji do uczestnictwa w badaniu ${studyName} w tym momencie.", "language": "pl"},
-  {"keyName": "ineligibleProvideYourEmail", "text": "Podaj swój adres e-mail poniżej, a będziemy cię informować na bieżąco o aktualnościach. Może się wypisać z subskrypcji w dowolnym momencie.", "language":  "pl"},
-  {"keyName": "ineligibleStayInformed", "text": "Bądź na bieżąco", "language": "pl"},
-  {"keyName": "backToPortalHomepage", "text": "Wróć do strony głównej ${portalName}", "language": "pl"},
-  {"keyName": "joinMailingList", "text": "Dołącz do listy mailingowej", "language": "pl"},
-  {"keyName": "mailingFormStayUpdated", "text":  "Bądź na bieżąco z wiadomościami dotyczącymi badania", "language": "pl"},
-  {"keyName": "yourName", "text": "Twoje imię i nazwisko", "language": "pl"},
-  {"keyName": "yourEmail", "text": "Twój adres e-mail", "language": "pl"},
-  {"keyName": "join", "text":  "Dołącz", "language": "pl"},
-  {"keyName": "thanksForJoining", "text": "Dziękujemy za dołączenie!", "language": "pl"},
-  {"keyName": "pageNotFoundTitle", "text": "Nie znaleziono strony", "language": "pl"},
-  {"keyName": "pageNotFoundMessage", "text": "Jeżeli uważasz, że wystąpił błąd, skontaktuj się z ${studyContactEmail}", "language": "pl"},
-  {"keyName": "pageNotFoundReturnHome", "text": "Powróć do strony głównej", "language": "pl"},
-  {"keyName": "authErrorPageTitle", "text": "Coś poszło nie tak", "language": "pl"},
-  {"keyName": "authErrorPageMessage", "text": "Wystąpił problem z usługą uwierzytelniania. Spróbuj ponownie. Jeżeli problem będzie się utrzymywał, skontaktuj się z nami pod adresem ${studyContactEmail}.", "language": "pl"},
-  {"keyName": "navbarSampleKits", "text":  "Zestawy do pobierania próbek", "language": "pl"},
-  {"keyName": "kitsPageTitle", "text": "Zestawy do pobierania próbek", "language": "pl"},
-  {"keyName": "kitsPageDescription", "text": "Zestawy do pobierania próbek stanowią istotną część procedury badawczej i pomogą dostarczyć badaczom ważnych spostrzeżeń. Poniżej znajdziesz status wszystkich zestawów, które ci dostarczyliśmy.", "language": "pl"},
-  {"keyName": "kitsPageInPersonTitle", "text": "Przekaż próbkę osobiście", "language": "pl"},
-  {"keyName": "kitsPageInPersonDescription", "text": "Niniejsze badanie obecnie oferuje możliwość osobistego uzupełnienia zestawu do pobierania próbek.", "language": "pl"},
-  {"keyName": "kitsPageInPersonCompleteButton", "text": "Ukończ zestaw osobiście", "language": "pl"},
-  {"keyName": "kitsPageYourKitsTitle", "text": "Twoje zestawy", "language": "pl"},
-  {"keyName": "kitsPageStatusPreparing", "text": "W przygotowaniu", "language": "pl"},
-  {"keyName": "kitsPageStatusShipped", "text": "Wysłano", "language": "pl"},
-  {"keyName": "kitsPageStatusReturned", "text": "Zwrócono", "language": "pl"},
-  {"keyName": "kitsPageStatusCreated", "text": "Utworzono", "language": "pl"},
-  {"keyName": "kitsPageStatusCollected", "text": "Zebrano", "language": "pl"},
-  {"keyName": "kitsPageNoKits", "text": "W tym momencie nie masz żadnych zestawów do pobierania próbek.", "language": "pl"},
-  {"keyName": "kitsInPersonTitle", "text": "Instrukcje dotyczące zestawu do pobierania próbek", "language": "pl"},
-  {"keyName": "kitsInPersonDescription", "text": "Jeżeli osobiście chcesz ukończyć zestaw do pobierania próbek, postępuj zgodnie z instrukcjami przekazanymi przez członka zespołu realizującego badanie. Wszystkie dodatkowe informacje, które mogą być potrzebne, takie jak unikalny identyfikator uczestnika, zostaną podane poniżej.", "language": "pl"},
-  {"keyName": "kitsInPersonSubDescription", "text": "Jeżeli masz jakieś pytania, spytaj członka zespołu realizującego badanie.", "language": "pl"},
-  {"keyName": "kitsInPersonYourKitTitle", "text": "Twój zestaw do pobierania próbek", "language": "pl"},
-  {"keyName": "kitsInPersonYourKitDescription", "text": "Członek zespołu realizującego badanie dostarczył ci zestaw do pobierania próbek. Ten zestaw do pobierania próbek jest powiązany z twoim kontem. Jeżeli pomagasz komuś z ich zestawem do pobierania próbek, zwróć uwagę na to, by każdy uczestnik ukończył zestaw do pobierania próbek, który mu przypisano.", "language": "pl"},
-  {"keyName": "kitsInPersonYourKitIdentifier", "text": "Identyfikator twojego zestawu", "language": "pl"},
-  {"keyName": "kitsInPersonReturnToDashboard", "text": "Powrót do panelu", "language": "pl"},
-  {"keyName": "kitsInPersonRefreshPage", "text": "Odśwież", "language": "pl"},
-  {"keyName": "kitsInPersonConsentRequiredTitle", "text": "Wymagana zgoda", "language": "pl"},
-  {"keyName": "kitsInPersonConsentRequiredDescription", "text": "Przed ukończeniem zestawu do pobierania próbek, musisz być wpierw zarejestrowany w badaniu. Jeżeli cię to interesuje, możesz znaleźć formularz zgody i podpisać go, korzystając z poniższego łącza.", "language": "pl"},
-  {"keyName": "kitsInPersonStartConsent", "text": "Zacznij proces zgody", "language": "pl"},
-  {"keyName": "kitsInPersonError", "text": "Nastąpił błąd przy wczytywaniu informacji o twoim zestawie. Skontaktuj się z członkiem zespołu realizującego badanie w celu uzyskania pomocy.", "language": "pl"},
-  {"keyName": "kitsInPersonCreatedInstructions", "text": "Po ukończeniu zestawu do pobierania próbek zwróć go do członka zespołu realizującego badanie i pokaż im poniższy kod uczestnictwa do zeskanowania.", "language": "pl"},
-  {"keyName": "kitsInPersonNoKitInstructions", "text": "Aby uzyskać zestaw do pobierania próbek, członek zespołu realizującego badanie musi zeskanować twój unikalny kod uczestnictwa poniżej, aby powiązać zestaw do pobierania próbek z twoim kontem.", "language": "pl"},
-  {"keyName": "kitsInPersonNoKitSubInstructions", "text": "Po otrzymaniu zestawu odśwież niniejszą stronę, aby wyświetlić informacje o tym zestawie i otrzymać dalsze instrukcje.", "language": "pl"},
-  {"keyName": "kitsInPersonCollectedDescription", "text": "Członek zespołu realizującego badanie odebrał twój zestaw do pobierania próbek. Otrzymasz wiadomość e-mail z powiadomieniem, gdy twoja próbka zostanie przetworzona, i będziesz mieć możliwość wyświetlenia stanu próbki na swoim panelu badania.", "language": "pl"},
-  {"keyName": "kitsInPersonCollectedThankYou", "text": "Dziękujemy za udział.", "language": "pl"},
-  {"keyName": "kitTypeSaliva", "text": "Zestaw do pobierania śliny", "language": "pl"},
-  {"keyName": "kitTypeStool", "text": "Zestaw do pobierania stolca", "language": "pl"},
-  {"keyName": "kitTypeBlood", "text": "Zestaw do pobierania krwi", "language": "pl"},
-  {"keyName": "documentDownloadButton", "text": "Pobierać", "language": "pl", "machineTranslated": true},
-  {"keyName": "documentsListNone", "text": "Nie przesłałeś jeszcze żadnych dokumentów", "language": "pl", "machineTranslated": true},
-  {"keyName": "documentsListCreatedOn", "text": "Utworzono dnia", "language": "pl", "machineTranslated": true},
-  {"keyName": "documentsPageTitle", "text": "Dokumenty", "language": "pl", "machineTranslated": true},
-  {"keyName": "documentsPageUploadedDocumentsTitle", "text": "Przesłane dokumenty", "language": "pl", "machineTranslated": true},
-  {"keyName": "documentsPageMessage", "text": "Wpodczas uczestnictwa w badaniu możesz zostać poproszony o przesłanie dokumentów jako części formularza lub ankiety. Poniżej możesz zarządzać przesłanymi dokumentami.", "language": "pl", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "Dokumenty", "language": "pl", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureTitle", "text": "Jesteś pewien?", "language": "pl", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureMessage", "text": "Czy na pewno chcesz usunąć ten dokument? Tego nie można cofnąć. Należy pamiętać, że jeśli członek personelu badawczego już pobrał ten dokument, nadal będzie on dla niego dostępny. Skontaktuj się z personelem badawczym, jeśli chcesz, aby dokument został całkowicie usunięty ze wszystkich rekordów.", "language": "pl", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseTitle", "text": "Ten dokument jest w użyciu", "language": "pl", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseMessage", "text": "Ten dokument jest obecnie udostępniany w odpowiedzi na co najmniej jedną ankietę. Przed usunięciem usuń go z odpowiedzi na ankietę.", "language": "pl", "machineTranslated": true},
-  {"keyName": "documentDeleteButton", "text": "Usuwać", "language": "pl", "machineTranslated": true},
-  {"keyName": "documentOptionsButton", "text": "Opcje", "language": "pl", "machineTranslated": true},
-  {"keyName": "documentSharedInResponseTo", "text": "udostępniono w odpowiedzi na", "language": "pl", "machineTranslated": true},
-  {"keyName": "documentUploaderSelectedDocuments", "text": "Wybrane dokumenty", "language": "pl", "machineTranslated": true},
-  {"keyName": "documentUploaderIncludedInResponse", "text": "Dokumenty te są dołączone do Twojej odpowiedzi", "language": "pl", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocumentsSelected", "text": "Nie wybrano dokumentów. Proszę przesłać nowy dokument lub wybrać istniejący dokument poniżej.", "language": "pl", "machineTranslated": true},
-  {"keyName": "documentUploaderAvailableDocuments", "text": "Dostępne dokumenty", "language": "pl", "machineTranslated": true},
-  {"keyName": "documentUploaderNotIncludedInResponse", "text": "Te dokumenty nie są zawarte w Twojej odpowiedzi", "language": "pl", "machineTranslated": true},
-  {"keyName": "documentUploaderClickToUpload", "text": "Upuść pliki tutaj lub kliknij, aby przesłać", "language": "pl", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocuments", "text": "Brak dostępnych dokumentów", "language": "pl", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeTitle", "text": "Twoja sesja wkrótce wygaśnie", "language": "pl", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeMessage", "text": "Aby zachować bezpieczeństwo i chronić Twoje dane, zostaniesz wylogowany za ${timeRemaining}.", "language": "pl", "machineTranslated": true}
+  {
+    "keyName": "navbarDashboard",
+    "text": "Panel",
+    "language": "pl"
+  },
+  {
+    "keyName": "navbarChangePassword",
+    "text": "Zmień hasło",
+    "language": "pl"
+  },
+  {
+    "keyName": "navbarLogout",
+    "text": "Wyloguj się",
+    "language": "pl"
+  },
+  {
+    "keyName": "profile",
+    "text": "Profil",
+    "language": "pl"
+  },
+  {
+    "keyName": "navbarLogin",
+    "text": "Zaloguj się",
+    "language": "pl"
+  },
+  {
+    "keyName": "navbarJoin",
+    "text": "Rejestracja",
+    "language": "pl"
+  },
+  {
+    "keyName": "taskComplete",
+    "text": "Ukończ",
+    "language": "pl"
+  },
+  {
+    "keyName": "taskInProgress",
+    "text": "W trakcie",
+    "language": "pl"
+  },
+  {
+    "keyName": "taskNotStarted",
+    "text": "Nie rozpoczęto",
+    "language": "pl"
+  },
+  {
+    "keyName": "taskDeclined",
+    "text": "Odrzucono",
+    "language": "pl"
+  },
+  {
+    "keyName": "taskLocked",
+    "text": "Zablokowano",
+    "language": "pl"
+  },
+  {
+    "keyName": "tasksNoneForStudy",
+    "text": "Brak zadań dla tego badania",
+    "language": "pl"
+  },
+  {
+    "keyName": "taskHistory",
+    "text": "historia",
+    "language": "pl"
+  },
+  {
+    "keyName": "taskNew",
+    "text": "NOWE",
+    "language": "pl"
+  },
+  {
+    "keyName": "surveysSomeLocked",
+    "text": "Niektóre badania ankietowe są zablokowane do momentu ukończenia wymaganych zadań.",
+    "language": "pl"
+  },
+  {
+    "keyName": "taskTypeSurvey",
+    "text": "Badanie ankietowe",
+    "language": "pl"
+  },
+  {
+    "keyName": "taskTypeSurveys",
+    "text": "Badania ankietowe",
+    "language": "pl"
+  },
+  {
+    "keyName": "taskTypeConsent",
+    "text": "Zgoda",
+    "language": "pl"
+  },
+  {
+    "keyName": "taskTypeForms",
+    "text": "Formularze",
+    "language": "pl"
+  },
+  {
+    "keyName": "start",
+    "text": "Rozpocznij",
+    "language": "pl"
+  },
+  {
+    "keyName": "continue",
+    "text": "Kontynuuj",
+    "language": "pl"
+  },
+  {
+    "keyName": "save",
+    "text": "Zapisz",
+    "language": "pl"
+  },
+  {
+    "keyName": "outreachLearnMore",
+    "text": "Dowiedz się więcej",
+    "language": "pl"
+  },
+  {
+    "keyName": "cancel",
+    "text": "Anuluj",
+    "language": "pl"
+  },
+  {
+    "keyName": "goBack",
+    "text": "Wróć",
+    "language": "pl"
+  },
+  {
+    "keyName": "name",
+    "text": "Imię i nazwisko",
+    "language": "pl"
+  },
+  {
+    "keyName": "givenName",
+    "text": "Imię",
+    "language": "pl"
+  },
+  {
+    "keyName": "familyName",
+    "text": "Nazwisko",
+    "language": "pl"
+  },
+  {
+    "keyName": "editName",
+    "text": "Edytuj imię i nazwisko",
+    "language": "pl"
+  },
+  {
+    "keyName": "editBirthDate",
+    "text": "Edytuj datę urodzenia",
+    "language": "pl"
+  },
+  {
+    "keyName": "birthDate",
+    "text": "Data urodzenia",
+    "language": "pl"
+  },
+  {
+    "keyName": "mailingAddress",
+    "text": "Adres do korespondencji",
+    "language": "pl"
+  },
+  {
+    "keyName": "editMailingAddress",
+    "text": "Edytuj adres do korespondencji",
+    "language": "pl"
+  },
+  {
+    "keyName": "primaryAddress",
+    "text": "Adres główny",
+    "language": "pl"
+  },
+  {
+    "keyName": "editPrimaryAddress",
+    "text": "Edytuj adres główny",
+    "language": "pl"
+  },
+  {
+    "keyName": "street1",
+    "text": "Ulica, wiersz 1",
+    "language": "pl"
+  },
+  {
+    "keyName": "street2",
+    "text": "Ulica, wiersz 2",
+    "language": "pl"
+  },
+  {
+    "keyName": "city",
+    "text": "Miejscowość",
+    "language": "pl"
+  },
+  {
+    "keyName": "state",
+    "text": "Stan/region",
+    "language": "pl"
+  },
+  {
+    "keyName": "postalCode",
+    "text": "Kod pocztowy",
+    "language": "pl"
+  },
+  {
+    "keyName": "country",
+    "text": "Kraj",
+    "language": "pl"
+  },
+  {
+    "keyName": "communicationPreferences",
+    "text": "Preferowany kanał komunikacji",
+    "language": "pl"
+  },
+  {
+    "keyName": "editCommunicationPreferences",
+    "text": "Edytuj preferowany kanał komunikacji",
+    "language": "pl"
+  },
+  {
+    "keyName": "contactEmail",
+    "text": "Kontaktowy adres e-mail",
+    "language": "pl"
+  },
+  {
+    "keyName": "editContactEmail",
+    "text": "Edytuj kontaktowy adres e-mail",
+    "language": "pl"
+  },
+  {
+    "keyName": "phoneNumber",
+    "text": "Numer telefonu",
+    "language": "pl"
+  },
+  {
+    "keyName": "editPhoneNumber",
+    "text": "Edytuj numer telefonu",
+    "language": "pl"
+  },
+  {
+    "keyName": "doNotSolicit",
+    "text": "Zakaz namawiania",
+    "language": "pl"
+  },
+  {
+    "keyName": "doNotContact",
+    "text": "Zakaz kontaktu",
+    "language": "pl"
+  },
+  {
+    "keyName": "editDoNotSolicit",
+    "text": "Edytuj zakaz namawiania",
+    "language": "pl"
+  },
+  {
+    "keyName": "editNotifications",
+    "text": "Edytuj powiadomienia",
+    "language": "pl"
+  },
+  {
+    "keyName": "notifications",
+    "text": "Powiadomienia",
+    "language": "pl"
+  },
+  {
+    "keyName": "on",
+    "text": "Wł.",
+    "language": "pl"
+  },
+  {
+    "keyName": "off",
+    "text": "Wył.",
+    "language": "pl"
+  },
+  {
+    "keyName": "notProvided",
+    "text": "Nie podano",
+    "language": "pl"
+  },
+  {
+    "keyName": "editProfileContactEmailWarning",
+    "text": "Naciśnij „Zapisz”, aby zaktualizować adres e-mail wykorzystywany do komunikacji. Pamiętaj, że dane logowania nie ulegną zmianie.",
+    "language": "pl"
+  },
+  {
+    "keyName": "privacyPolicy",
+    "text": "Polityka prywatności",
+    "language": "pl"
+  },
+  {
+    "keyName": "termsOfUse",
+    "text": "Warunki użytkowania",
+    "language": "pl"
+  },
+  {
+    "keyName": "addressInvalidPostalCode",
+    "text": "Nie udało się zweryfikować kodu pocztowego.",
+    "language": "pl"
+  },
+  {
+    "keyName": "addressInvalidCountry",
+    "text": "Nie udało się zweryfikować kraju.",
+    "language": "pl"
+  },
+  {
+    "keyName": "addressInvalidState",
+    "text": "Nie udało się zweryfikować stanu/regionu.",
+    "language": "pl"
+  },
+  {
+    "keyName": "addressInvalidCity",
+    "text": "Nie udało się zweryfikować miejscowości.",
+    "language": "pl"
+  },
+  {
+    "keyName": "addressInvalidHouseNumber",
+    "text": "Nie udało się zweryfikować numeru budynku.",
+    "language": "pl"
+  },
+  {
+    "keyName": "addressInvalidStreetName",
+    "text": "Nie udało się zweryfikować nazwy ulicy.",
+    "language": "pl"
+  },
+  {
+    "keyName": "addressInvalidStreetType",
+    "text": "Nie udało się zweryfikować rodzaju ulicy.",
+    "language": "pl"
+  },
+  {
+    "keyName": "addressNeedsSubpremise",
+    "text": "Podaj numer jednostki/mieszkania.",
+    "language": "pl"
+  },
+  {
+    "keyName": "addressFailedToValidate",
+    "text": "Nie udało się zweryfikować adresu.",
+    "language": "pl"
+  },
+  {
+    "keyName": "suggestBetterAddressHeader",
+    "text": "Czy to prawidłowy adres?",
+    "language": "pl"
+  },
+  {
+    "keyName": "suggestBetterAddressBody",
+    "text": "Udało nam się zweryfikować podobny adres. Wybierz ten, którego chcesz używać.",
+    "language": "pl"
+  },
+  {
+    "keyName": "newAddress",
+    "text": "Nowy adres",
+    "language": "pl"
+  },
+  {
+    "keyName": "oldAddress",
+    "text": "Stary adres",
+    "language": "pl"
+  },
+  {
+    "keyName": "you",
+    "text": "Ty",
+    "language": "pl"
+  },
+  {
+    "keyName": "yourDependent",
+    "text": "Twoje osoby zależne",
+    "language": "pl"
+  },
+  {
+    "keyName": "youInParens",
+    "text": "(Ty)",
+    "language": "pl"
+  },
+  {
+    "keyName": "allProfiles",
+    "text": "Wszystkie profile",
+    "language": "pl"
+  },
+  {
+    "keyName": "manageProfiles",
+    "text": "Zarządzaj profilami",
+    "language": "pl"
+  },
+  {
+    "keyName": "addNewParticipant",
+    "text": "Dodaj nowego uczestnika",
+    "language": "pl"
+  },
+  {
+    "keyName": "dashboard",
+    "text": "Panel",
+    "language": "pl"
+  },
+  {
+    "keyName": "selectParticipant",
+    "text": "Wybierz uczestnika",
+    "language": "pl"
+  },
+  {
+    "keyName": "hubUpdateFormSubmittedTitle",
+    "text": "Ukończono ${formName}",
+    "language": "pl"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesTitle",
+    "text": "Ukończono wszystkie działania",
+    "language": "pl"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesDetail",
+    "text": "Udało Ci się ukończyć wszystkie działania dla tego badania. Poinformujemy Cię, gdy tylko nowe działania będą dostępne. Dziękujemy za udział!",
+    "language": "pl"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyTitle",
+    "text": "Witamy w ${studyName}",
+    "language": "pl"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyDetail",
+    "text": "Zapoznaj się z formularzem zgody i podpisz go, aby kontynuować.",
+    "language": "pl"
+  },
+  {
+    "keyName": "hubUpdateAlreadyEnrolledTitle",
+    "text": "Jesteś już zapisany(-a) do badania ${studyName}.",
+    "language": "pl"
+  },
+  {
+    "keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle",
+    "text": "Użytkownik jest już zapisany(-a) do badania ${studyName}.",
+    "language": "pl"
+  },
+  {
+    "keyName": "cookieAlertTitle",
+    "text": "Pliki cookie",
+    "language": "pl"
+  },
+  {
+    "keyName": "cookieAlertDetail",
+    "text": "Niniejsza strona wykorzystuje tokeny zwane „ciasteczkami” albo plikami cookie w celu zapewnienia prawidłowego działania i bezpieczeństwa naszej strony, a także poprawienia komfortu użytkowania. Wszystkie wykorzystywane przez nas pliki cookie są niezbędnymi plikami cookie. Ten rodzaj plików cookie nie zbiera żadnych danych identyfikujących osobę na temat uzytkowników ani nie śledzi zwyczajów związanych z przeglądaniem. Jeśli chcesz dowiedzieć się więcej, [zapoznaj się z naszą Polityką prywatności](/privacy).",
+    "language": "pl"
+  },
+  {
+    "keyName": "joinStudy",
+    "text": "Dołącz do badania",
+    "language": "pl"
+  },
+  {
+    "keyName": "ineligibleThankYou",
+    "text": "Dziękujemy za zainteresowanie badaniem ${studyName}",
+    "language": "pl"
+  },
+  {
+    "keyName": "ineligibleDescription",
+    "text": "Niestety nie spełniasz kryteriów kwalifikacji do uczestnictwa w badaniu ${studyName} w tym momencie.",
+    "language": "pl"
+  },
+  {
+    "keyName": "ineligibleProvideYourEmail",
+    "text": "Podaj swój adres e-mail poniżej, a będziemy cię informować na bieżąco o aktualnościach. Może się wypisać z subskrypcji w dowolnym momencie.",
+    "language": "pl"
+  },
+  {
+    "keyName": "ineligibleStayInformed",
+    "text": "Bądź na bieżąco",
+    "language": "pl"
+  },
+  {
+    "keyName": "backToPortalHomepage",
+    "text": "Wróć do strony głównej ${portalName}",
+    "language": "pl"
+  },
+  {
+    "keyName": "joinMailingList",
+    "text": "Dołącz do listy mailingowej",
+    "language": "pl"
+  },
+  {
+    "keyName": "mailingFormStayUpdated",
+    "text": "Bądź na bieżąco z wiadomościami dotyczącymi badania",
+    "language": "pl"
+  },
+  {
+    "keyName": "yourName",
+    "text": "Twoje imię i nazwisko",
+    "language": "pl"
+  },
+  {
+    "keyName": "yourEmail",
+    "text": "Twój adres e-mail",
+    "language": "pl"
+  },
+  {
+    "keyName": "join",
+    "text": "Dołącz",
+    "language": "pl"
+  },
+  {
+    "keyName": "thanksForJoining",
+    "text": "Dziękujemy za dołączenie!",
+    "language": "pl"
+  },
+  {
+    "keyName": "pageNotFoundTitle",
+    "text": "Nie znaleziono strony",
+    "language": "pl"
+  },
+  {
+    "keyName": "pageNotFoundMessage",
+    "text": "Jeżeli uważasz, że wystąpił błąd, skontaktuj się z ${studyContactEmail}",
+    "language": "pl"
+  },
+  {
+    "keyName": "pageNotFoundReturnHome",
+    "text": "Powróć do strony głównej",
+    "language": "pl"
+  },
+  {
+    "keyName": "authErrorPageTitle",
+    "text": "Coś poszło nie tak",
+    "language": "pl"
+  },
+  {
+    "keyName": "authErrorPageMessage",
+    "text": "Wystąpił problem z usługą uwierzytelniania. Spróbuj ponownie. Jeżeli problem będzie się utrzymywał, skontaktuj się z nami pod adresem ${studyContactEmail}.",
+    "language": "pl"
+  },
+  {
+    "keyName": "navbarSampleKits",
+    "text": "Zestawy do pobierania próbek",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsPageTitle",
+    "text": "Zestawy do pobierania próbek",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsPageDescription",
+    "text": "Zestawy do pobierania próbek stanowią istotną część procedury badawczej i pomogą dostarczyć badaczom ważnych spostrzeżeń. Poniżej znajdziesz status wszystkich zestawów, które ci dostarczyliśmy.",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsPageInPersonTitle",
+    "text": "Przekaż próbkę osobiście",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsPageInPersonDescription",
+    "text": "Niniejsze badanie obecnie oferuje możliwość osobistego uzupełnienia zestawu do pobierania próbek.",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsPageInPersonCompleteButton",
+    "text": "Ukończ zestaw osobiście",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsPageYourKitsTitle",
+    "text": "Twoje zestawy",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsPageStatusPreparing",
+    "text": "W przygotowaniu",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsPageStatusShipped",
+    "text": "Wysłano",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsPageStatusReturned",
+    "text": "Zwrócono",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsPageStatusCreated",
+    "text": "Utworzono",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsPageStatusCollected",
+    "text": "Zebrano",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsPageNoKits",
+    "text": "W tym momencie nie masz żadnych zestawów do pobierania próbek.",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsInPersonTitle",
+    "text": "Instrukcje dotyczące zestawu do pobierania próbek",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsInPersonDescription",
+    "text": "Jeżeli osobiście chcesz ukończyć zestaw do pobierania próbek, postępuj zgodnie z instrukcjami przekazanymi przez członka zespołu realizującego badanie. Wszystkie dodatkowe informacje, które mogą być potrzebne, takie jak unikalny identyfikator uczestnika, zostaną podane poniżej.",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsInPersonSubDescription",
+    "text": "Jeżeli masz jakieś pytania, spytaj członka zespołu realizującego badanie.",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsInPersonYourKitTitle",
+    "text": "Twój zestaw do pobierania próbek",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsInPersonYourKitDescription",
+    "text": "Członek zespołu realizującego badanie dostarczył ci zestaw do pobierania próbek. Ten zestaw do pobierania próbek jest powiązany z twoim kontem. Jeżeli pomagasz komuś z ich zestawem do pobierania próbek, zwróć uwagę na to, by każdy uczestnik ukończył zestaw do pobierania próbek, który mu przypisano.",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsInPersonYourKitIdentifier",
+    "text": "Identyfikator twojego zestawu",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsInPersonReturnToDashboard",
+    "text": "Powrót do panelu",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsInPersonRefreshPage",
+    "text": "Odśwież",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredTitle",
+    "text": "Wymagana zgoda",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredDescription",
+    "text": "Przed ukończeniem zestawu do pobierania próbek, musisz być wpierw zarejestrowany w badaniu. Jeżeli cię to interesuje, możesz znaleźć formularz zgody i podpisać go, korzystając z poniższego łącza.",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsInPersonStartConsent",
+    "text": "Zacznij proces zgody",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsInPersonError",
+    "text": "Nastąpił błąd przy wczytywaniu informacji o twoim zestawie. Skontaktuj się z członkiem zespołu realizującego badanie w celu uzyskania pomocy.",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsInPersonCreatedInstructions",
+    "text": "Po ukończeniu zestawu do pobierania próbek zwróć go do członka zespołu realizującego badanie i pokaż im poniższy kod uczestnictwa do zeskanowania.",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsInPersonNoKitInstructions",
+    "text": "Aby uzyskać zestaw do pobierania próbek, członek zespołu realizującego badanie musi zeskanować twój unikalny kod uczestnictwa poniżej, aby powiązać zestaw do pobierania próbek z twoim kontem.",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsInPersonNoKitSubInstructions",
+    "text": "Po otrzymaniu zestawu odśwież niniejszą stronę, aby wyświetlić informacje o tym zestawie i otrzymać dalsze instrukcje.",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsInPersonCollectedDescription",
+    "text": "Członek zespołu realizującego badanie odebrał twój zestaw do pobierania próbek. Otrzymasz wiadomość e-mail z powiadomieniem, gdy twoja próbka zostanie przetworzona, i będziesz mieć możliwość wyświetlenia stanu próbki na swoim panelu badania.",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitsInPersonCollectedThankYou",
+    "text": "Dziękujemy za udział.",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitTypeSaliva",
+    "text": "Zestaw do pobierania śliny",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitTypeStool",
+    "text": "Zestaw do pobierania stolca",
+    "language": "pl"
+  },
+  {
+    "keyName": "kitTypeBlood",
+    "text": "Zestaw do pobierania krwi",
+    "language": "pl"
+  },
+  {
+    "keyName": "documentDownloadButton",
+    "text": "Pobierać",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListNone",
+    "text": "Nie przesłałeś jeszcze żadnych dokumentów",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListCreatedOn",
+    "text": "Utworzono dnia",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageTitle",
+    "text": "Dokumenty",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageUploadedDocumentsTitle",
+    "text": "Przesłane dokumenty",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageMessage",
+    "text": "Wpodczas uczestnictwa w badaniu możesz zostać poproszony o przesłanie dokumentów jako części formularza lub ankiety. Poniżej możesz zarządzać przesłanymi dokumentami.",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "navbarDocuments",
+    "text": "Dokumenty",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureTitle",
+    "text": "Jesteś pewien?",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureMessage",
+    "text": "Czy na pewno chcesz usunąć ten dokument? Tego nie można cofnąć. Należy pamiętać, że jeśli członek personelu badawczego już pobrał ten dokument, nadal będzie on dla niego dostępny. Skontaktuj się z personelem badawczym, jeśli chcesz, aby dokument został całkowicie usunięty ze wszystkich rekordów.",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseTitle",
+    "text": "Ten dokument jest w użyciu",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseMessage",
+    "text": "Ten dokument jest obecnie udostępniany w odpowiedzi na co najmniej jedną ankietę. Przed usunięciem usuń go z odpowiedzi na ankietę.",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteButton",
+    "text": "Usuwać",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentOptionsButton",
+    "text": "Opcje",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentSharedInResponseTo",
+    "text": "udostępniono w odpowiedzi na",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderSelectedDocuments",
+    "text": "Wybrane dokumenty",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderIncludedInResponse",
+    "text": "Dokumenty te są dołączone do Twojej odpowiedzi",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocumentsSelected",
+    "text": "Nie wybrano dokumentów. Proszę przesłać nowy dokument lub wybrać istniejący dokument poniżej.",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderAvailableDocuments",
+    "text": "Dostępne dokumenty",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNotIncludedInResponse",
+    "text": "Te dokumenty nie są zawarte w Twojej odpowiedzi",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderClickToUpload",
+    "text": "Upuść pliki tutaj lub kliknij, aby przesłać",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocuments",
+    "text": "Brak dostępnych dokumentów",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeTitle",
+    "text": "Twoja sesja wkrótce wygaśnie",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeMessage",
+    "text": "Aby zachować bezpieczeństwo i chronić Twoje dane, zostaniesz wylogowany za ${timeRemaining}.",
+    "language": "pl",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "failedToEnroll",
+    "language": "pl",
+    "text": "Coś poszło nie tak podczas procesu rejestracji. Wypełnij ponownie formularz.",
+    "machineTranslated": true
+  }
 ]

--- a/populate/src/main/resources/seed/i18n/pt/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/pt/languageTexts.json
@@ -1,163 +1,836 @@
 [
-  {"keyName": "navbarDashboard", "text": "Painel", "language": "pt"},
-  {"keyName": "navbarChangePassword", "text": "Alterar palavra-passe", "language": "pt"},
-  {"keyName": "navbarLogout", "text": "Terminar sessão", "language": "pt"},
-  {"keyName": "profile", "text": "Perfil", "language": "pt"},
-  {"keyName": "navbarLogin", "text": "Iniciar sessão", "language": "pt"},
-  {"keyName": "navbarJoin", "text": "Registar", "language": "pt"},
-  {"keyName": "taskComplete", "text": "Concluído", "language": "pt"},
-  {"keyName": "taskInProgress", "text": "Em progresso", "language": "pt"},
-  {"keyName": "taskNotStarted", "text": "Não iniciado", "language": "pt"},
-  {"keyName": "taskDeclined", "text": "Recusado", "language": "pt"},
-  {"keyName": "taskLocked", "text": "Bloqueado", "language": "pt"},
-  {"keyName": "tasksNoneForStudy", "text": "Não existem tarefas para este estudo", "language": "pt"},
-  {"keyName": "taskHistory", "text": "histórico", "language": "pt"},
-  {"keyName": "taskNew", "text": "NOVO", "language": "pt"},
-  {"keyName": "surveysSomeLocked", "text": "Alguns questionários estão bloqueados até que outras tarefas necessárias sejam concluídas.", "language": "pt"},
-  {"keyName": "taskTypeSurvey", "text": "Questionário", "language": "pt"},
-  {"keyName": "taskTypeSurveys", "text": "Questionários", "language": "pt"},
-  {"keyName": "taskTypeConsent", "text": "Consentimento", "language": "pt"},
-  {"keyName": "taskTypeForms", "text": "Formulários", "language": "pt"},
-  {"keyName": "start", "text": "Iniciar", "language": "pt"},
-  {"keyName": "continue", "text": "Continuar", "language": "pt"},
-  {"keyName": "save", "text": "Guardar", "language": "pt"},
-  {"keyName": "outreachLearnMore", "text": "Saber mais", "language": "pt"},
-  {"keyName": "cancel", "text": "Cancelar", "language": "pt"},
-  {"keyName": "goBack", "text": "Retroceder", "language": "pt"},
-  {"keyName": "name", "text": "Nome", "language": "pt"},
-  {"keyName": "givenName", "text": "Nome próprio", "language": "pt"},
-  {"keyName": "familyName", "text": "Apelido", "language": "pt"},
-  {"keyName": "editName", "text": "Editar nome", "language": "pt"},
-  {"keyName": "editBirthDate", "text": "Editar data de nascimento", "language": "pt"},
-  {"keyName": "birthDate", "text": "Aniversário", "language": "pt"},
-  {"keyName": "mailingAddress", "text": "Endereço postal", "language": "pt"},
-  {"keyName": "editMailingAddress", "text": "Editar endereço postal", "language": "pt"},
-  {"keyName": "primaryAddress", "text": "Endereço principal", "language": "pt"},
-  {"keyName": "editPrimaryAddress", "text": "Editar endereço principal", "language": "pt"},
-  {"keyName": "street1", "text": "Rua 1", "language": "pt"},
-  {"keyName": "street2", "text": "Rua 2", "language": "pt"},
-  {"keyName": "city", "text": "Cidade", "language": "pt"},
-  {"keyName": "state", "text": "Estado\/Província", "language": "pt"},
-  {"keyName": "postalCode", "text": "Código Postal", "language": "pt"},
-  {"keyName": "country", "text": "País", "language": "pt"},
-  {"keyName": "communicationPreferences", "text": "Preferências de comunicação", "language": "pt"},
-  {"keyName": "editCommunicationPreferences", "text": "Editar preferências de comunicação", "language": "pt"},
-  {"keyName": "contactEmail", "text": "E-mail de contacto", "language": "pt"},
-  {"keyName": "editContactEmail", "text": "Editar e-mail de contacto", "language": "pt"},
-  {"keyName": "phoneNumber", "text": "Número de telefone", "language": "pt"},
-  {"keyName": "editPhoneNumber", "text": "Editar número de telefone", "language": "pt"},
-  {"keyName": "doNotSolicit", "text": "Não solicitar", "language": "pt"},
-  {"keyName": "doNotContact", "text": "Não contactar", "language": "pt"},
-  {"keyName": "editDoNotSolicit", "text": "Editar não solicitar", "language": "pt"},
-  {"keyName": "editNotifications", "text": "Editar notificações", "language": "pt"},
-  {"keyName": "notifications", "text": "Notificações", "language": "pt"},
-  {"keyName": "on", "text": "Ativado", "language": "pt"},
-  {"keyName": "off", "text": "Desativado", "language": "pt"},
-  {"keyName": "notProvided", "text": "Não fornecido", "language": "pt"},
-  {"keyName": "editProfileContactEmailWarning", "text": "Prima “Guardar” para atualizar o e-mail utilizado para comunicações. Tenha em atenção que as suas informações de início de sessão não serão alteradas.", "language": "pt"},
-  {"keyName": "privacyPolicy", "text": "Política de Privacidade", "language": "pt"},
-  {"keyName": "termsOfUse", "text": "Termos de utilização", "language": "pt"},
-  {"keyName": "addressInvalidPostalCode", "text": "Não foi possível verificar o código postal.", "language": "pt"},
-  {"keyName": "addressInvalidCountry", "text": "Não foi possível verificar o país.", "language": "pt"},
-  {"keyName": "addressInvalidState", "text": "Não foi possível verificar o estado\/província.", "language": "pt"},
-  {"keyName": "addressInvalidCity", "text": "Não foi possível verificar a cidade.", "language": "pt"},
-  {"keyName": "addressInvalidHouseNumber", "text": "Não foi possível verificar o número de porta.", "language": "pt"},
-  {"keyName": "addressInvalidStreetName", "text": "Não foi possível verificar o nome da rua.", "language": "pt"},
-  {"keyName": "addressInvalidStreetType", "text": "Não foi possível verificar o tipo da rua.", "language": "pt"},
-  {"keyName": "addressNeedsSubpremise", "text": "Indique o número da unidade\/suite.", "language": "pt"},
-  {"keyName": "addressFailedToValidate", "text": "Não foi possível validar o endereço.", "language": "pt"},
-  {"keyName": "suggestBetterAddressHeader", "text": "Este endereço está correto?", "language": "pt"},
-  {"keyName": "suggestBetterAddressBody", "text": "Conseguimos verificar um endereço semelhante. Selecione qual o que pretende utilizar.", "language": "pt"},
-  {"keyName": "newAddress", "text": "Endereço novo", "language": "pt"},
-  {"keyName": "oldAddress", "text": "Endereço antigo", "language": "pt"},
-  {"keyName": "you", "text": "Você", "language": "pt"},
-  {"keyName": "yourDependent", "text": "O seu dependente", "language": "pt"},
-  {"keyName": "youInParens", "text": "(você)", "language": "pt"},
-  {"keyName": "allProfiles", "text": "Todos os perfis", "language": "pt"},
-  {"keyName": "manageProfiles", "text": "Gerir perfis", "language": "pt"},
-  {"keyName": "addNewParticipant", "text": "Adicionar novo participante", "language": "pt"},
-  {"keyName": "dashboard", "text": "Painel", "language": "pt"},
-  {"keyName": "selectParticipant", "text": "Selecionar participante", "language": "pt"},
-  {"keyName": "hubUpdateFormSubmittedTitle", "text": "${formName} preenchido", "language": "pt"},
-  {"keyName": "hubUpdateNoActivitiesTitle", "text": "Todas as atividades concluídas.", "language": "pt"},
-  {"keyName": "hubUpdateNoActivitiesDetail", "text": "Concluiu todas as atividades para este estudo. Iremos notificá-lo(a) assim que estiverem disponíveis novas atividades. Obrigado pela sua participação!", "language": "pt"},
-  {"keyName": "hubUpdateWelcomeToStudyTitle", "text": "Bem-vindo(a) ao ${studyName}", "language": "pt"},
-  {"keyName": "hubUpdateWelcomeToStudyDetail", "text": "Leia e assine o formulário de consentimento abaixo para continuar.", "language": "pt"},
-  {"keyName": "hubUpdateAlreadyEnrolledTitle", "text": "Já está incluído(a) no ${studyName}.", "language": "pt"},
-  {"keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle", "text": "Este utilizador já está incluído(a) no ${studyName}.", "language": "pt"},
-  {"keyName": "cookieAlertTitle", "text": "Cookies", "language": "pt"},
-  {"keyName": "cookieAlertDetail", "text": "Este sítio Web utiliza tokens de Internet, designados “cookies” para permitir o bom funcionamento e a segurança do nosso sítio Web e para melhorar a sua experiência enquanto o utiliza. Todos os cookies que usamos são cookies estritamente necessários. Este tipo de cookie não recolhe qualquer informação pessoal identificável sobre si e não rastreia os seus hábitos de navegação. Para saber mais, [leia a nossa Política de Privacidade](\/privacidade).", "language": "pt"},
-  {"keyName": "joinStudy", "text": "Aderir ao Estudo", "language": "pt"},
-  {"keyName": "ineligibleThankYou", "text": "Obrigado pelo seu interesse em ${studyName}", "language": "pt" },
-  {"keyName": "ineligibleDescription", "text": "Infelizmente, não preenche de momento os critérios de elegibilidade para participar no ${studyName}.", "language": "pt"},
-  {"keyName": "ineligibleProvideYourEmail", "text": "Introduza o seu e-mail abaixo e enviar-lhe-emos atualizações sobre futuros desenvolvimentos. Pode cancelar a subscrição em qualquer altura.", "language":  "pt"},
-  {"keyName": "ineligibleStayInformed", "text": "Mantenha-se informado(a)", "language": "pt"},
-  {"keyName": "backToPortalHomepage", "text": "Voltar à página inicial do ${portalName}", "language": "pt"},
-  {"keyName": "joinMailingList", "text": "Junte-se à lista de correio eletrónico", "language": "pt"},
-  {"keyName": "mailingFormStayUpdated", "text":  "Mantenha-se a par das notícias sobre o estudo", "language": "pt"},
-  {"keyName": "yourName", "text": "O seu nome", "language": "pt"},
-  {"keyName": "yourEmail", "text": "O seu e-mail", "language": "pt"},
-  {"keyName": "join", "text":  "Aderir", "language": "pt"},
-  {"keyName": "thanksForJoining", "text": "Obrigado por participar!", "language": "pt"},
-  {"keyName": "pageNotFoundTitle", "text": "Página não encontrada", "language": "pt"},
-  {"keyName": "pageNotFoundMessage", "text": "Se considerar que se trata de um erro, contacte ${studyContactEmail}", "language": "pt"},
-  {"keyName": "pageNotFoundReturnHome", "text": "Regressar à página inicial", "language": "pt"},
-  {"keyName": "authErrorPageTitle", "text": "Algo correu mal", "language": "pt"},
-  {"keyName": "authErrorPageMessage", "text": "Houve um problema com o nosso serviço de autenticação. Queira tentar de novo. Se o problema persistir, contacte ${studyContactEmail}.", "language": "pt"},
-  {"keyName": "navbarSampleKits", "text":  "Kits de amostra", "language": "pt"},
-  {"keyName": "kitsPageTitle", "text": "Kits de colheita de amostras", "language": "pt"},
-  {"keyName": "kitsPageDescription", "text": "Os kits de colheita de amostras são uma parte importante do processo do estudo e podem ajudar a fornecer informações importantes aos investigadores. Abaixo encontrará o estado de todos os kits que lhe foram fornecidos.", "language": "pt"},
-  {"keyName": "kitsPageInPersonTitle", "text": "Fornecer uma amostra pessoalmente", "language": "pt"},
-  {"keyName": "kitsPageInPersonDescription", "text": "Este estudo dá-lhe atualmente a possibilidade de realizar pessoalmente um kit de colheita de amostras.", "language": "pt"},
-  {"keyName": "kitsPageInPersonCompleteButton", "text": "Realizar um kit pessoalmente", "language": "pt"},
-  {"keyName": "kitsPageYourKitsTitle", "text": "Os seus kits", "language": "pt"},
-  {"keyName": "kitsPageStatusPreparing", "text": "A preparar", "language": "pt"},
-  {"keyName": "kitsPageStatusShipped", "text": "Enviado", "language": "pt"},
-  {"keyName": "kitsPageStatusReturned", "text": "Devolvido", "language": "pt"},
-  {"keyName": "kitsPageStatusCreated", "text": "Criado", "language": "pt"},
-  {"keyName": "kitsPageStatusCollected", "text": "Colhido", "language": "pt"},
-  {"keyName": "kitsPageNoKits", "text": "De momento, não dispõe de kits de colheita de amostras.", "language": "pt"},
-  {"keyName": "kitsInPersonTitle", "text": "Instruções para o kit de amostras", "language": "pt"},
-  {"keyName": "kitsInPersonDescription", "text": "Se estiver a realizar um kit de colheita de amostras pessoalmente, siga as instruções fornecidas por um membro da equipa do estudo. Quaisquer informações adicionais de que possa necessitar, tais como o seu identificador único de participante, serão fornecidas abaixo.", "language": "pt"},
-  {"keyName": "kitsInPersonSubDescription", "text": "Se tiver alguma dúvida, pergunte a um membro da equipa do estudo.", "language": "pt"},
-  {"keyName": "kitsInPersonYourKitTitle", "text": "O seu kit de colheita de amostras", "language": "pt"},
-  {"keyName": "kitsInPersonYourKitDescription", "text": "Um membro da equipa forneceu-lhe um kit de colheita de amostras. Este kit de amostras está associado à sua conta. Se estiver a ajudar outra pessoa com o seu kit de colheita de amostras, certifique-se de que cada participante realiza o kit de colheita de amostras que lhe foi atribuído.", "language": "pt"},
-  {"keyName": "kitsInPersonYourKitIdentifier", "text": "Identificador do seu kit", "language": "pt"},
-  {"keyName": "kitsInPersonReturnToDashboard", "text": "Voltar ao painel", "language": "pt"},
-  {"keyName": "kitsInPersonRefreshPage", "text": "Atualizar", "language": "pt"},
-  {"keyName": "kitsInPersonConsentRequiredTitle", "text": "Exigido consentimento", "language": "pt"},
-  {"keyName": "kitsInPersonConsentRequiredDescription", "text": "Antes de realizar um kit de colheita de amostras, tem de estar inscrito(a) no estudo. Se for do seu interesse, pode encontrar e assinar o formulário de consentimento através da ligação abaixo.", "language": "pt"},
-  {"keyName": "kitsInPersonStartConsent", "text": "Iniciar consentimento", "language": "pt"},
-  {"keyName": "kitsInPersonError", "text": "Ocorreu um erro ao carregar as informações do seu kit. Para obter ajuda, contacte um membro da equipa do estudo.", "language": "pt"},
-  {"keyName": "kitsInPersonCreatedInstructions", "text": "Depois de realizar o kit de colheita de amostras, entregue-o a um membro da equipa do estudo e permita-lhe digitalizar o seu código de participação abaixo.", "language": "pt"},
-  {"keyName": "kitsInPersonNoKitInstructions", "text": "Para receber um kit de colheita de amostras, um membro da equipa do estudo digitalizará o seu código de participação único abaixo para associar um kit de amostras à sua conta.", "language": "pt"},
-  {"keyName": "kitsInPersonNoKitSubInstructions", "text": "Depois de receber um kit, atualize esta página para ver as informações sobre o seu kit e receber mais instruções.", "language": "pt"},
-  {"keyName": "kitsInPersonCollectedDescription", "text": "Um membro da equipa do estudo recebeu o seu kit de colheita de amostras. Receberá uma notificação por e-mail quando a sua amostra for processada e poderá ver o estado da amostra no painel do seu estudo.", "language": "pt"},
-  {"keyName": "kitsInPersonCollectedThankYou", "text": "Obrigado pela sua participação.", "language": "pt"},
-  {"keyName": "kitTypeSaliva", "text": "Kit de saliva", "language": "pt"},
-  {"keyName": "kitTypeStool", "text": "Kit de fezes", "language": "pt"},
-  {"keyName": "kitTypeBlood", "text": "Kit de sangue", "language": "pt"},
-  {"keyName": "documentDownloadButton", "text": "Transferir", "language": "pt", "machineTranslated": true},
-  {"keyName": "documentsListNone", "text": "Ainda não carregou nenhum documento", "language": "pt", "machineTranslated": true},
-  {"keyName": "documentsListCreatedOn", "text": "Criado em", "language": "pt", "machineTranslated": true},
-  {"keyName": "documentsPageTitle", "text": "Documentos", "language": "pt", "machineTranslated": true},
-  {"keyName": "documentsPageUploadedDocumentsTitle", "text": "Documentos enviados", "language": "pt", "machineTranslated": true},
-  {"keyName": "documentsPageMessage", "text": "Ao participar num estudo, poderá ser-lhe pedido que envie documentos como parte de um formulário ou inquérito. Abaixo, pode gerir os documentos que enviou.", "language": "pt", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "Documentos", "language": "pt", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureTitle", "text": "Tem a certeza?", "language": "pt", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureMessage", "text": "Tem a certeza de que pretende eliminar este documento? Isso não pode ser desfeito. Note que se um membro da equipa do estudo já tiver descarregado este documento, ainda poderá ser acedido por ele. Entre em contacto com a equipa do estudo se desejar que o documento seja totalmente removido de todos os registos.", "language": "pt", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseTitle", "text": "Este documento está em uso", "language": "pt", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseMessage", "text": "Este documento está atualmente a ser partilhado em resposta a pelo menos um inquérito. Remova-o das respostas do inquérito antes de o eliminar.", "language": "pt", "machineTranslated": true},
-  {"keyName": "documentDeleteButton", "text": "Eliminar", "language": "pt", "machineTranslated": true},
-  {"keyName": "documentOptionsButton", "text": "Opções", "language": "pt", "machineTranslated": true},
-  {"keyName": "documentSharedInResponseTo", "text": "partilhado em resposta a", "language": "pt", "machineTranslated": true},
-  {"keyName": "documentUploaderSelectedDocuments", "text": "Documentos selecionados", "language": "pt", "machineTranslated": true},
-  {"keyName": "documentUploaderIncludedInResponse", "text": "Estes documentos estão incluídos na sua resposta", "language": "pt", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocumentsSelected", "text": "Nenhum documento selecionado. Faça o upload de um novo documento ou selecione um documento existente abaixo.", "language": "pt", "machineTranslated": true},
-  {"keyName": "documentUploaderAvailableDocuments", "text": "Documentos disponíveis", "language": "pt", "machineTranslated": true},
-  {"keyName": "documentUploaderNotIncludedInResponse", "text": "Estes documentos não estão incluídos na sua resposta", "language": "pt", "machineTranslated": true},
-  {"keyName": "documentUploaderClickToUpload", "text": "Solte os ficheiros aqui ou clique para fazer o upload", "language": "pt", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocuments", "text": "Nenhum documento disponível", "language": "pt", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeTitle", "text": "Sua sessão está prestes a expirar", "language": "pt", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeMessage", "text": "Para manter a segurança e proteger seus dados, você será desconectado em ${timeRemaining}.", "language": "pt", "machineTranslated": true}
+  {
+    "keyName": "navbarDashboard",
+    "text": "Painel",
+    "language": "pt"
+  },
+  {
+    "keyName": "navbarChangePassword",
+    "text": "Alterar palavra-passe",
+    "language": "pt"
+  },
+  {
+    "keyName": "navbarLogout",
+    "text": "Terminar sessão",
+    "language": "pt"
+  },
+  {
+    "keyName": "profile",
+    "text": "Perfil",
+    "language": "pt"
+  },
+  {
+    "keyName": "navbarLogin",
+    "text": "Iniciar sessão",
+    "language": "pt"
+  },
+  {
+    "keyName": "navbarJoin",
+    "text": "Registar",
+    "language": "pt"
+  },
+  {
+    "keyName": "taskComplete",
+    "text": "Concluído",
+    "language": "pt"
+  },
+  {
+    "keyName": "taskInProgress",
+    "text": "Em progresso",
+    "language": "pt"
+  },
+  {
+    "keyName": "taskNotStarted",
+    "text": "Não iniciado",
+    "language": "pt"
+  },
+  {
+    "keyName": "taskDeclined",
+    "text": "Recusado",
+    "language": "pt"
+  },
+  {
+    "keyName": "taskLocked",
+    "text": "Bloqueado",
+    "language": "pt"
+  },
+  {
+    "keyName": "tasksNoneForStudy",
+    "text": "Não existem tarefas para este estudo",
+    "language": "pt"
+  },
+  {
+    "keyName": "taskHistory",
+    "text": "histórico",
+    "language": "pt"
+  },
+  {
+    "keyName": "taskNew",
+    "text": "NOVO",
+    "language": "pt"
+  },
+  {
+    "keyName": "surveysSomeLocked",
+    "text": "Alguns questionários estão bloqueados até que outras tarefas necessárias sejam concluídas.",
+    "language": "pt"
+  },
+  {
+    "keyName": "taskTypeSurvey",
+    "text": "Questionário",
+    "language": "pt"
+  },
+  {
+    "keyName": "taskTypeSurveys",
+    "text": "Questionários",
+    "language": "pt"
+  },
+  {
+    "keyName": "taskTypeConsent",
+    "text": "Consentimento",
+    "language": "pt"
+  },
+  {
+    "keyName": "taskTypeForms",
+    "text": "Formulários",
+    "language": "pt"
+  },
+  {
+    "keyName": "start",
+    "text": "Iniciar",
+    "language": "pt"
+  },
+  {
+    "keyName": "continue",
+    "text": "Continuar",
+    "language": "pt"
+  },
+  {
+    "keyName": "save",
+    "text": "Guardar",
+    "language": "pt"
+  },
+  {
+    "keyName": "outreachLearnMore",
+    "text": "Saber mais",
+    "language": "pt"
+  },
+  {
+    "keyName": "cancel",
+    "text": "Cancelar",
+    "language": "pt"
+  },
+  {
+    "keyName": "goBack",
+    "text": "Retroceder",
+    "language": "pt"
+  },
+  {
+    "keyName": "name",
+    "text": "Nome",
+    "language": "pt"
+  },
+  {
+    "keyName": "givenName",
+    "text": "Nome próprio",
+    "language": "pt"
+  },
+  {
+    "keyName": "familyName",
+    "text": "Apelido",
+    "language": "pt"
+  },
+  {
+    "keyName": "editName",
+    "text": "Editar nome",
+    "language": "pt"
+  },
+  {
+    "keyName": "editBirthDate",
+    "text": "Editar data de nascimento",
+    "language": "pt"
+  },
+  {
+    "keyName": "birthDate",
+    "text": "Aniversário",
+    "language": "pt"
+  },
+  {
+    "keyName": "mailingAddress",
+    "text": "Endereço postal",
+    "language": "pt"
+  },
+  {
+    "keyName": "editMailingAddress",
+    "text": "Editar endereço postal",
+    "language": "pt"
+  },
+  {
+    "keyName": "primaryAddress",
+    "text": "Endereço principal",
+    "language": "pt"
+  },
+  {
+    "keyName": "editPrimaryAddress",
+    "text": "Editar endereço principal",
+    "language": "pt"
+  },
+  {
+    "keyName": "street1",
+    "text": "Rua 1",
+    "language": "pt"
+  },
+  {
+    "keyName": "street2",
+    "text": "Rua 2",
+    "language": "pt"
+  },
+  {
+    "keyName": "city",
+    "text": "Cidade",
+    "language": "pt"
+  },
+  {
+    "keyName": "state",
+    "text": "Estado/Província",
+    "language": "pt"
+  },
+  {
+    "keyName": "postalCode",
+    "text": "Código Postal",
+    "language": "pt"
+  },
+  {
+    "keyName": "country",
+    "text": "País",
+    "language": "pt"
+  },
+  {
+    "keyName": "communicationPreferences",
+    "text": "Preferências de comunicação",
+    "language": "pt"
+  },
+  {
+    "keyName": "editCommunicationPreferences",
+    "text": "Editar preferências de comunicação",
+    "language": "pt"
+  },
+  {
+    "keyName": "contactEmail",
+    "text": "E-mail de contacto",
+    "language": "pt"
+  },
+  {
+    "keyName": "editContactEmail",
+    "text": "Editar e-mail de contacto",
+    "language": "pt"
+  },
+  {
+    "keyName": "phoneNumber",
+    "text": "Número de telefone",
+    "language": "pt"
+  },
+  {
+    "keyName": "editPhoneNumber",
+    "text": "Editar número de telefone",
+    "language": "pt"
+  },
+  {
+    "keyName": "doNotSolicit",
+    "text": "Não solicitar",
+    "language": "pt"
+  },
+  {
+    "keyName": "doNotContact",
+    "text": "Não contactar",
+    "language": "pt"
+  },
+  {
+    "keyName": "editDoNotSolicit",
+    "text": "Editar não solicitar",
+    "language": "pt"
+  },
+  {
+    "keyName": "editNotifications",
+    "text": "Editar notificações",
+    "language": "pt"
+  },
+  {
+    "keyName": "notifications",
+    "text": "Notificações",
+    "language": "pt"
+  },
+  {
+    "keyName": "on",
+    "text": "Ativado",
+    "language": "pt"
+  },
+  {
+    "keyName": "off",
+    "text": "Desativado",
+    "language": "pt"
+  },
+  {
+    "keyName": "notProvided",
+    "text": "Não fornecido",
+    "language": "pt"
+  },
+  {
+    "keyName": "editProfileContactEmailWarning",
+    "text": "Prima “Guardar” para atualizar o e-mail utilizado para comunicações. Tenha em atenção que as suas informações de início de sessão não serão alteradas.",
+    "language": "pt"
+  },
+  {
+    "keyName": "privacyPolicy",
+    "text": "Política de Privacidade",
+    "language": "pt"
+  },
+  {
+    "keyName": "termsOfUse",
+    "text": "Termos de utilização",
+    "language": "pt"
+  },
+  {
+    "keyName": "addressInvalidPostalCode",
+    "text": "Não foi possível verificar o código postal.",
+    "language": "pt"
+  },
+  {
+    "keyName": "addressInvalidCountry",
+    "text": "Não foi possível verificar o país.",
+    "language": "pt"
+  },
+  {
+    "keyName": "addressInvalidState",
+    "text": "Não foi possível verificar o estado/província.",
+    "language": "pt"
+  },
+  {
+    "keyName": "addressInvalidCity",
+    "text": "Não foi possível verificar a cidade.",
+    "language": "pt"
+  },
+  {
+    "keyName": "addressInvalidHouseNumber",
+    "text": "Não foi possível verificar o número de porta.",
+    "language": "pt"
+  },
+  {
+    "keyName": "addressInvalidStreetName",
+    "text": "Não foi possível verificar o nome da rua.",
+    "language": "pt"
+  },
+  {
+    "keyName": "addressInvalidStreetType",
+    "text": "Não foi possível verificar o tipo da rua.",
+    "language": "pt"
+  },
+  {
+    "keyName": "addressNeedsSubpremise",
+    "text": "Indique o número da unidade/suite.",
+    "language": "pt"
+  },
+  {
+    "keyName": "addressFailedToValidate",
+    "text": "Não foi possível validar o endereço.",
+    "language": "pt"
+  },
+  {
+    "keyName": "suggestBetterAddressHeader",
+    "text": "Este endereço está correto?",
+    "language": "pt"
+  },
+  {
+    "keyName": "suggestBetterAddressBody",
+    "text": "Conseguimos verificar um endereço semelhante. Selecione qual o que pretende utilizar.",
+    "language": "pt"
+  },
+  {
+    "keyName": "newAddress",
+    "text": "Endereço novo",
+    "language": "pt"
+  },
+  {
+    "keyName": "oldAddress",
+    "text": "Endereço antigo",
+    "language": "pt"
+  },
+  {
+    "keyName": "you",
+    "text": "Você",
+    "language": "pt"
+  },
+  {
+    "keyName": "yourDependent",
+    "text": "O seu dependente",
+    "language": "pt"
+  },
+  {
+    "keyName": "youInParens",
+    "text": "(você)",
+    "language": "pt"
+  },
+  {
+    "keyName": "allProfiles",
+    "text": "Todos os perfis",
+    "language": "pt"
+  },
+  {
+    "keyName": "manageProfiles",
+    "text": "Gerir perfis",
+    "language": "pt"
+  },
+  {
+    "keyName": "addNewParticipant",
+    "text": "Adicionar novo participante",
+    "language": "pt"
+  },
+  {
+    "keyName": "dashboard",
+    "text": "Painel",
+    "language": "pt"
+  },
+  {
+    "keyName": "selectParticipant",
+    "text": "Selecionar participante",
+    "language": "pt"
+  },
+  {
+    "keyName": "hubUpdateFormSubmittedTitle",
+    "text": "${formName} preenchido",
+    "language": "pt"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesTitle",
+    "text": "Todas as atividades concluídas.",
+    "language": "pt"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesDetail",
+    "text": "Concluiu todas as atividades para este estudo. Iremos notificá-lo(a) assim que estiverem disponíveis novas atividades. Obrigado pela sua participação!",
+    "language": "pt"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyTitle",
+    "text": "Bem-vindo(a) ao ${studyName}",
+    "language": "pt"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyDetail",
+    "text": "Leia e assine o formulário de consentimento abaixo para continuar.",
+    "language": "pt"
+  },
+  {
+    "keyName": "hubUpdateAlreadyEnrolledTitle",
+    "text": "Já está incluído(a) no ${studyName}.",
+    "language": "pt"
+  },
+  {
+    "keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle",
+    "text": "Este utilizador já está incluído(a) no ${studyName}.",
+    "language": "pt"
+  },
+  {
+    "keyName": "cookieAlertTitle",
+    "text": "Cookies",
+    "language": "pt"
+  },
+  {
+    "keyName": "cookieAlertDetail",
+    "text": "Este sítio Web utiliza tokens de Internet, designados “cookies” para permitir o bom funcionamento e a segurança do nosso sítio Web e para melhorar a sua experiência enquanto o utiliza. Todos os cookies que usamos são cookies estritamente necessários. Este tipo de cookie não recolhe qualquer informação pessoal identificável sobre si e não rastreia os seus hábitos de navegação. Para saber mais, [leia a nossa Política de Privacidade](/privacidade).",
+    "language": "pt"
+  },
+  {
+    "keyName": "joinStudy",
+    "text": "Aderir ao Estudo",
+    "language": "pt"
+  },
+  {
+    "keyName": "ineligibleThankYou",
+    "text": "Obrigado pelo seu interesse em ${studyName}",
+    "language": "pt"
+  },
+  {
+    "keyName": "ineligibleDescription",
+    "text": "Infelizmente, não preenche de momento os critérios de elegibilidade para participar no ${studyName}.",
+    "language": "pt"
+  },
+  {
+    "keyName": "ineligibleProvideYourEmail",
+    "text": "Introduza o seu e-mail abaixo e enviar-lhe-emos atualizações sobre futuros desenvolvimentos. Pode cancelar a subscrição em qualquer altura.",
+    "language": "pt"
+  },
+  {
+    "keyName": "ineligibleStayInformed",
+    "text": "Mantenha-se informado(a)",
+    "language": "pt"
+  },
+  {
+    "keyName": "backToPortalHomepage",
+    "text": "Voltar à página inicial do ${portalName}",
+    "language": "pt"
+  },
+  {
+    "keyName": "joinMailingList",
+    "text": "Junte-se à lista de correio eletrónico",
+    "language": "pt"
+  },
+  {
+    "keyName": "mailingFormStayUpdated",
+    "text": "Mantenha-se a par das notícias sobre o estudo",
+    "language": "pt"
+  },
+  {
+    "keyName": "yourName",
+    "text": "O seu nome",
+    "language": "pt"
+  },
+  {
+    "keyName": "yourEmail",
+    "text": "O seu e-mail",
+    "language": "pt"
+  },
+  {
+    "keyName": "join",
+    "text": "Aderir",
+    "language": "pt"
+  },
+  {
+    "keyName": "thanksForJoining",
+    "text": "Obrigado por participar!",
+    "language": "pt"
+  },
+  {
+    "keyName": "pageNotFoundTitle",
+    "text": "Página não encontrada",
+    "language": "pt"
+  },
+  {
+    "keyName": "pageNotFoundMessage",
+    "text": "Se considerar que se trata de um erro, contacte ${studyContactEmail}",
+    "language": "pt"
+  },
+  {
+    "keyName": "pageNotFoundReturnHome",
+    "text": "Regressar à página inicial",
+    "language": "pt"
+  },
+  {
+    "keyName": "authErrorPageTitle",
+    "text": "Algo correu mal",
+    "language": "pt"
+  },
+  {
+    "keyName": "authErrorPageMessage",
+    "text": "Houve um problema com o nosso serviço de autenticação. Queira tentar de novo. Se o problema persistir, contacte ${studyContactEmail}.",
+    "language": "pt"
+  },
+  {
+    "keyName": "navbarSampleKits",
+    "text": "Kits de amostra",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsPageTitle",
+    "text": "Kits de colheita de amostras",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsPageDescription",
+    "text": "Os kits de colheita de amostras são uma parte importante do processo do estudo e podem ajudar a fornecer informações importantes aos investigadores. Abaixo encontrará o estado de todos os kits que lhe foram fornecidos.",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsPageInPersonTitle",
+    "text": "Fornecer uma amostra pessoalmente",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsPageInPersonDescription",
+    "text": "Este estudo dá-lhe atualmente a possibilidade de realizar pessoalmente um kit de colheita de amostras.",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsPageInPersonCompleteButton",
+    "text": "Realizar um kit pessoalmente",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsPageYourKitsTitle",
+    "text": "Os seus kits",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsPageStatusPreparing",
+    "text": "A preparar",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsPageStatusShipped",
+    "text": "Enviado",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsPageStatusReturned",
+    "text": "Devolvido",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsPageStatusCreated",
+    "text": "Criado",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsPageStatusCollected",
+    "text": "Colhido",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsPageNoKits",
+    "text": "De momento, não dispõe de kits de colheita de amostras.",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsInPersonTitle",
+    "text": "Instruções para o kit de amostras",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsInPersonDescription",
+    "text": "Se estiver a realizar um kit de colheita de amostras pessoalmente, siga as instruções fornecidas por um membro da equipa do estudo. Quaisquer informações adicionais de que possa necessitar, tais como o seu identificador único de participante, serão fornecidas abaixo.",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsInPersonSubDescription",
+    "text": "Se tiver alguma dúvida, pergunte a um membro da equipa do estudo.",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsInPersonYourKitTitle",
+    "text": "O seu kit de colheita de amostras",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsInPersonYourKitDescription",
+    "text": "Um membro da equipa forneceu-lhe um kit de colheita de amostras. Este kit de amostras está associado à sua conta. Se estiver a ajudar outra pessoa com o seu kit de colheita de amostras, certifique-se de que cada participante realiza o kit de colheita de amostras que lhe foi atribuído.",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsInPersonYourKitIdentifier",
+    "text": "Identificador do seu kit",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsInPersonReturnToDashboard",
+    "text": "Voltar ao painel",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsInPersonRefreshPage",
+    "text": "Atualizar",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredTitle",
+    "text": "Exigido consentimento",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredDescription",
+    "text": "Antes de realizar um kit de colheita de amostras, tem de estar inscrito(a) no estudo. Se for do seu interesse, pode encontrar e assinar o formulário de consentimento através da ligação abaixo.",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsInPersonStartConsent",
+    "text": "Iniciar consentimento",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsInPersonError",
+    "text": "Ocorreu um erro ao carregar as informações do seu kit. Para obter ajuda, contacte um membro da equipa do estudo.",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsInPersonCreatedInstructions",
+    "text": "Depois de realizar o kit de colheita de amostras, entregue-o a um membro da equipa do estudo e permita-lhe digitalizar o seu código de participação abaixo.",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsInPersonNoKitInstructions",
+    "text": "Para receber um kit de colheita de amostras, um membro da equipa do estudo digitalizará o seu código de participação único abaixo para associar um kit de amostras à sua conta.",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsInPersonNoKitSubInstructions",
+    "text": "Depois de receber um kit, atualize esta página para ver as informações sobre o seu kit e receber mais instruções.",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsInPersonCollectedDescription",
+    "text": "Um membro da equipa do estudo recebeu o seu kit de colheita de amostras. Receberá uma notificação por e-mail quando a sua amostra for processada e poderá ver o estado da amostra no painel do seu estudo.",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitsInPersonCollectedThankYou",
+    "text": "Obrigado pela sua participação.",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitTypeSaliva",
+    "text": "Kit de saliva",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitTypeStool",
+    "text": "Kit de fezes",
+    "language": "pt"
+  },
+  {
+    "keyName": "kitTypeBlood",
+    "text": "Kit de sangue",
+    "language": "pt"
+  },
+  {
+    "keyName": "documentDownloadButton",
+    "text": "Transferir",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListNone",
+    "text": "Ainda não carregou nenhum documento",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListCreatedOn",
+    "text": "Criado em",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageTitle",
+    "text": "Documentos",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageUploadedDocumentsTitle",
+    "text": "Documentos enviados",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageMessage",
+    "text": "Ao participar num estudo, poderá ser-lhe pedido que envie documentos como parte de um formulário ou inquérito. Abaixo, pode gerir os documentos que enviou.",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "navbarDocuments",
+    "text": "Documentos",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureTitle",
+    "text": "Tem a certeza?",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureMessage",
+    "text": "Tem a certeza de que pretende eliminar este documento? Isso não pode ser desfeito. Note que se um membro da equipa do estudo já tiver descarregado este documento, ainda poderá ser acedido por ele. Entre em contacto com a equipa do estudo se desejar que o documento seja totalmente removido de todos os registos.",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseTitle",
+    "text": "Este documento está em uso",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseMessage",
+    "text": "Este documento está atualmente a ser partilhado em resposta a pelo menos um inquérito. Remova-o das respostas do inquérito antes de o eliminar.",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteButton",
+    "text": "Eliminar",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentOptionsButton",
+    "text": "Opções",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentSharedInResponseTo",
+    "text": "partilhado em resposta a",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderSelectedDocuments",
+    "text": "Documentos selecionados",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderIncludedInResponse",
+    "text": "Estes documentos estão incluídos na sua resposta",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocumentsSelected",
+    "text": "Nenhum documento selecionado. Faça o upload de um novo documento ou selecione um documento existente abaixo.",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderAvailableDocuments",
+    "text": "Documentos disponíveis",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNotIncludedInResponse",
+    "text": "Estes documentos não estão incluídos na sua resposta",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderClickToUpload",
+    "text": "Solte os ficheiros aqui ou clique para fazer o upload",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocuments",
+    "text": "Nenhum documento disponível",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeTitle",
+    "text": "Sua sessão está prestes a expirar",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeMessage",
+    "text": "Para manter a segurança e proteger seus dados, você será desconectado em ${timeRemaining}.",
+    "language": "pt",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "failedToEnroll",
+    "language": "pt",
+    "text": "Algo deu errado durante o processo de inscrição. Por favor, preencha o formulário novamente.",
+    "machineTranslated": true
+  }
 ]

--- a/populate/src/main/resources/seed/i18n/ru/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/ru/languageTexts.json
@@ -1,163 +1,836 @@
 [
-  {"keyName": "navbarDashboard", "text": "Информационная панель", "language": "ru"},
-  {"keyName": "navbarChangePassword", "text": "Изменить пароль", "language": "ru"},
-  {"keyName": "navbarLogout", "text": "Выход из системы", "language": "ru"},
-  {"keyName": "profile", "text": "Профиль", "language": "ru"},
-  {"keyName": "navbarLogin", "text": "Вход в систему", "language": "ru"},
-  {"keyName": "navbarJoin", "text": "Зарегистрироваться", "language": "ru"},
-  {"keyName": "taskComplete", "text": "Завершено", "language": "ru"},
-  {"keyName": "taskInProgress", "text": "Выполняется", "language": "ru"},
-  {"keyName": "taskNotStarted", "text": "Не начато", "language": "ru"},
-  {"keyName": "taskDeclined", "text": "Отклонено", "language": "ru"},
-  {"keyName": "taskLocked", "text": "Заблокировано", "language": "ru"},
-  {"keyName": "tasksNoneForStudy", "text": "Нет задач для этого исследования", "language": "ru"},
-  {"keyName": "taskHistory", "text": "история", "language": "ru"},
-  {"keyName": "taskNew", "text": "НОВОЕ", "language": "ru"},
-  {"keyName": "surveysSomeLocked", "text": "Некоторые опросы заблокированы до тех пор, пока не будут выполнены другие необходимые задачи.", "language": "ru"},
-  {"keyName": "taskTypeSurvey", "text": "Опрос", "language": "ru"},
-  {"keyName": "taskTypeSurveys", "text": "Опросы", "language": "ru"},
-  {"keyName": "taskTypeConsent", "text": "Согласие", "language": "ru"},
-  {"keyName": "taskTypeForms", "text": "Формы", "language": "ru"},
-  {"keyName": "start", "text": "Начать", "language": "ru"},
-  {"keyName": "continue", "text": "Продолжить", "language": "ru"},
-  {"keyName": "save", "text": "Сохранить", "language": "ru"},
-  {"keyName": "outreachLearnMore", "text": "Узнать больше", "language": "ru"},
-  {"keyName": "cancel", "text": "Отменить", "language": "ru"},
-  {"keyName": "goBack", "text": "Вернуться назад", "language": "ru"},
-  {"keyName": "name", "text": "Ф.И.О.", "language": "ru"},
-  {"keyName": "givenName", "text": "Имя", "language": "ru"},
-  {"keyName": "familyName", "text": "Фамилия", "language": "ru"},
-  {"keyName": "editName", "text": "Отредактировать имя", "language": "ru"},
-  {"keyName": "editBirthDate", "text": "Отредактировать день рождения", "language": "ru"},
-  {"keyName": "birthDate", "text": "День рождения", "language": "ru"},
-  {"keyName": "mailingAddress", "text": "Почтовый адрес", "language": "ru"},
-  {"keyName": "editMailingAddress", "text": "Отредактировать почтовый адрес", "language": "ru"},
-  {"keyName": "primaryAddress", "text": "Основной адрес", "language": "ru"},
-  {"keyName": "editPrimaryAddress", "text": "Отредактировать основной адрес", "language": "ru"},
-  {"keyName": "street1", "text": "Улица 1", "language": "ru"},
-  {"keyName": "street2", "text": "Улица 2", "language": "ru"},
-  {"keyName": "city", "text": "Город", "language": "ru"},
-  {"keyName": "state", "text": "Штат\/провинция", "language": "ru"},
-  {"keyName": "postalCode", "text": "Почтовый индекс", "language": "ru"},
-  {"keyName": "country", "text": "Страна", "language": "ru"},
-  {"keyName": "communicationPreferences", "text": "Предпочитаемый способ связи", "language": "ru"},
-  {"keyName": "editCommunicationPreferences", "text": "Отредактировать предпочитаемый способ связи", "language": "ru"},
-  {"keyName": "contactEmail", "text": "Контактный адрес электронной почты", "language": "ru"},
-  {"keyName": "editContactEmail", "text": "Отредактировать контактный адрес электронной почты", "language": "ru"},
-  {"keyName": "phoneNumber", "text": "Номер телефона", "language": "ru"},
-  {"keyName": "editPhoneNumber", "text": "Отредактировать номер телефона", "language": "ru"},
-  {"keyName": "doNotSolicit", "text": "Не обращаться с предложениями", "language": "ru"},
-  {"keyName": "doNotContact", "text": "Не обращаться посредством контактных данных", "language": "ru"},
-  {"keyName": "editDoNotSolicit", "text": "Отредактировать «Не обращаться с предложениями»", "language": "ru"},
-  {"keyName": "editNotifications", "text": "Отредактировать уведомления", "language": "ru"},
-  {"keyName": "notifications", "text": "Уведомления", "language": "ru"},
-  {"keyName": "on", "text": "Включить", "language": "ru"},
-  {"keyName": "off", "text": "Выключить", "language": "ru"},
-  {"keyName": "notProvided", "text": "Не указано", "language": "ru"},
-  {"keyName": "editProfileContactEmailWarning", "text": "Нажмите «Сохранить», чтобы обновить адрес электронной почты, использующийся для связи. Обратите внимание, что ваши данные для входа не изменятся.", "language": "ru"},
-  {"keyName": "privacyPolicy", "text": "Политика конфиденциальности", "language": "ru"},
-  {"keyName": "termsOfUse", "text": "Условия использования", "language": "ru"},
-  {"keyName": "addressInvalidPostalCode", "text": "Не удалось проверить почтовый индекс.", "language": "ru"},
-  {"keyName": "addressInvalidCountry", "text": "Не удалось проверить страну.", "language": "ru"},
-  {"keyName": "addressInvalidState", "text": "Не удалось проверить штат\/провинцию.", "language": "ru"},
-  {"keyName": "addressInvalidCity", "text": "Не удалось проверить город.", "language": "ru"},
-  {"keyName": "addressInvalidHouseNumber", "text": "Не удалось проверить номер дома.", "language": "ru"},
-  {"keyName": "addressInvalidStreetName", "text": "Не удалось проверить название улицы.", "language": "ru"},
-  {"keyName": "addressInvalidStreetType", "text": "Не удалось проверить тип улицы.", "language": "ru"},
-  {"keyName": "addressNeedsSubpremise", "text": "Пожалуйста, укажите номер блока\/корпуса.", "language": "ru"},
-  {"keyName": "addressFailedToValidate", "text": "Не удалось подтвердить адрес.", "language": "ru"},
-  {"keyName": "suggestBetterAddressHeader", "text": "Это правильный адрес?", "language": "ru"},
-  {"keyName": "suggestBetterAddressBody", "text": "Нам удалось подтвердить похожий адрес. Пожалуйста, выберите тот, который вы хотели бы использовать.", "language": "ru"},
-  {"keyName": "newAddress", "text": "Новый адрес", "language": "ru"},
-  {"keyName": "oldAddress", "text": "Старый адрес", "language": "ru"},
-  {"keyName": "you", "text": "Вы", "language": "ru"},
-  {"keyName": "yourDependent", "text": "Лица, находящиеся на вашем иждивении", "language": "ru"},
-  {"keyName": "youInParens", "text": "(вы)", "language": "ru"},
-  {"keyName": "allProfiles", "text": "Все профили", "language": "ru"},
-  {"keyName": "manageProfiles", "text": "Управление профилями", "language": "ru"},
-  {"keyName": "addNewParticipant", "text": "Добавить нового участника", "language": "ru"},
-  {"keyName": "dashboard", "text": "Информационная панель", "language": "ru"},
-  {"keyName": "selectParticipant", "text": "Выбрать участника", "language": "ru"},
-  {"keyName": "hubUpdateFormSubmittedTitle", "text": "${formName} выполнено", "language": "ru"},
-  {"keyName": "hubUpdateNoActivitiesTitle", "text": "Все действия выполнены", "language": "ru"},
-  {"keyName": "hubUpdateNoActivitiesDetail", "text": "Вы выполнили все действия для этого исследования. Мы сообщим вам, когда появятся новые действия. Спасибо за участие!", "language": "ru"},
-  {"keyName": "hubUpdateWelcomeToStudyTitle", "text": "Добро пожаловать в ${studyName}", "language": "ru"},
-  {"keyName": "hubUpdateWelcomeToStudyDetail", "text": "Пожалуйста, прочитайте и подпишите форму согласия ниже, чтобы продолжить.", "language": "ru"},
-  {"keyName": "hubUpdateAlreadyEnrolledTitle", "text": "Вы уже включены в ${studyName}.", "language": "ru"},
-  {"keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle", "text": "Пользователь уже включен в ${studyName}.", "language": "ru"},
-  {"keyName": "cookieAlertTitle", "text": "Cookies", "language": "ru"},
-  {"keyName": "cookieAlertDetail", "text": "Для обеспечения правильного и безопасного функционирования нашего сайта, а также для улучшения вашей работы с ним, на сайте используются интернет-токены, которые называются cookies («кукис»). Все cookies, которые мы используем, являются строго необходимыми. Этот тип cookies не собирает никакой личной информации о вас и не отслеживает ваши привычки просмотра. Чтобы узнать больше, [прочитайте нашу Политику конфиденциальности] (\/конфиденциальность).", "language": "ru"},
-  {"keyName": "joinStudy", "text": "Присоединяйтесь к исследованию", "language": "ru"},
-  {"keyName": "ineligibleThankYou", "text": "Благодарим вас за интерес к ${studyName}", "language": "ru" },
-  {"keyName": "ineligibleDescription", "text": "К сожалению, в настоящее время вы не соответствуете критериям участия в ${studyName}.", "language": "ru"},
-  {"keyName": "ineligibleProvideYourEmail", "text": "Укажите ниже свой адрес электронной почты, и мы будем держать вас в курсе событий. Вы можете отписаться в любое время.", "language":  "ru"},
-  {"keyName": "ineligibleStayInformed", "text": "Будьте в курсе событий", "language": "ru"},
-  {"keyName": "backToPortalHomepage", "text": "Вернуться на домашнюю страницу ${portalName}", "language": "ru"},
-  {"keyName": "joinMailingList", "text": "Присоединяйтесь к списку рассылки", "language": "ru"},
-  {"keyName": "mailingFormStayUpdated", "text":  "Будьте в курсе новостей об исследовании", "language": "ru"},
-  {"keyName": "yourName", "text": "Ваше имя", "language": "ru"},
-  {"keyName": "yourEmail", "text": "Ваша электронная почта", "language": "ru"},
-  {"keyName": "join", "text":  "Присоединиться", "language": "ru"},
-  {"keyName": "thanksForJoining", "text": "Спасибо, что присоединились!", "language": "ru"},
-  {"keyName": "pageNotFoundTitle", "text": "Страница не найдена", "language": "ru"},
-  {"keyName": "pageNotFoundMessage", "text": "Если вы считаете, что это может быть ошибка, свяжитесь с ${studyContactEmail}", "language": "ru"},
-  {"keyName": "pageNotFoundReturnHome", "text": "Вернуться на главную страницу", "language": "ru"},
-  {"keyName": "authErrorPageTitle", "text": "Произошла ошибка", "language": "ru"},
-  {"keyName": "authErrorPageMessage", "text": "Возникла проблема с нашей службой проверки подлинности. Пожалуйста, повторите попытку. Если проблема не исчезает, свяжитесь с ${studyContactEmail}.", "language": "ru"},
-  {"keyName": "navbarSampleKits", "text":  "Наборы для образцов", "language": "ru"},
-  {"keyName": "kitsPageTitle", "text": "Наборы для сбора образцов", "language": "ru"},
-  {"keyName": "kitsPageDescription", "text": "Наборы для сбора образцов являются необходимой частью исследовательского процесса, с их помощью исследователи могут получить важную информацию. Ниже вы можете увидеть статус всех предоставленных вам наборов.", "language": "ru"},
-  {"keyName": "kitsPageInPersonTitle", "text": "Предоставьте образец самостоятельно", "language": "ru"},
-  {"keyName": "kitsPageInPersonDescription", "text": "На данный момент для этого исследования есть возможность собрать набор образцов самостоятельно.", "language": "ru"},
-  {"keyName": "kitsPageInPersonCompleteButton", "text": "Собрать набор образцов самостоятельно", "language": "ru"},
-  {"keyName": "kitsPageYourKitsTitle", "text": "Ваши наборы", "language": "ru"},
-  {"keyName": "kitsPageStatusPreparing", "text": "Подготовка", "language": "ru"},
-  {"keyName": "kitsPageStatusShipped", "text": "Отправлено", "language": "ru"},
-  {"keyName": "kitsPageStatusReturned", "text": "Возвращено", "language": "ru"},
-  {"keyName": "kitsPageStatusCreated", "text": "Создано", "language": "ru"},
-  {"keyName": "kitsPageStatusCollected", "text": "Взято", "language": "ru"},
-  {"keyName": "kitsPageNoKits", "text": "На данный момент у вас нет наборов для сбора образцов.", "language": "ru"},
-  {"keyName": "kitsInPersonTitle", "text": "Инструкция к набору для сбора образцов", "language": "ru"},
-  {"keyName": "kitsInPersonDescription", "text": "Если вы собираете образцы с помощью набора самостоятельно, следуйте инструкциям, предоставленным участником исследовательской группы. Любая дополнительная информация, которая может вам понадобиться, например ваш уникальный идентификатор участника, будет указана ниже.", "language": "ru"},
-  {"keyName": "kitsInPersonSubDescription", "text": "Если у вас есть вопросы, вы можете задать их участнику исследовательской группы.", "language": "ru"},
-  {"keyName": "kitsInPersonYourKitTitle", "text": "Ваш набор для сбора образцов", "language": "ru"},
-  {"keyName": "kitsInPersonYourKitDescription", "text": "Участник исследовательской группы предоставил вам набор для сбора образцов. Этот набор для сбора образцов привязан к вашей учетной записи. Если вы помогаете другому человеку собрать образцы с помощью набора, убедитесь, что каждый участник исследования использовал набор, который предназначался именно ему.", "language": "ru"},
-  {"keyName": "kitsInPersonYourKitIdentifier", "text": "Идентификатор вашего набора", "language": "ru"},
-  {"keyName": "kitsInPersonReturnToDashboard", "text": "Вернуться к информационной панели", "language": "ru"},
-  {"keyName": "kitsInPersonRefreshPage", "text": "Обновить", "language": "ru"},
-  {"keyName": "kitsInPersonConsentRequiredTitle", "text": "Требуется согласие", "language": "ru"},
-  {"keyName": "kitsInPersonConsentRequiredDescription", "text": "Прежде чем использовать набор для сбора образцов, вам нужно сначала зарегистрироваться для участия в исследовании. Если вас это заинтересовало, вы можете найти и подписать форму согласия по ссылке ниже.", "language": "ru"},
-  {"keyName": "kitsInPersonStartConsent", "text": "Начать подписание согласия", "language": "ru"},
-  {"keyName": "kitsInPersonError", "text": "Произошла ошибка при загрузке информации о вашем наборе. Пожалуйста, свяжитесь с участником исследовательской группы для решения вопроса.", "language": "ru"},
-  {"keyName": "kitsInPersonCreatedInstructions", "text": "После сбора образцов с помощью набора верните его участнику исследовательской группы, он отсканирует ваш код участника, указанный ниже.", "language": "ru"},
-  {"keyName": "kitsInPersonNoKitInstructions", "text": "Чтобы получить набор для сбора образцов, участник исследовательской группы отсканирует ваш уникальный код участника, указанный ниже, и привяжет набор образцов к вашей учетной записи.", "language": "ru"},
-  {"keyName": "kitsInPersonNoKitSubInstructions", "text": "После получения набора обновите эту страницу, чтобы увидеть информацию о наборе и получить дальнейшие инструкции.", "language": "ru"},
-  {"keyName": "kitsInPersonCollectedDescription", "text": "Участник исследовательской группы получил ваш набор для сбора образцов. Когда ваш образец поступит в обработку, вы получите уведомление по электронной почте и сможете увидеть статус образца в информационной панели вашего исследования.", "language": "ru"},
-  {"keyName": "kitsInPersonCollectedThankYou", "text": "Спасибо за участие.", "language": "ru"},
-  {"keyName": "kitTypeSaliva", "text": "Набор для сбора образца слюны", "language": "ru"},
-  {"keyName": "kitTypeStool", "text": "Набор для сбора образца кала", "language": "ru"},
-  {"keyName": "kitTypeBlood", "text": "Набор для сбора образца крови", "language": "ru"},
-  {"keyName": "documentDownloadButton", "text": "Скачать", "language": "ru", "machineTranslated": true},
-  {"keyName": "documentsListNone", "text": "Вы еще не загрузили ни одного документа", "language": "ru", "machineTranslated": true},
-  {"keyName": "documentsListCreatedOn", "text": "Создано", "language": "ru", "machineTranslated": true},
-  {"keyName": "documentsPageTitle", "text": "Документы", "language": "ru", "machineTranslated": true},
-  {"keyName": "documentsPageUploadedDocumentsTitle", "text": "Загруженные документы", "language": "ru", "machineTranslated": true},
-  {"keyName": "documentsPageMessage", "text": "При участии в исследовании вас могут попросить загрузить документы как часть формы или опроса. Ниже вы можете управлять загруженными вами документами.", "language": "ru", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "Документы", "language": "ru", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureTitle", "text": "Вы уверены?", "language": "ru", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureMessage", "text": "Вы уверены, что хотите удалить этот документ? Это действие нельзя отменить. Обратите внимание, что если член исследовательского персонала уже загрузил этот документ, он все равно будет ему доступен. Пожалуйста, свяжитесь с исследовательским персоналом, если вы хотите, чтобы документ был полностью удален из всех записей.", "language": "ru", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseTitle", "text": "Этот документ используется", "language": "ru", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseMessage", "text": "Этот документ в настоящее время распространяется в ответе по крайней мере на один опрос. Пожалуйста, удалите его из ответов на опросы перед его удалением.", "language": "ru", "machineTranslated": true},
-  {"keyName": "documentDeleteButton", "text": "Удалить", "language": "ru", "machineTranslated": true},
-  {"keyName": "documentOptionsButton", "text": "Параметры", "language": "ru", "machineTranslated": true},
-  {"keyName": "documentSharedInResponseTo", "text": "поделился в ответ на", "language": "ru", "machineTranslated": true},
-  {"keyName": "documentUploaderSelectedDocuments", "text": "Избранные документы", "language": "ru", "machineTranslated": true},
-  {"keyName": "documentUploaderIncludedInResponse", "text": "Эти документы включены в ваш ответ", "language": "ru", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocumentsSelected", "text": "Не выбрано ни одного документа. Загрузите новый документ или выберите существующий документ ниже.", "language": "ru", "machineTranslated": true},
-  {"keyName": "documentUploaderAvailableDocuments", "text": "Available documents", "language": "ru", "machineTranslated": true},
-  {"keyName": "documentUploaderNotIncludedInResponse", "text": "Эти документы не включены в ваш ответ", "language": "ru", "machineTranslated": true},
-  {"keyName": "documentUploaderClickToUpload", "text": "Перетащите файлы сюда или нажмите, чтобы загрузить", "language": "ru", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocuments", "text": "Нет доступных документов", "language": "ru", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeTitle", "text": "Ваш сеанс скоро истечет", "language": "ru", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeMessage", "text": "Для обеспечения безопасности и защиты ваших данных вы выйдете из системы через ${timeRemaining}.", "language": "ru", "machineTranslated": true}
+  {
+    "keyName": "navbarDashboard",
+    "text": "Информационная панель",
+    "language": "ru"
+  },
+  {
+    "keyName": "navbarChangePassword",
+    "text": "Изменить пароль",
+    "language": "ru"
+  },
+  {
+    "keyName": "navbarLogout",
+    "text": "Выход из системы",
+    "language": "ru"
+  },
+  {
+    "keyName": "profile",
+    "text": "Профиль",
+    "language": "ru"
+  },
+  {
+    "keyName": "navbarLogin",
+    "text": "Вход в систему",
+    "language": "ru"
+  },
+  {
+    "keyName": "navbarJoin",
+    "text": "Зарегистрироваться",
+    "language": "ru"
+  },
+  {
+    "keyName": "taskComplete",
+    "text": "Завершено",
+    "language": "ru"
+  },
+  {
+    "keyName": "taskInProgress",
+    "text": "Выполняется",
+    "language": "ru"
+  },
+  {
+    "keyName": "taskNotStarted",
+    "text": "Не начато",
+    "language": "ru"
+  },
+  {
+    "keyName": "taskDeclined",
+    "text": "Отклонено",
+    "language": "ru"
+  },
+  {
+    "keyName": "taskLocked",
+    "text": "Заблокировано",
+    "language": "ru"
+  },
+  {
+    "keyName": "tasksNoneForStudy",
+    "text": "Нет задач для этого исследования",
+    "language": "ru"
+  },
+  {
+    "keyName": "taskHistory",
+    "text": "история",
+    "language": "ru"
+  },
+  {
+    "keyName": "taskNew",
+    "text": "НОВОЕ",
+    "language": "ru"
+  },
+  {
+    "keyName": "surveysSomeLocked",
+    "text": "Некоторые опросы заблокированы до тех пор, пока не будут выполнены другие необходимые задачи.",
+    "language": "ru"
+  },
+  {
+    "keyName": "taskTypeSurvey",
+    "text": "Опрос",
+    "language": "ru"
+  },
+  {
+    "keyName": "taskTypeSurveys",
+    "text": "Опросы",
+    "language": "ru"
+  },
+  {
+    "keyName": "taskTypeConsent",
+    "text": "Согласие",
+    "language": "ru"
+  },
+  {
+    "keyName": "taskTypeForms",
+    "text": "Формы",
+    "language": "ru"
+  },
+  {
+    "keyName": "start",
+    "text": "Начать",
+    "language": "ru"
+  },
+  {
+    "keyName": "continue",
+    "text": "Продолжить",
+    "language": "ru"
+  },
+  {
+    "keyName": "save",
+    "text": "Сохранить",
+    "language": "ru"
+  },
+  {
+    "keyName": "outreachLearnMore",
+    "text": "Узнать больше",
+    "language": "ru"
+  },
+  {
+    "keyName": "cancel",
+    "text": "Отменить",
+    "language": "ru"
+  },
+  {
+    "keyName": "goBack",
+    "text": "Вернуться назад",
+    "language": "ru"
+  },
+  {
+    "keyName": "name",
+    "text": "Ф.И.О.",
+    "language": "ru"
+  },
+  {
+    "keyName": "givenName",
+    "text": "Имя",
+    "language": "ru"
+  },
+  {
+    "keyName": "familyName",
+    "text": "Фамилия",
+    "language": "ru"
+  },
+  {
+    "keyName": "editName",
+    "text": "Отредактировать имя",
+    "language": "ru"
+  },
+  {
+    "keyName": "editBirthDate",
+    "text": "Отредактировать день рождения",
+    "language": "ru"
+  },
+  {
+    "keyName": "birthDate",
+    "text": "День рождения",
+    "language": "ru"
+  },
+  {
+    "keyName": "mailingAddress",
+    "text": "Почтовый адрес",
+    "language": "ru"
+  },
+  {
+    "keyName": "editMailingAddress",
+    "text": "Отредактировать почтовый адрес",
+    "language": "ru"
+  },
+  {
+    "keyName": "primaryAddress",
+    "text": "Основной адрес",
+    "language": "ru"
+  },
+  {
+    "keyName": "editPrimaryAddress",
+    "text": "Отредактировать основной адрес",
+    "language": "ru"
+  },
+  {
+    "keyName": "street1",
+    "text": "Улица 1",
+    "language": "ru"
+  },
+  {
+    "keyName": "street2",
+    "text": "Улица 2",
+    "language": "ru"
+  },
+  {
+    "keyName": "city",
+    "text": "Город",
+    "language": "ru"
+  },
+  {
+    "keyName": "state",
+    "text": "Штат/провинция",
+    "language": "ru"
+  },
+  {
+    "keyName": "postalCode",
+    "text": "Почтовый индекс",
+    "language": "ru"
+  },
+  {
+    "keyName": "country",
+    "text": "Страна",
+    "language": "ru"
+  },
+  {
+    "keyName": "communicationPreferences",
+    "text": "Предпочитаемый способ связи",
+    "language": "ru"
+  },
+  {
+    "keyName": "editCommunicationPreferences",
+    "text": "Отредактировать предпочитаемый способ связи",
+    "language": "ru"
+  },
+  {
+    "keyName": "contactEmail",
+    "text": "Контактный адрес электронной почты",
+    "language": "ru"
+  },
+  {
+    "keyName": "editContactEmail",
+    "text": "Отредактировать контактный адрес электронной почты",
+    "language": "ru"
+  },
+  {
+    "keyName": "phoneNumber",
+    "text": "Номер телефона",
+    "language": "ru"
+  },
+  {
+    "keyName": "editPhoneNumber",
+    "text": "Отредактировать номер телефона",
+    "language": "ru"
+  },
+  {
+    "keyName": "doNotSolicit",
+    "text": "Не обращаться с предложениями",
+    "language": "ru"
+  },
+  {
+    "keyName": "doNotContact",
+    "text": "Не обращаться посредством контактных данных",
+    "language": "ru"
+  },
+  {
+    "keyName": "editDoNotSolicit",
+    "text": "Отредактировать «Не обращаться с предложениями»",
+    "language": "ru"
+  },
+  {
+    "keyName": "editNotifications",
+    "text": "Отредактировать уведомления",
+    "language": "ru"
+  },
+  {
+    "keyName": "notifications",
+    "text": "Уведомления",
+    "language": "ru"
+  },
+  {
+    "keyName": "on",
+    "text": "Включить",
+    "language": "ru"
+  },
+  {
+    "keyName": "off",
+    "text": "Выключить",
+    "language": "ru"
+  },
+  {
+    "keyName": "notProvided",
+    "text": "Не указано",
+    "language": "ru"
+  },
+  {
+    "keyName": "editProfileContactEmailWarning",
+    "text": "Нажмите «Сохранить», чтобы обновить адрес электронной почты, использующийся для связи. Обратите внимание, что ваши данные для входа не изменятся.",
+    "language": "ru"
+  },
+  {
+    "keyName": "privacyPolicy",
+    "text": "Политика конфиденциальности",
+    "language": "ru"
+  },
+  {
+    "keyName": "termsOfUse",
+    "text": "Условия использования",
+    "language": "ru"
+  },
+  {
+    "keyName": "addressInvalidPostalCode",
+    "text": "Не удалось проверить почтовый индекс.",
+    "language": "ru"
+  },
+  {
+    "keyName": "addressInvalidCountry",
+    "text": "Не удалось проверить страну.",
+    "language": "ru"
+  },
+  {
+    "keyName": "addressInvalidState",
+    "text": "Не удалось проверить штат/провинцию.",
+    "language": "ru"
+  },
+  {
+    "keyName": "addressInvalidCity",
+    "text": "Не удалось проверить город.",
+    "language": "ru"
+  },
+  {
+    "keyName": "addressInvalidHouseNumber",
+    "text": "Не удалось проверить номер дома.",
+    "language": "ru"
+  },
+  {
+    "keyName": "addressInvalidStreetName",
+    "text": "Не удалось проверить название улицы.",
+    "language": "ru"
+  },
+  {
+    "keyName": "addressInvalidStreetType",
+    "text": "Не удалось проверить тип улицы.",
+    "language": "ru"
+  },
+  {
+    "keyName": "addressNeedsSubpremise",
+    "text": "Пожалуйста, укажите номер блока/корпуса.",
+    "language": "ru"
+  },
+  {
+    "keyName": "addressFailedToValidate",
+    "text": "Не удалось подтвердить адрес.",
+    "language": "ru"
+  },
+  {
+    "keyName": "suggestBetterAddressHeader",
+    "text": "Это правильный адрес?",
+    "language": "ru"
+  },
+  {
+    "keyName": "suggestBetterAddressBody",
+    "text": "Нам удалось подтвердить похожий адрес. Пожалуйста, выберите тот, который вы хотели бы использовать.",
+    "language": "ru"
+  },
+  {
+    "keyName": "newAddress",
+    "text": "Новый адрес",
+    "language": "ru"
+  },
+  {
+    "keyName": "oldAddress",
+    "text": "Старый адрес",
+    "language": "ru"
+  },
+  {
+    "keyName": "you",
+    "text": "Вы",
+    "language": "ru"
+  },
+  {
+    "keyName": "yourDependent",
+    "text": "Лица, находящиеся на вашем иждивении",
+    "language": "ru"
+  },
+  {
+    "keyName": "youInParens",
+    "text": "(вы)",
+    "language": "ru"
+  },
+  {
+    "keyName": "allProfiles",
+    "text": "Все профили",
+    "language": "ru"
+  },
+  {
+    "keyName": "manageProfiles",
+    "text": "Управление профилями",
+    "language": "ru"
+  },
+  {
+    "keyName": "addNewParticipant",
+    "text": "Добавить нового участника",
+    "language": "ru"
+  },
+  {
+    "keyName": "dashboard",
+    "text": "Информационная панель",
+    "language": "ru"
+  },
+  {
+    "keyName": "selectParticipant",
+    "text": "Выбрать участника",
+    "language": "ru"
+  },
+  {
+    "keyName": "hubUpdateFormSubmittedTitle",
+    "text": "${formName} выполнено",
+    "language": "ru"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesTitle",
+    "text": "Все действия выполнены",
+    "language": "ru"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesDetail",
+    "text": "Вы выполнили все действия для этого исследования. Мы сообщим вам, когда появятся новые действия. Спасибо за участие!",
+    "language": "ru"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyTitle",
+    "text": "Добро пожаловать в ${studyName}",
+    "language": "ru"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyDetail",
+    "text": "Пожалуйста, прочитайте и подпишите форму согласия ниже, чтобы продолжить.",
+    "language": "ru"
+  },
+  {
+    "keyName": "hubUpdateAlreadyEnrolledTitle",
+    "text": "Вы уже включены в ${studyName}.",
+    "language": "ru"
+  },
+  {
+    "keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle",
+    "text": "Пользователь уже включен в ${studyName}.",
+    "language": "ru"
+  },
+  {
+    "keyName": "cookieAlertTitle",
+    "text": "Cookies",
+    "language": "ru"
+  },
+  {
+    "keyName": "cookieAlertDetail",
+    "text": "Для обеспечения правильного и безопасного функционирования нашего сайта, а также для улучшения вашей работы с ним, на сайте используются интернет-токены, которые называются cookies («кукис»). Все cookies, которые мы используем, являются строго необходимыми. Этот тип cookies не собирает никакой личной информации о вас и не отслеживает ваши привычки просмотра. Чтобы узнать больше, [прочитайте нашу Политику конфиденциальности] (/конфиденциальность).",
+    "language": "ru"
+  },
+  {
+    "keyName": "joinStudy",
+    "text": "Присоединяйтесь к исследованию",
+    "language": "ru"
+  },
+  {
+    "keyName": "ineligibleThankYou",
+    "text": "Благодарим вас за интерес к ${studyName}",
+    "language": "ru"
+  },
+  {
+    "keyName": "ineligibleDescription",
+    "text": "К сожалению, в настоящее время вы не соответствуете критериям участия в ${studyName}.",
+    "language": "ru"
+  },
+  {
+    "keyName": "ineligibleProvideYourEmail",
+    "text": "Укажите ниже свой адрес электронной почты, и мы будем держать вас в курсе событий. Вы можете отписаться в любое время.",
+    "language": "ru"
+  },
+  {
+    "keyName": "ineligibleStayInformed",
+    "text": "Будьте в курсе событий",
+    "language": "ru"
+  },
+  {
+    "keyName": "backToPortalHomepage",
+    "text": "Вернуться на домашнюю страницу ${portalName}",
+    "language": "ru"
+  },
+  {
+    "keyName": "joinMailingList",
+    "text": "Присоединяйтесь к списку рассылки",
+    "language": "ru"
+  },
+  {
+    "keyName": "mailingFormStayUpdated",
+    "text": "Будьте в курсе новостей об исследовании",
+    "language": "ru"
+  },
+  {
+    "keyName": "yourName",
+    "text": "Ваше имя",
+    "language": "ru"
+  },
+  {
+    "keyName": "yourEmail",
+    "text": "Ваша электронная почта",
+    "language": "ru"
+  },
+  {
+    "keyName": "join",
+    "text": "Присоединиться",
+    "language": "ru"
+  },
+  {
+    "keyName": "thanksForJoining",
+    "text": "Спасибо, что присоединились!",
+    "language": "ru"
+  },
+  {
+    "keyName": "pageNotFoundTitle",
+    "text": "Страница не найдена",
+    "language": "ru"
+  },
+  {
+    "keyName": "pageNotFoundMessage",
+    "text": "Если вы считаете, что это может быть ошибка, свяжитесь с ${studyContactEmail}",
+    "language": "ru"
+  },
+  {
+    "keyName": "pageNotFoundReturnHome",
+    "text": "Вернуться на главную страницу",
+    "language": "ru"
+  },
+  {
+    "keyName": "authErrorPageTitle",
+    "text": "Произошла ошибка",
+    "language": "ru"
+  },
+  {
+    "keyName": "authErrorPageMessage",
+    "text": "Возникла проблема с нашей службой проверки подлинности. Пожалуйста, повторите попытку. Если проблема не исчезает, свяжитесь с ${studyContactEmail}.",
+    "language": "ru"
+  },
+  {
+    "keyName": "navbarSampleKits",
+    "text": "Наборы для образцов",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsPageTitle",
+    "text": "Наборы для сбора образцов",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsPageDescription",
+    "text": "Наборы для сбора образцов являются необходимой частью исследовательского процесса, с их помощью исследователи могут получить важную информацию. Ниже вы можете увидеть статус всех предоставленных вам наборов.",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsPageInPersonTitle",
+    "text": "Предоставьте образец самостоятельно",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsPageInPersonDescription",
+    "text": "На данный момент для этого исследования есть возможность собрать набор образцов самостоятельно.",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsPageInPersonCompleteButton",
+    "text": "Собрать набор образцов самостоятельно",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsPageYourKitsTitle",
+    "text": "Ваши наборы",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsPageStatusPreparing",
+    "text": "Подготовка",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsPageStatusShipped",
+    "text": "Отправлено",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsPageStatusReturned",
+    "text": "Возвращено",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsPageStatusCreated",
+    "text": "Создано",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsPageStatusCollected",
+    "text": "Взято",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsPageNoKits",
+    "text": "На данный момент у вас нет наборов для сбора образцов.",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsInPersonTitle",
+    "text": "Инструкция к набору для сбора образцов",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsInPersonDescription",
+    "text": "Если вы собираете образцы с помощью набора самостоятельно, следуйте инструкциям, предоставленным участником исследовательской группы. Любая дополнительная информация, которая может вам понадобиться, например ваш уникальный идентификатор участника, будет указана ниже.",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsInPersonSubDescription",
+    "text": "Если у вас есть вопросы, вы можете задать их участнику исследовательской группы.",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsInPersonYourKitTitle",
+    "text": "Ваш набор для сбора образцов",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsInPersonYourKitDescription",
+    "text": "Участник исследовательской группы предоставил вам набор для сбора образцов. Этот набор для сбора образцов привязан к вашей учетной записи. Если вы помогаете другому человеку собрать образцы с помощью набора, убедитесь, что каждый участник исследования использовал набор, который предназначался именно ему.",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsInPersonYourKitIdentifier",
+    "text": "Идентификатор вашего набора",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsInPersonReturnToDashboard",
+    "text": "Вернуться к информационной панели",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsInPersonRefreshPage",
+    "text": "Обновить",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredTitle",
+    "text": "Требуется согласие",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredDescription",
+    "text": "Прежде чем использовать набор для сбора образцов, вам нужно сначала зарегистрироваться для участия в исследовании. Если вас это заинтересовало, вы можете найти и подписать форму согласия по ссылке ниже.",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsInPersonStartConsent",
+    "text": "Начать подписание согласия",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsInPersonError",
+    "text": "Произошла ошибка при загрузке информации о вашем наборе. Пожалуйста, свяжитесь с участником исследовательской группы для решения вопроса.",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsInPersonCreatedInstructions",
+    "text": "После сбора образцов с помощью набора верните его участнику исследовательской группы, он отсканирует ваш код участника, указанный ниже.",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsInPersonNoKitInstructions",
+    "text": "Чтобы получить набор для сбора образцов, участник исследовательской группы отсканирует ваш уникальный код участника, указанный ниже, и привяжет набор образцов к вашей учетной записи.",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsInPersonNoKitSubInstructions",
+    "text": "После получения набора обновите эту страницу, чтобы увидеть информацию о наборе и получить дальнейшие инструкции.",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsInPersonCollectedDescription",
+    "text": "Участник исследовательской группы получил ваш набор для сбора образцов. Когда ваш образец поступит в обработку, вы получите уведомление по электронной почте и сможете увидеть статус образца в информационной панели вашего исследования.",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitsInPersonCollectedThankYou",
+    "text": "Спасибо за участие.",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitTypeSaliva",
+    "text": "Набор для сбора образца слюны",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitTypeStool",
+    "text": "Набор для сбора образца кала",
+    "language": "ru"
+  },
+  {
+    "keyName": "kitTypeBlood",
+    "text": "Набор для сбора образца крови",
+    "language": "ru"
+  },
+  {
+    "keyName": "documentDownloadButton",
+    "text": "Скачать",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListNone",
+    "text": "Вы еще не загрузили ни одного документа",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListCreatedOn",
+    "text": "Создано",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageTitle",
+    "text": "Документы",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageUploadedDocumentsTitle",
+    "text": "Загруженные документы",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageMessage",
+    "text": "При участии в исследовании вас могут попросить загрузить документы как часть формы или опроса. Ниже вы можете управлять загруженными вами документами.",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "navbarDocuments",
+    "text": "Документы",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureTitle",
+    "text": "Вы уверены?",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureMessage",
+    "text": "Вы уверены, что хотите удалить этот документ? Это действие нельзя отменить. Обратите внимание, что если член исследовательского персонала уже загрузил этот документ, он все равно будет ему доступен. Пожалуйста, свяжитесь с исследовательским персоналом, если вы хотите, чтобы документ был полностью удален из всех записей.",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseTitle",
+    "text": "Этот документ используется",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseMessage",
+    "text": "Этот документ в настоящее время распространяется в ответе по крайней мере на один опрос. Пожалуйста, удалите его из ответов на опросы перед его удалением.",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteButton",
+    "text": "Удалить",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentOptionsButton",
+    "text": "Параметры",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentSharedInResponseTo",
+    "text": "поделился в ответ на",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderSelectedDocuments",
+    "text": "Избранные документы",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderIncludedInResponse",
+    "text": "Эти документы включены в ваш ответ",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocumentsSelected",
+    "text": "Не выбрано ни одного документа. Загрузите новый документ или выберите существующий документ ниже.",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderAvailableDocuments",
+    "text": "Available documents",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNotIncludedInResponse",
+    "text": "Эти документы не включены в ваш ответ",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderClickToUpload",
+    "text": "Перетащите файлы сюда или нажмите, чтобы загрузить",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocuments",
+    "text": "Нет доступных документов",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeTitle",
+    "text": "Ваш сеанс скоро истечет",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeMessage",
+    "text": "Для обеспечения безопасности и защиты ваших данных вы выйдете из системы через ${timeRemaining}.",
+    "language": "ru",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "failedToEnroll",
+    "language": "ru",
+    "text": "Что -то пошло не так в процессе зачисления. Пожалуйста, заполните форму еще раз.",
+    "machineTranslated": true
+  }
 ]

--- a/populate/src/main/resources/seed/i18n/tr/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/tr/languageTexts.json
@@ -1,163 +1,836 @@
 [
-  {"keyName": "navbarDashboard", "text": "Gösterge Paneli", "language": "tr"},
-  {"keyName": "navbarChangePassword", "text": "Parola Değiştir", "language": "tr"},
-  {"keyName": "navbarLogout", "text": "Oturumu Kapat", "language": "tr"},
-  {"keyName": "profile", "text": "Profil", "language": "tr"},
-  {"keyName": "navbarLogin", "text": "Oturumu Aç", "language": "tr"},
-  {"keyName": "navbarJoin", "text": "Kayıt Ol", "language": "tr"},
-  {"keyName": "taskComplete", "text": "Tamam", "language": "tr"},
-  {"keyName": "taskInProgress", "text": "Devam Ediyor", "language": "tr"},
-  {"keyName": "taskNotStarted", "text": "Başlatılmadı", "language": "tr"},
-  {"keyName": "taskDeclined", "text": "Reddedildi", "language": "tr"},
-  {"keyName": "taskLocked", "text": "Kilitlendi", "language": "tr"},
-  {"keyName": "tasksNoneForStudy", "text": "Bu çalışma için herhangi bir görev yok", "language": "tr"},
-  {"keyName": "taskHistory", "text": "geçmiş", "language": "tr"},
-  {"keyName": "taskNew", "text": "YENİ", "language": "tr"},
-  {"keyName": "surveysSomeLocked", "text": "Bazı anketler, gerekli diğer görevler tamamlanana kadar kilitli kalır.", "language": "tr"},
-  {"keyName": "taskTypeSurvey", "text": "Anket", "language": "tr"},
-  {"keyName": "taskTypeSurveys", "text": "Anketler", "language": "tr"},
-  {"keyName": "taskTypeConsent", "text": "Onay", "language": "tr"},
-  {"keyName": "taskTypeForms", "text": "Formlar", "language": "tr"},
-  {"keyName": "start", "text": "Başlat", "language": "tr"},
-  {"keyName": "continue", "text": "Devam Et", "language": "tr"},
-  {"keyName": "save", "text": "Kaydet", "language": "tr"},
-  {"keyName": "outreachLearnMore", "text": "Daha Fazla Bilgi", "language": "tr"},
-  {"keyName": "cancel", "text": "İptal Et", "language": "tr"},
-  {"keyName": "goBack", "text": "Geri Dön", "language": "tr"},
-  {"keyName": "name", "text": "Tam Adı", "language": "tr"},
-  {"keyName": "givenName", "text": "Adı", "language": "tr"},
-  {"keyName": "familyName", "text": "Soyadı", "language": "tr"},
-  {"keyName": "editName", "text": "Tam Adı Düzenle", "language": "tr"},
-  {"keyName": "editBirthDate", "text": "Doğum Gününü Düzenle", "language": "tr"},
-  {"keyName": "birthDate", "text": "Doğum günü", "language": "tr"},
-  {"keyName": "mailingAddress", "text": "Posta Adresi", "language": "tr"},
-  {"keyName": "editMailingAddress", "text": "Posta Adresini Düzenle", "language": "tr"},
-  {"keyName": "primaryAddress", "text": "Birincil Adres", "language": "tr"},
-  {"keyName": "editPrimaryAddress", "text": "Birincil Adres", "language": "tr"},
-  {"keyName": "street1", "text": "Sokak Adı 1", "language": "tr"},
-  {"keyName": "street2", "text": "Sokak Adı 2", "language": "tr"},
-  {"keyName": "city", "text": "Şehir", "language": "tr"},
-  {"keyName": "state", "text": "Bölge\/İl", "language": "tr"},
-  {"keyName": "postalCode", "text": "Posta Kodu", "language": "tr"},
-  {"keyName": "country", "text": "Ülke", "language": "tr"},
-  {"keyName": "communicationPreferences", "text": "İletişim Tercihleri", "language": "tr"},
-  {"keyName": "editCommunicationPreferences", "text": "İletişim Tercihlerini Düzenle", "language": "tr"},
-  {"keyName": "contactEmail", "text": "İletişim E-Posta Adresi", "language": "tr"},
-  {"keyName": "editContactEmail", "text": "İletişim E-Posta Adresini Düzenle", "language": "tr"},
-  {"keyName": "phoneNumber", "text": "Telefon Numarası", "language": "tr"},
-  {"keyName": "editPhoneNumber", "text": "Telefon Numarasını Düzenle", "language": "tr"},
-  {"keyName": "doNotSolicit", "text": "Talepte Bulunmayın", "language": "tr"},
-  {"keyName": "doNotContact", "text": "İletişimde Bulunmayın", "language": "tr"},
-  {"keyName": "editDoNotSolicit", "text": "Talepte Bulunmayın Seçeneğini Düzenle", "language": "tr"},
-  {"keyName": "editNotifications", "text": "Bildirimleri Düzenle", "language": "tr"},
-  {"keyName": "notifications", "text": "Bildirimler", "language": "tr"},
-  {"keyName": "on", "text": "Açık", "language": "tr"},
-  {"keyName": "off", "text": "Kapalı", "language": "tr"},
-  {"keyName": "notProvided", "text": "Belirtilmedi", "language": "tr"},
-  {"keyName": "editProfileContactEmailWarning", "text": "İletişim için kullanılacak e-postayı güncellemek için \"Kaydet\" seçeneğine basın. Oturum açma bilgilerinizin değişmeyeceğini unutmayın.", "language": "tr"},
-  {"keyName": "privacyPolicy", "text": "Gizlilik Politikası", "language": "tr"},
-  {"keyName": "termsOfUse", "text": "Kullanım Koşulları", "language": "tr"},
-  {"keyName": "addressInvalidPostalCode", "text": "Posta kodu doğrulanamadı.", "language": "tr"},
-  {"keyName": "addressInvalidCountry", "text": "Ülke doğrulanamadı.", "language": "tr"},
-  {"keyName": "addressInvalidState", "text": "Bölge\/İl doğrulanamadı.", "language": "tr"},
-  {"keyName": "addressInvalidCity", "text": "Şehir doğrulanamadı.", "language": "tr"},
-  {"keyName": "addressInvalidHouseNumber", "text": "Ev numarası doğrulanamadı.", "language": "tr"},
-  {"keyName": "addressInvalidStreetName", "text": "Sokak adı doğrulanamadı.", "language": "tr"},
-  {"keyName": "addressInvalidStreetType", "text": "Sokak türü doğrulanamadı.", "language": "tr"},
-  {"keyName": "addressNeedsSubpremise", "text": "Lütfen bir apartman\/daire numarası girin.", "language": "tr"},
-  {"keyName": "addressFailedToValidate", "text": "Adres doğrulanamadı.", "language": "tr"},
-  {"keyName": "suggestBetterAddressHeader", "text": "Doğru adresi girdiğinizden emin misiniz?", "language": "tr"},
-  {"keyName": "suggestBetterAddressBody", "text": "Benzer bir adresi doğrulayabiliyoruz. Lütfen hangisini kullanmak istediğinizi seçin.", "language": "tr"},
-  {"keyName": "newAddress", "text": "Yeni Adres", "language": "tr"},
-  {"keyName": "oldAddress", "text": "Eski Adres", "language": "tr"},
-  {"keyName": "you", "text": "Siz", "language": "tr"},
-  {"keyName": "yourDependent", "text": "Bakmakla Yükümlü Olduğunuz Kişi", "language": "tr"},
-  {"keyName": "youInParens", "text": "(siz)", "language": "tr"},
-  {"keyName": "allProfiles", "text": "Tüm Profiller", "language": "tr"},
-  {"keyName": "manageProfiles", "text": "Profilleri Yönet", "language": "tr"},
-  {"keyName": "addNewParticipant", "text": "Yeni Katılımcı Ekle", "language": "tr"},
-  {"keyName": "dashboard", "text": "Gösterge Paneli", "language": "tr"},
-  {"keyName": "selectParticipant", "text": "Katılımcı Seç", "language": "tr"},
-  {"keyName": "hubUpdateFormSubmittedTitle", "text": "${formName} tamamlandı", "language": "tr"},
-  {"keyName": "hubUpdateNoActivitiesTitle", "text": "Tüm eylemler tamamlandı", "language": "tr"},
-  {"keyName": "hubUpdateNoActivitiesDetail", "text": "Bu çalışma ile ilgili tüm eylemleri tamamladınız. Yeni eylemler mevcut olduğunda sizi bilgilendireceğiz. Katılımınız için teşekkür ederiz!", "language": "tr"},
-  {"keyName": "hubUpdateWelcomeToStudyTitle", "text": "${studyName} Çalışmasına Hoş Geldiniz", "language": "tr"},
-  {"keyName": "hubUpdateWelcomeToStudyDetail", "text": "Devam etmek için lütfen aşağıdaki onay formunu okuyun ve imzalayın.", "language": "tr"},
-  {"keyName": "hubUpdateAlreadyEnrolledTitle", "text": "${studyName} çalışmasına zaten kayıtlısınız.", "language": "tr"},
-  {"keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle", "text": "Bu kullanıcı ${studyName} çalışmasına zaten kayıtlı.", "language": "tr"},
-  {"keyName": "cookieAlertTitle", "text": "Çerezler", "language": "tr"},
-  {"keyName": "cookieAlertDetail", "text": "Bu site, web sitemizin düzgün çalışmasını ve güvenliğini sağlamak ve web sitemizi kullanırken deneyiminizi iyileştirmek amacıyla &quot;çerezler&quot; adı verilen internet belirteçlerini kullanır. Kullandığımız çerezlerin tümü kesinlikle gerekli çerezlerdir. Bu çerez türü, hakkınızda kişisel olarak tanımlanabilir herhangi bir bilgi toplamaz ve tarama alışkanlıklarınızı takip etmez. Daha fazla bilgi edinmek için [Gizlilik Politikamızı okuyun](\/privacy).", "language": "tr"},
-  {"keyName": "joinStudy", "text": "Çalışmaya Katıl", "language": "tr"},
-  {"keyName": "ineligibleThankYou", "text": "${studyName} çalışmasına gösterdiğiniz ilgi için teşekkür ederiz", "language": "tr" },
-  {"keyName": "ineligibleDescription", "text": "Ne yazık ki, şu anda ${studyName} çalışmasına katılmak için uygunluk kriterlerini karşılamıyorsunuz.", "language": "tr"},
-  {"keyName": "ineligibleProvideYourEmail", "text": "Sizi gelişmelerden haberdar edebilmemiz için e-posta adresinizi aşağıdaki alana girin. Dilediğiniz zaman abonelikten çıkabilirsiniz.", "language":  "tr"},
-  {"keyName": "ineligibleStayInformed", "text": "Gelişmelerden haberdar kalın", "language": "tr"},
-  {"keyName": "backToPortalHomepage", "text": "${portalName} ana sayfasına geri dön", "language": "tr"},
-  {"keyName": "joinMailingList", "text": "Posta Listesine Katıl", "language": "tr"},
-  {"keyName": "mailingFormStayUpdated", "text":  "Çalışmayla ilgili gelişmelerden haberdar olun", "language": "tr"},
-  {"keyName": "yourName", "text": "Adınız", "language": "tr"},
-  {"keyName": "yourEmail", "text": "E-posta adresiniz", "language": "tr"},
-  {"keyName": "join", "text":  "Katıl", "language": "tr"},
-  {"keyName": "thanksForJoining", "text": "Katıldığınız için teşekkürler", "language": "tr"},
-  {"keyName": "pageNotFoundTitle", "text": "Sayfa bulunamadı", "language": "tr"},
-  {"keyName": "pageNotFoundMessage", "text": "Bunun bir hata olduğunu düşünüyorsanız, lütfen ${studyContactEmail} adresiyle iletişime geçin", "language": "tr"},
-  {"keyName": "pageNotFoundReturnHome", "text": "Ana sayfaya geri dön", "language": "tr"},
-  {"keyName": "authErrorPageTitle", "text": "Bir hata oluştu", "language": "tr"},
-  {"keyName": "authErrorPageMessage", "text": "Kimlik doğrulama hizmetimizle ilgili bir sorun oluştu. Lütfen tekrar deneyin. Sorunun devam etmesi durumunda, lütfen ${studyContactEmail} adresiyle iletişime geçin.", "language": "tr"},
-  {"keyName": "navbarSampleKits", "text":  "Numune Kitleri", "language": "tr"},
-  {"keyName": "kitsPageTitle", "text": "Numune toplama kitleri", "language": "tr"},
-  {"keyName": "kitsPageDescription", "text": "Numune toplama kitleri, çalışma sürecinin önemli parçalarıdır ve araştırmacıların önemli iç görüler elde etmesine yardımcı olabilir. Aşağıda size sağlanan tüm kitlerin durumunu görebilirsiniz.", "language": "tr"},
-  {"keyName": "kitsPageInPersonTitle", "text": "Numuneyi şahsen sağlayın", "language": "tr"},
-  {"keyName": "kitsPageInPersonDescription", "text": "Bu çalışma şu anda bir numune toplama kitini şahsen tamamlama seçeneği sunuyor.", "language": "tr"},
-  {"keyName": "kitsPageInPersonCompleteButton", "text": "Bir kiti şahsen tamamlayın", "language": "tr"},
-  {"keyName": "kitsPageYourKitsTitle", "text": "Kitleriniz", "language": "tr"},
-  {"keyName": "kitsPageStatusPreparing", "text": "Hazırlanıyor", "language": "tr"},
-  {"keyName": "kitsPageStatusShipped", "text": "Gönderildi", "language": "tr"},
-  {"keyName": "kitsPageStatusReturned", "text": "İade Edildi", "language": "tr"},
-  {"keyName": "kitsPageStatusCreated", "text": "Oluşturuldu", "language": "tr"},
-  {"keyName": "kitsPageStatusCollected", "text": "Toplandı", "language": "tr"},
-  {"keyName": "kitsPageNoKits", "text": "Şu anda elinizde herhangi bir numune toplama kiti bulunmamaktadır.", "language": "tr"},
-  {"keyName": "kitsInPersonTitle", "text": "Numune kiti talimatları", "language": "tr"},
-  {"keyName": "kitsInPersonDescription", "text": "Numune toplama kitini şahsen tamamlayacaksanız, lütfen çalışma ekibinin bir üyesi tarafından verilmiş olan talimatları izleyin. Benzersiz katılımcı tanımlayıcınız gibi ihtiyaç duyabileceğiniz her türlü ek bilgiye aşağıdan ulaşabilirsiniz.", "language": "tr"},
-  {"keyName": "kitsInPersonSubDescription", "text": "Herhangi bir sorunuz olması durumunda lütfen çalışma ekibinin bir üyesine sorun.", "language": "tr"},
-  {"keyName": "kitsInPersonYourKitTitle", "text": "Numune toplama kitiniz", "language": "tr"},
-  {"keyName": "kitsInPersonYourKitDescription", "text": "Ekibin bir üyesi size bir numune toplama kiti sundu. Bu numune kiti hesabınızla ilişkilendirildi. Bir başkasına numune toplama kiti konusunda yardımcı oluyorsanız, lütfen her katılımcının kendisine atanan numune toplama kitini tamamladığından emin olun.", "language": "tr"},
-  {"keyName": "kitsInPersonYourKitIdentifier", "text": "Kit tanımlayıcınız", "language": "tr"},
-  {"keyName": "kitsInPersonReturnToDashboard", "text": "Gösterge paneline geri dön", "language": "tr"},
-  {"keyName": "kitsInPersonRefreshPage", "text": "Yenile", "language": "tr"},
-  {"keyName": "kitsInPersonConsentRequiredTitle", "text": "Onay Gerekiyor", "language": "tr"},
-  {"keyName": "kitsInPersonConsentRequiredDescription", "text": "Numune toplama kitini tamamlamadan önce çalışmaya kaydolmanız gereklidir. Çalışmayla ilgileniyorsanız, aşağıdaki bağlantıdan onay formuna erişebilir ve formu imzalayabilirsiniz.", "language": "tr"},
-  {"keyName": "kitsInPersonStartConsent", "text": "Onay Aşamasını Başlat", "language": "tr"},
-  {"keyName": "kitsInPersonError", "text": "Kit bilgileriniz yüklenirken bir hata oluştu. Yardım için lütfen çalışma ekibinin bir üyesiyle iletişime geçin.", "language": "tr"},
-  {"keyName": "kitsInPersonCreatedInstructions", "text": "Numune toplama kitini tamamladıktan sonra, lütfen çalışma ekibinin bir üyesine teslim edin ve aşağıda yer alan size özel katılım kodunu taramasını sağlayın.", "language": "tr"},
-  {"keyName": "kitsInPersonNoKitInstructions", "text": "Bir numune toplama kiti alabilmeniz için, çalışma ekibinden bir üye aşağıdaki size özel sağlanan benzersiz katılım kodunu tarayarak bir numune kitini hesabınızla ilişkilendirir.", "language": "tr"},
-  {"keyName": "kitsInPersonNoKitSubInstructions", "text": "Kiti teslim aldıktan sonra, kit bilgilerinizi görüntülemek ve daha fazla talimata erişmek için lütfen bu sayfayı yenileyin.", "language": "tr"},
-  {"keyName": "kitsInPersonCollectedDescription", "text": "Ekibin bir üyesi numune toplama kitinizi teslim aldı. Numunenizin işlenmesinin ardından tarafınıza bir e-posta bildirimi gönderilir ve numunenizin durumunu çalışmanın gösterge paneli üzerinden görüntüleyebilirsiniz.", "language": "tr"},
-  {"keyName": "kitsInPersonCollectedThankYou", "text": "Katılımınız için teşekkür ederiz.", "language": "tr"},
-  {"keyName": "kitTypeSaliva", "text": "Tükürük kiti", "language": "tr"},
-  {"keyName": "kitTypeStool", "text": "Dışkı kiti", "language": "tr"},
-  {"keyName": "kitTypeBlood", "text": "Kan kiti", "language": "tr"},
-  {"keyName": "documentDownloadButton", "text": "İndirmek", "language": "tr", "machineTranslated": true},
-  {"keyName": "documentsListNone", "text": "Henüz herhangi bir belge yüklemediniz", "language": "tr", "machineTranslated": true},
-  {"keyName": "documentsListCreatedOn", "text": "Oluşturuldu", "language": "tr", "machineTranslated": true},
-  {"keyName": "documentsPageTitle", "text": "Belgeler", "language": "tr", "machineTranslated": true},
-  {"keyName": "documentsPageUploadedDocumentsTitle", "text": "Yüklenen belgeler", "language": "tr", "machineTranslated": true},
-  {"keyName": "documentsPageMessage", "text": "Bir çalışmaya katılırken, bir form veya anketin parçası olarak belgeleri yüklemeniz istenebilir. Aşağıda, yüklediğiniz belgeleri yönetebilirsiniz.", "language": "tr", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "Belgeler", "language": "tr", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureTitle", "text": "Emin misin?", "language": "tr", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureMessage", "text": "Bu belgeyi silmek istediğinizden emin misiniz? Bu işlem geri alınamaz. Çalışma ekibinden bir üye bu belgeyi daha önce indirmişse, belgenin onlar için hala erişilebilir olacağını lütfen unutmayın. Belgenin tüm kayıtlardan tamamen kaldırılmasını istiyorsanız lütfen çalışma ekibiyle iletişime geçin.", "language": "tr", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseTitle", "text": "Bu belge kullanımda", "language": "tr", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseMessage", "text": "Bu belge şu anda en az bir ankete yanıt olarak paylaşılıyor. Lütfen silmeden önce anket yanıtlarından kaldırın.", "language": "tr", "machineTranslated": true},
-  {"keyName": "documentDeleteButton", "text": "Silmek", "language": "tr", "machineTranslated": true},
-  {"keyName": "documentOptionsButton", "text": "Seçenekler", "language": "tr", "machineTranslated": true},
-  {"keyName": "documentSharedInResponseTo", "text": "yanıt olarak paylaşıldı", "language": "tr", "machineTranslated": true},
-  {"keyName": "documentUploaderSelectedDocuments", "text": "Seçilmiş belgeler", "language": "tr", "machineTranslated": true},
-  {"keyName": "documentUploaderIncludedInResponse", "text": "Bu belgeler yanıtınıza dahildir", "language": "tr", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocumentsSelected", "text": "Hiçbir belge seçilmedi. Lütfen yeni bir belge yükleyin veya aşağıdan mevcut bir belgeyi seçin.", "language": "tr", "machineTranslated": true},
-  {"keyName": "documentUploaderAvailableDocuments", "text": "Mevcut belgeler", "language": "tr", "machineTranslated": true},
-  {"keyName": "documentUploaderNotIncludedInResponse", "text": "Bu belgeler yanıtınıza dahil değildir", "language": "tr", "machineTranslated": true},
-  {"keyName": "documentUploaderClickToUpload", "text": "Dosyaları buraya bırakın veya yüklemek için tıklayın", "language": "tr", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocuments", "text": "Hiçbir belge mevcut değil", "language": "tr", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeTitle", "text": "Oturumunuz sona ermek üzere", "language": "tr", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeMessage", "text": "Güvenliğinizi sağlamak ve verilerinizi korumak için ${timeRemaining} içinde oturumunuz kapatılacak.", "language": "tr", "machineTranslated": true}
+  {
+    "keyName": "navbarDashboard",
+    "text": "Gösterge Paneli",
+    "language": "tr"
+  },
+  {
+    "keyName": "navbarChangePassword",
+    "text": "Parola Değiştir",
+    "language": "tr"
+  },
+  {
+    "keyName": "navbarLogout",
+    "text": "Oturumu Kapat",
+    "language": "tr"
+  },
+  {
+    "keyName": "profile",
+    "text": "Profil",
+    "language": "tr"
+  },
+  {
+    "keyName": "navbarLogin",
+    "text": "Oturumu Aç",
+    "language": "tr"
+  },
+  {
+    "keyName": "navbarJoin",
+    "text": "Kayıt Ol",
+    "language": "tr"
+  },
+  {
+    "keyName": "taskComplete",
+    "text": "Tamam",
+    "language": "tr"
+  },
+  {
+    "keyName": "taskInProgress",
+    "text": "Devam Ediyor",
+    "language": "tr"
+  },
+  {
+    "keyName": "taskNotStarted",
+    "text": "Başlatılmadı",
+    "language": "tr"
+  },
+  {
+    "keyName": "taskDeclined",
+    "text": "Reddedildi",
+    "language": "tr"
+  },
+  {
+    "keyName": "taskLocked",
+    "text": "Kilitlendi",
+    "language": "tr"
+  },
+  {
+    "keyName": "tasksNoneForStudy",
+    "text": "Bu çalışma için herhangi bir görev yok",
+    "language": "tr"
+  },
+  {
+    "keyName": "taskHistory",
+    "text": "geçmiş",
+    "language": "tr"
+  },
+  {
+    "keyName": "taskNew",
+    "text": "YENİ",
+    "language": "tr"
+  },
+  {
+    "keyName": "surveysSomeLocked",
+    "text": "Bazı anketler, gerekli diğer görevler tamamlanana kadar kilitli kalır.",
+    "language": "tr"
+  },
+  {
+    "keyName": "taskTypeSurvey",
+    "text": "Anket",
+    "language": "tr"
+  },
+  {
+    "keyName": "taskTypeSurveys",
+    "text": "Anketler",
+    "language": "tr"
+  },
+  {
+    "keyName": "taskTypeConsent",
+    "text": "Onay",
+    "language": "tr"
+  },
+  {
+    "keyName": "taskTypeForms",
+    "text": "Formlar",
+    "language": "tr"
+  },
+  {
+    "keyName": "start",
+    "text": "Başlat",
+    "language": "tr"
+  },
+  {
+    "keyName": "continue",
+    "text": "Devam Et",
+    "language": "tr"
+  },
+  {
+    "keyName": "save",
+    "text": "Kaydet",
+    "language": "tr"
+  },
+  {
+    "keyName": "outreachLearnMore",
+    "text": "Daha Fazla Bilgi",
+    "language": "tr"
+  },
+  {
+    "keyName": "cancel",
+    "text": "İptal Et",
+    "language": "tr"
+  },
+  {
+    "keyName": "goBack",
+    "text": "Geri Dön",
+    "language": "tr"
+  },
+  {
+    "keyName": "name",
+    "text": "Tam Adı",
+    "language": "tr"
+  },
+  {
+    "keyName": "givenName",
+    "text": "Adı",
+    "language": "tr"
+  },
+  {
+    "keyName": "familyName",
+    "text": "Soyadı",
+    "language": "tr"
+  },
+  {
+    "keyName": "editName",
+    "text": "Tam Adı Düzenle",
+    "language": "tr"
+  },
+  {
+    "keyName": "editBirthDate",
+    "text": "Doğum Gününü Düzenle",
+    "language": "tr"
+  },
+  {
+    "keyName": "birthDate",
+    "text": "Doğum günü",
+    "language": "tr"
+  },
+  {
+    "keyName": "mailingAddress",
+    "text": "Posta Adresi",
+    "language": "tr"
+  },
+  {
+    "keyName": "editMailingAddress",
+    "text": "Posta Adresini Düzenle",
+    "language": "tr"
+  },
+  {
+    "keyName": "primaryAddress",
+    "text": "Birincil Adres",
+    "language": "tr"
+  },
+  {
+    "keyName": "editPrimaryAddress",
+    "text": "Birincil Adres",
+    "language": "tr"
+  },
+  {
+    "keyName": "street1",
+    "text": "Sokak Adı 1",
+    "language": "tr"
+  },
+  {
+    "keyName": "street2",
+    "text": "Sokak Adı 2",
+    "language": "tr"
+  },
+  {
+    "keyName": "city",
+    "text": "Şehir",
+    "language": "tr"
+  },
+  {
+    "keyName": "state",
+    "text": "Bölge/İl",
+    "language": "tr"
+  },
+  {
+    "keyName": "postalCode",
+    "text": "Posta Kodu",
+    "language": "tr"
+  },
+  {
+    "keyName": "country",
+    "text": "Ülke",
+    "language": "tr"
+  },
+  {
+    "keyName": "communicationPreferences",
+    "text": "İletişim Tercihleri",
+    "language": "tr"
+  },
+  {
+    "keyName": "editCommunicationPreferences",
+    "text": "İletişim Tercihlerini Düzenle",
+    "language": "tr"
+  },
+  {
+    "keyName": "contactEmail",
+    "text": "İletişim E-Posta Adresi",
+    "language": "tr"
+  },
+  {
+    "keyName": "editContactEmail",
+    "text": "İletişim E-Posta Adresini Düzenle",
+    "language": "tr"
+  },
+  {
+    "keyName": "phoneNumber",
+    "text": "Telefon Numarası",
+    "language": "tr"
+  },
+  {
+    "keyName": "editPhoneNumber",
+    "text": "Telefon Numarasını Düzenle",
+    "language": "tr"
+  },
+  {
+    "keyName": "doNotSolicit",
+    "text": "Talepte Bulunmayın",
+    "language": "tr"
+  },
+  {
+    "keyName": "doNotContact",
+    "text": "İletişimde Bulunmayın",
+    "language": "tr"
+  },
+  {
+    "keyName": "editDoNotSolicit",
+    "text": "Talepte Bulunmayın Seçeneğini Düzenle",
+    "language": "tr"
+  },
+  {
+    "keyName": "editNotifications",
+    "text": "Bildirimleri Düzenle",
+    "language": "tr"
+  },
+  {
+    "keyName": "notifications",
+    "text": "Bildirimler",
+    "language": "tr"
+  },
+  {
+    "keyName": "on",
+    "text": "Açık",
+    "language": "tr"
+  },
+  {
+    "keyName": "off",
+    "text": "Kapalı",
+    "language": "tr"
+  },
+  {
+    "keyName": "notProvided",
+    "text": "Belirtilmedi",
+    "language": "tr"
+  },
+  {
+    "keyName": "editProfileContactEmailWarning",
+    "text": "İletişim için kullanılacak e-postayı güncellemek için \"Kaydet\" seçeneğine basın. Oturum açma bilgilerinizin değişmeyeceğini unutmayın.",
+    "language": "tr"
+  },
+  {
+    "keyName": "privacyPolicy",
+    "text": "Gizlilik Politikası",
+    "language": "tr"
+  },
+  {
+    "keyName": "termsOfUse",
+    "text": "Kullanım Koşulları",
+    "language": "tr"
+  },
+  {
+    "keyName": "addressInvalidPostalCode",
+    "text": "Posta kodu doğrulanamadı.",
+    "language": "tr"
+  },
+  {
+    "keyName": "addressInvalidCountry",
+    "text": "Ülke doğrulanamadı.",
+    "language": "tr"
+  },
+  {
+    "keyName": "addressInvalidState",
+    "text": "Bölge/İl doğrulanamadı.",
+    "language": "tr"
+  },
+  {
+    "keyName": "addressInvalidCity",
+    "text": "Şehir doğrulanamadı.",
+    "language": "tr"
+  },
+  {
+    "keyName": "addressInvalidHouseNumber",
+    "text": "Ev numarası doğrulanamadı.",
+    "language": "tr"
+  },
+  {
+    "keyName": "addressInvalidStreetName",
+    "text": "Sokak adı doğrulanamadı.",
+    "language": "tr"
+  },
+  {
+    "keyName": "addressInvalidStreetType",
+    "text": "Sokak türü doğrulanamadı.",
+    "language": "tr"
+  },
+  {
+    "keyName": "addressNeedsSubpremise",
+    "text": "Lütfen bir apartman/daire numarası girin.",
+    "language": "tr"
+  },
+  {
+    "keyName": "addressFailedToValidate",
+    "text": "Adres doğrulanamadı.",
+    "language": "tr"
+  },
+  {
+    "keyName": "suggestBetterAddressHeader",
+    "text": "Doğru adresi girdiğinizden emin misiniz?",
+    "language": "tr"
+  },
+  {
+    "keyName": "suggestBetterAddressBody",
+    "text": "Benzer bir adresi doğrulayabiliyoruz. Lütfen hangisini kullanmak istediğinizi seçin.",
+    "language": "tr"
+  },
+  {
+    "keyName": "newAddress",
+    "text": "Yeni Adres",
+    "language": "tr"
+  },
+  {
+    "keyName": "oldAddress",
+    "text": "Eski Adres",
+    "language": "tr"
+  },
+  {
+    "keyName": "you",
+    "text": "Siz",
+    "language": "tr"
+  },
+  {
+    "keyName": "yourDependent",
+    "text": "Bakmakla Yükümlü Olduğunuz Kişi",
+    "language": "tr"
+  },
+  {
+    "keyName": "youInParens",
+    "text": "(siz)",
+    "language": "tr"
+  },
+  {
+    "keyName": "allProfiles",
+    "text": "Tüm Profiller",
+    "language": "tr"
+  },
+  {
+    "keyName": "manageProfiles",
+    "text": "Profilleri Yönet",
+    "language": "tr"
+  },
+  {
+    "keyName": "addNewParticipant",
+    "text": "Yeni Katılımcı Ekle",
+    "language": "tr"
+  },
+  {
+    "keyName": "dashboard",
+    "text": "Gösterge Paneli",
+    "language": "tr"
+  },
+  {
+    "keyName": "selectParticipant",
+    "text": "Katılımcı Seç",
+    "language": "tr"
+  },
+  {
+    "keyName": "hubUpdateFormSubmittedTitle",
+    "text": "${formName} tamamlandı",
+    "language": "tr"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesTitle",
+    "text": "Tüm eylemler tamamlandı",
+    "language": "tr"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesDetail",
+    "text": "Bu çalışma ile ilgili tüm eylemleri tamamladınız. Yeni eylemler mevcut olduğunda sizi bilgilendireceğiz. Katılımınız için teşekkür ederiz!",
+    "language": "tr"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyTitle",
+    "text": "${studyName} Çalışmasına Hoş Geldiniz",
+    "language": "tr"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyDetail",
+    "text": "Devam etmek için lütfen aşağıdaki onay formunu okuyun ve imzalayın.",
+    "language": "tr"
+  },
+  {
+    "keyName": "hubUpdateAlreadyEnrolledTitle",
+    "text": "${studyName} çalışmasına zaten kayıtlısınız.",
+    "language": "tr"
+  },
+  {
+    "keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle",
+    "text": "Bu kullanıcı ${studyName} çalışmasına zaten kayıtlı.",
+    "language": "tr"
+  },
+  {
+    "keyName": "cookieAlertTitle",
+    "text": "Çerezler",
+    "language": "tr"
+  },
+  {
+    "keyName": "cookieAlertDetail",
+    "text": "Bu site, web sitemizin düzgün çalışmasını ve güvenliğini sağlamak ve web sitemizi kullanırken deneyiminizi iyileştirmek amacıyla &quot;çerezler&quot; adı verilen internet belirteçlerini kullanır. Kullandığımız çerezlerin tümü kesinlikle gerekli çerezlerdir. Bu çerez türü, hakkınızda kişisel olarak tanımlanabilir herhangi bir bilgi toplamaz ve tarama alışkanlıklarınızı takip etmez. Daha fazla bilgi edinmek için [Gizlilik Politikamızı okuyun](/privacy).",
+    "language": "tr"
+  },
+  {
+    "keyName": "joinStudy",
+    "text": "Çalışmaya Katıl",
+    "language": "tr"
+  },
+  {
+    "keyName": "ineligibleThankYou",
+    "text": "${studyName} çalışmasına gösterdiğiniz ilgi için teşekkür ederiz",
+    "language": "tr"
+  },
+  {
+    "keyName": "ineligibleDescription",
+    "text": "Ne yazık ki, şu anda ${studyName} çalışmasına katılmak için uygunluk kriterlerini karşılamıyorsunuz.",
+    "language": "tr"
+  },
+  {
+    "keyName": "ineligibleProvideYourEmail",
+    "text": "Sizi gelişmelerden haberdar edebilmemiz için e-posta adresinizi aşağıdaki alana girin. Dilediğiniz zaman abonelikten çıkabilirsiniz.",
+    "language": "tr"
+  },
+  {
+    "keyName": "ineligibleStayInformed",
+    "text": "Gelişmelerden haberdar kalın",
+    "language": "tr"
+  },
+  {
+    "keyName": "backToPortalHomepage",
+    "text": "${portalName} ana sayfasına geri dön",
+    "language": "tr"
+  },
+  {
+    "keyName": "joinMailingList",
+    "text": "Posta Listesine Katıl",
+    "language": "tr"
+  },
+  {
+    "keyName": "mailingFormStayUpdated",
+    "text": "Çalışmayla ilgili gelişmelerden haberdar olun",
+    "language": "tr"
+  },
+  {
+    "keyName": "yourName",
+    "text": "Adınız",
+    "language": "tr"
+  },
+  {
+    "keyName": "yourEmail",
+    "text": "E-posta adresiniz",
+    "language": "tr"
+  },
+  {
+    "keyName": "join",
+    "text": "Katıl",
+    "language": "tr"
+  },
+  {
+    "keyName": "thanksForJoining",
+    "text": "Katıldığınız için teşekkürler",
+    "language": "tr"
+  },
+  {
+    "keyName": "pageNotFoundTitle",
+    "text": "Sayfa bulunamadı",
+    "language": "tr"
+  },
+  {
+    "keyName": "pageNotFoundMessage",
+    "text": "Bunun bir hata olduğunu düşünüyorsanız, lütfen ${studyContactEmail} adresiyle iletişime geçin",
+    "language": "tr"
+  },
+  {
+    "keyName": "pageNotFoundReturnHome",
+    "text": "Ana sayfaya geri dön",
+    "language": "tr"
+  },
+  {
+    "keyName": "authErrorPageTitle",
+    "text": "Bir hata oluştu",
+    "language": "tr"
+  },
+  {
+    "keyName": "authErrorPageMessage",
+    "text": "Kimlik doğrulama hizmetimizle ilgili bir sorun oluştu. Lütfen tekrar deneyin. Sorunun devam etmesi durumunda, lütfen ${studyContactEmail} adresiyle iletişime geçin.",
+    "language": "tr"
+  },
+  {
+    "keyName": "navbarSampleKits",
+    "text": "Numune Kitleri",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsPageTitle",
+    "text": "Numune toplama kitleri",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsPageDescription",
+    "text": "Numune toplama kitleri, çalışma sürecinin önemli parçalarıdır ve araştırmacıların önemli iç görüler elde etmesine yardımcı olabilir. Aşağıda size sağlanan tüm kitlerin durumunu görebilirsiniz.",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsPageInPersonTitle",
+    "text": "Numuneyi şahsen sağlayın",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsPageInPersonDescription",
+    "text": "Bu çalışma şu anda bir numune toplama kitini şahsen tamamlama seçeneği sunuyor.",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsPageInPersonCompleteButton",
+    "text": "Bir kiti şahsen tamamlayın",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsPageYourKitsTitle",
+    "text": "Kitleriniz",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsPageStatusPreparing",
+    "text": "Hazırlanıyor",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsPageStatusShipped",
+    "text": "Gönderildi",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsPageStatusReturned",
+    "text": "İade Edildi",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsPageStatusCreated",
+    "text": "Oluşturuldu",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsPageStatusCollected",
+    "text": "Toplandı",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsPageNoKits",
+    "text": "Şu anda elinizde herhangi bir numune toplama kiti bulunmamaktadır.",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsInPersonTitle",
+    "text": "Numune kiti talimatları",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsInPersonDescription",
+    "text": "Numune toplama kitini şahsen tamamlayacaksanız, lütfen çalışma ekibinin bir üyesi tarafından verilmiş olan talimatları izleyin. Benzersiz katılımcı tanımlayıcınız gibi ihtiyaç duyabileceğiniz her türlü ek bilgiye aşağıdan ulaşabilirsiniz.",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsInPersonSubDescription",
+    "text": "Herhangi bir sorunuz olması durumunda lütfen çalışma ekibinin bir üyesine sorun.",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsInPersonYourKitTitle",
+    "text": "Numune toplama kitiniz",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsInPersonYourKitDescription",
+    "text": "Ekibin bir üyesi size bir numune toplama kiti sundu. Bu numune kiti hesabınızla ilişkilendirildi. Bir başkasına numune toplama kiti konusunda yardımcı oluyorsanız, lütfen her katılımcının kendisine atanan numune toplama kitini tamamladığından emin olun.",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsInPersonYourKitIdentifier",
+    "text": "Kit tanımlayıcınız",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsInPersonReturnToDashboard",
+    "text": "Gösterge paneline geri dön",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsInPersonRefreshPage",
+    "text": "Yenile",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredTitle",
+    "text": "Onay Gerekiyor",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredDescription",
+    "text": "Numune toplama kitini tamamlamadan önce çalışmaya kaydolmanız gereklidir. Çalışmayla ilgileniyorsanız, aşağıdaki bağlantıdan onay formuna erişebilir ve formu imzalayabilirsiniz.",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsInPersonStartConsent",
+    "text": "Onay Aşamasını Başlat",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsInPersonError",
+    "text": "Kit bilgileriniz yüklenirken bir hata oluştu. Yardım için lütfen çalışma ekibinin bir üyesiyle iletişime geçin.",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsInPersonCreatedInstructions",
+    "text": "Numune toplama kitini tamamladıktan sonra, lütfen çalışma ekibinin bir üyesine teslim edin ve aşağıda yer alan size özel katılım kodunu taramasını sağlayın.",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsInPersonNoKitInstructions",
+    "text": "Bir numune toplama kiti alabilmeniz için, çalışma ekibinden bir üye aşağıdaki size özel sağlanan benzersiz katılım kodunu tarayarak bir numune kitini hesabınızla ilişkilendirir.",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsInPersonNoKitSubInstructions",
+    "text": "Kiti teslim aldıktan sonra, kit bilgilerinizi görüntülemek ve daha fazla talimata erişmek için lütfen bu sayfayı yenileyin.",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsInPersonCollectedDescription",
+    "text": "Ekibin bir üyesi numune toplama kitinizi teslim aldı. Numunenizin işlenmesinin ardından tarafınıza bir e-posta bildirimi gönderilir ve numunenizin durumunu çalışmanın gösterge paneli üzerinden görüntüleyebilirsiniz.",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitsInPersonCollectedThankYou",
+    "text": "Katılımınız için teşekkür ederiz.",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitTypeSaliva",
+    "text": "Tükürük kiti",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitTypeStool",
+    "text": "Dışkı kiti",
+    "language": "tr"
+  },
+  {
+    "keyName": "kitTypeBlood",
+    "text": "Kan kiti",
+    "language": "tr"
+  },
+  {
+    "keyName": "documentDownloadButton",
+    "text": "İndirmek",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListNone",
+    "text": "Henüz herhangi bir belge yüklemediniz",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListCreatedOn",
+    "text": "Oluşturuldu",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageTitle",
+    "text": "Belgeler",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageUploadedDocumentsTitle",
+    "text": "Yüklenen belgeler",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageMessage",
+    "text": "Bir çalışmaya katılırken, bir form veya anketin parçası olarak belgeleri yüklemeniz istenebilir. Aşağıda, yüklediğiniz belgeleri yönetebilirsiniz.",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "navbarDocuments",
+    "text": "Belgeler",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureTitle",
+    "text": "Emin misin?",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureMessage",
+    "text": "Bu belgeyi silmek istediğinizden emin misiniz? Bu işlem geri alınamaz. Çalışma ekibinden bir üye bu belgeyi daha önce indirmişse, belgenin onlar için hala erişilebilir olacağını lütfen unutmayın. Belgenin tüm kayıtlardan tamamen kaldırılmasını istiyorsanız lütfen çalışma ekibiyle iletişime geçin.",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseTitle",
+    "text": "Bu belge kullanımda",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseMessage",
+    "text": "Bu belge şu anda en az bir ankete yanıt olarak paylaşılıyor. Lütfen silmeden önce anket yanıtlarından kaldırın.",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteButton",
+    "text": "Silmek",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentOptionsButton",
+    "text": "Seçenekler",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentSharedInResponseTo",
+    "text": "yanıt olarak paylaşıldı",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderSelectedDocuments",
+    "text": "Seçilmiş belgeler",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderIncludedInResponse",
+    "text": "Bu belgeler yanıtınıza dahildir",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocumentsSelected",
+    "text": "Hiçbir belge seçilmedi. Lütfen yeni bir belge yükleyin veya aşağıdan mevcut bir belgeyi seçin.",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderAvailableDocuments",
+    "text": "Mevcut belgeler",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNotIncludedInResponse",
+    "text": "Bu belgeler yanıtınıza dahil değildir",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderClickToUpload",
+    "text": "Dosyaları buraya bırakın veya yüklemek için tıklayın",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocuments",
+    "text": "Hiçbir belge mevcut değil",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeTitle",
+    "text": "Oturumunuz sona ermek üzere",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeMessage",
+    "text": "Güvenliğinizi sağlamak ve verilerinizi korumak için ${timeRemaining} içinde oturumunuz kapatılacak.",
+    "language": "tr",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "failedToEnroll",
+    "language": "tr",
+    "text": "Kayıt sürecinde bir şeyler ters gitti. Lütfen formu tekrar doldurun.",
+    "machineTranslated": true
+  }
 ]

--- a/populate/src/main/resources/seed/i18n/zh/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/zh/languageTexts.json
@@ -1,163 +1,836 @@
 [
-  {"keyName": "navbarDashboard", "text": "信息面板", "language": "zh"},
-  {"keyName": "navbarChangePassword", "text": "更改密码", "language": "zh"},
-  {"keyName": "navbarLogout", "text": "退出", "language": "zh"},
-  {"keyName": "profile", "text": "个人资料", "language": "zh"},
-  {"keyName": "navbarLogin", "text": "登录", "language": "zh"},
-  {"keyName": "navbarJoin", "text": "注册", "language": "zh"},
-  {"keyName": "taskComplete", "text": "完成", "language": "zh"},
-  {"keyName": "taskInProgress", "text": "进行中", "language": "zh"},
-  {"keyName": "taskNotStarted", "text": "未开始", "language": "zh"},
-  {"keyName": "taskDeclined", "text": "已拒绝", "language": "zh"},
-  {"keyName": "taskLocked", "text": "已锁定", "language": "zh"},
-  {"keyName": "tasksNoneForStudy", "text": "无本研究的任务", "language": "zh"},
-  {"keyName": "taskHistory", "text": "历史", "language": "zh"},
-  {"keyName": "taskNew", "text": "新的", "language": "zh"},
-  {"keyName": "surveysSomeLocked", "text": "在完成其他必要任务之前某些调查会被锁定。", "language": "zh"},
-  {"keyName": "taskTypeSurvey", "text": "调查", "language": "zh"},
-  {"keyName": "taskTypeSurveys", "text": "调查", "language": "zh"},
-  {"keyName": "taskTypeConsent", "text": "同意", "language": "zh"},
-  {"keyName": "taskTypeForms", "text": "表单", "language": "zh"},
-  {"keyName": "start", "text": "开始", "language": "zh"},
-  {"keyName": "continue", "text": "继续", "language": "zh"},
-  {"keyName": "save", "text": "保存", "language": "zh"},
-  {"keyName": "outreachLearnMore", "text": "了解更多", "language": "zh"},
-  {"keyName": "cancel", "text": "取消", "language": "zh"},
-  {"keyName": "goBack", "text": "返回", "language": "zh"},
-  {"keyName": "name", "text": "姓名", "language": "zh"},
-  {"keyName": "givenName", "text": "名字", "language": "zh"},
-  {"keyName": "familyName", "text": "姓氏", "language": "zh"},
-  {"keyName": "editName", "text": "编辑姓名", "language": "zh"},
-  {"keyName": "editBirthDate", "text": "编辑生日", "language": "zh"},
-  {"keyName": "birthDate", "text": "生日", "language": "zh"},
-  {"keyName": "mailingAddress", "text": "邮寄地址", "language": "zh"},
-  {"keyName": "editMailingAddress", "text": "编辑邮寄地址", "language": "zh"},
-  {"keyName": "primaryAddress", "text": "主要地址", "language": "zh"},
-  {"keyName": "editPrimaryAddress", "text": "编辑主要地址", "language": "zh"},
-  {"keyName": "street1", "text": "街道 1", "language": "zh"},
-  {"keyName": "street2", "text": "街道 2", "language": "zh"},
-  {"keyName": "city", "text": "城市", "language": "zh"},
-  {"keyName": "state", "text": "州\/省", "language": "zh"},
-  {"keyName": "postalCode", "text": "邮政编码", "language": "zh"},
-  {"keyName": "country", "text": "国家", "language": "zh"},
-  {"keyName": "communicationPreferences", "text": "首选联系方式", "language": "zh"},
-  {"keyName": "editCommunicationPreferences", "text": "编辑首选联系方式", "language": "zh"},
-  {"keyName": "contactEmail", "text": "联系人电子邮件地址", "language": "zh"},
-  {"keyName": "editContactEmail", "text": "编辑联系人电子邮件地址", "language": "zh"},
-  {"keyName": "phoneNumber", "text": "电话号码", "language": "zh"},
-  {"keyName": "editPhoneNumber", "text": "编辑电话号码", "language": "zh"},
-  {"keyName": "doNotSolicit", "text": "请勿推销", "language": "zh"},
-  {"keyName": "doNotContact", "text": "请勿联系", "language": "zh"},
-  {"keyName": "editDoNotSolicit", "text": "编辑请勿推销", "language": "zh"},
-  {"keyName": "editNotifications", "text": "编辑通知", "language": "zh"},
-  {"keyName": "notifications", "text": "通知", "language": "zh"},
-  {"keyName": "on", "text": "开启", "language": "zh"},
-  {"keyName": "off", "text": "关闭", "language": "zh"},
-  {"keyName": "notProvided", "text": "未提供", "language": "zh"},
-  {"keyName": "editProfileContactEmailWarning", "text": "按“保存”以更新用于通信的电子邮件地址。请注意，您的登录信息不会改变。", "language": "zh"},
-  {"keyName": "privacyPolicy", "text": "隐私政策", "language": "zh"},
-  {"keyName": "termsOfUse", "text": "使用条款", "language": "zh"},
-  {"keyName": "addressInvalidPostalCode", "text": "无法验证邮政编码。", "language": "zh"},
-  {"keyName": "addressInvalidCountry", "text": "无法验证国家。", "language": "zh"},
-  {"keyName": "addressInvalidState", "text": "无法验证州\/省。", "language": "zh"},
-  {"keyName": "addressInvalidCity", "text": "无法验证城市。", "language": "zh"},
-  {"keyName": "addressInvalidHouseNumber", "text": "无法验证门牌号。", "language": "zh"},
-  {"keyName": "addressInvalidStreetName", "text": "无法验证街道名称。", "language": "zh"},
-  {"keyName": "addressInvalidStreetType", "text": "无法验证街道类型。", "language": "zh"},
-  {"keyName": "addressNeedsSubpremise", "text": "请提供单元\/套房号码。", "language": "zh"},
-  {"keyName": "addressFailedToValidate", "text": "无法验证地址。", "language": "zh"},
-  {"keyName": "suggestBetterAddressHeader", "text": "这是正确的地址吗？", "language": "zh"},
-  {"keyName": "suggestBetterAddressBody", "text": "我们验证了一个类似的地址。请选择您希望使用的选项。", "language": "zh"},
-  {"keyName": "newAddress", "text": "新地址", "language": "zh"},
-  {"keyName": "oldAddress", "text": "旧地址", "language": "zh"},
-  {"keyName": "you", "text": "您", "language": "zh"},
-  {"keyName": "yourDependent", "text": "您的受抚养人", "language": "zh"},
-  {"keyName": "youInParens", "text": "(您)", "language": "zh"},
-  {"keyName": "allProfiles", "text": "所有个人资料", "language": "zh"},
-  {"keyName": "manageProfiles", "text": "管理个人资料", "language": "zh"},
-  {"keyName": "addNewParticipant", "text": "添加新参与者", "language": "zh"},
-  {"keyName": "dashboard", "text": "信息面板", "language": "zh"},
-  {"keyName": "selectParticipant", "text": "选择参与者", "language": "zh"},
-  {"keyName": "hubUpdateFormSubmittedTitle", "text": "${表格名称} 已完成", "language": "zh"},
-  {"keyName": "hubUpdateNoActivitiesTitle", "text": "所有活动已完成", "language": "zh"},
-  {"keyName": "hubUpdateNoActivitiesDetail", "text": "您已完成此研究的所有活动。一旦有新的活动，我们将立即通知您。感谢您的参与！", "language": "zh"},
-  {"keyName": "hubUpdateWelcomeToStudyTitle", "text": "欢迎参加 ${研究名称}", "language": "zh"},
-  {"keyName": "hubUpdateWelcomeToStudyDetail", "text": "请阅读并签署以下同意书以继续。", "language": "zh"},
-  {"keyName": "hubUpdateAlreadyEnrolledTitle", "text": "您已注册参加 ${研究名称}。", "language": "zh"},
-  {"keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle", "text": "该用户已注册参加 ${研究名称}。", "language": "zh"},
-  {"keyName": "cookieAlertTitle", "text": "Cookie", "language": "zh"},
-  {"keyName": "cookieAlertDetail", "text": "本网站使用称为“cookie”的互联网令牌，以确保我们网站的正常运行和安全，并改善您的使用体验。我们使用的所有 cookie 都是严格必要的 cookie。此类 cookie 不会收集任何可识别您个人身份的信息，也不会跟踪您的浏览习惯。要了解更多信息，请[阅读我们的隐私政策](\/隐私)。", "language": "zh"},
-  {"keyName": "joinStudy", "text": "参加研究", "language": "zh"},
-  {"keyName": "ineligibleThankYou", "text": "感谢您对 ${研究名称} 的兴趣。", "language": "zh" },
-  {"keyName": "ineligibleDescription", "text": "遗憾的是，您目前不符合参加 ${研究名称} 的资格标准。", "language": "zh"},
-  {"keyName": "ineligibleProvideYourEmail", "text": "请在下面提供您的电子邮箱，我们会通过它让您了解最新研究进展。您随时可以退订。", "language":  "zh"},
-  {"keyName": "ineligibleStayInformed", "text": "获取最新信息", "language": "zh"},
-  {"keyName": "backToPortalHomepage", "text": "返回 ${门户网站名称} 主页", "language": "zh"},
-  {"keyName": "joinMailingList", "text": "加入邮件名单", "language": "zh"},
-  {"keyName": "mailingFormStayUpdated", "text":  "了解有关研究的最新消息", "language": "zh"},
-  {"keyName": "yourName", "text": "您的姓名", "language": "zh"},
-  {"keyName": "yourEmail", "text": "您的电子邮件地址", "language": "zh"},
-  {"keyName": "join", "text":  "加入", "language": "zh"},
-  {"keyName": "thanksForJoining", "text": "感谢加入！", "language": "zh"},
-  {"keyName": "pageNotFoundTitle", "text": "未找到页面", "language": "zh"},
-  {"keyName": "pageNotFoundMessage", "text": "如果您认为这是一个错误，请联系 ${研究联系人电子邮件地址} 。", "language": "zh"},
-  {"keyName": "pageNotFoundReturnHome", "text": "返回主页", "language": "zh"},
-  {"keyName": "authErrorPageTitle", "text": "出现了错误", "language": "zh"},
-  {"keyName": "authErrorPageMessage", "text": "我们的身份验证服务出现了问题。请重试。如果问题仍然存在，请联系 ${研究联系人电子邮件地址}。", "language": "zh"},
-  {"keyName": "navbarSampleKits", "text":  "样本套件", "language": "zh"},
-  {"keyName": "kitsPageTitle", "text": "样本采集套件", "language": "zh"},
-  {"keyName": "kitsPageDescription", "text": "样本采集套件是研究过程中的重要组成部分，有助于为研究人员提供重要的信息。以下是已提供给您的所有套件的状态。", "language": "zh"},
-  {"keyName": "kitsPageInPersonTitle", "text": "亲自提供样本", "language": "zh"},
-  {"keyName": "kitsPageInPersonDescription", "text": "本研究目前提供亲自完成样本采集套件的选项。", "language": "zh"},
-  {"keyName": "kitsPageInPersonCompleteButton", "text": "亲自完成套件", "language": "zh"},
-  {"keyName": "kitsPageYourKitsTitle", "text": "您的套件", "language": "zh"},
-  {"keyName": "kitsPageStatusPreparing", "text": "制备中", "language": "zh"},
-  {"keyName": "kitsPageStatusShipped", "text": "已发送", "language": "zh"},
-  {"keyName": "kitsPageStatusReturned", "text": "已送回", "language": "zh"},
-  {"keyName": "kitsPageStatusCreated", "text": "已创建", "language": "zh"},
-  {"keyName": "kitsPageStatusCollected", "text": "已采集", "language": "zh"},
-  {"keyName": "kitsPageNoKits", "text": "您目前没有任何样本采集套件。", "language": "zh"},
-  {"keyName": "kitsInPersonTitle", "text": "样本套件说明", "language": "zh"},
-  {"keyName": "kitsInPersonDescription", "text": "如果您亲自完成样本采集套件，请按照研究团队成员提供的说明进行操作。以下将提供您可能需要的任何其他信息，例如您的唯一参与者标识符。", "language": "zh"},
-  {"keyName": "kitsInPersonSubDescription", "text": "如果您有任何疑问，请咨询研究小组成员。", "language": "zh"},
-  {"keyName": "kitsInPersonYourKitTitle", "text": "您的样本采集套件", "language": "zh"},
-  {"keyName": "kitsInPersonYourKitDescription", "text": "小组成员已为您提供了样本采集套件。该样本套件与您的帐户相关联。如果您正在协助其他人使用其样本收集套件，请确保每位参与者均完成分配给他们的样本采集套件。", "language": "zh"},
-  {"keyName": "kitsInPersonYourKitIdentifier", "text": "您的套件标识符", "language": "zh"},
-  {"keyName": "kitsInPersonReturnToDashboard", "text": "返回信息面板", "language": "zh"},
-  {"keyName": "kitsInPersonRefreshPage", "text": "刷新", "language": "zh"},
-  {"keyName": "kitsInPersonConsentRequiredTitle", "text": "需要同意", "language": "zh"},
-  {"keyName": "kitsInPersonConsentRequiredDescription", "text": "在完成样本采集套件之前，您必须首先注册参加这项研究。如果有兴趣，您可以通过以下链接找到并签署同意书。", "language": "zh"},
-  {"keyName": "kitsInPersonStartConsent", "text": "开始同意", "language": "zh"},
-  {"keyName": "kitsInPersonError", "text": "加载您的套件信息时出错。请联系研究小组的成员寻求帮助。", "language": "zh"},
-  {"keyName": "kitsInPersonCreatedInstructions", "text": "完成样本采集套件后，请将其交还给研究小组成员，以让他们扫描以下的参与者代码。", "language": "zh"},
-  {"keyName": "kitsInPersonNoKitInstructions", "text": "为获得样本采集套件，研究小组成员将扫描以下的您的唯一参与者代码，以将样本套件与您的帐户相关联。", "language": "zh"},
-  {"keyName": "kitsInPersonNoKitSubInstructions", "text": "收到套件后，请刷新此页面以查看您的套件信息并接收进一步的说明。", "language": "zh"},
-  {"keyName": "kitsInPersonCollectedDescription", "text": "研究小组的成员已收到您的样本采集套件。样本处理完毕后，您将收到一封电子邮件通知，并且您可以在研究信息面板上查看样本状态。", "language": "zh"},
-  {"keyName": "kitsInPersonCollectedThankYou", "text": "感谢您的参与。", "language": "zh"},
-  {"keyName": "kitTypeSaliva", "text": "唾液套件", "language": "zh"},
-  {"keyName": "kitTypeStool", "text": "粪便套件", "language": "zh"},
-  {"keyName": "kitTypeBlood", "text": "血液套件", "language": "zh"},
-  {"keyName": "documentDownloadButton", "text": "下载", "language": "zh", "machineTranslated": true},
-  {"keyName": "documentsListNone", "text": "您尚未上传任何文件", "language": "zh", "machineTranslated": true},
-  {"keyName": "documentsListCreatedOn", "text": "创建于", "language": "zh", "machineTranslated": true},
-  {"keyName": "documentsPageTitle", "text": "文件", "language": "zh", "machineTranslated": true},
-  {"keyName": "documentsPageUploadedDocumentsTitle", "text": "已上传文件", "language": "zh", "machineTranslated": true},
-  {"keyName": "documentsPageMessage", "text": "在参与研究期间，您可能会被要求上传文件作为表格或调查的一部分。下面，您可以管理已上传的文件。", "language": "zh", "machineTranslated": true},
-  {"keyName": "navbarDocuments", "text": "文件", "language": "zh", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureTitle", "text": "你确定吗？", "language": "zh", "machineTranslated": true},
-  {"keyName": "documentDeleteAreYouSureMessage", "text": "您确定要删除此文档吗？此操作无法撤消。请注意，如果研究人员已经下载了此文档，他们仍然可以访问它。如果您希望将文档从所有记录中完全删除，请联系研究人员。", "language": "zh", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseTitle", "text": "此文件正在使用中", "language": "zh", "machineTranslated": true},
-  {"keyName": "documentDeleteDocumentInUseMessage", "text": "此文档目前已分享给至少一项调查。删除之前，请先将其从调查回复中移除。", "language": "zh", "machineTranslated": true},
-  {"keyName": "documentDeleteButton", "text": "删除", "language": "zh", "machineTranslated": true},
-  {"keyName": "documentOptionsButton", "text": "选项", "language": "zh", "machineTranslated": true},
-  {"keyName": "documentSharedInResponseTo", "text": "分享", "language": "zh", "machineTranslated": true},
-  {"keyName": "documentUploaderSelectedDocuments", "text": "精选文件", "language": "zh", "machineTranslated": true},
-  {"keyName": "documentUploaderIncludedInResponse", "text": "这些文件包含在您的回复中", "language": "zh", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocumentsSelected", "text": "未选择任何文档。请上传新文档或选择下面的现有文档。", "language": "zh", "machineTranslated": true},
-  {"keyName": "documentUploaderAvailableDocuments", "text": "可用文件", "language": "zh", "machineTranslated": true},
-  {"keyName": "documentUploaderNotIncludedInResponse", "text": "您的回复中未包含这些文件", "language": "zh", "machineTranslated": true},
-  {"keyName": "documentUploaderClickToUpload", "text": "将文件拖放到此处或单击上传", "language": "zh", "machineTranslated": true},
-  {"keyName": "documentUploaderNoDocuments", "text": "没有可用文件", "language": "zh", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeTitle", "text": "您的会话即将过期", "language": "zh", "machineTranslated": true},
-  {"keyName": "idleStatusNoticeMessage", "text": "为了维护安全并保护您的数据，您将在 ${timeRemaining} 后退出。", "language": "zh", "machineTranslated": true}
+  {
+    "keyName": "navbarDashboard",
+    "text": "信息面板",
+    "language": "zh"
+  },
+  {
+    "keyName": "navbarChangePassword",
+    "text": "更改密码",
+    "language": "zh"
+  },
+  {
+    "keyName": "navbarLogout",
+    "text": "退出",
+    "language": "zh"
+  },
+  {
+    "keyName": "profile",
+    "text": "个人资料",
+    "language": "zh"
+  },
+  {
+    "keyName": "navbarLogin",
+    "text": "登录",
+    "language": "zh"
+  },
+  {
+    "keyName": "navbarJoin",
+    "text": "注册",
+    "language": "zh"
+  },
+  {
+    "keyName": "taskComplete",
+    "text": "完成",
+    "language": "zh"
+  },
+  {
+    "keyName": "taskInProgress",
+    "text": "进行中",
+    "language": "zh"
+  },
+  {
+    "keyName": "taskNotStarted",
+    "text": "未开始",
+    "language": "zh"
+  },
+  {
+    "keyName": "taskDeclined",
+    "text": "已拒绝",
+    "language": "zh"
+  },
+  {
+    "keyName": "taskLocked",
+    "text": "已锁定",
+    "language": "zh"
+  },
+  {
+    "keyName": "tasksNoneForStudy",
+    "text": "无本研究的任务",
+    "language": "zh"
+  },
+  {
+    "keyName": "taskHistory",
+    "text": "历史",
+    "language": "zh"
+  },
+  {
+    "keyName": "taskNew",
+    "text": "新的",
+    "language": "zh"
+  },
+  {
+    "keyName": "surveysSomeLocked",
+    "text": "在完成其他必要任务之前某些调查会被锁定。",
+    "language": "zh"
+  },
+  {
+    "keyName": "taskTypeSurvey",
+    "text": "调查",
+    "language": "zh"
+  },
+  {
+    "keyName": "taskTypeSurveys",
+    "text": "调查",
+    "language": "zh"
+  },
+  {
+    "keyName": "taskTypeConsent",
+    "text": "同意",
+    "language": "zh"
+  },
+  {
+    "keyName": "taskTypeForms",
+    "text": "表单",
+    "language": "zh"
+  },
+  {
+    "keyName": "start",
+    "text": "开始",
+    "language": "zh"
+  },
+  {
+    "keyName": "continue",
+    "text": "继续",
+    "language": "zh"
+  },
+  {
+    "keyName": "save",
+    "text": "保存",
+    "language": "zh"
+  },
+  {
+    "keyName": "outreachLearnMore",
+    "text": "了解更多",
+    "language": "zh"
+  },
+  {
+    "keyName": "cancel",
+    "text": "取消",
+    "language": "zh"
+  },
+  {
+    "keyName": "goBack",
+    "text": "返回",
+    "language": "zh"
+  },
+  {
+    "keyName": "name",
+    "text": "姓名",
+    "language": "zh"
+  },
+  {
+    "keyName": "givenName",
+    "text": "名字",
+    "language": "zh"
+  },
+  {
+    "keyName": "familyName",
+    "text": "姓氏",
+    "language": "zh"
+  },
+  {
+    "keyName": "editName",
+    "text": "编辑姓名",
+    "language": "zh"
+  },
+  {
+    "keyName": "editBirthDate",
+    "text": "编辑生日",
+    "language": "zh"
+  },
+  {
+    "keyName": "birthDate",
+    "text": "生日",
+    "language": "zh"
+  },
+  {
+    "keyName": "mailingAddress",
+    "text": "邮寄地址",
+    "language": "zh"
+  },
+  {
+    "keyName": "editMailingAddress",
+    "text": "编辑邮寄地址",
+    "language": "zh"
+  },
+  {
+    "keyName": "primaryAddress",
+    "text": "主要地址",
+    "language": "zh"
+  },
+  {
+    "keyName": "editPrimaryAddress",
+    "text": "编辑主要地址",
+    "language": "zh"
+  },
+  {
+    "keyName": "street1",
+    "text": "街道 1",
+    "language": "zh"
+  },
+  {
+    "keyName": "street2",
+    "text": "街道 2",
+    "language": "zh"
+  },
+  {
+    "keyName": "city",
+    "text": "城市",
+    "language": "zh"
+  },
+  {
+    "keyName": "state",
+    "text": "州/省",
+    "language": "zh"
+  },
+  {
+    "keyName": "postalCode",
+    "text": "邮政编码",
+    "language": "zh"
+  },
+  {
+    "keyName": "country",
+    "text": "国家",
+    "language": "zh"
+  },
+  {
+    "keyName": "communicationPreferences",
+    "text": "首选联系方式",
+    "language": "zh"
+  },
+  {
+    "keyName": "editCommunicationPreferences",
+    "text": "编辑首选联系方式",
+    "language": "zh"
+  },
+  {
+    "keyName": "contactEmail",
+    "text": "联系人电子邮件地址",
+    "language": "zh"
+  },
+  {
+    "keyName": "editContactEmail",
+    "text": "编辑联系人电子邮件地址",
+    "language": "zh"
+  },
+  {
+    "keyName": "phoneNumber",
+    "text": "电话号码",
+    "language": "zh"
+  },
+  {
+    "keyName": "editPhoneNumber",
+    "text": "编辑电话号码",
+    "language": "zh"
+  },
+  {
+    "keyName": "doNotSolicit",
+    "text": "请勿推销",
+    "language": "zh"
+  },
+  {
+    "keyName": "doNotContact",
+    "text": "请勿联系",
+    "language": "zh"
+  },
+  {
+    "keyName": "editDoNotSolicit",
+    "text": "编辑请勿推销",
+    "language": "zh"
+  },
+  {
+    "keyName": "editNotifications",
+    "text": "编辑通知",
+    "language": "zh"
+  },
+  {
+    "keyName": "notifications",
+    "text": "通知",
+    "language": "zh"
+  },
+  {
+    "keyName": "on",
+    "text": "开启",
+    "language": "zh"
+  },
+  {
+    "keyName": "off",
+    "text": "关闭",
+    "language": "zh"
+  },
+  {
+    "keyName": "notProvided",
+    "text": "未提供",
+    "language": "zh"
+  },
+  {
+    "keyName": "editProfileContactEmailWarning",
+    "text": "按“保存”以更新用于通信的电子邮件地址。请注意，您的登录信息不会改变。",
+    "language": "zh"
+  },
+  {
+    "keyName": "privacyPolicy",
+    "text": "隐私政策",
+    "language": "zh"
+  },
+  {
+    "keyName": "termsOfUse",
+    "text": "使用条款",
+    "language": "zh"
+  },
+  {
+    "keyName": "addressInvalidPostalCode",
+    "text": "无法验证邮政编码。",
+    "language": "zh"
+  },
+  {
+    "keyName": "addressInvalidCountry",
+    "text": "无法验证国家。",
+    "language": "zh"
+  },
+  {
+    "keyName": "addressInvalidState",
+    "text": "无法验证州/省。",
+    "language": "zh"
+  },
+  {
+    "keyName": "addressInvalidCity",
+    "text": "无法验证城市。",
+    "language": "zh"
+  },
+  {
+    "keyName": "addressInvalidHouseNumber",
+    "text": "无法验证门牌号。",
+    "language": "zh"
+  },
+  {
+    "keyName": "addressInvalidStreetName",
+    "text": "无法验证街道名称。",
+    "language": "zh"
+  },
+  {
+    "keyName": "addressInvalidStreetType",
+    "text": "无法验证街道类型。",
+    "language": "zh"
+  },
+  {
+    "keyName": "addressNeedsSubpremise",
+    "text": "请提供单元/套房号码。",
+    "language": "zh"
+  },
+  {
+    "keyName": "addressFailedToValidate",
+    "text": "无法验证地址。",
+    "language": "zh"
+  },
+  {
+    "keyName": "suggestBetterAddressHeader",
+    "text": "这是正确的地址吗？",
+    "language": "zh"
+  },
+  {
+    "keyName": "suggestBetterAddressBody",
+    "text": "我们验证了一个类似的地址。请选择您希望使用的选项。",
+    "language": "zh"
+  },
+  {
+    "keyName": "newAddress",
+    "text": "新地址",
+    "language": "zh"
+  },
+  {
+    "keyName": "oldAddress",
+    "text": "旧地址",
+    "language": "zh"
+  },
+  {
+    "keyName": "you",
+    "text": "您",
+    "language": "zh"
+  },
+  {
+    "keyName": "yourDependent",
+    "text": "您的受抚养人",
+    "language": "zh"
+  },
+  {
+    "keyName": "youInParens",
+    "text": "(您)",
+    "language": "zh"
+  },
+  {
+    "keyName": "allProfiles",
+    "text": "所有个人资料",
+    "language": "zh"
+  },
+  {
+    "keyName": "manageProfiles",
+    "text": "管理个人资料",
+    "language": "zh"
+  },
+  {
+    "keyName": "addNewParticipant",
+    "text": "添加新参与者",
+    "language": "zh"
+  },
+  {
+    "keyName": "dashboard",
+    "text": "信息面板",
+    "language": "zh"
+  },
+  {
+    "keyName": "selectParticipant",
+    "text": "选择参与者",
+    "language": "zh"
+  },
+  {
+    "keyName": "hubUpdateFormSubmittedTitle",
+    "text": "${表格名称} 已完成",
+    "language": "zh"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesTitle",
+    "text": "所有活动已完成",
+    "language": "zh"
+  },
+  {
+    "keyName": "hubUpdateNoActivitiesDetail",
+    "text": "您已完成此研究的所有活动。一旦有新的活动，我们将立即通知您。感谢您的参与！",
+    "language": "zh"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyTitle",
+    "text": "欢迎参加 ${研究名称}",
+    "language": "zh"
+  },
+  {
+    "keyName": "hubUpdateWelcomeToStudyDetail",
+    "text": "请阅读并签署以下同意书以继续。",
+    "language": "zh"
+  },
+  {
+    "keyName": "hubUpdateAlreadyEnrolledTitle",
+    "text": "您已注册参加 ${研究名称}。",
+    "language": "zh"
+  },
+  {
+    "keyName": "hubUpdateGovernedUserAlreadyEnrolledTitle",
+    "text": "该用户已注册参加 ${研究名称}。",
+    "language": "zh"
+  },
+  {
+    "keyName": "cookieAlertTitle",
+    "text": "Cookie",
+    "language": "zh"
+  },
+  {
+    "keyName": "cookieAlertDetail",
+    "text": "本网站使用称为“cookie”的互联网令牌，以确保我们网站的正常运行和安全，并改善您的使用体验。我们使用的所有 cookie 都是严格必要的 cookie。此类 cookie 不会收集任何可识别您个人身份的信息，也不会跟踪您的浏览习惯。要了解更多信息，请[阅读我们的隐私政策](/隐私)。",
+    "language": "zh"
+  },
+  {
+    "keyName": "joinStudy",
+    "text": "参加研究",
+    "language": "zh"
+  },
+  {
+    "keyName": "ineligibleThankYou",
+    "text": "感谢您对 ${研究名称} 的兴趣。",
+    "language": "zh"
+  },
+  {
+    "keyName": "ineligibleDescription",
+    "text": "遗憾的是，您目前不符合参加 ${研究名称} 的资格标准。",
+    "language": "zh"
+  },
+  {
+    "keyName": "ineligibleProvideYourEmail",
+    "text": "请在下面提供您的电子邮箱，我们会通过它让您了解最新研究进展。您随时可以退订。",
+    "language": "zh"
+  },
+  {
+    "keyName": "ineligibleStayInformed",
+    "text": "获取最新信息",
+    "language": "zh"
+  },
+  {
+    "keyName": "backToPortalHomepage",
+    "text": "返回 ${门户网站名称} 主页",
+    "language": "zh"
+  },
+  {
+    "keyName": "joinMailingList",
+    "text": "加入邮件名单",
+    "language": "zh"
+  },
+  {
+    "keyName": "mailingFormStayUpdated",
+    "text": "了解有关研究的最新消息",
+    "language": "zh"
+  },
+  {
+    "keyName": "yourName",
+    "text": "您的姓名",
+    "language": "zh"
+  },
+  {
+    "keyName": "yourEmail",
+    "text": "您的电子邮件地址",
+    "language": "zh"
+  },
+  {
+    "keyName": "join",
+    "text": "加入",
+    "language": "zh"
+  },
+  {
+    "keyName": "thanksForJoining",
+    "text": "感谢加入！",
+    "language": "zh"
+  },
+  {
+    "keyName": "pageNotFoundTitle",
+    "text": "未找到页面",
+    "language": "zh"
+  },
+  {
+    "keyName": "pageNotFoundMessage",
+    "text": "如果您认为这是一个错误，请联系 ${研究联系人电子邮件地址} 。",
+    "language": "zh"
+  },
+  {
+    "keyName": "pageNotFoundReturnHome",
+    "text": "返回主页",
+    "language": "zh"
+  },
+  {
+    "keyName": "authErrorPageTitle",
+    "text": "出现了错误",
+    "language": "zh"
+  },
+  {
+    "keyName": "authErrorPageMessage",
+    "text": "我们的身份验证服务出现了问题。请重试。如果问题仍然存在，请联系 ${研究联系人电子邮件地址}。",
+    "language": "zh"
+  },
+  {
+    "keyName": "navbarSampleKits",
+    "text": "样本套件",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsPageTitle",
+    "text": "样本采集套件",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsPageDescription",
+    "text": "样本采集套件是研究过程中的重要组成部分，有助于为研究人员提供重要的信息。以下是已提供给您的所有套件的状态。",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsPageInPersonTitle",
+    "text": "亲自提供样本",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsPageInPersonDescription",
+    "text": "本研究目前提供亲自完成样本采集套件的选项。",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsPageInPersonCompleteButton",
+    "text": "亲自完成套件",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsPageYourKitsTitle",
+    "text": "您的套件",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsPageStatusPreparing",
+    "text": "制备中",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsPageStatusShipped",
+    "text": "已发送",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsPageStatusReturned",
+    "text": "已送回",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsPageStatusCreated",
+    "text": "已创建",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsPageStatusCollected",
+    "text": "已采集",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsPageNoKits",
+    "text": "您目前没有任何样本采集套件。",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsInPersonTitle",
+    "text": "样本套件说明",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsInPersonDescription",
+    "text": "如果您亲自完成样本采集套件，请按照研究团队成员提供的说明进行操作。以下将提供您可能需要的任何其他信息，例如您的唯一参与者标识符。",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsInPersonSubDescription",
+    "text": "如果您有任何疑问，请咨询研究小组成员。",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsInPersonYourKitTitle",
+    "text": "您的样本采集套件",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsInPersonYourKitDescription",
+    "text": "小组成员已为您提供了样本采集套件。该样本套件与您的帐户相关联。如果您正在协助其他人使用其样本收集套件，请确保每位参与者均完成分配给他们的样本采集套件。",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsInPersonYourKitIdentifier",
+    "text": "您的套件标识符",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsInPersonReturnToDashboard",
+    "text": "返回信息面板",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsInPersonRefreshPage",
+    "text": "刷新",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredTitle",
+    "text": "需要同意",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsInPersonConsentRequiredDescription",
+    "text": "在完成样本采集套件之前，您必须首先注册参加这项研究。如果有兴趣，您可以通过以下链接找到并签署同意书。",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsInPersonStartConsent",
+    "text": "开始同意",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsInPersonError",
+    "text": "加载您的套件信息时出错。请联系研究小组的成员寻求帮助。",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsInPersonCreatedInstructions",
+    "text": "完成样本采集套件后，请将其交还给研究小组成员，以让他们扫描以下的参与者代码。",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsInPersonNoKitInstructions",
+    "text": "为获得样本采集套件，研究小组成员将扫描以下的您的唯一参与者代码，以将样本套件与您的帐户相关联。",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsInPersonNoKitSubInstructions",
+    "text": "收到套件后，请刷新此页面以查看您的套件信息并接收进一步的说明。",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsInPersonCollectedDescription",
+    "text": "研究小组的成员已收到您的样本采集套件。样本处理完毕后，您将收到一封电子邮件通知，并且您可以在研究信息面板上查看样本状态。",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitsInPersonCollectedThankYou",
+    "text": "感谢您的参与。",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitTypeSaliva",
+    "text": "唾液套件",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitTypeStool",
+    "text": "粪便套件",
+    "language": "zh"
+  },
+  {
+    "keyName": "kitTypeBlood",
+    "text": "血液套件",
+    "language": "zh"
+  },
+  {
+    "keyName": "documentDownloadButton",
+    "text": "下载",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListNone",
+    "text": "您尚未上传任何文件",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsListCreatedOn",
+    "text": "创建于",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageTitle",
+    "text": "文件",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageUploadedDocumentsTitle",
+    "text": "已上传文件",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentsPageMessage",
+    "text": "在参与研究期间，您可能会被要求上传文件作为表格或调查的一部分。下面，您可以管理已上传的文件。",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "navbarDocuments",
+    "text": "文件",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureTitle",
+    "text": "你确定吗？",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteAreYouSureMessage",
+    "text": "您确定要删除此文档吗？此操作无法撤消。请注意，如果研究人员已经下载了此文档，他们仍然可以访问它。如果您希望将文档从所有记录中完全删除，请联系研究人员。",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseTitle",
+    "text": "此文件正在使用中",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteDocumentInUseMessage",
+    "text": "此文档目前已分享给至少一项调查。删除之前，请先将其从调查回复中移除。",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentDeleteButton",
+    "text": "删除",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentOptionsButton",
+    "text": "选项",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentSharedInResponseTo",
+    "text": "分享",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderSelectedDocuments",
+    "text": "精选文件",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderIncludedInResponse",
+    "text": "这些文件包含在您的回复中",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocumentsSelected",
+    "text": "未选择任何文档。请上传新文档或选择下面的现有文档。",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderAvailableDocuments",
+    "text": "可用文件",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNotIncludedInResponse",
+    "text": "您的回复中未包含这些文件",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderClickToUpload",
+    "text": "将文件拖放到此处或单击上传",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "documentUploaderNoDocuments",
+    "text": "没有可用文件",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeTitle",
+    "text": "您的会话即将过期",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "idleStatusNoticeMessage",
+    "text": "为了维护安全并保护您的数据，您将在 ${timeRemaining} 后退出。",
+    "language": "zh",
+    "machineTranslated": true
+  },
+  {
+    "keyName": "failedToEnroll",
+    "language": "zh",
+    "text": "在入学过程中出现了问题。请再次填写表格。",
+    "machineTranslated": true
+  }
 ]

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -336,8 +336,8 @@ export default {
   },
 
   /** creates an enrollee for the signed-in user and study.  */
-  async createEnrollee({ studyShortcode, preEnrollResponseId }: {
-    studyShortcode: string, preEnrollResponseId: string | null
+  async createEnrollee({ studyShortcode, preEnrollResponseId, opts }: {
+    studyShortcode: string, preEnrollResponseId: string | null, opts?: { alertErrors?: boolean }
   }):
     Promise<HubResponse> {
     const params = queryString.stringify({ preEnrollResponseId })
@@ -346,7 +346,7 @@ export default {
       method: 'POST',
       headers: this.getInitHeaders()
     })
-    return await this.processJsonResponse(response)
+    return await this.processJsonResponse(response, opts)
   },
 
   async createGovernedEnrollee({ studyShortcode, preEnrollResponseId, governedPpUserId }: {

--- a/ui-participant/src/login/RedirectFromOAuth.tsx
+++ b/ui-participant/src/login/RedirectFromOAuth.tsx
@@ -91,14 +91,20 @@ export const RedirectFromOAuth = () => {
 
             // Enroll in the study if not already enrolled in any other study
             if (defaultEnrollStudy && !loginResult.enrollees.length) {
-              const hubResponse = await enrollCurrentUserInStudy(
-                defaultEnrollStudy.shortcode, preEnrollResponseId, refreshLoginState)
+              try {
+                const hubResponse = await enrollCurrentUserInStudy(
+                  defaultEnrollStudy.shortcode, preEnrollResponseId, refreshLoginState, { alertErrors: false })
 
-              handleNewStudyEnroll(hubResponse,
-                defaultEnrollStudy.shortcode,
-                navigate,
-                i18n,
-                i18n(`${portal.shortcode}.${defaultEnrollStudy.shortcode}`, { defaultValue: defaultEnrollStudy.name }))
+                handleNewStudyEnroll(hubResponse,
+                  defaultEnrollStudy.shortcode,
+                  navigate,
+                  i18n,
+                  i18n(`${portal.shortcode}.${defaultEnrollStudy.shortcode}`, { defaultValue: defaultEnrollStudy.name })
+                )
+              } catch (e) {
+                alert(i18n('failedToEnroll'))
+                navigate(`/studies/${defaultEnrollStudy.shortcode}/join/preEnroll`, { replace: true })
+              }
             } else {
               navigate('/hub', { replace: true })
             }

--- a/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
+++ b/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
@@ -112,7 +112,7 @@ function StudyEnrollOutletMatched(props: StudyEnrollOutletMatchedProps) {
 
   /** updates the state and localStorage */
   function updatePreEnrollResponseId(preEnrollId: string | null) {
-    // setPreEnrollResponseId(preEnrollId)
+    setPreEnrollResponseId(preEnrollId)
     setPreEnrollSatisfied(!!preEnrollId)
   }
 

--- a/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
+++ b/ui-participant/src/studies/enroll/StudyEnrollRouter.tsx
@@ -112,7 +112,7 @@ function StudyEnrollOutletMatched(props: StudyEnrollOutletMatchedProps) {
 
   /** updates the state and localStorage */
   function updatePreEnrollResponseId(preEnrollId: string | null) {
-    setPreEnrollResponseId(preEnrollId)
+    // setPreEnrollResponseId(preEnrollId)
     setPreEnrollSatisfied(!!preEnrollId)
   }
 

--- a/ui-participant/src/util/enrolleeUtils.ts
+++ b/ui-participant/src/util/enrolleeUtils.ts
@@ -3,7 +3,8 @@ import Api, {
   Study
 } from 'api/api'
 import {
-  Enrollee, HubResponse,
+  Enrollee,
+  HubResponse,
   useI18n
 } from '@juniper/ui-core'
 import { useUser } from '../providers/UserProvider'
@@ -21,11 +22,13 @@ export function userHasJoinedStudy(study: Study, enrollees: Enrollee[]) {
 export async function enrollCurrentUserInStudy(
   studyShortcode: string,
   preEnrollResponseId: string | null,
-  refreshLogin: () => Promise<void>
+  refreshLogin: () => Promise<void>,
+  opts?: { alertErrors?: boolean }
 ): Promise<HubResponse> {
   const hubResponse = await Api.createEnrollee({
     studyShortcode,
-    preEnrollResponseId
+    preEnrollResponseId,
+    opts
   })
   await refreshLogin()
   return hubResponse


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Sends user back to pre-enroll if something goes wrong.

Tons of changes because of reformatting on language text keys; see [this pr](https://github.com/broadinstitute/juniper/pull/1550).


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
 I don't think there's an easy way to test this in dev. For local testing:
- Run participant ui WITH b2c
- Comment out line 115 of StudyEnrollRouter.tsx:
```
  function updatePreEnrollResponseId(preEnrollId: string | null) {
    // setPreEnrollResponseId(preEnrollId)
    setPreEnrollSatisfied(!!preEnrollId)
  }
```
- Submit pre-enroll; observe that no errors happen. This is because pre-enroll is not required.
- Set pre-enroll to required
- Enroll again, with it commented out still
- During b2c process, uncomment the line (so that second pre-enroll submission will work)
- After creating a password, observe that you get an alert
- Fill out pre-enroll again
- Observe you get taken to the consent
