### PR TITLE
[JN-1727] custom kit eligibility

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/model/study/StudyEnvironmentConfig.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/study/StudyEnvironmentConfig.java
@@ -52,6 +52,13 @@ public class StudyEnvironmentConfig extends BaseEntity {
     private boolean enableInPersonKits = false;
 
     /**
+     * enrollee search expression used to determine kit eligibility.
+     * if not specified, enrollees are eligible if they have completed all required surveys.
+     */
+    @Builder.Default
+    private String kitEligibilityRule = null;
+
+    /**
      * the "home" timezone of the study (e.g. where the study staff is located).  For now, this only impacts export behavior
      * This is a ZoneId stored as a String
      */

--- a/core/src/main/java/bio/terra/pearl/core/model/study/StudyEnvironmentConfig.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/study/StudyEnvironmentConfig.java
@@ -54,6 +54,7 @@ public class StudyEnvironmentConfig extends BaseEntity {
     /**
      * enrollee search expression used to determine kit eligibility.
      * if not specified, enrollees are eligible if they have completed all required surveys.
+     * note: this eligibility rule is not verified by the backend; it is only used as a frontend filter.
      */
     @Builder.Default
     private String kitEligibilityRule = null;

--- a/core/src/main/resources/db/changelog/changesets/2025_07_28_custom_kit_eligibility.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2025_07_28_custom_kit_eligibility.yaml
@@ -9,6 +9,4 @@ databaseChangeLog:
               - column:
                   name: kit_eligibility_rule
                   type: text
-                  constraints:
-                      nullable: true
 

--- a/core/src/main/resources/db/changelog/changesets/2025_07_28_custom_kit_eligibility.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2025_07_28_custom_kit_eligibility.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: "custom_kit_eligibility"
+      author: connorlbark
+      changes:
+        - addColumn:
+            tableName: study_environment_config
+            columns:
+              - column:
+                  name: kit_eligibility_rule
+                  type: text
+                  constraints:
+                      nullable: true
+

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -410,6 +410,9 @@ databaseChangeLog:
   - include:
       file: changesets/2025_07_10_trigger_min_minutes_since_last_notification.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2025_07_28_custom_kit_eligibility.yaml
+      relativeToChangelogFile: true
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements
 # are atomic. When they are grouped in a changeset and one fails the changeset cannot be
 # rolled back or rerun making recovery more difficult

--- a/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
+++ b/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
@@ -53,10 +53,7 @@ import {
   enrolleeConsentedColumn,
   getDynamicColumn
 } from 'util/table/columnUtils'
-import {
-  isEmpty,
-  isNil
-} from 'lodash'
+import { isNil } from 'lodash'
 import ParticipantSearch from 'study/participants/participantList/search/ParticipantSearch'
 
 type EnrolleeRow = EnrolleeSearchExpressionResult & {
@@ -70,7 +67,7 @@ export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvCont
   const { portal, study, currentEnv, currentEnvPath } = studyEnvContext
 
   const customKitEligibilityRule = currentEnv.studyEnvironmentConfig.kitEligibilityRule
-  const hasCustomKitEligibilityRule = !isNil(customKitEligibilityRule) && !isEmpty(customKitEligibilityRule)
+  const hasCustomKitEligibilityRule = !isNil(customKitEligibilityRule)
 
   const [studyEnvKitTypes, setStudyEnvKitTypes] = useState<KitType[]>([])
   const [enrollees, setEnrollees] = useState<EnrolleeRow[]>([])
@@ -270,6 +267,9 @@ export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvCont
           updateSearchState={updateSearchState}
           setSearchState={setSearchState}
           disabled={false}
+          customLabels={{
+            'custom': 'Kit Eligibility'
+          }}
         />
       </div>
     </div>

--- a/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
+++ b/ui-admin/src/study/kits/KitEnrolleeSelection.tsx
@@ -7,28 +7,57 @@ import {
   ColumnFiltersState,
   getCoreRowModel,
   getFilteredRowModel,
-  getSortedRowModel, SortingState,
+  getSortedRowModel,
+  SortingState,
   useReactTable,
   VisibilityState
 } from '@tanstack/react-table'
 
-import Api, { EnrolleeSearchExpressionResult, KeyedSearchValueTypeDefinition, ParticipantTask } from 'api/api'
-import { paramsFromContext, StudyEnvContextT } from 'study/StudyEnvironmentRouter'
+import Api, {
+  EnrolleeSearchExpressionResult,
+  KeyedSearchValueTypeDefinition,
+  ParticipantTask
+} from 'api/api'
+import {
+  paramsFromContext,
+  StudyEnvContextT
+} from 'study/StudyEnvironmentRouter'
 import {
   basicTableLayout,
-  IndeterminateCheckbox, renderEmptyMessage,
-  RowVisibilityCount, checkboxColumnCell, DownloadControl
+  checkboxColumnCell,
+  DownloadControl,
+  IndeterminateCheckbox,
+  renderEmptyMessage,
+  RowVisibilityCount
 } from 'util/table/tableUtils'
 import LoadingSpinner from 'util/LoadingSpinner'
-import { currentIsoDate, Enrollee, instantToDateString, KitType, StudyEnvParams } from '@juniper/ui-core'
+import {
+  currentIsoDate,
+  Enrollee,
+  instantToDateString,
+  KitType,
+  StudyEnvParams
+} from '@juniper/ui-core'
 import RequestKitsModal from './RequestKitsModal'
 import { useLoadingEffect } from 'api/api-utils'
 import { enrolleeKitRequestPath } from 'study/participants/enrolleeView/EnrolleeView'
 import { Button } from 'components/forms/Button'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faPaperPlane, faQrcode } from '@fortawesome/free-solid-svg-icons'
+import {
+  faPaperPlane,
+  faQrcode
+} from '@fortawesome/free-solid-svg-icons'
 import { useParticipantSearchState } from 'util/participantSearchUtils'
-import { ColumnVisibilityControl, enrolleeConsentedColumn, getDynamicColumn } from 'util/table/columnUtils'
+import {
+  ColumnVisibilityControl,
+  enrolleeConsentedColumn,
+  getDynamicColumn
+} from 'util/table/columnUtils'
+import {
+  isEmpty,
+  isNil
+} from 'lodash'
+import ParticipantSearch from 'study/participants/participantList/search/ParticipantSearch'
 
 type EnrolleeRow = EnrolleeSearchExpressionResult & {
   taskCompletionStatus: Record<string, boolean>
@@ -39,24 +68,41 @@ type EnrolleeRow = EnrolleeSearchExpressionResult & {
  */
 export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvContext: StudyEnvContextT }) {
   const { portal, study, currentEnv, currentEnvPath } = studyEnvContext
+
+  const customKitEligibilityRule = currentEnv.studyEnvironmentConfig.kitEligibilityRule
+  const hasCustomKitEligibilityRule = !isNil(customKitEligibilityRule) && !isEmpty(customKitEligibilityRule)
+
   const [studyEnvKitTypes, setStudyEnvKitTypes] = useState<KitType[]>([])
   const [enrollees, setEnrollees] = useState<EnrolleeRow[]>([])
   const [sorting, setSorting] = React.useState<SortingState>([
     { id: 'enrollee.createdAt', desc: true },
     { id: 'optionalSurveys', desc: true }
-
   ])
+
   const [rowSelection, setRowSelection] = useState<Record<string, boolean>>({})
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({})
-  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([
+  // if no custom kit eligibility rule, add default filters
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(hasCustomKitEligibilityRule ? [] : [
     { id: 'enrollee.consented', value: true },
     { id: 'requiredSurveysComplete', value: true }
   ])
 
   const [showRequestKitModal, setShowRequestKitModal] = useState(false)
 
-  const { searchState, setSearchState, searchExpression, facets } = useParticipantSearchState([], false,
-    paramsFromContext(studyEnvContext))
+  const {
+    searchState,
+    setSearchState,
+    updateSearchState,
+    searchExpression,
+    facets
+  } = useParticipantSearchState(
+    [],
+    false,
+    paramsFromContext(studyEnvContext),
+    'kitSearch',
+    {
+      custom: hasCustomKitEligibilityRule ? customKitEligibilityRule : ''
+    })
 
 
   const { isLoading, reload } = useLoadingEffect(async () => {
@@ -64,8 +110,12 @@ export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvCont
 
     const [kitTypes, enrollees] = await Promise.all([
       Api.fetchKitTypes(studyEnvParams),
-      Api.executeSearchExpression(portal.shortcode, study.shortcode, currentEnv.environmentName,
-        searchExpression, { includes: ['tasks', 'kitRequests'] })
+      Api.executeSearchExpression(
+        portal.shortcode,
+        study.shortcode,
+        currentEnv.environmentName,
+        searchExpression,
+        { includes: ['tasks', 'kitRequests'] })
     ])
 
     setStudyEnvKitTypes(kitTypes)
@@ -212,29 +262,44 @@ export default function KitEnrolleeSelection({ studyEnvContext }: { studyEnvCont
 
   return <LoadingSpinner isLoading={isLoading}>
     <div className="d-flex align-items-center justify-content-between">
-      <div className="d-flex align-items-center">
+      <div className="flex-grow-1 d-flex align-content-center align-items-center justify-content-between">
+        <ParticipantSearch
+          key={currentEnv.environmentName}
+          studyEnvContext={studyEnvContext}
+          searchState={searchState}
+          updateSearchState={updateSearchState}
+          setSearchState={setSearchState}
+          disabled={false}
+        />
+      </div>
+    </div>
+    <div className="d-flex align-items-center justify-content-between">
+      <div className="ps-2">
         <RowVisibilityCount table={table}/>
       </div>
-      <div className="d-flex">
+      <div className="d-flex align-items-center">
         <Link to={'../scan'}>
           <Button variant="light" className="border m-1"><FontAwesomeIcon icon={faQrcode}/> Scan kit</Button>
         </Link>
-        <Button onClick={() => { setShowRequestKitModal(true) }}
-          variant="light" className="border m-1" disabled={!enableActionButtons}
-          tooltip={enableActionButtons ? 'Send sample collection kit' : 'Select at least one participant'}>
+        <Button onClick={() => {
+          setShowRequestKitModal(true)
+        }}
+        variant="light" className="border m-1" disabled={!enableActionButtons}
+        tooltip={enableActionButtons ? 'Send sample collection kit' : 'Select at least one participant'}>
           <FontAwesomeIcon icon={faPaperPlane} className="fa-lg"/> Send sample collection kit
         </Button>
         <ColumnVisibilityControl table={table} dynamicColOpts={dynamicColOpts}/>
-        <div><DownloadControl table={table}
-          fileName={`kits-${currentIsoDate()}`}/></div>
-        { showRequestKitModal && <RequestKitsModal
+        <div>
+          <DownloadControl table={table}
+            fileName={`kits-${currentIsoDate()}`}/></div>
+        {showRequestKitModal && <RequestKitsModal
           studyEnvContext={studyEnvContext}
           onDismiss={() => setShowRequestKitModal(false)}
           enrolleeShortcodes={enrolleesSelected}
-          onSubmit={onSubmit}/> }
+          onSubmit={onSubmit}/>}
       </div>
     </div>
-    { basicTableLayout(table, { filterable: true }) }
-    { renderEmptyMessage(enrollees, 'No participants') }
+    {basicTableLayout(table, { filterable: true })}
+    {renderEmptyMessage(enrollees, 'No participants')}
   </LoadingSpinner>
 }

--- a/ui-admin/src/study/participants/participantList/search/ParticipantSearch.tsx
+++ b/ui-admin/src/study/participants/participantList/search/ParticipantSearch.tsx
@@ -10,12 +10,20 @@ import { faFilter } from '@fortawesome/free-solid-svg-icons'
 
 
 /** Participant search component for participant list page */
-function ParticipantSearch({ studyEnvContext, searchState, updateSearchState, setSearchState, disabled = false }: {
+function ParticipantSearch({
+  studyEnvContext,
+  searchState,
+  updateSearchState,
+  setSearchState,
+  disabled = false,
+  customLabels = {}
+}: {
   studyEnvContext: StudyEnvContextT,
   searchState: ParticipantSearchState,
   updateSearchState: (field: keyof ParticipantSearchState, value: unknown) => void,
   setSearchState: (searchState: ParticipantSearchState) => void,
-  disabled?: boolean
+  disabled?: boolean,
+  customLabels?: { [index: string]: string }
 }) {
   const [advancedSearch, setAdvancedSearch] = useState(false)
 
@@ -41,7 +49,9 @@ function ParticipantSearch({ studyEnvContext, searchState, updateSearchState, se
     </div>
     <SearchCriteriaView
       searchState={searchState}
-      updateSearchState={updateSearchState}/>
+      updateSearchState={updateSearchState}
+      customLabels={customLabels}
+    />
   </>
 }
 

--- a/ui-admin/src/study/participants/participantList/search/SearchCriteriaView.tsx
+++ b/ui-admin/src/study/participants/participantList/search/SearchCriteriaView.tsx
@@ -12,26 +12,28 @@ import {
  * Provides a view of the current search criteria showing the facets and values that have been selected,
  * and allowing the user to delete criteria.
  */
-const SearchCriteriaView = ({ searchState, updateSearchState }: {
+const SearchCriteriaView = ({ searchState, updateSearchState, customLabels }: {
   searchState: ParticipantSearchState,
-  updateSearchState: (field: keyof ParticipantSearchState, value: unknown) => void
+  updateSearchState: (field: keyof ParticipantSearchState, value: unknown) => void,
+  customLabels?: { [index: string]: string }
 }) => {
-  const handleDelete = (label: string) => {
+  const handleDelete = (labelToDelete: string) => {
     // technically, task names could conflict with another facet label (e.g., Age), but it's unlikely
-    if (searchState.tasks.findIndex(task => task.task === label) !== -1) {
-      updateSearchState('tasks', searchState.tasks.filter(task => task.task !== label))
+    if (searchState.tasks.findIndex(task => task.task === labelToDelete) !== -1) {
+      updateSearchState('tasks', searchState.tasks.filter(task => task.task !== labelToDelete))
     } else {
-      for (const [key, value] of Object.entries(ParticipantSearchStateLabels)) {
-        if (value === label) {
-          updateSearchState(key as keyof ParticipantSearchState,
-            DefaultParticipantSearchState[key as keyof ParticipantSearchState])
+      for (const [field, label] of Object.entries(ParticipantSearchStateLabels)) {
+        const customLabel = customLabels?.[field]
+        if (label === labelToDelete || customLabel === labelToDelete) {
+          updateSearchState(field as keyof ParticipantSearchState,
+            DefaultParticipantSearchState[field as keyof ParticipantSearchState])
           return
         }
       }
     }
   }
 
-  const advancedSearchFacets = getFacets(searchState)
+  const advancedSearchFacets = getFacets(searchState, { customLabels })
 
   if (advancedSearchFacets.length === 0) {
     return <></>

--- a/ui-admin/src/study/settings/study/KitSettings.tsx
+++ b/ui-admin/src/study/settings/study/KitSettings.tsx
@@ -21,10 +21,13 @@ import {
 import { LoadedPortalContextT } from 'portal/PortalProvider'
 import {
   InfoCard,
+  InfoCardBody,
   InfoCardHeader,
   InfoCardTitle
 } from 'components/InfoCard'
 import { RequireUserPermission } from 'util/RequireUserPermission'
+import { LazySearchQueryBuilder } from 'search/LazySearchQueryBuilder'
+import { isEmpty } from 'lodash'
 
 export const KitSettings = (
   {
@@ -83,9 +86,9 @@ export const KitSettings = (
               isClearable={false}
               isDisabled={studyEnv.environmentName !== 'sandbox'}
               onChange={selected => setSelectedKitTypes(selected as {
-                    value: string,
-                    label: string
-                  }[])}
+                value: string,
+                label: string
+              }[])}
             />
           </div>
           <Button onClick={saveKitTypes}
@@ -102,7 +105,7 @@ export const KitSettings = (
 
       <div>
         <label className="form-label">
-        Use mock kit requests <InfoPopup content={
+          Use mock kit requests <InfoPopup content={
           `If checked, kit requests will be mocked for this environment, `
           + `and not sent to any external services.`
           }/>
@@ -112,9 +115,9 @@ export const KitSettings = (
       </div>
       <div>
         <label className="form-label">
-        Use kit request development realm
+          Use kit request development realm
           <InfoPopup content={
-          `If checked, kit requests will be sent to DSM, but to a development realm so they can be reviewed, but 
+            `If checked, kit requests will be sent to DSM, but to a development realm so they can be reviewed, but 
                will not be shipped. To actually mail kits, this and the above field should be unchecked.`}/>
           <input type="checkbox" checked={config.useDevDsmRealm}
             onChange={e => updateConfig('useDevDsmRealm', e.target.checked)}/>
@@ -124,12 +127,35 @@ export const KitSettings = (
     <div>
       <label className="form-label">
         Enable in-person kits <InfoPopup content={
-          `If checked, in-person kit requests will be enabled for this study environment.
+        `If checked, in-person kit requests will be enabled for this study environment.
           Participants will see information about completing in-person kits on the participant dashboard.`
         }/>
         <input type="checkbox" checked={config.enableInPersonKits}
           onChange={e => updateConfig('enableInPersonKits', e.target.checked)}/>
       </label>
     </div>
+
+    <InfoCard>
+      <InfoCardHeader>
+        <InfoCardTitle title={'Kit eligibility'}/>
+      </InfoCardHeader>
+      <InfoCardBody>
+        <div>
+          If specified, overrides the default kit eligibility rule.
+          <LazySearchQueryBuilder
+            studyEnvContext={studyEnvContext}
+            onSearchExpressionChange={searchExp => {
+              if (!isEmpty(searchExp)) {
+                updateConfig('kitEligibilityRule', searchExp)
+              } else {
+                updateConfig('kitEligibilityRule', undefined)
+              }
+            }}
+            searchExpression={config.kitEligibilityRule || ''}
+          />
+        </div>
+      </InfoCardBody>
+
+    </InfoCard>
   </>
 }

--- a/ui-admin/src/study/settings/study/KitSettings.tsx
+++ b/ui-admin/src/study/settings/study/KitSettings.tsx
@@ -27,7 +27,7 @@ import {
 } from 'components/InfoCard'
 import { RequireUserPermission } from 'util/RequireUserPermission'
 import { LazySearchQueryBuilder } from 'search/LazySearchQueryBuilder'
-import { isEmpty } from 'lodash'
+import { isNil } from 'lodash'
 
 export const KitSettings = (
   {
@@ -135,27 +135,36 @@ export const KitSettings = (
       </label>
     </div>
 
+    <label className="form-label">
+      Use custom kit eligibility rule <InfoPopup content={
+      `If checked, the Kits page will use the provided search expression as the default filter for enrollees.
+          If not checked, the Kits page will only show enrollees that have completed all required surveys.`
+      }/>
+      <input type="checkbox" checked={!isNil(config.kitEligibilityRule)}
+        onChange={e => {
+          if (e.target.checked) {
+            updateConfig('kitEligibilityRule', '')
+          } else {
+            updateConfig('kitEligibilityRule', undefined)
+          }
+        }}/>
+    </label>
+    {!isNil(config.kitEligibilityRule) &&
     <InfoCard>
       <InfoCardHeader>
-        <InfoCardTitle title={'Kit eligibility'}/>
+        <InfoCardTitle title={'Kit eligibility rule'}/>
       </InfoCardHeader>
       <InfoCardBody>
-        <div>
-          If specified, overrides the default kit eligibility rule.
-          <LazySearchQueryBuilder
-            studyEnvContext={studyEnvContext}
-            onSearchExpressionChange={searchExp => {
-              if (!isEmpty(searchExp)) {
-                updateConfig('kitEligibilityRule', searchExp)
-              } else {
-                updateConfig('kitEligibilityRule', undefined)
-              }
-            }}
-            searchExpression={config.kitEligibilityRule || ''}
-          />
-        </div>
+        <LazySearchQueryBuilder
+          studyEnvContext={studyEnvContext}
+          onSearchExpressionChange={searchExp => {
+            updateConfig('kitEligibilityRule', searchExp)
+          }}
+          searchExpression={config.kitEligibilityRule || ''}
+        />
       </InfoCardBody>
 
     </InfoCard>
+    }
   </>
 }

--- a/ui-admin/src/util/participantSearchUtils.tsx
+++ b/ui-admin/src/util/participantSearchUtils.tsx
@@ -6,7 +6,10 @@ import {
 } from 'lodash'
 import { useSearchParams } from 'react-router-dom'
 import { useState } from 'react'
-import Api, { ExpressionSearchFacets, KeyedSearchValueTypeDefinition } from '../api/api'
+import Api, {
+  ExpressionSearchFacets,
+  KeyedSearchValueTypeDefinition
+} from '../api/api'
 import { StudyEnvParams } from '@juniper/ui-core'
 import { useLoadingEffect } from '../api/api-utils'
 
@@ -59,12 +62,15 @@ export const ParticipantSearchStateLabels: { [key in keyof ParticipantSearchStat
 /**
  * Hook for managing the participant search state from the page URL.
  */
-export const useParticipantSearchState = (defaultIncludes: string[], familyLinkageEnabled: boolean,
-  studyEnvParams: StudyEnvParams, searchParamName = 'search') => {
+export const useParticipantSearchState = (
+  defaultIncludes: string[],
+  familyLinkageEnabled: boolean,
+  studyEnvParams: StudyEnvParams,
+  searchParamName = 'search',
+  defaultState: Partial<ParticipantSearchState> = {}) => {
   const [searchParams, setSearchParams] = useSearchParams()
 
-
-  const searchState = urlParamsToSearchState(searchParams, searchParamName)
+  const searchState = urlParamsToSearchState(searchParams, searchParamName, defaultState)
   const searchExpression = toExpression(searchState, defaultIncludes, familyLinkageEnabled)
   const setSearchState = (newSearchState: ParticipantSearchState) => {
     setSearchParams(params => {
@@ -119,8 +125,12 @@ const searchStateToUrlParam = (searchState: ParticipantSearchState) => {
   return JSON.stringify(explicitSearchState)
 }
 /** maps url params to a search state, using DefaultParticipantSearchState for any unspecified fields */
-const urlParamsToSearchState = (searchParams: URLSearchParams, searchParamName: string): ParticipantSearchState => {
-  let searchState = DefaultParticipantSearchState
+const urlParamsToSearchState = (
+  searchParams: URLSearchParams,
+  searchParamName: string,
+  defaultState: Partial<ParticipantSearchState> = {}
+): ParticipantSearchState => {
+  let searchState = { ...DefaultParticipantSearchState, ...defaultState }
   if (searchParams.get(searchParamName)) {
     try {
       const explicitSearchState = JSON.parse(searchParams.get(searchParamName) as string)

--- a/ui-admin/src/util/participantSearchUtils.tsx
+++ b/ui-admin/src/util/participantSearchUtils.tsx
@@ -67,14 +67,19 @@ export const useParticipantSearchState = (
   familyLinkageEnabled: boolean,
   studyEnvParams: StudyEnvParams,
   searchParamName = 'search',
-  defaultState: Partial<ParticipantSearchState> = {}) => {
+  defaults: Partial<ParticipantSearchState> = {}) => {
   const [searchParams, setSearchParams] = useSearchParams()
+
+  const defaultState = {
+    ...DefaultParticipantSearchState,
+    ...defaults
+  }
 
   const searchState = urlParamsToSearchState(searchParams, searchParamName, defaultState)
   const searchExpression = toExpression(searchState, defaultIncludes, familyLinkageEnabled)
   const setSearchState = (newSearchState: ParticipantSearchState) => {
     setSearchParams(params => {
-      params.set(searchParamName, searchStateToUrlParam(newSearchState))
+      params.set(searchParamName, searchStateToUrlParam(newSearchState, defaultState))
       return params
     })
   }
@@ -113,10 +118,13 @@ export const useParticipantSearchFacets = (searchState: ParticipantSearchState, 
 }
 
 /** maps search state to a url param excluding default params */
-const searchStateToUrlParam = (searchState: ParticipantSearchState) => {
+const searchStateToUrlParam = (
+  searchState: ParticipantSearchState,
+  defaultState: ParticipantSearchState = DefaultParticipantSearchState
+) => {
   const explicitSearchState: Partial<ParticipantSearchState> = {}
   for (const [key, value] of Object.entries(searchState)) {
-    if (!isEqual(value, DefaultParticipantSearchState[key as keyof ParticipantSearchState]) &&
+    if (!isEqual(value, defaultState[key as keyof ParticipantSearchState]) &&
     !['includeFacets', 'queryFacets'].includes(key)) {
       // @ts-ignore
       explicitSearchState[key as keyof ParticipantSearchState] = value
@@ -128,9 +136,9 @@ const searchStateToUrlParam = (searchState: ParticipantSearchState) => {
 const urlParamsToSearchState = (
   searchParams: URLSearchParams,
   searchParamName: string,
-  defaultState: Partial<ParticipantSearchState> = {}
+  defaultState: ParticipantSearchState = DefaultParticipantSearchState
 ): ParticipantSearchState => {
-  let searchState = { ...DefaultParticipantSearchState, ...defaultState }
+  let searchState = defaultState
   if (searchParams.get(searchParamName)) {
     try {
       const explicitSearchState = JSON.parse(searchParams.get(searchParamName) as string)
@@ -224,7 +232,10 @@ export const toExpression = (searchState: ParticipantSearchState,
 /**
  * Returns the search expression state as a list of human-readable facets.
  */
-export const getFacets = (searchState: ParticipantSearchState, opts?: { includeKeywordSearch: boolean }): {
+export const getFacets = (searchState: ParticipantSearchState, opts?: {
+  includeKeywordSearch?: boolean,
+  customLabels?: { [index: string]: string }
+}): {
   label: string,
   value: string
 }[] => {
@@ -243,8 +254,13 @@ export const getFacets = (searchState: ParticipantSearchState, opts?: { includeK
       } else if (['includeFacets', 'queryFacets', 'includeFacetKeys'].includes(key)) {
         // skip -- not shown directly to users
       } else {
+        const label = (
+          opts?.customLabels?.[key]
+          || ParticipantSearchStateLabels[key as keyof ParticipantSearchState]
+          || key)
+
         facets.push({
-          label: ParticipantSearchStateLabels[key as keyof ParticipantSearchState] || key,
+          label,
           value: getValueAsString(key as keyof ParticipantSearchState, value as string | number | boolean)
         })
       }

--- a/ui-core/src/types/study.ts
+++ b/ui-core/src/types/study.ts
@@ -45,6 +45,7 @@ export type StudyEnvironmentConfig = {
   useDevDsmRealm: boolean
   enableInPersonKits: boolean
   timeZone: string
+  kitEligibilityRule?: string
 }
 
 export type StudyEnvironmentSurvey = {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

anticipating an A-T ask. i was planning on saying no and giving them a workaround until i realized that this already used the search exp backend. decided to time box this and it was easier than expected (~1 hr).

makes the kits page even more alike to the participant list. adds new study environment config option, kit_eligibility_rule. if specified, it will become the default "custom" filter on this page.

Kits page
<img width="2292" height="930" alt="image" src="https://github.com/user-attachments/assets/123bf593-a968-44ed-b890-5d165cc7376c" />

Study settings
<img width="2292" height="930" alt="Screenshot 2025-07-28 at 2 58 56 PM" src="https://github.com/user-attachments/assets/35e362b9-1863-4a0a-99ef-22742c43eb04" />
<img width="2292" height="930" alt="Screenshot 2025-07-28 at 2 58 52 PM" src="https://github.com/user-attachments/assets/69f3f5f5-4b16-4de4-913e-fef230b56840" />



i don't _love_ the UX. i think it's kinda weird that it becomes the custom rule. i tried to make it be robust but spend minimal time here, and i think this gets the job done well enough.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- make sure kitting page not broken normally
- add custom kit eligibility rule
- make sure kitting page now uses the new rule by default