### PR TITLE
[JN-1701] pass down search params

### DIFF
--- a/ui-admin/src/study/participants/survey/SurveyResponseEditor.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyResponseEditor.tsx
@@ -1,13 +1,26 @@
 import React, { useEffect } from 'react'
-import { Survey, SurveyResponse } from 'api/api'
+import {
+  Survey,
+  SurveyResponse
+} from 'api/api'
 import DocumentTitle from 'util/DocumentTitle'
 
 import _cloneDeep from 'lodash/cloneDeep'
-import { AutosaveStatus, Enrollee, PagedSurveyView, useTaskIdParam, makeSurveyJsData } from '@juniper/ui-core'
+import {
+  AutosaveStatus,
+  Enrollee,
+  makeSurveyJsData,
+  PagedSurveyView,
+  useTaskIdParam
+} from '@juniper/ui-core'
 import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
 import { Store } from 'react-notifications-component'
-import { failureNotification, successNotification } from 'util/notifications'
+import {
+  failureNotification,
+  successNotification
+} from 'util/notifications'
 import { usePortalLanguage } from 'portal/languages/usePortalLanguage'
+import { useSearchParams } from 'react-router-dom'
 
 /** allows editing of a survey response */
 export default function SurveyResponseEditor({
@@ -19,7 +32,8 @@ export default function SurveyResponseEditor({
   updateResponseMap: (stableId: string, response: SurveyResponse) => void, justification?: string
 }) {
   const { defaultLanguage } = usePortalLanguage()
-  const { taskId, setTaskId } = useTaskIdParam()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { taskId, setTaskId } = useTaskIdParam(searchParams, setSearchParams)
   if (!taskId) {
     return <span>Task Id must be specified</span>
   }
@@ -59,7 +73,10 @@ export default function SurveyResponseEditor({
         taskId={taskId}
         setTaskId={setTaskId}
         justification={justification}
-        showHeaders={false}/>
+        showHeaders={false}
+        searchParams={searchParams}
+        setSearchParams={setSearchParams}
+      />
     </div>
   </div>
 }

--- a/ui-admin/src/study/participants/survey/SurveyResponseView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyResponseView.tsx
@@ -10,7 +10,8 @@ import {
 
 import {
   NavLink,
-  useParams
+  useParams,
+  useSearchParams
 } from 'react-router-dom'
 import SurveyFullDataView from './SurveyFullDataView'
 import SurveyResponseEditor from './SurveyResponseEditor'
@@ -71,7 +72,10 @@ export default function SurveyResponseView({ enrollee, responseMap, updateRespon
 }) {
   const params = useParams<EnrolleeParams>()
   const [showAssignModal, setShowAssignModal] = useState(false)
-  let { taskId } = useTaskIdParam()
+
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  let { taskId } = useTaskIdParam(searchParams, setSearchParams)
 
   const surveyStableId: string | undefined = params.surveyStableId
 

--- a/ui-core/src/components/forms/PagedSurveyView.test.tsx
+++ b/ui-core/src/components/forms/PagedSurveyView.test.tsx
@@ -469,7 +469,9 @@ const setupSurveyTest = (survey: Survey, profile?: Profile, referencedAnswers?: 
           studyEnvParams={{ studyShortcode: 'study', portalShortcode: 'portal', envName: 'sandbox' }}
           updateResponseMap={jest.fn()} referencedAnswers={referencedAnswers || []}
           selectedLanguage={'en'} updateProfile={jest.fn()} setAutosaveStatus={jest.fn()} setTaskId={jest.fn()}
-          taskId={'guid34'} adminUserId={null} updateEnrollee={jest.fn()} onFailure={jest.fn()} onSuccess={jest.fn()}/>
+          taskId={'guid34'} adminUserId={null} updateEnrollee={jest.fn()} onFailure={jest.fn()}
+          onSuccess={jest.fn()}
+          searchParams={new URLSearchParams()} setSearchParams={jest.fn()}/>
       </MockI18nProvider>
     </ApiProvider>)
   render(RoutedComponent)

--- a/ui-core/src/components/forms/PagedSurveyView.tsx
+++ b/ui-core/src/components/forms/PagedSurveyView.tsx
@@ -46,7 +46,9 @@ export function PagedSurveyView({
   setTaskId,
   selectedLanguage,
   justification,
-  setAutosaveStatus, enrollee, proxyProfile, adminUserId, onSuccess, onFailure, showHeaders = true
+  setAutosaveStatus, enrollee, proxyProfile, adminUserId, onSuccess, onFailure,
+  searchParams, setSearchParams,
+  showHeaders = true
 }: {
   studyEnvParams: StudyEnvParams, form: Survey, response: SurveyResponse, referencedAnswers?: Answer[],
     updateResponseMap: (stableId: string, response: SurveyResponse) => void
@@ -60,9 +62,11 @@ export function PagedSurveyView({
     taskId: string,
     setTaskId: (taskId: string) => void,
     adminUserId: string | null, enrollee: Enrollee, showHeaders?: boolean,
+  searchParams: URLSearchParams,
+  setSearchParams: (params: URLSearchParams) => void
 }) {
   const resumableData = makeSurveyJsData(response?.resumeData, response?.answers, enrollee.participantUserId)
-  const pager = useRoutablePageNumber()
+  const pager = useRoutablePageNumber(searchParams, setSearchParams)
 
   const Api = useApiContext()
   const { i18n } = useI18n()

--- a/ui-core/src/surveyUtils.tsx
+++ b/ui-core/src/surveyUtils.tsx
@@ -21,7 +21,6 @@ import {
   Survey,
   VersionedForm
 } from './types/forms'
-import { useSearchParams } from 'react-router-dom'
 import React, {
   useEffect,
   useState
@@ -325,8 +324,10 @@ export type PageNumberControl = {
 /**
  * hook for reading/writing pageNumbers to url search params as 'page'
  * */
-export function useRoutablePageNumber(): PageNumberControl {
-  const [searchParams, setSearchParams] = useSearchParams()
+export function useRoutablePageNumber(
+  searchParams: URLSearchParams,
+  setSearchParams: (params: URLSearchParams) => void
+): PageNumberControl {
   const pageParam = searchParams.get(PAGE_NUMBER_PARAM_NAME)
   let urlPageNumber = null
   if (pageParam) {

--- a/ui-core/src/useTaskIdParam.ts
+++ b/ui-core/src/useTaskIdParam.ts
@@ -1,9 +1,10 @@
-import { useSearchParams } from 'react-router-dom'
 
 const TASK_ID_PARAM = 'taskId'
 /** gets the task ID from the URL */
-export const useTaskIdParam = (): {taskId: string | null, setTaskId: (taskId: string) => void} => {
-  const [searchParams, setSearchParams] = useSearchParams()
+export const useTaskIdParam = (searchParams: URLSearchParams, setSearchParams: (params: URLSearchParams) => void): {
+  taskId: string | null,
+  setTaskId: (taskId: string) => void
+} => {
   return {
     taskId: searchParams.get(TASK_ID_PARAM),
     setTaskId: (taskId: string) => {

--- a/ui-participant/src/hub/OutreachTasks.tsx
+++ b/ui-participant/src/hub/OutreachTasks.tsx
@@ -12,7 +12,8 @@ import {
   Link,
   useLocation,
   useNavigate,
-  useParams
+  useParams,
+  useSearchParams
 } from 'react-router-dom'
 import SurveyModal from './SurveyModal'
 import {
@@ -34,7 +35,8 @@ type OutreachParams = {
 /** gets the outreach params from the URL */
 const useOutreachParams = () => {
   const params = useParams<OutreachParams>()
-  const { taskId } = useTaskIdParam()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const { taskId } = useTaskIdParam(searchParams, setSearchParams)
   return {
     ...params,
     taskId,

--- a/ui-participant/src/hub/survey/PrintSurveyView.tsx
+++ b/ui-participant/src/hub/survey/PrintSurveyView.tsx
@@ -4,7 +4,8 @@ import React, {
 } from 'react'
 import {
   useNavigate,
-  useParams
+  useParams,
+  useSearchParams
 } from 'react-router-dom'
 import { Model } from 'survey-core'
 import { Survey as SurveyComponent } from 'survey-react-ui'
@@ -51,11 +52,13 @@ const usePrintableSurvey = (args: UsePrintableConsentArgs) => {
 
   const { ppUser } = useActiveUser()
 
+  const [searchParams, setSearchParams] = useSearchParams()
+
 
   const [loading, setLoading] = useState(true)
   const [surveyModel, setSurveyModel] = useState<Model | null>(null)
   const navigate = useNavigate()
-  const { taskId } = useTaskIdParam()
+  const { taskId } = useTaskIdParam(searchParams, setSearchParams)
 
   useEffect(() => {
     const loadForm = async () => {

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -4,7 +4,8 @@ import React, {
 } from 'react'
 import {
   useNavigate,
-  useParams
+  useParams,
+  useSearchParams
 } from 'react-router-dom'
 import 'survey-core/survey.i18n'
 
@@ -47,6 +48,7 @@ ReactQuestionFactory.Instance.registerQuestion('documentrequest', props => {
 function SurveyView({ showHeaders = true }: { showHeaders?: boolean }) {
   const { portal, portalEnv } = usePortalEnv()
   const { enrollees, ppUser } = useActiveUser()
+  const [searchParams, setSearchParams] = useSearchParams()
   const { user, updateEnrollee, updateProfile, enrollees: allEnrollees } = useUser()
   const [formAndResponses, setFormAndResponse] = useState<SurveyWithResponse | null>(null)
   const params = useParams()
@@ -59,7 +61,7 @@ function SurveyView({ showHeaders = true }: { showHeaders?: boolean }) {
     ?.profile : undefined
 
   const { i18n, selectedLanguage } = useI18n()
-  const { taskId, setTaskId } = useTaskIdParam()
+  const { taskId, setTaskId } = useTaskIdParam(searchParams, setSearchParams)
   const navigate = useNavigate()
 
   if (!stableId || !version || !studyShortcode) {
@@ -133,6 +135,8 @@ function SurveyView({ showHeaders = true }: { showHeaders?: boolean }) {
         taskId={taskId || ''}
         setTaskId={setTaskId}
         showHeaders={showHeaders}
+        setSearchParams={setSearchParams}
+        searchParams={searchParams}
       />
     </ApiProvider>
   )

--- a/ui-participant/src/util/surveyJsUtils.test.tsx
+++ b/ui-participant/src/util/surveyJsUtils.test.tsx
@@ -37,6 +37,7 @@ import {
   mockEnrollee,
   mockProfile
 } from '../test-utils/test-participant-factory'
+import { useSearchParams } from 'react-router-dom'
 
 jest.mock('providers/PortalProvider', () => ({ usePortalEnv: jest.fn() }))
 jest.mock('providers/UserProvider')
@@ -48,7 +49,9 @@ beforeEach(() => {
 
 /** does nothing except render a survey using the hooks from surveyJsUtils */
 function PlainSurveyComponent({ formModel, profile }: { formModel: Survey, profile?: Profile }) {
-  const pager = useRoutablePageNumber()
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const pager = useRoutablePageNumber(searchParams, setSearchParams)
   const mockStudyEnvParams = { studyShortcode: 'foo', envName: 'sandbox' as EnvironmentName, portalShortcode: 'bar' }
   const { surveyModel } = useSurveyJSModel(
     formModel,


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Alternative solution to https://github.com/broadinstitute/juniper/pull/1642

It works better; I don't think it's very common, so I'm not too worried about it, but I could see a world where we have to pass this up another layer (e.g., make it a prop for SurveyView - already, there are technically two useSearchParams happening on outreach tasks, but they don't try to override each other).

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- populate demo
- make basics longitudinal and make it save completed as new repsonse after 1 day
- update all in sandbox to this new version of the basics
- log in as jsalk
- update basics
- observe task id change
- go to next page
- continue making changes; does not cause issues.

general regression tests for surveys (admin editing, different survey types, etc.)