### PR TITLE
[JN-1731] Adding sleep between DSM requests

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/kit/KitExtService.java
@@ -103,6 +103,14 @@ public class KitExtService {
                 authContext.getStudyShortcode(),
                 enrollee,
                 kitRequestCreationDto);
+        if (!enrolleeShortcode.equals(enrolleeShortcodes.getLast())) {
+          // add a small sleep between repeated requests to take it easy on DSM.
+          try {
+            Thread.sleep(200);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+        }
         response.addKitRequest(createdKit);
       } catch (Exception e) {
         // add the enrollee shortcode to the message for disambiguation.  Once we refine the UX for


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

This adds a small sleep between DSM requests.  @MatthewBemis  I looked for any "connection reset by peer" logs, and didn't see any, so I don't *think* this is the same error you previously fixed, but curious if anything about this rings a bell or if you have better ideas for the fix.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  select >1 participants for kit requests
2. send the requests
3. confirm they send