### PR TITLE
[JN-1729] refresh proxy profile as well as governed profile on survey submit

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/workflow/HubResponse.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/workflow/HubResponse.java
@@ -3,10 +3,11 @@ package bio.terra.pearl.core.model.workflow;
 import bio.terra.pearl.core.model.BaseEntity;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.Profile;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.List;
 
 /**
  * Designed for API responses which also need to keep hub content in sync.  For example,
@@ -20,4 +21,7 @@ public class HubResponse<T extends BaseEntity> {
     private Enrollee enrollee;
     /** the hub response should include an updated profile so surveys can branch based on it */
     private Profile profile;
+
+    private Enrollee proxyEnrollee;
+    private Profile proxyProfile;
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -272,7 +272,9 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         }
 
         logger.info("SurveyResponse received -- enrollee: {}, surveyStabledId: {}", enrollee.getShortcode(), survey.getStableId());
-        HubResponse<SurveyResponse> hubResponse = eventService.buildHubResponse(enrollee, enrolleeContext, response);
+        HubResponse<SurveyResponse> hubResponse;
+        UUID operatorUserId = operator.getParticipantUser() != null ? operator.getParticipantUser().getId() : enrollee.getParticipantUserId();
+        hubResponse = eventService.buildHubResponse(operatorUserId, enrollee, enrolleeContext, response);
         return hubResponse;
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
@@ -170,7 +170,7 @@ public class EnrollmentService {
         EnrolleeEvent event = eventService.publishEnrolleeCreationEvent(enrollee, ppUser);
         log.info("Enrollee created: user {}, study {}, shortcode {}, {} tasks added",
                 user.getId(), studyShortcode, enrollee.getShortcode(), enrollee.getParticipantTasks().size());
-        HubResponse hubResponse = eventService.buildHubResponse(event, enrollee);
+        HubResponse hubResponse = eventService.buildHubResponse(operator.getParticipantUserId(), enrollee, event.getEnrolleeContext(), enrollee);
         return hubResponse;
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EventService.java
@@ -8,6 +8,7 @@ import bio.terra.pearl.core.model.kit.KitRequestStatus;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.model.participant.PortalParticipantUser;
+import bio.terra.pearl.core.model.participant.Profile;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
@@ -19,6 +20,8 @@ import bio.terra.pearl.core.service.ImmutableEntityService;
 import bio.terra.pearl.core.service.consent.EnrolleeConsentEvent;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.kit.KitStatusEvent;
+import bio.terra.pearl.core.service.participant.EnrolleeService;
+import bio.terra.pearl.core.service.participant.ProfileService;
 import bio.terra.pearl.core.service.rule.EnrolleeContext;
 import bio.terra.pearl.core.service.rule.EnrolleeContextService;
 import bio.terra.pearl.core.service.survey.event.EnrolleeSurveyEvent;
@@ -26,10 +29,12 @@ import bio.terra.pearl.core.service.survey.event.SurveyPublishedEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -43,13 +48,21 @@ public class EventService extends ImmutableEntityService<Event, EventDao> {
     private final ParticipantTaskService participantTaskService;
     private final EnrolleeContextService enrolleeContextService;
     private final KitTypeDao kitTypeDao;
+    private final EnrolleeService enrolleeService;
+    private final ProfileService profileService;
 
-    public EventService(EventDao dao, ParticipantTaskService participantTaskService,
-                        EnrolleeContextService enrolleeContextService, KitTypeDao kitTypeDao) {
+    public EventService(EventDao dao,
+                        ParticipantTaskService participantTaskService,
+                        EnrolleeContextService enrolleeContextService,
+                        KitTypeDao kitTypeDao,
+                        @Lazy EnrolleeService enrolleeService,
+                        ProfileService profileService) {
         super(dao);
         this.participantTaskService = participantTaskService;
         this.enrolleeContextService = enrolleeContextService;
         this.kitTypeDao = kitTypeDao;
+        this.enrolleeService = enrolleeService;
+        this.profileService = profileService;
     }
 
     /**
@@ -209,18 +222,31 @@ public class EventService extends ImmutableEntityService<Event, EventDao> {
      * Assembles a HubResponse using the objects attached to the event.  this makes sure that the
      * response reflects the latest task list and profile
      */
-    public <T extends BaseEntity> HubResponse<T> buildHubResponse(EnrolleeEvent event, T response) {
-        return buildHubResponse(event.getEnrollee(), event.getEnrolleeContext(), response);
+    public <T extends BaseEntity> HubResponse<T> buildHubResponse(UUID operatorUserId, Enrollee enrollee, EnrolleeContext context, T response) {
+        HubResponse.HubResponseBuilder builder = hubResponseBuilder(context.getEnrollee(), context, response);
+
+        if (operatorUserId != null && !enrollee.getParticipantUserId().equals(operatorUserId)) {
+            Optional<Enrollee> proxyEnrollee = enrolleeService.findByParticipantUserIdAndStudyEnvId(operatorUserId, enrollee.getStudyEnvironmentId());
+            Optional<Profile> proxyProfile = proxyEnrollee.isPresent() ? profileService.find(proxyEnrollee.get().getProfileId()) : Optional.empty();
+
+            if (proxyEnrollee.isPresent() && proxyProfile.isPresent()) {
+                builder = builder.proxyProfile(proxyProfile.get()).proxyEnrollee(proxyEnrollee.get());
+            }
+
+        }
+        return builder.build();
     }
 
-    public <T extends BaseEntity> HubResponse<T> buildHubResponse(Enrollee enrollee, EnrolleeContext enrolleeContext, T response) {
-        HubResponse hubResponse = HubResponse.builder()
+
+    private <T extends BaseEntity> HubResponse.HubResponseBuilder<T> hubResponseBuilder(Enrollee enrollee,
+                                                                                        EnrolleeContext enrolleeContext,
+                                                                                        T response) {
+        HubResponse.HubResponseBuilder builder = HubResponse.builder()
                 .response(response)
                 .tasks(enrollee.getParticipantTasks().stream().toList())
                 .enrollee(enrollee)
-                .profile(enrolleeContext.getProfile())
-                .build();
-        return hubResponse;
+                .profile(enrolleeContext.getProfile());
+        return builder;
     }
 
     @Autowired

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
@@ -44,8 +44,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SurveyResponseServiceTests extends BaseSpringBootTest {
     @Autowired
@@ -672,9 +671,17 @@ public class SurveyResponseServiceTests extends BaseSpringBootTest {
         });
 
         // doesn't throw updating newest
-        surveyResponseService.updateResponse(
+        HubResponse hubResponse = surveyResponseService.updateResponse(
                 newResponse2, new ResponsibleEntity(proxyUser), "test",
                 proxyPpUser, governedEnrollee, task2.getId(), survey.getPortalId());
+
+        // make sure hub response includes proxy info
+        assertNotNull(hubResponse.getProxyEnrollee());
+        assertEquals(hubResponse.getProxyEnrollee().getId(), proxyEnrollee.getId());
+
+        assertNotNull(hubResponse.getProxyProfile());
+        assertEquals(hubResponse.getProxyProfile().getId(), proxyEnrollee.getProfileId());
+
 
     }
 

--- a/core/src/test/java/bio/terra/pearl/core/service/workflow/EventServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/workflow/EventServiceTests.java
@@ -2,16 +2,20 @@ package bio.terra.pearl.core.service.workflow;
 
 import bio.terra.pearl.core.BaseSpringBootTest;
 import bio.terra.pearl.core.factory.kit.KitRequestFactory;
+import bio.terra.pearl.core.factory.participant.EnrolleeAndProxy;
 import bio.terra.pearl.core.factory.participant.EnrolleeBundle;
 import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
 import bio.terra.pearl.core.factory.portal.PortalEnvironmentFactory;
-import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.kit.KitRequestStatus;
+import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
 import bio.terra.pearl.core.model.workflow.Event;
 import bio.terra.pearl.core.model.workflow.EventClass;
+import bio.terra.pearl.core.model.workflow.HubResponse;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
+import bio.terra.pearl.core.service.rule.EnrolleeContext;
+import bio.terra.pearl.core.service.rule.EnrolleeContextService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -19,6 +23,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class EventServiceTests extends BaseSpringBootTest {
     @Autowired
@@ -29,6 +36,8 @@ public class EventServiceTests extends BaseSpringBootTest {
     private EnrolleeFactory enrolleeFactory;
     @Autowired
     private KitRequestFactory kitRequestFactory;
+    @Autowired
+    private EnrolleeContextService enrolleeContextService;
 
     @Test
     @Transactional
@@ -117,14 +126,55 @@ public class EventServiceTests extends BaseSpringBootTest {
         Assertions.assertEquals(1, createdEvents.size());
 
         Event createdEvent = createdEvents.get(0);
-        Assertions.assertNotNull(createdEvent.getCreatedAt());
+        assertNotNull(createdEvent.getCreatedAt());
         Assertions.assertEquals(EventClass.PORTAL_REGISTRATION_EVENT, createdEvent.getEventClass());
         Assertions.assertNull(createdEvent.getEnrolleeId());
         Assertions.assertEquals(portalEnv.getId(), createdEvent.getPortalEnvironmentId());
     }
 
+    @Test
+    @Transactional
+    public void testBuildHubResponseProxy(TestInfo info) {
+        EnrolleeAndProxy bundle = enrolleeFactory.buildProxyAndGovernedEnrollee(getTestName(info), "proxy@test.com");
+        PortalEnvironment portalEnv = bundle.portalEnv();
+
+        Enrollee enrollee = bundle.governedEnrollee();
+        EnrolleeContext context = enrolleeContextService.fetchData(bundle.governedEnrollee());
+
+        UUID proxyUserId = bundle.proxy().getParticipantUserId();
+        UUID governedEnrolleeId = bundle.governedEnrollee().getId();
+
+        // call as proxy user
+        HubResponse proxyResponse = eventService.buildHubResponse(proxyUserId, enrollee, context, enrollee);
+
+
+        assertEquals(bundle.proxy().getId(), proxyResponse.getProxyEnrollee().getId());
+        assertEquals(bundle.proxy().getProfileId(), proxyResponse.getProxyProfile().getId());
+
+        assertEquals(enrollee.getId(), proxyResponse.getEnrollee().getId());
+        assertEquals(enrollee.getProfileId(), proxyResponse.getProfile().getId());
+
+        // call without proxy user
+        HubResponse governedResponse = eventService.buildHubResponse(governedEnrolleeId, enrollee, context, enrollee);
+
+        assertEquals(enrollee.getId(), governedResponse.getEnrollee().getId());
+        assertEquals(enrollee.getProfileId(), governedResponse.getProfile().getId());
+
+        assertNull(governedResponse.getProxyEnrollee());
+        assertNull(governedResponse.getProxyProfile());
+
+        // call with null user id; should be same as governedResponse
+        governedResponse = eventService.buildHubResponse(null, enrollee, context, enrollee);
+
+        assertEquals(enrollee.getId(), governedResponse.getEnrollee().getId());
+        assertEquals(enrollee.getProfileId(), governedResponse.getProfile().getId());
+
+        assertNull(governedResponse.getProxyEnrollee());
+        assertNull(governedResponse.getProxyProfile());
+    }
+
     private void assertValidCreatedEventForEnrollee(Event created, EventClass eventClass, EnrolleeBundle bundle) {
-        Assertions.assertNotNull(created.getCreatedAt());
+        assertNotNull(created.getCreatedAt());
         Assertions.assertEquals(eventClass, created.getEventClass());
         Assertions.assertEquals(bundle.enrollee().getId(), created.getEnrolleeId());
         Assertions.assertEquals(bundle.portalParticipantUser().getPortalEnvironmentId(), created.getPortalEnvironmentId());

--- a/ui-core/src/components/forms/PagedSurveyView.tsx
+++ b/ui-core/src/components/forms/PagedSurveyView.tsx
@@ -190,6 +190,13 @@ export function PagedSurveyView({
       response.enrollee.participantTasks = response.tasks
       updateEnrollee(response.enrollee)
       updateProfile(response.profile)
+      if (!isNil(response.proxyEnrollee)) {
+        updateEnrollee(response.proxyEnrollee)
+      }
+      if (!isNil(response.proxyProfile)) {
+        updateProfile(response.proxyProfile)
+      }
+
       refreshSurvey(surveyModel, null)
       onSuccess()
     } catch {

--- a/ui-core/src/types/user.ts
+++ b/ui-core/src/types/user.ts
@@ -63,6 +63,9 @@ export type HubResponse = {
     tasks: ParticipantTask[]
     response: SurveyResponse
     profile: Profile
+
+    proxyEnrollee?: Enrollee
+    proxyProfile?: Profile
 }
 
 export type Profile = {

--- a/ui-participant/src/providers/UserProvider.tsx
+++ b/ui-participant/src/providers/UserProvider.tsx
@@ -149,8 +149,6 @@ export default function UserProvider({ children }: { children: React.ReactNode }
       loginState?.ppUsers.find(ppUser => ppUser.profileId === profile.id)?.participantUserId === loginState?.user?.id
     )
 
-    console.log('updating profile', profile, 'isPrimaryUser', isPrimaryUser)
-
     if (updateWithoutRerender && loginState) {
       // update the underlying value, but don't call setLoginState, so no refresh
       // this should obviously be used with great care

--- a/ui-participant/src/providers/UserProvider.tsx
+++ b/ui-participant/src/providers/UserProvider.tsx
@@ -149,6 +149,8 @@ export default function UserProvider({ children }: { children: React.ReactNode }
       loginState?.ppUsers.find(ppUser => ppUser.profileId === profile.id)?.participantUserId === loginState?.user?.id
     )
 
+    console.log('updating profile', profile, 'isPrimaryUser', isPrimaryUser)
+
     if (updateWithoutRerender && loginState) {
       // update the underlying value, but don't call setLoginState, so no refresh
       // this should obviously be used with great care


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

trcc ran into this because a survey would submit but because the hub response did not include the proxy profile subsequent surveys that utilized `proxyProfile` would be missing the value.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- add question & answer mapping for proxyProfile.givenName in the basics survey
- enroll proxy user & complete basics. WITHOUT refreshing, click on the user dropdown and make sure it shows the proxy name you provided 