### PR TITLE
[JN-1690] fix multiple reminders not sending

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/dataimport/TimeShiftDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/dataimport/TimeShiftDao.java
@@ -145,4 +145,13 @@ public class TimeShiftDao {
         );
     }
 
+    public void changeNotificationCreationTime(UUID notificationId, Instant creationTime) {
+        jdbi.withHandle(handle ->
+                handle.createUpdate("update notification set created_at = :creationTime where id = :notificationId;")
+                        .bind("notificationId", notificationId)
+                        .bind("creationTime", creationTime)
+                        .execute()
+        );
+    }
+
 }

--- a/core/src/main/java/bio/terra/pearl/core/dao/workflow/ParticipantTaskDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/workflow/ParticipantTaskDao.java
@@ -213,7 +213,7 @@ public class ParticipantTaskDao extends BaseMutableJdbiDao<ParticipantTask> impl
                                     and created_at > :maxTimeSinceCreationInstant 
                                     and status in (<statuses>)
                                     %s
-                                    and (:lastNotificationCutoff > last_notification_time OR last_notification_time < created_at OR last_notification_time IS NULL)
+                                    and (:lastNotificationCutoff > last_notification_time OR last_notification_time IS NULL)
                                     group by enrollee_id order by enrollee_id;
                                     """.formatted(triggerScopeString, stableIdString))
                             .bind("studyEnvironmentId", studyEnvironmentId)

--- a/core/src/main/java/bio/terra/pearl/core/dao/workflow/ParticipantTaskDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/workflow/ParticipantTaskDao.java
@@ -225,9 +225,9 @@ public class ParticipantTaskDao extends BaseMutableJdbiDao<ParticipantTask> impl
                     if (targetStableIds != null) {
                         query.bindList("targetStableIds", targetStableIds);
                     }
-            if (triggerScopeId != null) {
-                query.bind("triggerScopeId", triggerScopeId);
-            }
+                    if (triggerScopeId != null) {
+                        query.bind("triggerScopeId", triggerScopeId);
+                    }
                     return query.map(enrolleeWithTasksMapper).list();
                 }
         );

--- a/core/src/main/java/bio/terra/pearl/core/dao/workflow/ParticipantTaskDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/workflow/ParticipantTaskDao.java
@@ -54,7 +54,9 @@ public class ParticipantTaskDao extends BaseMutableJdbiDao<ParticipantTask> impl
         return findAllByProperty("portal_participant_user_id", ppUserId);
     }
 
-    /** Attempts to find a task for the given activity and study.  If there are multiple, it will return the most recently created */
+    /**
+     * Attempts to find a task for the given activity and study.  If there are multiple, it will return the most recently created
+     */
     public Optional<ParticipantTask> findTaskForActivity(UUID ppUserId, UUID studyEnvironmentId, String activityStableId) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("""
@@ -111,7 +113,9 @@ public class ParticipantTaskDao extends BaseMutableJdbiDao<ParticipantTask> impl
         );
     }
 
-    /** Attempts to find a task for the given activity and study, but before the given timestamp.  If there are multiple, it will return the most recently created */
+    /**
+     * Attempts to find a task for the given activity and study, but before the given timestamp.  If there are multiple, it will return the most recently created
+     */
     public Optional<ParticipantTask> findTaskForActivity(UUID ppUserId, UUID studyEnvironmentId, String activityStableId, Instant createdBefore) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("""
@@ -129,7 +133,9 @@ public class ParticipantTaskDao extends BaseMutableJdbiDao<ParticipantTask> impl
         );
     }
 
-    /** Attempts to find a task for the given activity and study.  If there are multiple, it will return the most recently created */
+    /**
+     * Attempts to find a task for the given activity and study.  If there are multiple, it will return the most recently created
+     */
     public Optional<ParticipantTask> findTaskForActivity(Enrollee enrollee, UUID studyEnvironmentId, String activityStableId) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("""
@@ -162,16 +168,16 @@ public class ParticipantTaskDao extends BaseMutableJdbiDao<ParticipantTask> impl
                                                        Duration maxTimeSinceCreation,
                                                        Duration minTimeSinceLastNotification,
                                                        List<TaskStatus> statuses) {
-        return findByStatusAndTime(studyEnvironmentId, taskType, minTimeSinceCreation, maxTimeSinceCreation, minTimeSinceLastNotification, statuses, null);
+        return findByStatusAndTime(studyEnvironmentId, taskType, minTimeSinceCreation, maxTimeSinceCreation, minTimeSinceLastNotification, statuses, null, null);
     }
 
     /**
      * minTimeSinceLastNotification covers *any* notification, not just ones for the given activity, and any status.
      * Our main goal is to reduce the likelihood of spam/exceeding quotas.
-     *
+     * <p>
      * We assume that a notification that was skipped/failed is just as likely to skip/fail again, so we don't retry
      * until the next time we would ordinarily send a notification.
-     *
+     * <p>
      * if targetStableIds is not null, it will filter to only tasks with those targetStableIds.  If null, all targets will be included
      */
     public List<EnrolleeWithTasks> findByStatusAndTime(UUID studyEnvironmentId,
@@ -179,8 +185,7 @@ public class ParticipantTaskDao extends BaseMutableJdbiDao<ParticipantTask> impl
                                                        Duration minTimeSinceCreation,
                                                        Duration maxTimeSinceCreation,
                                                        Duration minTimeSinceLastNotification,
-                                                       List<TaskStatus> statuses,
-                                                       List<String> targetStableIds) {
+                                                       List<TaskStatus> statuses, List<String> targetStableIds, UUID triggerScopeId) {
         Instant minTimeSinceCreationInstant = Instant.now().minus(minTimeSinceCreation);
         Instant maxTimeSinceCreationInstant = Instant.now().minus(maxTimeSinceCreation);
         Instant lastNotificationCutoff = Instant.now().minus(minTimeSinceLastNotification);
@@ -190,11 +195,12 @@ public class ParticipantTaskDao extends BaseMutableJdbiDao<ParticipantTask> impl
             return new ArrayList<>();
         }
         String stableIdString = targetStableIds == null ? "" : "and target_stable_id IN (<targetStableIds>)";
+        String triggerScopeString = triggerScopeId == null ? "" : "and trigger_id = :triggerScopeId";
 
         return jdbi.withHandle(handle -> {
                     Query query = handle.createQuery("""
                                     with enrollee_times as (select enrollee_id as notification_enrollee_id, MAX(created_at) as last_notification_time
-                                      from notification where study_environment_id = :studyEnvironmentId group by enrollee_id)
+                                      from notification where study_environment_id = :studyEnvironmentId %s group by enrollee_id)
                                     select enrollee_id as enrolleeId,
                                           array_agg(target_name) as taskTargetNames, 
                                           array_agg(id) as taskIds,
@@ -207,9 +213,9 @@ public class ParticipantTaskDao extends BaseMutableJdbiDao<ParticipantTask> impl
                                     and created_at > :maxTimeSinceCreationInstant 
                                     and status in (<statuses>)
                                     %s
-                                    and (:lastNotificationCutoff > last_notification_time OR last_notification_time IS NULL)
+                                    and (:lastNotificationCutoff > last_notification_time OR last_notification_time < created_at OR last_notification_time IS NULL)
                                     group by enrollee_id order by enrollee_id;
-                                    """.formatted(stableIdString))
+                                    """.formatted(triggerScopeString, stableIdString))
                             .bind("studyEnvironmentId", studyEnvironmentId)
                             .bindList("statuses", statuses)
                             .bind("lastNotificationCutoff", lastNotificationCutoff)
@@ -219,11 +225,13 @@ public class ParticipantTaskDao extends BaseMutableJdbiDao<ParticipantTask> impl
                     if (targetStableIds != null) {
                         query.bindList("targetStableIds", targetStableIds);
                     }
+            if (triggerScopeId != null) {
+                query.bind("triggerScopeId", triggerScopeId);
+            }
                     return query.map(enrolleeWithTasksMapper).list();
                 }
         );
     }
-
 
 
     /**
@@ -250,7 +258,8 @@ public class ParticipantTaskDao extends BaseMutableJdbiDao<ParticipantTask> impl
     }
 
     @Getter
-    @Setter @NoArgsConstructor
+    @Setter
+    @NoArgsConstructor
     public static class EnrolleeWithTasks {
         private UUID enrolleeId;
         private List<String> taskTargetNames;
@@ -261,7 +270,8 @@ public class ParticipantTaskDao extends BaseMutableJdbiDao<ParticipantTask> impl
     public final RowMapper<EnrolleeWithTasks> enrolleeWithTasksMapper = BeanMapper.of(EnrolleeWithTasks.class);
 
     @Getter
-    @Setter @NoArgsConstructor
+    @Setter
+    @NoArgsConstructor
     @SuperBuilder
     public static class EnrolleeTasks {
         private String targetName;

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/EnrolleeReminderService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/EnrolleeReminderService.java
@@ -1,9 +1,7 @@
 package bio.terra.pearl.core.service.notification;
 
-import bio.terra.pearl.core.dao.kit.KitRequestDao;
 import bio.terra.pearl.core.dao.kit.KitTypeDao;
 import bio.terra.pearl.core.dao.workflow.ParticipantTaskDao;
-import bio.terra.pearl.core.model.kit.KitType;
 import bio.terra.pearl.core.model.notification.Trigger;
 import bio.terra.pearl.core.model.notification.TriggerType;
 import bio.terra.pearl.core.model.participant.EnrolleeSourceType;
@@ -17,9 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
-import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 
 @Service
 @Slf4j
@@ -79,7 +75,10 @@ public class EnrolleeReminderService {
                         maxTimeSinceCreation,
                         timeSinceLastNotification,
                         // if the list is empty, it applies to all targets, so pass null
-                        trigger.getFilterTargetStableIds().isEmpty() ? null : trigger.getFilterTargetStableIds());
+                        trigger.getFilterTargetStableIds().isEmpty() ? null : trigger.getFilterTargetStableIds(),
+                        // in the case that there's a filter, we need to send this reminder out
+                        // regardless of other reminders being sent out about other things
+                        trigger.getFilterTargetStableIds().isEmpty() ? null : trigger.getId());
 
         log.info("Found {} enrollees with tasks needing reminder from config {}: taskType {}",
                 enrolleesWithTasks.size(), trigger.getId(), trigger.getTaskType());

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/ParticipantTaskQueryService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/ParticipantTaskQueryService.java
@@ -4,10 +4,11 @@ import bio.terra.pearl.core.dao.notification.NotificationDao;
 import bio.terra.pearl.core.dao.workflow.ParticipantTaskDao;
 import bio.terra.pearl.core.model.workflow.TaskStatus;
 import bio.terra.pearl.core.model.workflow.TaskType;
+import org.springframework.stereotype.Service;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
-import org.springframework.stereotype.Service;
 
 @Service
 public class ParticipantTaskQueryService {
@@ -25,9 +26,10 @@ public class ParticipantTaskQueryService {
                                                                           Duration maxTimeSinceCreation,
                                                                           Duration timeSinceLastNotification,
                                                                           List<TaskStatus> statuses,
-                                                                          List<String> targetStableIds) {
+                                                                          List<String> targetStableIds,
+                                                                          UUID triggerScopeId) {
         return participantTaskDao.findByStatusAndTime(studyEnvironmentId, taskType, timeSinceCreation, maxTimeSinceCreation,
-                timeSinceLastNotification, statuses, targetStableIds);
+                timeSinceLastNotification, statuses, targetStableIds, triggerScopeId);
     }
 
     public List<ParticipantTaskDao.EnrolleeWithTasks> findIncompleteByTime(UUID studyEnvironmentId,
@@ -35,8 +37,9 @@ public class ParticipantTaskQueryService {
                                                                            Duration timeSinceCreation,
                                                                            Duration maxTimeSinceCreation,
                                                                            Duration timeSinceLastNotification,
-                                                                           List<String> targetStableIds) {
+                                                                           List<String> targetStableIds,
+                                                                           UUID triggerScopeId) {
         return findByStatusAndTime(studyEnvironmentId, taskType, timeSinceCreation, maxTimeSinceCreation, timeSinceLastNotification,
-                List.of(TaskStatus.NEW, TaskStatus.IN_PROGRESS), targetStableIds);
+                List.of(TaskStatus.NEW, TaskStatus.IN_PROGRESS), targetStableIds, triggerScopeId);
     }
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/EnrolleeReminderServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/EnrolleeReminderServiceTests.java
@@ -2,6 +2,8 @@ package bio.terra.pearl.core.service.notification;
 
 import bio.terra.pearl.core.BaseSpringBootTest;
 import bio.terra.pearl.core.dao.notification.NotificationDao;
+import bio.terra.pearl.core.dao.workflow.ParticipantTaskDao;
+import bio.terra.pearl.core.factory.StudyEnvironmentBundle;
 import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
 import bio.terra.pearl.core.factory.kit.KitRequestFactory;
 import bio.terra.pearl.core.factory.kit.KitTypeFactory;
@@ -9,6 +11,8 @@ import bio.terra.pearl.core.factory.participant.EnrolleeBundle;
 import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
 import bio.terra.pearl.core.factory.participant.ParticipantTaskFactory;
 import bio.terra.pearl.core.factory.portal.PortalEnvironmentFactory;
+import bio.terra.pearl.core.factory.survey.SurveyFactory;
+import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.kit.KitType;
 import bio.terra.pearl.core.model.notification.Notification;
@@ -18,6 +22,7 @@ import bio.terra.pearl.core.model.notification.TriggerType;
 import bio.terra.pearl.core.model.participant.EnrolleeSourceType;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
+import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
 import bio.terra.pearl.core.model.workflow.TaskStatus;
 import bio.terra.pearl.core.model.workflow.TaskType;
@@ -28,6 +33,8 @@ import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -182,6 +189,110 @@ public class EnrolleeReminderServiceTests extends BaseSpringBootTest {
     assertThat(notificationList, hasSize(0));
   }
 
+  @Test
+  @Transactional
+  public void testSendFilteredReminderEvenIfOtherReminderSent(TestInfo info) {
+    // create 2 surveys
+    StudyEnvironmentBundle studyEnvBundle = studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.sandbox);
+    Survey survey1 = surveyFactory.buildPersisted(getTestName(info), studyEnvBundle.getPortal().getId());
+    Survey survey2 = surveyFactory.buildPersisted(getTestName(info), studyEnvBundle.getPortal().getId());
+
+    surveyFactory.attachToEnv(survey1, studyEnvBundle.getStudyEnv().getId(), true);
+    surveyFactory.attachToEnv(survey2, studyEnvBundle.getStudyEnv().getId(), true);
+    // create reminder config for all surveys
+
+    Trigger configAllSurveys = Trigger.builder()
+            .triggerType(TriggerType.TASK_REMINDER)
+            .taskType(TaskType.SURVEY)
+            .afterMinutesIncomplete(0)
+            .deliveryType(NotificationDeliveryType.EMAIL)
+            .studyEnvironmentId(studyEnvBundle.getStudyEnv().getId())
+            .portalEnvironmentId(studyEnvBundle.getPortalEnv().getId())
+            .build();
+
+    triggerService.create(configAllSurveys);
+
+    Trigger configOnlySurvey1 = Trigger.builder()
+            .triggerType(TriggerType.TASK_REMINDER)
+            .taskType(TaskType.SURVEY)
+            .filterTargetStableIds(List.of(survey1.getStableId()))
+            .afterMinutesIncomplete(0)
+            .deliveryType(NotificationDeliveryType.EMAIL)
+            .studyEnvironmentId(studyEnvBundle.getStudyEnv().getId())
+            .portalEnvironmentId(studyEnvBundle.getPortalEnv().getId())
+            .build();
+
+    triggerService.create(configOnlySurvey1);
+
+    // create enrollee with both surveys
+
+    EnrolleeBundle enrolleeBundle = enrolleeFactory.buildWithPortalUser(getTestName(info), studyEnvBundle.getPortalEnv(), studyEnvBundle.getStudyEnv(), true);
+
+    participantTaskFactory.buildPersisted(enrolleeBundle, survey1.getStableId(), TaskStatus.NEW, TaskType.SURVEY);
+    participantTaskFactory.buildPersisted(enrolleeBundle, survey2.getStableId(), TaskStatus.NEW, TaskType.SURVEY);
+
+    // ensure both get sent
+    enrolleeReminderService.sendTaskReminders(studyEnvBundle.getStudyEnv());
+
+    List<Notification> notificationList = notificationDao.findByEnrolleeId(enrolleeBundle.enrollee().getId());
+    assertThat(notificationList, hasSize(2));
+  }
+
+  @Test
+  @Transactional
+  public void testSendLongitudinalReminders(TestInfo info) {
+
+    String testName = getTestName(info);
+    StudyEnvironmentBundle studyEnvBundle = studyEnvironmentFactory.buildBundle(testName, EnvironmentName.sandbox);
+    PortalEnvironment portalEnv = studyEnvBundle.getPortalEnv();
+    StudyEnvironment studyEnv = studyEnvBundle.getStudyEnv();
+
+    EnrolleeBundle enrolleeBundle = enrolleeFactory.buildWithPortalUser(testName, portalEnv, studyEnv, true);
+    Survey survey1 = surveyFactory.buildPersisted(testName, studyEnvBundle.getPortal().getId());
+    surveyFactory.attachToEnv(survey1, studyEnv.getId(), true);
+
+    ParticipantTask firstTask = participantTaskFactory.buildPersisted(enrolleeBundle, survey1.getStableId(), TaskStatus.NEW, TaskType.SURVEY);
+
+    Trigger config = Trigger.builder()
+            .triggerType(TriggerType.TASK_REMINDER)
+            .taskType(TaskType.SURVEY)
+            .afterMinutesIncomplete(0)
+            .deliveryType(NotificationDeliveryType.EMAIL)
+            .studyEnvironmentId(studyEnv.getId())
+            .portalEnvironmentId(portalEnv.getId())
+            .maxNumReminders(1)
+            .build();
+    triggerService.create(config);
+    enrolleeReminderService.sendTaskReminders(studyEnv);
+
+    List<Notification> notificationList = notificationDao.findByEnrolleeId(enrolleeBundle.enrollee().getId());
+    assertThat(notificationList, hasSize(1));
+
+    Notification firstNotification = notificationList.get(0);
+
+    firstNotification.setCreatedAt(Instant.now().minus(365, ChronoUnit.DAYS));
+    notificationDao.update(firstNotification);
+
+    firstTask = participantTaskDao.find(firstTask.getId()).orElseThrow();
+    firstTask.setStatus(TaskStatus.IN_PROGRESS);
+    firstTask.setCreatedAt(Instant.now().minus(365, ChronoUnit.DAYS));
+    participantTaskDao.update(firstTask);
+
+    enrolleeReminderService.sendTaskReminders(studyEnv);
+
+    notificationList = notificationDao.findByEnrolleeId(enrolleeBundle.enrollee().getId());
+    assertThat(notificationList, hasSize(1));
+
+    // create new task
+
+    ParticipantTask newTask = participantTaskFactory.buildPersisted(enrolleeBundle, survey1.getStableId(), TaskStatus.NEW, TaskType.SURVEY);
+
+    enrolleeReminderService.sendTaskReminders(studyEnv);
+
+    notificationList = notificationDao.findByEnrolleeId(enrolleeBundle.enrollee().getId());
+    assertThat(notificationList, hasSize(2));
+  }
+
   @Autowired
   private ParticipantTaskFactory participantTaskFactory;
   @Autowired
@@ -202,4 +313,8 @@ public class EnrolleeReminderServiceTests extends BaseSpringBootTest {
   private KitTypeFactory kitTypeFactory;
   @Autowired
   private KitRequestFactory kitRequestFactory;
+  @Autowired
+  private SurveyFactory surveyFactory;
+  @Autowired
+  private ParticipantTaskDao participantTaskDao;
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/EnrolleeReminderServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/EnrolleeReminderServiceTests.java
@@ -241,6 +241,56 @@ public class EnrolleeReminderServiceTests extends BaseSpringBootTest {
 
   @Test
   @Transactional
+  public void testSendMultipleFilteredReminders(TestInfo info) {
+    // create 2 surveys
+    StudyEnvironmentBundle studyEnvBundle = studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.sandbox);
+    Survey survey1 = surveyFactory.buildPersisted(getTestName(info), studyEnvBundle.getPortal().getId());
+    Survey survey2 = surveyFactory.buildPersisted(getTestName(info), studyEnvBundle.getPortal().getId());
+
+    surveyFactory.attachToEnv(survey1, studyEnvBundle.getStudyEnv().getId(), true);
+    surveyFactory.attachToEnv(survey2, studyEnvBundle.getStudyEnv().getId(), true);
+    // create reminder config for all surveys
+
+    Trigger configOnlySurvey1 = Trigger.builder()
+            .triggerType(TriggerType.TASK_REMINDER)
+            .taskType(TaskType.SURVEY)
+            .afterMinutesIncomplete(0)
+            .filterTargetStableIds(List.of(survey1.getStableId()))
+            .deliveryType(NotificationDeliveryType.EMAIL)
+            .studyEnvironmentId(studyEnvBundle.getStudyEnv().getId())
+            .portalEnvironmentId(studyEnvBundle.getPortalEnv().getId())
+            .build();
+
+    triggerService.create(configOnlySurvey1);
+
+    Trigger configOnlySurvey2 = Trigger.builder()
+            .triggerType(TriggerType.TASK_REMINDER)
+            .taskType(TaskType.SURVEY)
+            .filterTargetStableIds(List.of(survey2.getStableId()))
+            .afterMinutesIncomplete(0)
+            .deliveryType(NotificationDeliveryType.EMAIL)
+            .studyEnvironmentId(studyEnvBundle.getStudyEnv().getId())
+            .portalEnvironmentId(studyEnvBundle.getPortalEnv().getId())
+            .build();
+
+    triggerService.create(configOnlySurvey2);
+
+    // create enrollee with both surveys
+
+    EnrolleeBundle enrolleeBundle = enrolleeFactory.buildWithPortalUser(getTestName(info), studyEnvBundle.getPortalEnv(), studyEnvBundle.getStudyEnv(), true);
+
+    participantTaskFactory.buildPersisted(enrolleeBundle, survey1.getStableId(), TaskStatus.NEW, TaskType.SURVEY);
+    participantTaskFactory.buildPersisted(enrolleeBundle, survey2.getStableId(), TaskStatus.NEW, TaskType.SURVEY);
+
+    // ensure both get sent
+    enrolleeReminderService.sendTaskReminders(studyEnvBundle.getStudyEnv());
+
+    List<Notification> notificationList = notificationDao.findByEnrolleeId(enrolleeBundle.enrollee().getId());
+    assertThat(notificationList, hasSize(2));
+  }
+
+  @Test
+  @Transactional
   public void testSendLongitudinalReminders(TestInfo info) {
 
     String testName = getTestName(info);

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/EnrolleeReminderServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/EnrolleeReminderServiceTests.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.service.notification;
 
 import bio.terra.pearl.core.BaseSpringBootTest;
+import bio.terra.pearl.core.dao.dataimport.TimeShiftDao;
 import bio.terra.pearl.core.dao.notification.NotificationDao;
 import bio.terra.pearl.core.dao.workflow.ParticipantTaskDao;
 import bio.terra.pearl.core.factory.StudyEnvironmentBundle;
@@ -270,23 +271,23 @@ public class EnrolleeReminderServiceTests extends BaseSpringBootTest {
 
     Notification firstNotification = notificationList.get(0);
 
-    firstNotification.setCreatedAt(Instant.now().minus(365, ChronoUnit.DAYS));
-    notificationDao.update(firstNotification);
+    timeShiftDao.changeNotificationCreationTime(firstNotification.getId(), Instant.now().minus(365, ChronoUnit.DAYS));
 
     firstTask = participantTaskDao.find(firstTask.getId()).orElseThrow();
     firstTask.setStatus(TaskStatus.IN_PROGRESS);
-    firstTask.setCreatedAt(Instant.now().minus(365, ChronoUnit.DAYS));
     participantTaskDao.update(firstTask);
+    timeShiftDao.changeTasksCreationTime(List.of(firstTask.getId()), Instant.now().minus(365, ChronoUnit.DAYS));
 
+    // shouldn't send when it's old
     enrolleeReminderService.sendTaskReminders(studyEnv);
 
     notificationList = notificationDao.findByEnrolleeId(enrolleeBundle.enrollee().getId());
     assertThat(notificationList, hasSize(1));
 
     // create new task
-
     ParticipantTask newTask = participantTaskFactory.buildPersisted(enrolleeBundle, survey1.getStableId(), TaskStatus.NEW, TaskType.SURVEY);
 
+    // should send again now since there's a new task
     enrolleeReminderService.sendTaskReminders(studyEnv);
 
     notificationList = notificationDao.findByEnrolleeId(enrolleeBundle.enrollee().getId());
@@ -317,4 +318,6 @@ public class EnrolleeReminderServiceTests extends BaseSpringBootTest {
   private SurveyFactory surveyFactory;
   @Autowired
   private ParticipantTaskDao participantTaskDao;
+  @Autowired
+  private TimeShiftDao timeShiftDao;
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds more tests (mostly just for my own sanity), including one just to make sure longitudinal reminders work as i expect. 

Also, fixes a case where A-T has multiple unrelated reminders with filters; only one of the reminders would send because the reminders would be filtered out if ANY notification has been sent recently. This PR makes reminder debouncing trigger-specific in the case that we have a filter, so that multiple reminders can send out at once in these cases.


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- Create multiple zero-hour reminders with filters on the stable ids
- Enroll
- Make sure you get all of them