### PR TITLE
[JN-1663] save new responses as in-progress

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -192,15 +192,14 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         //if the survey is longitudinal and we're past the cutoff point for updating an existing response, we need to create a new response and task
         if (survey.getRecurrenceType() == RecurrenceType.LONGITUDINAL
                 && priorResponse != null
+                && task.getStatus() == TaskStatus.COMPLETE
                 && shouldCreateNewLongitudinalTaskAndResponse(survey.getCreateNewResponseAfterDays(), priorResponse.getLastUpdatedAt())
                 // admin saving update should never trigger a new response;
                 // they can re-assign if they want a fresh response
                 && operator.getParticipantUser() != null
         ) {
             ParticipantTask newTask = participantTaskService.cleanForCopying(task);
-            if(newTask.getCompletedAt() != null) {
-                newTask.setCompletedAt(Instant.now());
-            }
+            newTask.setStatus(TaskStatus.IN_PROGRESS);
             priorResponse.getAnswers().forEach(a -> a.setSurveyResponseId(null));
             response = surveyTaskDispatcher.createPrepopulatedSurveyResponse(priorResponse);
             newTask.setSurveyResponseId(response.getId());

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -200,6 +200,7 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         ) {
             ParticipantTask newTask = participantTaskService.cleanForCopying(task);
             newTask.setStatus(TaskStatus.IN_PROGRESS);
+            newTask.setCompletedAt(null);
             priorResponse.getAnswers().forEach(a -> a.setSurveyResponseId(null));
             response = surveyTaskDispatcher.createPrepopulatedSurveyResponse(priorResponse);
             newTask.setSurveyResponseId(response.getId());

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
@@ -15,7 +15,6 @@ import bio.terra.pearl.core.service.survey.event.EnrolleeSurveyEvent;
 import bio.terra.pearl.core.service.survey.event.SurveyPublishedEvent;
 import bio.terra.pearl.core.service.workflow.*;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.BeanUtils;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
@@ -170,6 +169,7 @@ public class SurveyTaskDispatcher extends TaskDispatcher<SurveyTaskConfigDto> {
                 .lastUpdatedAt(Instant.now())
                 .answers(answers)
                 .participantFiles(priorResponse.getParticipantFiles())
+                .complete(false)
                 .build();
 
         return surveyResponseService.create(newResponse);

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
@@ -381,6 +381,7 @@ public class SurveyResponseServiceTests extends BaseSpringBootTest {
         Survey survey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
                 .portalId(studyEnvBundle.getPortal().getId())
                 .recurrenceType(RecurrenceType.LONGITUDINAL)
+                .recurrenceIntervalDays(365)
                 .createNewResponseAfterDays(7));
 
         StudyEnvironmentSurvey ses = surveyFactory.attachToEnv(survey, studyEnvBundle.getStudyEnv().getId(), true);
@@ -396,9 +397,11 @@ public class SurveyResponseServiceTests extends BaseSpringBootTest {
                 .creatingParticipantUserId(enrollee1.getParticipantUserId())
                 .surveyId(survey.getId())
                 .lastUpdatedAt(Instant.now().minus(1, ChronoUnit.DAYS))
+                .complete(true)
                 .build());
         ParticipantTask task1 = surveyTaskDispatcher.buildTask(enrolleeBundle1.enrollee(), enrolleeBundle1.portalParticipantUser(), new SurveyTaskConfigDto(ses));
         task1.setSurveyResponseId(response1.getId());
+        task1.setStatus(TaskStatus.COMPLETE);
         task1 = participantTaskService.create(task1, getAuditInfo(info));
 
 
@@ -407,9 +410,11 @@ public class SurveyResponseServiceTests extends BaseSpringBootTest {
                 .creatingParticipantUserId(enrollee2.getParticipantUserId())
                 .surveyId(survey.getId())
                 .lastUpdatedAt(Instant.now().minus(8, ChronoUnit.DAYS))
+                .complete(true)
                 .build());
         ParticipantTask task2 = surveyTaskDispatcher.buildTask(enrolleeBundle2.enrollee(), enrolleeBundle2.portalParticipantUser(), new SurveyTaskConfigDto(ses));
         task2.setSurveyResponseId(response2.getId());
+        task2.setStatus(TaskStatus.COMPLETE);
         task2 = participantTaskService.create(task2, getAuditInfo(info));
 
         SurveyResponse newResponse1 = SurveyResponse.builder()
@@ -444,6 +449,53 @@ public class SurveyResponseServiceTests extends BaseSpringBootTest {
 
         // created a new task
         assertThat(responseTask2.getId(), not(equalTo(task2.getId())));
+    }
+
+    @Test
+    @Transactional
+    public void testLongitudinalDoesNotSaveInProgressEditAsNewTask(TestInfo info) {
+        StudyEnvironmentBundle studyEnvBundle = studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.sandbox);
+
+        Survey survey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .portalId(studyEnvBundle.getPortal().getId())
+                .recurrenceType(RecurrenceType.LONGITUDINAL)
+                .recurrenceIntervalDays(365)
+                .createNewResponseAfterDays(7));
+
+        StudyEnvironmentSurvey ses = surveyFactory.attachToEnv(survey, studyEnvBundle.getStudyEnv().getId(), true);
+
+        EnrolleeBundle enrolleeBundle = enrolleeFactory.buildWithPortalUser(getTestName(info), studyEnvBundle.getPortalEnv(), studyEnvBundle.getStudyEnv());
+        Enrollee enrollee = enrolleeBundle.enrollee();
+
+
+        SurveyResponse response = surveyResponseService.create(SurveyResponse.builder()
+                .enrolleeId(enrollee.getId())
+                .creatingParticipantUserId(enrollee.getParticipantUserId())
+                .surveyId(survey.getId())
+                .lastUpdatedAt(Instant.now().minus(9, ChronoUnit.DAYS))
+                .complete(true)
+                .build());
+        ParticipantTask task = surveyTaskDispatcher.buildTask(enrolleeBundle.enrollee(), enrolleeBundle.portalParticipantUser(), new SurveyTaskConfigDto(ses));
+        task.setSurveyResponseId(response.getId());
+        task.setStatus(TaskStatus.IN_PROGRESS);
+        task = participantTaskService.create(task, getAuditInfo(info));
+
+
+        SurveyResponse newResponse = SurveyResponse.builder()
+                .enrolleeId(enrollee.getId())
+                .creatingParticipantUserId(enrollee.getParticipantUserId())
+                .surveyId(survey.getId())
+                .lastUpdatedAt(Instant.now())
+                .build();
+        // update response
+        HubResponse<SurveyResponse> hubResponse = surveyResponseService.updateResponse(
+                newResponse, new ResponsibleEntity(enrolleeBundle.participantUser()), null,
+                enrolleeBundle.portalParticipantUser(), enrollee, task.getId(), survey.getPortalId());
+
+        ParticipantTask responseTask = hubResponse.getTasks().stream().filter(t -> t.getSurveyResponseId().equals(hubResponse.getResponse().getId())).findFirst().get();
+
+        // did not create a new task
+        assertThat(responseTask.getId(), equalTo(task.getId()));
     }
 
     @Test

--- a/ui-core/src/components/forms/PagedSurveyView.tsx
+++ b/ui-core/src/components/forms/PagedSurveyView.tsx
@@ -188,11 +188,17 @@ export function PagedSurveyView({
         .participantTasks
         .filter(task => task.targetStableId === form.stableId)
 
-      if (tasks.length > 0) {
+      const allTasksCompleted = tasks.every(task => task.status === 'COMPLETE')
+
+      if (!allTasksCompleted) {
+        return tasks.find(task => task.id === taskId)?.status !== 'IN_PROGRESS'
+      }
+
+      if (tasks.length > 1) {
         const latestTask = tasks.reduce(
           (
             a, b
-          ) => a.completedAt && b.completedAt && a.completedAt > b.completedAt ? a : b)
+          ) => a.createdAt && b.createdAt && a.createdAt > b.createdAt ? a : b)
 
         // if the task is not the latest task, then it should be readonly
         if (taskId != latestTask.id) {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Cleans up longitudinal surveys to make a bit more sense
- Editing an old survey saves an In Progress response 
    - From a-t's perspective (which makes sense to me), you can't guarantee that some random edit is, from the enrollee's perspective, a complete response, and could lead to misleading data if they decide to leave for a while then come back and end up making a whole new response. So we should force them to hit complete. If they don't, they will get survey reminders and/or study staff can update the status.
- Doesn't create new longitudinal response if editing in-progress survey, only creates new response for (old) complete surveys. 
    - That way if a response is lingering for a while and an enrollee goes back to edit it, it doesn't start adding unexpected columns to their data until the enrollee confirms the survey is completed.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- log in as jsalk
- edit lifestyle 
- observe it becomes in progress
- observe read-only survey logic still works as expected
