### PR TITLE
[JN-1689] import page email button should not send multiple emails to proxies

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/dataimport/ImportItem.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/dataimport/ImportItem.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.core.model.dataimport;
 
 import bio.terra.pearl.core.model.BaseEntity;
 import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.participant.ParticipantUser;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -16,6 +17,7 @@ import java.util.UUID;
 public class ImportItem extends BaseEntity {
     private UUID createdEnrolleeId;
     private Enrollee createdEnrollee;
+    private ParticipantUser createdParticipantUser;
     private UUID createdParticipantUserId;
     private UUID importId;
     private ImportItemStatus status;

--- a/core/src/main/java/bio/terra/pearl/core/service/export/dataimport/ImportItemService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/dataimport/ImportItemService.java
@@ -5,9 +5,12 @@ import bio.terra.pearl.core.model.dataimport.Import;
 import bio.terra.pearl.core.model.dataimport.ImportItem;
 import bio.terra.pearl.core.model.dataimport.ImportItemStatus;
 import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.service.CrudService;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
+import bio.terra.pearl.core.service.participant.ParticipantUserService;
+import bio.terra.pearl.core.service.rule.EnrolleeContextService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,10 +25,14 @@ import java.util.UUID;
 public class ImportItemService extends CrudService<ImportItem, ImportItemDao> {
 
     private final EnrolleeService enrolleeService;
+    private final EnrolleeContextService enrolleeContextService;
+    private final ParticipantUserService participantUserService;
 
-    public ImportItemService(ImportItemDao dao, EnrolleeService enrolleeService) {
+    public ImportItemService(ImportItemDao dao, EnrolleeService enrolleeService, EnrolleeContextService enrolleeContextService, ParticipantUserService participantUserService) {
         super(dao);
         this.enrolleeService = enrolleeService;
+        this.enrolleeContextService = enrolleeContextService;
+        this.participantUserService = participantUserService;
     }
 
     public void attachImportItems(Import dataImport) {
@@ -43,6 +50,10 @@ public class ImportItemService extends CrudService<ImportItem, ImportItemDao> {
 
         if (!enrolleeIds.isEmpty()) {
             List<Enrollee> enrollees = enrolleeService.findAll(enrolleeIds);
+            List<ParticipantUser> participantUsers = participantUserService.findAll(enrollees.stream()
+                    .map(Enrollee::getParticipantUserId)
+                    .filter(Objects::nonNull)
+                    .toList());
 
             for (ImportItem item : items) {
                 if (item.getCreatedEnrolleeId() != null) {
@@ -50,7 +61,17 @@ public class ImportItemService extends CrudService<ImportItem, ImportItemDao> {
                             .filter(e -> e.getId().equals(item.getCreatedEnrolleeId()))
                             .findFirst()
                             .orElse(null);
+                    if (enrollee == null) {
+                        continue;
+                    }
+
+                    ParticipantUser participantUser = participantUsers.stream()
+                            .filter(pu -> pu.getId().equals(enrollee.getParticipantUserId()))
+                            .findFirst()
+                            .orElse(null);
+                    
                     item.setCreatedEnrollee(enrollee);
+                    item.setCreatedParticipantUser(participantUser);
                 }
             }
         }

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -214,6 +214,7 @@ export type DataImportItem = {
   createdParticipantUserId?: string,
   createdEnrolleeId?: string,
   createdEnrollee?: Enrollee,
+  createdParticipantUser?: ParticipantUser,
   status: DataImportItemStatus,
   message?: string,
   detail?: string,

--- a/ui-admin/src/portal/DataImportView.tsx
+++ b/ui-admin/src/portal/DataImportView.tsx
@@ -162,7 +162,6 @@ export default function DataImportView({ studyEnvContext }:
 
 const removeProxyEmailSuffix = (email: string) => {
   // remove -prox-ABCD from the end of the email
-
   const regex = /-prox-[A-Z0-9]{4}$/
 
   const match = email.match(regex)
@@ -177,18 +176,16 @@ const removeProxyEmailSuffix = (email: string) => {
 // invitation email doesn't go to the same email multiple times
 const getSingleEnrolleePerAccount = (dataImportItems: DataImportItem[]): Enrollee[] => {
   return dataImportItems
+    // only successfully imported subjects
     .filter(item => item.createdEnrollee && item.createdEnrollee.shortcode && item.createdEnrollee.subject)
-    .map(item => {
-      return {
-        enrollee: item.createdEnrollee,
-        email: removeProxyEmailSuffix(item.createdParticipantUser?.username || '')
-      }
-    })
     .reduce((acc, data) => {
       // remove any duplicate emails
-      if (!acc.some(item => item.email === data.email)) {
-        acc.push(data)
+      const email = removeProxyEmailSuffix(data.createdParticipantUser?.username || '')
+
+      if (!acc.some(item => item.email === email)) {
+        acc.push({ enrollee: data.createdEnrollee, email })
       }
+
       return acc
     }, [] as { enrollee: Enrollee | undefined, email: string }[])
     .map(data => data.enrollee)

--- a/ui-admin/src/portal/DataImportView.tsx
+++ b/ui-admin/src/portal/DataImportView.tsx
@@ -16,6 +16,7 @@ import {
 } from '../util/table/tableUtils'
 import {
   currentIsoDate,
+  Enrollee,
   instantToDefaultString
 } from '@juniper/ui-core'
 import { useLoadingEffect } from '../api/api-utils'
@@ -41,10 +42,7 @@ export default function DataImportView({ studyEnvContext }:
   const [sorting, setSorting] = React.useState<SortingState>([{ 'id': 'createdAt', 'desc': true }])
   const [showSendEmailModal, setShowSendEmailModal] = useState(false)
 
-  const shortcodes: string[] = dataImportItems
-    .filter(item => item.createdEnrollee && item.createdEnrollee.shortcode && item.createdEnrollee.subject)
-    .map(item => item.createdEnrollee?.shortcode || '')
-    .filter(shortcode => shortcode != '') // I would have done an isNil check but typescript was being annoying
+  const enrolleesToInvite: Enrollee[] = getSingleEnrolleePerAccount(dataImportItems)
 
   const importedDate = instantToDefaultString(dataImportItems[0]?.createdAt)
   const columns: ColumnDef<DataImportItem>[] = [
@@ -157,7 +155,42 @@ export default function DataImportView({ studyEnvContext }:
           onDismiss={() => setShowSendEmailModal(false)}
           recipient={{
             type: 'shortcodes',
-            enrolleeShortcodes: shortcodes
+            enrolleeShortcodes: enrolleesToInvite.map(enrollee => enrollee.shortcode)
           }}/>}
   </div>
+}
+
+const removeProxyEmailSuffix = (email: string) => {
+  // remove -prox-ABCD from the end of the email
+
+  const regex = /-prox-[A-Z0-9]{4}$/
+
+  const match = email.match(regex)
+  if (match) {
+    return email.slice(0, match.index)
+  }
+  return email
+}
+
+// if there are multiple enrollee for the same email, e.g. with proxies,
+// make sure we only return one enrollee per email. that way the
+// invitation email doesn't go to the same email multiple times
+const getSingleEnrolleePerAccount = (dataImportItems: DataImportItem[]): Enrollee[] => {
+  return dataImportItems
+    .filter(item => item.createdEnrollee && item.createdEnrollee.shortcode && item.createdEnrollee.subject)
+    .map(item => {
+      return {
+        enrollee: item.createdEnrollee,
+        email: removeProxyEmailSuffix(item.createdParticipantUser?.username || '')
+      }
+    })
+    .reduce((acc, data) => {
+      // remove any duplicate emails
+      if (!acc.some(item => item.email === data.email)) {
+        acc.push(data)
+      }
+      return acc
+    }, [] as { enrollee: Enrollee | undefined, email: string }[])
+    .map(data => data.enrollee)
+    .filter(enrollee => enrollee !== undefined) as Enrollee[]
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

See this example; 1 self enrolled, 2 proxy accounts both with 4 governed users. Instead of sending these proxies 4 emails, we only send 1 per account:
<img width="1162" alt="image" src="https://github.com/user-attachments/assets/d14bca15-151b-43a1-8b45-e9175f09d523" />

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

