### PR TITLE
[JN-1701] make search params globally shared via context

### DIFF
--- a/ui-admin/src/App.tsx
+++ b/ui-admin/src/App.tsx
@@ -5,7 +5,13 @@ import 'survey-core/defaultV2.min.css'
 import './App.css'
 import './print.css'
 
-import { BrowserRouter, Outlet, Route, Routes, useLocation } from 'react-router-dom'
+import {
+  BrowserRouter,
+  Outlet,
+  Route,
+  Routes,
+  useLocation
+} from 'react-router-dom'
 import { ReactNotifications } from 'react-notifications-component'
 
 import { Config } from 'api/api'
@@ -30,7 +36,12 @@ import PopulateRouteSelect from './populate/PopulateRouteSelect'
 import IntegrationDashboard from './integration/IntegrationDashboard'
 import AdminUserRouter from './user/AdminUserRouter'
 import LogEventViewer from './health/LogEventViewer'
-import { ApiProvider, initializeMixpanel, MaintenanceMode } from '@juniper/ui-core'
+import {
+  ApiProvider,
+  GlobalSearchParamsProvider,
+  initializeMixpanel,
+  MaintenanceMode
+} from '@juniper/ui-core'
 import mixpanel from 'mixpanel-browser'
 import { StatusPage } from './status/StatusPage'
 import SystemSettingsEditor from './system/SystemSettingsEditor'
@@ -63,29 +74,31 @@ function App() {
                     <IdleStatusMonitor maxIdleSessionDuration={30 * 60 * 1000} idleWarningDuration={5 * 60 * 1000}/>
                     <ReactNotifications />
                     <BrowserRouter>
-                      <ScrollToTop/>
-                      <Routes>
-                        <Route path="/">
-                          <Route path="/system/status" element={<StatusPage/>}/>
-                          <Route element={<ProtectedRoute>
-                            <NavContextProvider><PageFrame config={config}/></NavContextProvider>
-                          </ProtectedRoute>}>
-                            <Route path="populate/*" element={<PopulateRouteSelect/>}/>
-                            <Route path="logEvents/*" element={<LogEventViewer/>}/>
-                            <Route path="system/settings" element={<SystemSettingsEditor/>}/>
-                            <Route path="users/*" element={<AdminUserRouter/>}/>
-                            <Route path="integrations/*" element={<IntegrationDashboard/>}/>
-                            <Route path=":portalShortcode/*" element={
-                              <PortalProvider><PortalRouter/></PortalProvider>
-                            }/>
-                            <Route index element={<HomePage/>}/>
+                      <GlobalSearchParamsProvider>
+                        <ScrollToTop/>
+                        <Routes>
+                          <Route path="/">
+                            <Route path="/system/status" element={<StatusPage/>}/>
+                            <Route element={<ProtectedRoute>
+                              <NavContextProvider><PageFrame config={config}/></NavContextProvider>
+                            </ProtectedRoute>}>
+                              <Route path="populate/*" element={<PopulateRouteSelect/>}/>
+                              <Route path="logEvents/*" element={<LogEventViewer/>}/>
+                              <Route path="system/settings" element={<SystemSettingsEditor/>}/>
+                              <Route path="users/*" element={<AdminUserRouter/>}/>
+                              <Route path="integrations/*" element={<IntegrationDashboard/>}/>
+                              <Route path=":portalShortcode/*" element={
+                                <PortalProvider><PortalRouter/></PortalProvider>
+                              }/>
+                              <Route index element={<HomePage/>}/>
+                            </Route>
+                            <Route path="privacy" element={<PrivacyPolicyPage/>}/>
+                            <Route path="terms" element={<InvestigatorTermsOfUsePage/>}/>
+                            <Route path="*" element={<div>Unknown page</div>}/>
                           </Route>
-                          <Route path="privacy" element={<PrivacyPolicyPage />} />
-                          <Route path="terms" element={<InvestigatorTermsOfUsePage />} />
-                          <Route path="*" element={<div>Unknown page</div>}/>
-                        </Route>
-                        <Route path='redirect-from-oauth' element={<RedirectFromOAuth/>}/>
-                      </Routes>
+                          <Route path='redirect-from-oauth' element={<RedirectFromOAuth/>}/>
+                        </Routes>
+                      </GlobalSearchParamsProvider>
                     </BrowserRouter>
                   </div>
                 </UserProvider>

--- a/ui-core/src/components/forms/PagedSurveyView.test.tsx
+++ b/ui-core/src/components/forms/PagedSurveyView.test.tsx
@@ -29,6 +29,7 @@ import {
   Survey
 } from 'src/types/forms'
 import { Profile } from 'src/types/user'
+import { GlobalSearchParamsProvider } from 'src/util/GlobalSearchParamsProvider'
 
 jest.mock('src/autoSaveUtils', () => {
   return {
@@ -465,11 +466,16 @@ const setupSurveyTest = (survey: Survey, profile?: Profile, referencedAnswers?: 
   const { RoutedComponent } = setupRouterTest(
     <ApiProvider api={mockApi}>
       <MockI18nProvider>
-        <PagedSurveyView enrollee={enrollee} form={configuredSurvey.survey} response={mockHubResponse().response}
-          studyEnvParams={{ studyShortcode: 'study', portalShortcode: 'portal', envName: 'sandbox' }}
-          updateResponseMap={jest.fn()} referencedAnswers={referencedAnswers || []}
-          selectedLanguage={'en'} updateProfile={jest.fn()} setAutosaveStatus={jest.fn()} setTaskId={jest.fn()}
-          taskId={'guid34'} adminUserId={null} updateEnrollee={jest.fn()} onFailure={jest.fn()} onSuccess={jest.fn()}/>
+        <GlobalSearchParamsProvider>
+          <PagedSurveyView enrollee={enrollee} form={configuredSurvey.survey} response={mockHubResponse().response}
+            studyEnvParams={{ studyShortcode: 'study', portalShortcode: 'portal', envName: 'sandbox' }}
+            updateResponseMap={jest.fn()} referencedAnswers={referencedAnswers || []}
+            selectedLanguage={'en'} updateProfile={jest.fn()} setAutosaveStatus={jest.fn()}
+            setTaskId={jest.fn()}
+            taskId={'guid34'} adminUserId={null} updateEnrollee={jest.fn()} onFailure={jest.fn()}
+            onSuccess={jest.fn()}
+          />
+        </GlobalSearchParamsProvider>
       </MockI18nProvider>
     </ApiProvider>)
   render(RoutedComponent)

--- a/ui-core/src/index.ts
+++ b/ui-core/src/index.ts
@@ -41,6 +41,7 @@ export * from './util/mixpanelUtils'
 export * from './util/supportUtils'
 export * from './util/downloadUtils'
 export * from './util/taskUtils'
+export * from './util/GlobalSearchParamsProvider'
 
 export * from './test-utils/asMockedFn'
 export * from './test-utils/mocking-utils'

--- a/ui-core/src/surveyUtils.tsx
+++ b/ui-core/src/surveyUtils.tsx
@@ -21,7 +21,6 @@ import {
   Survey,
   VersionedForm
 } from './types/forms'
-import { useSearchParams } from 'react-router-dom'
 import React, {
   useEffect,
   useState
@@ -39,6 +38,7 @@ import { useApiContext } from './participant/ApiProvider'
 import { OptionalStudyEnvParams } from './types/study'
 import { Profile } from 'src/types/user'
 import { DefaultLight } from 'survey-core/themes'
+import { useGlobalSearchParams } from './util/GlobalSearchParamsProvider'
 
 export type SurveyJsResumeData = {
   currentPageNo: number,
@@ -326,7 +326,7 @@ export type PageNumberControl = {
  * hook for reading/writing pageNumbers to url search params as 'page'
  * */
 export function useRoutablePageNumber(): PageNumberControl {
-  const [searchParams, setSearchParams] = useSearchParams()
+  const { searchParams, setSearchParams } = useGlobalSearchParams()
   const pageParam = searchParams.get(PAGE_NUMBER_PARAM_NAME)
   let urlPageNumber = null
   if (pageParam) {
@@ -336,6 +336,7 @@ export function useRoutablePageNumber(): PageNumberControl {
   /** update the url with the new page number */
   function updatePageNumber(newPageNumber: number) {
     searchParams.set('page', (newPageNumber).toString())
+
     setSearchParams(searchParams)
   }
 

--- a/ui-core/src/test-utils/router-testing-utils.tsx
+++ b/ui-core/src/test-utils/router-testing-utils.tsx
@@ -1,7 +1,15 @@
 import React, { ReactElement } from 'react'
-import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import {
+  createMemoryRouter,
+  RouterProvider
+} from 'react-router-dom'
 import { Router as RemixRouter } from '@remix-run/router/dist/router'
-import { render, RenderResult, waitFor } from '@testing-library/react'
+import {
+  render,
+  RenderResult,
+  waitFor
+} from '@testing-library/react'
+import { GlobalSearchParamsProvider } from '../util/GlobalSearchParamsProvider'
 
 /**
  * return both the component wrapped in a router, and the router object itself,
@@ -54,7 +62,10 @@ export async function expectNever(callable: () => unknown): Promise<void> {
  * */
 export function renderWithRouter(ComponentToRender: ReactElement,
   initialEntries = ['/'], componentPath = '*'): RenderResult {
-  const { RoutedComponent } = setupRouterTest(ComponentToRender, initialEntries, componentPath)
+  const { RoutedComponent } = setupRouterTest(
+    <GlobalSearchParamsProvider>{ComponentToRender}</GlobalSearchParamsProvider>,
+    initialEntries,
+    componentPath)
   return render(RoutedComponent)
 }
 

--- a/ui-core/src/useTaskIdParam.ts
+++ b/ui-core/src/useTaskIdParam.ts
@@ -1,9 +1,9 @@
-import { useSearchParams } from 'react-router-dom'
+import { useGlobalSearchParams } from './util/GlobalSearchParamsProvider'
 
 const TASK_ID_PARAM = 'taskId'
 /** gets the task ID from the URL */
 export const useTaskIdParam = (): {taskId: string | null, setTaskId: (taskId: string) => void} => {
-  const [searchParams, setSearchParams] = useSearchParams()
+  const { searchParams, setSearchParams } = useGlobalSearchParams()
   return {
     taskId: searchParams.get(TASK_ID_PARAM),
     setTaskId: (taskId: string) => {

--- a/ui-core/src/util/GlobalSearchParamsProvider.tsx
+++ b/ui-core/src/util/GlobalSearchParamsProvider.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { useSearchParams } from 'react-router-dom'
+
+export type GlobalSearchParamsProviderT = {
+  searchParams: URLSearchParams
+  setSearchParams: React.Dispatch<URLSearchParams>
+}
+
+
+export const GlobalSearchParamsContext = React.createContext<GlobalSearchParamsProviderT | undefined>(undefined)
+
+export const GlobalSearchParamsProvider = ({ children }: { children: React.ReactNode }) => {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  return (
+    <GlobalSearchParamsContext.Provider value={{
+      searchParams,
+      setSearchParams
+    }}>
+      {children}
+    </GlobalSearchParamsContext.Provider>
+  )
+}
+
+export const useGlobalSearchParams = () => {
+  const context = React.useContext(GlobalSearchParamsContext)
+  if (!context) {
+    throw new Error('useGlobalSearchParams must be used within a GlobalSearchParamsProvider')
+  }
+  return context
+}

--- a/ui-participant/src/App.tsx
+++ b/ui-participant/src/App.tsx
@@ -32,6 +32,7 @@ import { IdleStatusMonitor } from 'login/IdleStatusMonitor'
 import {
   ApiProvider,
   EnvironmentName,
+  GlobalSearchParamsProvider,
   I18nProvider,
   initializeMixpanel,
   MaintenanceMode
@@ -144,32 +145,34 @@ function App() {
                             defaultLanguage={portalEnv.portalEnvironmentConfig.defaultLanguage}
                             portalShortcode={portal.shortcode}
                             environmentName={portalEnv.environmentName as EnvironmentName}>
-                            <DocumentTitle/>
+                            <GlobalSearchParamsProvider>
+                              <DocumentTitle/>
 
-                            <Suspense fallback={<PageLoadingIndicator/>}>
-                              <IdleStatusMonitor
-                                maxIdleSessionDuration={30 * 60 * 1000} idleWarningDuration={5 * 60 * 1000}/>
-                              <Routes>
-                                <Route path="/hub/*" element={<ProtectedRoute><HubRouter/></ProtectedRoute>}/>
-                                <Route path="/studies/:studyShortcode">
-                                  <Route path="join/*" element={<StudyEnrollRouter/>}/>
-                                  <Route index element={<div>study specific page -- TBD</div>}/>
-                                  <Route path="*" element={<div>unmatched study route</div>}/>
-                                </Route>
-                                <Route path="/" element={<LandingPage localContent={localContent}/>}>
-                                  {landingRoutes}
-                                </Route>
-                                <Route path="/redirect-from-oauth">
-                                  <Route index element={<RedirectFromOAuth/>}/>
-                                  <Route path="error" element={<AuthError/>}/>
-                                </Route>
-                                <Route path="/privacy" element={<PrivacyPolicyPage/>}/>
-                                <Route path="/terms/investigator" element={<InvestigatorTermsOfUsePage/>}/>
-                                <Route path="/terms/participant" element={<ParticipantTermsOfUsePage/>}/>
-                                <Route path="*" element={<PageNotFound/>}/>
-                              </Routes>
-                            </Suspense>
-                            {!cookiesAcknowledged && <CookieAlert onDismiss={() => setCookiesAcknowledged()} />}
+                              <Suspense fallback={<PageLoadingIndicator/>}>
+                                <IdleStatusMonitor
+                                  maxIdleSessionDuration={30 * 60 * 1000} idleWarningDuration={5 * 60 * 1000}/>
+                                <Routes>
+                                  <Route path="/hub/*" element={<ProtectedRoute><HubRouter/></ProtectedRoute>}/>
+                                  <Route path="/studies/:studyShortcode">
+                                    <Route path="join/*" element={<StudyEnrollRouter/>}/>
+                                    <Route index element={<div>study specific page -- TBD</div>}/>
+                                    <Route path="*" element={<div>unmatched study route</div>}/>
+                                  </Route>
+                                  <Route path="/" element={<LandingPage localContent={localContent}/>}>
+                                    {landingRoutes}
+                                  </Route>
+                                  <Route path="/redirect-from-oauth">
+                                    <Route index element={<RedirectFromOAuth/>}/>
+                                    <Route path="error" element={<AuthError/>}/>
+                                  </Route>
+                                  <Route path="/privacy" element={<PrivacyPolicyPage/>}/>
+                                  <Route path="/terms/investigator" element={<InvestigatorTermsOfUsePage/>}/>
+                                  <Route path="/terms/participant" element={<ParticipantTermsOfUsePage/>}/>
+                                  <Route path="*" element={<PageNotFound/>}/>
+                                </Routes>
+                              </Suspense>
+                              {!cookiesAcknowledged && <CookieAlert onDismiss={() => setCookiesAcknowledged()}/>}
+                            </GlobalSearchParamsProvider>
                           </I18nProvider>
                         </ActiveUserProvider>
                       </UserProvider>

--- a/ui-participant/src/hub/HubPage.test.tsx
+++ b/ui-participant/src/hub/HubPage.test.tsx
@@ -5,6 +5,7 @@ import {
 import React from 'react'
 import HubPage from './HubPage'
 import {
+  GlobalSearchParamsProvider,
   MockI18nProvider,
   mockTextsDefault,
   setupRouterTest
@@ -84,9 +85,11 @@ jest.mock('../providers/ActiveUserProvider', () => {
 describe('HubPage', () => {
   it('is rendered with the study name', () => {
     const { RoutedComponent } = setupRouterTest(
-      <MockI18nProvider useDefaultTexts={true}>
-        <HubPage/>
-      </MockI18nProvider>)
+      <GlobalSearchParamsProvider>
+        <MockI18nProvider useDefaultTexts={true}>
+          <HubPage/>
+        </MockI18nProvider>
+      </GlobalSearchParamsProvider>)
     render(RoutedComponent)
 
     expect(screen.getByText('Test Study')).toBeInTheDocument()
@@ -94,9 +97,11 @@ describe('HubPage', () => {
 
   it('is rendered with a Start button for the next new task', () => {
     const { RoutedComponent } = setupRouterTest(
-      <MockI18nProvider mockTexts={mockTextsDefault}>
-        <HubPage />
-      </MockI18nProvider>)
+      <GlobalSearchParamsProvider>
+        <MockI18nProvider mockTexts={mockTextsDefault}>
+          <HubPage />
+        </MockI18nProvider>
+      </GlobalSearchParamsProvider>)
     render(RoutedComponent)
 
     expect(screen.getByText('Start Consent')).toBeInTheDocument()

--- a/ui-participant/src/hub/HubPageWithProxies.test.tsx
+++ b/ui-participant/src/hub/HubPageWithProxies.test.tsx
@@ -7,6 +7,7 @@ import {
 import React from 'react'
 import HubPage from './HubPage'
 import {
+  GlobalSearchParamsProvider,
   MockI18nProvider,
   setupRouterTest
 } from '@juniper/ui-core'
@@ -41,7 +42,9 @@ describe('HubPage with proxies', () => {
         portal={mockPortal}
       >
         <MockI18nProvider useDefaultTexts={true}>
-          <HubPage/>
+          <GlobalSearchParamsProvider>
+            <HubPage/>
+          </GlobalSearchParamsProvider>
         </MockI18nProvider>
       </ProvideFullTestUserContext>
     )
@@ -63,7 +66,9 @@ describe('HubPage with proxies', () => {
         portal={mockPortal}
       >
         <MockI18nProvider>
-          <HubPage/>
+          <GlobalSearchParamsProvider>
+            <HubPage/>
+          </GlobalSearchParamsProvider>
         </MockI18nProvider>
       </ProvideFullTestUserContext>
     )

--- a/ui-participant/src/hub/OutreachTasks.test.tsx
+++ b/ui-participant/src/hub/OutreachTasks.test.tsx
@@ -1,10 +1,25 @@
 import React from 'react'
-import { render, screen, waitFor } from '@testing-library/react'
-import { mockEnrollee, mockParticipantTask, mockSurvey } from 'test-utils/test-participant-factory'
+import {
+  render,
+  screen,
+  waitFor
+} from '@testing-library/react'
+import {
+  mockEnrollee,
+  mockParticipantTask,
+  mockSurvey
+} from 'test-utils/test-participant-factory'
 import OutreachTasks from './OutreachTasks'
-import { mockStudy, mockStudyEnv } from 'test-utils/test-portal-factory'
+import {
+  mockStudy,
+  mockStudyEnv
+} from 'test-utils/test-portal-factory'
 import Api, { TaskWithSurvey } from 'api/api'
-import { MockI18nProvider, setupRouterTest } from '@juniper/ui-core'
+import {
+  GlobalSearchParamsProvider,
+  MockI18nProvider,
+  setupRouterTest
+} from '@juniper/ui-core'
 
 jest.mock('providers/PortalProvider', () => ({ usePortalEnv: jest.fn() }))
 
@@ -43,9 +58,11 @@ describe('OutreachTasks', () => {
     ]
     jest.spyOn(Api, 'listOutreachActivities').mockResolvedValue(tasksWithSurvey)
     const { RoutedComponent } = setupRouterTest(
-      <MockI18nProvider>
-        <OutreachTasks enrollees={[enrollee]} studies={[study]}/>
-      </MockI18nProvider>
+      <GlobalSearchParamsProvider>
+        <MockI18nProvider>
+          <OutreachTasks enrollees={[enrollee]} studies={[study]}/>
+        </MockI18nProvider>
+      </GlobalSearchParamsProvider>
     )
     render(RoutedComponent)
     await waitFor(() => expect(screen.getByText('Survey 1 blurb')).toBeInTheDocument())
@@ -87,9 +104,11 @@ describe('OutreachTasks', () => {
     ]
     jest.spyOn(Api, 'listOutreachActivities').mockResolvedValue(tasksWithSurvey)
     const { RoutedComponent } = setupRouterTest(
-      <MockI18nProvider>
-        <OutreachTasks enrollees={[enrollee]} studies={[study]}/>
-      </MockI18nProvider>
+      <GlobalSearchParamsProvider>
+        <MockI18nProvider>
+          <OutreachTasks enrollees={[enrollee]} studies={[study]}/>
+        </MockI18nProvider>
+      </GlobalSearchParamsProvider>
     )
     render(RoutedComponent)
     await waitFor(() => expect(screen.getByText('Survey 2 blurb')).toBeInTheDocument())

--- a/ui-participant/src/util/surveyJsUtils.test.tsx
+++ b/ui-participant/src/util/surveyJsUtils.test.tsx
@@ -20,6 +20,7 @@ import {
   EnvironmentName,
   getSurveyJsAnswerList,
   getUpdatedAnswers,
+  GlobalSearchParamsProvider,
   MockI18nProvider,
   Profile,
   setupRouterTest,
@@ -67,9 +68,11 @@ test('it starts on the first page', () => {
   asMockedFn(useActiveUser).mockReturnValue(mockUseActiveUser())
 
   const { RoutedComponent } = setupRouterTest(
-    <MockI18nProvider>
-      <PlainSurveyComponent formModel={generateThreePageSurvey()}/>
-    </MockI18nProvider>)
+    <GlobalSearchParamsProvider>
+      <MockI18nProvider>
+        <PlainSurveyComponent formModel={generateThreePageSurvey()}/>
+      </MockI18nProvider>
+    </GlobalSearchParamsProvider>)
   render(RoutedComponent)
   expect(screen.getByText('You are on page1')).toBeInTheDocument()
 })
@@ -79,9 +82,11 @@ test('handles page numbers in initial url', () => {
   asMockedFn(useActiveUser).mockReturnValue(mockUseActiveUser())
 
   const { RoutedComponent } = setupRouterTest(
-    <MockI18nProvider>
-      <PlainSurveyComponent formModel={generateThreePageSurvey()}/>
-    </MockI18nProvider>,
+    <GlobalSearchParamsProvider>
+      <MockI18nProvider>
+        <PlainSurveyComponent formModel={generateThreePageSurvey()}/>
+      </MockI18nProvider>
+    </GlobalSearchParamsProvider>,
     ['/foo?page=2'])
   render(RoutedComponent)
   expect(screen.getByText('You are on page2')).toBeInTheDocument()
@@ -93,9 +98,11 @@ test('updates urls on page navigation', async () => {
 
   const user = userEvent.setup()
   const { RoutedComponent, router } = setupRouterTest(
-    <MockI18nProvider>
-      <PlainSurveyComponent formModel={generateThreePageSurvey()}/>
-    </MockI18nProvider>)
+    <GlobalSearchParamsProvider>
+      <MockI18nProvider>
+        <PlainSurveyComponent formModel={generateThreePageSurvey()}/>
+      </MockI18nProvider>
+    </GlobalSearchParamsProvider>)
   render(RoutedComponent)
   expect(screen.getByText('You are on page1')).toBeInTheDocument()
   await act(() => user.click(screen.getByText('Next')))
@@ -142,9 +149,11 @@ test('enables hide on profile attributes', () => {
   })
 
   const { RoutedComponent } = setupRouterTest(
-    <MockI18nProvider>
-      <PlainSurveyComponent formModel={dynamicSurvey} profile={maleProfile}/>
-    </MockI18nProvider>)
+    <GlobalSearchParamsProvider>
+      <MockI18nProvider>
+        <PlainSurveyComponent formModel={dynamicSurvey} profile={maleProfile}/>
+      </MockI18nProvider>
+    </GlobalSearchParamsProvider>)
   render(RoutedComponent)
   expect(screen.getByText('You are on page1')).toBeInTheDocument()
   const dynamicText = screen.queryByText('You have a sex of female')
@@ -160,9 +169,11 @@ test('enables show on profile attributes', () => {
   })
 
   const { RoutedComponent } = setupRouterTest(
-    <MockI18nProvider>
-      <PlainSurveyComponent formModel={dynamicSurvey} profile={femaleProfile}/>
-    </MockI18nProvider>)
+    <GlobalSearchParamsProvider>
+      <MockI18nProvider>
+        <PlainSurveyComponent formModel={dynamicSurvey} profile={femaleProfile}/>
+      </MockI18nProvider>
+    </GlobalSearchParamsProvider>)
   render(RoutedComponent)
   expect(screen.getByText('You are on page1')).toBeInTheDocument()
   expect(screen.getByText('You have a sex of female')).toBeInTheDocument()


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

I finally figured out how to reproduce a bug that had been causing issues for A-T.

If someone updates an old longitudinal survey, a new task ID is returned, which updates the URL via useSearchParams. The issue is that if you then _go to the next page_ then you run into issues. When you go to the next page, there's another hook that updates the URL via a different instance of useSearchParams.

Since they didn't have the same underlying searchParams instance, they would overwrite each other and the old task id would return, and then would cause any new updates to fail since that old task is now read only.

I think this is the cleanest way to solve this problem; the other way would be to drill down a useSearchParams across a few children, which I think would be pretty ugly.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- populate demo
- make basics longitudinal and make it save completed as new repsonse after 1 day
- update all in sandbox to this new version of the basics
- log in as jsalk
- update basics
- observe task id change
- go to next page
- continue making changes; does not cause issues.