### PR TITLE
[JN-1698]: allow editing of survey blurbs

### DIFF
--- a/ui-admin/src/study/surveys/FormOptionsModal.tsx
+++ b/ui-admin/src/study/surveys/FormOptionsModal.tsx
@@ -118,6 +118,18 @@ export const FormOptions = ({ studyEnvContext, initialWorkingForm, updateWorking
                 })}
               /> Required
             </label>
+            { workingForm.surveyType === 'OUTREACH' && <label className="form-label d-block">
+              <div>Dashboard blurb <InfoPopup placement="right" content={<div>
+                For outreach surveys, 1-2 sentences that will be shown in the block that appears in the
+                participant dashboard.
+              </div>}/></div>
+              <textarea rows={3} cols={40}
+                value={workingForm.blurb}
+                onChange={e => updateWorkingForm({
+                  ...workingForm, blurb: e.target.value
+                })}
+              />
+            </label>}
             <label className="form-label d-block">
               <input type="checkbox" checked={workingForm.autoAssign}
                 onChange={e => updateWorkingForm({

--- a/ui-admin/src/study/surveys/SurveyView.tsx
+++ b/ui-admin/src/study/surveys/SurveyView.tsx
@@ -44,6 +44,7 @@ export type SaveableFormProps = {
   recurrenceType: RecurrenceType
   recurOn: RecurOn
   prepopulate: boolean
+  blurb?: string
   createNewResponseAfterDays?: number
   recurrenceIntervalDays?: number
   daysAfterEligible?: number

--- a/ui-admin/src/util/downloadUtils.ts
+++ b/ui-admin/src/util/downloadUtils.ts
@@ -1,6 +1,6 @@
 /** escapes double quotes with an extra ", and adds double quotes around any values that contain commas or newlines */
 export const escapeCsvValue = (value?: string) => {
-  if (!value) {
+  if (!value || !value.replaceAll) {
     return ''
   }
   value = value.replaceAll('"', '""')


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Enables editing of the blurb for Outreach surveys.  Also does some drive-by upgrades of font awesome dependencies to fix typescript warnings

Also contains a fix for JN-1706


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/forms/surveys/depressionOutreach
2. confirm you can see and edit the blurb under "configuration"
3. confirm the blurb is not visible/editable for non-outreach surveys