### PR TITLE
[JN-1704] remove old in-progress surveys during import 

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/workflow/ParticipantTaskDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/workflow/ParticipantTaskDao.java
@@ -293,6 +293,21 @@ public class ParticipantTaskDao extends BaseMutableJdbiDao<ParticipantTask> impl
         return findByProperty("kit_request_id", kitRequestId);
     }
 
+    public List<ParticipantTask> findTasksByEnrolleeAndSurveyResponse(UUID enrolleeId, List<UUID> surveyResponseId) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("""
+                                select * from %s
+                                where enrollee_id = :enrolleeId
+                                and survey_response_id in (<surveyResponseId>)
+                                order by created_at desc
+                                """.formatted(tableName))
+                        .bind("enrolleeId", enrolleeId)
+                        .bindList("surveyResponseId", surveyResponseId)
+                        .mapTo(clazz)
+                        .list()
+        );
+    }
+
     @Getter
     @Setter
     @NoArgsConstructor

--- a/core/src/main/java/bio/terra/pearl/core/model/workflow/TaskStatus.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/workflow/TaskStatus.java
@@ -19,6 +19,6 @@ public enum TaskStatus {
 
 
     public boolean isTerminalStatus() {
-        return Arrays.asList(COMPLETE, REJECTED).contains(this);
+        return Arrays.asList(COMPLETE, REMOVED, REJECTED).contains(this);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -14,6 +14,7 @@ import bio.terra.pearl.core.model.study.StudyEnvironmentConfig;
 import bio.terra.pearl.core.model.survey.*;
 import bio.terra.pearl.core.model.workflow.HubResponse;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
+import bio.terra.pearl.core.model.workflow.TaskStatus;
 import bio.terra.pearl.core.model.workflow.TaskType;
 import bio.terra.pearl.core.service.export.dataimport.ImportFileFormat;
 import bio.terra.pearl.core.service.export.dataimport.ImportItemService;
@@ -554,11 +555,48 @@ public class EnrolleeImportService {
         List<SurveyResponse> imported = new ArrayList<>();
         for (int i = 0; i < responses.size(); i++) {
             SurveyResponseWithTaskDto response = responses.get(i);
-            imported.add(importSurveyResponse(ppUser, enrollee, studyEnv, formatter, response, portalId, auditInfo, enrolleeMap, i + 1, exportOptions));
+            SurveyResponse importedResponse = importSurveyResponse(ppUser, enrollee, studyEnv, formatter, response, portalId, auditInfo, enrolleeMap, i + 1, exportOptions);
+
+            // is null if the survey is pre-enrollment, which is already imported
+            if (importedResponse != null) {
+                imported.add(importedResponse);
+            }
         }
+
+        removeOldInProgressSurveys(enrollee, imported, auditInfo);
 
         return imported;
     }
+
+    /**
+     * For longitudinal surveys, DSM will often give us response histories like:
+     * complete 05/01, complete 04/20, in-progress 04/20, complete 04/01, in-progress 03/20, etc.
+     * Those in-progress surveys will cause edge cases that never happen with normal Juniper data,
+     * so we remove them.
+     */
+    private void removeOldInProgressSurveys(Enrollee enrollee, List<SurveyResponse> importedResponses, DataAuditInfo auditInfo) {
+        List<ParticipantTask> tasks = participantTaskService.findTasksByEnrolleeAndSurveyResponse(enrollee.getId(), importedResponses.stream()
+                .map(SurveyResponse::getId)
+                .toList());
+
+        // only applies to tasks that are non-latest
+        if (tasks.isEmpty() || tasks.size() == 1) {
+            return;
+        }
+
+        tasks.sort(Comparator.comparing(ParticipantTask::getCreatedAt).reversed());
+
+        // remove any task that isn't the latest and isn't complete
+        for (int i = 1; i < tasks.size(); i++) {
+            ParticipantTask task = tasks.get(i);
+            if (!task.getStatus().isTerminalStatus()) {
+                task.setStatus(TaskStatus.REMOVED);
+
+                participantTaskService.update(task, auditInfo);
+            }
+        }
+    }
+
 
     private SurveyResponse importSurveyResponse(PortalParticipantUser ppUser, Enrollee enrollee, StudyEnvironment studyEnv, SurveyFormatter formatter, SurveyResponseWithTaskDto response, UUID portalId, DataAuditInfo auditInfo, Map<String, String> enrolleeMap, Integer repeatNum, ExportOptions options) {
         Survey survey = surveyService.findLatestActiveByStudyEnvironmentIdAndStableIdNoContent(studyEnv.getId(), formatter.getModuleName())

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/ParticipantTaskService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/ParticipantTaskService.java
@@ -85,6 +85,13 @@ public class ParticipantTaskService extends ParticipantDataAuditedService<Partic
         return dao.findByKitRequestId(kitRequestId);
     }
 
+    public List<ParticipantTask> findTasksByEnrolleeAndSurveyResponse(UUID enrolleeId, List<UUID> surveyResponseId) {
+        if (surveyResponseId.isEmpty()) {
+            return List.of();
+        }
+        return dao.findTasksByEnrolleeAndSurveyResponse(enrolleeId, surveyResponseId);
+    }
+
     @Transactional
     @Override
     public ParticipantTask update(ParticipantTask task, DataAuditInfo dataAuditInfo) {

--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
@@ -898,8 +898,6 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
         assertThat(latestResponse.getLastUpdatedAt(), equalTo(instantFromZone("2023-08-21 05:17AM")));
         assertThat(latestResponse.getAnswers().stream().filter(answer -> answer.getQuestionStableId().equals("importFirstName"))
                 .findFirst().get().getStringValue(), equalTo("Jeff"));
-
-
     }
 
     @Test
@@ -1011,6 +1009,100 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
         assertThat(importedLatestTask.getSurveyResponseId(), equalTo(importedLatestResponse.getId()));
         assertThat(importedLatestResponse.getAnswers().size(), equalTo(2));
         assertThat(importedLatestResponse.getAnswers().stream().map(Answer::valueAsString).collect(Collectors.toSet()), equalTo(Set.of("Alex", "[\"aquamarine\", \"purple\"]")));
+    }
+
+    @Test
+    @Transactional
+    public void testImportRemovesOldInProgressResponses(TestInfo info) {
+        StudyEnvironmentBundle bundle = studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.irb);
+        Survey survey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .stableId("importTest1")
+                .content(TWO_QUESTION_SURVEY_CONTENT)
+                .portalId(bundle.getPortal().getId())
+                .version(1)
+        );
+        surveyFactory.attachToEnv(survey, bundle.getStudyEnv().getId(), true);
+        Survey survey2 = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .stableId("importTest2")
+                .content(TWO_QUESTION_SURVEY_CONTENT)
+                .portalId(bundle.getPortal().getId())
+                .version(1)
+        );
+        surveyFactory.attachToEnv(survey2, bundle.getStudyEnv().getId(), true);
+        String username = "test@test.com";
+
+        Map<String, String> enrolleeMap = Map.ofEntries(
+                Map.entry("enrollee.subject", "true"),
+                Map.entry("account.username", username),
+
+                // survey1: 4 responses with latest complete, 2 in-progress
+                Map.entry("importTest1.complete", "true"),
+                Map.entry("importTest1.importFirstName", "Jeff"),
+                Map.entry("importTest1.importFavColors", "[\"red\", \"blue\"]"),
+                Map.entry("importTest1.createdAt", "2023-08-21 05:17AM"),
+                Map.entry("importTest1[2].complete", "true"),
+                Map.entry("importTest1[2].importFirstName", "Jeffrey"),
+                Map.entry("importTest1[2].importFavColors", "[\"green\"]"),
+                Map.entry("importTest1[2].createdAt", "2023-08-20 05:17AM"),
+                Map.entry("importTest1[3].complete", "false"),
+                Map.entry("importTest1[3].importFirstName", "Jeffrey"),
+                Map.entry("importTest1[3].importFavColors", "[\"green\"]"),
+                Map.entry("importTest1[3].createdAt", "2023-08-19 05:17AM"),
+                Map.entry("importTest1[4].complete", "false"),
+                Map.entry("importTest1[4].importFirstName", "Jeffrey"),
+                Map.entry("importTest1[4].importFavColors", "[\"green\"]"),
+                Map.entry("importTest1[4].createdAt", "2023-08-17 05:17AM"),
+
+                // survey 2: 2 responses with latest in-progress, 1 old in-progress
+                Map.entry("importTest2.complete", "false"),
+                Map.entry("importTest2.importFirstName", "Alex"),
+                Map.entry("importTest2.importFavColors", "[\"orange\"]"),
+                Map.entry("importTest2.createdAt", "2023-08-21 05:17AM"),
+                Map.entry("importTest2[2].complete", "true"),
+                Map.entry("importTest2[2].importFirstName", "Alex"),
+                Map.entry("importTest2[2].importFavColors", "[\"orange\"]"),
+                Map.entry("importTest2[2].createdAt", "2023-08-20 05:17AM"),
+                Map.entry("importTest2[3].complete", "false"),
+                Map.entry("importTest2[3].importFirstName", "Alex"),
+                Map.entry("importTest2[3].importFavColors", "[\"orange\"]"),
+                Map.entry("importTest2[3].createdAt", "2023-08-19 05:17AM")
+        );
+
+        Enrollee enrollee = enrolleeImportService.importEnrollee(
+                bundle.getPortal().getShortcode(),
+                bundle.getStudy().getShortcode(),
+                bundle.getStudyEnv(),
+                enrolleeMap,
+                new ExportOptions(), null);
+
+        List<SurveyResponse> responses = surveyResponseService.findByEnrolleeId(enrollee.getId());
+        assertThat(responses, hasSize(7));
+
+        List<ParticipantTask> tasks = participantTaskService.findByEnrolleeId(enrollee.getId());
+        assertThat(tasks, hasSize(7));
+
+        List<ParticipantTask> survey1Tasks = tasks.stream()
+                .filter(task -> task.getTargetStableId().equals(survey.getStableId()))
+                .sorted(Comparator.comparing(ParticipantTask::getCreatedAt).reversed())
+                .collect(Collectors.toList());
+
+        assertThat(survey1Tasks, hasSize(4));
+
+        List<ParticipantTask> survey2Tasks = tasks.stream()
+                .filter(task -> task.getTargetStableId().equals(survey2.getStableId()))
+                .sorted(Comparator.comparing(ParticipantTask::getCreatedAt).reversed())
+                .collect(Collectors.toList());
+
+        assertThat(survey2Tasks, hasSize(3));
+
+        assertEquals(TaskStatus.COMPLETE, survey1Tasks.get(0).getStatus());
+        assertEquals(TaskStatus.COMPLETE, survey1Tasks.get(1).getStatus());
+        assertEquals(TaskStatus.REMOVED, survey1Tasks.get(2).getStatus());
+        assertEquals(TaskStatus.REMOVED, survey1Tasks.get(3).getStatus());
+
+        assertEquals(TaskStatus.IN_PROGRESS, survey2Tasks.get(0).getStatus());
+        assertEquals(TaskStatus.COMPLETE, survey2Tasks.get(1).getStatus());
+        assertEquals(TaskStatus.REMOVED, survey2Tasks.get(2).getStatus());
     }
 
     @Test


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

If we don't remove them, it causes weird edge cases here and there, I've found. Since it's kind of garbage data, anyway, I think it makes sense to set status to REMOVED - this indicates it's valid data actual put in by a participant, it can be brought back if needed, but it's cruft that may not be actually meaningful. in most cases, these in-progress responses are followed up almost immediately by a completed full response.

I debated if this is "overkill" - I _could_ put this logic in the transplate.py script. But I feel like this both makes it easier to test, and prevents a "gotcha" scenario that almost certainly will happen if/when future DSM studies migrate.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- import this file into demo
[2025-06-04-enrollees.tsv.zip](https://github.com/user-attachments/files/20594047/2025-06-04-enrollees.tsv.zip)
- observe that there are 3 responses to the basics: the latest is in-progress, the middle is removed, and the oldest is completed.