### PR TITLE
[JN-1719] unset do not email on proxy import

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -386,7 +386,7 @@ public class EnrolleeImportService {
 
         importSurveyResponses(portalShortcode, enrolleeMap, exportOptions, studyEnv, regResult.participantUser(), regResult.portalParticipantUser(), enrollee, auditInfo);
 
-        /** restore email -- reload the pr5ofile since answermappings may have changed it */
+        /** restore email -- reload the profile since answermappings may have changed it */
         profile = profileService.find(profile.getId()).orElseThrow();
         profile.setDoNotEmail(false);
         profileService.update(profile, auditInfo);
@@ -478,9 +478,14 @@ public class EnrolleeImportService {
         }
         profileService.update(profile, auditInfo);
 
-        Optional<Enrollee> enrollee = enrolleeService.findByParticipantUserIdAndStudyEnvId(registration.participantUser().getId(), studyEnv.getId());
+        Optional<Enrollee> enrolleeOpt = enrolleeService.findByParticipantUserIdAndStudyEnvId(registration.participantUser().getId(), studyEnv.getId());
 
-        return enrollee.orElseGet(() -> this.enrollmentService.enroll(registration.portalParticipantUser(), studyEnv.getEnvironmentName(), studyShortcode, registration.participantUser(), registration.portalParticipantUser(), null, false).getEnrollee());
+        Enrollee enrollee = enrolleeOpt.orElseGet(() -> this.enrollmentService.enroll(registration.portalParticipantUser(), studyEnv.getEnvironmentName(), studyShortcode, registration.participantUser(), registration.portalParticipantUser(), null, false).getEnrollee());
+
+        profile = profileService.find(enrollee.getProfileId()).orElseThrow();
+        profile.setDoNotEmail(false);
+        profileService.update(profile, auditInfo);
+        return enrollee;
     }
 
     protected Profile importProfile(Map<String, String> enrolleeMap, Profile registrationProfile,


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

This was happening for governed users but not proxies. So my testing of the A-T reset password workflow was not working since it emails proxies directly on failed login, and they were getting skipped. Normally this wouldn't matter since emails go through the governed user anyway.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- import:
[test_import_2.csv](https://github.com/user-attachments/files/21319070/test_import_2.csv)
- observe do not email is false, no extra emails sent during import process.