### PR TITLE
[JN-1372] adding bluesky icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24858,6 +24858,7 @@
       "name": "@juniper/ui-core",
       "version": "0.0.1",
       "dependencies": {
+        "@fortawesome/free-brands-svg-icons": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@tanstack/react-virtual": "^3.0.0-beta.54",
@@ -27719,6 +27720,7 @@
       "version": "file:ui-core",
       "requires": {
         "@babel/cli": "^7.21.5",
+        "@fortawesome/free-brands-svg-icons": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@tanstack/react-virtual": "^3.0.0-beta.54",

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/footerSection.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/footerSection.json
@@ -50,6 +50,9 @@
       },{
         "text": "YouTube",
         "href": "https://youtube.com/@ourhealthstudy"
+      },{
+        "text": "BlueSky",
+        "href": "https://bsky.app/@ourhealthstudy"
       }]
     },{
       "title": "Contact Us",

--- a/ui-core/package.json
+++ b/ui-core/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
+    "@fortawesome/free-brands-svg-icons": "^6.7.2",
     "@tanstack/react-virtual": "^3.0.0-beta.54",
     "@types/diff": "^7.0.1",
     "classnames": "^2.5.1",

--- a/ui-core/src/participant/landing/sections/SocialMediaTemplate.tsx
+++ b/ui-core/src/participant/landing/sections/SocialMediaTemplate.tsx
@@ -8,7 +8,8 @@ import {
   faTiktok,
   faTwitter,
   faXTwitter,
-  faYoutube
+  faYoutube,
+  faBluesky
 } from '@fortawesome/free-brands-svg-icons'
 import React from 'react'
 
@@ -27,7 +28,8 @@ type SocialMediaSite = 'Facebook' |
     'TikTok' |
     'Threads' |
     'LinkedIn' |
-    'YouTube'
+    'YouTube' |
+    'BlueSky'
 
 type SocialMediaSiteConfig = {
   domain: string
@@ -91,6 +93,12 @@ export const socialMediaSites: SocialMediaSiteConfig[] = [
     icon: faYoutube,
     label: 'YouTube',
     renderUrl: ({ domain, handle }) => `https://${domain}/@${handle}`
+  },
+  {
+    domain: 'bsky.app',
+    icon: faBluesky,
+    label: 'BlueSky',
+    renderUrl: ({ domain, handle }) => `https://${domain}/${handle}`
   }
 ]
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

At the request of gVasc
<img width="647" height="348" alt="image" src="https://github.com/user-attachments/assets/ba2f05a3-da03-421e-9c6b-ab9de6353e4c" />


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. you'll need to re-run npm install for this to work locally
2. repopulate demo
3. go to `https://sandbox.demo.localhost:3001/`
4. scroll down to the bottom, and observe the bluesky link (that doesn't link to an actual bluesky account)