### PR TITLE
[JN-1648] fix answer mapping null issue

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/AnswerProcessingService.java
@@ -161,14 +161,14 @@ public class AnswerProcessingService {
     }
 
     public static final Map<AnswerMappingMapType, BiFunction<Answer, AnswerMapping, Object>> JSON_MAPPERS = Map.of(
-            AnswerMappingMapType.STRING_TO_STRING, (Answer answer, AnswerMapping mapping) -> StringUtils.trim(answer.getStringValue()),
+            AnswerMappingMapType.STRING_TO_STRING, (Answer answer, AnswerMapping mapping) -> StringUtils.trim(answer.valueAsString()),
             AnswerMappingMapType.STRING_TO_LOCAL_DATE, (Answer answer, AnswerMapping mapping) ->
-                    mapToDate(answer.getStringValue(), mapping),
-            AnswerMappingMapType.STRING_TO_BOOLEAN, (Answer answer, AnswerMapping mapping) -> parseBoolean(answer.getStringValue())
+                    mapToDate(answer.valueAsString(), mapping),
+            AnswerMappingMapType.STRING_TO_BOOLEAN, (Answer answer, AnswerMapping mapping) -> parseBoolean(answer.valueAsString())
     );
 
     private static Boolean parseBoolean(String value) {
-        return Boolean.parseBoolean(value) || value.equalsIgnoreCase("yes");
+        return Boolean.parseBoolean(value);
     }
 
     public static LocalDate mapToDate(String dateString, AnswerMapping mapping) {

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/AnswerProcessingServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/AnswerProcessingServiceTests.java
@@ -125,10 +125,6 @@ public class AnswerProcessingServiceTests extends BaseSpringBootTest {
         assertThat((Boolean) result, equalTo(true));
 
         result = AnswerProcessingService.JSON_MAPPERS.get(AnswerMappingMapType.STRING_TO_BOOLEAN)
-                .apply(Answer.builder().stringValue("Yes").build(), mapping);
-        assertThat((Boolean) result, equalTo(true));
-
-        result = AnswerProcessingService.JSON_MAPPERS.get(AnswerMappingMapType.STRING_TO_BOOLEAN)
                 .apply(Answer.builder().stringValue("false").build(), mapping);
         assertThat((Boolean) result, equalTo(false));
     }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Bleh. the A-T answer mapping thing I did earlier isn't everything I need.

Answer mappings will throw null if non-string answer is mapped against; I am mapping against a calculated value, which has a boolean value, so when it returns `answer.getStringValue()` it fails.

I realized I didn't need the `|| value.equalsIgnoreCase("yes")` because calculated values exist. I removed that bit as well.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- n/a