### PR TITLE
[JN-1678] account username

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
@@ -50,15 +50,18 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
         valueMap.put("participantSupportEmailLink", getParticipantSupportEmailLink(contextInfo.portalEnv(), contextInfo.portalEnvConfig()));
         valueMap.put("siteMediaBaseUrl", getImageBaseUrl(contextInfo.portalEnv(), contextInfo.portalEnvConfig(), contextInfo.portal().getShortcode()));
         valueMap.put("siteImageBaseUrl", getImageBaseUrl(contextInfo.portalEnv(), contextInfo.portalEnvConfig(), contextInfo.portal().getShortcode()));
+        valueMap.put("participantUser", ruleData.getParticipantUser());
+
         boolean isProxy = isProxy(ruleData);
         if (isProxy) {
             valueMap.put("isProxy", "true");
         } else {
             valueMap.put("isProxy", "false");
         }
+
+        valueMap.put("accountUsername", getUsername(ruleData.getParticipantUser(), isProxy));
         valueMap.put("enrollee", ruleData.getEnrollee());
         valueMap.put("study", contextInfo.study());
-        valueMap.put("participantUser", ruleData.getParticipantUser());
         valueMap.put("invitationLink", getInvitationLink(contextInfo.portalEnv(), contextInfo.portalEnvConfig(), contextInfo.portal().getShortcode(), ruleData.getParticipantUser(), enrolleeContext.getProfile(), isProxy));
         if (messages != null) {
             valueMap.putAll(messages);
@@ -183,11 +186,7 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
                                     Profile profile,
                                     boolean isProxy) {
         try {
-            String username = participantUser != null ? participantUser.getUsername() : "";
-
-            if (isProxy) {
-                username = RegistrationService.removeProxySuffix(username);
-            }
+            String username = getUsername(participantUser, isProxy);
 
             String url = "%s%s?accountName=%s".formatted(
                     routingPaths.getParticipantBaseUrl(portalEnv, config, portalShortcode),
@@ -203,6 +202,20 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
         } catch (UnsupportedEncodingException e) {
             throw new IOInternalException("unable to encode username");
         }
+    }
+
+    private String getUsername(ParticipantUser participantUser, boolean isProxy) {
+        if (participantUser == null) {
+            return "";
+        }
+        String username = participantUser.getUsername();
+        if (StringUtils.isBlank(username)) {
+            return "";
+        }
+        if (isProxy) {
+            username = RegistrationService.removeProxySuffix(username);
+        }
+        return username;
     }
 
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailSubstitutorTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/email/EnrolleeEmailSubstitutorTests.java
@@ -143,6 +143,35 @@ public class EnrolleeEmailSubstitutorTests extends BaseSpringBootTest {
     }
 
     @Test
+    public void testProxyParticipantUsernameReplaced(TestInfo info) {
+        UUID enrolleeId = UUID.randomUUID();
+
+        ParticipantUser user = ParticipantUser.builder().username("test123@test.com-prox-ABCD").build();
+
+        EnrolleeContext nonProxyRuleData = new EnrolleeContext(new Enrollee(), new Profile(), user, null);
+        PortalEnvironment portalEnv = PortalEnvironment.builder().environmentName(EnvironmentName.irb).build();
+        NotificationContextInfo contextInfo = new NotificationContextInfo(new Portal(), portalEnv, new PortalEnvironmentConfig(), null, null);
+        StringSubstitutor nonProxyReplacer = EnrolleeEmailSubstitutor.newSubstitutor(nonProxyRuleData, contextInfo, routingPaths);
+
+        assertThat(nonProxyReplacer.replace("your username is ${participantUser.username}"), equalTo("your username is test123@test.com-prox-ABCD"));
+        assertThat(nonProxyReplacer.replace("your username is ${accountUsername}"), equalTo("your username is test123@test.com-prox-ABCD"));
+
+
+        EnrolleeContext proxyRuleData = new EnrolleeContext(Enrollee.builder().id(enrolleeId).build(), new Profile(), user, List.of(
+                EnrolleeRelation.builder()
+                        .relationshipType(RelationshipType.PROXY)
+                        .targetEnrolleeId(enrolleeId)
+                        .build()
+        ));
+        StringSubstitutor proxyReplacer = EnrolleeEmailSubstitutor.newSubstitutor(proxyRuleData, contextInfo, routingPaths);
+
+        assertThat(proxyReplacer.replace("your username is ${participantUser.username}"), equalTo("your username is test123@test.com-prox-ABCD"));
+        assertThat(proxyReplacer.replace("your username is ${accountUsername}"), equalTo("your username is test123@test.com"));
+
+
+    }
+
+    @Test
     public void testInvitationLinkReplaced(TestInfo info) {
         EnrolleeContext ruleData = new EnrolleeContext(new Enrollee(), new Profile(), ParticipantUser.builder().username("test123@test.com").build(), null);
         PortalEnvironmentConfig portalEnvironmentConfig = PortalEnvironmentConfig.builder()


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

A-T's invitation email puts the email in the content to remind them that they have to sign up with the given email. With the prepopulate stuff now working, it probably doesn't matter, but they already translated the email with it embedding the login email already, so it would be a hassle to remove...

This would populate with the fake governed user email; adds new key, `accountUsername`, that populates with the non-proxy account email always.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- see tests.