### PR TITLE
[JN-1696] completed at should not import for incomplete surveys

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -642,7 +642,7 @@ public class EnrolleeImportService {
         Instant createdAt = createdAtOpt.orElseGet(() -> completedAtOpt.orElseGet(() -> lastUpdatedAtOpt.orElse(null)));
         Instant lastUpdatedAt = lastUpdatedAtOpt.orElseGet(() -> completedAtOpt.orElseGet(() -> createdAtOpt.orElse(null)));
 
-        if (completedAt != null) {
+        if (completedAt != null && surveyResponse.isComplete()) {
             timeShiftDao.changeTaskCompleteTime(relatedTask.getId(), completedAt);
         }
         if (createdAt != null) {

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/TaskDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/TaskDispatcher.java
@@ -364,7 +364,7 @@ public abstract class TaskDispatcher<T extends TaskConfig> {
                 ? latestTask.getCompletedAt()
                 : latestTask.getCreatedAt();
 
-        if (date == null) {
+        if (date == null || (taskDispatchConfig.getRecurOn() == RecurOn.COMPLETION && latestTask.getStatus() != TaskStatus.COMPLETE)) {
             return false; // never recur on incomplete tasks
         }
 
@@ -377,7 +377,7 @@ public abstract class TaskDispatcher<T extends TaskConfig> {
         BeanUtils.copyProperties(
                 oldTask,
                 newTask,
-                "id", "createdAt", "updatedAt",
+                "id", "createdAt", "lastUpdatedAt", "completedAt",
                 "version", "status", "taskType",
                 "targetName", "targetStableId", "targetAssignedVersion",
                 "taskOrder", "blocksHub", "studyEnvironmentId",

--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
@@ -45,6 +45,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.ByteArrayInputStream;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -1010,6 +1011,97 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
         assertThat(importedLatestTask.getSurveyResponseId(), equalTo(importedLatestResponse.getId()));
         assertThat(importedLatestResponse.getAnswers().size(), equalTo(2));
         assertThat(importedLatestResponse.getAnswers().stream().map(Answer::valueAsString).collect(Collectors.toSet()), equalTo(Set.of("Alex", "[\"aquamarine\", \"purple\"]")));
+    }
+
+    @Test
+    @Transactional
+    public void testCompletedAtOnlyInferredIfCompleted(TestInfo info) {
+        StudyEnvironmentBundle studyEnvBundle = studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.irb);
+        Survey survey1 = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .stableId("importTest1")
+                .content(TWO_QUESTION_SURVEY_CONTENT)
+                .portalId(studyEnvBundle.getPortal().getId())
+                .autoAssign(true)
+                .version(1)
+        );
+        surveyFactory.attachToEnv(survey1, studyEnvBundle.getStudyEnv().getId(), true);
+
+        Survey survey2 = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .stableId("importTest2")
+                .content(TWO_QUESTION_SURVEY_CONTENT)
+                .portalId(studyEnvBundle.getPortal().getId())
+                .autoAssign(true)
+                .version(1)
+        );
+        surveyFactory.attachToEnv(survey2, studyEnvBundle.getStudyEnv().getId(), true);
+
+        Survey survey3 = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .stableId("importTest3")
+                .content(TWO_QUESTION_SURVEY_CONTENT)
+                .portalId(studyEnvBundle.getPortal().getId())
+                .autoAssign(true)
+                .version(1)
+        );
+        surveyFactory.attachToEnv(survey3, studyEnvBundle.getStudyEnv().getId(), true);
+
+        Survey survey4 = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .stableId("importTest4")
+                .content(TWO_QUESTION_SURVEY_CONTENT)
+                .portalId(studyEnvBundle.getPortal().getId())
+                .autoAssign(true)
+                .version(1)
+        );
+        surveyFactory.attachToEnv(survey4, studyEnvBundle.getStudyEnv().getId(), true);
+
+
+        Map<String, String> enrolleeMap = Map.ofEntries(
+                Map.entry("enrollee.subject", "true"),
+                Map.entry("account.username", "test@test.com"),
+                Map.entry("importTest1.complete", "true"), // 1: completed, no completedat but has createdat
+                Map.entry("importTest1.importFirstName", "Jeff"),
+                Map.entry("importTest1.importFavColors", "[\"red\", \"blue\"]"),
+                Map.entry("importTest1.createdAt", "2023-08-21 05:17AM"),
+                Map.entry("importTest2.complete", "false"), // 2: incomplete, no completedat
+                Map.entry("importTest2.importFirstName", "Jeffrey"),
+                Map.entry("importTest2.importFavColors", "[\"green\"]"),
+                Map.entry("importTest2.createdAt", "2023-08-20 05:17AM"),
+                Map.entry("importTest3.complete", "true"), // 3: completed, has completedat
+                Map.entry("importTest3.importFirstName", "Alex"),
+                Map.entry("importTest3.importFavColors", "[\"aquamarine\", \"purple\"]"),
+                Map.entry("importTest3.createdAt", "2023-08-23 05:17AM"),
+                Map.entry("importTest3.completedAt", "2023-08-22 05:17AM"),
+                Map.entry("importTest4.complete", "true"), // 4: completed, no completedat no createdat
+                Map.entry("importTest4.importFirstName", "Alex"),
+                Map.entry("importTest4.importFavColors", "[\"orange\"]")
+        );
+
+        Enrollee enrollee = enrolleeImportService.importEnrollee(
+                studyEnvBundle.getPortal().getShortcode(),
+                studyEnvBundle.getStudy().getShortcode(),
+                studyEnvBundle.getStudyEnv(),
+                enrolleeMap,
+                new ExportOptions(), null);
+
+
+        List<ParticipantTask> tasks = participantTaskService.findByEnrolleeId(enrollee.getId());
+
+        assertThat(tasks, hasSize(4));
+
+        ParticipantTask task1 = tasks.stream().filter(task -> task.getTargetStableId().equals(survey1.getStableId())).findFirst().orElseThrow();
+        assertThat(task1.getCompletedAt(), equalTo(instantFromZone("2023-08-21 05:17AM")));
+        assertThat(task1.getStatus(), equalTo(TaskStatus.COMPLETE));
+
+        ParticipantTask task2 = tasks.stream().filter(task -> task.getTargetStableId().equals(survey2.getStableId())).findFirst().orElseThrow();
+        assertThat(task2.getCompletedAt(), nullValue());
+        assertThat(task2.getStatus(), equalTo(TaskStatus.IN_PROGRESS));
+
+        ParticipantTask task3 = tasks.stream().filter(task -> task.getTargetStableId().equals(survey3.getStableId())).findFirst().orElseThrow();
+        assertThat(task3.getCompletedAt(), equalTo(instantFromZone("2023-08-22 05:17AM")));
+        assertThat(task3.getStatus(), equalTo(TaskStatus.COMPLETE));
+
+        ParticipantTask task4 = tasks.stream().filter(task -> task.getTargetStableId().equals(survey4.getStableId())).findFirst().orElseThrow();
+        assertTrue(Duration.between(Instant.now(), task4.getCompletedAt()).toSeconds() < 60); // task4 should be completed recently
+        assertThat(task4.getStatus(), equalTo(TaskStatus.COMPLETE));
 
     }
 

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyTaskDispatcherTest.java
@@ -401,6 +401,8 @@ class SurveyTaskDispatcherTest extends BaseSpringBootTest {
 
         // make first task old but not completed
         sandbox1Task.setCreatedAt(Instant.now().minus(8, ChronoUnit.DAYS));
+        // also set completedAt (should never be the case, but make sure it's not a problem)
+        sandbox1Task.setCompletedAt(Instant.now().minus(8, ChronoUnit.DAYS));
         sandbox1Task.setStatus(TaskStatus.IN_PROGRESS);
 
         participantTaskService.update(sandbox1Task, DataAuditInfo.builder().systemProcess(getTestName(testInfo)).build());


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Completed at was sneakily being set on import; this caused a minor problem in how we compute recurring windows. Both makes the logic more robust to this issue but also stops it from populating completed at for incomplete surveys in the first place.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- import user with old in-progress longitudinal survey that's set up to recur on completion
- ensure it doesn't recur