### PR TITLE
[JN-1662] adding table download controls

### DIFF
--- a/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
+++ b/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
@@ -17,10 +17,10 @@ import { paramsFromContext, StudyEnvContextT } from 'study/StudyEnvironmentRoute
 import {
   basicTableLayout,
   IndeterminateCheckbox, renderEmptyMessage,
-  RowVisibilityCount, checkboxColumnCell
+  RowVisibilityCount, checkboxColumnCell, DownloadControl
 } from 'util/table/tableUtils'
 import LoadingSpinner from 'util/LoadingSpinner'
-import { Enrollee, instantToDateString, KitType, StudyEnvParams } from '@juniper/ui-core'
+import { currentIsoDate, Enrollee, instantToDateString, KitType, StudyEnvParams } from '@juniper/ui-core'
 import RequestKitsModal from './RequestKitsModal'
 import { useLoadingEffect } from 'api/api-utils'
 import { enrolleeKitRequestPath } from 'study/participants/enrolleeView/EnrolleeView'
@@ -140,6 +140,9 @@ export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvCont
     header: 'Join date',
     accessorKey: 'enrollee.createdAt',
     id: 'enrollee.createdAt',
+    meta: {
+      columnType: 'instant'
+    },
     cell: data => instantToDateString(Number(data.getValue()))
   },
   enrolleeConsentedColumn(),
@@ -160,6 +163,9 @@ export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvCont
     header: '# Optional surveys complete',
     id: 'optionalSurveys',
     enableColumnFilter: false,
+    meta: {
+      columnType: 'number'
+    },
     accessorFn: enrollee => optionalSurveysCompleted(enrollee)
   },
   ...studyEnvKitTypes.map(kitType => ({
@@ -219,6 +225,8 @@ export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvCont
           <FontAwesomeIcon icon={faPaperPlane} className="fa-lg"/> Send sample collection kit
         </Button>
         <ColumnVisibilityControl table={table} dynamicColOpts={dynamicColOpts}/>
+        <div><DownloadControl table={table}
+          fileName={`kits-${currentIsoDate()}`}/></div>
         { showRequestKitModal && <RequestKitsModal
           studyEnvContext={studyEnvContext}
           onDismiss={() => setShowRequestKitModal(false)}

--- a/ui-admin/src/study/kits/KitList.tsx
+++ b/ui-admin/src/study/kits/KitList.tsx
@@ -16,8 +16,8 @@ import {
 import Api from 'api/api'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
 import LoadingSpinner from 'util/LoadingSpinner'
-import { basicTableLayout, renderEmptyMessage } from 'util/table/tableUtils'
-import { instantToDateString, KitRequest } from '@juniper/ui-core'
+import { basicTableLayout, DownloadControl, renderEmptyMessage } from 'util/table/tableUtils'
+import { currentIsoDate, instantToDateString, KitRequest } from '@juniper/ui-core'
 import { doApiLoad, useLoadingEffect } from 'api/api-utils'
 import { enrolleeKitRequestPath } from 'study/participants/enrolleeView/EnrolleeView'
 import KitStatusCell from 'study/participants/KitStatusCell'
@@ -229,6 +229,9 @@ function KitListView({ studyEnvContext, tab, kits, initialColumnVisibility }: {
   }, {
     header: 'Created',
     accessorKey: 'createdAt',
+    meta: {
+      columnType: 'instant'
+    },
     cell: data => instantToDateString(Number(data.getValue())),
     enableColumnFilter: false
   }, {
@@ -262,6 +265,9 @@ function KitListView({ studyEnvContext, tab, kits, initialColumnVisibility }: {
   }, {
     header: 'Sent',
     accessorKey: 'sentAt',
+    meta: {
+      columnType: 'instant'
+    },
     cell: data => instantToDateString(Number(data.getValue())),
     enableColumnFilter: false
   }, {
@@ -271,6 +277,9 @@ function KitListView({ studyEnvContext, tab, kits, initialColumnVisibility }: {
   }, {
     header: 'Returned',
     accessorKey: 'receivedAt',
+    meta: {
+      columnType: 'instant'
+    },
     cell: data => instantToDateString(Number(data.getValue())),
     enableColumnFilter: false
   }, {
@@ -297,9 +306,12 @@ function KitListView({ studyEnvContext, tab, kits, initialColumnVisibility }: {
   })
 
   return <>
-    <div className="d-flex align-items-center justify-content-between">
+    <div className="d-flex align-items-center justify-content-end">
       <ColumnVisibilityControl table={table}/>
+      <div><DownloadControl table={table}
+        fileName={`kits-${currentIsoDate()}`}/></div>
     </div>
+
     { basicTableLayout(table, { filterable: true }) }
     { renderEmptyMessage(kits, `No kits with status ${tab}`) }
   </>

--- a/ui-admin/src/study/notifications/TriggerNotifications.tsx
+++ b/ui-admin/src/study/notifications/TriggerNotifications.tsx
@@ -1,14 +1,15 @@
 import React, { useState } from 'react'
-import { instantToDefaultString } from '@juniper/ui-core'
+import { currentIsoDate, instantToDefaultString } from '@juniper/ui-core'
 import { StudyEnvContextT } from '../StudyEnvironmentRouter'
 import { ColumnDef, getCoreRowModel, getSortedRowModel, SortingState, useReactTable } from '@tanstack/react-table'
 import { useLoadingEffect } from '../../api/api-utils'
 import Api, { Notification } from '../../api/api'
-import { basicTableLayout } from 'util/table/tableUtils'
+import { basicTableLayout, DownloadControl } from 'util/table/tableUtils'
 import LoadingSpinner from 'util/LoadingSpinner'
-import { NavLink, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import InfoPopup from '../../components/forms/InfoPopup'
 import { renderEmailActivityIcon } from '../participants/enrolleeView/EnrolleeTimeline'
+import { enrolleeShortcodeColumn } from '../../util/table/columnUtils'
 
 /** loads the list of notifications for a given trigger config */
 export default function TriggerNotifications({ studyEnvContext }:
@@ -21,16 +22,7 @@ export default function TriggerNotifications({ studyEnvContext }:
 
 
   const columns: ColumnDef<Notification>[] = [
-    {
-      header: 'Enrollee',
-      id: 'enrollee',
-      cell: ({ row }) => <>
-        {row.original.enrollee && <NavLink
-          to={`../../participants/${row.original.enrollee?.shortcode}`}>
-          {row.original.enrollee?.shortcode}
-        </NavLink>}
-      </>
-    },
+    enrolleeShortcodeColumn(studyEnvContext.currentEnvPath),
     {
       header: 'Sent To',
       accessorKey: 'sentTo'
@@ -57,7 +49,10 @@ export default function TriggerNotifications({ studyEnvContext }:
             }
           /></div>
         </div>,
-      accessorKey: 'opened',
+      accessorKey: 'eventDetails.opensCount',
+      meta: {
+        columnType: 'boolean'
+      },
       cell: ({ row }) => {
         return renderEmailActivityIcon(row.original)
       }
@@ -65,6 +60,9 @@ export default function TriggerNotifications({ studyEnvContext }:
     {
       header: 'time',
       accessorKey: 'createdAt',
+      meta: {
+        columnType: 'instant'
+      },
       cell: info => instantToDefaultString(info.getValue() as number)
     }
   ]
@@ -94,6 +92,8 @@ export default function TriggerNotifications({ studyEnvContext }:
     <h5>Notifications</h5>
     {/* eslint-disable-next-line react/jsx-no-undef */}
     <LoadingSpinner isLoading={isLoading}>
+      <DownloadControl table={table}
+        fileName={`SentNotifications-${currentIsoDate()}`}/>
       {basicTableLayout(table)}
     </LoadingSpinner>
   </div>

--- a/ui-admin/src/study/notifications/TriggerNotifications.tsx
+++ b/ui-admin/src/study/notifications/TriggerNotifications.tsx
@@ -92,8 +92,12 @@ export default function TriggerNotifications({ studyEnvContext }:
     <h5>Notifications</h5>
     {/* eslint-disable-next-line react/jsx-no-undef */}
     <LoadingSpinner isLoading={isLoading}>
-      <DownloadControl table={table}
-        fileName={`SentNotifications-${currentIsoDate()}`}/>
+      <div className="d-flex align-items-center">
+        Sent {tableData.length} notifications
+        <DownloadControl table={table}
+          fileName={`SentNotifications-${currentIsoDate()}`}/>
+      </div>
+
       {basicTableLayout(table)}
     </LoadingSpinner>
   </div>

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeTimeline.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeTimeline.tsx
@@ -153,11 +153,11 @@ export default function EnrolleeTimeline({ enrollee, studyEnvContext }:
 export function renderEmailActivityIcon(row: Notification) {
   const notificationEventDetails = row.eventDetails
   if (notificationEventDetails && notificationEventDetails.opensCount > 0) {
-    return <FontAwesomeIcon icon={faEnvelopeOpen} aria-label={'Email opened'}/>
+    return <FontAwesomeIcon icon={faEnvelopeOpen} aria-label={'Email opened'} />
   }
 
   if (notificationEventDetails) {
-    return <FontAwesomeIcon icon={faEnvelope} aria-label={'Email not yet opened'}/>
+    return <FontAwesomeIcon icon={faEnvelope} aria-label={'Email not yet opened'} />
   }
 
   return <span className="fw-light fst-italic">n/a</span>

--- a/ui-admin/src/util/downloadUtils.ts
+++ b/ui-admin/src/util/downloadUtils.ts
@@ -1,5 +1,8 @@
 /** escapes double quotes with an extra ", and adds double quotes around any values that contain commas or newlines */
-export const escapeCsvValue = (value: string) => {
+export const escapeCsvValue = (value?: string) => {
+  if (!value) {
+    return ''
+  }
   value = value.replaceAll('"', '""')
   if (value && (value.includes(',') || value.includes('\n') || value.includes('"'))) {
     return `"${value}"`

--- a/ui-admin/src/util/table/columnUtils.tsx
+++ b/ui-admin/src/util/table/columnUtils.tsx
@@ -122,8 +122,12 @@ export function DynamicColumnControl({ facets, dynamicFacets, setDynamicFacets }
   </div>
 }
 
-
-export const enrolleeShortcodeColumn = <T extends EnrolleeSearchExpressionResult, >(currentEnvPath: string):
+export type HasEnrolleeShortcode = {
+  enrollee?: {
+    shortcode: string
+  }
+}
+export const enrolleeShortcodeColumn = <T extends HasEnrolleeShortcode, >(currentEnvPath: string):
   ColumnDef<T> => {
   return {
     header: 'Shortcode',

--- a/ui-admin/src/util/table/tableUtils.tsx
+++ b/ui-admin/src/util/table/tableUtils.tsx
@@ -284,6 +284,8 @@ function cellToCsvString(cellType: string, cellValue: unknown): string {
       return cellValue ? escapeCsvValue(cellValue as string) : ''
     case 'instant':
       return escapeCsvValue(instantToDefaultString(cellValue as number))
+    case 'number':
+      return cellValue !== undefined ? (cellValue as number).toString() : ''
     case 'boolean':
       return cellValue as boolean ? 'true' : 'false'
     default:


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds some table download controls to tables that didn't have them previously.  

<img width="1290" alt="image" src="https://github.com/user-attachments/assets/a7bee5c5-dd95-455b-bbae-2bc4f556c96a" />

<img width="1291" alt="image" src="https://github.com/user-attachments/assets/455aaa89-77c4-491c-a975-ff369bf0459e" />

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
1. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/triggers
2. click enrollment email
3. click download, confirm the download shows all columns correctly
4. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/kits/requested/sent
5. click download, confirm it shows correctly 
