### PR TITLE
[JN-1716] reset password page + link in email substitutor

### DIFF
--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/B2cEventController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/B2cEventController.java
@@ -1,6 +1,6 @@
 package bio.terra.pearl.api.participant.controller;
 
-import bio.terra.pearl.api.participant.api.ExternalEventApi;
+import bio.terra.pearl.api.participant.api.B2cEventApi;
 import bio.terra.pearl.api.participant.model.ExternalEventFailedLoginBody;
 import bio.terra.pearl.api.participant.service.B2cEventExtService;
 import bio.terra.pearl.core.model.EnvironmentName;
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 
 @Controller
 @Slf4j
-public class B2cEventController implements ExternalEventApi {
+public class B2cEventController implements B2cEventApi {
 
   private final B2cEventExtService b2cEventExtService;
 
@@ -38,7 +38,7 @@ public class B2cEventController implements ExternalEventApi {
         "https://trccproject.b2clogin.com" // tRCC (prod)
       },
       maxAge = 3600,
-      methods = {RequestMethod.GET, RequestMethod.OPTIONS})
+      methods = {RequestMethod.POST, RequestMethod.OPTIONS})
   public ResponseEntity<Void> trackFailedLogin(
       String portalShortcode, String envName, ExternalEventFailedLoginBody body) {
     try {

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/B2cEventController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/B2cEventController.java
@@ -1,14 +1,12 @@
 package bio.terra.pearl.api.participant.controller;
 
 import bio.terra.pearl.api.participant.api.B2cEventApi;
-import bio.terra.pearl.api.participant.model.ExternalEventFailedLoginBody;
 import bio.terra.pearl.api.participant.service.B2cEventExtService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.RequestMethod;
 
 @Controller
 @Slf4j
@@ -37,14 +35,14 @@ public class B2cEventController implements B2cEventApi {
         "https://juniperatcp.b2clogin.com", // ATCP (prod)
         "https://trccproject.b2clogin.com" // tRCC (prod)
       },
-      maxAge = 3600,
-      methods = {RequestMethod.POST, RequestMethod.OPTIONS})
+      allowedHeaders = "*",
+      maxAge = 3600)
   public ResponseEntity<Void> trackFailedLogin(
-      String portalShortcode, String envName, ExternalEventFailedLoginBody body) {
+      String portalShortcode, String envName, String email) {
     try {
       // track asynchronously; caller doesn't care if it succeeds or fails
       b2cEventExtService.trackFailedLoginEventAsync(
-          portalShortcode, EnvironmentName.valueOfCaseInsensitive(envName), body.getUsername());
+          portalShortcode, EnvironmentName.valueOfCaseInsensitive(envName), email);
     } catch (Exception e) {
       log.error("Failed to call failed login async method: {}", e.getMessage());
     }

--- a/api-participant/src/main/resources/api/openapi.yml
+++ b/api-participant/src/main/resources/api/openapi.yml
@@ -576,7 +576,7 @@ paths:
   /api/public/portals/v1/{portalShortcode}/env/{envName}/externalEvent/failedLogin:
     post:
       summary: Tracks a failed login attempt
-      tags: [ externalEvent ]
+      tags: [ b2cEvent ]
       operationId: trackFailedLogin
       parameters:
         - { name: portalShortcode, in: path, required: true, schema: { type: string } }

--- a/api-participant/src/main/resources/api/openapi.yml
+++ b/api-participant/src/main/resources/api/openapi.yml
@@ -584,13 +584,10 @@ paths:
       requestBody:
         description: The username used in the failed login attempt
         content:
-          application/json:
-            schema: {
-              type: object,
-              properties: {
-                username: { type: string, description: "The username used in the failed login attempt" },
-              }
-            }
+          text/plain:
+            schema:
+              type: string
+              description: The username used in the failed login attempt
       responses:
         '204':
           description: always returns 204 No Content

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
@@ -7,7 +7,6 @@ import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.portal.PortalEnvironmentConfig;
 import bio.terra.pearl.core.model.study.Study;
-import bio.terra.pearl.core.service.exception.internal.IOInternalException;
 import bio.terra.pearl.core.service.notification.NotificationContextInfo;
 import bio.terra.pearl.core.service.rule.EnrolleeContext;
 import bio.terra.pearl.core.service.workflow.RegistrationService;
@@ -18,7 +17,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.apache.commons.text.lookup.StringLookup;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -30,8 +28,8 @@ import java.util.regex.Pattern;
 @Slf4j
 public class EnrolleeEmailSubstitutor implements StringLookup {
     private final Map<String, Object> valueMap = new HashMap<>();
-    private EnrolleeContext enrolleeContext;
-    private NotificationContextInfo contextInfo;
+    private final EnrolleeContext enrolleeContext;
+    private final NotificationContextInfo contextInfo;
     private final ApplicationRoutingPaths routingPaths;
 
     protected EnrolleeEmailSubstitutor(EnrolleeContext ruleData,
@@ -196,8 +194,9 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
     }
 
     /**
-     * gets a b2c redirect link; e.g., invitation or reset password link. Path must be from
-     * ApplicationRoutingPaths.
+     * builds URL from path with `accountName` and `preferredLanguage` query parameters,
+     * used by juniper links that redirect unauthenticated users to B2C to provide
+     * B2C with account information.
      */
     public String getB2cRedirectLink(
             String path,
@@ -207,23 +206,19 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
             ParticipantUser participantUser,
             Profile profile,
             boolean isProxy) {
-        try {
-            String username = getUsername(participantUser, isProxy);
+        String username = getUsername(participantUser, isProxy);
 
-            String url = "%s%s?accountName=%s".formatted(
-                    routingPaths.getParticipantBaseUrl(portalEnv, config, portalShortcode),
-                    path,
-                            URLEncoder.encode(
-                                    username,
-                                    StandardCharsets.UTF_8.toString()));
+        String url = "%s%s?accountName=%s".formatted(
+                routingPaths.getParticipantBaseUrl(portalEnv, config, portalShortcode),
+                path,
+                URLEncoder.encode(
+                        username,
+                        StandardCharsets.UTF_8));
 
-            if (profile != null && StringUtils.isNotEmpty(profile.getPreferredLanguage())) {
-                url += "&preferredLanguage=" + profile.getPreferredLanguage();
-            }
-            return url;
-        } catch (UnsupportedEncodingException e) {
-            throw new IOInternalException("unable to encode username");
+        if (profile != null && StringUtils.isNotEmpty(profile.getPreferredLanguage())) {
+            url += "&preferredLanguage=" + profile.getPreferredLanguage();
         }
+        return url;
     }
 
     private String getUsername(ParticipantUser participantUser, boolean isProxy) {

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/substitutors/EnrolleeEmailSubstitutor.java
@@ -62,7 +62,26 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
         valueMap.put("accountUsername", getUsername(ruleData.getParticipantUser(), isProxy));
         valueMap.put("enrollee", ruleData.getEnrollee());
         valueMap.put("study", contextInfo.study());
-        valueMap.put("invitationLink", getInvitationLink(contextInfo.portalEnv(), contextInfo.portalEnvConfig(), contextInfo.portal().getShortcode(), ruleData.getParticipantUser(), enrolleeContext.getProfile(), isProxy));
+
+
+        // b2c redirect links (with login_hint and preferredLanguage query params)
+        valueMap.put("invitationLink", getB2cRedirectLink(
+                routingPaths.getParticipantInvitationPath(),
+                contextInfo.portalEnv(),
+                contextInfo.portalEnvConfig(),
+                contextInfo.portal().getShortcode(),
+                ruleData.getParticipantUser(),
+                enrolleeContext.getProfile(),
+                isProxy));
+        valueMap.put("resetPasswordLink", getB2cRedirectLink(
+                routingPaths.getResetPasswordPath(),
+                contextInfo.portalEnv(),
+                contextInfo.portalEnvConfig(),
+                contextInfo.portal().getShortcode(),
+                ruleData.getParticipantUser(),
+                enrolleeContext.getProfile(),
+                isProxy));
+
         if (messages != null) {
             valueMap.putAll(messages);
         }
@@ -177,20 +196,23 @@ public class EnrolleeEmailSubstitutor implements StringLookup {
     }
 
     /**
-     * gets a link the participant can use to create their b2c account, given that they already exist in Juniper
+     * gets a b2c redirect link; e.g., invitation or reset password link. Path must be from
+     * ApplicationRoutingPaths.
      */
-    public String getInvitationLink(PortalEnvironment portalEnv,
-                                    PortalEnvironmentConfig config,
-                                    String portalShortcode,
-                                    ParticipantUser participantUser,
-                                    Profile profile,
-                                    boolean isProxy) {
+    public String getB2cRedirectLink(
+            String path,
+            PortalEnvironment portalEnv,
+            PortalEnvironmentConfig config,
+            String portalShortcode,
+            ParticipantUser participantUser,
+            Profile profile,
+            boolean isProxy) {
         try {
             String username = getUsername(participantUser, isProxy);
 
             String url = "%s%s?accountName=%s".formatted(
                     routingPaths.getParticipantBaseUrl(portalEnv, config, portalShortcode),
-                    routingPaths.getParticipantInvitationPath(),
+                    path,
                             URLEncoder.encode(
                                     username,
                                     StandardCharsets.UTF_8.toString()));

--- a/core/src/main/java/bio/terra/pearl/core/shared/ApplicationRoutingPaths.java
+++ b/core/src/main/java/bio/terra/pearl/core/shared/ApplicationRoutingPaths.java
@@ -23,6 +23,8 @@ public class ApplicationRoutingPaths {
     @Getter
     private final String participantInvitationPath = "/join/invitation";
     @Getter
+    private final String resetPasswordPath = "/reset-password";
+    @Getter
     private final String supportEmailAddress;  // the site-wide support email address (e.g. support@juniper...) NOT study-specific
     @Getter
     private final String deploymentZone; // demo|prod|local

--- a/ui-participant/src/App.tsx
+++ b/ui-participant/src/App.tsx
@@ -47,6 +47,7 @@ import ActiveUserProvider from './providers/ActiveUserProvider'
 import { CookieAlert } from './CookieAlert'
 import PageNotFound from './PageNotFound'
 import mixpanel from 'mixpanel-browser'
+import ResetPasswordPage from 'landing/registration/ResetPasswordPage'
 
 const PrivacyPolicyPage = lazy(() => import('terms/PrivacyPolicyPage'))
 const InvestigatorTermsOfUsePage = lazy(() => import('terms/InvestigatorTermsOfUsePage'))
@@ -114,6 +115,9 @@ function App() {
     )
   }
   // add routes for portal registration and invitations not tied to a specific study (e.g. 'join HeartHive')
+  landingRoutes.push(<Route key="portalReg" path="/reset-password"
+    element={<ResetPasswordPage/>}>
+  </Route>)
   landingRoutes.push(<Route key="portalReg" path="/join/invitation"
     element={<InvitationPage/>}>
   </Route>)

--- a/ui-participant/src/landing/registration/ResetPasswordPage.tsx
+++ b/ui-participant/src/landing/registration/ResetPasswordPage.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { useAuth } from 'react-oidc-context'
+import { PageLoadingIndicator } from 'util/LoadingSpinner'
+import { getEnvSpec } from 'api/api'
+import { getB2CLocale } from '@juniper/ui-core'
+
+/** Page for participants who already have enrollee data in Juniper (from a migration or admin action), and need
+ * to join to link their account */
+export default function ResetPasswordPage() {
+  const auth = useAuth()
+  const [searchParams] = useSearchParams()
+  const accountName = searchParams.get('accountName') || ''
+  const preferredLanguage = searchParams.get('preferredLanguage') || ''
+  const envSpec = getEnvSpec()
+
+  const createAccount = async () => {
+    auth.signinRedirect({
+      redirectMethod: 'replace',
+
+      extraQueryParams: {
+        option: 'resetpassword',
+        originUrl: window.location.origin,
+        portalEnvironment: envSpec.envName,
+        portalShortcode: envSpec.shortcode as string,
+        // eslint-disable-next-line camelcase
+        login_hint: accountName,
+        // eslint-disable-next-line camelcase
+        ui_locales: getB2CLocale(preferredLanguage)
+      }
+    })
+  }
+
+  useEffect(() => {
+    createAccount()
+  }, [])
+
+  return <PageLoadingIndicator />
+}


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

review in parallel with: https://github.com/broadinstitute/terraform-ap-deployments/pull/1913

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- sign up user
- set up reset password email and use ${resetPasswordLink}
- log out
- open network tab
- attempt to sign in with random email
- see network tab sends failedLog
- attempt to sign in with correct email but use wrong password
- see network tab sends failedLogin 
- check that you received an email
- click on the reset password link in the email
- follow the reset password flow
- log out
- log in using new password 