### PR TITLE
[JN-1722] match participant site media behavior with admin

### DIFF
--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/SiteMediaController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/SiteMediaController.java
@@ -47,16 +47,29 @@ public class SiteMediaController implements SiteMediaApi {
    * limited to b2c origins that we control.
    */
   public ResponseEntity<Resource> get(
-      String portalShortcode, String envName, String cleanFileName, Integer version) {
-    Optional<SiteMedia> siteMediaOpt;
+      String portalShortcode, String envName, String cleanFileName, String version) {
+    cleanFileName = cleanFileName.toLowerCase();
+    if (version.equalsIgnoreCase("latest")) {
+      Optional<SiteMedia> siteMediaOpt =
+          siteMediaService.findOneLatestVersion(portalShortcode, cleanFileName);
+      return convertToResourceResponse(siteMediaOpt);
+    }
 
-    siteMediaOpt = siteMediaService.findOne(portalShortcode, cleanFileName.toLowerCase(), version);
+    int versionInt;
+    try {
+      versionInt = Integer.parseInt(version);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("version must be an integer or 'latest'");
+    }
+
+    Optional<SiteMedia> siteMediaOpt =
+        siteMediaService.findOne(portalShortcode, cleanFileName, versionInt);
     return convertToResourceResponse(siteMediaOpt);
   }
 
   @Override
   public ResponseEntity<Resource> getLegacy(
-      String portalShortcode, String envName, String cleanFileName, Integer version) {
+      String portalShortcode, String envName, String cleanFileName, String version) {
     return get(portalShortcode, envName, cleanFileName, version);
   }
 

--- a/api-participant/src/main/resources/api/openapi.yml
+++ b/api-participant/src/main/resources/api/openapi.yml
@@ -602,7 +602,7 @@ paths:
         - { name: portalShortcode, in: path, required: true, schema: { type: string } }
         - { name: envName, in: path, required: true, schema: { type: string } }
         - { name: cleanFileName, in: path, required: true, schema: { type: string } }
-        - { name: version, in: path, required: true, schema: { type: integer } }
+        - { name: version, in: path, required: true, schema: { type: string } }
       responses:
         '200':
           description: image data
@@ -622,7 +622,7 @@ paths:
         - { name: portalShortcode, in: path, required: true, schema: { type: string } }
         - { name: envName, in: path, required: true, schema: { type: string } }
         - { name: cleanFileName, in: path, required: true, schema: { type: string } }
-        - { name: version, in: path, required: true, schema: { type: integer } }
+        - { name: version, in: path, required: true, schema: { type: string } }
       responses:
         '200':
           description: image data


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Admin api was already doing this. Caused some amount of confusion between parker and I during testing.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

update demo consent's mgb logo to use latest (or stick this in pre-enroll)
```
            {
              "type": "html",
              "name": "mgbLogo",
              "html": {
                "en": "<img alt='Mass General Brigham logo' src='/api/public/portals/v1/demo/env/{portalEnvironmentName}/siteMedia/latest/mgb_logo.svg' style='margin-top:2rem' />",
                "es": "<img alt='Logotipo de Mass General Brigham' src='/api/public/portals/v1/demo/env/{portalEnvironmentName}/siteMedia/latest/mgb_logo.svg' style='margin-top:2rem' />",
                "dev": "<img alt='DEV_Mass General Brigham logo' src='/api/public/portals/v1/demo/env/{portalEnvironmentName}/siteMedia/latest/mgb_logo.svg' style='margin-top:2rem' />"
              }
            },
```

make sure the logo shows up in both the admin & the participant side