### PR TITLE
[JN-1679] fix not equals sql behavior

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/search/expressions/SearchOperators.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/expressions/SearchOperators.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public enum SearchOperators {
     EQUALS("="),
-    NOT_EQUALS("!="),
+    NOT_EQUALS("IS DISTINCT FROM"),
     GREATER_THAN(">"),
     LESS_THAN("<"),
     GREATER_THAN_EQ(">="),

--- a/core/src/test/java/bio/terra/pearl/core/dao/search/EnrolleeSearchExpressionDaoTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/search/EnrolleeSearchExpressionDaoTests.java
@@ -27,7 +27,6 @@ import bio.terra.pearl.core.service.participant.ProfileService;
 import bio.terra.pearl.core.service.search.EnrolleeSearchExpression;
 import bio.terra.pearl.core.service.search.EnrolleeSearchExpressionParser;
 import bio.terra.pearl.core.service.search.EnrolleeSearchOptions;
-import bio.terra.pearl.core.service.search.expressions.DefaultSearchExpression;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Assertions;
@@ -892,6 +891,41 @@ public class EnrolleeSearchExpressionDaoTests extends BaseSpringBootTest {
         Assertions.assertTrue(results.stream().anyMatch(r -> r.getEnrollee().getId().equals(enrolleeBundle3.enrollee().getId()) &&
                 r.getKitRequests().size() == 1 &&
                 r.getKitRequests().stream().allMatch(t -> t.getId().equals(kitRequest3.getId()))));
+    }
+
+    @Test
+    @Transactional
+    public void testNotEqualsNullable(TestInfo info) {
+        StudyEnvironment studyEnv = studyEnvironmentFactory.buildPersisted(getTestName(info));
+        Survey survey = surveyFactory.buildPersisted(getTestName(info));
+        surveyFactory.attachToEnv(survey, studyEnv.getId(), true);
+
+        Enrollee enrollee1 = enrolleeFactory.buildPersisted(getTestName(info), studyEnv); // has survey response and answer
+        Enrollee enrollee2 = enrolleeFactory.buildPersisted(getTestName(info), studyEnv); // has survey response and answer, but not 'answer1'
+        Enrollee enrollee3 = enrolleeFactory.buildPersisted(getTestName(info), studyEnv); // has survey response but no answer
+        Enrollee enrollee4 = enrolleeFactory.buildPersisted(getTestName(info), studyEnv); // no survey response
+        
+        surveyResponseFactory.buildWithAnswers(enrollee1, survey, Map.of(
+                "testquestion", "answer1"
+        ));
+
+        surveyResponseFactory.buildWithAnswers(enrollee2, survey, Map.of(
+                "testquestion", "answer2"
+        ));
+
+        surveyResponseFactory.buildWithAnswers(enrollee3, survey, Map.of());
+
+
+        EnrolleeSearchExpression searchExp = enrolleeSearchExpressionParser.parseRule(
+                "{answer.%s.testquestion} != 'answer1'".formatted(survey.getStableId())
+        );
+
+        List<EnrolleeSearchExpressionResult> results = enrolleeSearchExpressionDao.executeSearch(searchExp, studyEnv.getId());
+
+        Assertions.assertEquals(3, results.size());
+        Assertions.assertTrue(results.stream().anyMatch(r -> r.getEnrollee().getId().equals(enrollee2.getId())));
+        Assertions.assertTrue(results.stream().anyMatch(r -> r.getEnrollee().getId().equals(enrollee3.getId())));
+        Assertions.assertTrue(results.stream().anyMatch(r -> r.getEnrollee().getId().equals(enrollee4.getId())));
     }
 
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/search/expressions/EnrolleeSearchExpressionTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/search/expressions/EnrolleeSearchExpressionTest.java
@@ -1,7 +1,6 @@
 package bio.terra.pearl.core.service.search.expressions;
 
 import bio.terra.pearl.core.BaseSpringBootTest;
-import bio.terra.pearl.core.dao.dataimport.TimeShiftDao;
 import bio.terra.pearl.core.factory.StudyEnvironmentBundle;
 import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
 import bio.terra.pearl.core.factory.kit.KitRequestFactory;
@@ -732,6 +731,39 @@ class EnrolleeSearchExpressionTest extends BaseSpringBootTest {
 
         assertFalse(wrongQuestion.evaluate(enrollee1Context));
         assertFalse(wrongQuestion.evaluate(enrollee2Context));
+    }
+
+    @Test
+    @Transactional
+    public void testNotEqualsNullable(TestInfo info) {
+        StudyEnvironment studyEnv = studyEnvironmentFactory.buildPersisted(getTestName(info));
+        Survey survey = surveyFactory.buildPersisted(getTestName(info));
+        surveyFactory.attachToEnv(survey, studyEnv.getId(), true);
+
+        Enrollee enrollee1 = enrolleeFactory.buildPersisted(getTestName(info), studyEnv); // has survey response and answer
+        Enrollee enrollee2 = enrolleeFactory.buildPersisted(getTestName(info), studyEnv); // has survey response and answer, but not 'answer1'
+        Enrollee enrollee3 = enrolleeFactory.buildPersisted(getTestName(info), studyEnv); // has survey response but no answer
+        Enrollee enrollee4 = enrolleeFactory.buildPersisted(getTestName(info), studyEnv); // no survey response
+
+        surveyResponseFactory.buildWithAnswers(enrollee1, survey, Map.of(
+                "testquestion", "answer1"
+        ));
+
+        surveyResponseFactory.buildWithAnswers(enrollee2, survey, Map.of(
+                "testquestion", "answer2"
+        ));
+
+        surveyResponseFactory.buildWithAnswers(enrollee3, survey, Map.of());
+
+
+        EnrolleeSearchExpression searchExp = enrolleeSearchExpressionParser.parseRule(
+                "{answer.%s.testquestion} != 'answer1'".formatted(survey.getStableId())
+        );
+
+        assertFalse(searchExp.evaluate(EnrolleeSearchContext.builder().enrollee(enrollee1).build()));
+        assertTrue(searchExp.evaluate(EnrolleeSearchContext.builder().enrollee(enrollee2).build()));
+        assertTrue(searchExp.evaluate(EnrolleeSearchContext.builder().enrollee(enrollee3).build()));
+        assertTrue(searchExp.evaluate(EnrolleeSearchContext.builder().enrollee(enrollee4).build()));
     }
 
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Search expressions didn't work exactly as you expected when executing SQL because they used `!=` instead of `IS DISTINCT FROM`.... so e.g. `'test' != null` -> Unknown -> false.

This was causing an annoyance for A-T who need to filter by `deceased != true` but many people had nothing for deceased.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- test making != on questions that are blank for many enrollees.