### PR TITLE
[JN-1709] superuser-only username editor

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/participant/ParticipantUserController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/participant/ParticipantUserController.java
@@ -6,6 +6,8 @@ import bio.terra.pearl.api.admin.service.auth.context.PortalEnvAuthContext;
 import bio.terra.pearl.api.admin.service.participant.ParticipantUserExtService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.model.participant.ParticipantUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Controller;
 
 @Controller
 public class ParticipantUserController implements ParticipantUserApi {
+  private final ObjectMapper objectMapper;
   private AuthUtilService authUtilService;
   private ParticipantUserExtService participantUserExtService;
   private HttpServletRequest request;
@@ -20,10 +23,12 @@ public class ParticipantUserController implements ParticipantUserApi {
   public ParticipantUserController(
       AuthUtilService authUtilService,
       ParticipantUserExtService participantUserExtService,
-      HttpServletRequest request) {
+      HttpServletRequest request,
+      ObjectMapper objectMapper) {
     this.authUtilService = authUtilService;
     this.participantUserExtService = participantUserExtService;
     this.request = request;
+    this.objectMapper = objectMapper;
   }
 
   @Override
@@ -44,5 +49,19 @@ public class ParticipantUserController implements ParticipantUserApi {
             PortalEnvAuthContext.of(
                 user, portalShortcode, EnvironmentName.valueOfCaseInsensitive(envName)),
             participantUserId));
+  }
+
+  @Override
+  public ResponseEntity<Object> update(
+      String portalShortcode, String envName, UUID participantUserId, Object body) {
+
+    ParticipantUser participantUser = objectMapper.convertValue(body, ParticipantUser.class);
+    AdminUser user = authUtilService.requireAdminUser(request);
+    return ResponseEntity.ok(
+        this.participantUserExtService.update(
+            PortalEnvAuthContext.of(
+                user, portalShortcode, EnvironmentName.valueOfCaseInsensitive(envName)),
+            participantUserId,
+            participantUser));
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/participant/ParticipantUserExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/participant/ParticipantUserExtService.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.api.admin.service.participant;
 
 import bio.terra.pearl.api.admin.service.auth.EnforcePortalEnvPermission;
+import bio.terra.pearl.api.admin.service.auth.SuperuserOnly;
 import bio.terra.pearl.api.admin.service.auth.context.PortalEnvAuthContext;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
@@ -55,5 +56,25 @@ public class ParticipantUserExtService {
             .orElseThrow(() -> new NotFoundException("Participant user not found"));
     participantUser.setPortalParticipantUsers(List.of(portalParticipantUser));
     return participantUser;
+  }
+
+  @EnforcePortalEnvPermission(permission = "participant_data_edit")
+  @SuperuserOnly
+  public ParticipantUser update(
+      PortalEnvAuthContext authContext, UUID participantUserId, ParticipantUser updatedUser) {
+
+    ParticipantUser participantUser =
+        participantUserService
+            .find(participantUserId)
+            .orElseThrow(() -> new NotFoundException("Participant user not found"));
+
+    // since this is superuser-only, mostly checking as a sanity check that we're in the right
+    // environment
+    portalParticipantUserService
+        .findOne(participantUser.getId(), authContext.getPortalEnvironment().getId())
+        .orElseThrow(() -> new NotFoundException("Participant user not found"));
+
+    participantUser.setUsername(updatedUser.getUsername());
+    return participantUserService.update(participantUser);
   }
 }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/participant/ParticipantUserExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/participant/ParticipantUserExtService.java
@@ -57,7 +57,8 @@ public class ParticipantUserExtService {
     participantUser.setPortalParticipantUsers(List.of(portalParticipantUser));
     return participantUser;
   }
-/** updates the participantUser -- currently only supports editing the username */
+
+  /** updates the participantUser -- currently only supports editing the username */
   @EnforcePortalEnvPermission(permission = "participant_data_edit")
   @SuperuserOnly
   public ParticipantUser update(

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/participant/ParticipantUserExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/participant/ParticipantUserExtService.java
@@ -57,7 +57,7 @@ public class ParticipantUserExtService {
     participantUser.setPortalParticipantUsers(List.of(portalParticipantUser));
     return participantUser;
   }
-
+/** updates the participantUser -- currently only supports editing the username */
   @EnforcePortalEnvPermission(permission = "participant_data_edit")
   @SuperuserOnly
   public ParticipantUser update(

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -577,6 +577,25 @@ paths:
           content: *jsonContent
         '500':
           $ref: '#/components/responses/ServerError'
+    patch:
+      summary: Updates participant user; currently, only the username field can be updated.
+      tags: [ participantUser ]
+      operationId: update
+      parameters:
+        - *portalShortcodeParam
+        - *envNameParam
+        - { name: id, in: path, required: true, schema: { type: string, format: uuid } }
+      requestBody:
+        required: true
+        description: participant user with all desired changes
+        content: *jsonContent
+      responses:
+        '200':
+          description: updated participant user
+          content: *jsonContent
+        '500':
+          $ref: '#/components/responses/ServerError'
+  
   /api/portals/v1/{portalShortcode}/env/{envName}/participantUsers/merge/plan:
     post:
       summary: gets a merge plan for the given participant users. This does not perform the merge.

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/participant/ParticipantUserExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/participant/ParticipantUserExtServiceTests.java
@@ -1,0 +1,100 @@
+package bio.terra.pearl.api.admin.service.participant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import bio.terra.pearl.api.admin.AuthAnnotationSpec;
+import bio.terra.pearl.api.admin.AuthTestUtils;
+import bio.terra.pearl.api.admin.BaseSpringBootTest;
+import bio.terra.pearl.api.admin.service.auth.SuperuserOnly;
+import bio.terra.pearl.api.admin.service.auth.context.PortalEnvAuthContext;
+import bio.terra.pearl.core.factory.admin.AdminUserFactory;
+import bio.terra.pearl.core.factory.participant.EnrolleeBundle;
+import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
+import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.model.participant.ParticipantUser;
+import bio.terra.pearl.core.model.portal.Portal;
+import bio.terra.pearl.core.model.portal.PortalEnvironment;
+import bio.terra.pearl.core.service.participant.ParticipantUserService;
+import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
+import bio.terra.pearl.core.service.portal.PortalService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+public class ParticipantUserExtServiceTests extends BaseSpringBootTest {
+  @Autowired ParticipantUserExtService participantUserExtService;
+  @Autowired EnrolleeFactory enrolleeFactory;
+  @Autowired ParticipantUserService participantUserService;
+  @Autowired PortalService portalService;
+  @Autowired PortalEnvironmentService portalEnvironmentService;
+  @Autowired AdminUserFactory adminUserFactory;
+
+  @Test
+  public void testAllAuthenticated() {
+    AuthTestUtils.assertAllMethodsAnnotated(
+        participantUserExtService,
+        Map.of(
+            "list",
+            AuthAnnotationSpec.withPortalEnvPerm("participant_data_view"),
+            "findWithPortalUser",
+            AuthAnnotationSpec.withPortalEnvPerm("participant_data_view"),
+            "update",
+            AuthAnnotationSpec.withPortalEnvPerm(
+                "participant_data_edit", List.of(SuperuserOnly.class))));
+  }
+
+  @Test
+  @Transactional
+  public void testCanOnlyUpdateUsername(TestInfo info) {
+
+    AdminUser superuser = adminUserFactory.buildPersisted(getTestName(info), true);
+
+    EnrolleeBundle bundle = enrolleeFactory.buildWithPortalUser(getTestName(info));
+    ParticipantUser participantUser = bundle.participantUser();
+
+    Portal portal =
+        portalService
+            .find(bundle.portalId())
+            .orElseThrow(() -> new RuntimeException("Portal not found"));
+
+    PortalEnvironment portalEnvironment =
+        portalEnvironmentService
+            .find(bundle.portalParticipantUser().getPortalEnvironmentId())
+            .orElseThrow(() -> new RuntimeException("Portal environment not found"));
+
+    ParticipantUser update =
+        participantUserService
+            .find(participantUser.getId())
+            .orElseThrow(() -> new RuntimeException("Participant user not found"));
+
+    update.setUsername("otheremail@other.net");
+    update.setShortcode("ACC_123456789"); // this should be ignored
+    update.setId(UUID.randomUUID()); // this should be ignored
+    update.setEnvironmentName(EnvironmentName.irb); // this should be ignored
+    update.setLastUpdatedAt(Instant.MIN);
+    update.setCreatedAt(Instant.MIN);
+    update.setLastLogin(Instant.MIN);
+
+    ParticipantUser updated =
+        participantUserExtService.update(
+            PortalEnvAuthContext.of(
+                superuser, portal.getShortcode(), portalEnvironment.getEnvironmentName()),
+            participantUser.getId(),
+            update);
+
+    assertEquals("otheremail@other.net", updated.getUsername());
+    assertEquals(participantUser.getShortcode(), updated.getShortcode());
+    assertEquals(participantUser.getId(), updated.getId());
+    assertEquals(participantUser.getEnvironmentName(), updated.getEnvironmentName());
+    assertNotEquals(participantUser.getLastUpdatedAt(), Instant.MIN);
+    assertEquals(participantUser.getCreatedAt(), updated.getCreatedAt());
+    assertEquals(participantUser.getLastLogin(), updated.getLastLogin());
+  }
+}

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -873,6 +873,19 @@ export default {
     return await this.processJsonResponse(response)
   },
 
+  async updateParticipantUser(
+    portalShortcode: string, envName: string, id: string, update: Partial<ParticipantUser>
+  ): Promise<ParticipantUser> {
+    const response = await fetch(`${basePortalUrl(portalShortcode)}/env/${envName}/participantUsers/${id}`,
+      {
+        method: 'PATCH',
+        headers: this.getInitHeaders(),
+        body: JSON.stringify(update)
+      })
+    return await this.processJsonResponse(response)
+  },
+
+
   async fetchMergePlan(portalShortcode: string, envName: string, sourceEmail: string, targetEmail: string):
     Promise<ParticipantUserMerge> {
     const response = await fetch(`${basePortalUrl(portalShortcode)}/env/${envName}/participantUsers/merge/plan`, {

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeOverview.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeOverview.tsx
@@ -26,6 +26,8 @@ import LoadingSpinner from 'util/LoadingSpinner'
 import Families from 'study/participants/Families'
 import { studyEnvParticipantPath } from '../ParticipantsRouter'
 import { Link } from 'react-router-dom'
+import { useUser } from 'user/UserProvider'
+import { UsernameEditor } from 'study/participants/enrolleeView/UsernameEditor'
 
 /** Shows minimal identifying information, and then kits and notes */
 export default function EnrolleeOverview({ enrollee, studyEnvContext, onUpdate }:
@@ -45,6 +47,7 @@ export default function EnrolleeOverview({ enrollee, studyEnvContext, onUpdate }
     setRelations(relations)
     setParticipantUser(participantUser)
   }, [enrollee.shortcode])
+  const { user } = useUser()
 
   const familyLinkageEnabled = studyEnvContext.currentEnv.studyEnvironmentConfig.enableFamilyLinkage
   const proxyForRelations = relations.filter(relation =>
@@ -67,11 +70,13 @@ export default function EnrolleeOverview({ enrollee, studyEnvContext, onUpdate }
           condensed={true}
           values={[dateToDefaultString(enrollee.profile.birthDate) || '']}
         />
-        <InfoCardValue
-          title={'Username'}
-          condensed={true}
-          values={[participantUser?.username || '']}
-        />
+        {user?.superuser && participantUser
+          ? <UsernameEditor participantUser={participantUser} studyEnvContext={studyEnvContext} onUpdate={onUpdate}/>
+          : <InfoCardValue
+            title={'Username'}
+            condensed={true}
+            values={[participantUser?.username || '']}
+          />}
         <InfoCardValue
           title={'Last login'}
           condensed={true}

--- a/ui-admin/src/study/participants/enrolleeView/UsernameEditor.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/UsernameEditor.tsx
@@ -1,0 +1,128 @@
+import React from 'react'
+import { ParticipantUser } from '@juniper/ui-core'
+import { StudyEnvContextT } from 'study/StudyEnvironmentRouter'
+import { InfoCardRow } from 'components/InfoCard'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faPencil } from '@fortawesome/free-solid-svg-icons'
+import Api from 'api/api'
+import { Store } from 'react-notifications-component'
+import {
+  failureNotification,
+  successNotification
+} from 'util/notifications'
+import Modal from 'react-bootstrap/Modal'
+
+export const UsernameEditor = ({ participantUser, studyEnvContext, onUpdate }: {
+  participantUser: ParticipantUser,
+  studyEnvContext: StudyEnvContextT,
+  onUpdate: () => void
+}) => {
+  const [editMode, setEditMode] = React.useState(false)
+  const [username, setUsername] = React.useState(participantUser.username)
+  const [showConfirm, setShowConfirm] = React.useState(false)
+  const unchanged = participantUser.username === username
+
+  const updateUsername = async (newUsername: string) => {
+    try {
+      await Api.updateParticipantUser(
+        studyEnvContext.portal.shortcode,
+        studyEnvContext.currentEnv.environmentName,
+        participantUser.id,
+        { username: newUsername }
+      )
+      onUpdate()
+      setEditMode(false)
+      Store.addNotification(successNotification(`Username successfully updated to ${newUsername}`))
+    } catch (error) {
+      Store.addNotification(
+        failureNotification(`Failed to update username${  error instanceof Error ? `: ${error.message}` : ''}`)
+      )
+    }
+  }
+
+  return <InfoCardRow title={'Username'} condensed={true}>
+    <div className='d-flex align-items-end h-100 m-0'>
+      {editMode ? <>
+        <input
+          type="text"
+          className="form-control form-control-sm w-50 me-2"
+          defaultValue={username}
+          onChange={e => {
+            setUsername(e.target.value)
+          }}
+        />
+        <button
+          className="btn btn-sm btn-primary me-2"
+          onClick={() => {
+            setShowConfirm(true)
+          }}
+          disabled={unchanged}
+        >
+            Save
+        </button>
+        <button
+          className="btn btn-sm btn-secondary"
+          onClick={() => setEditMode(false)}
+        >
+            Cancel
+        </button>
+      </>
+        :<>
+          <span className="m-0">{participantUser.username}</span>
+          <button
+            className="btn btn-sm ms-2 p-0"
+            onClick={() => {
+              setEditMode(true)
+            }}
+          >
+            <FontAwesomeIcon icon={faPencil}/>
+          </button>
+        </>}
+    </div>
+    {showConfirm && <ConfirmUsernameChange
+      oldUsername={participantUser.username}
+      newUsername={username}
+      onConfirm={() => {
+        updateUsername(username)
+        setShowConfirm(false)
+      }}
+      onCancel={() => setShowConfirm(false)}/>
+    }
+  </InfoCardRow>
+}
+
+const ConfirmUsernameChange = ({ oldUsername, newUsername, onConfirm, onCancel }: {
+  oldUsername: string,
+  newUsername: string,
+  onConfirm: () => void,
+  onCancel: () => void
+}) => {
+  return <Modal show={true} onHide={onCancel}>
+    <Modal.Header closeButton>
+      <Modal.Title>Confirm Username Change</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>
+      <p>
+        Are you sure you want to change the username from <strong>
+          {oldUsername}
+        </strong> to <strong>
+          {newUsername}
+        </strong>?</p>
+
+      { !simpleEmailValidate(newUsername) &&
+      <p className="mx-2 text-danger">
+        warning: {newUsername} does not appear to be a valid email address.
+      </p>}
+    </Modal.Body>
+    <Modal.Footer>
+      <button className="btn btn-secondary" onClick={onCancel}>Cancel</button>
+      <button className="btn btn-primary" onClick={onConfirm}>Confirm</button>
+    </Modal.Footer>
+
+  </Modal>
+}
+
+const simpleEmailValidate = (email: string) => {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  return emailRegex.test(email)
+}


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

This is normally the kind of thing that I feel like you'd want to make "hard" to do / make next steps (invitation email) easier to find / make sure it also updates contact email -  but since it's superuser only I think it makes sense to just keep it  basic.

<img width="1049" alt="Screenshot 2025-06-20 at 3 05 06 PM" src="https://github.com/user-attachments/assets/e5874e80-e0a7-4ef5-9149-479898cb97c1" />

<img width="1049" alt="Screenshot 2025-06-20 at 3 05 17 PM" src="https://github.com/user-attachments/assets/34415658-88de-4b06-a019-0841db85869e" />

<img width="1049" alt="Screenshot 2025-06-20 at 3 05 20 PM" src="https://github.com/user-attachments/assets/ecf4de23-292c-42c7-bd2f-434d9c3acef7" />


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- edit jsalk's username
- save it
- ensure it updates
- turn off superuser mode in the ui; see that the pencil icon leaves