### PR TITLE
[JN-1739] set up trcc mx record

### DIFF
--- a/terraform/gcp/dns_customer.tf
+++ b/terraform/gcp/dns_customer.tf
@@ -90,7 +90,9 @@ resource "google_dns_record_set" "additional_customer_records" {
   }
 
   managed_zone = google_dns_managed_zone.customer_dns_zone[each.value.customer_key].name
-  name = "${each.value.name}.${google_dns_managed_zone.customer_dns_zone[each.value.customer_key].dns_name}"
+  name = (each.value.name == ""
+            ? google_dns_managed_zone.customer_dns_zone[each.value.customer_key].dns_name
+            : "${each.value.name}.${google_dns_managed_zone.customer_dns_zone[each.value.customer_key].dns_name}")
   type         = each.value.type
   rrdatas      = [each.value.record_value]
   ttl          = each.value.ttl

--- a/terraform/gcp/dns_customer.tf
+++ b/terraform/gcp/dns_customer.tf
@@ -81,19 +81,20 @@ resource "google_dns_record_set" "additional_customer_records" {
           for dns_record in dns_config.additional_records : {
             customer_key        = customer_key
             name   = dns_record.name
+            domain_prefix = dns_record.domain_prefix
             type   = dns_record.type
             ttl    = dns_record.ttl
-            record_value  = dns_record.record_value
+            record_values  = dns_record.record_values
         }
         ]
       ]) : "${item.customer_key}.${item.name}" => item # for_each expects maps, so convert the list of objects to a map
   }
 
   managed_zone = google_dns_managed_zone.customer_dns_zone[each.value.customer_key].name
-  name = (each.value.name == ""
+  name = (each.value.domain_prefix == ""
             ? google_dns_managed_zone.customer_dns_zone[each.value.customer_key].dns_name
-            : "${each.value.name}.${google_dns_managed_zone.customer_dns_zone[each.value.customer_key].dns_name}")
+            : "${each.value.domain_prefix}.${google_dns_managed_zone.customer_dns_zone[each.value.customer_key].dns_name}")
   type         = each.value.type
-  rrdatas      = [each.value.record_value]
+  rrdatas      = each.value.record_values
   ttl          = each.value.ttl
 }

--- a/terraform/gcp/envs/prod.tfvars
+++ b/terraform/gcp/envs/prod.tfvars
@@ -100,7 +100,14 @@ customer_urls = {
   trcc = {
     url    = "trccproject.org"
     dnssec = "off"
-    additional_records = []
+    additional_records = [
+      {
+        name = ""
+        type = "MX"
+        ttl = 3600
+        record_value = "smtp.google.com."
+      },
+    ]
   }
 }
 

--- a/terraform/gcp/envs/prod.tfvars
+++ b/terraform/gcp/envs/prod.tfvars
@@ -116,7 +116,7 @@ customer_urls = {
         domain_prefix = ""
         type = "MX"
         ttl = 3600
-        record_values = ["smtp.google.com."]
+        record_values = ["1 smtp.google.com."]
       },
     ]
   }

--- a/terraform/gcp/envs/prod.tfvars
+++ b/terraform/gcp/envs/prod.tfvars
@@ -26,39 +26,45 @@ customer_urls = {
     additional_records = [
       {
         name = "s1._domainkey"
+        domain_prefix = "s1._domainkey"
         type = "CNAME"
         ttl = 3600
-        record_value = "s1.domainkey.u33588015.wl016.sendgrid.net."
+        record_values = ["s1.domainkey.u33588015.wl016.sendgrid.net."]
       },
       {
         name = "s2._domainkey"
+        domain_prefix = "s2._domainkey"
         type = "CNAME"
         ttl = 3600
-        record_value = "s2.domainkey.u33588015.wl016.sendgrid.net."
+        record_values = ["s2.domainkey.u33588015.wl016.sendgrid.net."]
       },
       {
         name = "em6454"
+        domain_prefix = "em6454"
         type = "CNAME"
         ttl = 3600
-        record_value = "u33588015.wl016.sendgrid.net."
+        record_values = ["u33588015.wl016.sendgrid.net."]
       },
       {
         name = "url9076"
+        domain_prefix = "url9076"
         type = "CNAME"
         ttl = 3600
-        record_value = "sendgrid.net."
+        record_values = ["sendgrid.net."]
       },
       {
         name = "_dmarc"
+        domain_prefix = "_dmarc"
         type = "TXT"
         ttl = 3600
-        record_value = "v=DMARC1; p=none;"
+        record_values = ["v=DMARC1;p=none;"]
       },
       {
         name = "33588015"
+        domain_prefix = "33588015"
         type = "CNAME"
         ttl = 3600
-        record_value = "sendgrid.net."
+        record_values = ["sendgrid.net."]
       }
     ]
   }
@@ -68,27 +74,31 @@ customer_urls = {
     additional_records = [
       {
         name = "s1._domainkey"
+        domain_prefix = "s1._domainkey"
         type = "CNAME"
         ttl = 3600
-        record_value = "s1.domainkey.u33588015.wl016.sendgrid.net."
+        record_values = ["s1.domainkey.u33588015.wl016.sendgrid.net."]
       },
       {
         name = "s2._domainkey"
+        domain_prefix = "s2._domainkey"
         type = "CNAME"
         ttl = 3600
-        record_value = "s2.domainkey.u33588015.wl016.sendgrid.net."
+        record_values = ["s2.domainkey.u33588015.wl016.sendgrid.net."]
       },
       {
         name = "em1287"
+        domain_prefix = "em1287"
         type = "CNAME"
         ttl = 3600
-        record_value = "u33588015.wl016.sendgrid.net."
+        record_values = ["u33588015.wl016.sendgrid.net."]
       },
       {
         name = "em1800"
+        domain_prefix = "em1800"
         type = "CNAME"
         ttl = 3600
-        record_value = "u32431094.wl095.sendgrid.net."
+        record_values = ["u32431094.wl095.sendgrid.net."]
       }
     ]
   }
@@ -102,10 +112,11 @@ customer_urls = {
     dnssec = "off"
     additional_records = [
       {
-        name = ""
+        name = "mx_record"
+        domain_prefix = ""
         type = "MX"
         ttl = 3600
-        record_value = "smtp.google.com."
+        record_values = ["smtp.google.com."]
       },
     ]
   }

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -64,9 +64,10 @@ variable "customer_urls" {
     dnssec = string
     additional_records = list(object({
       name = string
+      domain_prefix = string
       type = string
       ttl = number
-      record_value = string
+      record_values = list(string)
     }))
   }))
   description = "Customer URLs"


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Steps to use google workspace as email server:
1. [Add this MX record](https://support.google.com/a/answer/16004259?hl=en&visit_id=638913916007568377-1824030626&rd=1#priorities)
2. Create BITS ticket
3. [BITS will give us TXT record used for authorizing the Broad workspace to this domain](https://support.google.com/a/answer/16018515)
4. We add it to the domain
5. BITS handles it from there


Before this ticket, you can't have 2 additional records on the same subdomain; the key of the record in terraform _was_ the subdomain. Since the MX and TXT records need to both be on the root domain, this wouldn't have worked; refactors a bit to separate domain prefix / terraform key.

Also, theoretically fixes the hearthive issues; removes space, which [should work](https://www.mailhardener.com/blog/how-to-enter-txt-values-in-google-cloud-dns).

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*


