### PR TITLE
[JN-1735] fixing email editor width

### DIFF
--- a/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
+++ b/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
@@ -165,10 +165,12 @@ export default function EmailTemplateEditor({ emailTemplate, updateEmailTemplate
               key={localizedEmailTemplate.language}
               ref={emailEditorRef}
               onLoad={onEditorLoaded}
-              onReady={() => 1}
               options={{ tools: { image: { enabled: false } }, className: 'w-100' }}
-              style={{ maxWidth: '0px', width: '0px' }}
             />
+            <div className="fst-italic text-muted mx-5">
+              If the email editor does not appear here,
+              click &quot;Html&quot; above, then &quot;Designer&quot;
+            </div>
           </Tab>
           <Tab eventKey="html" title="Html">
             <textarea rows={20} cols={100} value={localizedEmailTemplate.body}


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

email editor was showing a half-width, and disappears if you click somewhere else first.

This fixes the width issue.  30mins of futzing with useMemo and onReady couldn't solve why it disappears, so I just added some help text below to recommend they toggle the tabs to restore the editor.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/triggers
2. confirm the email editor shows full-width