### PR TITLE
use setup java caching

### DIFF
--- a/.github/actions/juniper-eng-build-push-image/action.yaml
+++ b/.github/actions/juniper-eng-build-push-image/action.yaml
@@ -25,7 +25,7 @@ runs:
   using: composite
   steps:
     - name: Setup JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '21'
         distribution: 'adopt'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -36,7 +36,7 @@ jobs:
         distribution: 'adopt'
         cache: 'gradle'
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3.5.0
+      uses: gradle/actions/setup-gradle@v4
     - uses: actions/setup-node@v4
       with:
         node-version: 20.x

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,11 +34,13 @@ jobs:
       with:
         java-version: '21'
         distribution: 'adopt'
+        cache: 'gradle'
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v3.5.0
     - uses: actions/setup-node@v4
       with:
         node-version: 20.x
+        cache: 'npm'
     - name: Install dependencies
       run: npm ci
     - name: Build applications

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           java-version: '21'
           distribution: 'adopt'
+          cache: 'gradle'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6
       - name: Build with Gradle

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -49,10 +49,10 @@ jobs:
           java-version: '21'
           distribution: 'adopt'
           cache: 'gradle'
-      - name: Build with Gradle
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          arguments: build --info # if you need to see test failure full stacktraces, change this to `build --info`
+      - name: Build gradle
+        run: ./gradlew build --info --build-cache
       - name: Upload test artifacts
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Build gradle
-        run: ./gradlew build --info --build-cache
+        run: ./gradlew --build-cache build --info
       - name: Upload test artifacts
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -49,10 +49,8 @@ jobs:
           java-version: '21'
           distribution: 'adopt'
           cache: 'gradle'
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@093dfe9d598ec5a42246855d09b49dc76803c005
+        uses: gradle/actions/setup-gradle@v4
         with:
           arguments: build --info # if you need to see test failure full stacktraces, change this to `build --info`
       - name: Upload test artifacts

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -20,6 +20,7 @@ jobs:
         with:
           java-version: '21'
           distribution: 'adopt'
+          cache: 'gradle'
       - name: Scan via gradle
         run: >-
           ./gradlew

--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20.x
+          cache: 'npm'
       - name: Install dependencies
         run: npm ci
       - name: Lint


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

it's been taking a really long time to do Java CI lately, mostly because it takes forever to redownload (maybe the new URL we changed to recently is slower?).

We already populated these caches during build, but didn't use them everywhere, so this just shares the caches in more places.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- verify cache hits