### PR TITLE
[JN-1665 & JN-1668] fix invitation process for proxies and non-english enrollees

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -286,8 +286,13 @@ public class EnrolleeImportService {
                         portalShortcode,
                         studyEnv,
                         ParticipantUser.builder().username(accountData.getEmail()).build());
-
-                accountEnrollee = createProxyEnrolleeIfNeeded(studyShortcode, studyEnv, regResult, auditInfo);
+                String preferredLanguage = accountData.proxyData
+                        .stream()
+                        .map(proxyData -> proxyData.get("profile.preferredLanguage"))
+                        .filter(Objects::nonNull)
+                        .findFirst()
+                        .orElse(null);
+                accountEnrollee = createProxyEnrolleeIfNeeded(studyShortcode, studyEnv, regResult, preferredLanguage, auditInfo);
                 importItems.add(createImportItemFromEnrollee(accountEnrollee, importId));
             }
         } catch (Exception e) {
@@ -455,9 +460,12 @@ public class EnrolleeImportService {
         });
     }
 
-    private @NotNull Enrollee createProxyEnrolleeIfNeeded(String studyShortcode, StudyEnvironment studyEnv, RegistrationService.RegistrationResult registration, DataAuditInfo auditInfo) {
+    private @NotNull Enrollee createProxyEnrolleeIfNeeded(String studyShortcode, StudyEnvironment studyEnv, RegistrationService.RegistrationResult registration, String preferredLanguage, DataAuditInfo auditInfo) {
 
         registration.profile().setDoNotEmail(true);
+        if (preferredLanguage != null) {
+            registration.profile().setPreferredLanguage(preferredLanguage);
+        }
         profileService.update(registration.profile(), auditInfo);
 
         Optional<Enrollee> enrollee = enrolleeService.findByParticipantUserIdAndStudyEnvId(registration.participantUser().getId(), studyEnv.getId());

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
@@ -48,7 +48,8 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
         valueMap.put("participantSupportEmailLink", getParticipantSupportEmailLink(contextInfo.portalEnv(), contextInfo.portalEnvConfig()));
         valueMap.put("siteMediaBaseUrl", getImageBaseUrl(contextInfo.portalEnv(), contextInfo.portalEnvConfig(), contextInfo.portal().getShortcode()));
         valueMap.put("siteImageBaseUrl", getImageBaseUrl(contextInfo.portalEnv(), contextInfo.portalEnvConfig(), contextInfo.portal().getShortcode()));
-        if (isProxy(ruleData)) {
+        boolean isProxy = isProxy(ruleData);
+        if (isProxy) {
             valueMap.put("isProxy", "true");
         } else {
             valueMap.put("isProxy", "false");
@@ -56,7 +57,7 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
         valueMap.put("enrollee", ruleData.getEnrollee());
         valueMap.put("study", contextInfo.study());
         valueMap.put("participantUser", ruleData.getParticipantUser());
-        valueMap.put("invitationLink", getInvitationLink(contextInfo.portalEnv(), contextInfo.portalEnvConfig(), contextInfo.portal().getShortcode(), ruleData.getParticipantUser()));
+        valueMap.put("invitationLink", getInvitationLink(contextInfo.portalEnv(), contextInfo.portalEnvConfig(), contextInfo.portal().getShortcode(), ruleData.getParticipantUser(), isProxy));
         if (messages != null) {
             valueMap.putAll(messages);
         }
@@ -173,15 +174,27 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
     /**
      * gets a link the participant can use to create their b2c account, given that they already exist in Juniper
      */
-    public String getInvitationLink(PortalEnvironment portalEnv, PortalEnvironmentConfig config, String portalShortcode, ParticipantUser participantUser) {
+    public String getInvitationLink(PortalEnvironment portalEnv, PortalEnvironmentConfig config, String portalShortcode, ParticipantUser participantUser, boolean isProxy) {
         try {
+            String username = isProxy
+                    ? removeProxySuffix(participantUser.getUsername())
+                    : participantUser.getUsername();
             return "%s%s?accountName=%s".formatted(
                     routingPaths.getParticipantBaseUrl(portalEnv, config, portalShortcode),
                     routingPaths.getParticipantInvitationPath(),
                     participantUser != null ?
-                            URLEncoder.encode(participantUser.getUsername(), StandardCharsets.UTF_8.toString()) : "");
+                            URLEncoder.encode(
+                                    username,
+                                    StandardCharsets.UTF_8.toString()) : "");
         } catch (UnsupportedEncodingException e) {
             throw new IOInternalException("unable to encode username");
         }
+    }
+
+    private String removeProxySuffix(String email) {
+        // if the email ends with -prox-XXXX, remove it
+        Pattern proxySuffix = Pattern.compile("-prox-[A-Z]{4}$");
+
+        return proxySuffix.matcher(email).replaceAll("");
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
@@ -182,17 +182,18 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
                                     Profile profile,
                                     boolean isProxy) {
         try {
-            String username = isProxy
-                    ? removeProxySuffix(participantUser.getUsername())
-                    : participantUser.getUsername();
+            String username = participantUser != null ? participantUser.getUsername() : "";
+
+            if (isProxy) {
+                username = removeProxySuffix(username);
+            }
 
             String url = "%s%s?accountName=%s".formatted(
                     routingPaths.getParticipantBaseUrl(portalEnv, config, portalShortcode),
                     routingPaths.getParticipantInvitationPath(),
-                    participantUser != null ?
                             URLEncoder.encode(
                                     username,
-                                    StandardCharsets.UTF_8.toString()) : "");
+                                    StandardCharsets.UTF_8.toString()));
 
             if (profile != null && StringUtils.isNotEmpty(profile.getPreferredLanguage())) {
                 url += "&preferredLanguage=" + profile.getPreferredLanguage();

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
@@ -65,8 +65,6 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
     }
 
     private boolean isProxy(EnrolleeContext context) {
-        System.out.println("Relations: " + context.getRelations());
-
         if (context.getRelations() == null) {
             return false;
         }
@@ -184,7 +182,6 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
                                     Profile profile,
                                     boolean isProxy) {
         try {
-            System.out.println("are we da proxy " + isProxy);
             String username = isProxy
                     ? removeProxySuffix(participantUser.getUsername())
                     : participantUser.getUsername();
@@ -207,7 +204,6 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
     }
 
     private String removeProxySuffix(String email) {
-        System.out.println("YEAH WE REMOVE THAT SHIT");
         // if the email ends with -prox-XXXX, remove it
         Pattern proxySuffix = Pattern.compile("-prox-[A-Z]{4}$");
 

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
@@ -10,6 +10,7 @@ import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.service.exception.internal.IOInternalException;
 import bio.terra.pearl.core.service.notification.NotificationContextInfo;
 import bio.terra.pearl.core.service.rule.EnrolleeContext;
+import bio.terra.pearl.core.service.workflow.RegistrationService;
 import bio.terra.pearl.core.shared.ApplicationRoutingPaths;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.beanutils.PropertyUtils;
@@ -185,7 +186,7 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
             String username = participantUser != null ? participantUser.getUsername() : "";
 
             if (isProxy) {
-                username = removeProxySuffix(username);
+                username = RegistrationService.removeProxySuffix(username);
             }
 
             String url = "%s%s?accountName=%s".formatted(
@@ -204,10 +205,4 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
         }
     }
 
-    private String removeProxySuffix(String email) {
-        // if the email ends with -prox-XXXX, remove it
-        Pattern proxySuffix = Pattern.compile("-prox-[A-Z]{4}$");
-
-        return proxySuffix.matcher(email).replaceAll("");
-    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.service.notification.substitutors;
 
 import bio.terra.pearl.core.model.participant.ParticipantUser;
+import bio.terra.pearl.core.model.participant.Profile;
 import bio.terra.pearl.core.model.participant.RelationshipType;
 import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
@@ -57,13 +58,15 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
         valueMap.put("enrollee", ruleData.getEnrollee());
         valueMap.put("study", contextInfo.study());
         valueMap.put("participantUser", ruleData.getParticipantUser());
-        valueMap.put("invitationLink", getInvitationLink(contextInfo.portalEnv(), contextInfo.portalEnvConfig(), contextInfo.portal().getShortcode(), ruleData.getParticipantUser(), isProxy));
+        valueMap.put("invitationLink", getInvitationLink(contextInfo.portalEnv(), contextInfo.portalEnvConfig(), contextInfo.portal().getShortcode(), ruleData.getParticipantUser(), enrolleeContext.getProfile(), isProxy));
         if (messages != null) {
             valueMap.putAll(messages);
         }
     }
 
     private boolean isProxy(EnrolleeContext context) {
+        System.out.println("Relations: " + context.getRelations());
+
         if (context.getRelations() == null) {
             return false;
         }
@@ -174,24 +177,37 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
     /**
      * gets a link the participant can use to create their b2c account, given that they already exist in Juniper
      */
-    public String getInvitationLink(PortalEnvironment portalEnv, PortalEnvironmentConfig config, String portalShortcode, ParticipantUser participantUser, boolean isProxy) {
+    public String getInvitationLink(PortalEnvironment portalEnv,
+                                    PortalEnvironmentConfig config,
+                                    String portalShortcode,
+                                    ParticipantUser participantUser,
+                                    Profile profile,
+                                    boolean isProxy) {
         try {
+            System.out.println("are we da proxy " + isProxy);
             String username = isProxy
                     ? removeProxySuffix(participantUser.getUsername())
                     : participantUser.getUsername();
-            return "%s%s?accountName=%s".formatted(
+
+            String url = "%s%s?accountName=%s".formatted(
                     routingPaths.getParticipantBaseUrl(portalEnv, config, portalShortcode),
                     routingPaths.getParticipantInvitationPath(),
                     participantUser != null ?
                             URLEncoder.encode(
                                     username,
                                     StandardCharsets.UTF_8.toString()) : "");
+
+            if (profile != null && StringUtils.isNotEmpty(profile.getPreferredLanguage())) {
+                url += "&preferredLanguage=" + profile.getPreferredLanguage();
+            }
+            return url;
         } catch (UnsupportedEncodingException e) {
             throw new IOInternalException("unable to encode username");
         }
     }
 
     private String removeProxySuffix(String email) {
+        System.out.println("YEAH WE REMOVE THAT SHIT");
         // if the email ends with -prox-XXXX, remove it
         Pattern proxySuffix = Pattern.compile("-prox-[A-Z]{4}$");
 

--- a/core/src/main/java/bio/terra/pearl/core/service/rule/EnrolleeContextService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/rule/EnrolleeContextService.java
@@ -67,7 +67,7 @@ public class EnrolleeContextService {
         for (Enrollee enrollee : enrollees) {
             List<EnrolleeRelation> enrolleeRelations = new ArrayList<>();
             for (EnrolleeRelation relation : allRelations) {
-                if (relation.getEnrolleeId().equals(enrollee.getId())) {
+                if (relation.getEnrolleeId().equals(enrollee.getId()) || relation.getTargetEnrolleeId().equals(enrollee.getId())) {
                     enrolleeRelations.add(relation);
                 }
             }

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/RegistrationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/RegistrationService.java
@@ -31,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 @Service
 @Slf4j
@@ -206,6 +207,15 @@ public class RegistrationService {
         return GOVERNED_USERNAME_INDICATOR.formatted(proxyUserName, governedUsernameSuffix);//a@b.com-prox-guid
 
     }
+
+    public static String removeProxySuffix(String email) {
+        // if the email ends with -prox-XXXX, remove it
+        Pattern proxySuffix = Pattern.compile("-prox-[A-Z]{4}$");
+
+        return proxySuffix.matcher(email).replaceAll("");
+    }
+
+
     public record RegistrationResult(ParticipantUser participantUser,
                                      PortalParticipantUser portalParticipantUser,
                                      Profile profile) {

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailSubstitutorTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailSubstitutorTests.java
@@ -155,7 +155,7 @@ public class EnrolleeEmailSubstitutorTests extends BaseSpringBootTest {
         NotificationContextInfo contextInfo = new NotificationContextInfo(portal, portalEnv, portalEnvironmentConfig, null, null);
         StringSubstitutor replacer = EnrolleeEmailSubstitutor.newSubstitutor(ruleData, contextInfo, routingPaths);
         assertThat(replacer.replace("here's an invite: ${invitationLink}"),
-                equalTo("here's an invite: https://irb.newstudy.org/join/invitation?accountName=test123%40test.com"));
+                equalTo("here's an invite: https://irb.newstudy.org/join/invitation?accountName=test123%40test.com&preferredLanguage=en"));
     }
 
     @Test
@@ -243,8 +243,43 @@ public class EnrolleeEmailSubstitutorTests extends BaseSpringBootTest {
         StringSubstitutor nonProxyReplacer = EnrolleeEmailSubstitutor.newSubstitutor(nonProxyData, contextInfo, routingPaths);
 
         assertThat(proxyReplacer.replace("here's an invite: ${invitationLink}"),
-                equalTo("here's an invite: https://irb.newstudy.org/join/invitation?accountName=asdf%40asdf.com"));
+                equalTo("here's an invite: https://irb.newstudy.org/join/invitation?accountName=asdf%40asdf.com&preferredLanguage=en"));
         assertThat(nonProxyReplacer.replace("here's an invite: ${invitationLink}"),
-                equalTo("here's an invite: https://irb.newstudy.org/join/invitation?accountName=asdf%40asdf.com"));
+                equalTo("here's an invite: https://irb.newstudy.org/join/invitation?accountName=asdf%40asdf.com&preferredLanguage=en"));
+    }
+
+    @Test
+    public void testInvitationLinkSpecifiesLanguage(TestInfo info) {
+        UUID enrolleeId = UUID.randomUUID();
+        EnrolleeContext esData = new EnrolleeContext(
+                Enrollee.builder().id(enrolleeId).build(),
+                Profile.builder().preferredLanguage("es").build(),
+                ParticipantUser.builder().username("asdf@asdf.com").build(),
+                null);
+
+        EnrolleeContext zhData = new EnrolleeContext(
+                Enrollee.builder().id(enrolleeId).build(),
+                Profile.builder().givenName("test name").preferredLanguage("zh").build(),
+                ParticipantUser.builder().username("asdf@asdf.com").build(),
+                null);
+
+        PortalEnvironmentConfig portalEnvironmentConfig = PortalEnvironmentConfig.builder()
+                .participantHostname("newstudy.org")
+                .build();
+
+        PortalEnvironment portalEnv = portalEnvironmentFactory.builder(getTestName(info))
+                .portalEnvironmentConfig(portalEnvironmentConfig).environmentName(EnvironmentName.irb).build();
+
+        Portal portal = Portal.builder().name("PortalA").build();
+
+        NotificationContextInfo contextInfo = new NotificationContextInfo(portal, portalEnv, portalEnvironmentConfig, null, null);
+
+        StringSubstitutor esReplacer = EnrolleeEmailSubstitutor.newSubstitutor(esData, contextInfo, routingPaths);
+        StringSubstitutor zhReplacer = EnrolleeEmailSubstitutor.newSubstitutor(zhData, contextInfo, routingPaths);
+
+        assertThat(esReplacer.replace("here's an invite: ${invitationLink}"),
+                equalTo("here's an invite: https://irb.newstudy.org/join/invitation?accountName=asdf%40asdf.com&preferredLanguage=es"));
+        assertThat(zhReplacer.replace("here's an invite: ${invitationLink}"),
+                equalTo("here's an invite: https://irb.newstudy.org/join/invitation?accountName=asdf%40asdf.com&preferredLanguage=zh"));
     }
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailSubstitutorTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailSubstitutorTests.java
@@ -205,4 +205,46 @@ public class EnrolleeEmailSubstitutorTests extends BaseSpringBootTest {
                 equalTo("test name"));
 
     }
+
+    @Test
+    public void testProxyInvitationLink(TestInfo info) {
+        UUID enrolleeId = UUID.randomUUID();
+        EnrolleeContext proxyData = new EnrolleeContext(
+                Enrollee.builder().id(enrolleeId).build(),
+                Profile.builder().givenName("test name").build(),
+                ParticipantUser.builder().username("asdf@asdf.com-prox-TEST").build(),
+                List.of(
+                        // enrollee has a proxy
+                        EnrolleeRelation
+                                .builder()
+                                .targetEnrolleeId(enrolleeId)
+                                .relationshipType(RelationshipType.PROXY)
+                                .build()
+                ));
+
+        EnrolleeContext nonProxyData = new EnrolleeContext(
+                Enrollee.builder().id(enrolleeId).build(),
+                Profile.builder().givenName("test name").build(),
+                ParticipantUser.builder().username("asdf@asdf.com").build(),
+                null);
+
+        PortalEnvironmentConfig portalEnvironmentConfig = PortalEnvironmentConfig.builder()
+                .participantHostname("newstudy.org")
+                .build();
+
+        PortalEnvironment portalEnv = portalEnvironmentFactory.builder(getTestName(info))
+                .portalEnvironmentConfig(portalEnvironmentConfig).environmentName(EnvironmentName.irb).build();
+
+        Portal portal = Portal.builder().name("PortalA").build();
+
+        NotificationContextInfo contextInfo = new NotificationContextInfo(portal, portalEnv, portalEnvironmentConfig, null, null);
+
+        StringSubstitutor proxyReplacer = EnrolleeEmailSubstitutor.newSubstitutor(proxyData, contextInfo, routingPaths);
+        StringSubstitutor nonProxyReplacer = EnrolleeEmailSubstitutor.newSubstitutor(nonProxyData, contextInfo, routingPaths);
+
+        assertThat(proxyReplacer.replace("here's an invite: ${invitationLink}"),
+                equalTo("here's an invite: https://irb.newstudy.org/join/invitation?accountName=asdf%40asdf.com"));
+        assertThat(nonProxyReplacer.replace("here's an invite: ${invitationLink}"),
+                equalTo("here's an invite: https://irb.newstudy.org/join/invitation?accountName=asdf%40asdf.com"));
+    }
 }

--- a/ui-participant/src/Navbar.tsx
+++ b/ui-participant/src/Navbar.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 
 import Api, { getEnvSpec } from 'api/api'
 import {
+  getB2CLocale,
   ParticipantNavbar,
-  useI18n,
-  getB2CLocale
+  useI18n
 } from '@juniper/ui-core'
 import { useUser } from 'providers/UserProvider'
 import { useConfig } from 'providers/ConfigProvider'
@@ -20,7 +20,7 @@ type NavbarProps = JSX.IntrinsicElements['nav']
 export default function Navbar(props: NavbarProps) {
   const { user, logoutUser, proxyRelations } = useUser()
   const { profile, ppUser } = useActiveUser()
-  const { selectedLanguage } = useI18n()
+  const { selectedLanguage, changeLanguage } = useI18n()
   const config = useConfig()
   const envSpec = getEnvSpec()
 
@@ -30,6 +30,13 @@ export default function Navbar(props: NavbarProps) {
     reloadPortal,
     localContent
   } = usePortalEnv()
+
+  useEffect(() => {
+    if (profile && profile.preferredLanguage && selectedLanguage !== profile.preferredLanguage) {
+      changeLanguage(profile.preferredLanguage)
+      reloadPortal()
+    }
+  }, [profile?.preferredLanguage, selectedLanguage, changeLanguage])
 
 
   async function updatePreferredLanguage(selectedLanguage: string) {

--- a/ui-participant/src/landing/registration/InvitationPage.tsx
+++ b/ui-participant/src/landing/registration/InvitationPage.tsx
@@ -1,11 +1,15 @@
 import React, { useEffect } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import {
+  useNavigate,
+  useSearchParams
+} from 'react-router-dom'
 import { useAuth } from 'react-oidc-context'
 import { PageLoadingIndicator } from 'util/LoadingSpinner'
 import { useUser } from 'providers/UserProvider'
 import Api, { getEnvSpec } from 'api/api'
 import { useInvitationType } from 'browserPersistentState'
 import envVars from 'util/envVars'
+import { getB2CLocale } from '@juniper/ui-core'
 
 /** Page for participants who already have enrollee data in Juniper (from a migration or admin action), and need
  * to join to link their account */
@@ -13,6 +17,7 @@ export default function InvitationPage() {
   const auth = useAuth()
   const [searchParams] = useSearchParams()
   const accountName = searchParams.get('accountName') || ''
+  const preferredLanguage = searchParams.get('preferredLanguage') || ''
   const navigate = useNavigate()
   const { loginUser } = useUser()
   const [, setInvitationType] = useInvitationType()
@@ -36,7 +41,9 @@ export default function InvitationPage() {
         portalEnvironment: envSpec.envName,
         portalShortcode: envSpec.shortcode as string,
         // eslint-disable-next-line camelcase
-        login_hint: accountName
+        login_hint: accountName,
+        // eslint-disable-next-line camelcase
+        ui_locales: getB2CLocale(preferredLanguage)
       }
     })
   }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Now, invitations will prefill properly for proxies. Also, `preferredLanguage` will propagate to the proxy, which will now also be maintained across the import/invitation process.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- import this spanish enrollee with proxy:
[2025-04-18-enrollees.tsv.zip](https://github.com/user-attachments/files/19814909/2025-04-18-enrollees.tsv.zip)
(if on demo server search and replace `testspanishproxy@test.com` with your email)
- send invitation email to imported governed user
- observe that it prefills with the correct email (no `-prox-ASDF`) and in the correct language
- observe upon landing that it shows the correct language
