### PR TITLE
[JN-1697] fix proxies not being able to edit longitudinal imported surveys

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/workflow/ParticipantTaskDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/workflow/ParticipantTaskDao.java
@@ -113,6 +113,21 @@ public class ParticipantTaskDao extends BaseMutableJdbiDao<ParticipantTask> impl
         );
     }
 
+    public List<ParticipantTask> findAllTasksForActivityByEnrolleeId(UUID enrolleeId, String activityStableId) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("""
+                                select * from %s 
+                                where enrollee_id = :enrolleeId
+                                and target_stable_id = :activityStableId 
+                                order by created_at desc""".formatted(tableName)
+                        )
+                        .bind("enrolleeId", enrolleeId)
+                        .bind("activityStableId", activityStableId)
+                        .mapTo(clazz)
+                        .list()
+        );
+    }
+
     public Optional<ParticipantTask> findTaskForActivityWithCreationTime(UUID ppUserId, UUID studyEnvironmentId, String activityStableId, Instant createdAt) {
         return jdbi.withHandle(handle ->
                 // Note: 43200 seconds is 12 hours. Any task that was completed within 12 hours of the given time is considered a match

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -152,9 +152,9 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
     /**
      * Longitudinal tasks are editable by the participant if (and only if) the task is the most recent task for the survey
      */
-    private boolean isLongitudinalTaskEditable(PortalParticipantUser ppUser, UUID studyEnvId, SurveyResponse surveyResponse, String surveyStableId) {
+    private boolean isLongitudinalTaskEditable(Enrollee enrollee, SurveyResponse surveyResponse, String surveyStableId) {
 
-        List<ParticipantTask> tasks = participantTaskService.findAllTasksForActivity(ppUser.getId(), studyEnvId, surveyStableId);
+        List<ParticipantTask> tasks = participantTaskService.findAllTasksForActivityByEnrollee(enrollee.getId(), surveyStableId);
 
         Optional<ParticipantTask> taskOpt = tasks.stream().filter(t -> surveyResponse.getId().equals(t.getSurveyResponseId())).findFirst();
         if (taskOpt.isEmpty()) {
@@ -205,7 +205,7 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
 
         if (survey.getRecurrenceType() == RecurrenceType.LONGITUDINAL
                 && priorResponse != null
-                && !isLongitudinalTaskEditable(ppUser, enrollee.getStudyEnvironmentId(), priorResponse, survey.getStableId())
+                && !isLongitudinalTaskEditable(enrollee, priorResponse, survey.getStableId())
                 // admins should be able to update old responses
                 && operator.getParticipantUser() != null) {
             throw new IllegalArgumentException("Cannot update previous responses for longitudinal surveys");

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/ParticipantTaskService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/ParticipantTaskService.java
@@ -73,6 +73,10 @@ public class ParticipantTaskService extends ParticipantDataAuditedService<Partic
         return dao.findAllTasksForActivity(ppUserId, studyEnvironmentId, activityStableId);
     }
 
+    public List<ParticipantTask> findAllTasksForActivityByEnrollee(UUID enrolleeId, String activityStableId) {
+        return dao.findAllTasksForActivityByEnrolleeId(enrolleeId, activityStableId);
+    }
+
     public Optional<ParticipantTask> findTaskForActivityWithCreationTime(UUID ppUserId, UUID studyEnvironmentId, String activityStableId, Instant createdAt) {
         return dao.findTaskForActivityWithCreationTime(ppUserId, studyEnvironmentId, activityStableId, createdAt);
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/TaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/TaskDispatcher.java
@@ -364,7 +364,7 @@ public abstract class TaskDispatcher<T extends TaskConfig> {
                 ? latestTask.getCompletedAt()
                 : latestTask.getCreatedAt();
 
-        if (date == null) {
+        if (date == null || (taskDispatchConfig.getRecurOn() == RecurOn.COMPLETION && latestTask.getStatus() != TaskStatus.COMPLETE)) {
             return false; // never recur on incomplete tasks
         }
 
@@ -377,7 +377,7 @@ public abstract class TaskDispatcher<T extends TaskConfig> {
         BeanUtils.copyProperties(
                 oldTask,
                 newTask,
-                "id", "createdAt", "updatedAt",
+                "id", "createdAt", "updatedAt", "completedAt", "lastUpdatedAt",
                 "version", "status", "taskType",
                 "targetName", "targetStableId", "targetAssignedVersion",
                 "taskOrder", "blocksHub", "studyEnvironmentId",

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
@@ -5,6 +5,7 @@ import bio.terra.pearl.core.factory.DaoTestUtils;
 import bio.terra.pearl.core.factory.StudyEnvironmentBundle;
 import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
 import bio.terra.pearl.core.factory.fileupload.ParticipantFileFactory;
+import bio.terra.pearl.core.factory.participant.EnrolleeAndProxy;
 import bio.terra.pearl.core.factory.participant.EnrolleeBundle;
 import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
 import bio.terra.pearl.core.factory.participant.PortalParticipantUserFactory;
@@ -27,6 +28,7 @@ import bio.terra.pearl.core.model.workflow.TaskStatus;
 import bio.terra.pearl.core.service.file.ParticipantFileService;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.participant.ParticipantUserService;
+import bio.terra.pearl.core.service.participant.PortalParticipantUserService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
 import bio.terra.pearl.core.service.workflow.ParticipantDataChangeService;
 import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
@@ -78,6 +80,8 @@ public class SurveyResponseServiceTests extends BaseSpringBootTest {
     private ParticipantFileFactory participantFileFactory;
     @Autowired
     private ParticipantFileService participantFileService;
+    @Autowired
+    private PortalParticipantUserService portalParticipantUserService;
 
     @Test
     @Transactional
@@ -600,6 +604,78 @@ public class SurveyResponseServiceTests extends BaseSpringBootTest {
         surveyResponseService.updateResponse(
                 newResponse, new ResponsibleEntity(new AdminUser()), null,
                 enrolleeBundle.portalParticipantUser(), enrollee, task1.getId(), survey.getPortalId());
+    }
+    
+    @Test
+    @Transactional
+    public void testCannotUpdateLongitudinalProxies(TestInfo info) {
+        StudyEnvironmentBundle studyEnvBundle = studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.sandbox);
+
+        Survey survey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .portalId(studyEnvBundle.getPortal().getId())
+                .recurrenceType(RecurrenceType.LONGITUDINAL)
+                .recurrenceIntervalDays(7)
+                .createNewResponseAfterDays(7));
+
+        StudyEnvironmentSurvey ses = surveyFactory.attachToEnv(survey, studyEnvBundle.getStudyEnv().getId(), true);
+
+        EnrolleeAndProxy enrolleeAndProxy = enrolleeFactory.buildProxyAndGovernedEnrollee(getTestName(info), studyEnvBundle.getPortalEnv(), studyEnvBundle.getStudyEnv());
+
+        Enrollee governedEnrollee = enrolleeAndProxy.governedEnrollee();
+        Enrollee proxyEnrollee = enrolleeAndProxy.proxy();
+        ParticipantUser proxyUser = participantUserService.find(proxyEnrollee.getParticipantUserId()).orElseThrow();
+        PortalParticipantUser governedPpUser = portalParticipantUserService.findForEnrollee(governedEnrollee);
+        PortalParticipantUser proxyPpUser = enrolleeAndProxy.proxyPpUser();
+
+        SurveyResponse response1 = surveyResponseService.create(SurveyResponse.builder()
+                .enrolleeId(governedEnrollee.getId())
+                .creatingParticipantUserId(governedEnrollee.getParticipantUserId())
+                .surveyId(survey.getId())
+                .lastUpdatedAt(Instant.now().minus(10, ChronoUnit.DAYS))
+                .complete(true)
+                .build());
+        ParticipantTask task1 = surveyTaskDispatcher.buildTask(governedEnrollee, governedPpUser, new SurveyTaskConfigDto(ses));
+        task1.setStatus(TaskStatus.COMPLETE);
+        task1.setSurveyResponseId(response1.getId());
+        task1.setCompletedAt(Instant.now().minus(10, ChronoUnit.DAYS));
+        task1 = participantTaskService.create(task1, getAuditInfo(info));
+
+
+        SurveyResponse response2 = surveyResponseService.create(SurveyResponse.builder()
+                .enrolleeId(governedEnrollee.getId())
+                .creatingParticipantUserId(governedEnrollee.getParticipantUserId())
+                .surveyId(survey.getId())
+                .lastUpdatedAt(Instant.now().minus(1, ChronoUnit.DAYS))
+                .complete(true)
+                .build());
+
+        ParticipantTask task2 = surveyTaskDispatcher.buildTask(governedEnrollee, governedPpUser, new SurveyTaskConfigDto(ses));
+        task2.setStatus(TaskStatus.COMPLETE);
+        task2.setCompletedAt(Instant.now().minus(1, ChronoUnit.DAYS));
+        task2.setSurveyResponseId(response2.getId());
+        task2 = participantTaskService.create(task2, getAuditInfo(info));
+
+        // task2 should be editable by proxy
+        SurveyResponse newResponse2 = SurveyResponse.builder()
+                .enrolleeId(governedEnrollee.getId())
+                .creatingParticipantUserId(governedEnrollee.getParticipantUserId())
+                .surveyId(survey.getId())
+                .lastUpdatedAt(Instant.now())
+                .build();
+
+        // throws updating old response
+        ParticipantTask finalTask1 = task1;
+        assertThrows(IllegalArgumentException.class, () -> {
+            surveyResponseService.updateResponse(
+                    newResponse2, new ResponsibleEntity(proxyUser), "test",
+                    proxyPpUser, governedEnrollee, finalTask1.getId(), survey.getPortalId());
+        });
+
+        // doesn't throw updating newest
+        surveyResponseService.updateResponse(
+                newResponse2, new ResponsibleEntity(proxyUser), "test",
+                proxyPpUser, governedEnrollee, task2.getId(), survey.getPortalId());
+
     }
 
     @Test


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

This one was tough; imported surveys would have the ppUserId of the _governed user_. Since this logic relied on finding the activities for the active pp user (which is incorrect, but is easy to not notice because in most proxy environments, the proxy pp user does everything). Since the proxy pp user doesn't have any tasks, it breaks, even though the enrollee had tasks.

So, this fixes the logic to do the correct thing - grab all tasks for the enrollee, not the active pp user.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- import a proxy user into a study with a longitudinal survey
- ensure you can edit it