### PR TITLE
[JN-1687] recur on completion date

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeDao.java
@@ -14,8 +14,6 @@ import org.jdbi.v3.core.statement.Query;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -176,27 +174,19 @@ public class EnrolleeDao extends BaseMutableJdbiDao<Enrollee> implements StudyEn
         });
     }
 
-
-    /** returns enrollees who were assigned a tasks with the given target stable id in the past */
-    public List<Enrollee> findWithTaskInPast(UUID studyEnvironmentId,
-                                              String taskTargetStableId,
-                                              Duration minTimeSinceMostRecent) {
-        Instant minTimeSinceMostRecentInstant = Instant.now().minus(minTimeSinceMostRecent);
-        return jdbi.withHandle(handle ->
-                handle.createQuery("""
-                        with enrollee_times as (select enrollee_id as task_enrollee_id, MAX(created_at) as most_recent_task_time
-                          from participant_task where target_stable_id = :taskTargetStableId group by enrollee_id)
-                        select enrollee.* from enrollee 
-                        join enrollee_times on enrollee.id = task_enrollee_id
-                        where study_environment_id = :studyEnvironmentId
-                        and most_recent_task_time < :minTimeSinceCreationInstant
+    public List<Enrollee> findAssignedToTask(UUID studyEnvironmentId,
+                                             String targetStableId) {
+        return jdbi.withHandle(handle -> handle.createQuery("""
+                            select enrollee.* from enrollee
+                            inner join participant_task
+                            on (enrollee.id = participant_task.enrollee_id
+                                 and participant_task.target_stable_id = :targetStableId)
+                             where enrollee.study_environment_id = :studyEnvironmentId
                         """)
-                        .bind("studyEnvironmentId", studyEnvironmentId)
-                        .bind("taskTargetStableId", taskTargetStableId)
-                        .bind("minTimeSinceCreationInstant", minTimeSinceMostRecentInstant)
-                        .mapTo(clazz)
-                        .list()
-        );
+                .bind("targetStableId", targetStableId)
+                .bind("studyEnvironmentId", studyEnvironmentId)
+                .mapTo(clazz)
+                .list());
     }
 
 }

--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/EnrolleeDao.java
@@ -177,11 +177,14 @@ public class EnrolleeDao extends BaseMutableJdbiDao<Enrollee> implements StudyEn
     public List<Enrollee> findAssignedToTask(UUID studyEnvironmentId,
                                              String targetStableId) {
         return jdbi.withHandle(handle -> handle.createQuery("""
-                            select enrollee.* from enrollee
-                            inner join participant_task
-                            on (enrollee.id = participant_task.enrollee_id
-                                 and participant_task.target_stable_id = :targetStableId)
-                             where enrollee.study_environment_id = :studyEnvironmentId
+                            select distinct on (e.id) e.* from enrollee e
+                            inner join participant_task pt
+                            on (e.id = pt.enrollee_id
+                                 and pt.target_stable_id = :targetStableId
+                                 and pt.status not in ('REMOVED', 'REJECTED')
+                            )
+                             where e.study_environment_id = :studyEnvironmentId
+                             order by e.id
                         """)
                 .bind("targetStableId", targetStableId)
                 .bind("studyEnvironmentId", studyEnvironmentId)

--- a/core/src/main/java/bio/terra/pearl/core/dao/workflow/ParticipantTaskDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/workflow/ParticipantTaskDao.java
@@ -50,18 +50,24 @@ public class ParticipantTaskDao extends BaseMutableJdbiDao<ParticipantTask> impl
                 .stream().collect(Collectors.groupingBy(ParticipantTask::getEnrolleeId, Collectors.toList()));
     }
 
-    public Map<UUID, ParticipantTask> findLatestNotRemovedByEnrolleeIds(Collection<UUID> enrolleeIds) {
+    public Map<UUID, ParticipantTask> findLatestNotRemovedByEnrolleeIds(Collection<UUID> enrolleeIds, String stableId) {
+        if (enrolleeIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
         return jdbi.withHandle(handle ->
                 handle.createQuery("""
                                 select * from %s
                                 where enrollee_id in (<enrolleeIds>)
                                 and status not in ('REMOVED', 'REJECTED')
+                                and target_stable_id = :stableId
                                 order by created_at desc
                                 """.formatted(tableName))
                         .bindList("enrolleeIds", enrolleeIds)
+                        .bind("stableId", stableId)
                         .mapTo(clazz)
                         .stream()
-                        .collect(Collectors.toMap(ParticipantTask::getEnrolleeId, task -> task, (task1, task2) -> task1.getCreatedAt().isAfter(task2.getCreatedAt()) ? task1 : task2))
+                        .collect(Collectors.toMap(ParticipantTask::getEnrolleeId, task -> task, (task1, task2) -> task1))
         );
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/dao/workflow/ParticipantTaskDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/workflow/ParticipantTaskDao.java
@@ -50,6 +50,21 @@ public class ParticipantTaskDao extends BaseMutableJdbiDao<ParticipantTask> impl
                 .stream().collect(Collectors.groupingBy(ParticipantTask::getEnrolleeId, Collectors.toList()));
     }
 
+    public Map<UUID, ParticipantTask> findLatestNotRemovedByEnrolleeIds(Collection<UUID> enrolleeIds) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("""
+                                select * from %s
+                                where enrollee_id in (<enrolleeIds>)
+                                and status not in ('REMOVED', 'REJECTED')
+                                order by created_at desc
+                                """.formatted(tableName))
+                        .bindList("enrolleeIds", enrolleeIds)
+                        .mapTo(clazz)
+                        .stream()
+                        .collect(Collectors.toMap(ParticipantTask::getEnrolleeId, task -> task, (task1, task2) -> task1.getCreatedAt().isAfter(task2.getCreatedAt()) ? task1 : task2))
+        );
+    }
+
     public List<ParticipantTask> findByPortalParticipantUserId(UUID ppUserId) {
         return findAllByProperty("portal_participant_user_id", ppUserId);
     }

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/Survey.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/Survey.java
@@ -3,6 +3,7 @@ package bio.terra.pearl.core.model.survey;
 import bio.terra.pearl.core.model.BaseEntity;
 import bio.terra.pearl.core.model.PortalAttached;
 import bio.terra.pearl.core.model.Versioned;
+import bio.terra.pearl.core.model.workflow.RecurOn;
 import bio.terra.pearl.core.model.workflow.RecurrenceType;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,6 +40,8 @@ public class Survey extends BaseEntity implements Versioned, PortalAttached {
 
     @Builder.Default
     private RecurrenceType recurrenceType = RecurrenceType.NONE;
+    @Builder.Default
+    private RecurOn recurOn = RecurOn.COMPLETION; // date used for recurrence calculations
     @Builder.Default
     private boolean required = false; // whether this is required before other non-required surveys can be taken
     // how many days between offerings of this survey (e.g. 365 for one year)

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/SurveyTaskConfigDto.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/SurveyTaskConfigDto.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.core.model.survey;
 
+import bio.terra.pearl.core.model.workflow.RecurOn;
 import bio.terra.pearl.core.model.workflow.RecurrenceType;
 import bio.terra.pearl.core.service.workflow.TaskConfig;
 import lombok.Getter;
@@ -50,6 +51,11 @@ public class SurveyTaskConfigDto implements TaskConfig {
     @Override
     public RecurrenceType getRecurrenceType() {
         return survey.getRecurrenceType();
+    }
+
+    @Override
+    public RecurOn getRecurOn() {
+        return survey.getRecurOn();
     }
 
     @Override

--- a/core/src/main/java/bio/terra/pearl/core/model/workflow/RecurOn.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/workflow/RecurOn.java
@@ -1,0 +1,6 @@
+package bio.terra.pearl.core.model.workflow;
+
+public enum RecurOn {
+    COMPLETION, // recur based on task completion date
+    CREATION // recur based on task creation date
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/EnrolleeService.java
@@ -6,17 +6,14 @@ import bio.terra.pearl.core.dao.survey.SurveyResponseDao;
 import bio.terra.pearl.core.dao.workflow.ParticipantTaskDao;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.participant.Enrollee;
-import bio.terra.pearl.core.model.participant.EnrolleeRelation;
 import bio.terra.pearl.core.model.participant.PortalParticipantUser;
 import bio.terra.pearl.core.model.participant.Profile;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
-import bio.terra.pearl.core.model.workflow.ParticipantTask;
 import bio.terra.pearl.core.service.CascadeProperty;
 import bio.terra.pearl.core.service.CrudService;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.file.ParticipantFileService;
-import bio.terra.pearl.core.service.kit.KitRequestDto;
 import bio.terra.pearl.core.service.kit.KitRequestService;
 import bio.terra.pearl.core.service.notification.NotificationService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
@@ -24,14 +21,14 @@ import bio.terra.pearl.core.service.survey.SurveyResponseService;
 import bio.terra.pearl.core.service.workflow.ParticipantDataChangeService;
 import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
-import java.time.Duration;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 
 @Service
 public class EnrolleeService extends CrudService<Enrollee, EnrolleeDao> {
@@ -234,8 +231,9 @@ public class EnrolleeService extends CrudService<Enrollee, EnrolleeDao> {
         return dao.findUnassignedToTask(studyEnvironmentId, targetStableId, targetAssignedVersion);
     }
 
-    public List<Enrollee> findWithTaskInPast(UUID studyEnvId, String taskTargetStableId, Duration minTimeSinceMostRecent ) {
-        return dao.findWithTaskInPast(studyEnvId, taskTargetStableId, minTimeSinceMostRecent);
+    public List<Enrollee> findAssignedToTask(UUID studyEnvironmentId,
+                                             String targetStableId) {
+        return dao.findAssignedToTask(studyEnvironmentId, targetStableId);
     }
 
     public Optional<Enrollee> findByParticipantUserIdAndStudyEnvId(UUID participantUserId, UUID studyEnvId) {

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcher.java
@@ -141,6 +141,8 @@ public class SurveyTaskDispatcher extends TaskDispatcher<SurveyTaskConfigDto> {
 
         newTask.setSurveyResponseId(null);
         newTask.setCompletedAt(null);
+        newTask.setLastUpdatedAt(Instant.now());
+        newTask.setCreatedAt(Instant.now());
 
         // if the survey is set to prepopulate, copy the answers from the old task to the new task
         // we need to also create a new survey response for the new task and attach it to that task

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/ParticipantTaskService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/ParticipantTaskService.java
@@ -153,8 +153,8 @@ public class ParticipantTaskService extends ParticipantDataAuditedService<Partic
         return null;
     }
 
-    public Map<UUID, ParticipantTask> findLatestNotRemovedByEnrolleeIds(Collection<UUID> enrolleeIds) {
-        return dao.findLatestNotRemovedByEnrolleeIds(enrolleeIds);
+    public Map<UUID, ParticipantTask> findLatestNotRemovedByEnrolleeIds(Collection<UUID> enrolleeIds, String stableId) {
+        return dao.findLatestNotRemovedByEnrolleeIds(enrolleeIds, stableId);
     }
 
     public ParticipantTaskTaskListDto findAdminTasksByStudyEnvironmentId(UUID studyEnvId, List<String> includedRelations) {

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/ParticipantTaskService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/ParticipantTaskService.java
@@ -153,6 +153,10 @@ public class ParticipantTaskService extends ParticipantDataAuditedService<Partic
         return null;
     }
 
+    public Map<UUID, ParticipantTask> findLatestNotRemovedByEnrolleeIds(Collection<UUID> enrolleeIds) {
+        return dao.findLatestNotRemovedByEnrolleeIds(enrolleeIds);
+    }
+
     public ParticipantTaskTaskListDto findAdminTasksByStudyEnvironmentId(UUID studyEnvId, List<String> includedRelations) {
         List<ParticipantTask> tasks = dao.findByStudyEnvironmentIdAndTaskType(studyEnvId, List.of(TaskType.ADMIN_NOTE, TaskType.ADMIN_FORM)).stream().toList();
         List<Enrollee> enrollees = List.of();

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/TaskConfig.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/TaskConfig.java
@@ -1,5 +1,6 @@
 package bio.terra.pearl.core.service.workflow;
 
+import bio.terra.pearl.core.model.workflow.RecurOn;
 import bio.terra.pearl.core.model.workflow.RecurrenceType;
 
 import java.util.UUID;
@@ -14,6 +15,8 @@ public interface TaskConfig {
     UUID getStudyEnvironmentId();
 
     RecurrenceType getRecurrenceType();
+
+    RecurOn getRecurOn();
 
     Integer getDaysAfterEligible();
 

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/TaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/TaskDispatcher.java
@@ -195,13 +195,15 @@ public abstract class TaskDispatcher<T extends TaskConfig> {
         // not the most efficient, but lets us reuse "isRecurrenceWindowOpen"
         List<Enrollee> enrolleesWithTask = enrolleeService.findAssignedToTask(taskConfig.getStudyEnvironmentId(), taskConfig.getStableId());
         Map<UUID, ParticipantTask> latestTasks = participantTaskService.findLatestNotRemovedByEnrolleeIds(
-                enrolleesWithTask.stream().map(Enrollee::getId).toList());
-
+                enrolleesWithTask.stream().map(Enrollee::getId).toList(),
+                taskConfig.getStableId());
+        
         List<Enrollee> eligibleEnrollees = new ArrayList<>();
 
         for (Enrollee enrollee : enrolleesWithTask) {
             ParticipantTask latestTask = latestTasks.get(enrollee.getId());
-            if (latestTask != null && isRecurrenceWindowOpen(taskConfig, latestTask)) {
+            if (latestTask != null
+                    && isRecurrenceWindowOpen(taskConfig, latestTask)) {
                 eligibleEnrollees.add(enrollee);
             }
         }
@@ -282,6 +284,7 @@ public abstract class TaskDispatcher<T extends TaskConfig> {
         if (taskDispatchConfig.getRecurrenceType().equals(RecurrenceType.UPDATE)) {
             Optional<ParticipantTask> existingTask = existingTasks.stream()
                     .filter(t -> t.getTargetStableId().equals(task.getTargetStableId()))
+                    .filter(t -> t.getStatus() != TaskStatus.REMOVED && t.getStatus() != TaskStatus.REJECTED)
                     .max(Comparator.comparing(ParticipantTask::getCreatedAt));
             existingTask.ifPresent(participantTask -> copyTaskData(task, participantTask, taskDispatchConfig));
         }
@@ -289,6 +292,7 @@ public abstract class TaskDispatcher<T extends TaskConfig> {
             Optional<ParticipantTask> existingTask = existingTasks.stream()
                     .filter(t -> t.getTargetStableId() != null)
                     .filter(t -> t.getTargetStableId().equals(task.getTargetStableId()))
+                    .filter(t -> t.getStatus() != TaskStatus.REMOVED && t.getStatus() != TaskStatus.REJECTED)
                     .max(Comparator.comparing(ParticipantTask::getCreatedAt));
             existingTask.ifPresent(participantTask -> copyTaskData(task, participantTask, taskDispatchConfig));
         }

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/TaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/TaskDispatcher.java
@@ -20,7 +20,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 
-import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -193,11 +192,21 @@ public abstract class TaskDispatcher<T extends TaskConfig> {
      * will assign a recurring task to enrollees who have already taken it at least once, but are due to take it again
      */
     private void assignRecurring(T taskConfig) {
-        List<Enrollee> enrollees = enrolleeService.findWithTaskInPast(
-                taskConfig.getStudyEnvironmentId(),
-                taskConfig.getStableId(),
-                Duration.of(taskConfig.getRecurrenceIntervalDays(), ChronoUnit.DAYS));
-        assign(enrollees, taskConfig, false, "scheduled",
+        // not the most efficient, but lets us reuse "isRecurrenceWindowOpen"
+        List<Enrollee> enrolleesWithTask = enrolleeService.findAssignedToTask(taskConfig.getStudyEnvironmentId(), taskConfig.getStableId());
+        Map<UUID, ParticipantTask> latestTasks = participantTaskService.findLatestNotRemovedByEnrolleeIds(
+                enrolleesWithTask.stream().map(Enrollee::getId).toList());
+
+        List<Enrollee> eligibleEnrollees = new ArrayList<>();
+
+        for (Enrollee enrollee : enrolleesWithTask) {
+            ParticipantTask latestTask = latestTasks.get(enrollee.getId());
+            if (latestTask != null && isRecurrenceWindowOpen(taskConfig, latestTask)) {
+                eligibleEnrollees.add(enrollee);
+            }
+        }
+
+        assign(eligibleEnrollees, taskConfig, false, "scheduled",
                 new ResponsibleEntity(DataAuditInfo.systemProcessName(getClass(), "assignRecurringSurvey")));
     }
 
@@ -318,25 +327,44 @@ public abstract class TaskDispatcher<T extends TaskConfig> {
      */
     public boolean isDuplicateTask(T taskDispatchConfig, ParticipantTask task,
                                    List<ParticipantTask> allTasks) {
-        return !allTasks.stream()
-                .filter(existingTask ->
-                        existingTask.getTaskType().equals(task.getTaskType()) &&
-                        existingTask.getTargetStableId().equals(task.getTargetStableId()) &&
-                                !isRecurrenceWindowOpen(taskDispatchConfig, existingTask))
-                .toList().isEmpty();
+        // get all non-removed tasks matching this current task config
+        List<ParticipantTask> matchingTasks = allTasks.stream()
+                .filter(existingTask -> existingTask.getStatus() != TaskStatus.REMOVED && existingTask.getStatus() != TaskStatus.REJECTED)
+                .filter(existingTask -> existingTask.getTargetStableId() != null && existingTask.getTargetStableId().equals(task.getTargetStableId()))
+                .sorted(Comparator.comparing(ParticipantTask::getCreatedAt).reversed())
+                .toList();
+
+        if (matchingTasks.isEmpty()) {
+            return false; // first task for this stableId, so it can't be a duplicate
+        }
+
+
+        // if there's an existing task and it's not recurring, it's a duplicate
+        if (taskDispatchConfig.getRecurrenceType() == RecurrenceType.NONE) {
+            return true; // no recurrence, so it's a duplicate
+        }
+
+        // if it's recurring, check against the latest task to see if recurrence window is open.
+        // if not, then it's a duplicate, we already have the needed task.
+        ParticipantTask latestTask = matchingTasks.get(0);
+        return !isRecurrenceWindowOpen(taskDispatchConfig, latestTask);
     }
 
     /**
      * whether or not sufficient time has passed since a previous instance of a task being assigned to assign
-     * a new one
+     * a new one. must be used with the latest non-removed task
      */
-    private boolean isRecurrenceWindowOpen(T taskDispatchConfig, ParticipantTask pastTask) {
+    private boolean isRecurrenceWindowOpen(T taskDispatchConfig, ParticipantTask latestTask) {
         if (taskDispatchConfig.getRecurrenceType() == RecurrenceType.NONE) {
             return false;
         }
+        if (latestTask.getCompletedAt() == null) {
+            return false; // never recur on incomplete tasks
+        }
+
         Instant pastCutoffTime = ZonedDateTime.now(ZoneOffset.UTC)
                 .minusDays(taskDispatchConfig.getRecurrenceIntervalDays()).toInstant();
-        return pastTask.getCreatedAt().isBefore(pastCutoffTime);
+        return latestTask.getCompletedAt().isBefore(pastCutoffTime);
     }
 
     protected void copyTaskData(ParticipantTask newTask, ParticipantTask oldTask, T taskDispatchConfig) {

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/TaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/TaskDispatcher.java
@@ -5,10 +5,7 @@ import bio.terra.pearl.core.model.audit.ResponsibleEntity;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.PortalParticipantUser;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
-import bio.terra.pearl.core.model.workflow.ParticipantTask;
-import bio.terra.pearl.core.model.workflow.RecurrenceType;
-import bio.terra.pearl.core.model.workflow.TaskStatus;
-import bio.terra.pearl.core.model.workflow.TaskType;
+import bio.terra.pearl.core.model.workflow.*;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.participant.PortalParticipantUserService;
 import bio.terra.pearl.core.service.rule.EnrolleeContext;
@@ -362,13 +359,18 @@ public abstract class TaskDispatcher<T extends TaskConfig> {
         if (taskDispatchConfig.getRecurrenceType() == RecurrenceType.NONE) {
             return false;
         }
-        if (latestTask.getCompletedAt() == null) {
+
+        Instant date = taskDispatchConfig.getRecurOn() == RecurOn.COMPLETION
+                ? latestTask.getCompletedAt()
+                : latestTask.getCreatedAt();
+
+        if (date == null) {
             return false; // never recur on incomplete tasks
         }
 
         Instant pastCutoffTime = ZonedDateTime.now(ZoneOffset.UTC)
                 .minusDays(taskDispatchConfig.getRecurrenceIntervalDays()).toInstant();
-        return latestTask.getCompletedAt().isBefore(pastCutoffTime);
+        return date.isBefore(pastCutoffTime);
     }
 
     protected void copyTaskData(ParticipantTask newTask, ParticipantTask oldTask, T taskDispatchConfig) {

--- a/core/src/main/resources/db/changelog/changesets/2025_05_20_recur_on.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2025_05_20_recur_on.yaml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: "export_options_only_complete"
+      author: connorlbark
+      changes:
+        - addColumn:
+            tableName: survey
+            columns:
+              - column:
+                  name: recur_on
+                  type: text
+        - sql:
+            sql: |
+              UPDATE survey
+              SET recur_on = 'COMPLETION'
+              WHERE recur_on IS NULL;
+  

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -404,7 +404,9 @@ databaseChangeLog:
   - include:
       file: changesets/2025_04_11_export_option_only_complete.yaml
       relativeToChangelogFile: true
-
+  - include:
+      file: changesets/2025_05_20_recur_on.yaml
+      relativeToChangelogFile: true
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements
 # are atomic. When they are grouped in a changeset and one fails the changeset cannot be
 # rolled back or rerun making recovery more difficult

--- a/core/src/test/java/bio/terra/pearl/core/dao/participant/EnrolleeDaoTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/participant/EnrolleeDaoTests.java
@@ -8,8 +8,6 @@ import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
 import bio.terra.pearl.core.factory.participant.ParticipantTaskFactory;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.participant.Enrollee;
-import bio.terra.pearl.core.model.study.StudyEnvironment;
-import bio.terra.pearl.core.model.workflow.ParticipantTask;
 import bio.terra.pearl.core.model.workflow.TaskStatus;
 import bio.terra.pearl.core.model.workflow.TaskType;
 import org.junit.jupiter.api.Test;
@@ -17,9 +15,6 @@ import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -97,47 +92,6 @@ public class EnrolleeDaoTests extends BaseSpringBootTest {
         unassignedEnrollees = enrolleeDao.findUnassignedToTask(sandboxBundle.getStudyEnv().getId(), TASK_STABLE_ID, 2);
         assertThat(unassignedEnrollees, containsInAnyOrder(sandbox1.enrollee()));
     }
-
-
-    @Test
-    @Transactional
-    public void testFindWithTaskInPast(TestInfo testInfo) {
-        String TASK_STABLE_ID = "testFindWithTaskInPast";
-        // set up a sandbox and irb environment, with 2 enrollees in each
-        StudyEnvironmentBundle sandboxBundle = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.sandbox);
-        EnrolleeBundle sandbox1 = enrolleeFactory.buildWithPortalUser(getTestName(testInfo), sandboxBundle.getPortalEnv(), sandboxBundle.getStudyEnv());
-        EnrolleeBundle sandbox2 = enrolleeFactory.buildWithPortalUser(getTestName(testInfo), sandboxBundle.getPortalEnv(), sandboxBundle.getStudyEnv());
-
-        StudyEnvironmentBundle irbBundle = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.irb);
-        EnrolleeBundle irb1 = enrolleeFactory.buildWithPortalUser(getTestName(testInfo), irbBundle.getPortalEnv(), irbBundle.getStudyEnv());
-        EnrolleeBundle irb2 = enrolleeFactory.buildWithPortalUser(getTestName(testInfo), irbBundle.getPortalEnv(), irbBundle.getStudyEnv());
-
-        Duration oneDay = Duration.of(1, ChronoUnit.DAYS);
-        // returns no enrollees if no one is assigned any tasks
-        List<Enrollee> enrolleesWithTask = enrolleeDao.findWithTaskInPast(sandboxBundle.getStudyEnv().getId(), TASK_STABLE_ID, oneDay);
-        assertThat(enrolleesWithTask, hasSize(0));
-
-        // still returns no enrollees if someone from another environment is assigned
-        participantTaskFactory.buildPersisted(irb1, ParticipantTaskFactory.DEFAULT_BUILDER.targetStableId(TASK_STABLE_ID), Instant.now().minus(2, ChronoUnit.DAYS));
-        enrolleesWithTask = enrolleeDao.findWithTaskInPast(sandboxBundle.getStudyEnv().getId(), TASK_STABLE_ID, oneDay);
-        assertThat(enrolleesWithTask, hasSize(0));
-
-        // still returns no enrollees if someone from this environment is assigned less than a day ago
-        participantTaskFactory.buildPersisted(sandbox1, ParticipantTaskFactory.DEFAULT_BUILDER.targetStableId(TASK_STABLE_ID), Instant.now().minus(1, ChronoUnit.HOURS));
-        enrolleesWithTask = enrolleeDao.findWithTaskInPast(sandboxBundle.getStudyEnv().getId(), TASK_STABLE_ID, oneDay);
-        assertThat(enrolleesWithTask, hasSize(0));
-
-        // returns an enrollee who was assigned the task more than a day ago
-        participantTaskFactory.buildPersisted(sandbox2, ParticipantTaskFactory.DEFAULT_BUILDER.targetStableId(TASK_STABLE_ID), Instant.now().minus(2, ChronoUnit.DAYS));
-        enrolleesWithTask = enrolleeDao.findWithTaskInPast(sandboxBundle.getStudyEnv().getId(), TASK_STABLE_ID, oneDay);
-        assertThat(enrolleesWithTask, containsInAnyOrder(sandbox2.enrollee()));
-
-        // still only returns that enrollee if another enrollee was assigned a different task more than a day ago
-        participantTaskFactory.buildPersisted(sandbox1, ParticipantTaskFactory.DEFAULT_BUILDER.targetStableId("SOMETHING_ELSE"), Instant.now().minus(2, ChronoUnit.DAYS));
-        enrolleesWithTask = enrolleeDao.findWithTaskInPast(sandboxBundle.getStudyEnv().getId(), TASK_STABLE_ID, oneDay);
-        assertThat(enrolleesWithTask, containsInAnyOrder(sandbox2.enrollee()));
-    }
-
 
     @Test
     @Transactional

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
@@ -18,10 +18,7 @@ import bio.terra.pearl.core.model.audit.DataAuditInfo;
 import bio.terra.pearl.core.model.audit.ResponsibleEntity;
 import bio.terra.pearl.core.model.participant.Profile;
 import bio.terra.pearl.core.model.survey.*;
-import bio.terra.pearl.core.model.workflow.ParticipantTask;
-import bio.terra.pearl.core.model.workflow.RecurrenceType;
-import bio.terra.pearl.core.model.workflow.TaskStatus;
-import bio.terra.pearl.core.model.workflow.TaskType;
+import bio.terra.pearl.core.model.workflow.*;
 import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
 import bio.terra.pearl.core.service.workflow.ParticipantTaskAssignDto;
 import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
@@ -380,12 +377,13 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
 
     @Test
     @Transactional
-    public void testRecurringAssignDoesNotRecurIfTaskInProgress(TestInfo testInfo) {
+    public void testRecurringAssignDoesNotRecurIfTaskInProgressAndRecurOnCompletion(TestInfo testInfo) {
         // create a 7-day recurring survey, confirm it gets reassigned
         StudyEnvironmentBundle sandboxBundle = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.sandbox);
         Survey survey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(testInfo))
                 .portalId(sandboxBundle.getPortal().getId())
                 .recurrenceType(RecurrenceType.LONGITUDINAL)
+                .recurOn(RecurOn.COMPLETION)
                 .recurrenceIntervalDays(7));
         surveyFactory.attachToEnv(survey, sandboxBundle.getStudyEnv().getId(), true);
 
@@ -438,6 +436,60 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
         assertThat(participantTaskService.findByEnrolleeId(sandbox1.enrollee().getId()), hasSize(1));
         assertThat(participantTaskService.findByEnrolleeId(sandbox2.enrollee().getId()), hasSize(2));
         assertThat(participantTaskService.findByEnrolleeId(sandbox3.enrollee().getId()), hasSize(1));
+    }
+
+    @Test
+    @Transactional
+    public void testRecurOnCreation(TestInfo testInfo) {
+        // create a 7-day recurring survey, confirm it gets reassigned
+        StudyEnvironmentBundle sandboxBundle = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.sandbox);
+        Survey survey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(testInfo))
+                .portalId(sandboxBundle.getPortal().getId())
+                .recurrenceType(RecurrenceType.LONGITUDINAL)
+                .recurOn(RecurOn.CREATION)
+                .recurrenceIntervalDays(7));
+        surveyFactory.attachToEnv(survey, sandboxBundle.getStudyEnv().getId(), true);
+
+        EnrolleeBundle sandbox1 = enrolleeFactory.enroll(getTestName(testInfo) + "1", sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
+        EnrolleeBundle sandbox2 = enrolleeFactory.enroll(getTestName(testInfo) + "2", sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
+        // this enrollee has a task that should not recur
+        EnrolleeBundle sandbox3 = enrolleeFactory.enroll(getTestName(testInfo) + "3", sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
+
+        List<ParticipantTask> tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
+        // task should be assigned to all enrollees on creation
+        assertThat(tasks, hasSize(3));
+
+        ParticipantTask sandbox1Task = tasks.stream().filter(task ->
+                task.getEnrolleeId().equals(sandbox1.enrollee().getId())).findFirst().get();
+
+        // make first task old but not completed
+        sandbox1Task.setCreatedAt(Instant.now().minus(8, ChronoUnit.DAYS));
+        sandbox1Task.setStatus(TaskStatus.IN_PROGRESS);
+
+        participantTaskService.update(sandbox1Task, DataAuditInfo.builder().systemProcess(getTestName(testInfo)).build());
+        timeShiftDao.changeTasksCreationTime(List.of(sandbox1Task.getId()), Instant.now().minus(8, ChronoUnit.DAYS));
+
+        // make second task old but completed recently
+        ParticipantTask sandbox2Task = tasks.stream().filter(task ->
+                task.getEnrolleeId().equals(sandbox2.enrollee().getId())).findFirst().get();
+        sandbox2Task.setCompletedAt(Instant.now().minus(1, ChronoUnit.DAYS));
+        sandbox2Task.setStatus(TaskStatus.COMPLETE);
+
+        participantTaskService.update(sandbox2Task, DataAuditInfo.builder().systemProcess(getTestName(testInfo)).build());
+        timeShiftDao.changeTasksCreationTime(List.of(sandbox2Task.getId()), Instant.now().minus(8, ChronoUnit.DAYS));
+
+        surveyTaskDispatcher.assignScheduledTasks();
+
+        tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
+        assertThat(tasks, hasSize(5));
+
+        // should have assigned a new task to the first and second enrollee
+
+        assertThat(participantTaskService.findByEnrolleeId(sandbox1.enrollee().getId()), hasSize(2));
+        assertThat(participantTaskService.findByEnrolleeId(sandbox2.enrollee().getId()), hasSize(2));
+        assertThat(participantTaskService.findByEnrolleeId(sandbox3.enrollee().getId()), hasSize(1));
+
+
     }
 
     @Test

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
@@ -22,6 +22,7 @@ import bio.terra.pearl.core.model.workflow.ParticipantTask;
 import bio.terra.pearl.core.model.workflow.RecurrenceType;
 import bio.terra.pearl.core.model.workflow.TaskStatus;
 import bio.terra.pearl.core.model.workflow.TaskType;
+import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
 import bio.terra.pearl.core.service.workflow.ParticipantTaskAssignDto;
 import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 
@@ -60,6 +62,8 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
     private TimeShiftDao timeShiftDao;
     @Autowired
     private SurveyResponseDao surveyResponseDao;
+    @Autowired
+    private StudyEnvironmentSurveyService studyEnvironmentSurveyService;
 
 
     @Test
@@ -344,6 +348,8 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
                 .recurrenceIntervalDays(7));
         surveyFactory.attachToEnv(survey, sandboxBundle.getStudyEnv().getId(), true);
 
+        surveyTaskDispatcher.assignScheduledTasks(); // should be no-op
+
         EnrolleeBundle sandbox1 = enrolleeFactory.enroll(getTestName(testInfo) + "1", sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
         EnrolleeBundle sandbox2 = enrolleeFactory.enroll(getTestName(testInfo) + "2", sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
         EnrolleeBundle sandbox3 = enrolleeFactory.enroll(getTestName(testInfo) + "3", sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
@@ -460,7 +466,10 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
                 new ParticipantTaskAssignDto(TaskType.SURVEY, survey.getStableId(), survey.getVersion(), List.of(sandbox.enrollee().getId()), true, true, "reason"),
                 sandboxBundle.getStudyEnv().getId(), new ResponsibleEntity(adminUserFactory.buildPersisted(getTestName(testInfo), true)));
 
-        tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
+        tasks = participantTaskService
+                .findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId())
+                .stream().sorted(Comparator.comparing(ParticipantTask::getCreatedAt).reversed())
+                .toList();
 
         assertThat(tasks, hasSize(3));
 
@@ -493,12 +502,12 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
 
         assertThat(tasks, hasSize(3));
 
-        // make task3 old complete
+        // make task1 (latest task) old & complete
 
-        task3.setCompletedAt(Instant.now().minus(8, ChronoUnit.DAYS));
-        task3.setStatus(TaskStatus.COMPLETE);
+        task1.setCompletedAt(Instant.now().minus(8, ChronoUnit.DAYS));
+        task1.setStatus(TaskStatus.COMPLETE);
 
-        participantTaskService.update(task3, DataAuditInfo.builder().systemProcess(getTestName(testInfo)).build());
+        participantTaskService.update(task1, DataAuditInfo.builder().systemProcess(getTestName(testInfo)).build());
 
         // this should assign a new task to the enrollee, since the latest task is now complete
         surveyTaskDispatcher.assignScheduledTasks();
@@ -574,6 +583,90 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
         tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
 
         assertThat(tasks, hasSize(3));
+    }
+
+    @Test
+    @Transactional
+    public void testMultipleVersionMultipleSurveyRecurringAssign(TestInfo testInfo) {
+        // make sure re-assign is smart enough to not get confused if multiple recurring surveys
+        StudyEnvironmentBundle sandboxBundle = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.sandbox);
+        Survey survey1V1 = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(testInfo))
+                .portalId(sandboxBundle.getPortal().getId())
+                .recurrenceType(RecurrenceType.LONGITUDINAL)
+                .version(1)
+                .autoAssign(true)
+                .stableId("survey1")
+                .recurrenceIntervalDays(7));
+
+        Survey survey2 = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(testInfo))
+                .portalId(sandboxBundle.getPortal().getId())
+                .recurrenceType(RecurrenceType.LONGITUDINAL)
+                .version(1)
+                .autoAssign(true)
+                .stableId("survey2")
+                .recurrenceIntervalDays(7));
+
+
+        StudyEnvironmentSurvey survey1V1ses = surveyFactory.attachToEnv(survey1V1, sandboxBundle.getStudyEnv().getId(), true);
+        surveyFactory.attachToEnv(survey2, sandboxBundle.getStudyEnv().getId(), true);
+
+        EnrolleeBundle enrollee1 = enrolleeFactory.enroll(getTestName(testInfo) + "1", sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
+        EnrolleeBundle enrollee2 = enrolleeFactory.enroll(getTestName(testInfo) + "2", sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
+
+        Survey survey1V2 = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(testInfo))
+                .portalId(sandboxBundle.getPortal().getId())
+                .recurrenceType(RecurrenceType.LONGITUDINAL)
+                .version(2)
+                .autoAssign(true)
+                .stableId("survey1")
+                .recurrenceIntervalDays(7));
+
+        // make v1 outdated as v2 is the latest
+        survey1V1ses.setActive(false);
+        studyEnvironmentSurveyService.update(survey1V1ses); // deactivate old version
+
+        // activate new version
+        surveyFactory.attachToEnv(survey1V2, sandboxBundle.getStudyEnv().getId(), true);
+
+        // assign new version of survey1
+        surveyTaskDispatcher.assign(
+                new ParticipantTaskAssignDto(TaskType.SURVEY, survey1V2.getStableId(), survey1V2.getVersion(), List.of(enrollee1.enrollee().getId()), true, true, "reason"),
+                sandboxBundle.getStudyEnv().getId(), new ResponsibleEntity(adminUserFactory.buildPersisted(getTestName(testInfo), true)));
+
+        List<ParticipantTask> tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
+        for (ParticipantTask task : tasks) {
+            task.setStatus(TaskStatus.COMPLETE);
+            task.setCompletedAt(Instant.now().minus(8, ChronoUnit.DAYS));
+            participantTaskService.update(task, DataAuditInfo.builder().systemProcess(getTestName(testInfo)).build());
+            // make them all eligible for recurrence
+        }
+
+        // at this point:
+        // enrollee 1 has 2 tasks, one for survey1 V1, one for survey1 V2, one for survey2
+        // enrollee 2 has 2 tasks, one for survey1 V1 and survey2
+        // on recurrence: enrollee1 should only recur on V2, enrollee2 should recur on V2 and survey2
+
+        surveyTaskDispatcher.assignScheduledTasks();
+
+        tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
+
+        List<ParticipantTask> enrollee1Tasks = tasks.stream().filter(task -> task.getEnrolleeId().equals(enrollee1.enrollee().getId())).toList();
+        List<ParticipantTask> enrollee2Tasks = tasks.stream().filter(task -> task.getEnrolleeId().equals(enrollee2.enrollee().getId())).toList();
+
+        assertThat(enrollee1Tasks, hasSize(5));
+        assertThat(enrollee2Tasks, hasSize(4));
+
+        // enrollee 1 should have 3 tasks, one for survey1 V1, two for survey1 V2
+
+        assertThat(enrollee1Tasks.stream().filter(task -> task.getTargetStableId().equals(survey1V1.getStableId()) && task.getTargetAssignedVersion() == 1).toList(), hasSize(1));
+        assertThat(enrollee1Tasks.stream().filter(task -> task.getTargetStableId().equals(survey1V2.getStableId()) && task.getTargetAssignedVersion() == 2).toList(), hasSize(2));
+        assertThat(enrollee1Tasks.stream().filter(task -> task.getTargetStableId().equals(survey2.getStableId())).toList(), hasSize(2));
+
+        // enrollee 2 should have 4 tasks, one for survey1 V1, one for survey1 V2, two for survey2
+        assertThat(enrollee2Tasks.stream().filter(task -> task.getTargetStableId().equals(survey1V2.getStableId()) && task.getTargetAssignedVersion() == 1).toList(), hasSize(1));
+        assertThat(enrollee2Tasks.stream().filter(task -> task.getTargetStableId().equals(survey1V2.getStableId()) && task.getTargetAssignedVersion() == 2).toList(), hasSize(1));
+        assertThat(enrollee2Tasks.stream().filter(task -> task.getTargetStableId().equals(survey2.getStableId())).toList(), hasSize(2));
+
 
     }
 
@@ -625,7 +718,7 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
 
         ParticipantTask finalInitialTask = initialTask;
         ParticipantTask reassignedTask = latestParticipantTasks.stream().filter(task -> !task.getId().equals(finalInitialTask.getId())).findFirst().get();
-        
+
         SurveyResponse reassignedResponse = surveyResponseDao.findOneWithAnswers(reassignedTask.getSurveyResponseId()).get();
 
         //confirm diagnosis answer was prepopulated in the new response

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
@@ -16,7 +16,6 @@ import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.audit.DataAuditInfo;
 import bio.terra.pearl.core.model.audit.ResponsibleEntity;
-import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.Profile;
 import bio.terra.pearl.core.model.survey.*;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
@@ -357,8 +356,12 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
         participantTaskService.delete(tasks.stream().filter(task ->
                 task.getEnrolleeId().equals(sandbox1.enrollee().getId())).findFirst().get().getId(), DataAuditInfo.builder().systemProcess(getTestName(testInfo)).build());
         // change the second enrollee's task time to 8 days ago
-        timeShiftDao.changeTaskCreationTime(tasks.stream().filter(task ->
-                task.getEnrolleeId().equals(sandbox2.enrollee().getId())).findFirst().get().getId(), Instant.now().minus(8, ChronoUnit.DAYS));
+        ParticipantTask sandbox2Task = tasks.stream().filter(task ->
+                task.getEnrolleeId().equals(sandbox2.enrollee().getId())).findFirst().get();
+        sandbox2Task.setCompletedAt(Instant.now().minus(8, ChronoUnit.DAYS));
+        sandbox2Task.setStatus(TaskStatus.COMPLETE);
+        participantTaskService.update(sandbox2Task, DataAuditInfo.builder().systemProcess(getTestName(testInfo)).build());
+
 
         // this should not assign to 1 (since it has no prior task) or 3 (since its task was assigned recently)
         surveyTaskDispatcher.assignScheduledTasks();
@@ -367,6 +370,211 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
         assertThat(participantTaskService.findByEnrolleeId(sandbox1.enrollee().getId()), hasSize(0));
         assertThat(participantTaskService.findByEnrolleeId(sandbox2.enrollee().getId()), hasSize(2));
         assertThat(participantTaskService.findByEnrolleeId(sandbox3.enrollee().getId()), hasSize(1));
+    }
+
+    @Test
+    @Transactional
+    public void testRecurringAssignDoesNotRecurIfTaskInProgress(TestInfo testInfo) {
+        // create a 7-day recurring survey, confirm it gets reassigned
+        StudyEnvironmentBundle sandboxBundle = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.sandbox);
+        Survey survey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(testInfo))
+                .portalId(sandboxBundle.getPortal().getId())
+                .recurrenceType(RecurrenceType.LONGITUDINAL)
+                .recurrenceIntervalDays(7));
+        surveyFactory.attachToEnv(survey, sandboxBundle.getStudyEnv().getId(), true);
+
+        EnrolleeBundle sandbox1 = enrolleeFactory.enroll(getTestName(testInfo) + "1", sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
+        EnrolleeBundle sandbox2 = enrolleeFactory.enroll(getTestName(testInfo) + "2", sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
+        EnrolleeBundle sandbox3 = enrolleeFactory.enroll(getTestName(testInfo) + "3", sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
+
+        List<ParticipantTask> tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
+        // task should be assigned to all enrollees on creation
+        assertThat(tasks, hasSize(3));
+
+
+        ParticipantTask sandbox1Task = tasks.stream().filter(task ->
+                task.getEnrolleeId().equals(sandbox1.enrollee().getId())).findFirst().get();
+
+        // make first task old but not completed
+        sandbox1Task.setCreatedAt(Instant.now().minus(8, ChronoUnit.DAYS));
+        sandbox1Task.setStatus(TaskStatus.IN_PROGRESS);
+
+        participantTaskService.update(sandbox1Task, DataAuditInfo.builder().systemProcess(getTestName(testInfo)).build());
+
+        // make second task old and completed
+        ParticipantTask sandbox2Task = tasks.stream().filter(task ->
+                task.getEnrolleeId().equals(sandbox2.enrollee().getId())).findFirst().get();
+
+        sandbox2Task.setCreatedAt(Instant.now().minus(8, ChronoUnit.DAYS));
+        sandbox2Task.setCompletedAt(Instant.now().minus(8, ChronoUnit.DAYS));
+        sandbox2Task.setStatus(TaskStatus.COMPLETE);
+
+        participantTaskService.update(sandbox2Task, DataAuditInfo.builder().systemProcess(getTestName(testInfo)).build());
+
+        // make third task recently completed
+
+        ParticipantTask sandbox3Task = tasks.stream().filter(task ->
+                task.getEnrolleeId().equals(sandbox3.enrollee().getId())).findFirst().get();
+
+        sandbox3Task.setCreatedAt(Instant.now().minus(1, ChronoUnit.DAYS));
+        sandbox3Task.setCompletedAt(Instant.now().minus(1, ChronoUnit.DAYS));
+        sandbox3Task.setStatus(TaskStatus.COMPLETE);
+
+        participantTaskService.update(sandbox3Task, DataAuditInfo.builder().systemProcess(getTestName(testInfo)).build());
+
+
+        // this should only assign to 2
+
+        surveyTaskDispatcher.assignScheduledTasks();
+
+        tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
+        assertThat(tasks, hasSize(4));
+        assertThat(participantTaskService.findByEnrolleeId(sandbox1.enrollee().getId()), hasSize(1));
+        assertThat(participantTaskService.findByEnrolleeId(sandbox2.enrollee().getId()), hasSize(2));
+        assertThat(participantTaskService.findByEnrolleeId(sandbox3.enrollee().getId()), hasSize(1));
+    }
+
+    @Test
+    @Transactional
+    public void testRecurringOnlyCaresAboutLatest(TestInfo testInfo) {
+        // create a 7-day recurring survey, confirm it gets reassigned
+        StudyEnvironmentBundle sandboxBundle = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.sandbox);
+        Survey survey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(testInfo))
+                .portalId(sandboxBundle.getPortal().getId())
+                .recurrenceType(RecurrenceType.LONGITUDINAL)
+                .recurrenceIntervalDays(7));
+        surveyFactory.attachToEnv(survey, sandboxBundle.getStudyEnv().getId(), true);
+
+        EnrolleeBundle sandbox = enrolleeFactory.enroll(getTestName(testInfo) + "1", sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
+
+        List<ParticipantTask> tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
+        // task should be assigned to all enrollees on creation
+        assertThat(tasks, hasSize(1));
+
+
+        // assign some new versions of the task
+        surveyTaskDispatcher.assign(
+                new ParticipantTaskAssignDto(TaskType.SURVEY, survey.getStableId(), survey.getVersion(), List.of(sandbox.enrollee().getId()), true, true, "reason"),
+                sandboxBundle.getStudyEnv().getId(), new ResponsibleEntity(adminUserFactory.buildPersisted(getTestName(testInfo), true)));
+        surveyTaskDispatcher.assign(
+                new ParticipantTaskAssignDto(TaskType.SURVEY, survey.getStableId(), survey.getVersion(), List.of(sandbox.enrollee().getId()), true, true, "reason"),
+                sandboxBundle.getStudyEnv().getId(), new ResponsibleEntity(adminUserFactory.buildPersisted(getTestName(testInfo), true)));
+
+        tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
+
+        assertThat(tasks, hasSize(3));
+
+        ParticipantTask task1 = tasks.get(0);
+        ParticipantTask task2 = tasks.get(1);
+        ParticipantTask task3 = tasks.get(2);
+
+        // make task1 old and in-progress
+        task1.setCreatedAt(Instant.now().minus(10, ChronoUnit.DAYS));
+        task1.setStatus(TaskStatus.IN_PROGRESS);
+        participantTaskService.update(task1, DataAuditInfo.builder().systemProcess(getTestName(testInfo)).build());
+
+        // make task2 old and complete
+        task2.setCreatedAt(Instant.now().minus(9, ChronoUnit.DAYS));
+        task2.setCompletedAt(Instant.now().minus(9, ChronoUnit.DAYS));
+        task2.setStatus(TaskStatus.COMPLETE);
+
+        participantTaskService.update(task2, DataAuditInfo.builder().systemProcess(getTestName(testInfo)).build());
+
+        // make task3 old and in-progress
+        task3.setCreatedAt(Instant.now().minus(8, ChronoUnit.DAYS));
+        task3.setStatus(TaskStatus.IN_PROGRESS);
+        participantTaskService.update(task3, DataAuditInfo.builder().systemProcess(getTestName(testInfo)).build());
+
+        // this should not assign anything even though participant has an old completed one
+
+        surveyTaskDispatcher.assignScheduledTasks();
+
+        tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
+
+        assertThat(tasks, hasSize(3));
+
+        // make task3 old complete
+
+        task3.setCompletedAt(Instant.now().minus(8, ChronoUnit.DAYS));
+        task3.setStatus(TaskStatus.COMPLETE);
+
+        participantTaskService.update(task3, DataAuditInfo.builder().systemProcess(getTestName(testInfo)).build());
+
+        // this should assign a new task to the enrollee, since the latest task is now complete
+        surveyTaskDispatcher.assignScheduledTasks();
+
+        tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
+
+        assertThat(tasks, hasSize(4));
+    }
+
+
+    @Test
+    @Transactional
+    public void testRecurringAssignIgnoresRemovedTasks(TestInfo testInfo) {
+        // create a 7-day recurring survey, confirm it gets reassigned
+        StudyEnvironmentBundle sandboxBundle = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.sandbox);
+        Survey survey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(testInfo))
+                .portalId(sandboxBundle.getPortal().getId())
+                .recurrenceType(RecurrenceType.LONGITUDINAL)
+                .recurrenceIntervalDays(7));
+        surveyFactory.attachToEnv(survey, sandboxBundle.getStudyEnv().getId(), true);
+
+        EnrolleeBundle sandbox = enrolleeFactory.enroll(getTestName(testInfo) + "1", sandboxBundle.getPortal().getShortcode(), sandboxBundle.getStudy().getShortcode(), EnvironmentName.sandbox);
+
+        List<ParticipantTask> tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
+        // task should be assigned to all enrollees on creation
+        assertThat(tasks, hasSize(1));
+
+
+        // assign some new versions of the task
+        surveyTaskDispatcher.assign(
+                new ParticipantTaskAssignDto(TaskType.SURVEY, survey.getStableId(), survey.getVersion(), List.of(sandbox.enrollee().getId()), true, true, "reason"),
+                sandboxBundle.getStudyEnv().getId(), new ResponsibleEntity(adminUserFactory.buildPersisted(getTestName(testInfo), true)));
+
+
+        tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
+
+        assertThat(tasks, hasSize(2));
+
+        ParticipantTask task1 = tasks.get(0);
+        ParticipantTask task2 = tasks.get(1);
+
+        // make task1 old and in-progress
+
+        task1.setCreatedAt(Instant.now().minus(10, ChronoUnit.DAYS));
+        task1.setStatus(TaskStatus.IN_PROGRESS);
+
+        participantTaskService.update(task1, DataAuditInfo.builder().systemProcess(getTestName(testInfo)).build());
+
+        // make task2 old and removed
+
+        task2.setCreatedAt(Instant.now().minus(9, ChronoUnit.DAYS));
+        task2.setStatus(TaskStatus.REMOVED);
+
+        participantTaskService.update(task2, DataAuditInfo.builder().systemProcess(getTestName(testInfo)).build());
+
+        // this should not assign since latest non-removed is in progress
+        surveyTaskDispatcher.assignScheduledTasks();
+
+        tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
+        assertThat(tasks, hasSize(2));
+
+
+        // make task1 old complete
+
+        task1.setCompletedAt(Instant.now().minus(10, ChronoUnit.DAYS));
+        task1.setStatus(TaskStatus.COMPLETE);
+
+        participantTaskService.update(task1, DataAuditInfo.builder().systemProcess(getTestName(testInfo)).build());
+
+        // this should assign a new task to the enrollee, since the latest non-removed task is now complete
+        surveyTaskDispatcher.assignScheduledTasks();
+
+        tasks = participantTaskService.findByStudyEnvironmentId(sandboxBundle.getStudyEnv().getId());
+
+        assertThat(tasks, hasSize(3));
+
     }
 
     @Test
@@ -402,16 +610,22 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
                 enrollee);
 
         // change the task time to 8 days ago, so it can be re-assigned during the next scheduled task assignment
-        timeShiftDao.changeTaskCreationTime(initialTask.getId(), Instant.now().minus(8, ChronoUnit.DAYS));
+        initialTask = participantTaskService.find(initialTask.getId()).get();
+        initialTask.setStatus(TaskStatus.COMPLETE);
+        initialTask.setCompletedAt(Instant.now().minus(8, ChronoUnit.DAYS));
+        participantTaskService.update(initialTask, DataAuditInfo.builder().systemProcess(getTestName(testInfo)).build());
 
         // test that task is re-assigned and answer was prepopulated in the new response
         surveyTaskDispatcher.assignScheduledTasks();
 
         // confirm the task was re-assigned
-        List<ParticipantTask> latestParticipantTasks = participantTaskService.findByEnrolleeId(enrollee.enrollee().getId());
+        List<ParticipantTask> latestParticipantTasks = participantTaskService
+                .findByEnrolleeId(enrollee.enrollee().getId());
         assertThat(latestParticipantTasks, hasSize(2));
 
-        ParticipantTask reassignedTask = latestParticipantTasks.get(1);
+        ParticipantTask finalInitialTask = initialTask;
+        ParticipantTask reassignedTask = latestParticipantTasks.stream().filter(task -> !task.getId().equals(finalInitialTask.getId())).findFirst().get();
+        
         SurveyResponse reassignedResponse = surveyResponseDao.findOneWithAnswers(reassignedTask.getSurveyResponseId()).get();
 
         //confirm diagnosis answer was prepopulated in the new response

--- a/ui-admin/src/study/surveys/CreateSurveyModal.tsx
+++ b/ui-admin/src/study/surveys/CreateSurveyModal.tsx
@@ -65,7 +65,8 @@ const CreateSurveyModal = ({ studyEnvContext, onDismiss, type }:
     createdAt: new Date().getDate(),
     lastUpdatedAt: new Date().getDate(),
     eligibilityRule: '',
-    recurrenceType: 'NONE'
+    recurrenceType: 'NONE',
+    recurOn: 'COMPLETION'
   })
 
   const { clearFields, NameInput, StableIdInput } = useFormCreationNameFields(form, setForm)
@@ -164,7 +165,8 @@ const CreateSurveyModal = ({ studyEnvContext, onDismiss, type }:
               version: importForm.version ?? 1,
               name: importForm.name,
               content: JSON.stringify(importForm.jsonContent),
-              recurrenceType: importForm.recurrenceType ?? 'NONE'
+              recurrenceType: importForm.recurrenceType ?? 'NONE',
+              recurOn: importForm.recurOn ?? 'COMPLETION'
             })
           }}/>
         </div>}

--- a/ui-admin/src/study/surveys/FormOptionsModal.tsx
+++ b/ui-admin/src/study/surveys/FormOptionsModal.tsx
@@ -18,7 +18,10 @@ import { LazySearchQueryBuilder } from 'search/LazySearchQueryBuilder'
 import { TextInput } from '../../components/forms/TextInput'
 import { useNonNullReactSingleSelect } from 'util/react-select-utils'
 import Select from 'react-select'
-import { RecurrenceType } from '@juniper/ui-core'
+import {
+  RecurOn,
+  RecurrenceType
+} from '@juniper/ui-core'
 
 
 /** component for selecting versions of a form */
@@ -31,7 +34,7 @@ export default function FormOptionsModal({
                                              updateWorkingForm: (props: SaveableFormProps) => void,
                                              onDismiss: () => void
                                            }) {
-  return <Modal show={true} onHide={onDismiss} size="lg">
+  return <Modal show={true} onHide={onDismiss} size="xl">
     <Modal.Header closeButton>
       <Modal.Title>{workingForm.name} - configuration</Modal.Title>
     </Modal.Header>
@@ -64,6 +67,16 @@ const RECURRENCE_OPTS: {label: string, value: RecurrenceType}[] = [{
   value: 'UPDATE',
   label: 'Update in-place'
 }]
+
+const RECUR_ON_OPTS: { label: string, value: RecurOn }[] = [
+  {
+    value: 'COMPLETION',
+    label: 'Survey Completion'
+  }, {
+    value: 'CREATION',
+    label: 'Survey Assignment'
+  }
+]
 
 /**
  * Renders the 'options' for a form, e.g. who is allowed to take it, if it's required, how it's assigned, etc...
@@ -164,12 +177,12 @@ export const FormOptions = ({ studyEnvContext, initialWorkingForm, updateWorking
                 styles={{
                   control: baseStyles => ({
                     ...baseStyles,
-                    minWidth: '13em'
+                    minWidth: '10em'
                   })
                 }}
                 options={recurrenceOpts} onChange={onRecurrenceTypeChange}
                 value={selectedRecurrenceType}/>
-              <label className="d-flex align-items-center ms-3">
+              <label className="d-flex align-items-center ms-2">
                 every <TextInput value={workingForm.recurrenceIntervalDays} type="number" min={1} max={9999}
                   className="mx-2"
                   onChange={val => updateWorkingForm({
@@ -177,8 +190,22 @@ export const FormOptions = ({ studyEnvContext, initialWorkingForm, updateWorking
                     recurrenceIntervalDays: parseInt(val),
                     recurrenceType: workingForm.recurrenceType === 'NONE' ? 'LONGITUDINAL' : workingForm.recurrenceType
                   })}
-                /> days
+                />
               </label>
+              <span className="me-2">
+                days after
+              </span>
+              <Select
+                options={RECUR_ON_OPTS}
+                value={RECUR_ON_OPTS.find(opt => opt.value === workingForm.recurOn)}
+                onChange={val => {
+                  updateWorkingForm({
+                    ...workingForm,
+                    recurOn: val?.value ?? 'COMPLETION'
+                  })
+                }
+                }
+              />
             </div>
             {workingForm.recurrenceType === 'LONGITUDINAL' && <><label className="form-label d-block">
               <input type="checkbox" checked={workingForm.prepopulate}

--- a/ui-admin/src/study/surveys/SurveyView.tsx
+++ b/ui-admin/src/study/surveys/SurveyView.tsx
@@ -1,16 +1,33 @@
 import React, { useState } from 'react'
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import {
+  useNavigate,
+  useParams,
+  useSearchParams
+} from 'react-router-dom'
 import { Store } from 'react-notifications-component'
 
 import { StudyParams } from 'study/StudyRouter'
-import { StudyEnvContextT, studyEnvFormsPath } from 'study/StudyEnvironmentRouter'
-import Api, { StudyEnvironmentSurvey, Survey } from 'api/api'
+import {
+  StudyEnvContextT,
+  studyEnvFormsPath
+} from 'study/StudyEnvironmentRouter'
+import Api, {
+  StudyEnvironmentSurvey,
+  Survey
+} from 'api/api'
 
 import { successNotification } from 'util/notifications'
 import SurveyEditorView from './SurveyEditorView'
 import LoadingSpinner from 'util/LoadingSpinner'
-import { doApiLoad, useLoadingEffect } from 'api/api-utils'
-import { AnswerMapping, RecurrenceType } from '@juniper/ui-core'
+import {
+  doApiLoad,
+  useLoadingEffect
+} from 'api/api-utils'
+import {
+  AnswerMapping,
+  RecurOn,
+  RecurrenceType
+} from '@juniper/ui-core'
 
 export type SurveyParamsT = StudyParams & {
   surveyStableId: string,
@@ -25,6 +42,7 @@ export type SaveableFormProps = {
   assignToExistingEnrollees?: boolean
   rule?: string
   recurrenceType: RecurrenceType
+  recurOn: RecurOn
   prepopulate: boolean
   createNewResponseAfterDays?: number
   recurrenceIntervalDays?: number

--- a/ui-core/src/types/forms.ts
+++ b/ui-core/src/types/forms.ts
@@ -32,6 +32,7 @@ export type VersionedForm = {
 
 export type SurveyType = 'RESEARCH' | 'OUTREACH' | 'CONSENT' | 'ADMIN' | 'DOCUMENT_REQUEST' | 'PRE_ENROLL'
 export type RecurrenceType = 'NONE' | 'LONGITUDINAL' | 'UPDATE'
+export type RecurOn = 'CREATION' | 'COMPLETION'
 export type Survey = VersionedForm & {
   surveyType: SurveyType
   blurb?: string
@@ -41,6 +42,7 @@ export type Survey = VersionedForm & {
   assignToExistingEnrollees: boolean
   autoUpdateTaskAssignments: boolean
   recurrenceType: RecurrenceType
+  recurOn: RecurOn
   recurrenceIntervalDays: number
   daysAfterEligible?: number
   allowAdminEdit: boolean
@@ -57,6 +59,7 @@ export const defaultSurvey = {
   assignToExistingEnrollees: false,
   autoUpdateTaskAssignments: false,
   recurrenceType: 'NONE' as RecurrenceType,
+  recurOn: 'COMPLETION' as RecurOn,
   recurrenceIntervalDays: 0,
   allowAdminEdit: true,
   allowParticipantStart: true,


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

From A-T's perspective they only want a new recurrence to come out if the task is completed, and it's one year after the completion date. Since hearthive wants it the other way, (recur every year no matter if completed or not based on creation date), it's configurable with a new option:

<img width="832" alt="image" src="https://github.com/user-attachments/assets/0e61b591-feee-4498-a044-a6c20660950b" />

Also makes it more robust to removed tasks and makes testing more complete.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- I did some testing locally, but I think it will be easiest to make sure the unit tests make sense and then on merge I'll add a bunch of test participants to demo to make sure it works as expected before we release it to production.