### PR TITLE
DDO-4133 read from google artifact registry

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -5,6 +5,7 @@ plugins {
 repositories {
     mavenCentral()
     maven {
+        // todo: plugins-snapshot not provisioned yet in GAR
         url 'https://broadinstitute.jfrog.io/artifactory/plugins-snapshot'
     }
     gradlePluginPortal()

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -5,8 +5,7 @@ plugins {
 repositories {
     mavenCentral()
     maven {
-        // todo: plugins-snapshot not provisioned yet in GAR
-        url 'https://broadinstitute.jfrog.io/artifactory/plugins-snapshot'
+        url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/'
     }
     gradlePluginPortal()
 }

--- a/buildSrc/src/main/groovy/bio.terra.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/bio.terra.java-common-conventions.gradle
@@ -29,14 +29,14 @@ java {
 repositories {
     maven {
         // Terra proxy for maven central
-        url 'https://broadinstitute.jfrog.io/broadinstitute/maven-central/'
+        url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/maven-central/'
     }
     mavenCentral()
     maven {
-        url 'https://broadinstitute.jfrog.io/broadinstitute/libs-release/'
+        url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/'
     }
     maven {
-        url 'https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot-local/'
+        url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/'
     }
 }
 

--- a/compliance/build.gradle
+++ b/compliance/build.gradle
@@ -21,6 +21,7 @@ java {
 repositories {
     mavenCentral()
     maven {
+        // todo: plugins-snapshot not provisioned yet in GAR
         url 'https://broadinstitute.jfrog.io/artifactory/plugins-snapshot'
     }
 }

--- a/compliance/build.gradle
+++ b/compliance/build.gradle
@@ -21,8 +21,7 @@ java {
 repositories {
     mavenCentral()
     maven {
-        // todo: plugins-snapshot not provisioned yet in GAR
-        url 'https://broadinstitute.jfrog.io/artifactory/plugins-snapshot'
+        url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/'
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -14,8 +14,7 @@ sourceCompatibility = '21'
 repositories {
     mavenCentral()
     maven {
-        // todo: plugins-snapshot not provisioned yet in GAR
-        url 'https://broadinstitute.jfrog.io/artifactory/plugins-snapshot'
+        url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/'
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -14,6 +14,7 @@ sourceCompatibility = '21'
 repositories {
     mavenCentral()
     maven {
+        // todo: plugins-snapshot not provisioned yet in GAR
         url 'https://broadinstitute.jfrog.io/artifactory/plugins-snapshot'
     }
 }

--- a/pepper-import/build.gradle
+++ b/pepper-import/build.gradle
@@ -17,8 +17,7 @@ java {
 repositories {
     mavenCentral()
     maven {
-        // todo: plugins-snapshot not provisioned yet in GAR
-        url 'https://broadinstitute.jfrog.io/artifactory/plugins-snapshot'
+        url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/'
     }
 }
 

--- a/pepper-import/build.gradle
+++ b/pepper-import/build.gradle
@@ -17,6 +17,7 @@ java {
 repositories {
     mavenCentral()
     maven {
+        // todo: plugins-snapshot not provisioned yet in GAR
         url 'https://broadinstitute.jfrog.io/artifactory/plugins-snapshot'
     }
 }

--- a/populate/build.gradle
+++ b/populate/build.gradle
@@ -11,6 +11,7 @@ sourceCompatibility = '21'
 repositories {
     mavenCentral()
     maven {
+        // todo: plugins-snapshot not provisioned yet in GAR
         url 'https://broadinstitute.jfrog.io/artifactory/plugins-snapshot'
     }
 }

--- a/populate/build.gradle
+++ b/populate/build.gradle
@@ -11,8 +11,7 @@ sourceCompatibility = '21'
 repositories {
     mavenCentral()
     maven {
-        // todo: plugins-snapshot not provisioned yet in GAR
-        url 'https://broadinstitute.jfrog.io/artifactory/plugins-snapshot'
+        url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/'
     }
 }
 


### PR DESCRIPTION
JIRA ticket https://broadworkbench.atlassian.net/browse/DDO-4133 


**Summary of changes**
Updated the artifact source for this service to read artifacts from Google Artifact Registry instead of JFrog.

**What**
Modified the config to pull artifacts from GAR. No publishing changes were made.

**Why**
This is part of Phase 2 of the artifact migration effort to deprecated JFrog and consolidate artifacts in GAR.

**Testing these changes**
Relied on passing CI checks and tests. Artifact reading-related issues are expected to surface as pipeline failures. For example these jobs [here](https://github.com/DataBiosphere/terra-scientific-pipelines-service/actions/runs/15309876591/job/43071753325?pr=222) and [here](https://github.com/DataBiosphere/leonardo/actions/runs/15324072477/job/43114134405?pr=4858) failed due to access issues (which have since been resolved).