### PR TITLE
[JN-1730] fixing multiple task bug

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
@@ -318,7 +318,7 @@ public abstract class BaseJdbiDao<T extends BaseEntity> implements JdbiDao<T> {
         String lockString = withLock ? "FOR UPDATE" : "";
         return jdbi.withHandle(handle ->
                 handle.createQuery("""
-                            select * from %s where %s = :column1Value"
+                            select * from %s where %s = :column1Value
                             and %s = :column2Value %s;
                             """.formatted(tableName, column1Name, column2Name, lockString))
                         .bind("column1Value", column1Value)

--- a/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/BaseJdbiDao.java
@@ -309,9 +309,18 @@ public abstract class BaseJdbiDao<T extends BaseEntity> implements JdbiDao<T> {
 
     protected Optional<T> findByTwoProperties(String column1Name, Object column1Value,
                                               String column2Name, Object column2Value) {
+        return findByTwoProperties(column1Name, column1Value, column2Name, column2Value, false);
+    }
+
+    protected Optional<T> findByTwoProperties(String column1Name, Object column1Value,
+                                              String column2Name, Object column2Value,
+                                              boolean withLock) {
+        String lockString = withLock ? "FOR UPDATE" : "";
         return jdbi.withHandle(handle ->
-                handle.createQuery("select * from " + tableName + " where " + column1Name + " = :column1Value"
-                        + " and " + column2Name + " = :column2Value;")
+                handle.createQuery("""
+                            select * from %s where %s = :column1Value"
+                            and %s = :column2Value %s;
+                            """.formatted(tableName, column1Name, column2Name, lockString))
                         .bind("column1Value", column1Value)
                         .bind("column2Value", column2Value)
                         .mapTo(clazz)

--- a/core/src/main/java/bio/terra/pearl/core/dao/workflow/ParticipantTaskDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/workflow/ParticipantTaskDao.java
@@ -41,8 +41,8 @@ public class ParticipantTaskDao extends BaseMutableJdbiDao<ParticipantTask> impl
         return findAllByTwoProperties("study_environment_id", studyEnvId, "task_type", taskTypes);
     }
 
-    public Optional<ParticipantTask> findByEnrolleeId(UUID taskId, UUID enrolleeId) {
-        return findByTwoProperties("id", taskId, "enrollee_id", enrolleeId);
+    public Optional<ParticipantTask> findByEnrolleeId(UUID taskId, UUID enrolleeId, boolean withLock) {
+        return findByTwoProperties("id", taskId, "enrollee_id", enrolleeId, withLock);
     }
 
     public Map<UUID, List<ParticipantTask>> findByEnrolleeIds(Collection<UUID> enrolleeIds) {

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -157,7 +157,7 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
 
     /**
      * Longitudinal tasks are editable by the participant if (and only if) the task is the most recent task for the survey.
-     * admins can update any response.
+     * admins can update any valid response.
      */
     private boolean isLongitudinalTaskEditable(Enrollee enrollee, SurveyResponse surveyResponse, String surveyStableId, ResponsibleEntity operator) {
 
@@ -171,6 +171,9 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
 
         if (task.getStatus() == TaskStatus.REJECTED || task.getStatus() == TaskStatus.REMOVED) {
             return false; // cannot edit removed/rejected tasks
+        }
+        if (operator.getParticipantUser() == null) {
+            return true; // admins and system processes can update any task
         }
 
         // with a completed task, we can only edit if it's the

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -193,50 +193,54 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
                                                       Enrollee enrollee, UUID taskId, UUID portalId) {
 
 
-        ParticipantTask task = participantTaskService.authTaskToEnrolleeId(taskId, enrollee.getId()).orElseThrow(() -> new NotFoundException("Task not found or not authorized for enrollee %s and task %s".formatted(enrollee.getId(), taskId)));
+        ParticipantTask task = participantTaskService.authTaskToEnrolleeId(taskId, enrollee.getId(), true).orElseThrow(() -> new NotFoundException("Task not found or not authorized for enrollee %s and task %s".formatted(enrollee.getId(), taskId)));
 
         Survey survey = surveyService.findByStableIdWithMappings(task.getTargetStableId(),
                 task.getTargetAssignedVersion(), portalId).get();
         validateResponse(survey, task, responseDto.getAnswers());
 
 
-        SurveyResponse priorResponse = dao.findOneWithAnswers(task.getSurveyResponseId()).orElse(null);
-        SurveyResponse response;
+        SurveyResponse response = task.getSurveyResponseId() != null ?
+                dao.findOneWithAnswers(task.getSurveyResponseId()).orElseThrow() : null;
 
         if (survey.getRecurrenceType() == RecurrenceType.LONGITUDINAL
-                && priorResponse != null
-                && !isLongitudinalTaskEditable(enrollee, priorResponse, survey.getStableId())
-                // admins should be able to update old responses
-                && operator.getParticipantUser() != null) {
-            throw new IllegalArgumentException("Cannot update previous responses for longitudinal surveys");
+         && operator.getParticipantUser() != null && response != null) {
+            // handle participant response to a longitudinal survey with prior response
+            if (!isLongitudinalTaskEditable(enrollee, response, survey.getStableId())) {
+                // only admins can edit old longitudinal responses
+                throw new IllegalArgumentException("Cannot update previous responses for longitudinal surveys");
+            }
+            if (task.getStatus() == TaskStatus.COMPLETE
+                    && shouldCreateNewLongitudinalTaskAndResponse(survey.getCreateNewResponseAfterDays(), response.getLastUpdatedAt())
+            ) {
+                ParticipantTask newTask = participantTaskService.cleanForCopying(task);
+                newTask.setStatus(TaskStatus.IN_PROGRESS);
+                newTask.setCompletedAt(null);
+                response.getAnswers().forEach(a -> a.setSurveyResponseId(null));
+                response = surveyTaskDispatcher.createPrepopulatedSurveyResponse(response);
+                newTask.setSurveyResponseId(response.getId());
+                task = participantTaskService.create(newTask, null);
+            }
         }
 
-        //if the survey is longitudinal and we're past the cutoff point for updating an existing response, we need to create a new response and task
-        if (survey.getRecurrenceType() == RecurrenceType.LONGITUDINAL
-                && priorResponse != null
-                && task.getStatus() == TaskStatus.COMPLETE
-                && shouldCreateNewLongitudinalTaskAndResponse(survey.getCreateNewResponseAfterDays(), priorResponse.getLastUpdatedAt())
-                // admin saving update should never trigger a new response;
-                // they can re-assign if they want a fresh response
-                && operator.getParticipantUser() != null
-        ) {
-            ParticipantTask newTask = participantTaskService.cleanForCopying(task);
-            newTask.setStatus(TaskStatus.IN_PROGRESS);
-            newTask.setCompletedAt(null);
-            priorResponse.getAnswers().forEach(a -> a.setSurveyResponseId(null));
-            response = surveyTaskDispatcher.createPrepopulatedSurveyResponse(priorResponse);
-            newTask.setSurveyResponseId(response.getId());
-            task = participantTaskService.create(newTask, null);
+        if (response == null) {
+            SurveyResponse newResponse = SurveyResponse.builder()
+                    .enrolleeId(enrollee.getId())
+                    .surveyId(survey.getId())
+                    .complete(responseDto.isComplete())
+                    .resumeData(responseDto.getResumeData())
+                    .createdAt(responseDto.getCreatedAt())
+                    .lastUpdatedAt(responseDto.getLastUpdatedAt())
+                    .build();
+            newResponse.setResponsibleUser(operator);
+            response = dao.create(newResponse);
         } else {
-            // find or create the SurveyResponse object to attach the snapshot
-            response = findOrCreateResponse(task, enrollee, enrollee.getParticipantUserId(), responseDto, portalId, operator);
+            updateExistingResponse(response, responseDto);
         }
 
         List<Answer> updatedAnswers = createOrUpdateAnswers(responseDto.getAnswers(), response, justification, survey, ppUser, operator);
-        List<Answer> allAnswers = new ArrayList<>(response.getAnswers());
         List<Answer> existingAnswers = answerService.findByResponse(response.getId());
-        allAnswers.addAll(existingAnswers);
-        response.setAnswers(allAnswers);
+        response.setAnswers(existingAnswers);
 
         DataAuditInfo auditInfo = DataAuditInfo.builder()
                 .enrolleeId(enrollee.getId())
@@ -278,40 +282,14 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         return hubResponse;
     }
 
-    /**
-     * creates a new snapshot (along with a SurveyResponse container if needed) for the given task
-     * This method does not do any validation or authorization -- callers should ensure the user
-     * is authorized to update the given task/enrollee, and that the task corresponds to the snapshot
-     */
-    protected SurveyResponse findOrCreateResponse(ParticipantTask task, Enrollee enrollee,
-                                                  UUID participantUserId, SurveyResponse responseDto,
-                                                  UUID portalId, ResponsibleEntity operator) {
-        UUID taskResponseId = task.getSurveyResponseId();
-        Survey survey = surveyService.findByStableId(task.getTargetStableId(), task.getTargetAssignedVersion(), portalId).get();
-        SurveyResponse response;
-        if (taskResponseId != null) {
-            response = dao.find(taskResponseId).get();
-            // don't allow the response to be marked incomplete if it's already complete
-            if (!response.isComplete()) {
-                response.setComplete(responseDto.isComplete());
-            }
-            // to enable simultaneous editing with page-saving, update this to be a merge, rather than a set
-            response.setResumeData(responseDto.getResumeData());
-            dao.update(response);
-        } else {
-            SurveyResponse newResponse = SurveyResponse.builder()
-                    .enrolleeId(enrollee.getId())
-                    .surveyId(survey.getId())
-                    .complete(responseDto.isComplete())
-                    .resumeData(responseDto.getResumeData())
-                    .createdAt(responseDto.getCreatedAt())
-                    .lastUpdatedAt(responseDto.getLastUpdatedAt())
-                    .build();
-            newResponse.setResponsibleUser(operator);
-            response = dao.create(newResponse);
+    protected void updateExistingResponse(SurveyResponse response, SurveyResponse responseDto) {
+        // don't allow the response to be marked incomplete if it's already complete
+        if (!response.isComplete()) {
+            response.setComplete(responseDto.isComplete());
         }
-
-        return response;
+        // to enable simultaneous editing with page-saving, update this to be a merge, rather than a set
+        response.setResumeData(responseDto.getResumeData());
+        dao.update(response);
     }
 
     protected ParticipantTask updateTaskToResponse(ParticipantTask task, SurveyResponse response,

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -140,8 +140,14 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
     }
 
     //if the cutoff time has passed, create a new task and response
-    private boolean shouldCreateNewLongitudinalTaskAndResponse(Integer createNewResponseAfterDays, Instant surveyResponseLastUpdatedAt) {
-        if(createNewResponseAfterDays == null) {
+    private boolean shouldCreateNewLongitudinalTaskAndResponse(ParticipantTask task, Integer createNewResponseAfterDays, Instant surveyResponseLastUpdatedAt, ResponsibleEntity operator) {
+        if (task.getStatus() != TaskStatus.COMPLETE) {
+            return false; // if the prior task wasn't complete, no new task
+        }
+        if (operator.getParticipantUser() == null) {
+            return false; // only participants automatically create new responses
+        }
+        if (createNewResponseAfterDays == null) {
             return false;
         }
         Instant cutoffTime = ZonedDateTime.now(ZoneOffset.UTC)
@@ -150,9 +156,10 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
     }
 
     /**
-     * Longitudinal tasks are editable by the participant if (and only if) the task is the most recent task for the survey
+     * Longitudinal tasks are editable by the participant if (and only if) the task is the most recent task for the survey.
+     * admins can update any response.
      */
-    private boolean isLongitudinalTaskEditable(Enrollee enrollee, SurveyResponse surveyResponse, String surveyStableId) {
+    private boolean isLongitudinalTaskEditable(Enrollee enrollee, SurveyResponse surveyResponse, String surveyStableId, ResponsibleEntity operator) {
 
         List<ParticipantTask> tasks = participantTaskService.findAllTasksForActivityByEnrollee(enrollee.getId(), surveyStableId);
 
@@ -199,19 +206,19 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
                 task.getTargetAssignedVersion(), portalId).get();
         validateResponse(survey, task, responseDto.getAnswers());
 
-
         SurveyResponse response = task.getSurveyResponseId() != null ?
                 dao.findOneWithAnswers(task.getSurveyResponseId()).orElseThrow() : null;
 
-        if (survey.getRecurrenceType() == RecurrenceType.LONGITUDINAL
-         && operator.getParticipantUser() != null && response != null) {
-            // handle participant response to a longitudinal survey with prior response
-            if (!isLongitudinalTaskEditable(enrollee, response, survey.getStableId())) {
-                // only admins can edit old longitudinal responses
+        // handle response to a longitudinal survey with prior response
+        if (survey.getRecurrenceType() == RecurrenceType.LONGITUDINAL && response != null) {
+            if (!isLongitudinalTaskEditable(enrollee, response, survey.getStableId(), operator)) {
                 throw new IllegalArgumentException("Cannot update previous responses for longitudinal surveys");
             }
-            if (task.getStatus() == TaskStatus.COMPLETE
-                    && shouldCreateNewLongitudinalTaskAndResponse(survey.getCreateNewResponseAfterDays(), response.getLastUpdatedAt())
+            if (shouldCreateNewLongitudinalTaskAndResponse(
+                            task,
+                            survey.getCreateNewResponseAfterDays(),
+                            response.getLastUpdatedAt(),
+                            operator)
             ) {
                 ParticipantTask newTask = participantTaskService.cleanForCopying(task);
                 newTask.setStatus(TaskStatus.IN_PROGRESS);

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/ParticipantTaskService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/ParticipantTaskService.java
@@ -57,8 +57,8 @@ public class ParticipantTaskService extends ParticipantDataAuditedService<Partic
 
     public void deleteByEnrolleeId(UUID enrolleeId) { dao.deleteByEnrolleeId(enrolleeId);}
 
-    public Optional<ParticipantTask> authTaskToEnrolleeId(UUID taskId, UUID enrolleeId) {
-        return dao.findByEnrolleeId(taskId, enrolleeId);
+    public Optional<ParticipantTask> authTaskToEnrolleeId(UUID taskId, UUID enrolleeId, boolean withLock) {
+        return dao.findByEnrolleeId(taskId, enrolleeId, withLock);
     }
 
     public Optional<ParticipantTask> findTaskForActivity(UUID ppUserId, UUID studyEnvironmentId, String activityStableId) {

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
@@ -761,27 +761,4 @@ public class SurveyResponseServiceTests extends BaseSpringBootTest {
                 enrolleeBundle.portalParticipantUser(), enrollee, task1.getId(), survey.getPortalId());
     }
 
-    @Test
-    public void testSimultaneousResponses(TestInfo info) {
-        StudyEnvironmentBundle studyEnvBundle = studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.sandbox);
-
-        Survey survey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
-                .portalId(studyEnvBundle.getPortal().getId())
-                .recurrenceType(RecurrenceType.NONE)
-                .createNewResponseAfterDays(7));
-
-        StudyEnvironmentSurvey ses = surveyFactory.attachToEnv(survey, studyEnvBundle.getStudyEnv().getId(), true);
-
-        EnrolleeBundle enrolleeBundle = enrolleeFactory.buildWithPortalUser(getTestName(info), studyEnvBundle.getPortalEnv(), studyEnvBundle.getStudyEnv());
-        Enrollee enrollee = enrolleeBundle.enrollee();
-        participantTaskFactory.buildPersisted(enrolleeBundle, survey.getStableId(), TaskStatus.NEW, TaskType.SURVEY);
-
-        int NUM_THREADS = 3;
-        ExecutorService service = Executors.newFixedThreadPool(NUM_THREADS);
-        for (int i = 0; i < NUM_THREADS; i++) {
-
-        }
-
-    }
-
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
@@ -5,10 +5,7 @@ import bio.terra.pearl.core.factory.DaoTestUtils;
 import bio.terra.pearl.core.factory.StudyEnvironmentBundle;
 import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
 import bio.terra.pearl.core.factory.fileupload.ParticipantFileFactory;
-import bio.terra.pearl.core.factory.participant.EnrolleeAndProxy;
-import bio.terra.pearl.core.factory.participant.EnrolleeBundle;
-import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
-import bio.terra.pearl.core.factory.participant.PortalParticipantUserFactory;
+import bio.terra.pearl.core.factory.participant.*;
 import bio.terra.pearl.core.factory.survey.AnswerFactory;
 import bio.terra.pearl.core.factory.survey.SurveyFactory;
 import bio.terra.pearl.core.factory.survey.SurveyResponseFactory;
@@ -21,10 +18,7 @@ import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.model.participant.PortalParticipantUser;
 import bio.terra.pearl.core.model.survey.*;
-import bio.terra.pearl.core.model.workflow.HubResponse;
-import bio.terra.pearl.core.model.workflow.ParticipantTask;
-import bio.terra.pearl.core.model.workflow.RecurrenceType;
-import bio.terra.pearl.core.model.workflow.TaskStatus;
+import bio.terra.pearl.core.model.workflow.*;
 import bio.terra.pearl.core.service.file.ParticipantFileService;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.participant.ParticipantUserService;
@@ -41,6 +35,8 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -81,6 +77,8 @@ public class SurveyResponseServiceTests extends BaseSpringBootTest {
     private ParticipantFileService participantFileService;
     @Autowired
     private PortalParticipantUserService portalParticipantUserService;
+    @Autowired
+    private ParticipantTaskFactory participantTaskFactory;
 
     @Test
     @Transactional
@@ -604,7 +602,7 @@ public class SurveyResponseServiceTests extends BaseSpringBootTest {
                 newResponse, new ResponsibleEntity(new AdminUser()), null,
                 enrolleeBundle.portalParticipantUser(), enrollee, task1.getId(), survey.getPortalId());
     }
-    
+
     @Test
     @Transactional
     public void testCannotUpdateLongitudinalProxies(TestInfo info) {
@@ -761,6 +759,29 @@ public class SurveyResponseServiceTests extends BaseSpringBootTest {
         surveyResponseService.updateResponse(
                 newResponse, new ResponsibleEntity(new AdminUser()), null,
                 enrolleeBundle.portalParticipantUser(), enrollee, task1.getId(), survey.getPortalId());
+    }
+
+    @Test
+    public void testSimultaneousResponses(TestInfo info) {
+        StudyEnvironmentBundle studyEnvBundle = studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.sandbox);
+
+        Survey survey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .portalId(studyEnvBundle.getPortal().getId())
+                .recurrenceType(RecurrenceType.NONE)
+                .createNewResponseAfterDays(7));
+
+        StudyEnvironmentSurvey ses = surveyFactory.attachToEnv(survey, studyEnvBundle.getStudyEnv().getId(), true);
+
+        EnrolleeBundle enrolleeBundle = enrolleeFactory.buildWithPortalUser(getTestName(info), studyEnvBundle.getPortalEnv(), studyEnvBundle.getStudyEnv());
+        Enrollee enrollee = enrolleeBundle.enrollee();
+        participantTaskFactory.buildPersisted(enrolleeBundle, survey.getStableId(), TaskStatus.NEW, TaskType.SURVEY);
+
+        int NUM_THREADS = 3;
+        ExecutorService service = Executors.newFixedThreadPool(NUM_THREADS);
+        for (int i = 0; i < NUM_THREADS; i++) {
+
+        }
+
     }
 
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds a lock on the task when updating a response to ensure double-responses aren't created.  Cleans up some survey response service code, but otherwise should have no user-visible impact.

Currently researching ways to test this, will write an automated test if it's reasonably doable

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. Complete surveys on the participant side, confirm functionality works as always
2. complete admin forms, confirm functionality works as expected