### PR TITLE
[JN-1734] - pre-enroll branches on signed-in status

### DIFF
--- a/populate/src/main/java/bio/terra/pearl/populate/service/PortalPopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/PortalPopulator.java
@@ -162,6 +162,12 @@ public class PortalPopulator extends BasePopulator<Portal, PortalPopDto, FilePop
         if (context.getShortcodeOverride() != null) {
             popDto.setShortcode(context.getShortcodeOverride());
             popDto.setName(context.getShortcodeOverride());
+            for (PortalEnvironmentPopDto environmentPopDto : popDto.getPortalEnvironmentDtos()) {
+                if (environmentPopDto.getPortalEnvironmentConfig().getPrimaryStudy() != null) {
+                    environmentPopDto.getPortalEnvironmentConfig()
+                            .setPrimaryStudy(context.applyShortcodeOverride(environmentPopDto.getPortalEnvironmentConfig().getPrimaryStudy()));
+                }
+            }
         }
     }
 

--- a/populate/src/main/resources/seed/portals/demo/portal.json
+++ b/populate/src/main/resources/seed/portals/demo/portal.json
@@ -17,7 +17,8 @@
         "password": "broad_institute",
         "initialized": true,
         "emailSourceAddress": "support@juniper.terra.bio",
-        "defaultLanguage": "en"
+        "defaultLanguage": "en",
+        "primaryStudy": "heartdemo"
       },
       "supportedLanguages": [{
         "languageName": "English",
@@ -74,7 +75,8 @@
         "password": "broad_institute",
         "initialized": true,
         "emailSourceAddress": "support@juniper.terra.bio",
-        "defaultLanguage": "en"
+        "defaultLanguage": "en",
+        "primaryStudy": "heartdemo"
       },
       "supportedLanguages": [{
         "languageName": "English",
@@ -92,7 +94,8 @@
         "initialized": true,
         "participantHostname" : "juniperdemostudy.dev",
         "emailSourceAddress": "support@juniper.terra.bio",
-        "defaultLanguage": "en"
+        "defaultLanguage": "en",
+        "primaryStudy": "heartdemo"
       },
       "supportedLanguages": [{
         "languageName": "English",

--- a/populate/src/main/resources/seed/portals/demo/portal.json
+++ b/populate/src/main/resources/seed/portals/demo/portal.json
@@ -2,7 +2,8 @@
   "name": "Juniper Heart Demo",
   "shortcode": "demo",
   "populateStudyFiles": [
-    "studies/heartdemo/study.json"
+    "studies/heartdemo/study.json",
+    "studies/sleep/study.json"
   ],
   "siteContentFiles": [
     "siteContent/siteContent-1/siteContent.json", "siteContent/siteContent-2/siteContent.json"

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/sleepStudy.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/en/sleepStudy.json
@@ -1,0 +1,24 @@
+{
+  "itemType": "INTERNAL",
+  "text": "Sleep study",
+  "htmlPageDto": {
+    "title": "Sleep study",
+    "path": "sleep",
+    "sectionDtos": [{
+      "sectionType": "HERO_CENTERED",
+      "sectionConfigJson": {
+        "title": "Sleep study",
+        "blurb": "Have trouble sleeping?  We can give you a PRS report for sleep risk",
+        "blurbAlign": "center",
+        "buttons": [
+          {
+            "type": "join",
+            "text": "Join sleep study",
+            "href": "",
+            "studyShortcode": "demosleep"
+          }
+        ]
+      }
+    }]
+  }
+}

--- a/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/siteContent.json
+++ b/populate/src/main/resources/seed/portals/demo/siteContent/siteContent-2/siteContent.json
@@ -13,6 +13,8 @@
       "populateFileName": "en/participation.json"
     }, {
       "populateFileName": "en/learnMore.json"
+    }, {
+      "populateFileName": "en/sleepStudy.json"
     }],
     "languageTextOverrides": [
       {

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/consentReminder.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/consentReminder.json
@@ -1,0 +1,19 @@
+{
+  "stableId": "sleepReminderConsent",
+  "name": "Consent reminder",
+  "version": 1,
+  "publishedVersion": 1,
+  "localizedEmailTemplateDtos": [{
+    "language": "en",
+    "subject": "Reminder: Please complete the ${study.name} Consent form",
+    "bodyPopulateFile": "en/consentReminder.html"
+  },{
+    "language": "es",
+    "subject": "Recordatorio: complete el formulario de consentimiento de ${study.name}",
+    "bodyPopulateFile": "es/consentReminder.html"
+  },{
+    "language": "dev",
+    "subject": "DEV_Reminder: Please complete the ${study.name} Consent form",
+    "bodyPopulateFile": "dev/consentReminder.html"
+  }]
+}

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/dev/consentReminder.html
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/dev/consentReminder.html
@@ -1,0 +1,280 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <!--[if gte mso 9]>
+    <xml>
+        <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+    </xml>
+    <![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="x-apple-disable-message-reformatting">
+    <!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
+    <title></title>
+
+    <style type="text/css">
+        @media only screen and (min-width: 620px) {
+            .u-row {
+                width: 600px !important;
+            }
+            .u-row .u-col {
+                vertical-align: top;
+            }
+
+            .u-row .u-col-100 {
+                width: 600px !important;
+            }
+
+        }
+
+        @media (max-width: 620px) {
+            .u-row-container {
+                max-width: 100% !important;
+                padding-left: 0px !important;
+                padding-right: 0px !important;
+            }
+            .u-row .u-col {
+                min-width: 320px !important;
+                max-width: 100% !important;
+                display: block !important;
+            }
+            .u-row {
+                width: 100% !important;
+            }
+            .u-col {
+                width: 100% !important;
+            }
+            .u-col > div {
+                margin: 0 auto;
+            }
+        }
+        body {
+            margin: 0;
+            padding: 0;
+        }
+
+        table,
+        tr,
+        td {
+            vertical-align: top;
+            border-collapse: collapse;
+        }
+
+        p {
+            margin: 0;
+        }
+
+        .ie-container table,
+        .mso-container table {
+            table-layout: fixed;
+        }
+
+        * {
+            line-height: inherit;
+        }
+
+        a[x-apple-data-detectors='true'] {
+            color: inherit !important;
+            text-decoration: none !important;
+        }
+
+        table, td { color: #000000; } #u_body a { color: #9b2485; text-decoration: underline; } @media (max-width: 480px) { #u_content_image_1 .v-src-width { width: auto !important; } #u_content_image_1 .v-src-max-width { max-width: 87% !important; } #u_content_text_2 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_3 .v-container-padding-padding { padding: 10px 20px !important; } #u_content_divider_6 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_deprecated_1 .v-container-padding-padding { padding: 20px !important; } #u_content_text_4 .v-container-padding-padding { padding: 20px 20px 10px !important; } }
+    </style>
+
+
+
+    <!--[if !mso]><!--><link href="https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap" rel="stylesheet" type="text/css"><!--<![endif]-->
+
+</head>
+
+<body class="clean-body u_body" style="margin: 0;padding: 0;-webkit-text-size-adjust: 100%;background-color: #eeeeee;color: #000000">
+<!--[if IE]><div class="ie-container"><![endif]-->
+<!--[if mso]><div class="mso-container"><![endif]-->
+<table id="u_body" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;min-width: 320px;Margin: 0 auto;background-color: #eeeeee;width:100%" cellpadding="0" cellspacing="0">
+    <tbody>
+
+    <tr style="vertical-align: top">
+        <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top">
+            <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td align="center" style="background-color: #eeeeee;"><![endif]-->
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_image_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:40px 0px 20px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                                                <tr>
+                                                    <td style="padding-right: 0px;padding-left: 0px;" align="center">
+
+                                                        <img align="center" border="0"
+                                                             src="${siteMediaBaseUrl}/1/juniper-demo-logo.png"
+                                                             alt="Juniper Heart Demo logo"
+                                                             style="outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;clear: both;display: inline-block !important;border: none;height: auto;float: none;width: 34%;max-width: 204px;"
+                                                             width="204" class="v-src-width v-src-max-width"/>
+
+                                                    </td>
+                                                </tr>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;"><!--<![endif]-->
+
+                                <table id="u_content_text_2" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">Thank you for participating in Juniper Heart Demo. It's very important to complete each of the study activities in order to provide as much information to our researchers as possible.</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Please return to the study at your earliest convenience to finish your activities.</p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_text_3" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">${dashboardLink}</p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_divider_6" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:20px 50px 10px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table height="0px" align="left" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;border-top: 1px solid #ced4d9;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%">
+                                                <tbody>
+                                                <tr style="vertical-align: top">
+                                                    <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top;font-size: 0px;line-height: 0px;mso-line-height-rule: exactly;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%">
+                                                        <span>&#160;</span>
+                                                    </td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_text_deprecated_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at ${participantSupportEmailLink} if you have any questions.</span></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_text_4" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">We are so grateful for your participation - thank you again!</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Best regards,</p>
+                                                <p style="line-height: 140%;"><em>The Juniper Heart Demo Study Staff</em></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+            <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
+        </td>
+    </tr>
+    </tbody>
+</table>
+<!--[if mso]></div><![endif]-->
+<!--[if IE]></div><![endif]-->
+</body>
+
+</html>

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/dev/studyConsent.html
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/dev/studyConsent.html
@@ -1,0 +1,201 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <!--[if gte mso 9]>
+    <xml>
+        <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+    </xml>
+    <![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="x-apple-disable-message-reformatting">
+    <!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
+    <title></title>
+
+    <style type="text/css">
+        @media only screen and (min-width: 620px) {
+            .u-row {
+                width: 600px !important;
+            }
+            .u-row .u-col {
+                vertical-align: top;
+            }
+
+            .u-row .u-col-100 {
+                width: 600px !important;
+            }
+
+        }
+
+        @media (max-width: 620px) {
+            .u-row-container {
+                max-width: 100% !important;
+                padding-left: 0px !important;
+                padding-right: 0px !important;
+            }
+            .u-row .u-col {
+                min-width: 320px !important;
+                max-width: 100% !important;
+                display: block !important;
+            }
+            .u-row {
+                width: 100% !important;
+            }
+            .u-col {
+                width: 100% !important;
+            }
+            .u-col > div {
+                margin: 0 auto;
+            }
+        }
+        body {
+            margin: 0;
+            padding: 0;
+        }
+
+        table,
+        tr,
+        td {
+            vertical-align: top;
+            border-collapse: collapse;
+        }
+
+        p {
+            margin: 0;
+        }
+
+        .ie-container table,
+        .mso-container table {
+            table-layout: fixed;
+        }
+
+        * {
+            line-height: inherit;
+        }
+
+        a[x-apple-data-detectors='true'] {
+            color: inherit !important;
+            text-decoration: none !important;
+        }
+
+        table, td { color: #000000; } #u_body a { color: #9b2485; text-decoration: underline; } @media (max-width: 480px) { #u_content_image_1 .v-src-width { width: auto !important; } #u_content_image_1 .v-src-max-width { max-width: 87% !important; } #u_content_text_2 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_3 .v-container-padding-padding { padding: 10px 20px !important; } #u_content_divider_6 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_deprecated_1 .v-container-padding-padding { padding: 20px !important; } #u_content_text_4 .v-container-padding-padding { padding: 20px 20px 10px !important; } }
+    </style>
+
+
+
+    <!--[if !mso]><!--><link href="https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap" rel="stylesheet" type="text/css"><!--<![endif]-->
+
+</head>
+
+<body class="clean-body u_body" style="margin: 0;padding: 0;-webkit-text-size-adjust: 100%;background-color: #eeeeee;color: #000000">
+<!--[if IE]><div class="ie-container"><![endif]-->
+<!--[if mso]><div class="mso-container"><![endif]-->
+<table id="u_body" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;min-width: 320px;Margin: 0 auto;background-color: #eeeeee;width:100%" cellpadding="0" cellspacing="0">
+    <tbody>
+
+    <tr style="vertical-align: top">
+        <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top">
+            <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td align="center" style="background-color: #eeeeee;"><![endif]-->
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_image_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:40px 0px 20px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                                                <tr>
+                                                    <td style="padding-right: 0px;padding-left: 0px;" align="center">
+
+                                                        <img align="center" border="0"
+                                                             src="${siteMediaBaseUrl}/1/juniper-demo-logo.png"
+                                                             alt="Juniper Heart Demo logo"
+                                                             style="outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;clear: both;display: inline-block !important;border: none;height: auto;float: none;width: 34%;max-width: 204px;"
+                                                             width="204" class="v-src-width v-src-max-width"/>
+
+                                                    </td>
+                                                </tr>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;"><!--<![endif]-->
+
+                                <table id="u_content_text_2" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">Thank you again for your interest in our study.</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">You can access your signed study consent form from the <a rel="noopener" href="${dashboardUrl}">study dashboard</a>.</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">You can contact us at <a rel="noopener" href="mailto:support@juniper.terra.bio" target="_blank">support@juniper.terra.bio</a> if you have any questions.</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Your participation is very much appreciated - thank you again!</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Sincerely,</p>
+                                                <p style="line-height: 140%;"><em>The Juniper Heart Demo Study Staff</em></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+            <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
+        </td>
+    </tr>
+    </tbody>
+</table>
+<!--[if mso]></div><![endif]-->
+<!--[if IE]></div><![endif]-->
+</body>
+
+</html>

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/dev/studyEnroll.html
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/dev/studyEnroll.html
@@ -1,0 +1,280 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <!--[if gte mso 9]>
+    <xml>
+        <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+    </xml>
+    <![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="x-apple-disable-message-reformatting">
+    <!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
+    <title></title>
+
+    <style type="text/css">
+        @media only screen and (min-width: 620px) {
+            .u-row {
+                width: 600px !important;
+            }
+            .u-row .u-col {
+                vertical-align: top;
+            }
+
+            .u-row .u-col-100 {
+                width: 600px !important;
+            }
+
+        }
+
+        @media (max-width: 620px) {
+            .u-row-container {
+                max-width: 100% !important;
+                padding-left: 0px !important;
+                padding-right: 0px !important;
+            }
+            .u-row .u-col {
+                min-width: 320px !important;
+                max-width: 100% !important;
+                display: block !important;
+            }
+            .u-row {
+                width: 100% !important;
+            }
+            .u-col {
+                width: 100% !important;
+            }
+            .u-col > div {
+                margin: 0 auto;
+            }
+        }
+        body {
+            margin: 0;
+            padding: 0;
+        }
+
+        table,
+        tr,
+        td {
+            vertical-align: top;
+            border-collapse: collapse;
+        }
+
+        p {
+            margin: 0;
+        }
+
+        .ie-container table,
+        .mso-container table {
+            table-layout: fixed;
+        }
+
+        * {
+            line-height: inherit;
+        }
+
+        a[x-apple-data-detectors='true'] {
+            color: inherit !important;
+            text-decoration: none !important;
+        }
+
+        table, td { color: #000000; } #u_body a { color: #9b2485; text-decoration: underline; } @media (max-width: 480px) { #u_content_image_1 .v-src-width { width: auto !important; } #u_content_image_1 .v-src-max-width { max-width: 87% !important; } #u_content_text_2 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_3 .v-container-padding-padding { padding: 10px 20px !important; } #u_content_divider_6 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_deprecated_1 .v-container-padding-padding { padding: 20px !important; } #u_content_text_4 .v-container-padding-padding { padding: 20px 20px 10px !important; } }
+    </style>
+
+
+
+    <!--[if !mso]><!--><link href="https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap" rel="stylesheet" type="text/css"><!--<![endif]-->
+
+</head>
+
+<body class="clean-body u_body" style="margin: 0;padding: 0;-webkit-text-size-adjust: 100%;background-color: #eeeeee;color: #000000">
+<!--[if IE]><div class="ie-container"><![endif]-->
+<!--[if mso]><div class="mso-container"><![endif]-->
+<table id="u_body" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;min-width: 320px;Margin: 0 auto;background-color: #eeeeee;width:100%" cellpadding="0" cellspacing="0">
+    <tbody>
+
+    <tr style="vertical-align: top">
+        <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top">
+            <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td align="center" style="background-color: #eeeeee;"><![endif]-->
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_image_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:40px 0px 20px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                                                <tr>
+                                                    <td style="padding-right: 0px;padding-left: 0px;" align="center">
+
+                                                        <img align="center" border="0"
+                                                             src="${siteMediaBaseUrl}/1/juniper-demo-logo.png"
+                                                             alt="Juniper Heart Demo logo"
+                                                             style="outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;clear: both;display: inline-block !important;border: none;height: auto;float: none;width: 34%;max-width: 204px;"
+                                                             width="204" class="v-src-width v-src-max-width"/>
+
+                                                    </td>
+                                                </tr>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;"><!--<![endif]-->
+
+                                <table id="u_content_text_2" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">Thank you for your interest in Juniper Heart Demo.</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">If you have not already done so, please review and complete the study’s Consent Form. You can also begin or continue one of the study activities.</p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_text_3" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">${dashboardLink}</p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_divider_6" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:20px 50px 10px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table height="0px" align="left" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;border-top: 1px solid #ced4d9;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%">
+                                                <tbody>
+                                                <tr style="vertical-align: top">
+                                                    <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top;font-size: 0px;line-height: 0px;mso-line-height-rule: exactly;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%">
+                                                        <span>&#160;</span>
+                                                    </td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_text_deprecated_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at ${participantSupportEmailLink} if you have any questions.</span></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_text_4" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">We are so grateful for your participation - thank you again!</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Best regards,</p>
+                                                <p style="line-height: 140%;"><em>The Juniper Heart Demo Study Staff</em></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+            <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
+        </td>
+    </tr>
+    </tbody>
+</table>
+<!--[if mso]></div><![endif]-->
+<!--[if IE]></div><![endif]-->
+</body>
+
+</html>

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/dev/surveyReminder.html
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/dev/surveyReminder.html
@@ -1,0 +1,280 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <!--[if gte mso 9]>
+    <xml>
+        <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+    </xml>
+    <![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="x-apple-disable-message-reformatting">
+    <!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
+    <title></title>
+
+    <style type="text/css">
+        @media only screen and (min-width: 620px) {
+            .u-row {
+                width: 600px !important;
+            }
+            .u-row .u-col {
+                vertical-align: top;
+            }
+
+            .u-row .u-col-100 {
+                width: 600px !important;
+            }
+
+        }
+
+        @media (max-width: 620px) {
+            .u-row-container {
+                max-width: 100% !important;
+                padding-left: 0px !important;
+                padding-right: 0px !important;
+            }
+            .u-row .u-col {
+                min-width: 320px !important;
+                max-width: 100% !important;
+                display: block !important;
+            }
+            .u-row {
+                width: 100% !important;
+            }
+            .u-col {
+                width: 100% !important;
+            }
+            .u-col > div {
+                margin: 0 auto;
+            }
+        }
+        body {
+            margin: 0;
+            padding: 0;
+        }
+
+        table,
+        tr,
+        td {
+            vertical-align: top;
+            border-collapse: collapse;
+        }
+
+        p {
+            margin: 0;
+        }
+
+        .ie-container table,
+        .mso-container table {
+            table-layout: fixed;
+        }
+
+        * {
+            line-height: inherit;
+        }
+
+        a[x-apple-data-detectors='true'] {
+            color: inherit !important;
+            text-decoration: none !important;
+        }
+
+        table, td { color: #000000; } #u_body a { color: #9b2485; text-decoration: underline; } @media (max-width: 480px) { #u_content_image_1 .v-src-width { width: auto !important; } #u_content_image_1 .v-src-max-width { max-width: 87% !important; } #u_content_text_2 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_3 .v-container-padding-padding { padding: 10px 20px !important; } #u_content_divider_6 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_deprecated_1 .v-container-padding-padding { padding: 20px !important; } #u_content_text_4 .v-container-padding-padding { padding: 20px 20px 10px !important; } }
+    </style>
+
+
+
+    <!--[if !mso]><!--><link href="https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap" rel="stylesheet" type="text/css"><!--<![endif]-->
+
+</head>
+
+<body class="clean-body u_body" style="margin: 0;padding: 0;-webkit-text-size-adjust: 100%;background-color: #eeeeee;color: #000000">
+<!--[if IE]><div class="ie-container"><![endif]-->
+<!--[if mso]><div class="mso-container"><![endif]-->
+<table id="u_body" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;min-width: 320px;Margin: 0 auto;background-color: #eeeeee;width:100%" cellpadding="0" cellspacing="0">
+    <tbody>
+
+    <tr style="vertical-align: top">
+        <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top">
+            <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td align="center" style="background-color: #eeeeee;"><![endif]-->
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_image_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:40px 0px 20px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                                                <tr>
+                                                    <td style="padding-right: 0px;padding-left: 0px;" align="center">
+
+                                                        <img align="center" border="0"
+                                                             src="${siteMediaBaseUrl}/1/juniper-demo-logo.png"
+                                                             alt="Juniper Heart Demo logo"
+                                                             style="outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;clear: both;display: inline-block !important;border: none;height: auto;float: none;width: 34%;max-width: 204px;"
+                                                             width="204" class="v-src-width v-src-max-width"/>
+
+                                                    </td>
+                                                </tr>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;"><!--<![endif]-->
+
+                                <table id="u_content_text_2" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">Thank you for participating in Juniper Heart Demo. It's very important to complete each of the study activities in order to provide as much information to our researchers as possible.</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Please return to the study at your earliest convenience to finish your activities.</p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_text_3" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">${dashboardLink}</p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_divider_6" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:20px 50px 10px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table height="0px" align="left" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;border-top: 1px solid #ced4d9;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%">
+                                                <tbody>
+                                                <tr style="vertical-align: top">
+                                                    <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top;font-size: 0px;line-height: 0px;mso-line-height-rule: exactly;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%">
+                                                        <span>&#160;</span>
+                                                    </td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_text_deprecated_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at ${participantSupportEmailLink} if you have any questions.</span></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_text_4" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">We are so grateful for your participation - thank you again!</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Best regards,</p>
+                                                <p style="line-height: 140%;"><em>The Juniper Heart Demo Study Staff</em></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+            <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
+        </td>
+    </tr>
+    </tbody>
+</table>
+<!--[if mso]></div><![endif]-->
+<!--[if IE]></div><![endif]-->
+</body>
+
+</html>

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/en/consentReminder.html
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/en/consentReminder.html
@@ -1,0 +1,280 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <!--[if gte mso 9]>
+    <xml>
+        <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+    </xml>
+    <![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="x-apple-disable-message-reformatting">
+    <!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
+    <title></title>
+
+    <style type="text/css">
+        @media only screen and (min-width: 620px) {
+            .u-row {
+                width: 600px !important;
+            }
+            .u-row .u-col {
+                vertical-align: top;
+            }
+
+            .u-row .u-col-100 {
+                width: 600px !important;
+            }
+
+        }
+
+        @media (max-width: 620px) {
+            .u-row-container {
+                max-width: 100% !important;
+                padding-left: 0px !important;
+                padding-right: 0px !important;
+            }
+            .u-row .u-col {
+                min-width: 320px !important;
+                max-width: 100% !important;
+                display: block !important;
+            }
+            .u-row {
+                width: 100% !important;
+            }
+            .u-col {
+                width: 100% !important;
+            }
+            .u-col > div {
+                margin: 0 auto;
+            }
+        }
+        body {
+            margin: 0;
+            padding: 0;
+        }
+
+        table,
+        tr,
+        td {
+            vertical-align: top;
+            border-collapse: collapse;
+        }
+
+        p {
+            margin: 0;
+        }
+
+        .ie-container table,
+        .mso-container table {
+            table-layout: fixed;
+        }
+
+        * {
+            line-height: inherit;
+        }
+
+        a[x-apple-data-detectors='true'] {
+            color: inherit !important;
+            text-decoration: none !important;
+        }
+
+        table, td { color: #000000; } #u_body a { color: #9b2485; text-decoration: underline; } @media (max-width: 480px) { #u_content_image_1 .v-src-width { width: auto !important; } #u_content_image_1 .v-src-max-width { max-width: 87% !important; } #u_content_text_2 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_3 .v-container-padding-padding { padding: 10px 20px !important; } #u_content_divider_6 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_deprecated_1 .v-container-padding-padding { padding: 20px !important; } #u_content_text_4 .v-container-padding-padding { padding: 20px 20px 10px !important; } }
+    </style>
+
+
+
+    <!--[if !mso]><!--><link href="https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap" rel="stylesheet" type="text/css"><!--<![endif]-->
+
+</head>
+
+<body class="clean-body u_body" style="margin: 0;padding: 0;-webkit-text-size-adjust: 100%;background-color: #eeeeee;color: #000000">
+<!--[if IE]><div class="ie-container"><![endif]-->
+<!--[if mso]><div class="mso-container"><![endif]-->
+<table id="u_body" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;min-width: 320px;Margin: 0 auto;background-color: #eeeeee;width:100%" cellpadding="0" cellspacing="0">
+    <tbody>
+
+    <tr style="vertical-align: top">
+        <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top">
+            <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td align="center" style="background-color: #eeeeee;"><![endif]-->
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_image_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:40px 0px 20px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                                                <tr>
+                                                    <td style="padding-right: 0px;padding-left: 0px;" align="center">
+
+                                                        <img align="center" border="0"
+                                                             src="${siteMediaBaseUrl}/1/juniper-demo-logo.png"
+                                                             alt="Juniper Heart Demo logo"
+                                                             style="outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;clear: both;display: inline-block !important;border: none;height: auto;float: none;width: 34%;max-width: 204px;"
+                                                             width="204" class="v-src-width v-src-max-width"/>
+
+                                                    </td>
+                                                </tr>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;"><!--<![endif]-->
+
+                                <table id="u_content_text_2" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">Thank you for participating in Juniper Heart Demo. It's very important to complete each of the study activities in order to provide as much information to our researchers as possible.</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Please return to the study at your earliest convenience to finish your activities.</p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_text_3" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">${dashboardLink}</p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_divider_6" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:20px 50px 10px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table height="0px" align="left" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;border-top: 1px solid #ced4d9;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%">
+                                                <tbody>
+                                                <tr style="vertical-align: top">
+                                                    <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top;font-size: 0px;line-height: 0px;mso-line-height-rule: exactly;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%">
+                                                        <span>&#160;</span>
+                                                    </td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_text_deprecated_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at ${participantSupportEmailLink} if you have any questions.</span></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_text_4" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">We are so grateful for your participation - thank you again!</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Best regards,</p>
+                                                <p style="line-height: 140%;"><em>The Juniper Heart Demo Study Staff</em></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+            <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
+        </td>
+    </tr>
+    </tbody>
+</table>
+<!--[if mso]></div><![endif]-->
+<!--[if IE]></div><![endif]-->
+</body>
+
+</html>

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/en/consentReminder.html
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/en/consentReminder.html
@@ -162,7 +162,7 @@
                                         <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
 
                                             <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
-                                                <p style="line-height: 140%;">Thank you for participating in Juniper Heart Demo. It's very important to complete each of the study activities in order to provide as much information to our researchers as possible.</p>
+                                                <p style="line-height: 140%;">Thank you for participating in Juniper Demo Sleep Study. It's very important to complete each of the study activities in order to provide as much information to our researchers as possible.</p>
                                                 <p style="line-height: 140%;">&nbsp;</p>
                                                 <p style="line-height: 140%;">Please return to the study at your earliest convenience to finish your activities.</p>
                                             </div>

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/en/studyConsent.html
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/en/studyConsent.html
@@ -1,0 +1,204 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <!--[if gte mso 9]>
+    <xml>
+        <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+    </xml>
+    <![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="x-apple-disable-message-reformatting">
+    <!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
+    <title></title>
+
+    <style type="text/css">
+        @media only screen and (min-width: 620px) {
+            .u-row {
+                width: 600px !important;
+            }
+            .u-row .u-col {
+                vertical-align: top;
+            }
+
+            .u-row .u-col-100 {
+                width: 600px !important;
+            }
+
+        }
+
+        @media (max-width: 620px) {
+            .u-row-container {
+                max-width: 100% !important;
+                padding-left: 0px !important;
+                padding-right: 0px !important;
+            }
+            .u-row .u-col {
+                min-width: 320px !important;
+                max-width: 100% !important;
+                display: block !important;
+            }
+            .u-row {
+                width: 100% !important;
+            }
+            .u-col {
+                width: 100% !important;
+            }
+            .u-col > div {
+                margin: 0 auto;
+            }
+        }
+        body {
+            margin: 0;
+            padding: 0;
+        }
+
+        table,
+        tr,
+        td {
+            vertical-align: top;
+            border-collapse: collapse;
+        }
+
+        p {
+            margin: 0;
+        }
+
+        .ie-container table,
+        .mso-container table {
+            table-layout: fixed;
+        }
+
+        * {
+            line-height: inherit;
+        }
+
+        a[x-apple-data-detectors='true'] {
+            color: inherit !important;
+            text-decoration: none !important;
+        }
+
+        table, td { color: #000000; } #u_body a { color: #9b2485; text-decoration: underline; } @media (max-width: 480px) { #u_content_image_1 .v-src-width { width: auto !important; } #u_content_image_1 .v-src-max-width { max-width: 87% !important; } #u_content_text_2 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_3 .v-container-padding-padding { padding: 10px 20px !important; } #u_content_divider_6 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_deprecated_1 .v-container-padding-padding { padding: 20px !important; } #u_content_text_4 .v-container-padding-padding { padding: 20px 20px 10px !important; } }
+    </style>
+
+
+
+    <!--[if !mso]><!--><link href="https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap" rel="stylesheet" type="text/css"><!--<![endif]-->
+
+</head>
+
+<body class="clean-body u_body" style="margin: 0;padding: 0;-webkit-text-size-adjust: 100%;background-color: #eeeeee;color: #000000">
+<!--[if IE]><div class="ie-container"><![endif]-->
+<!--[if mso]><div class="mso-container"><![endif]-->
+<table id="u_body" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;min-width: 320px;Margin: 0 auto;background-color: #eeeeee;width:100%" cellpadding="0" cellspacing="0">
+    <tbody>
+
+    <tr style="vertical-align: top">
+        <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top">
+            <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td align="center" style="background-color: #eeeeee;"><![endif]-->
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_image_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:40px 0px 20px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                                                <tr>
+                                                    <td style="padding-right: 0px;padding-left: 0px;" align="center">
+
+                                                        <img align="center" border="0"
+                                                             src="${siteMediaBaseUrl}/1/juniper-demo-logo.png"
+                                                             alt="Juniper Demo logo"
+                                                             style="outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;clear: both;display: inline-block !important;border: none;height: auto;float: none;width: 34%;max-width: 204px;"
+                                                             width="204" class="v-src-width v-src-max-width"/>
+
+                                                    </td>
+                                                </tr>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;"><!--<![endif]-->
+
+                                <table id="u_content_text_2" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">Thank you again for your interest in our study.</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">
+                                                    You can access ${isProxy ? "your child's" : "your"} signed study
+                                                    consent form from the <a rel="noopener" href="${dashboardUrl}">study
+                                                    dashboard</a>.</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">You can contact us at <a rel="noopener" href="mailto:support@juniper.terra.bio" target="_blank">support@juniper.terra.bio</a> if you have any questions.</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Your participation is very much appreciated - thank you again!</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Sincerely,</p>
+                                                <p style="line-height: 140%;"><em>The Juniper Heart Demo Study Staff</em></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+            <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
+        </td>
+    </tr>
+    </tbody>
+</table>
+<!--[if mso]></div><![endif]-->
+<!--[if IE]></div><![endif]-->
+</body>
+
+</html>

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/en/studyEnroll.html
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/en/studyEnroll.html
@@ -1,0 +1,280 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <!--[if gte mso 9]>
+    <xml>
+        <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+    </xml>
+    <![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="x-apple-disable-message-reformatting">
+    <!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
+    <title></title>
+
+    <style type="text/css">
+        @media only screen and (min-width: 620px) {
+            .u-row {
+                width: 600px !important;
+            }
+            .u-row .u-col {
+                vertical-align: top;
+            }
+
+            .u-row .u-col-100 {
+                width: 600px !important;
+            }
+
+        }
+
+        @media (max-width: 620px) {
+            .u-row-container {
+                max-width: 100% !important;
+                padding-left: 0px !important;
+                padding-right: 0px !important;
+            }
+            .u-row .u-col {
+                min-width: 320px !important;
+                max-width: 100% !important;
+                display: block !important;
+            }
+            .u-row {
+                width: 100% !important;
+            }
+            .u-col {
+                width: 100% !important;
+            }
+            .u-col > div {
+                margin: 0 auto;
+            }
+        }
+        body {
+            margin: 0;
+            padding: 0;
+        }
+
+        table,
+        tr,
+        td {
+            vertical-align: top;
+            border-collapse: collapse;
+        }
+
+        p {
+            margin: 0;
+        }
+
+        .ie-container table,
+        .mso-container table {
+            table-layout: fixed;
+        }
+
+        * {
+            line-height: inherit;
+        }
+
+        a[x-apple-data-detectors='true'] {
+            color: inherit !important;
+            text-decoration: none !important;
+        }
+
+        table, td { color: #000000; } #u_body a { color: #9b2485; text-decoration: underline; } @media (max-width: 480px) { #u_content_image_1 .v-src-width { width: auto !important; } #u_content_image_1 .v-src-max-width { max-width: 87% !important; } #u_content_text_2 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_3 .v-container-padding-padding { padding: 10px 20px !important; } #u_content_divider_6 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_deprecated_1 .v-container-padding-padding { padding: 20px !important; } #u_content_text_4 .v-container-padding-padding { padding: 20px 20px 10px !important; } }
+    </style>
+
+
+
+    <!--[if !mso]><!--><link href="https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap" rel="stylesheet" type="text/css"><!--<![endif]-->
+
+</head>
+
+<body class="clean-body u_body" style="margin: 0;padding: 0;-webkit-text-size-adjust: 100%;background-color: #eeeeee;color: #000000">
+<!--[if IE]><div class="ie-container"><![endif]-->
+<!--[if mso]><div class="mso-container"><![endif]-->
+<table id="u_body" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;min-width: 320px;Margin: 0 auto;background-color: #eeeeee;width:100%" cellpadding="0" cellspacing="0">
+    <tbody>
+
+    <tr style="vertical-align: top">
+        <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top">
+            <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td align="center" style="background-color: #eeeeee;"><![endif]-->
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_image_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:40px 0px 20px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                                                <tr>
+                                                    <td style="padding-right: 0px;padding-left: 0px;" align="center">
+
+                                                        <img align="center" border="0"
+                                                             src="${siteMediaBaseUrl}/1/juniper-demo-logo.png"
+                                                             alt="Juniper Heart Demo logo"
+                                                             style="outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;clear: both;display: inline-block !important;border: none;height: auto;float: none;width: 34%;max-width: 204px;"
+                                                             width="204" class="v-src-width v-src-max-width"/>
+
+                                                    </td>
+                                                </tr>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;"><!--<![endif]-->
+
+                                <table id="u_content_text_2" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">Thank you for your interest in Juniper Heart Demo.</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">If you have not already done so, please review and complete the study’s Consent Form. You can also begin or continue one of the study activities.</p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_text_3" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">${dashboardLink}</p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_divider_6" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:20px 50px 10px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table height="0px" align="left" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;border-top: 1px solid #ced4d9;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%">
+                                                <tbody>
+                                                <tr style="vertical-align: top">
+                                                    <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top;font-size: 0px;line-height: 0px;mso-line-height-rule: exactly;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%">
+                                                        <span>&#160;</span>
+                                                    </td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_text_deprecated_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at ${participantSupportEmailLink} if you have any questions.</span></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_text_4" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">We are so grateful for your participation - thank you again!</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Best regards,</p>
+                                                <p style="line-height: 140%;"><em>The Juniper Heart Demo Study Staff</em></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+            <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
+        </td>
+    </tr>
+    </tbody>
+</table>
+<!--[if mso]></div><![endif]-->
+<!--[if IE]></div><![endif]-->
+</body>
+
+</html>

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/en/studyEnroll.html
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/en/studyEnroll.html
@@ -162,7 +162,7 @@
                                         <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
 
                                             <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
-                                                <p style="line-height: 140%;">Thank you for your interest in Juniper Heart Demo.</p>
+                                                <p style="line-height: 140%;">Thank you for your interest in the Demo Sleep study.</p>
                                                 <p style="line-height: 140%;">&nbsp;</p>
                                                 <p style="line-height: 140%;">If you have not already done so, please review and complete the study’s Consent Form. You can also begin or continue one of the study activities.</p>
                                             </div>

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/en/surveyReminder.html
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/en/surveyReminder.html
@@ -1,0 +1,280 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <!--[if gte mso 9]>
+    <xml>
+        <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+    </xml>
+    <![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="x-apple-disable-message-reformatting">
+    <!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
+    <title></title>
+
+    <style type="text/css">
+        @media only screen and (min-width: 620px) {
+            .u-row {
+                width: 600px !important;
+            }
+            .u-row .u-col {
+                vertical-align: top;
+            }
+
+            .u-row .u-col-100 {
+                width: 600px !important;
+            }
+
+        }
+
+        @media (max-width: 620px) {
+            .u-row-container {
+                max-width: 100% !important;
+                padding-left: 0px !important;
+                padding-right: 0px !important;
+            }
+            .u-row .u-col {
+                min-width: 320px !important;
+                max-width: 100% !important;
+                display: block !important;
+            }
+            .u-row {
+                width: 100% !important;
+            }
+            .u-col {
+                width: 100% !important;
+            }
+            .u-col > div {
+                margin: 0 auto;
+            }
+        }
+        body {
+            margin: 0;
+            padding: 0;
+        }
+
+        table,
+        tr,
+        td {
+            vertical-align: top;
+            border-collapse: collapse;
+        }
+
+        p {
+            margin: 0;
+        }
+
+        .ie-container table,
+        .mso-container table {
+            table-layout: fixed;
+        }
+
+        * {
+            line-height: inherit;
+        }
+
+        a[x-apple-data-detectors='true'] {
+            color: inherit !important;
+            text-decoration: none !important;
+        }
+
+        table, td { color: #000000; } #u_body a { color: #9b2485; text-decoration: underline; } @media (max-width: 480px) { #u_content_image_1 .v-src-width { width: auto !important; } #u_content_image_1 .v-src-max-width { max-width: 87% !important; } #u_content_text_2 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_3 .v-container-padding-padding { padding: 10px 20px !important; } #u_content_divider_6 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_deprecated_1 .v-container-padding-padding { padding: 20px !important; } #u_content_text_4 .v-container-padding-padding { padding: 20px 20px 10px !important; } }
+    </style>
+
+
+
+    <!--[if !mso]><!--><link href="https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap" rel="stylesheet" type="text/css"><!--<![endif]-->
+
+</head>
+
+<body class="clean-body u_body" style="margin: 0;padding: 0;-webkit-text-size-adjust: 100%;background-color: #eeeeee;color: #000000">
+<!--[if IE]><div class="ie-container"><![endif]-->
+<!--[if mso]><div class="mso-container"><![endif]-->
+<table id="u_body" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;min-width: 320px;Margin: 0 auto;background-color: #eeeeee;width:100%" cellpadding="0" cellspacing="0">
+    <tbody>
+
+    <tr style="vertical-align: top">
+        <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top">
+            <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td align="center" style="background-color: #eeeeee;"><![endif]-->
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_image_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:40px 0px 20px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                                                <tr>
+                                                    <td style="padding-right: 0px;padding-left: 0px;" align="center">
+
+                                                        <img align="center" border="0"
+                                                             src="${siteMediaBaseUrl}/1/juniper-demo-logo.png"
+                                                             alt="Juniper Heart Demo logo"
+                                                             style="outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;clear: both;display: inline-block !important;border: none;height: auto;float: none;width: 34%;max-width: 204px;"
+                                                             width="204" class="v-src-width v-src-max-width"/>
+
+                                                    </td>
+                                                </tr>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;"><!--<![endif]-->
+
+                                <table id="u_content_text_2" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">Thank you for participating in Juniper Heart Demo. It's very important to complete each of the study activities in order to provide as much information to our researchers as possible.</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Please return to the study at your earliest convenience to finish your activities.</p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_text_3" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">${dashboardLink}</p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_divider_6" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:20px 50px 10px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table height="0px" align="left" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;border-top: 1px solid #ced4d9;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%">
+                                                <tbody>
+                                                <tr style="vertical-align: top">
+                                                    <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top;font-size: 0px;line-height: 0px;mso-line-height-rule: exactly;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%">
+                                                        <span>&#160;</span>
+                                                    </td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_text_deprecated_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Please contact us at ${participantSupportEmailLink} if you have any questions.</span></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_text_4" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">We are so grateful for your participation - thank you again!</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Best regards,</p>
+                                                <p style="line-height: 140%;"><em>The Juniper Heart Demo Study Staff</em></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+            <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
+        </td>
+    </tr>
+    </tbody>
+</table>
+<!--[if mso]></div><![endif]-->
+<!--[if IE]></div><![endif]-->
+</body>
+
+</html>

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/es/consentReminder.html
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/es/consentReminder.html
@@ -1,0 +1,280 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <!--[if gte mso 9]>
+    <xml>
+        <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+    </xml>
+    <![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="x-apple-disable-message-reformatting">
+    <!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
+    <title></title>
+
+    <style type="text/css">
+        @media only screen and (min-width: 620px) {
+            .u-row {
+                width: 600px !important;
+            }
+            .u-row .u-col {
+                vertical-align: top;
+            }
+
+            .u-row .u-col-100 {
+                width: 600px !important;
+            }
+
+        }
+
+        @media (max-width: 620px) {
+            .u-row-container {
+                max-width: 100% !important;
+                padding-left: 0px !important;
+                padding-right: 0px !important;
+            }
+            .u-row .u-col {
+                min-width: 320px !important;
+                max-width: 100% !important;
+                display: block !important;
+            }
+            .u-row {
+                width: 100% !important;
+            }
+            .u-col {
+                width: 100% !important;
+            }
+            .u-col > div {
+                margin: 0 auto;
+            }
+        }
+        body {
+            margin: 0;
+            padding: 0;
+        }
+
+        table,
+        tr,
+        td {
+            vertical-align: top;
+            border-collapse: collapse;
+        }
+
+        p {
+            margin: 0;
+        }
+
+        .ie-container table,
+        .mso-container table {
+            table-layout: fixed;
+        }
+
+        * {
+            line-height: inherit;
+        }
+
+        a[x-apple-data-detectors='true'] {
+            color: inherit !important;
+            text-decoration: none !important;
+        }
+
+        table, td { color: #000000; } #u_body a { color: #9b2485; text-decoration: underline; } @media (max-width: 480px) { #u_content_image_1 .v-src-width { width: auto !important; } #u_content_image_1 .v-src-max-width { max-width: 87% !important; } #u_content_text_2 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_3 .v-container-padding-padding { padding: 10px 20px !important; } #u_content_divider_6 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_deprecated_1 .v-container-padding-padding { padding: 20px !important; } #u_content_text_4 .v-container-padding-padding { padding: 20px 20px 10px !important; } }
+    </style>
+
+
+
+    <!--[if !mso]><!--><link href="https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap" rel="stylesheet" type="text/css"><!--<![endif]-->
+
+</head>
+
+<body class="clean-body u_body" style="margin: 0;padding: 0;-webkit-text-size-adjust: 100%;background-color: #eeeeee;color: #000000">
+<!--[if IE]><div class="ie-container"><![endif]-->
+<!--[if mso]><div class="mso-container"><![endif]-->
+<table id="u_body" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;min-width: 320px;Margin: 0 auto;background-color: #eeeeee;width:100%" cellpadding="0" cellspacing="0">
+    <tbody>
+
+    <tr style="vertical-align: top">
+        <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top">
+            <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td align="center" style="background-color: #eeeeee;"><![endif]-->
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_image_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:40px 0px 20px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                                                <tr>
+                                                    <td style="padding-right: 0px;padding-left: 0px;" align="center">
+
+                                                        <img align="center" border="0"
+                                                             src="${siteMediaBaseUrl}/1/juniper-demo-logo.png"
+                                                             alt="Logotipo de demostración de Juniper Heart"
+                                                             style="outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;clear: both;display: inline-block !important;border: none;height: auto;float: none;width: 34%;max-width: 204px;"
+                                                             width="204" class="v-src-width v-src-max-width"/>
+
+                                                    </td>
+                                                </tr>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;"><!--<![endif]-->
+
+                                <table id="u_content_text_2" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">Gracias por participar en el demostración de Juniper Heart. Es muy importante completar cada una de las actividades del estudio para poder brindar la mayor cantidad de información posible a nuestros investigadores.</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Regrese al estudio lo antes posible para finalizar sus actividades.</p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_text_3" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">${dashboardLink}</p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_divider_6" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:20px 50px 10px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table height="0px" align="left" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;border-top: 1px solid #ced4d9;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%">
+                                                <tbody>
+                                                <tr style="vertical-align: top">
+                                                    <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top;font-size: 0px;line-height: 0px;mso-line-height-rule: exactly;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%">
+                                                        <span>&#160;</span>
+                                                    </td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_text_deprecated_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Comuníquese con nosotros en ${participantSupportEmailLink} si tiene alguna pregunta.</span></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_text_4" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">Estamos muy agradecidos por su participación. ¡Gracias de nuevo!</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Atentamente,</p>
+                                                <p style="line-height: 140%;"><em>El personal del demostración de Juniper Heart</em></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+            <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
+        </td>
+    </tr>
+    </tbody>
+</table>
+<!--[if mso]></div><![endif]-->
+<!--[if IE]></div><![endif]-->
+</body>
+
+</html>

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/es/studyConsent.html
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/es/studyConsent.html
@@ -1,0 +1,201 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <!--[if gte mso 9]>
+    <xml>
+        <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+    </xml>
+    <![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="x-apple-disable-message-reformatting">
+    <!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
+    <title></title>
+
+    <style type="text/css">
+        @media only screen and (min-width: 620px) {
+            .u-row {
+                width: 600px !important;
+            }
+            .u-row .u-col {
+                vertical-align: top;
+            }
+
+            .u-row .u-col-100 {
+                width: 600px !important;
+            }
+
+        }
+
+        @media (max-width: 620px) {
+            .u-row-container {
+                max-width: 100% !important;
+                padding-left: 0px !important;
+                padding-right: 0px !important;
+            }
+            .u-row .u-col {
+                min-width: 320px !important;
+                max-width: 100% !important;
+                display: block !important;
+            }
+            .u-row {
+                width: 100% !important;
+            }
+            .u-col {
+                width: 100% !important;
+            }
+            .u-col > div {
+                margin: 0 auto;
+            }
+        }
+        body {
+            margin: 0;
+            padding: 0;
+        }
+
+        table,
+        tr,
+        td {
+            vertical-align: top;
+            border-collapse: collapse;
+        }
+
+        p {
+            margin: 0;
+        }
+
+        .ie-container table,
+        .mso-container table {
+            table-layout: fixed;
+        }
+
+        * {
+            line-height: inherit;
+        }
+
+        a[x-apple-data-detectors='true'] {
+            color: inherit !important;
+            text-decoration: none !important;
+        }
+
+        table, td { color: #000000; } #u_body a { color: #9b2485; text-decoration: underline; } @media (max-width: 480px) { #u_content_image_1 .v-src-width { width: auto !important; } #u_content_image_1 .v-src-max-width { max-width: 87% !important; } #u_content_text_2 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_3 .v-container-padding-padding { padding: 10px 20px !important; } #u_content_divider_6 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_deprecated_1 .v-container-padding-padding { padding: 20px !important; } #u_content_text_4 .v-container-padding-padding { padding: 20px 20px 10px !important; } }
+    </style>
+
+
+
+    <!--[if !mso]><!--><link href="https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap" rel="stylesheet" type="text/css"><!--<![endif]-->
+
+</head>
+
+<body class="clean-body u_body" style="margin: 0;padding: 0;-webkit-text-size-adjust: 100%;background-color: #eeeeee;color: #000000">
+<!--[if IE]><div class="ie-container"><![endif]-->
+<!--[if mso]><div class="mso-container"><![endif]-->
+<table id="u_body" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;min-width: 320px;Margin: 0 auto;background-color: #eeeeee;width:100%" cellpadding="0" cellspacing="0">
+    <tbody>
+
+    <tr style="vertical-align: top">
+        <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top">
+            <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td align="center" style="background-color: #eeeeee;"><![endif]-->
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_image_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:40px 0px 20px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                                                <tr>
+                                                    <td style="padding-right: 0px;padding-left: 0px;" align="center">
+
+                                                        <img align="center" border="0"
+                                                             src="${siteMediaBaseUrl}/1/juniper-demo-logo.png"
+                                                             alt="Logotipo de demostración de Juniper Heart"
+                                                             style="outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;clear: both;display: inline-block !important;border: none;height: auto;float: none;width: 34%;max-width: 204px;"
+                                                             width="204" class="v-src-width v-src-max-width"/>
+
+                                                    </td>
+                                                </tr>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;"><!--<![endif]-->
+
+                                <table id="u_content_text_2" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">Gracias nuevamente por su interés en nuestro estudio.</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Puede acceder a su formulario de consentimiento del estudio firmado desde el <a rel="noopener" href="${dashboardUrl}">panel de estudio</a>.</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Puede contactarnos en <a rel="noopener" href="mailto:support@juniper.terra.bio" target="_blank">support@juniper.terra.bio</a> si tiene alguna pregunta.</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Agradecemos mucho su participación. ¡Gracias de nuevo!</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Atentamente,</p>
+                                                <p style="line-height: 140%;"><em>El personal del demostración de Juniper Heart</em></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+            <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
+        </td>
+    </tr>
+    </tbody>
+</table>
+<!--[if mso]></div><![endif]-->
+<!--[if IE]></div><![endif]-->
+</body>
+
+</html>

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/es/studyEnroll.html
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/es/studyEnroll.html
@@ -1,0 +1,280 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <!--[if gte mso 9]>
+    <xml>
+        <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+    </xml>
+    <![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="x-apple-disable-message-reformatting">
+    <!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
+    <title></title>
+
+    <style type="text/css">
+        @media only screen and (min-width: 620px) {
+            .u-row {
+                width: 600px !important;
+            }
+            .u-row .u-col {
+                vertical-align: top;
+            }
+
+            .u-row .u-col-100 {
+                width: 600px !important;
+            }
+
+        }
+
+        @media (max-width: 620px) {
+            .u-row-container {
+                max-width: 100% !important;
+                padding-left: 0px !important;
+                padding-right: 0px !important;
+            }
+            .u-row .u-col {
+                min-width: 320px !important;
+                max-width: 100% !important;
+                display: block !important;
+            }
+            .u-row {
+                width: 100% !important;
+            }
+            .u-col {
+                width: 100% !important;
+            }
+            .u-col > div {
+                margin: 0 auto;
+            }
+        }
+        body {
+            margin: 0;
+            padding: 0;
+        }
+
+        table,
+        tr,
+        td {
+            vertical-align: top;
+            border-collapse: collapse;
+        }
+
+        p {
+            margin: 0;
+        }
+
+        .ie-container table,
+        .mso-container table {
+            table-layout: fixed;
+        }
+
+        * {
+            line-height: inherit;
+        }
+
+        a[x-apple-data-detectors='true'] {
+            color: inherit !important;
+            text-decoration: none !important;
+        }
+
+        table, td { color: #000000; } #u_body a { color: #9b2485; text-decoration: underline; } @media (max-width: 480px) { #u_content_image_1 .v-src-width { width: auto !important; } #u_content_image_1 .v-src-max-width { max-width: 87% !important; } #u_content_text_2 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_3 .v-container-padding-padding { padding: 10px 20px !important; } #u_content_divider_6 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_deprecated_1 .v-container-padding-padding { padding: 20px !important; } #u_content_text_4 .v-container-padding-padding { padding: 20px 20px 10px !important; } }
+    </style>
+
+
+
+    <!--[if !mso]><!--><link href="https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap" rel="stylesheet" type="text/css"><!--<![endif]-->
+
+</head>
+
+<body class="clean-body u_body" style="margin: 0;padding: 0;-webkit-text-size-adjust: 100%;background-color: #eeeeee;color: #000000">
+<!--[if IE]><div class="ie-container"><![endif]-->
+<!--[if mso]><div class="mso-container"><![endif]-->
+<table id="u_body" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;min-width: 320px;Margin: 0 auto;background-color: #eeeeee;width:100%" cellpadding="0" cellspacing="0">
+    <tbody>
+
+    <tr style="vertical-align: top">
+        <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top">
+            <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td align="center" style="background-color: #eeeeee;"><![endif]-->
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_image_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:40px 0px 20px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                                                <tr>
+                                                    <td style="padding-right: 0px;padding-left: 0px;" align="center">
+
+                                                        <img align="center" border="0"
+                                                             src="${siteMediaBaseUrl}/1/juniper-demo-logo.png"
+                                                             alt="Logotipo de demostración de Juniper Heart"
+                                                             style="outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;clear: both;display: inline-block !important;border: none;height: auto;float: none;width: 34%;max-width: 204px;"
+                                                             width="204" class="v-src-width v-src-max-width"/>
+
+                                                    </td>
+                                                </tr>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;"><!--<![endif]-->
+
+                                <table id="u_content_text_2" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">Gracias por su interés en Nuestra Salud.</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Si aún no lo ha hecho, revise y complete el Formulario de consentimiento del estudio. También puedes comenzar o continuar una de las actividades del estudio.</p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_text_3" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">${dashboardLink}</p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_divider_6" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:20px 50px 10px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table height="0px" align="left" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;border-top: 1px solid #ced4d9;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%">
+                                                <tbody>
+                                                <tr style="vertical-align: top">
+                                                    <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top;font-size: 0px;line-height: 0px;mso-line-height-rule: exactly;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%">
+                                                        <span>&#160;</span>
+                                                    </td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_text_deprecated_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Comuníquese con nosotros en ${participantSupportEmailLink} si tiene alguna pregunta.</span></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_text_4" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">Estamos muy agradecidos por su participación. ¡Gracias de nuevo!</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Atentamente,</p>
+                                                <p style="line-height: 140%;"><em>El personal del demostración de Juniper Heart</em></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+            <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
+        </td>
+    </tr>
+    </tbody>
+</table>
+<!--[if mso]></div><![endif]-->
+<!--[if IE]></div><![endif]-->
+</body>
+
+</html>

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/es/surveyReminder.html
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/es/surveyReminder.html
@@ -1,0 +1,280 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD XHTML 1.0 Transitional //EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <!--[if gte mso 9]>
+    <xml>
+        <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+    </xml>
+    <![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="x-apple-disable-message-reformatting">
+    <!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
+    <title></title>
+
+    <style type="text/css">
+        @media only screen and (min-width: 620px) {
+            .u-row {
+                width: 600px !important;
+            }
+            .u-row .u-col {
+                vertical-align: top;
+            }
+
+            .u-row .u-col-100 {
+                width: 600px !important;
+            }
+
+        }
+
+        @media (max-width: 620px) {
+            .u-row-container {
+                max-width: 100% !important;
+                padding-left: 0px !important;
+                padding-right: 0px !important;
+            }
+            .u-row .u-col {
+                min-width: 320px !important;
+                max-width: 100% !important;
+                display: block !important;
+            }
+            .u-row {
+                width: 100% !important;
+            }
+            .u-col {
+                width: 100% !important;
+            }
+            .u-col > div {
+                margin: 0 auto;
+            }
+        }
+        body {
+            margin: 0;
+            padding: 0;
+        }
+
+        table,
+        tr,
+        td {
+            vertical-align: top;
+            border-collapse: collapse;
+        }
+
+        p {
+            margin: 0;
+        }
+
+        .ie-container table,
+        .mso-container table {
+            table-layout: fixed;
+        }
+
+        * {
+            line-height: inherit;
+        }
+
+        a[x-apple-data-detectors='true'] {
+            color: inherit !important;
+            text-decoration: none !important;
+        }
+
+        table, td { color: #000000; } #u_body a { color: #9b2485; text-decoration: underline; } @media (max-width: 480px) { #u_content_image_1 .v-src-width { width: auto !important; } #u_content_image_1 .v-src-max-width { max-width: 87% !important; } #u_content_text_2 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_3 .v-container-padding-padding { padding: 10px 20px !important; } #u_content_divider_6 .v-container-padding-padding { padding: 20px 20px 10px !important; } #u_content_text_deprecated_1 .v-container-padding-padding { padding: 20px !important; } #u_content_text_4 .v-container-padding-padding { padding: 20px 20px 10px !important; } }
+    </style>
+
+
+
+    <!--[if !mso]><!--><link href="https://fonts.googleapis.com/css?family=Montserrat:400,700&display=swap" rel="stylesheet" type="text/css"><!--<![endif]-->
+
+</head>
+
+<body class="clean-body u_body" style="margin: 0;padding: 0;-webkit-text-size-adjust: 100%;background-color: #eeeeee;color: #000000">
+<!--[if IE]><div class="ie-container"><![endif]-->
+<!--[if mso]><div class="mso-container"><![endif]-->
+<table id="u_body" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;min-width: 320px;Margin: 0 auto;background-color: #eeeeee;width:100%" cellpadding="0" cellspacing="0">
+    <tbody>
+
+    <tr style="vertical-align: top">
+        <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top">
+            <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td align="center" style="background-color: #eeeeee;"><![endif]-->
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_image_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:40px 0px 20px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table width="100%" cellpadding="0" cellspacing="0" border="0">
+                                                <tr>
+                                                    <td style="padding-right: 0px;padding-left: 0px;" align="center">
+
+                                                        <img align="center" border="0"
+                                                             src="${siteMediaBaseUrl}/1/juniper-demo-logo.png"
+                                                             alt="Logotipo de demostración de Juniper Heart"
+                                                             style="outline: none;text-decoration: none;-ms-interpolation-mode: bicubic;clear: both;display: inline-block !important;border: none;height: auto;float: none;width: 34%;max-width: 204px;"
+                                                             width="204" class="v-src-width v-src-max-width"/>
+
+                                                    </td>
+                                                </tr>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;"><!--<![endif]-->
+
+                                <table id="u_content_text_2" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">Gracias por participar en el demostración de Juniper Heart. Es muy importante completar cada una de las actividades del estudio para poder brindar la mayor cantidad de información posible a nuestros investigadores.</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Regrese al estudio lo antes posible para finalizar sus actividades.</p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+
+            <div class="u-row-container" style="padding: 0px;background-color: transparent">
+                <div class="u-row" style="Margin: 0 auto;min-width: 320px;max-width: 600px;overflow-wrap: break-word;word-wrap: break-word;word-break: break-word;background-color: transparent;">
+                    <div style="border-collapse: collapse;display: table;width: 100%;height: 100%;background-color: transparent;">
+                        <!--[if (mso)|(IE)]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding: 0px;background-color: transparent;" align="center"><table cellpadding="0" cellspacing="0" border="0" style="width:600px;"><tr style="background-color: transparent;"><![endif]-->
+
+                        <!--[if (mso)|(IE)]><td align="center" width="600" style="background-color: #ffffff;width: 600px;padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;" valign="top"><![endif]-->
+                        <div class="u-col u-col-100" style="max-width: 320px;min-width: 600px;display: table-cell;vertical-align: top;">
+                            <div style="background-color: #ffffff;height: 100%;width: 100% !important;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;">
+                                <!--[if (!mso)&(!IE)]><!--><div style="box-sizing: border-box; height: 100%; padding: 0px;border-top: 0px solid transparent;border-left: 0px solid transparent;border-right: 0px solid transparent;border-bottom: 0px solid transparent;border-radius: 0px;-webkit-border-radius: 0px; -moz-border-radius: 0px;"><!--<![endif]-->
+
+                                <table id="u_content_text_3" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">${dashboardLink}</p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_divider_6" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:20px 50px 10px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <table height="0px" align="left" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse;table-layout: fixed;border-spacing: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;vertical-align: top;border-top: 1px solid #ced4d9;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%">
+                                                <tbody>
+                                                <tr style="vertical-align: top">
+                                                    <td style="word-break: break-word;border-collapse: collapse !important;vertical-align: top;font-size: 0px;line-height: 0px;mso-line-height-rule: exactly;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%">
+                                                        <span>&#160;</span>
+                                                    </td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_text_deprecated_1" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="font-size: 14px; line-height: 140%; text-align: left;"><span style="font-family: Montserrat, sans-serif; line-height: 19.6px;">Comuníquese con nosotros en ${participantSupportEmailLink} si tiene alguna pregunta.</span></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <table id="u_content_text_4" style="font-family:'Montserrat',sans-serif;" role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                                    <tbody>
+                                    <tr>
+                                        <td class="v-container-padding-padding" style="overflow-wrap:break-word;word-break:break-word;padding:10px 50px 50px;font-family:'Montserrat',sans-serif;" align="left">
+
+                                            <div style="font-family: 'Montserrat',sans-serif; font-size: 14px; line-height: 140%; text-align: left; word-wrap: break-word;">
+                                                <p style="line-height: 140%;">Estamos muy agradecidos por su participación. ¡Gracias de nuevo!</p>
+                                                <p style="line-height: 140%;">&nbsp;</p>
+                                                <p style="line-height: 140%;">Atentamente,</p>
+                                                <p style="line-height: 140%;"><em>El personal del demostración de Juniper Heart</em></p>
+                                            </div>
+
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+
+                                <!--[if (!mso)&(!IE)]><!--></div><!--<![endif]-->
+                            </div>
+                        </div>
+                        <!--[if (mso)|(IE)]></td><![endif]-->
+                        <!--[if (mso)|(IE)]></tr></table></td></tr></table><![endif]-->
+                    </div>
+                </div>
+            </div>
+
+
+            <!--[if (mso)|(IE)]></td></tr></table><![endif]-->
+        </td>
+    </tr>
+    </tbody>
+</table>
+<!--[if mso]></div><![endif]-->
+<!--[if IE]></div><![endif]-->
+</body>
+
+</html>

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/studyConsent.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/studyConsent.json
@@ -1,0 +1,19 @@
+{
+  "stableId": "sleepStudyConsent",
+  "name": "Consent email",
+  "version": 1,
+  "publishedVersion": 1,
+  "localizedEmailTemplateDtos": [{
+    "language": "en",
+    "subject": "Thank you!",
+    "bodyPopulateFile": "en/studyConsent.html"
+  },{
+    "language": "es",
+    "subject": "¡Gracias!",
+    "bodyPopulateFile": "es/studyConsent.html"
+  }, {
+    "language": "dev",
+    "subject": "DEV_Thank you!",
+    "bodyPopulateFile": "dev/studyConsent.html"
+  }]
+}

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/studyEnroll.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/studyEnroll.json
@@ -1,0 +1,19 @@
+{
+  "stableId": "sleepStudyEnroll",
+  "name": "Enrollment email",
+  "version": 1,
+  "publishedVersion": 1,
+  "localizedEmailTemplateDtos": [{
+    "language": "en",
+    "subject": "Welcome!",
+    "bodyPopulateFile": "en/studyEnroll.html"
+  },{
+    "language": "es",
+    "subject": "¡Bienvenido!",
+    "bodyPopulateFile": "es/studyEnroll.html"
+  },{
+    "language": "dev",
+    "subject": "DEV_Welcome!",
+    "bodyPopulateFile": "dev/studyEnroll.html"
+  }]
+}

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/surveyReminder.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/emails/surveyReminder.json
@@ -1,0 +1,19 @@
+{
+  "stableId": "sleepReminderSurvey",
+  "name": "Survey reminder",
+  "version": 1,
+  "publishedVersion": 1,
+  "localizedEmailTemplateDtos": [{
+    "language": "en",
+    "subject": "Please come back to finish your study activities",
+    "bodyPopulateFile": "en/surveyReminder.html"
+  },{
+    "language": "es",
+    "subject": "Por favor regresa para finalizar tus actividades de estudio",
+    "bodyPopulateFile": "es/surveyReminder.html"
+  },{
+    "language": "dev",
+    "subject": "DEV_Please come back to finish your study activities",
+    "bodyPopulateFile": "dev/surveyReminder.html"
+  }]
+}

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/study.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/study.json
@@ -1,0 +1,128 @@
+{
+  "name": "Sleep study",
+  "shortcode": "demosleep",
+  "surveyFiles": [
+    "surveys/preEnroll.json",
+    "surveys/sleepConsent.json",
+    "surveys/sleepMain.json"
+  ],
+  "emailTemplateFiles": [
+    "emails/studyConsent.json",
+    "emails/studyEnroll.json",
+    "emails/consentReminder.json",
+    "emails/surveyReminder.json"
+  ],
+  "studyEnvironmentDtos": [
+    {
+      "environmentName": "sandbox",
+      "studyEnvironmentConfig": {
+        "acceptingEnrollment": true,
+        "acceptingProxyEnrollment": true,
+        "enableFamilyLinkage": true,
+        "passwordProtected": false,
+        "password": "broad_institute",
+        "initialized": true,
+        "enableInPersonKits": true
+      },
+      "configuredSurveyDtos": [
+        {"populateFileName": "surveys/preEnroll.json"},
+        {"populateFileName": "surveys/sleepConsent.json"},
+        {"populateFileName": "surveys/sleepMain.json"}
+      ],
+      "triggerDtos": [{
+        "triggerType": "EVENT",
+        "eventType": "STUDY_ENROLLMENT",
+        "populateFileName": "emails/studyEnroll.json"
+      },{
+        "triggerType": "EVENT",
+        "eventType": "STUDY_CONSENT",
+        "populateFileName": "emails/studyConsent.json"
+      },{
+        "triggerType": "TASK_REMINDER",
+        "taskType": "CONSENT",
+        "populateFileName": "emails/consentReminder.json"
+      },{
+        "triggerType": "TASK_REMINDER",
+        "taskType": "SURVEY",
+        "reminderIntervalMinutes": 10080,
+        "maxNumReminders": 2,
+        "populateFileName": "emails/surveyReminder.json"
+      }],
+      "enrolleeFiles": []
+    },
+    {
+      "environmentName": "irb",
+      "studyEnvironmentConfig": {
+        "acceptingEnrollment": true,
+        "acceptingProxyEnrollment": true,
+        "enableFamilyLinkage": true,
+        "passwordProtected": false,
+        "password": "broad_institute",
+        "initialized": true,
+        "enableInPersonKits": true
+      },
+      "configuredSurveyDtos": [
+        {"populateFileName": "surveys/preEnroll.json"},
+        {"populateFileName": "surveys/sleepConsent.json"},
+        {"populateFileName": "surveys/sleepMain.json"}
+      ],
+      "triggerDtos": [{
+        "triggerType": "EVENT",
+        "eventType": "STUDY_ENROLLMENT",
+        "populateFileName": "emails/studyEnroll.json"
+      },{
+        "triggerType": "EVENT",
+        "eventType": "STUDY_CONSENT",
+        "populateFileName": "emails/studyConsent.json"
+      },{
+        "triggerType": "TASK_REMINDER",
+        "taskType": "CONSENT",
+        "populateFileName": "emails/consentReminder.json"
+      },{
+        "triggerType": "TASK_REMINDER",
+        "taskType": "SURVEY",
+        "reminderIntervalMinutes": 10080,
+        "maxNumReminders": 2,
+        "populateFileName": "emails/surveyReminder.json"
+      }],
+      "enrolleeFiles": []
+    },
+    {
+      "environmentName": "live",
+      "studyEnvironmentConfig": {
+        "acceptingEnrollment": true,
+        "acceptingProxyEnrollment": true,
+        "enableFamilyLinkage": true,
+        "passwordProtected": false,
+        "password": "broad_institute",
+        "initialized": true,
+        "enableInPersonKits": true
+      },
+      "configuredSurveyDtos": [
+        {"populateFileName": "surveys/preEnroll.json"},
+        {"populateFileName": "surveys/sleepConsent.json"},
+        {"populateFileName": "surveys/sleepMain.json"}
+      ],
+      "triggerDtos": [{
+        "triggerType": "EVENT",
+        "eventType": "STUDY_ENROLLMENT",
+        "populateFileName": "emails/studyEnroll.json"
+      },{
+        "triggerType": "EVENT",
+        "eventType": "STUDY_CONSENT",
+        "populateFileName": "emails/studyConsent.json"
+      },{
+        "triggerType": "TASK_REMINDER",
+        "taskType": "CONSENT",
+        "populateFileName": "emails/consentReminder.json"
+      },{
+        "triggerType": "TASK_REMINDER",
+        "taskType": "SURVEY",
+        "reminderIntervalMinutes": 10080,
+        "maxNumReminders": 2,
+        "populateFileName": "emails/surveyReminder.json"
+      }],
+      "enrolleeFiles": []
+    }
+  ]
+}

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/surveys/preEnroll.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/surveys/preEnroll.json
@@ -1,0 +1,72 @@
+{
+  "stableId": "sleepPreenroll",
+  "version": 1,
+  "name": "Pre-enroll",
+  "surveyType": "PRE_ENROLL",
+  "assignToAllNewEnrollees": false,
+  "autoAssign": false,
+  "jsonContent": {
+    "title": {
+      "en": "Sleep study pre-enroll",
+      "es": "Preinscripción de sleep",
+      "dev": "DEV_Sleep pre-enroll"
+    },
+    "logoPosition": "right",
+    "showProgressBar": "bottom",
+    "showQuestionNumbers": "off",
+    "progressBarType": "requiredQuestions",
+    "completeText": "Submit",
+    "pages": [
+      {
+        "name": "page2",
+        "title": {
+          "en": "Study Eligibility",
+          "es": "Elegibilidad para el estudio",
+          "dev": "DEV_Study Eligibility"
+        },
+        "description": {
+          "en": "Thank you for your interest in participating in the Sleep study. To get started, please answer these questions to make sure you’re eligible to participate.",
+          "es": "Gracias por su interés en participar en Sleep Study. Para comenzar, responda estas preguntas para asegurarse de que es elegible para participar.",
+          "dev": "DEV_Thank you for your interest in participating in Sleep study. To get started, please answer these questions to make sure you’re eligible to participate."
+        },
+        "elements": [
+          {
+            "type": "radiogroup",
+            "name": "sleep_troubleSleeping",
+            "title": {
+              "en": "I often have trouble sleeping.",
+              "es": "Yo sleep mal.",
+              "dev": "DEV_I often have trouble sleeping."
+            },
+            "isRequired": true,
+            "choices": [
+              {
+                "value": "yes",
+                "text": {
+                  "en": "Yes",
+                  "es": "Sí",
+                  "dev": "DEV_Yes"
+                }
+              },
+              {
+                "value": "no",
+                "text": {
+                  "en": "No",
+                  "es": "No",
+                  "dev": "DEV_No"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "calculatedValues": [
+      {
+        "name": "qualified",
+        "expression": "{sleep_troubleSleeping} = 'yes'",
+        "includeIntoResult": true
+      }
+    ]
+  }
+}

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/surveys/preEnroll.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/surveys/preEnroll.json
@@ -18,45 +18,52 @@
     "completeText": "Submit",
     "pages": [
       {
-        "name": "page2",
-        "title": {
-          "en": "Study Eligibility",
-          "es": "Elegibilidad para el estudio",
-          "dev": "DEV_Study Eligibility"
-        },
-        "description": {
-          "en": "Thank you for your interest in participating in the Sleep study. To get started, please answer these questions to make sure you’re eligible to participate.",
-          "es": "Gracias por su interés en participar en Sleep Study. Para comenzar, responda estas preguntas para asegurarse de que es elegible para participar.",
-          "dev": "DEV_Thank you for your interest in participating in Sleep study. To get started, please answer these questions to make sure you’re eligible to participate."
-        },
+        "name": "page1",
         "elements": [
           {
-            "type": "radiogroup",
-            "name": "sleep_troubleSleeping",
-            "title": {
-              "en": "I often have trouble sleeping.",
-              "es": "Yo sleep mal.",
-              "dev": "DEV_I often have trouble sleeping."
-            },
-            "isRequired": true,
-            "choices": [
+            "type": "panel",
+            "visibleIf": "{user.username} notempty",
+            "elements": [
               {
-                "value": "yes",
-                "text": {
-                  "en": "Yes",
-                  "es": "Sí",
-                  "dev": "DEV_Yes"
-                }
+                "type": "html",
+                "name": "thanksInterest",
+                "html": "Thank you for your interest in joining the sleep study. This study builds on the main study that you have already joined, and will deliver you a PRS report for sleep-related disorders.  Please answer the questions below to confirm your eligibility."
               },
               {
-                "value": "no",
-                "text": {
-                  "en": "No",
-                  "es": "No",
-                  "dev": "DEV_No"
-                }
+                "type": "radiogroup",
+                "name": "sleep_troubleSleeping",
+                "title": {
+                  "en": "I often have trouble sleeping.",
+                  "es": "Yo sleep mal.",
+                  "dev": "DEV_I often have trouble sleeping."
+                },
+                "isRequired": true,
+                "choices": [
+                  {
+                    "value": "yes",
+                    "text": {
+                      "en": "Yes",
+                      "es": "Sí",
+                      "dev": "DEV_Yes"
+                    }
+                  },
+                  {
+                    "value": "no",
+                    "text": {
+                      "en": "No",
+                      "es": "No",
+                      "dev": "DEV_No"
+                    }
+                  }
+                ]
               }
             ]
+          },
+          {
+            "type": "html",
+            "name": "notLoggedIn",
+            "visibleIf": "{user.username} empty",
+            "html": "You must be logged in to join this study. <br/><br/> If you already have joined the OurHealth study, please log in now. <br/><br/> Otherwise, please use the 'Join' link above to join the main study."
           }
         ]
       }
@@ -66,6 +73,10 @@
         "name": "qualified",
         "expression": "{sleep_troubleSleeping} = 'yes'",
         "includeIntoResult": true
+      },
+      {
+        "name": "removeCompleteButton",
+        "expression": "{user.username} empty"
       }
     ]
   }

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/surveys/sleepConsent.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/surveys/sleepConsent.json
@@ -1,0 +1,203 @@
+{
+  "name": "Sleep Consent",
+  "stableId": "sleepConsent",
+  "surveyType": "CONSENT",
+  "version": 1,
+  "jsonContent":
+  {
+    "title": {
+      "en": "Sleep Consent",
+      "es": "Consentimiento OurHealth",
+      "dev": "DEV_Sleep Consent"
+    },
+    "logoPosition": "right",
+    "showQuestionNumbers": "off",
+    "showProgressBar": "bottom",
+    "calculatedValues": [
+      {
+        "name": "sleep_signatureDate",
+        "expression": "iif({sleep_signatureDate}, {sleep_signatureDate}, currentDate())",
+        "includeIntoResult": true
+      },
+      {
+        "name": "sleep_formattedSignatureDate",
+        "expression": "formatDate({sleep_signatureDate})",
+        "includeIntoResult": true
+      }
+    ],
+    "pages": [
+      {
+        "name": "infoPage",
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "mgbLogo",
+                "html": {
+                  "en": "<img alt='Mass General Brigham logo' src='/api/public/portals/v1/demo/env/{portalEnvironmentName}/siteMedia/1/mgb_logo.svg' style='margin-top:2rem' />",
+                  "es": "<img alt='Logotipo de Mass General Brigham' src='/api/public/portals/v1/demo/env/{portalEnvironmentName}/siteMedia/1/mgb_logo.svg' style='margin-top:2rem' />",
+                  "dev": "<img alt='DEV_Mass General Brigham logo' src='/api/public/portals/v1/demo/env/{portalEnvironmentName}/siteMedia/1/mgb_logo.svg' style='margin-top:2rem' />"
+                }
+              },
+              {
+                "type": "html",
+                "name": "consentInfo1",
+                "html": {
+                  "en": "<h1 class='mt-4'>Sleep Research Consent Form<br><span class='h6'>Collection of Samples and Health Information for Research</span></h1><p><span class='fw-bold'>Research Tissue Bank</span> <span class='fw-bold'>Version</span>: February 2022</p><dl class='p-3 border border-dark'><div><dt class='d-inline'>Protocol Title: </dt><dd class='d-inline'>OurHealth</dd></div><div><dt class='d-inline'>Principal Investigator: </dt><dd class='d-inline'>Pradeep Natarajan, MD, MMSc</dd></div><div><dt class='d-inline'>Broad Institute Responsible Investigator: </dt><dd class='d-inline'>Pradeep Natarajan, MD, MMSc</dd></div><div><dt class='d-inline'>Description of Subject Population: </dt><dd class='d-inline'>South Asian individuals living in United States</dd></div></dl>",
+                  "es": "<h1 class='mt-4'>Formulario de consentimiento para investigación<br><span class='h6'>Recolección de muestras e información de salud para investigación</span></h1><p><span class='fw -bold'>Banco de Tejidos de Investigación</span> <span class='fw-bold'>Versión</span>: febrero de 2022</p><dl class='p-3 border border-dark'><div> <dt class='d-inline'>Título del protocolo: </dt><dd class='d-inline'>Nuestra Salud</dd></div><div><dt class='d-inline'>Principal Investigador: </dt><dd class='d-inline'>Pradeep Natarajan, MD, MMSc</dd></div><div><dt class='d-inline'>Investigador responsable del Broad Institute: </ dt><dd class='d-inline'>Pradeep Natarajan, MD, MMSc</dd></div><div><dt class='d-inline'>Descripción de la población sujeta: </dt><dd class='d-inline'>Individuos del sur de Asia que viven en Estados Unidos</dd></div></dl>",
+                  "dev": "<h1 class='mt-4'>DEV_Research Consent Form<br><span class='h6'>Collection of Samples and Health Information for Research</span></h1><p><span class='fw-bold'>Research Tissue Bank</span> <span class='fw-bold'>Version</span>: February 2022</p><dl class='p-3 border border-dark'><div><dt class='d-inline'>Protocol Title: </dt><dd class='d-inline'>OurHealth</dd></div><div><dt class='d-inline'>Principal Investigator: </dt><dd class='d-inline'>Pradeep Natarajan, MD, MMSc</dd></div><div><dt class='d-inline'>Broad Institute Responsible Investigator: </dt><dd class='d-inline'>Pradeep Natarajan, MD, MMSc</dd></div><div><dt class='d-inline'>Description of Subject Population: </dt><dd class='d-inline'>South Asian individuals living in United States</dd></div></dl>"
+                }
+              },
+              {
+                "type": "html",
+                "name": "aboutThisForm",
+                "html": {
+                  "en": "<h2 class='my-4'>About this consent form</h2><p>Please read this form carefully and click “Next” when you are done to move on to the next section.</p><p>This form tells you important information about the collection and storage of samples for research. If you have questions about this study or the consent form at any time, please contact the OurHealth staff at <a href='tel:6177241240'>617-724-1240</a> or by email at <a href='mailto:info@ourhealthstudy.org'>info@ourhealthstudy.org</a>. If you decide to take part in this research study, you must sign this form, by typing and signing your name, to give your permission. We will email you a link to download a signed copy of this form to keep.</p>",
+                  "es": "<h2 class='my-4'>Acerca de este formulario de consentimiento</h2><p>Lea este formulario detenidamente y haga clic en “Siguiente”, cuando haya terminado para pasar a la siguiente sección.</p><p >Este formulario le brinda información importante sobre la recolección y el almacenamiento de muestras para la investigación. Si tiene preguntas sobre este estudio o el formulario de consentimiento en cualquier momento, comuníquese con el personal de OurHealth al <a href='tel:6177241240'>617- 724-1240</a> o por correo electrónico a <a href='mailto:info@ourhealthstudy.org'>info@ourhealthstudy.org</a>. Si decide participar en este estudio de investigación, debe firmar este formulario, escribiendo y firmando su nombre, para dar su permiso. Le enviaremos por correo electrónico un enlace para descargar una copia firmada de este formulario para conservarla.</p>",
+                  "dev": "<h2 class='my-4'>DEV_About this consent form</h2><p>Please read this form carefully and click “Next” when you are done to move on to the next section.</p><p>This form tells you important information about the collection and storage of samples for research. If you have questions about this study or the consent form at any time, please contact the OurHealth staff at <a href='tel:6177241240'>617-724-1240</a> or by email at <a href='mailto:info@ourhealthstudy.org'>info@ourhealthstudy.org</a>. If you decide to take part in this research study, you must sign this form, by typing and signing your name, to give your permission. We will email you a link to download a signed copy of this form to keep.</p>"
+                }
+              },
+              {
+                "type": "html",
+                "name": "keyPoints",
+                "html": {
+                  "en": "<h2 class='my-4'>Key Points</h2><p>We are asking you to be in this sleep study because researchers at Mass General Brigham (Massachusetts General Hospital, Brigham & Women’s Hospital, and other Mass General Brigham institutions) are studying how genes and other factors affect the health of South Asians. To perform this research, we are asking you to provide your contact information, complete surveys, and provide a saliva sample to be stored for research purposes, including genetic testing.</p><p>The Broad Institute of MIT and Harvard’s Data Donation Platform (DDP), also known as Juniper, is the web-based participant platform being used by subjects to review, sign (by typing your name) the consent, and complete the surveys.</p><p>Taking part in this research study is voluntary. Your decision whether or not to participate <strong style='font-weight:normal;text-decoration:underline;'>will not affect your ability to get clinical care in any way</strong>. You may not directly benefit from participating in this study; however, your participation may help us better understand, treat, and even prevent diseases that may affect you, your family, and your community in the future.</p><p>The OurHealth staff is available at <a href='tel:6177241240'>617-724-1240</a> from Monday to Friday 9am – 5pm to assist with questions. You can also email the OurHealth staff at <a href='mailto:info@ourhealthstudy.org'>info@ourhealthstudy.org</a>. Pradeep Natarajan, MD, MMSc is the person in charge of this research study.</p><p>If you want to speak with someone not directly involved in this research study, please contact the Mass General Brigham internal review board (IRB). You can call them at <a href='tel:8572821900'>857-282-1900</a>. You can talk to them about your rights as a research subject, your concerns about the research, a complaint about the research, or any complaints about pressure to take part in or to continue in the research study.</p>",
+                  "dev": "<h2 class='my-4'>DEV_Key Points</h2><p>DEV_We are asking you to be in this study because researchers at Mass General Brigham (Massachusetts General Hospital, Brigham & Women’s Hospital, and other Mass General Brigham institutions) are studying how genes and other factors affect the health of South Asians. To perform this research, we are asking you to provide your contact information, complete surveys, and provide a saliva sample to be stored for research purposes, including genetic testing.</p><p>The Broad Institute of MIT and Harvard’s Data Donation Platform (DDP), also known as Juniper, is the web-based participant platform being used by subjects to review, sign (by typing your name) the consent, and complete the surveys.</p><p>Taking part in this research study is voluntary. Your decision whether or not to participate <strong style='font-weight:normal;text-decoration:underline;'>will not affect your ability to get clinical care in any way</strong>. You may not directly benefit from participating in this study; however, your participation may help us better understand, treat, and even prevent diseases that may affect you, your family, and your community in the future.</p><p>The OurHealth staff is available at <a href='tel:6177241240'>617-724-1240</a> from Monday to Friday 9am – 5pm to assist with questions. You can also email the OurHealth staff at <a href='mailto:info@ourhealthstudy.org'>info@ourhealthstudy.org</a>. Pradeep Natarajan, MD, MMSc is the person in charge of this research study.</p><p>If you want to speak with someone not directly involved in this research study, please contact the Mass General Brigham internal review board (IRB). You can call them at <a href='tel:8572821900'>857-282-1900</a>. You can talk to them about your rights as a research subject, your concerns about the research, a complaint about the research, or any complaints about pressure to take part in or to continue in the research study.</p>",
+                  "es": "<h2 class='my-4'>Puntos clave</h2><p>Le pedimos que participe en este estudio porque los investigadores del Mass General Brigham (Hospital General de Massachusetts, el Hospital Brigham & Women's y otros hospitales de Mass General Brigham) instituciones) están estudiando cómo los genes y otros factores afectan la salud de los asiáticos del sur. Para realizar esta investigación, le pedimos que proporcione su información de contacto, complete encuestas y proporcione una muestra de saliva para almacenarla con fines de investigación, incluidas pruebas genéticas. </p><p>El Broad Institute del MIT y la Plataforma de Donación de Datos (DDP) de Harvard, también conocida como Juniper, es la plataforma de participación basada en la web que utilizan los sujetos para revisar, firmar (escribiendo su nombre) el consentimiento, y complete las encuestas.</p><p>Participar en este estudio de investigación es voluntario. Su decisión de participar o no <strong style='font-weight:normal;text-decoration:underline;'>no afectará su capacidad para recibir atención clínica de cualquier manera</strong>. Es posible que no se beneficie directamente de participar en este estudio; sin embargo, su participación puede ayudarnos a comprender, tratar e incluso prevenir mejor enfermedades que puedan afectarlo a usted, a su familia y a su comunidad en el futuro.</p><p>El personal de OurHealth está disponible en <a href='tel :6177241240'>617-724-1240</a> de lunes a viernes de 9 a. m. a 5 p. m. para ayudar con sus preguntas. También puede enviar un correo electrónico al personal de OurHealth a <a href='mailto:info@ourhealthstudy.org'>info@ourhealthstudy.org</a>. Pradeep Natarajan, MD, MMSc es la persona a cargo de este estudio de investigación.</p><p>Si desea hablar con alguien que no esté directamente involucrado en este estudio de investigación, comuníquese con la junta de revisión interna (IRB) de Mass General Brigham. . Puede llamarlos al <a href='tel:8572821900'>857-282-1900</a>. Puede hablar con ellos sobre sus derechos como sujeto de investigación, sus inquietudes sobre la investigación, una queja sobre la investigación o cualquier queja sobre presión para participar o continuar en el estudio de investigación.</p>"
+                }
+              },
+              {
+                "type": "html",
+                "name": "whatWillHappenIfYouTakePart",
+                "html": {
+                  "en": "<h2 class='my-4'>What will happen if you take part in this research sample biobank?</h2><ul><li>We will ask you if you have ever been a past or current patient within the Mass General Brigham system. If yes, we will look at your electronic health records now and, in the future, to update your health information (i.e., procedures, office visits, test results). A notation that you are taking part in this research study may be made in your electronic health record.  If no, we may contact you in the future to ask if you would be willing to sign any additional forms or documents that some hospitals or centers may require in order to share your electronic health records with us.</li><li>We will ask you for your contact information and mailing address. We will also ask you to complete surveys about your health and the health of your family. Additional survey(s) may become available during this study that you can choose to complete.</li><li>We will likely ask you to provide a sample of saliva at home—if so, we will use the address you provided to mail you a kit with detailed instructions on how to provide a saliva sample. We will ask you to send the saliva sample to us in a pre-stamped package that we will provide. We will study the cells from your saliva sample, including the genes found in the cells. No additional procedures will be required.</li><li>We will store your health information with your sample in a secure study database.</li><li>We may re-contact you in the future to get additional information or to ask if you are interested in joining other research studies.</li><li>The National Institutes of Health (NIH) and other organizations have developed central data (information) banks that analyze, collect, and share the information and results of certain types of genetic studies. Some (controlled-access) central data banks may store your genetic and medical information and provide the de-identified information to qualified researchers to use for further research. Other (open-access) data banks have de-identified data that are publicly viewable by anyone with internet access. We may share your de-identified information with other qualified researchers and central data banks. Therefore, you are providing your consent to share your results with these special data banks and other researchers, and have your information used for future research studies, including studies that have not yet been designed, studies involving diseases, and/or studies that may be for commercial purposes (such as the development or approval of new drugs). Your information will be de-identified and labeled only with a code number before it will be sent to central banks and other researchers. Your name and other information that could readily identify you will not be shared with central banks or other researchers. We will never sell your readily identifiable information to anyone under any circumstances.</li></ul>",
+                  "dev": "<h2 class='my-4'>DEV_What will happen if you take part in this research sample biobank?</h2><ul><li>DEV_We will ask you if you have ever been a past or current patient within the Mass General Brigham system. If yes, we will look at your electronic health records now and, in the future, to update your health information (i.e., procedures, office visits, test results). A notation that you are taking part in this research study may be made in your electronic health record.  If no, we may contact you in the future to ask if you would be willing to sign any additional forms or documents that some hospitals or centers may require in order to share your electronic health records with us.</li><li>We will ask you for your contact information and mailing address. We will also ask you to complete surveys about your health and the health of your family. Additional survey(s) may become available during this study that you can choose to complete.</li><li>We will likely ask you to provide a sample of saliva at home—if so, we will use the address you provided to mail you a kit with detailed instructions on how to provide a saliva sample. We will ask you to send the saliva sample to us in a pre-stamped package that we will provide. We will study the cells from your saliva sample, including the genes found in the cells. No additional procedures will be required.</li><li>We will store your health information with your sample in a secure study database.</li><li>We may re-contact you in the future to get additional information or to ask if you are interested in joining other research studies.</li><li>The National Institutes of Health (NIH) and other organizations have developed central data (information) banks that analyze, collect, and share the information and results of certain types of genetic studies. Some (controlled-access) central data banks may store your genetic and medical information and provide the de-identified information to qualified researchers to use for further research. Other (open-access) data banks have de-identified data that are publicly viewable by anyone with internet access. We may share your de-identified information with other qualified researchers and central data banks. Therefore, you are providing your consent to share your results with these special data banks and other researchers, and have your information used for future research studies, including studies that have not yet been designed, studies involving diseases, and/or studies that may be for commercial purposes (such as the development or approval of new drugs). Your information will be de-identified and labeled only with a code number before it will be sent to central banks and other researchers. Your name and other information that could readily identify you will not be shared with central banks or other researchers. We will never sell your readily identifiable information to anyone under any circumstances.</li></ul>",
+                  "es": "<h2 class='my-4'>¿Qué pasará si participa en este biobanco de muestras de investigación?</h2><ul><li>Le preguntaremos si alguna vez ha sido paciente actual o pasado dentro del Sistema Mass General Brigham. En caso afirmativo, revisaremos sus registros médicos electrónicos ahora y, en el futuro, actualizaremos su información médica (es decir, procedimientos, visitas al consultorio, resultados de pruebas). Una notación de que usted está participando en esta investigación. Se puede realizar un estudio en su registro médico electrónico. De lo contrario, es posible que nos comuniquemos con usted en el futuro para preguntarle si estaría dispuesto a firmar algún formulario o documento adicional que algunos hospitales o centros puedan requerir para compartir sus registros médicos electrónicos con nosotros.</li><li>Le pediremos su información de contacto y dirección postal. También le pediremos que complete encuestas sobre su salud y la salud de su familia. Es posible que haya encuestas adicionales disponibles durante este estudio. que puede elegir completar.</li><li>Probablemente le pediremos que proporcione una muestra de saliva en casa; de ser así, usaremos la dirección que proporcionó para enviarle por correo un kit con instrucciones detalladas sobre cómo proporcionar una muestra de saliva. Le pediremos que nos envíe la muestra de saliva en un paquete presellado que le proporcionaremos. Estudiaremos las células de su muestra de saliva, incluidos los genes que se encuentran en las células. No se requerirán procedimientos adicionales.</li><li>Almacenaremos su información de salud con su muestra en una base de datos segura del estudio.</li><li>Podemos volver a comunicarnos con usted en el futuro para obtener información adicional o para preguntar si está interesado en participar en otros estudios de investigación.</li><li>Los Institutos Nacionales de Salud (NIH) y otras organizaciones han desarrollado bancos centrales de datos (información) que analizan, recopilan y comparten la información y los resultados de ciertos tipos de estudios genéticos. Algunos bancos de datos centrales (de acceso controlado) pueden almacenar su información genética y médica y proporcionar la información no identificada a investigadores calificados para que la utilicen en futuras investigaciones. Otros bancos de datos (de acceso abierto) tienen datos anonimizados que cualquier persona con acceso a Internet puede ver públicamente. Podemos compartir su información no identificada con otros investigadores calificados y bancos de datos centrales. Por lo tanto, usted brinda su consentimiento para compartir sus resultados con estos bancos de datos especiales y otros investigadores, y que su información se utilice para futuros estudios de investigación, incluidos estudios que aún no se han diseñado, estudios que involucran enfermedades y/o estudios que puedan ser con fines comerciales (como el desarrollo o aprobación de nuevos medicamentos). Su información será anonimizada y etiquetada únicamente con un número de código antes de ser enviada a los bancos centrales y otros investigadores. Su nombre y otra información que pueda identificarlo fácilmente no se compartirá con los bancos centrales ni con otros investigadores. Nunca venderemos su información fácilmente identificable a nadie bajo ninguna circunstancia.</li></ul>"
+                }
+              },
+              {
+                "type": "html",
+                "name": "whatAreTheCosts",
+                "html": "<h2 class='my-4'>What are the costs to me to take part in the research tissue bank?</h2><p>There are no costs to participate in OurHealth.</p>"
+              },
+              {
+                "type": "html",
+                "name": "howWillPrivacyBeProtected",
+                "html": "<h2 class='my-4'>If you take part in this research study, how will we protect your privacy?</h2><p>Federal law requires Mass General Brigham to protect the privacy of health information and related information that identifies you. We refer to this information simply as “identifiable information.” The same federal laws that protect your health information will protect your research information.</p><p>In addition to Mass General Brigham researchers listed on this IRB application, the following people or groups may be able to see, use, and share your identifiable health information from the research:</p><ul><li>The Mass General Brigham IRB that oversees the project and the Mass General Brigham research quality improvement programs.</li><li>People from organizations that provide independent accreditation and oversight of hospitals and research.</li><li>People or organizations that we hire to do work for us, such as data storage companies, insurers, and lawyers, Federal and state agencies (such as the Food and Drug Administration, the Department of Health and Human Services, the National Institutes of Health, and other US or foreign government bodies that oversee or review research).</li></ul><p>We share your identifiable health information only when we must, and we ask anyone who receives it from us to protect your privacy.</p>"
+              },
+              {
+                "type": "html",
+                "name": "privacyRights",
+                "html": "<h2 class='my-4'>Your Privacy Rights</h2><p>You have the right not to sign this form that allows us to use and share your health information for research; however, if you don’t sign it, you can’t take part in this research study.</p>"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "documentationOfConsentPage",
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "documentationOfConsent",
+                "html": "<h1 class='mb-4' style='margin-top:2rem;'>Documentation of Consent</h1><p>This is what I agree to:</p><ol><li>You can perform (or work with others to perform) genomic or molecular tests on my saliva sample and store the sample(s) until this research study is complete.</li><li>You can store the answers that I provide in study surveys until this research study is complete.</li><li>You can study and share the results of the genomic or molecular tests, survey responses, and my health information with established public databases (e.g., NIH data portals) and with other qualified researchers in a manner that does not include my name, or any other information that could be used to readily identify me, to be used by other qualified researchers to perform future research studies, including studies that have not yet been designed, studies for diseases other than cancer, and studies that may be for commercial purposes.</li><li>You can use the results of studying my saliva sample and my health information for future research studies, including studies that have not yet been designed, studies for any disease, and/or studies that may be for commercial purposes.</li><li>You can contact me in the future for reasons related to this research study.</li></ol>"
+              }
+            ]
+          },
+          {
+            "type": "radiogroup",
+            "name": "sleep_consent_agree",
+            "title": "Do you agree to the above?",
+            "titleLocation": "hidden",
+            "isRequired": true,
+            "choices": [
+              {
+                "value": "agree",
+                "text": "I agree"
+              },
+              {
+                "value": "doNotAgree",
+                "text": "I do not agree"
+              }
+            ],
+            "validators": [{
+              "type": "expression",
+              "text": "You must agree in order to take part in the study.",
+              "expression": "{sleep_consent_agree} = 'agree'"
+            }]
+          },{
+            "type": "matrixdropdown",
+            "name": "initials",
+            "title": "Confirm consent",
+            "columns": [
+              {
+                "name": "initials",
+                "width": "15%"
+              }
+            ],
+            "cellType": "text",
+            "rows": [
+              {
+                "value": "withdraw",
+                "text": "I understand that my participation is voluntary and I am free to withdraw at any time"
+              },
+              {
+                "value": "samples",
+                "text": "I give permission for my saliva samples to be used to obtain DNA for use in this study"
+              },
+              {
+                "value": "contact",
+                "text": "I agree to be contacted by the research team to be invited to participate in future medical and health-related studies"
+              }
+            ],
+            "isRequired": true,
+            "description": "Please read the statements and enter your initials in the box to agree. "
+          }
+        ]
+      },
+      {
+        "name": "signaturePage",
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "statementOfPerson",
+                "html": "<h1 class='mb-4' style='margin-top:2rem;'>Statement of Person Giving Informed Consent and Authorization</h1><p>My full typed name below indicates:</p><ul><li>I have had enough time to read the consent and think about agreeing to participate in this study.</li><li>I have had all of my questions answered to my satisfaction.</li><li>I am willing to participate in this research study.</li><li>I have been told that my participation is voluntary and if I decide not to participate it will have no impact on my medical care.</li><li>I have been told that if I decide to participate now, I can decide to stop being in the study at any time. </li><li>I acknowledge that a copy of the signed consent form will be sent to my email address</li></ul>"
+              }
+            ]
+          },
+          {
+            "type": "text",
+            "isRequired": true,
+            "name": "sleep_consent_legalName",
+            "title": "Full legal name"
+          },
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "type": "html",
+                "name": "signatureDateDisplay",
+                "html": "<p style='padding-top:2rem;margin:0;'><span style='font-weight:600;'>Today's date</span>: {sleep_consent_formattedSignatureDate}.</p>"
+              }
+            ]
+          },
+          {
+            "type": "signaturepad",
+            "isRequired": true,
+            "name": "sleep_consent_signature",
+            "title": "Signature of Subject",
+            "description": "I give my consent to take part in this research study and agree to allow my health information to be used and shared as described above."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/surveys/sleepMain.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/surveys/sleepMain.json
@@ -1,0 +1,41 @@
+{
+  "stableId": "sleepMain",
+  "version": 1,
+  "name": "Sleep questionnaire",
+  "jsonContent": {
+    "title": {
+      "en": "Sleep",
+      "es": "El Sleep",
+      "dev": "DEV_Sleep"
+    },
+    "showQuestionNumbers": "off",
+    "showProgressBar": "bottom",
+    "pages": [
+      {
+        "elements": [
+          {
+            "type": "panel",
+            "elements": [
+              {
+                "name": "sleep_description",
+                "type": "html",
+                "html": "<p>The next set of questions asks about your Sleep.</p>"
+              }
+            ]
+          },
+          {
+            "name": "sleep_detail",
+            "type": "radiogroup",
+            "title": "How often in a given week do you stay up after midnight.",
+            "choices": [
+              {"text": "Not at all", "value": "notAtAll"},
+              {"text": "Several days", "value": "severalDays"},
+              {"text": "More than half the days", "value": "moreThanHalf"},
+              {"text": "Nearly every day", "value": "everyDay"}
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/PopulateDemoTest.java
@@ -7,6 +7,7 @@ import bio.terra.pearl.core.model.portal.Portal;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.publishing.PortalEnvironmentChangeRecord;
 import bio.terra.pearl.core.model.site.SiteContent;
+import bio.terra.pearl.core.model.study.PortalStudy;
 import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.survey.Answer;
@@ -48,9 +49,10 @@ public class PopulateDemoTest extends BasePopulatePortalsTest {
         baseSeedPopulator.populateKitTypes();
         Portal portal = portalPopulator.populate(new FilePopulateContext("portals/demo/portal.json"), true);
         Assertions.assertEquals("demo", portal.getShortcode());
-        PortalEnvironment sandbox = portalEnvironmentService.findOne("demo", EnvironmentName.sandbox).get();
-        assertThat(portal.getPortalStudies(), hasSize(1));
-        Study mainStudy = portal.getPortalStudies().stream().findFirst().get().getStudy();
+        assertThat(portal.getPortalStudies(), hasSize(2));
+        Study mainStudy = studyService.findByShortcode("heartdemo").get();
+        assertThat(portal.getPortalStudies().stream().map(PortalStudy::getStudyId)
+                .filter(id -> id.equals(mainStudy.getId())).count(), is(1L));
         List<StudyEnvironment> studyEnvs = studyEnvironmentService.findByStudy(mainStudy.getId());
         Assertions.assertEquals(3, studyEnvs.size());
         UUID sandboxEnvironmentId = studyEnvs.stream().filter(
@@ -239,17 +241,18 @@ public class PopulateDemoTest extends BasePopulatePortalsTest {
         baseSeedPopulator.populateKitTypes();
         Portal portal = portalPopulator.populate(new FilePopulateContext("portals/demo/portal.json", false, newShortcode), true);
         assertThat(portal.getShortcode(), equalTo(newShortcode));
-        Study mainStudy = portal.getPortalStudies().stream().findFirst().get().getStudy();
-        assertThat(mainStudy.getShortcode(), equalTo(newShortcode + "_heartdemo"));
+        Study mainStudy = studyService.findByShortcode(newShortcode + "_heartdemo").orElseThrow();
+        assertThat(portal.getPortalStudies().stream().map(PortalStudy::getStudyId)
+                .filter(id -> id.equals(mainStudy.getId())).count(), is(1L));
         List<Survey> surveys = surveyService.findByPortalId(portal.getId());
-        assertThat(surveys, hasSize(17));
+        assertThat(surveys, hasSize(20));
         List<SiteContent> siteContents = siteContentService.findByPortalId(portal.getId());
         assertThat(siteContents, hasSize(2));
         siteContents.forEach(siteContent -> {
             assertThat(siteContent.getStableId(), Matchers.startsWith(newShortcode));
         });
         List<EmailTemplate> emailTemplates = emailTemplateService.findByPortalId(portal.getId());
-        assertThat(emailTemplates, hasSize(13));
+        assertThat(emailTemplates, hasSize(17));
         emailTemplates.forEach(emailTemplate -> {
             assertThat(emailTemplate.getStableId(), Matchers.startsWith(newShortcode));
         });

--- a/populate/src/test/java/bio/terra/pearl/populate/extract/PortalExtractTest.java
+++ b/populate/src/test/java/bio/terra/pearl/populate/extract/PortalExtractTest.java
@@ -61,9 +61,9 @@ public class PortalExtractTest extends BasePopulatePortalsTest {
         assertThat(portalEnvironmentLanguageService.findByPortalEnvId(sandboxPortalEnv.getId()), hasSize(3));
 
         // confirm all templates got repopulated
-        assertThat(surveyService.findByPortalId(restoredPortal.getId()), hasSize(17));
-        assertThat(studyService.findByPortalId(restoredPortal.getId()), hasSize(1));
-        assertThat(emailTemplateService.findByPortalId(restoredPortal.getId()), hasSize(13));
+        assertThat(surveyService.findByPortalId(restoredPortal.getId()), hasSize(20));
+        assertThat(studyService.findByPortalId(restoredPortal.getId()), hasSize(2));
+        assertThat(emailTemplateService.findByPortalId(restoredPortal.getId()), hasSize(17));
         // confirm both the old and current versions of the site content got populated
 
         List<SiteContent> allSiteContent = siteContentService.findByPortalId(restoredPortal.getId()).stream().sorted(Comparator.comparing(SiteContent::getVersion, Comparator.reverseOrder())).toList();
@@ -76,7 +76,7 @@ public class PortalExtractTest extends BasePopulatePortalsTest {
                 equalTo(Set.of("en", "es", "dev")));
 
         // confirm the sandbox got configured
-        Study study = studyService.findByPortalId(restoredPortal.getId()).get(0);
+        Study study = studyService.findByShortcode("heartdemo").orElseThrow();
         StudyEnvironment sandboxEnv = studyEnvironmentService.findByStudy(study.getShortcode(), EnvironmentName.sandbox).orElseThrow();
         assertThat(triggerService.findByStudyEnvironmentId(sandboxEnv.getId()), hasSize(13));
         assertThat(studyEnvironmentKitTypeService.findKitTypesByStudyEnvironmentId(sandboxEnv.getId()), hasSize(2));

--- a/ui-core/src/components/forms/PagedSurveyView.tsx
+++ b/ui-core/src/components/forms/PagedSurveyView.tsx
@@ -22,7 +22,7 @@ import { SurveyReviewModeButton } from './ReviewModeButton'
 import { StudyEnvParams } from 'src/types/study'
 import {
   Enrollee,
-  HubResponse,
+  HubResponse, ParticipantUser,
   Profile
 } from 'src/types/user'
 import classNames from 'classnames'
@@ -47,6 +47,7 @@ export function PagedSurveyView({
   selectedLanguage,
   justification,
   setAutosaveStatus,
+  participantUser,
   enrollee,
   proxyProfile,
   adminUserId,
@@ -54,18 +55,24 @@ export function PagedSurveyView({
   onFailure,
   showHeaders = true
 }: {
-  studyEnvParams: StudyEnvParams, form: Survey, response: SurveyResponse, referencedAnswers?: Answer[],
-    updateResponseMap: (stableId: string, response: SurveyResponse) => void
-    onSuccess: () => void, onFailure: () => void,
-    selectedLanguage: string,
-    setAutosaveStatus: (status: AutosaveStatus) => void,
-    updateEnrollee: (enrollee: Enrollee, updateWithoutRerender?: boolean) => void,
-    updateProfile: (profile: Profile, updateWithoutRerender?: boolean) => void,
-    proxyProfile?: Profile,
-    justification?: string,
-    taskId: string,
-    setTaskId: (taskId: string) => void,
-    adminUserId: string | null, enrollee: Enrollee, showHeaders?: boolean,
+  studyEnvParams: StudyEnvParams,
+  form: Survey,
+  response: SurveyResponse,
+  referencedAnswers?: Answer[],
+  updateResponseMap: (stableId: string, response: SurveyResponse) => void
+  onSuccess: () => void, onFailure: () => void,
+  selectedLanguage: string,
+  setAutosaveStatus: (status: AutosaveStatus) => void,
+  updateEnrollee: (enrollee: Enrollee, updateWithoutRerender?: boolean) => void,
+  updateProfile: (profile: Profile, updateWithoutRerender?: boolean) => void,
+  proxyProfile?: Profile,
+  justification?: string,
+  taskId: string,
+  setTaskId: (taskId: string) => void,
+  adminUserId: string | null,
+  enrollee: Enrollee,
+  participantUser?: ParticipantUser | null,
+  showHeaders?: boolean,
 }) {
   const resumableData = makeSurveyJsData(response?.resumeData, response?.answers, enrollee.participantUserId)
   // it's not entirely clear, but we cannot rely on the response object passed into
@@ -231,6 +238,7 @@ export function PagedSurveyView({
   const { surveyModel, refreshSurvey } = useSurveyJSModel(
     form, resumableData, onComplete, pager, {
       studyEnvParams,
+      user: participantUser,
       enrolleeShortcode: enrollee.shortcode,
       profile: enrollee.profile,
       proxyProfile,

--- a/ui-core/src/participant/ParticipantNavbar.tsx
+++ b/ui-core/src/participant/ParticipantNavbar.tsx
@@ -273,15 +273,16 @@ export const getJoinLink = (studyShortcode: string, opts?: { isProxyEnrollment?:
 }
 
 /** the default join link -- will be rendered in the top right corner */
-export const getMainJoinLink = (portalStudies: PortalStudy[], portalEnvConfig: PortalEnvironmentConfig) => {
+export const getMainJoinLink = (portalStudies: PortalStudy[], portalEnvConfig: PortalEnvironmentConfig,
+  isProxyEnrollment?: boolean) => {
   // if there's a primary study, link to it
   if (portalEnvConfig.primaryStudy) {
-    return getJoinLink(portalEnvConfig.primaryStudy)
+    return getJoinLink(portalEnvConfig.primaryStudy, { isProxyEnrollment })
   }
   const joinable = filterUnjoinableStudies(portalStudies)
   /** if there's only one joinable study, link directly to it */
   const joinPath = joinable.length === 1
-    ? getJoinLink(joinable[0].study.shortcode)
+    ? getJoinLink(joinable[0].study.shortcode, { isProxyEnrollment })
     : '/join'
   return joinPath
 }

--- a/ui-core/src/surveyUtils.tsx
+++ b/ui-core/src/surveyUtils.tsx
@@ -440,6 +440,14 @@ export function useSurveyJSModel(
         newSurveyModel.showCompleteButton = !valAsBool
       }
     })
+    newSurveyModel.onAfterRenderSurvey.add((_model, event) => {
+      event.survey.calculatedValues.forEach(val => {
+        const valAsBool = isString(val.value) ? val.value === 'true' : !!val.value
+        if (val.name.toLowerCase() === 'removecompletebutton' && valAsBool) {
+          newSurveyModel.showCompleteButton = false
+        }
+      })
+    })
 
     if (readonly) {
       newSurveyModel.mode = 'display'

--- a/ui-core/src/surveyUtils.tsx
+++ b/ui-core/src/surveyUtils.tsx
@@ -37,7 +37,7 @@ import { useI18n } from './participant/I18nProvider'
 import { createAddressValidator } from './surveyjs/address-validator'
 import { useApiContext } from './participant/ApiProvider'
 import { OptionalStudyEnvParams } from './types/study'
-import { Profile } from 'src/types/user'
+import { ParticipantUser, Profile } from './types/user'
 import { DefaultLight } from 'survey-core/themes'
 
 export type SurveyJsResumeData = {
@@ -95,6 +95,7 @@ export const surveyJSModelFromFormContent = (formContent: FormContent): SurveyMo
 }
 
 export type SurveyJsVariableContext = {
+  user?: ParticipantUser | null,
   profile?: Profile,
   proxyProfile?: Profile,
   studyEnvParams?: OptionalStudyEnvParams,

--- a/ui-participant/src/hub/survey/SurveyView.tsx
+++ b/ui-participant/src/hub/survey/SurveyView.tsx
@@ -17,7 +17,7 @@ import {
   ApiProvider,
   Enrollee,
   EnvironmentName,
-  PagedSurveyView,
+  PagedSurveyView, SurveyResponse,
   useI18n,
   useTaskIdParam
 } from '@juniper/ui-core'
@@ -119,9 +119,10 @@ function SurveyView({ showHeaders = true }: { showHeaders?: boolean }) {
         studyEnvParams={studyEnvParams}
         form={formAndResponses.studyEnvironmentSurvey.survey}
         enrollee={enrollee}
+        participantUser={user}
         updateResponseMap={() => { /* no-op */ }}
         proxyProfile={proxyProfile}
-        response={formAndResponses.surveyResponse}
+        response={formAndResponses.surveyResponse as SurveyResponse}
         referencedAnswers={formAndResponses.referencedAnswers}
         selectedLanguage={selectedLanguage}
         setAutosaveStatus={() => { /* no-op */ }}

--- a/ui-participant/src/participant/ParticipantSelector.tsx
+++ b/ui-participant/src/participant/ParticipantSelector.tsx
@@ -6,8 +6,7 @@ import { faAngleDown, faPlus, faUser, faUsers } from '@fortawesome/free-solid-sv
 import { useName } from '../util/enrolleeUtils'
 import { Link } from 'react-router-dom'
 import { usePortalEnv } from '../providers/PortalProvider'
-import { findDefaultEnrollmentStudy } from '../login/RedirectFromOAuth'
-import { Enrollee, useI18n } from '@juniper/ui-core'
+import { Enrollee, getMainJoinLink, useI18n } from '@juniper/ui-core'
 import { sum } from 'lodash'
 import classNames from 'classnames'
 
@@ -23,11 +22,11 @@ export default function ParticipantSelector() {
 
   const activeUserName = useName(ppUser || undefined)
 
-  const { portal } = usePortalEnv()
+  const { portal, portalEnv } = usePortalEnv()
 
-  // in the future, this will need to be refactored to be multi-study compatible. possibly, it could
+  // in the future, this will need to be refactored to be truly multi-study compatible. possibly, it could
   // link to a separate page where you select the desired study to enroll in.
-  const defaultStudyToEnroll = findDefaultEnrollmentStudy(null, portal.portalStudies)
+  const joinLink = getMainJoinLink(portal.portalStudies, portalEnv.portalEnvironmentConfig, true)
 
   return (
     <div className="dropdown participant-selector">
@@ -64,11 +63,7 @@ export default function ParticipantSelector() {
         }
         <li>
           <Link className="dropdown-item"
-            to={
-              defaultStudyToEnroll
-                ? `/studies/${defaultStudyToEnroll.shortcode}/join?isProxyEnrollment=true`
-                : '#'
-            }>
+            to={joinLink}>
             <FontAwesomeIcon icon={faPlus}/>
             <span className='ms-2'>{i18n('addNewParticipant')}</span>
           </Link>

--- a/ui-participant/src/studies/enroll/PreEnroll.tsx
+++ b/ui-participant/src/studies/enroll/PreEnroll.tsx
@@ -61,7 +61,7 @@ export default function PreEnrollView({ enrollContext, survey }:
       studyEnvParams: { envName: studyEnv.environmentName, studyShortcode, portalShortcode },
       enrolleeShortcode: enrollee?.shortcode || '',
       referencedAnswers: [],
-      extraVariables: { isProxyEnrollment, isSubjectEnrollment }
+      extraVariables: { isProxyEnrollment, isSubjectEnrollment, user }
     },
     { extraCssClasses: { container: 'my-0' } }
   )


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds the user (ParticipantUser) to the survey variables that can be branched on.   Also updates the removeCompleteButton logic to handle if the expression was true at the beginning.  
<img width="603" height="271" alt="image" src="https://github.com/user-attachments/assets/11538752-ce0f-4097-8f11-4678da87a2eb" />


In order to test this (and also to support testing of other multi-study stuff), I've added a second "sleep" study to the demo.  I think this also correctly reflects that multi-study is now Juniper's main use case.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  repopulate demo
2.  go to https://sandbox.demo.localhost:3001/sleep -- make sure you are *not* signed in
3. click "Join sleep study"
4. Observe that you can't join, and the complete button does not appear
5. sign in as jsalk@test.com
6. click on the "Join Sleep study" again
7. confirm you see a one-question survey now
8. answer "yes"
9. hit submit
10. confirm you have enrolled in the sleep study