### PR TITLE
[JN-1703] import & export proxy profile

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/participant/ProfileDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/participant/ProfileDao.java
@@ -41,4 +41,16 @@ public class ProfileDao extends BaseMutableJdbiDao<Profile> {
         });
         return profiles;
     }
+
+    public List<Profile> findAllByEnrolleeIds(List<UUID> enrolleeIds) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("""
+                                SELECT p.* FROM profile p INNER JOIN enrollee e ON p.id = e.profile_id
+                                WHERE e.id IN (<enrolleeIds>)
+                                """)
+                        .bindList("enrolleeIds", enrolleeIds)
+                        .mapToBean(Profile.class)
+                        .list()
+        );
+    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/DataAuditedService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/DataAuditedService.java
@@ -4,7 +4,6 @@ import bio.terra.pearl.core.dao.BaseMutableJdbiDao;
 import bio.terra.pearl.core.model.BaseEntity;
 import bio.terra.pearl.core.model.audit.DataAuditInfo;
 import bio.terra.pearl.core.model.audit.DataChange;
-import bio.terra.pearl.core.model.audit.ParticipantDataChange;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportData.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportData.java
@@ -19,6 +19,7 @@ public class EnrolleeExportData {
     private Enrollee enrollee;
     private ParticipantUser participantUser;
     private Profile profile;
+    private List<Profile> proxyProfiles;
     private List<Answer> answers;
     private List<ParticipantTask> tasks;
     private List<SurveyResponseWithTaskDto> responses;

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
@@ -151,7 +151,8 @@ public class EnrolleeExportService {
                 new KitRequestFormatter(exportOptions),
                 new EnrolleeRelationFormatter(exportOptions),
                 new FamilyFormatter(exportOptions),
-                new ProxyFormatter(exportOptions));
+                new ProxyFormatter(exportOptions),
+                new ProxyProfileFormatter(exportOptions));
 
         List<ModuleFormatter> moduleFormatters = allSimpleFormatters.stream().filter(
                 moduleFormatter -> !exportOptions.getExcludeModules().contains(moduleFormatter.getModuleName())
@@ -231,12 +232,16 @@ public class EnrolleeExportService {
 
         List<EnrolleeRelation> enrolleeRelations = loadRelations(config, enrollee);
         List<ParticipantUser> proxies = loadProxyUsers(config, enrolleeRelations, enrollee);
+        // technically, there could be more than one proxy, but in practice this does not happen.
+        // if it does, there's no way to tell which profile belongs to which proxy.
+        List<Profile> proxyProfiles = loadProxyProfiles(config, enrolleeRelations, enrollee);
 
         return new EnrolleeExportData(
                 study,
                 enrollee,
                 participantUsers.get(enrollee.getParticipantUserId()),
                 profiles.get(enrollee.getProfileId()),
+                proxyProfiles,
                 answers.getOrDefault(enrollee.getId(), Collections.emptyList()),
                 tasks.getOrDefault(enrollee.getId(), Collections.emptyList()),
                 surveyResponses
@@ -259,6 +264,24 @@ public class EnrolleeExportService {
         }
 
         return Collections.emptyList();
+    }
+
+    private List<Profile> loadProxyProfiles(StudyEnvironmentConfig config, List<EnrolleeRelation> enrolleeRelations, Enrollee enrollee) {
+        if (!config.isAcceptingProxyEnrollment()) {
+            return Collections.emptyList();
+        }
+
+        List<UUID> proxyIds = enrolleeRelations.stream()
+                .filter(relation -> relation.getRelationshipType().equals(RelationshipType.PROXY))
+                .filter(relation -> relation.getTargetEnrolleeId().equals(enrollee.getId()))
+                .map(EnrolleeRelation::getEnrolleeId)
+                .toList();
+
+        if (proxyIds.isEmpty()) {
+            return Collections.emptyList();
+        } else {
+            return profileService.loadAllByEnrolleeIdsWithMailingList(proxyIds);
+        }
     }
 
     private List<EnrolleeRelation> loadRelations(StudyEnvironmentConfig config, Enrollee enrollee) {

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeExportService.java
@@ -280,7 +280,7 @@ public class EnrolleeExportService {
         if (proxyIds.isEmpty()) {
             return Collections.emptyList();
         } else {
-            return profileService.loadAllByEnrolleeIdsWithMailingList(proxyIds);
+            return profileService.loadAllByEnrolleeIdsWithMailingAddress(proxyIds);
         }
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -291,7 +291,7 @@ public class EnrolleeImportService {
                         .filter(Objects::nonNull)
                         .findFirst()
                         .orElse(null);
-                accountEnrollee = createProxyEnrolleeIfNeeded(studyShortcode, studyEnv, regResult, preferredLanguage, auditInfo);
+                accountEnrollee = createProxyEnrolleeIfNeeded(studyShortcode, studyEnv, regResult, preferredLanguage, exportOptions, accountData.proxyData.getFirst(), auditInfo);
                 importItems.add(createImportItemFromEnrollee(accountEnrollee, importId));
             }
         } catch (Exception e) {
@@ -461,13 +461,21 @@ public class EnrolleeImportService {
         });
     }
 
-    private @NotNull Enrollee createProxyEnrolleeIfNeeded(String studyShortcode, StudyEnvironment studyEnv, RegistrationService.RegistrationResult registration, String preferredLanguage, DataAuditInfo auditInfo) {
+    private @NotNull Enrollee createProxyEnrolleeIfNeeded(String studyShortcode, StudyEnvironment studyEnv, RegistrationService.RegistrationResult registration, String preferredLanguage, ExportOptions exportOptions, Map<String, String> data, DataAuditInfo auditInfo) {
 
-        registration.profile().setDoNotEmail(true);
+        ProxyProfileFormatter proxyProfileFormatter = new ProxyProfileFormatter(exportOptions);
+
+        Profile importedProfileData = proxyProfileFormatter.fromStringMap(studyEnv.getId(), data, 1);
+
+        Profile profile = profileService.loadWithMailingAddress(registration.profile().getId()).get();
+
+        copyNonNullProperties(importedProfileData, profile, List.of("id", "createdAt", "lastUpdatedAt", "doNotEmail"));
+
+        profile.setDoNotEmail(true);
         if (preferredLanguage != null) {
-            registration.profile().setPreferredLanguage(preferredLanguage);
+            profile.setPreferredLanguage(preferredLanguage);
         }
-        profileService.update(registration.profile(), auditInfo);
+        profileService.update(profile, auditInfo);
 
         Optional<Enrollee> enrollee = enrolleeService.findByParticipantUserIdAndStudyEnvId(registration.participantUser().getId(), studyEnv.getId());
 

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/BeanListModuleFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/BeanListModuleFormatter.java
@@ -6,11 +6,9 @@ import bio.terra.pearl.core.service.export.EnrolleeExportData;
 import bio.terra.pearl.core.service.export.formatters.ExportFormatUtils;
 import bio.terra.pearl.core.service.export.formatters.item.PropertyItemFormatter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.NotImplementedException;
 
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Slf4j
 /** ModuleFormatter for just listing properties of a thing -- e.g. fields from a profile */
@@ -45,6 +43,22 @@ public abstract class BeanListModuleFormatter<T> extends ModuleFormatter<T, Prop
         }
         maxNumRepeats = Math.max(maxNumRepeats, beanList.size());
         return valueMap;
+    }
+
+    @Override
+    public T fromStringMap(UUID studyEnvironmentId, Map<String, String> enrolleeMap, int moduleRepeatNum) {
+        T bean = newBean();
+        for (PropertyItemFormatter<T> itemInfo : getItemFormatters()) {
+            String columnName = getColumnKey(itemInfo, false, null, moduleRepeatNum);
+
+            String stringVal = enrolleeMap.get(columnName);
+            itemInfo.importValueToBean(bean, stringVal);
+        }
+        return bean;
+    }
+
+    protected T newBean() {
+        throw new NotImplementedException("newBean() not implemented");
     }
 
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ProfileFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ProfileFormatter.java
@@ -1,9 +1,9 @@
 package bio.terra.pearl.core.service.export.formatters.module;
 
 import bio.terra.pearl.core.model.address.MailingAddress;
+import bio.terra.pearl.core.model.export.ExportOptions;
 import bio.terra.pearl.core.model.participant.Profile;
 import bio.terra.pearl.core.service.export.EnrolleeExportData;
-import bio.terra.pearl.core.model.export.ExportOptions;
 import bio.terra.pearl.core.service.export.formatters.ExportFormatUtils;
 import bio.terra.pearl.core.service.export.formatters.item.PropertyItemFormatter;
 
@@ -12,9 +12,9 @@ import java.util.stream.Collectors;
 
 
 public class ProfileFormatter extends BeanModuleFormatter<Profile> {
-    private static final List<String> PROFILE_EXCLUDED_PROPERTIES = List.of("id", "createdAt",
+    public static final List<String> PROFILE_EXCLUDED_PROPERTIES = List.of("id", "createdAt",
             "lastUpdatedAt", "mailingAddress", "mailingAddressId", "class");
-    private static final List<String> MAILING_ADDRESS_EXCLUDED_PROPERTIES = List.of("id", "createdAt",
+    public static final List<String> MAILING_ADDRESS_EXCLUDED_PROPERTIES = List.of("id", "createdAt",
             "lastUpdatedAt", "class");
 
     @Override

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ProxyProfileFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ProxyProfileFormatter.java
@@ -1,0 +1,53 @@
+package bio.terra.pearl.core.service.export.formatters.module;
+
+import bio.terra.pearl.core.model.address.MailingAddress;
+import bio.terra.pearl.core.model.export.ExportOptions;
+import bio.terra.pearl.core.model.participant.Profile;
+import bio.terra.pearl.core.service.export.EnrolleeExportData;
+import bio.terra.pearl.core.service.export.formatters.ExportFormatUtils;
+import bio.terra.pearl.core.service.export.formatters.item.PropertyItemFormatter;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+public class ProxyProfileFormatter extends BeanListModuleFormatter<Profile> {
+    private static final List<String> PROFILE_EXCLUDED_PROPERTIES = List.of("id", "createdAt",
+            "lastUpdatedAt", "mailingAddress", "mailingAddressId", "class");
+    private static final List<String> MAILING_ADDRESS_EXCLUDED_PROPERTIES = List.of("id", "createdAt",
+            "lastUpdatedAt", "class");
+
+    @Override
+    public List<Profile> getBeans(EnrolleeExportData enrolleeExportData) {
+        return enrolleeExportData.getProxyProfiles();
+    }
+
+    public ProxyProfileFormatter(ExportOptions exportOptions) {
+        super(exportOptions, "proxyProfile", "Proxy profile");
+    }
+
+    @Override
+    protected List<PropertyItemFormatter<Profile>> generateItemFormatters(ExportOptions options) {
+        List<PropertyItemFormatter<Profile>> formatters = ExportFormatUtils.getIncludedProperties(Profile.class, PROFILE_EXCLUDED_PROPERTIES)
+                .stream().map(propName -> new PropertyItemFormatter<Profile>(propName, Profile.class, options.getZoneId()))
+                .collect(Collectors.toList());
+        formatters.addAll(ExportFormatUtils.getIncludedProperties(MailingAddress.class, MAILING_ADDRESS_EXCLUDED_PROPERTIES)
+                .stream().map(propName -> new PropertyItemFormatter<Profile>("mailingAddress." + propName, Profile.class, options.getZoneId()))
+                .toList());
+        return formatters;
+    }
+
+    @Override
+    public Comparator<Profile> getComparator() {
+        return Comparator.comparing(Profile::getCreatedAt).reversed();
+    }
+
+    @Override
+    protected Profile newBean() {
+        return Profile.builder()
+                .mailingAddress(new MailingAddress())
+                .build();
+    };
+
+}

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ProxyProfileFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/ProxyProfileFormatter.java
@@ -13,11 +13,6 @@ import java.util.stream.Collectors;
 
 
 public class ProxyProfileFormatter extends BeanListModuleFormatter<Profile> {
-    private static final List<String> PROFILE_EXCLUDED_PROPERTIES = List.of("id", "createdAt",
-            "lastUpdatedAt", "mailingAddress", "mailingAddressId", "class");
-    private static final List<String> MAILING_ADDRESS_EXCLUDED_PROPERTIES = List.of("id", "createdAt",
-            "lastUpdatedAt", "class");
-
     @Override
     public List<Profile> getBeans(EnrolleeExportData enrolleeExportData) {
         return enrolleeExportData.getProxyProfiles();
@@ -29,10 +24,10 @@ public class ProxyProfileFormatter extends BeanListModuleFormatter<Profile> {
 
     @Override
     protected List<PropertyItemFormatter<Profile>> generateItemFormatters(ExportOptions options) {
-        List<PropertyItemFormatter<Profile>> formatters = ExportFormatUtils.getIncludedProperties(Profile.class, PROFILE_EXCLUDED_PROPERTIES)
+        List<PropertyItemFormatter<Profile>> formatters = ExportFormatUtils.getIncludedProperties(Profile.class, ProfileFormatter.PROFILE_EXCLUDED_PROPERTIES)
                 .stream().map(propName -> new PropertyItemFormatter<Profile>(propName, Profile.class, options.getZoneId()))
                 .collect(Collectors.toList());
-        formatters.addAll(ExportFormatUtils.getIncludedProperties(MailingAddress.class, MAILING_ADDRESS_EXCLUDED_PROPERTIES)
+        formatters.addAll(ExportFormatUtils.getIncludedProperties(MailingAddress.class, ProfileFormatter.MAILING_ADDRESS_EXCLUDED_PROPERTIES)
                 .stream().map(propName -> new PropertyItemFormatter<Profile>("mailingAddress." + propName, Profile.class, options.getZoneId()))
                 .toList());
         return formatters;

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/ProfileService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/ProfileService.java
@@ -6,7 +6,6 @@ import bio.terra.pearl.core.model.address.MailingAddress;
 import bio.terra.pearl.core.model.audit.DataAuditInfo;
 import bio.terra.pearl.core.model.participant.PortalParticipantUser;
 import bio.terra.pearl.core.model.participant.Profile;
-import bio.terra.pearl.core.service.DataAuditedService;
 import bio.terra.pearl.core.service.ParticipantDataAuditedService;
 import bio.terra.pearl.core.service.workflow.ParticipantDataChangeService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -43,6 +42,15 @@ public class ProfileService extends ParticipantDataAuditedService<Profile, Profi
     public Map<UUID, Profile> loadAllWithMailingAddress(List<UUID> profileIds) {
         return dao.loadAllWithMailingAddress(profileIds).stream()
                 .collect(Collectors.toMap(Profile::getId, Function.identity()));
+    }
+
+    public List<Profile> loadAllByEnrolleeIdsWithMailingList(List<UUID> enrolleeIds) {
+        List<Profile> profiles = dao.findAllByEnrolleeIds(enrolleeIds);
+        List<MailingAddress> addresses = mailingAddressDao.findAllPreserveOrder(profiles.stream().map(Profile::getMailingAddressId).toList());
+        for (int i = 0; i < profiles.size(); i++) {
+            profiles.get(i).setMailingAddress(addresses.get(i));
+        }
+        return profiles;
     }
 
     @Transactional

--- a/core/src/main/java/bio/terra/pearl/core/service/participant/ProfileService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/participant/ProfileService.java
@@ -44,7 +44,7 @@ public class ProfileService extends ParticipantDataAuditedService<Profile, Profi
                 .collect(Collectors.toMap(Profile::getId, Function.identity()));
     }
 
-    public List<Profile> loadAllByEnrolleeIdsWithMailingList(List<UUID> enrolleeIds) {
+    public List<Profile> loadAllByEnrolleeIdsWithMailingAddress(List<UUID> enrolleeIds) {
         List<Profile> profiles = dao.findAllByEnrolleeIds(enrolleeIds);
         List<MailingAddress> addresses = mailingAddressDao.findAllPreserveOrder(profiles.stream().map(Profile::getMailingAddressId).toList());
         for (int i = 0; i < profiles.size(); i++) {

--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeExportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeExportServiceTests.java
@@ -29,10 +29,7 @@ import bio.terra.pearl.core.service.export.formatters.item.ItemFormatter;
 import bio.terra.pearl.core.service.export.formatters.item.PropertyItemFormatter;
 import bio.terra.pearl.core.service.export.formatters.module.ModuleFormatter;
 import bio.terra.pearl.core.service.export.formatters.module.SurveyFormatter;
-import bio.terra.pearl.core.service.participant.EnrolleeRelationService;
-import bio.terra.pearl.core.service.participant.FamilyEnrolleeService;
-import bio.terra.pearl.core.service.participant.FamilyService;
-import bio.terra.pearl.core.service.participant.ParticipantUserService;
+import bio.terra.pearl.core.service.participant.*;
 import bio.terra.pearl.core.service.search.EnrolleeSearchExpressionParser;
 import bio.terra.pearl.core.service.study.StudyEnvironmentConfigService;
 import bio.terra.pearl.core.service.survey.SurveyService;
@@ -88,6 +85,8 @@ public class EnrolleeExportServiceTests extends BaseSpringBootTest {
     private SurveyResponseFactory surveyResponseFactory;
     @Autowired
     private ParticipantTaskFactory participantTaskFactory;
+    @Autowired
+    private ProfileService profileService;
 
     @Test
     @Transactional
@@ -208,6 +207,16 @@ public class EnrolleeExportServiceTests extends BaseSpringBootTest {
         EnrolleeAndProxy enrolleeWithProxy = enrolleeFactory.buildProxyAndGovernedEnrollee(testName, studyEnvBundle.getPortalEnv(), studyEnvBundle.getStudyEnv());
         Enrollee regularEnrollee = enrolleeFactory.buildPersisted(testName, studyEnv, new Profile());
 
+        Profile proxyProfile = profileService.loadWithMailingAddress(enrolleeWithProxy.proxy().getProfileId()).get();
+
+        proxyProfile.setGivenName("Proxy Given Name");
+        proxyProfile.setFamilyName("Proxy Family Name");
+
+        proxyProfile.getMailingAddress().setStreet1("123 Proxy St");
+        proxyProfile.getMailingAddress().setCity("Proxy City");
+
+        profileService.updateWithMailingAddress(proxyProfile, getAuditInfo(testInfo));
+
         ParticipantUser proxyUser = participantUserService.findByEnrolleeId(enrolleeWithProxy.proxy().getId()).get();
 
         List<EnrolleeExportData> exportData = enrolleeExportService.loadEnrolleeExportData(studyEnv.getId(), new ExportOptionsWithExpression());
@@ -226,15 +235,21 @@ public class EnrolleeExportServiceTests extends BaseSpringBootTest {
 
         assertThat(exportMapsWithProxies.get(0).get("enrollee.shortcode"), equalTo(regularEnrollee.getShortcode()));
         assertThat(exportMapsWithProxies.get(0).get("enrollee.subject"), equalTo("true"));
-        assertThat(exportMapsWithProxies.get(1).get("proxy.username"), equalTo(proxyUser.getUsername()));
+        assertThat(exportMapsWithProxies.get(0).get("proxyProfile.givenName"), equalTo(null));
 
+        assertThat(exportMapsWithProxies.get(1).get("proxy.username"), equalTo(proxyUser.getUsername()));
         assertThat(exportMapsWithProxies.get(1).get("enrollee.shortcode"), equalTo(enrolleeWithProxy.governedEnrollee().getShortcode()));
         assertThat(exportMapsWithProxies.get(1).get("enrollee.subject"), equalTo("true"));
         assertThat(exportMapsWithProxies.get(1).get("proxy.username"), equalTo(proxyUser.getUsername()));
+        assertThat(exportMapsWithProxies.get(1).get("proxyProfile.givenName"), equalTo(proxyProfile.getGivenName()));
+        assertThat(exportMapsWithProxies.get(1).get("proxyProfile.familyName"), equalTo(proxyProfile.getFamilyName()));
+        assertThat(exportMapsWithProxies.get(1).get("proxyProfile.mailingAddress.street1"), equalTo(proxyProfile.getMailingAddress().getStreet1()));
+        assertThat(exportMapsWithProxies.get(1).get("proxyProfile.mailingAddress.city"), equalTo(proxyProfile.getMailingAddress().getCity()));
 
         assertThat(exportMapsWithProxies.get(2).get("enrollee.shortcode"), equalTo(enrolleeWithProxy.proxy().getShortcode()));
         assertThat(exportMapsWithProxies.get(2).get("enrollee.subject"), equalTo("false"));
         assertThat(exportMapsWithProxies.get(2).get("proxy.username"), equalTo(null));
+        assertThat(exportMapsWithProxies.get(2).get("proxyProfile.givenName"), equalTo(null));
 
         List<EnrolleeExportData> exportDataNoProxies = enrolleeExportService.loadEnrolleeExportData(
                 studyEnv.getId(),

--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
@@ -690,9 +690,9 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
         StudyEnvironmentBundle bundle = studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.irb);
 
         List<Map<String, String>> proxies = List.of(
-                Map.of("proxy.username", "proxy@test.com", "profile.givenName", "Proxy1"),
-                Map.of("proxy.username", "proxy@test.com", "profile.givenName", "Proxy2"),
-                Map.of("proxy.username", "proxy@test.com", "profile.givenName", "Proxy3"));
+                Map.of("proxy.username", "proxy@test.com", "profile.givenName", "Proxy1", "proxyProfile.givenName", "Proxy", "proxyProfile.familyName", "User"),
+                Map.of("proxy.username", "proxy@test.com", "profile.givenName", "Proxy2", "proxyProfile.givenName", "Proxy", "proxyProfile.familyName", "User"),
+                Map.of("proxy.username", "proxy@test.com", "profile.givenName", "Proxy3", "proxyProfile.givenName", "Proxy", "proxyProfile.familyName", "User"));
 
         String username = "proxy@test.com";
 
@@ -707,6 +707,12 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
 
         List<Enrollee> nonSubject = enrollees.stream().filter(enrollee -> !enrollee.isSubject()).toList();
         assertThat(nonSubject, hasSize(1));
+
+        Profile nonSubjectProfile = profileService.loadWithMailingAddress(nonSubject.get(0).getProfileId()).orElseThrow();
+
+        assertThat(nonSubjectProfile.getGivenName(), equalTo("Proxy"));
+        assertThat(nonSubjectProfile.getFamilyName(), equalTo("User"));
+        assertThat(nonSubjectProfile.getContactEmail(), equalTo(username));
 
         Enrollee proxy = nonSubject.get(0);
 
@@ -1102,7 +1108,6 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
         ParticipantTask task4 = tasks.stream().filter(task -> task.getTargetStableId().equals(survey4.getStableId())).findFirst().orElseThrow();
         assertTrue(Duration.between(Instant.now(), task4.getCompletedAt()).toSeconds() < 60); // task4 should be completed recently
         assertThat(task4.getStatus(), equalTo(TaskStatus.COMPLETE));
-
     }
 
     private void verifyParticipant(ImportItem importItem, UUID studyEnvId,
@@ -1191,7 +1196,7 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
                         bundle.getStudy().getShortcode(),
                         bundle.getStudyEnv(),
                         new ExportOptions(),
-                        null,
+                        adminUser.getId(),
                         dataImport.getId())
                 .stream()
                 .map(item -> {

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/EnrolleeFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/EnrolleeFormatterTests.java
@@ -22,7 +22,7 @@ public class EnrolleeFormatterTests {
                 .createdAt(Instant.parse("2023-08-21T05:17:25.00Z"))
                 .build();
         EnrolleeFormatter moduleFormatter = new EnrolleeFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(null, enrollee, null, null, null, null, null, null, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, enrollee, null, null, null, null, null, null, null, null, null, null);
         Map<String, String> valueMap = moduleFormatter.toStringMap(exportData);
 
         assertThat(valueMap.get("enrollee.shortcode"), equalTo("TESTER"));

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/FamilyFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/FamilyFormatterTests.java
@@ -27,7 +27,7 @@ public class FamilyFormatterTests {
                 .shortcode("F_FAM2")
                 .build();
         FamilyFormatter familyFormatter = new FamilyFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null, null, null, null, null, null, List.of(family1, family2), null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null, null, null, null, null, null, null, List.of(family1, family2), null);
         Map<String, String> enrolleeMap = familyFormatter.toStringMap(exportData);
 
         assertThat(enrolleeMap.size(), equalTo(4));

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/KitRequestFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/KitRequestFormatterTests.java
@@ -39,7 +39,7 @@ public class KitRequestFormatterTests {
                 .createdAt(Instant.now().minus(1, java.time.temporal.ChronoUnit.DAYS))
                 .build()
         );
-        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null, null, null, null, kitRequests, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null, null, null, null, null, kitRequests, null, null, null);
         Map<String, String> valueMap = moduleFormatter.toStringMap(exportData);
 
         // the older kit should be first

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ParticipantUserFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ParticipantUserFormatterTests.java
@@ -23,7 +23,7 @@ public class ParticipantUserFormatterTests {
                 .createdAt(Instant.parse("2023-08-21T05:17:25.00Z"))
                 .build();
         ParticipantUserFormatter moduleFormatter = new ParticipantUserFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(null, null, user, null, null, null, null, null, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, user, null, null,  null,null, null, null, null, null, null);
         Map<String, String> valueMap = moduleFormatter.toStringMap(exportData);
 
         assertThat(valueMap.get("account.username"), equalTo(user.getUsername()));

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ProfileFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ProfileFormatterTests.java
@@ -26,7 +26,7 @@ public class ProfileFormatterTests {
                         .build())
                 .build();
         ProfileFormatter moduleFormatter = new ProfileFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, profile, null, null, null, null, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, profile, null, null, null, null, null, null, null, null);
         Map<String, String> enrolleeMap = moduleFormatter.toStringMap(exportData);
 
         assertThat(enrolleeMap.get("profile.familyName"), equalTo("Tester"));
@@ -42,7 +42,7 @@ public class ProfileFormatterTests {
                 .familyName("Tester")
                 .build();
         ProfileFormatter moduleFormatter = new ProfileFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, profile, null, null, null, null, null, null, null);
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, profile, null, null, null, null, null, null, null, null);
         Map<String, String> enrolleeMap = moduleFormatter.toStringMap(exportData);
 
         assertThat(enrolleeMap.get("profile.familyName"), equalTo("Tester"));

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ProxyFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ProxyFormatterTests.java
@@ -24,7 +24,7 @@ public class ProxyFormatterTests {
                 .username("proxy2@test.com")
                 .build();
         ProxyFormatter proxyFormatter = new ProxyFormatter(new ExportOptions());
-        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null, null, null, null, null, null, null, List.of(user1, user2));
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null,  null,null, null, null, null, null, null, List.of(user1, user2));
         Map<String, String> enrolleeMap = proxyFormatter.toStringMap(exportData);
 
         assertThat(enrolleeMap.size(), equalTo(2));

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ProxyProfileFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/ProxyProfileFormatterTests.java
@@ -1,0 +1,92 @@
+package bio.terra.pearl.core.service.export.formatters;
+
+import bio.terra.pearl.core.model.address.MailingAddress;
+import bio.terra.pearl.core.model.export.ExportOptions;
+import bio.terra.pearl.core.model.participant.Profile;
+import bio.terra.pearl.core.service.export.EnrolleeExportData;
+import bio.terra.pearl.core.service.export.formatters.module.ProxyProfileFormatter;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ProxyProfileFormatterTests {
+    @Test
+    public void testToStringMap() throws Exception {
+        Profile proxy1 = Profile.builder()
+                .createdAt(Instant.now())
+                .familyName("First")
+                .givenName("Proxy")
+                .birthDate(LocalDate.ofYearDay(1997, 4))
+                .doNotEmail(false)
+                .mailingAddress(MailingAddress.builder()
+                        .city("Boston")
+                        .build())
+                .build();
+        Profile proxy2 = Profile.builder()
+                .createdAt(Instant.now())
+                .familyName("Second")
+                .givenName("Proxy")
+                .birthDate(LocalDate.ofYearDay(1994, 2))
+                .doNotEmail(false)
+                .mailingAddress(MailingAddress.builder()
+                        .city("Cambridge")
+                        .build())
+                .build();
+        ProxyProfileFormatter moduleFormatter = new ProxyProfileFormatter(new ExportOptions());
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null, List.of(proxy1, proxy2), null, null, null, null, null, null, null);
+        Map<String, String> enrolleeMap = moduleFormatter.toStringMap(exportData);
+
+        // gets most recent first (e.g., proxy2)
+        assertThat(enrolleeMap.get("proxyProfile.familyName"), equalTo("Second"));
+        assertThat(enrolleeMap.get("proxyProfile.givenName"), equalTo("Proxy"));
+        assertThat(enrolleeMap.get("proxyProfile.birthDate"), equalTo("1994-01-02"));
+        assertThat(enrolleeMap.get("proxyProfile.doNotEmail"), equalTo("false"));
+        assertThat(enrolleeMap.get("proxyProfile.mailingAddress.city"), equalTo("Cambridge"));
+
+        assertThat(enrolleeMap.get("proxyProfile[2].familyName"), equalTo("First"));
+        assertThat(enrolleeMap.get("proxyProfile[2].givenName"), equalTo("Proxy"));
+        assertThat(enrolleeMap.get("proxyProfile[2].birthDate"), equalTo("1997-01-04"));
+        assertThat(enrolleeMap.get("proxyProfile[2].doNotEmail"), equalTo("false"));
+        assertThat(enrolleeMap.get("proxyProfile[2].mailingAddress.city"), equalTo("Boston"));
+
+    }
+
+    @Test
+    public void testToStringMapWithNoAddress() throws Exception {
+        Profile profile = Profile.builder()
+                .familyName("Tester")
+                .build();
+        ProxyProfileFormatter moduleFormatter = new ProxyProfileFormatter(new ExportOptions());
+        EnrolleeExportData exportData = new EnrolleeExportData(null, null, null, null, List.of(profile), null, null, null, null, null, null, null);
+        Map<String, String> enrolleeMap = moduleFormatter.toStringMap(exportData);
+
+        assertThat(enrolleeMap.get("proxyProfile.familyName"), equalTo("Tester"));
+        assertThat(enrolleeMap.get("proxyProfile.mailingAddress.city"), equalTo(""));
+    }
+
+    @Test
+    public void testFromStringMap() {
+        Map<String, String> valueMap = Map.of(
+                "proxyProfile.familyName", "Tester",
+                "proxyProfile.givenName", "Bob",
+                "proxyProfile.birthDate", "1997-01-04",
+                "proxyProfile.doNotEmail", "false",
+                "proxyProfile.mailingAddress.city", "Boston"
+        );
+        ProxyProfileFormatter moduleFormatter = new ProxyProfileFormatter(new ExportOptions());
+        Profile profile = moduleFormatter.fromStringMap(UUID.randomUUID(), valueMap, 1);
+
+        assertThat(profile.getFamilyName(), equalTo(valueMap.get("proxyProfile.familyName")));
+        assertThat(profile.getGivenName(), equalTo(valueMap.get("proxyProfile.givenName")));
+        assertThat(profile.getBirthDate().toString(), equalTo(valueMap.get("proxyProfile.birthDate")));
+        assertThat(profile.isDoNotEmail(), equalTo(Boolean.parseBoolean(valueMap.get("proxyProfile.doNotEmail"))));
+        assertThat(profile.getMailingAddress().getCity(), equalTo(valueMap.get("proxyProfile.mailingAddress.city")));
+    }
+}

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatterTests.java
@@ -43,7 +43,7 @@ public class SurveyFormatterTests extends BaseSpringBootTest {
                 .surveyResponseId(testResponse.getId())
                 .stringValue("easyValue")
                 .build();
-        EnrolleeExportData enrolleeExportData = new EnrolleeExportData(null, null, null, null,
+        EnrolleeExportData enrolleeExportData = new EnrolleeExportData(null, null, null, null, null,
                 List.of(answer), null, List.of(testResponse), null, null, null, null);
         Map<String, String> valueMap = moduleFormatter.toStringMap(enrolleeExportData);
 
@@ -80,7 +80,7 @@ public class SurveyFormatterTests extends BaseSpringBootTest {
                 .stringValue("value2")
                 .build();
 
-        EnrolleeExportData enrolleeExportData = new EnrolleeExportData(null, null, null, null,
+        EnrolleeExportData enrolleeExportData = new EnrolleeExportData(null, null, null, null, null,
                 List.of(answer1, answer2), null, List.of(testResponse1, testResponse2), null, null, null, null);
         Map<String, String> valueMap = moduleFormatter.toStringMap(enrolleeExportData);
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds proxy profile to import and export systems.

Exports 1-many proxy profiles, but import is limited to only one proxy, so import only imports 1 proxy profile.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

import this file into demo portal
[2025-04-18-enrollees 2.tsv.zip](https://github.com/user-attachments/files/20592938/2025-04-18-enrollees.2.tsv.zip)
observe they have a name & contact email