### PR TITLE
[JN-1712] send sex at birth to dsm

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/study/StudyEnvironmentConfig.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/study/StudyEnvironmentConfig.java
@@ -52,6 +52,14 @@ public class StudyEnvironmentConfig extends BaseEntity {
     private boolean enableInPersonKits = false;
 
     /**
+     * if true, send the participant's sex at birth to DSM/BSP based on their
+     * profile. likely, this setting should be per-kit-type, but this would be
+     * a decent lift and a rare need, so, for now, it's a global study env setting.
+     */
+    @Builder.Default
+    private boolean includeSexAtBirthInKitMetadata = false;
+
+    /**
      * the "home" timezone of the study (e.g. where the study staff is located).  For now, this only impacts export behavior
      * This is a ZoneId stored as a String
      */

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/KitRequestService.java
@@ -17,12 +17,7 @@ import bio.terra.pearl.core.service.CascadeProperty;
 import bio.terra.pearl.core.service.CrudService;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.exception.internal.InternalServerException;
-import bio.terra.pearl.core.service.kit.pepper.PepperApiException;
-import bio.terra.pearl.core.service.kit.pepper.PepperDSMClientWrapper;
-import bio.terra.pearl.core.service.kit.pepper.PepperKit;
-import bio.terra.pearl.core.service.kit.pepper.PepperKitAddress;
-import bio.terra.pearl.core.service.kit.pepper.PepperKitStatus;
-import bio.terra.pearl.core.service.kit.pepper.PepperParseException;
+import bio.terra.pearl.core.service.kit.pepper.*;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.participant.PortalParticipantUserService;
 import bio.terra.pearl.core.service.participant.ProfileService;
@@ -33,18 +28,13 @@ import bio.terra.pearl.core.service.workflow.EventService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.jooq.tools.StringUtils;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -128,9 +118,10 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
 
     private KitRequestDto createNewPepperReturnOnlyKitRequest(AdminUser operator, String studyShortcode, Enrollee enrollee, KitRequest kitRequest) {
         StudyEnvironmentConfig studyEnvironmentConfig = studyEnvironmentConfigService.findByStudyEnvironmentId(enrollee.getStudyEnvironmentId());
+        Profile profile = profileService.find(enrollee.getProfileId()).get();
         // send kit request to DSM
         try {
-            PepperKit pepperKit = pepperDSMClientWrapper.sendKitRequest(studyShortcode, studyEnvironmentConfig, enrollee, kitRequest, null);
+            PepperKit pepperKit = pepperDSMClientWrapper.sendKitRequest(studyShortcode, studyEnvironmentConfig, enrollee, kitRequest, null, buildMetadata(studyEnvironmentConfig, profile));
             // write out the PepperKitStatus as a string for storage
             String pepperRequestJson = objectMapper.writeValueAsString(pepperKit);
             kitRequest.setExternalKit(pepperRequestJson);
@@ -147,6 +138,30 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
         return new KitRequestDto(kitRequest, kitRequest.getKitType(), enrollee.getShortcode(), objectMapper);
     }
 
+    private PepperKitMetadata buildMetadata(StudyEnvironmentConfig studyEnvConfig, Profile profile) {
+        PepperKitMetadata metadata = new PepperKitMetadata();
+
+        if (studyEnvConfig.isIncludeSexAtBirthInKitMetadata()) {
+            metadata.setSexAtBirth(normalizeSexAtBirth(profile.getSexAtBirth()));
+        }
+
+        return metadata;
+    }
+
+    private String normalizeSexAtBirth(String sexAtBirth) {
+        if (StringUtils.isEmpty(sexAtBirth)) {
+            return "";
+        } else if (sexAtBirth.toLowerCase().startsWith("m")) {
+            return "M";
+        } else if (sexAtBirth.toLowerCase().startsWith("f")) {
+            return "F";
+        } else {
+            // BSP can only process M or F; it won't error given other values,
+            // so return them to give as much info as possible.
+            return sexAtBirth;
+        }
+    }
+
     private KitRequestDto createNewPepperKitRequest(AdminUser operator, String studyShortcode, Enrollee enrollee, KitRequestCreationDto kitRequestCreationDto) {
         Profile profile = profileService.loadWithMailingAddress(enrollee.getProfileId()).get();
         PepperKitAddress pepperKitAddress = makePepperKitAddress(profile);
@@ -154,7 +169,7 @@ public class KitRequestService extends CrudService<KitRequest, KitRequestDao> {
         StudyEnvironmentConfig studyEnvironmentConfig = studyEnvironmentConfigService.findByStudyEnvironmentId(enrollee.getStudyEnvironmentId());
         // send kit request to DSM
         try {
-            PepperKit pepperKit = pepperDSMClientWrapper.sendKitRequest(studyShortcode, studyEnvironmentConfig, enrollee, kitRequest, pepperKitAddress);
+            PepperKit pepperKit = pepperDSMClientWrapper.sendKitRequest(studyShortcode, studyEnvironmentConfig, enrollee, kitRequest, pepperKitAddress, buildMetadata(studyEnvironmentConfig, profile));
             // write out the PepperKitStatus as a string for storage
             String pepperRequestJson = objectMapper.writeValueAsString(pepperKit);
             kitRequest.setExternalKit(pepperRequestJson);

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClient.java
@@ -10,6 +10,7 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -20,8 +21,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
-
-import jakarta.validation.Validator;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.resources.ConnectionProvider;
 
@@ -65,14 +64,14 @@ public class LivePepperDSMClient implements PepperDSMClient {
     }
 
     @Override
-    public PepperKit sendKitRequest(String studyShortcode, StudyEnvironmentConfig studyEnvironmentConfig, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address)
+    public PepperKit sendKitRequest(String studyShortcode, StudyEnvironmentConfig studyEnvironmentConfig, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address, PepperKitMetadata metadata)
     throws PepperApiException, PepperParseException {
         String kitRequestBody;
 
         if (kitRequest.getDistributionMethod() == DistributionMethod.IN_PERSON) {
-            kitRequestBody = makeKitReturnOnlyRequestBody(studyShortcode, studyEnvironmentConfig, enrollee, kitRequest);
+            kitRequestBody = makeKitReturnOnlyRequestBody(studyShortcode, studyEnvironmentConfig, enrollee, kitRequest, metadata);
         } else {
-            kitRequestBody = makeKitRequestBody(studyShortcode, studyEnvironmentConfig, enrollee, kitRequest, address);
+            kitRequestBody = makeKitRequestBody(studyShortcode, studyEnvironmentConfig, enrollee, kitRequest, address, metadata);
         }
 
         WebClient.RequestHeadersSpec<? extends WebClient.RequestHeadersSpec<?>> request = buildAuthedPostRequest("shipKit", kitRequestBody);
@@ -110,11 +109,12 @@ public class LivePepperDSMClient implements PepperDSMClient {
         return "juniper-%s".formatted(studyShortcode);
     }
 
-    private String makeKitRequestBody(String studyShortcode, StudyEnvironmentConfig studyEnvironmentConfig, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address) {
+    private String makeKitRequestBody(String studyShortcode, StudyEnvironmentConfig studyEnvironmentConfig, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address, PepperKitMetadata metadata) {
         PepperDSMKitRequest.JuniperKitRequest juniperKitRequest = PepperDSMKitRequest.JuniperKitRequest.builderWithAddress(address)
                 .juniperKitId(kitRequest.getId().toString())
                 .juniperParticipantId(enrollee.getShortcode())
                 .skipAddressValidation(kitRequest.isSkipAddressValidation())
+                .sexAtBirth(metadata.getSexAtBirth())
                 .build();
         PepperDSMKitRequest pepperDSMKitRequest = PepperDSMKitRequest.builder()
                 .juniperKitRequest(juniperKitRequest)
@@ -131,7 +131,7 @@ public class LivePepperDSMClient implements PepperDSMClient {
         }
     }
 
-    private String makeKitReturnOnlyRequestBody(String studyShortcode, StudyEnvironmentConfig studyEnvironmentConfig, Enrollee enrollee, KitRequest kitRequest) {
+    private String makeKitReturnOnlyRequestBody(String studyShortcode, StudyEnvironmentConfig studyEnvironmentConfig, Enrollee enrollee, KitRequest kitRequest, PepperKitMetadata metadata) {
         PepperDSMKitRequest.JuniperKitRequest juniperKitRequest = PepperDSMKitRequest.JuniperKitRequest.builder()
                 .juniperKitId(kitRequest.getId().toString())
                 .juniperParticipantId(enrollee.getShortcode())
@@ -139,6 +139,7 @@ public class LivePepperDSMClient implements PepperDSMClient {
                 .kitLabel(kitRequest.getKitLabel())
                 .returnOnly(true)
                 .returnTrackingId(kitRequest.getReturnTrackingNumber())
+                .sexAtBirth(metadata.getSexAtBirth())
                 .build();
         PepperDSMKitRequest pepperDSMKitRequest = PepperDSMKitRequest.builder()
                 .juniperKitRequest(juniperKitRequest)

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperDSMClient.java
@@ -18,7 +18,7 @@ public interface PepperDSMClient {
      * @return status result from Pepper
      * @throws PepperApiException on error from Pepper or failure to process the Pepper response
      */
-    PepperKit sendKitRequest(String studyShortcode, StudyEnvironmentConfig studyEnvironmentConfig, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address) throws PepperApiException, PepperParseException;
+    PepperKit sendKitRequest(String studyShortcode, StudyEnvironmentConfig studyEnvironmentConfig, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address, PepperKitMetadata metadata) throws PepperApiException, PepperParseException;
     PepperKit fetchKitStatus(StudyEnvironmentConfig studyEnvironmentConfig, UUID kitRequestId) throws PepperApiException, PepperParseException;
     Collection<PepperKit> fetchKitStatusByStudy(String studyShortcode, StudyEnvironmentConfig studyEnvironmentConfig) throws PepperApiException, PepperParseException;
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperDSMClientWrapper.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperDSMClientWrapper.java
@@ -3,8 +3,6 @@ package bio.terra.pearl.core.service.kit.pepper;
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.study.StudyEnvironmentConfig;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
@@ -36,9 +34,9 @@ public class PepperDSMClientWrapper implements PepperDSMClient {
     }
 
     @Override
-    public PepperKit sendKitRequest(String studyShortcode, StudyEnvironmentConfig studyEnvironmentConfig, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address) throws PepperApiException, PepperParseException {
+    public PepperKit sendKitRequest(String studyShortcode, StudyEnvironmentConfig studyEnvironmentConfig, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address, PepperKitMetadata metadata) throws PepperApiException, PepperParseException {
         return getPepperDSMClient(studyEnvironmentConfig)
-                .sendKitRequest(studyShortcode, studyEnvironmentConfig, enrollee, kitRequest, address);
+                .sendKitRequest(studyShortcode, studyEnvironmentConfig, enrollee, kitRequest, address, metadata);
     }
 
     @Override

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperDSMKitRequest.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperDSMKitRequest.java
@@ -1,6 +1,5 @@
 package bio.terra.pearl.core.service.kit.pepper;
 
-import bio.terra.pearl.core.service.kit.pepper.PepperKitAddress;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,6 +23,7 @@ public class PepperDSMKitRequest {
         private String postalCode;
         private String country;
         private String phoneNumber;
+        private String sexAtBirth;
         private String juniperKitId;
         @JsonProperty("juniperParticipantID")
         private String juniperParticipantId;

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperKitMetadata.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/PepperKitMetadata.java
@@ -1,0 +1,18 @@
+package bio.terra.pearl.core.service.kit.pepper;
+
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * Additional fields included in the request to DSM when requesting a kit.
+ */
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class PepperKitMetadata {
+    private String sexAtBirth;
+}
+

--- a/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/StubPepperDSMClient.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/kit/pepper/StubPepperDSMClient.java
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Component;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 
 @Component
@@ -39,7 +38,7 @@ public class StubPepperDSMClient implements PepperDSMClient {
     }
 
     @Override
-    public PepperKit sendKitRequest(String studyShortcode, StudyEnvironmentConfig config, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address) {
+    public PepperKit sendKitRequest(String studyShortcode, StudyEnvironmentConfig config, Enrollee enrollee, KitRequest kitRequest, PepperKitAddress address, PepperKitMetadata metadata) {
         log.info("STUB sending kit request");
         if (kitRequest.getDistributionMethod().equals(DistributionMethod.MAILED) && (address.getCity().startsWith(BAD_ADDRESS_PREFIX) || address.getStreet1().startsWith(BAD_ADDRESS_PREFIX))) {
             throw new  PepperApiException(

--- a/core/src/main/resources/db/changelog/changesets/2025_07_22_kit_metadata_sex_at_birth.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2025_07_22_kit_metadata_sex_at_birth.yaml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: "kit_metadata_sex_at_birth"
+      author: connorlbark
+      changes:
+        - addColumn:
+            tableName: study_environment_config
+            columns:
+              - column:
+                  name: include_sex_at_birth_in_kit_metadata
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false
+

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -410,6 +410,9 @@ databaseChangeLog:
   - include:
       file: changesets/2025_07_10_trigger_min_minutes_since_last_notification.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2025_07_22_kit_metadata_sex_at_birth.yaml
+      relativeToChangelogFile: true
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements
 # are atomic. When they are grouped in a changeset and one fails the changeset cannot be
 # rolled back or rerun making recovery more difficult

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/KitRequestServiceTest.java
@@ -13,6 +13,7 @@ import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
 import bio.terra.pearl.core.factory.portal.PortalEnvironmentFactory;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
+import bio.terra.pearl.core.model.audit.DataAuditInfo;
 import bio.terra.pearl.core.model.kit.DistributionMethod;
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.kit.KitRequestStatus;
@@ -23,7 +24,6 @@ import bio.terra.pearl.core.model.participant.Profile;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
-import bio.terra.pearl.core.model.audit.DataAuditInfo;
 import bio.terra.pearl.core.model.study.StudyEnvironmentConfig;
 import bio.terra.pearl.core.service.kit.pepper.*;
 import bio.terra.pearl.core.service.participant.ProfileService;
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -102,7 +103,7 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
         profile.getMailingAddress().setStreet1("123 Fake Street");
         profileService.updateWithMailingAddress(profile, DataAuditInfo.builder().build());
 
-        when(mockPepperDSMClient.sendKitRequest(any(), any(), any(), any(), any())).thenAnswer(invocation -> {
+        when(mockPepperDSMClient.sendKitRequest(any(), any(), any(), any(), any(), any())).thenAnswer(invocation -> {
             KitRequest kitRequest = (KitRequest) invocation.getArguments()[3];
             throw new PepperApiException("Error from Pepper with unexpected format: boom",
                     PepperErrorResponse.builder()
@@ -143,7 +144,7 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
         assertThat(savedKit.getSentToAddress(), equalTo(objectMapper.writeValueAsString(expectedSentToAddress)));
         assertThat(savedKit.getDistributionMethod(), equalTo(DistributionMethod.MAILED));
 
-        verify(mockPepperDSMClient).sendKitRequest(any(), any(), any(), any(), any());
+        verify(mockPepperDSMClient).sendKitRequest(any(), any(), any(), any(), any(), any());
     }
 
     @Transactional
@@ -361,7 +362,7 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
         assertThat(collectedKit.getCreatingAdminUserId(), equalTo(adminUser.getId()));
         assertThat(collectedKit.getCollectingAdminUserId(), equalTo(adminUser.getId()));
 
-        verify(mockPepperDSMClient).sendKitRequest(any(), any(), any(), any(), any());
+        verify(mockPepperDSMClient).sendKitRequest(any(), any(), any(), any(), any(), any());
     }
 
     @Transactional
@@ -565,7 +566,7 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
     /** test that requests are dispatched to the live/stub DSM based on the study environment config */
     @Transactional
     @Test
-    public void testRequestKitStudyEnvConfig(TestInfo testInfo) throws Exception {
+    public void testUseLiveBasedOnStudyEnvConfig(TestInfo testInfo) throws Exception {
         PepperKit mockKit = PepperKit.builder().currentStatus("blah").build();
         // set up a study and enrollee, initially set the study env to use stub DSM
         String testName = getTestName(testInfo);
@@ -575,25 +576,62 @@ public class KitRequestServiceTest extends BaseSpringBootTest {
         config.setUseStubDsm(true);
         studyEnvironmentConfigService.update(config);
         Enrollee enrollee = enrolleeFactory.buildWithPortalUser(testName, envBundle.getPortalEnv(), envBundle.getStudyEnv(), new Profile()).enrollee();
-        when(mockPepperDSMClient.sendKitRequest(any(), any(), any(), any(), any())).thenReturn(mockKit);
+        when(mockPepperDSMClient.sendKitRequest(any(), any(), any(), any(), any(), any())).thenReturn(mockKit);
         when(mockPepperDSMClient.fetchKitStatus(any(), any())).thenReturn(mockKit);
         KitRequestDto kitRequestDto = kitRequestService.requestKit(adminUser, envBundle.getStudy().getShortcode(),
                 enrollee, new KitRequestService.KitRequestCreationDto("SALIVA", DistributionMethod.MAILED, null, true) );
         kitRequestService.syncKitStatusFromPepper(kitRequestDto.getId());
         Mockito.verify(mockPepperDSMClient).fetchKitStatus(any(), any());
-        Mockito.verify(mockPepperDSMClient).sendKitRequest(any(), any(), any(), any(), any());
+        Mockito.verify(mockPepperDSMClient).sendKitRequest(any(), any(), any(), any(), any(), any());
         Mockito.verifyNoInteractions(livePepperDSMClient);
 
         // now configure to use the live dsmClient
         config.setUseStubDsm(false);
         studyEnvironmentConfigService.update(config);
-        when(livePepperDSMClient.sendKitRequest(any(), any(), any(), any(), any())).thenReturn(mockKit);
+        when(livePepperDSMClient.sendKitRequest(any(), any(), any(), any(), any(), any())).thenReturn(mockKit);
         when(livePepperDSMClient.fetchKitStatus(any(), any())).thenReturn(mockKit);
         kitRequestDto = kitRequestService.requestKit(adminUser, envBundle.getStudy().getShortcode(),
                 enrollee, new KitRequestService.KitRequestCreationDto("SALIVA", DistributionMethod.MAILED, null, true) );
         kitRequestService.syncKitStatusFromPepper(kitRequestDto.getId());
-        Mockito.verify(livePepperDSMClient).sendKitRequest(any(), any(), any(), any(), any());
+        Mockito.verify(livePepperDSMClient).sendKitRequest(any(), any(), any(), any(), any(), any());
         Mockito.verify(livePepperDSMClient).fetchKitStatus(any(), any());
+    }
+
+    @Transactional
+    @Test
+    public void testSendSexAtBirthBasedOnStudyEnvConfig(TestInfo testInfo) throws Exception {
+        PepperKit mockKit = PepperKit.builder().currentStatus("blah").build();
+        // set up a study and enrollee, initially set the study env to use stub DSM
+        String testName = getTestName(testInfo);
+        AdminUser adminUser = adminUserFactory.buildPersisted(testName);
+        StudyEnvironmentBundle envBundle = studyEnvironmentFactory.buildBundle(testName, EnvironmentName.sandbox);
+        StudyEnvironmentConfig config = studyEnvironmentConfigService.find(envBundle.getStudyEnv().getStudyEnvironmentConfigId()).orElseThrow();
+        config.setUseStubDsm(true);
+        config.setIncludeSexAtBirthInKitMetadata(true);
+        studyEnvironmentConfigService.update(config);
+
+
+        Enrollee enrollee = enrolleeFactory.buildWithPortalUser(testName, envBundle.getPortalEnv(), envBundle.getStudyEnv(), Profile.builder().sexAtBirth("Female").build()).enrollee();
+
+        // first kit: request with includeSexAtBirthInKitMetadata true
+        when(mockPepperDSMClient.sendKitRequest(any(), any(), any(), any(), any(), any())).thenReturn(mockKit);
+        kitRequestService.requestKit(adminUser, envBundle.getStudy().getShortcode(),
+                enrollee, new KitRequestService.KitRequestCreationDto("SALIVA", DistributionMethod.MAILED, null, true));
+
+        // second kit: request with includeSexAtBirthInKitMetadata false
+        config = studyEnvironmentConfigService.find(envBundle.getStudyEnv().getStudyEnvironmentConfigId()).orElseThrow();
+        config.setIncludeSexAtBirthInKitMetadata(false);
+        studyEnvironmentConfigService.update(config);
+
+        kitRequestService.requestKit(adminUser, envBundle.getStudy().getShortcode(),
+                enrollee, new KitRequestService.KitRequestCreationDto("SALIVA", DistributionMethod.MAILED, null, true));
+
+
+        // check first kit request call has normalized sex at birth and second has empty metadata
+        InOrder inOrder = Mockito.inOrder(mockPepperDSMClient);
+        inOrder.verify(mockPepperDSMClient).sendKitRequest(any(), any(), any(), any(), any(), eq(PepperKitMetadata.builder().sexAtBirth("F").build()));
+        inOrder.verify(mockPepperDSMClient).sendKitRequest(any(), any(), any(), any(), any(), eq(PepperKitMetadata.builder().build()));
+        Mockito.verifyNoMoreInteractions(mockPepperDSMClient);
     }
 
     private void verifyKit(KitRequest kit, PepperKit expectedDSMStatus, KitRequestStatus expectedStatus)

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientIntegrationTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientIntegrationTest.java
@@ -22,11 +22,7 @@ import java.util.UUID;
 
 import static com.github.seregamorph.hamcrest.MoreMatchers.where;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.everyItem;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -62,7 +58,7 @@ public class LivePepperDSMClientIntegrationTest extends BaseSpringBootTest {
                 .country("USA")
                 .build();
         StudyEnvironmentConfig studyEnvironmentConfig = studyEnvironmentConfigService.findByStudyEnvironmentId(enrollee.getStudyEnvironmentId());
-        PepperKit sendKitResponse = livePepperDSMClient.sendKitRequest(STUDY_SHORTCODE, studyEnvironmentConfig, enrollee, kitRequest, address);
+        PepperKit sendKitResponse = livePepperDSMClient.sendKitRequest(STUDY_SHORTCODE, studyEnvironmentConfig, enrollee, kitRequest, address, new PepperKitMetadata());
         assertThat(sendKitResponse.getCurrentStatus(), equalTo("Kit without label"));
     }
 
@@ -84,7 +80,7 @@ public class LivePepperDSMClientIntegrationTest extends BaseSpringBootTest {
         StudyEnvironmentConfig studyEnvironmentConfig = studyEnvironmentConfigService.findByStudyEnvironmentId(enrollee.getStudyEnvironmentId());
 
         PepperApiException pepperApiException = assertThrows(PepperApiException.class, () -> {
-            livePepperDSMClient.sendKitRequest(STUDY_SHORTCODE, studyEnvironmentConfig, enrollee, kitRequest, address);
+            livePepperDSMClient.sendKitRequest(STUDY_SHORTCODE, studyEnvironmentConfig, enrollee, kitRequest, address, new PepperKitMetadata());
         });
         assertThat(pepperApiException.getMessage(), pepperApiException.getErrorResponse(), notNullValue());
         assertThat(pepperApiException.getMessage(), equalTo("UNKNOWN_KIT_TYPE"));

--- a/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/kit/pepper/LivePepperDSMClientTest.java
@@ -28,11 +28,8 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.matchesRegex;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -83,7 +80,7 @@ public class LivePepperDSMClientTest extends BaseSpringBootTest {
         mockPepperResponse(HttpStatus.BAD_REQUEST, unexpectedJsonBody);
 
         // "Act"
-        Executable act = () -> client.sendKitRequest("testStudy", new StudyEnvironmentConfig(), enrollee, kitRequest, address);
+        Executable act = () -> client.sendKitRequest("testStudy", new StudyEnvironmentConfig(), enrollee, kitRequest, address, new PepperKitMetadata());
 
         // Assert
         PepperApiException pepperApiException = assertThrows(PepperApiException.class, act);
@@ -109,7 +106,7 @@ public class LivePepperDSMClientTest extends BaseSpringBootTest {
         mockPepperResponse(HttpStatus.BAD_REQUEST, unexpectedJsonBody);
 
         PepperApiException pepperApiException = assertThrows(PepperApiException.class,
-                () -> client.sendKitRequest("testStudy", new StudyEnvironmentConfig(), enrollee, kitRequest, address));
+                () -> client.sendKitRequest("testStudy", new StudyEnvironmentConfig(), enrollee, kitRequest, address, new PepperKitMetadata()));
 
         assertThat(pepperApiException.getMessage(), pepperApiException.getErrorResponse(), notNullValue());
         assertThat(pepperApiException.getErrorResponse().getErrorMessage(), equalTo("unknown kit"));
@@ -137,7 +134,7 @@ public class LivePepperDSMClientTest extends BaseSpringBootTest {
 
         // Assert
         PepperApiException pepperException = assertThrows(PepperApiException.class,
-                () -> client.sendKitRequest("testStudy", new StudyEnvironmentConfig(), enrollee, kitRequest, address)
+                () -> client.sendKitRequest("testStudy", new StudyEnvironmentConfig(), enrollee, kitRequest, address, new PepperKitMetadata())
         );
         assertThat(pepperException.getMessage(), containsString(kitId));
         assertThat(pepperException.getMessage(), containsString(errorMessage));
@@ -155,7 +152,7 @@ public class LivePepperDSMClientTest extends BaseSpringBootTest {
         mockPepperResponse(HttpStatus.INTERNAL_SERVER_ERROR, errorResponseBody);
 
         // "Act"
-        Executable act = () -> client.sendKitRequest("testStudy", new StudyEnvironmentConfig(), enrollee, kitRequest, address);
+        Executable act = () -> client.sendKitRequest("testStudy", new StudyEnvironmentConfig(), enrollee, kitRequest, address, new PepperKitMetadata());
 
         // Assert
         PepperApiException pepperException = assertThrows(PepperApiException.class, act);
@@ -180,10 +177,50 @@ public class LivePepperDSMClientTest extends BaseSpringBootTest {
 
         mockPepperResponse(HttpStatus.OK, objectMapper.writeValueAsString(mockResponse));
 
-        PepperKit parsedResponse = client.sendKitRequest("testStudy", new StudyEnvironmentConfig(), enrollee, kitRequest, address);
+        PepperKit parsedResponse = client.sendKitRequest("testStudy", new StudyEnvironmentConfig(), enrollee, kitRequest, address, new PepperKitMetadata());
 
         assertThat(parsedResponse.getCurrentStatus(), equalTo(PepperKitStatus.CREATED.pepperString));
-        verifyRequestForPath("/shipKit");
+        RecordedRequest request = verifyRequestForPath("/shipKit");
+
+        assertThat(request.getMethod(), equalTo("POST"));
+
+
+        String requestBodyStr = request.getBody().readUtf8();
+
+        PepperDSMKitRequest requestBody = objectMapper.readValue(requestBodyStr, PepperDSMKitRequest.class);
+        assertNull(requestBody.getJuniperKitRequest().getSexAtBirth());
+    }
+
+    @Transactional
+    @Test
+    public void testSendKitRequestWithSexAtBirth(TestInfo info) throws Exception {
+        Enrollee enrollee = enrolleeFactory.buildPersisted(getTestName(info));
+        KitRequest kitRequest = kitRequestFactory.buildPersisted(getTestName(info), enrollee);
+        PepperKitAddress address = PepperKitAddress.builder().build();
+
+        PepperKit kitStatus = PepperKit.builder()
+                .juniperKitId(kitRequest.getId().toString())
+                .currentStatus(PepperKitStatus.CREATED.pepperString)
+                .build();
+        PepperKitStatusResponse mockResponse = PepperKitStatusResponse.builder()
+                .isError(false)
+                .kits(new PepperKit[]{kitStatus})
+                .build();
+
+        mockPepperResponse(HttpStatus.OK, objectMapper.writeValueAsString(mockResponse));
+
+        PepperKit parsedResponse = client.sendKitRequest("testStudy", new StudyEnvironmentConfig(), enrollee, kitRequest, address, PepperKitMetadata.builder().sexAtBirth("M").build());
+
+        assertThat(parsedResponse.getCurrentStatus(), equalTo(PepperKitStatus.CREATED.pepperString));
+        RecordedRequest request = verifyRequestForPath("/shipKit");
+
+        assertThat(request.getMethod(), equalTo("POST"));
+
+
+        String requestBodyStr = request.getBody().readUtf8();
+
+        PepperDSMKitRequest requestBody = objectMapper.readValue(requestBodyStr, PepperDSMKitRequest.class);
+        assertThat(requestBody.getJuniperKitRequest().getSexAtBirth(), equalTo("M"));
     }
 
     @Transactional
@@ -251,9 +288,11 @@ public class LivePepperDSMClientTest extends BaseSpringBootTest {
                 .setBody(pepperResponse));
     }
 
-    private void verifyRequestForPath(String path) throws Exception {
+    private RecordedRequest verifyRequestForPath(String path) throws Exception {
         RecordedRequest recordedRequest = mockWebServer.takeRequest(5, TimeUnit.SECONDS);
         assertThat(recordedRequest.getPath(), equalTo(path));
         assertThat(recordedRequest.getHeader("Authorization"), matchesRegex("Bearer .+"));
+
+        return recordedRequest;
     }
 }

--- a/ui-admin/src/study/settings/SettingsView.test.tsx
+++ b/ui-admin/src/study/settings/SettingsView.test.tsx
@@ -1,5 +1,8 @@
 import React from 'react'
-import { renderWithRouter, setupRouterTest } from '@juniper/ui-core'
+import {
+  renderWithRouter,
+  setupRouterTest
+} from '@juniper/ui-core'
 import {
   mockPortalContext,
   mockPortalEnvironmentConfig,
@@ -170,7 +173,8 @@ describe('Study Settings', () => {
         'useDevDsmRealm': false,
         'useStubDsm': false,
         'enableInPersonKits': false,
-        timeZone: 'America/New_York'
+        timeZone: 'America/New_York',
+        'includeSexAtBirthInKitMetadata': false
       }
     )
   })

--- a/ui-admin/src/study/settings/study/KitSettings.tsx
+++ b/ui-admin/src/study/settings/study/KitSettings.tsx
@@ -105,7 +105,6 @@ export const KitSettings = (
 
       <div>
         <label className="form-label">
-<<<<<<< HEAD
           Include sex at birth <InfoPopup content={
           `If checked, kit requests sent to DSM/BSP will include the participant's sexAtBirth value, if available, `
           + `from their profile.`
@@ -117,8 +116,6 @@ export const KitSettings = (
 
       <div>
         <label className="form-label">
-=======
->>>>>>> origin/development
           Use mock kit requests <InfoPopup content={
           `If checked, kit requests will be mocked for this environment, `
           + `and not sent to any external services.`

--- a/ui-admin/src/study/settings/study/KitSettings.tsx
+++ b/ui-admin/src/study/settings/study/KitSettings.tsx
@@ -83,9 +83,9 @@ export const KitSettings = (
               isClearable={false}
               isDisabled={studyEnv.environmentName !== 'sandbox'}
               onChange={selected => setSelectedKitTypes(selected as {
-                    value: string,
-                    label: string
-                  }[])}
+                value: string,
+                label: string
+              }[])}
             />
           </div>
           <Button onClick={saveKitTypes}
@@ -102,7 +102,18 @@ export const KitSettings = (
 
       <div>
         <label className="form-label">
-        Use mock kit requests <InfoPopup content={
+          Include sex at birth <InfoPopup content={
+          `If checked, kit requests sent to DSM/BSP will include the participant's sexAtBirth value, if available, `
+          + `from their profile.`
+          }/>
+          <input type="checkbox" checked={config.includeSexAtBirthInKitMetadata}
+            onChange={e => updateConfig('includeSexAtBirthInKitMetadata', e.target.checked)}/>
+        </label>
+      </div>
+
+      <div>
+        <label className="form-label">
+          Use mock kit requests <InfoPopup content={
           `If checked, kit requests will be mocked for this environment, `
           + `and not sent to any external services.`
           }/>
@@ -112,9 +123,9 @@ export const KitSettings = (
       </div>
       <div>
         <label className="form-label">
-        Use kit request development realm
+          Use kit request development realm
           <InfoPopup content={
-          `If checked, kit requests will be sent to DSM, but to a development realm so they can be reviewed, but 
+            `If checked, kit requests will be sent to DSM, but to a development realm so they can be reviewed, but 
                will not be shipped. To actually mail kits, this and the above field should be unchecked.`}/>
           <input type="checkbox" checked={config.useDevDsmRealm}
             onChange={e => updateConfig('useDevDsmRealm', e.target.checked)}/>
@@ -124,7 +135,7 @@ export const KitSettings = (
     <div>
       <label className="form-label">
         Enable in-person kits <InfoPopup content={
-          `If checked, in-person kit requests will be enabled for this study environment.
+        `If checked, in-person kit requests will be enabled for this study environment.
           Participants will see information about completing in-person kits on the participant dashboard.`
         }/>
         <input type="checkbox" checked={config.enableInPersonKits}

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -194,6 +194,7 @@ export const mockStudyEnvironmentConfig = (): StudyEnvironmentConfig => {
     useDevDsmRealm: false,
     useStubDsm: false,
     enableInPersonKits: false,
+    includeSexAtBirthInKitMetadata: false,
     timeZone: 'America/New_York'
   }
 }

--- a/ui-core/src/types/study.ts
+++ b/ui-core/src/types/study.ts
@@ -44,6 +44,7 @@ export type StudyEnvironmentConfig = {
   useStubDsm: boolean
   useDevDsmRealm: boolean
   enableInPersonKits: boolean
+  includeSexAtBirthInKitMetadata: boolean
   timeZone: string
 }
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Not sure this is the cleanest way to go about it.

I figured making no changes to existing study ops is the way to go - e.g., for trcc they determine sex at birth through other processes and I could see us including it for them causing confusion. Thus, it's a study env config option.

as mentioned in the code comments, I think it would make sense for this config option to be configurable per-kit-type. considering how much work this would be (right now, the study env kit type get/update methods are hardcoded to just a string) and how rare it would be, i went with the simpler option.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- honestly... not easy to test becuase DSM does not send us this value back. I created a few kits locally in the dev ourheart and Kiara was able to check in the DSM database that the values were serialized properly. otherwise, I think we just need to make sure nothing broke.