### PR TITLE
[JN-1700] make sure new longitudinal responses stay in-progress

### DIFF
--- a/ui-core/src/components/forms/PagedSurveyView.tsx
+++ b/ui-core/src/components/forms/PagedSurveyView.tsx
@@ -62,6 +62,13 @@ export function PagedSurveyView({
     adminUserId: string | null, enrollee: Enrollee, showHeaders?: boolean,
 }) {
   const resumableData = makeSurveyJsData(response?.resumeData, response?.answers, enrollee.participantUserId)
+  // it's not entirely clear, but we cannot rely on the response object passed into
+  // the component to have the most up-to-date complete status despite calling
+  // updateResponseMap. this is because, on the participant side, updateResponseMap
+  // is a no-op, presumably because of surveyjs re-render issues.
+  // TODO: JN-1707 refactor this component to clarify state management
+  const [complete, setComplete] = React.useState(response?.complete ?? false)
+
   const pager = useRoutablePageNumber()
 
   const Api = useApiContext()
@@ -89,7 +96,7 @@ export function PagedSurveyView({
       creatingAdminUserId: adminUserId,
       surveyId: form.id,
       justification,
-      complete: response?.complete ?? false,
+      complete,
       participantFiles: response?.participantFiles || []
     } as SurveyResponse
     // only log & alert if this is the first autosave problem to avoid spamming logs & alerts
@@ -110,6 +117,7 @@ export function PagedSurveyView({
       }
       // update the taskId in case this is an update to a longitudinal survey which will create a new task & response
       updateTaskId(response)
+      setComplete(response.response.complete)
       /**
        * CAREFUL -- we're updating the enrollee object so that if they navigate back to the dashboard, they'll
        * see this survey as 'in progress' and capture any profile changes.
@@ -150,6 +158,7 @@ export function PagedSurveyView({
     if (!surveyModel || !refreshSurvey) {
       return
     }
+    setComplete(true)
     const currentModelValues = getDataWithCalculatedValues(surveyModel)
     const responseDto = {
       resumeData: getResumeData(surveyModel, adminUserId || enrollee.participantUserId, true),


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

before, it would keep the "complete" of the old response, so on next save it would go from in-progress to complete.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- do the same testing as https://github.com/broadinstitute/juniper/pull/1642
- make sure after filling oiut basics completely, it still says "in progress" on dashboard
- hit complete
- make sure it is now complete
- edit the completed response
- ensure no errors, stays complete