### PR TITLE
[JN-1694] fix prefill answers

### DIFF
--- a/ui-admin/src/study/surveys/PreEnrollShortcutModal.tsx
+++ b/ui-admin/src/study/surveys/PreEnrollShortcutModal.tsx
@@ -52,7 +52,7 @@ export default function PreEnrollShortcutModal({
     const params = {
       ...queryParams,
       referralSource: queryParams.referralSource ? JSON.stringify(queryParams.referralSource) : undefined,
-      preFilledAnswers: queryParams.preFilledAnswers ? JSON.stringify(queryParams.preFilledAnswers) : undefined
+      preFilledAnswers: queryParams.preFilledAnswers ? queryParams.preFilledAnswers : undefined
     }
 
     const allParamsEmpty = Object.values(params).every(v => v === undefined)

--- a/ui-participant/src/studies/enroll/useEnrollmentParams.tsx
+++ b/ui-participant/src/studies/enroll/useEnrollmentParams.tsx
@@ -86,7 +86,16 @@ const parsePreFilledAnswers = (preFilledAnswers: string | null): Answer[] => {
   }
 
   try {
-    return JSON.parse(preFilledAnswers) as Answer[]
+    let parsedAnswers = JSON.parse(preFilledAnswers)
+    if (typeof parsedAnswers === 'string') {
+      parsedAnswers = JSON.parse(parsedAnswers)
+    }
+
+    if (!Array.isArray(parsedAnswers)) {
+      console.error('Invalid preFilledAnswers format:', parsedAnswers)
+      return []
+    }
+    return parsedAnswers as Answer[]
   } catch (error) {
     console.error('Failed to parse preFilledAnswers:', error)
     return []


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

It was stringify-ing twice. So it would end up being `"[{stuff}]"` instead of `[{stuff}]`.

Both stops double-stringifying and also makes it robust against double stringify-ing so any existing links out there will not be broken.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Both of these links should work:
```
https://sandbox.demo.localhost:3001?preFilledAnswers=%22%5B%7B%5C%22questionStableId%5C%22%3A%5C%22proxy_enrollment%5C%22%2C%5C%22stringValue%5C%22%3A%5C%22false%5C%22%7D%2C%7B%5C%22questionStableId%5C%22%3A%5C%22governed_given_name%5C%22%2C%5C%22stringValue%5C%22%3A%5C%22asdf%5C%22%7D%5D%22&referralSource=%7B%22referringSite%22%3A%22asdfasdfasdfasdfasdf%22%7D

https://sandbox.demo.localhost:3001?preFilledAnswers=%5B%7B%22questionStableId%22%3A%22proxy_enrollment%22%2C%22stringValue%22%3A%22false%22%7D%2C%7B%22questionStableId%22%3A%22governed_given_name%22%2C%22stringValue%22%3A%22asdf%22%7D%5D&referralSource=%7B%22referringSite%22%3A%22asdfasdfasdfasdf%22%7D
```
