### PR TITLE
[JN-1740] Adding study eligibility rule

### DIFF
--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/enrollment/EnrollmentController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/enrollment/EnrollmentController.java
@@ -6,11 +6,15 @@ import bio.terra.pearl.api.participant.service.EnrollmentExtService;
 import bio.terra.pearl.api.participant.service.RequestUtilService;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
+import bio.terra.pearl.core.model.study.StudyEnvironmentConfig;
 import bio.terra.pearl.core.model.workflow.HubResponse;
 import bio.terra.pearl.core.service.portal.PortalWithPortalUser;
+import bio.terra.pearl.core.service.study.StudyEnvironmentConfigService;
 import bio.terra.pearl.core.service.workflow.EnrollmentService;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
@@ -21,18 +25,21 @@ public class EnrollmentController implements EnrollmentApi {
   private final HttpServletRequest request;
   private final AuthUtilService authUtilService;
   private final EnrollmentExtService enrollmentExtService;
+  private final StudyEnvironmentConfigService studyEnvironmentConfigService;
 
   public EnrollmentController(
       EnrollmentService enrollmentService,
       RequestUtilService requestUtilService,
       HttpServletRequest request,
       AuthUtilService authUtilService,
-      EnrollmentExtService enrollmentExtService) {
+      EnrollmentExtService enrollmentExtService,
+      StudyEnvironmentConfigService studyEnvironmentConfigService) {
     this.enrollmentService = enrollmentService;
     this.requestUtilService = requestUtilService;
     this.request = request;
     this.authUtilService = authUtilService;
     this.enrollmentExtService = enrollmentExtService;
+    this.studyEnvironmentConfigService = studyEnvironmentConfigService;
   }
 
   @Override
@@ -72,5 +79,25 @@ public class EnrollmentController implements EnrollmentApi {
             governedPpUserId);
 
     return ResponseEntity.ok(response);
+  }
+
+  @Override
+  public ResponseEntity<Object> checkEligible(
+      String portalShortcode, String envName, String studyShortcode) {
+    ParticipantUser user = requestUtilService.requireUser(request);
+    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
+    PortalWithPortalUser portalWithPortalUser =
+        authUtilService.authParticipantToPortal(user.getId(), portalShortcode, environmentName);
+    StudyEnvironmentConfig config =
+        studyEnvironmentConfigService.findByStudyShortcode(studyShortcode, environmentName);
+    boolean isEligible =
+        enrollmentService.isEligibleForStudy(user, portalWithPortalUser.ppUser(), config);
+    return ResponseEntity.ok(new EligibilityResponse(isEligible));
+  }
+
+  @Getter
+  @AllArgsConstructor
+  class EligibilityResponse {
+    boolean eligible;
   }
 }

--- a/api-participant/src/main/resources/api/openapi.yml
+++ b/api-participant/src/main/resources/api/openapi.yml
@@ -303,6 +303,21 @@ paths:
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/env/{envName}/studies/{studyShortcode}/checkEligible:
+    get:
+      summary: Checks whether the signed-in user is eligible for the given study
+      tags: [ enrollment ]
+      operationId: checkEligible
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: envName, in: path, required: true, schema: { type: string } }
+        - { name: studyShortcode, in: path, required: true, schema: { type: string } }
+      responses:
+        '200':
+          description: object with 'eligible' boolean
+          content: { application/json: { schema: { type: object } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/env/{envName}/studies/{studyShortcode}/governedUser:
     post:
       summary:

--- a/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalEnvironmentDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/portal/PortalEnvironmentDao.java
@@ -54,6 +54,10 @@ public class PortalEnvironmentDao extends BaseMutableJdbiDao<PortalEnvironment> 
         );
     }
 
+    public Optional<PortalEnvironment> findOne(UUID portalId, EnvironmentName environmentName) {
+        return findByTwoProperties("portal_id", portalId, "environment_name", environmentName);
+    }
+
     /** load with everything needed to display the participant-facing site */
     public Optional<PortalEnvironment> loadWithSiteContent(String shortcode,
                                                                       EnvironmentName environmentName,

--- a/core/src/main/java/bio/terra/pearl/core/dao/survey/AnswerDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/survey/AnswerDao.java
@@ -88,7 +88,7 @@ public class AnswerDao extends BaseMutableJdbiDao<Answer> {
         );
     }
 
-    public Optional<Answer> findByProfileIdStudyAndQuestion(UUID profileId, String studyName, String surveyStableId, String questionStableId) {
+    public Optional<Answer> findByProfileIdStudyAndQuestion(UUID profileId, String studyShortcode, String surveyStableId, String questionStableId) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("""
                                 select a.* from %s a
@@ -96,14 +96,14 @@ public class AnswerDao extends BaseMutableJdbiDao<Answer> {
                                 inner join study_environment se on se.id = e.study_environment_id
                                 inner join study s on s.id = se.study_id
                                 where e.profile_id = :profileId
-                                and s.name = :studyName
+                                and s.shortcode = :studyShortcode
                                 and a.survey_stable_id = :surveyStableId
                                 and a.question_stable_id = :questionStableId
                                 order by last_updated_at
                                 desc limit 1
                                 """.formatted(tableName))
                         .bind("profileId", profileId)
-                        .bind("studyName", studyName)
+                        .bind("studyShortcode", studyShortcode)
                         .bind("surveyStableId", surveyStableId)
                         .bind("questionStableId", questionStableId)
                         .mapTo(clazz)

--- a/core/src/main/java/bio/terra/pearl/core/model/study/StudyEnvironmentConfig.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/study/StudyEnvironmentConfig.java
@@ -51,13 +51,14 @@ public class StudyEnvironmentConfig extends BaseEntity {
     @Builder.Default
     private boolean enableInPersonKits = false;
 
+    /**
      * if true, send the participant's sex at birth to DSM/BSP based on their
      * profile. likely, this setting should be per-kit-type, but this would be
      * a decent lift and a rare need, so, for now, it's a global study env setting.
      */
     @Builder.Default
     private boolean includeSexAtBirthInKitMetadata = false;
-  
+
     /**
      * enrollee search expression used to study eligibility.
      * if not specified, allow anyone with a portal account to join

--- a/core/src/main/java/bio/terra/pearl/core/model/study/StudyEnvironmentConfig.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/study/StudyEnvironmentConfig.java
@@ -52,6 +52,13 @@ public class StudyEnvironmentConfig extends BaseEntity {
     private boolean enableInPersonKits = false;
 
     /**
+     * enrollee search expression used to study eligibility.
+     * if not specified, allow anyone with a portal account to join
+     */
+    @Builder.Default
+    private String studyEligibilityRule = null;
+
+    /**
      * enrollee search expression used to determine kit eligibility.
      * if not specified, enrollees are eligible if they have completed all required surveys.
      * note: this eligibility rule is not verified by the backend; it is only used as a frontend filter.

--- a/core/src/main/java/bio/terra/pearl/core/service/portal/PortalEnvironmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/portal/PortalEnvironmentService.java
@@ -77,6 +77,10 @@ public class PortalEnvironmentService extends CrudService<PortalEnvironment, Por
         return dao.findOne(portalShortcode, environmentName);
     }
 
+    public Optional<PortalEnvironment> findOne(UUID portalId, EnvironmentName environmentName) {
+        return dao.findOne(portalId, environmentName);
+    }
+
     /** loads a portal environment with everything needed to render the participant-facing site */
     public Optional<PortalEnvironment> loadWithParticipantSiteContent(String portalShortcode,
                                                                        EnvironmentName environmentName,

--- a/core/src/main/java/bio/terra/pearl/core/service/rule/EnrolleeContext.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/rule/EnrolleeContext.java
@@ -19,4 +19,9 @@ public class EnrolleeContext {
     private final Profile profile; // profile is assumed to have the mailing address attached
     private final ParticipantUser participantUser;
     private final List<EnrolleeRelation> relations;
+
+    /** helper function to harmonize this with EnrolleeSearchExpressions */
+    public ParticipantUser getUser() {
+        return participantUser;
+    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/AnswerTerm.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/AnswerTerm.java
@@ -18,17 +18,17 @@ import static org.jooq.impl.DSL.condition;
  * this term requires a SQL call to the database per enrollee and as such could be slow for a large list of enrollees.
  */
 public class AnswerTerm extends SearchTerm {
-    private final String studyName;
+    private final String studyShortcode;
     private final String questionStableId;
     private final String surveyStableId;
     private final AnswerDao answerDao;
 
-    public AnswerTerm(AnswerDao answerDao, String studyName, String surveyStableId, String questionStableId) {
-        if (!isAlphaNumeric(questionStableId) || !isAlphaNumeric(surveyStableId) || !isAlphaNumeric(studyName)) {
+    public AnswerTerm(AnswerDao answerDao, String studyShortcode, String surveyStableId, String questionStableId) {
+        if (!isAlphaNumeric(questionStableId) || !isAlphaNumeric(surveyStableId) || !isAlphaNumeric(studyShortcode)) {
             throw new IllegalArgumentException("Invalid stable ids: must be alphanumeric and underscore only");
         }
 
-        this.studyName = studyName;
+        this.studyShortcode = studyShortcode;
         this.questionStableId = questionStableId;
         this.surveyStableId = surveyStableId;
         this.answerDao = answerDao;
@@ -41,9 +41,9 @@ public class AnswerTerm extends SearchTerm {
     @Override
     public SearchValue extract(EnrolleeSearchContext context) {
         Optional<Answer> answerOpt =
-                this.studyName == null
+                this.studyShortcode == null
                         ? answerDao.findForEnrolleeByQuestion(context.getEnrollee().getId(), surveyStableId, questionStableId)
-                        : answerDao.findByProfileIdStudyAndQuestion(context.getEnrollee().getProfileId(), studyName, surveyStableId, questionStableId);
+                        : answerDao.findByProfileIdStudyAndQuestion(context.getEnrollee().getProfileId(), studyShortcode, surveyStableId, questionStableId);
         if (answerOpt.isEmpty()) {
             return new SearchValue();
         }
@@ -64,9 +64,9 @@ public class AnswerTerm extends SearchTerm {
     @Override
     public List<EnrolleeSearchQueryBuilder.JoinClause> requiredJoinClauses() {
 
-        if (Objects.nonNull(studyName)) {
+        if (Objects.nonNull(studyShortcode)) {
             List<EnrolleeSearchQueryBuilder.JoinClause> joinClauses = this
-                    .joinClausesForStudy(studyName);
+                    .joinClausesForStudy(studyShortcode);
 
             joinClauses.add(
                     /** CAREFUL! this raw inclusion of the stableIds in the query is only safe because they are validated in the constructor */
@@ -75,7 +75,7 @@ public class AnswerTerm extends SearchTerm {
                             and %s.survey_stable_id = '%s' \
                             and %s.question_stable_id = '%s'\
                             """.formatted(
-                            addStudySuffix("enrollee", studyName),
+                            addStudySuffix("enrollee", studyShortcode),
                             alias(), alias(),
                             surveyStableId, alias(), questionStableId))
             );
@@ -129,8 +129,8 @@ public class AnswerTerm extends SearchTerm {
     }
 
     private String alias() {
-        if (Objects.nonNull(studyName)) {
-            return "answer_" + studyName + "_" + questionStableId;
+        if (Objects.nonNull(studyShortcode)) {
+            return "answer_" + studyShortcode + "_" + questionStableId;
         }
 
         return "answer_" + questionStableId;

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/AnswerTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/AnswerTermParser.java
@@ -38,14 +38,14 @@ public class AnswerTermParser extends SearchTermParser<AnswerTerm> {
     }
 
     @Override
-    public AnswerTerm parse(String studyName, String variables) {
+    public AnswerTerm parse(String studyShortcode, String variables) {
         List<String> arguments = splitArguments(variables, 2);
 
         if (arguments.size() != 2) {
             throw new IllegalArgumentException("Answer terms must be in the format {answer.surveyStableId.questionStableId}. Instead, got: " + variables);
         }
 
-        return new AnswerTerm(answerDao, studyName, arguments.get(0), arguments.get(1));
+        return new AnswerTerm(answerDao, studyShortcode, arguments.get(0), arguments.get(1));
     }
 
     @Override

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/SearchTermParser.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/SearchTermParser.java
@@ -17,12 +17,12 @@ public abstract class SearchTermParser<T extends SearchTerm> {
         List<String> splitModelName = List.of(variableNoBraces.split("\\.", 2));
 
         String modelName = splitModelName.get(0);
-        String studyName = null;
+        String studyShortcode = null;
 
         if (modelName.contains("[")) {
             int startIndex = modelName.indexOf("[");
             int endIndex = modelName.indexOf("]");
-            studyName = modelName.substring(startIndex + 2, endIndex - 1);
+            studyShortcode = modelName.substring(startIndex + 2, endIndex - 1);
             modelName = modelName.substring(0, startIndex);
         }
 
@@ -32,10 +32,10 @@ public abstract class SearchTermParser<T extends SearchTerm> {
 
         String arguments = splitModelName.size() == 1 ? "" : splitModelName.get(1);
 
-        if (studyName == null) {
+        if (studyShortcode == null) {
             return this.parse(arguments);
         } else {
-            return this.parse(studyName, arguments);
+            return this.parse(studyShortcode, arguments);
         }
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/study/StudyEnvironmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/study/StudyEnvironmentService.java
@@ -7,10 +7,12 @@ import bio.terra.pearl.core.dao.survey.PreEnrollmentResponseDao;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.notification.Trigger;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
+import bio.terra.pearl.core.model.portal.PortalEnvironmentConfig;
 import bio.terra.pearl.core.model.publishing.ListChange;
 import bio.terra.pearl.core.model.publishing.StudyEnvironmentChange;
 import bio.terra.pearl.core.model.publishing.VersionedConfigChange;
 import bio.terra.pearl.core.model.publishing.VersionedEntityChange;
+import bio.terra.pearl.core.model.study.Study;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.study.StudyEnvironmentConfig;
 import bio.terra.pearl.core.model.survey.StudyEnvironmentSurvey;
@@ -26,6 +28,8 @@ import bio.terra.pearl.core.service.participant.EnrolleeRelationService;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.participant.FamilyEnrolleeService;
 import bio.terra.pearl.core.service.participant.FamilyService;
+import bio.terra.pearl.core.service.portal.PortalEnvironmentConfigService;
+import bio.terra.pearl.core.service.portal.PortalEnvironmentService;
 import bio.terra.pearl.core.service.publishing.PortalEnvPublishable;
 import bio.terra.pearl.core.service.publishing.PublishingUtils;
 import bio.terra.pearl.core.service.publishing.StudyEnvPublishable;
@@ -58,6 +62,9 @@ public class StudyEnvironmentService extends CrudService<StudyEnvironment, Study
     private final ImportService importService;
     private final ExportIntegrationService exportIntegrationService;
     private final SurveyService surveyService;
+    private final PortalEnvironmentConfigService portalEnvironmentConfigService;
+    private final PortalEnvironmentService portalEnvironmentService;
+    private final StudyService studyService;
 
 
     public StudyEnvironmentService(StudyEnvironmentDao studyEnvironmentDao,
@@ -72,7 +79,11 @@ public class StudyEnvironmentService extends CrudService<StudyEnvironment, Study
                                    FamilyEnrolleeService familyEnrolleeService,
                                    EnrolleeRelationService enrolleeRelationService,
                                    ParticipantDataChangeService participantDataChangeService,
-                                   @Lazy ExportIntegrationService exportIntegrationService, SurveyService surveyService) {
+                                   @Lazy ExportIntegrationService exportIntegrationService,
+                                   SurveyService surveyService,
+                                   @Lazy PortalEnvironmentConfigService portalEnvironmentConfigService,
+                                   @Lazy PortalEnvironmentService portalEnvironmentService,
+                                   StudyService studyService) {
         super(studyEnvironmentDao);
         this.studyEnvironmentSurveyDao = studyEnvironmentSurveyDao;
         this.studyEnvironmentConfigService = studyEnvironmentConfigService;
@@ -88,6 +99,9 @@ public class StudyEnvironmentService extends CrudService<StudyEnvironment, Study
         this.participantDataChangeService = participantDataChangeService;
         this.exportIntegrationService = exportIntegrationService;
         this.surveyService = surveyService;
+        this.portalEnvironmentConfigService = portalEnvironmentConfigService;
+        this.portalEnvironmentService = portalEnvironmentService;
+        this.studyService = studyService;
     }
 
     public List<StudyEnvironment> findByStudy(UUID studyId) {
@@ -100,6 +114,23 @@ public class StudyEnvironmentService extends CrudService<StudyEnvironment, Study
 
     public List<StudyEnvironment> findAllByPortalAndEnvironment(UUID portalId, EnvironmentName environmentName) {
         return dao.findAllByPortalAndEnvironment(portalId, environmentName);
+    }
+
+    public Optional<StudyEnvironment> findPrimaryStudyByPortalEnvId(UUID portalEnvId) {
+        PortalEnvironment portalEnvironment = portalEnvironmentService.find(portalEnvId).orElseThrow();
+        PortalEnvironmentConfig portalEnvironmentConfig = portalEnvironmentConfigService.findByPortalEnvId(portalEnvId).orElseThrow();
+        List<Study> studies = studyService.findByPortalId(portalEnvironment.getPortalId());
+
+        if (studies.isEmpty()) {
+            throw new NotFoundException("no studies");
+        }
+        Study primaryStudy = studies.get(0);
+        for (Study study : studies) {
+            if (study.getShortcode().equals(portalEnvironmentConfig.getPrimaryStudy())) {
+                primaryStudy = study;
+            }
+        }
+        return findByStudy(primaryStudy.getShortcode(), portalEnvironment.getEnvironmentName());
     }
 
     public StudyEnvironment verifyStudy(String studyShortcode, EnvironmentName environmentName) {

--- a/core/src/main/java/bio/terra/pearl/core/service/study/StudyService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/study/StudyService.java
@@ -9,6 +9,7 @@ import bio.terra.pearl.core.service.CrudService;
 import bio.terra.pearl.core.service.kit.StudyEnvironmentKitTypeService;
 import lombok.extern.slf4j.Slf4j;
 import org.postgresql.util.PSQLException;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,7 +29,8 @@ public class StudyService extends CrudService<Study, StudyDao> {
         STUDY_ENVIRONMENTS
     }
 
-    public StudyService(StudyDao studyDao, StudyEnvironmentService studyEnvironmentService,
+    public StudyService(StudyDao studyDao,
+                        @Lazy StudyEnvironmentService studyEnvironmentService,
                         PortalStudyService portalStudyService, StudyEnvironmentKitTypeService studyEnvironmentKitTypeService) {
         super(studyDao);
         this.studyEnvironmentService = studyEnvironmentService;

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
@@ -439,7 +439,7 @@ public class EnrollmentService {
                         .build());
         EnrolleeSearchContext context = new EnrolleeSearchContext(
                 primaryStudyEnrollee,
-                profileService.find(ppUser.getProfileId()).orElse(new Profile())
+                profileService.loadWithMailingAddress(ppUser.getProfileId()).orElse(new Profile())
         );
         return enrolleeSearchExpressionParser
                 .parseRule(envConfig.getStudyEligibilityRule())

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
@@ -12,10 +12,11 @@ import bio.terra.pearl.core.model.study.StudyEnvironmentConfig;
 import bio.terra.pearl.core.model.survey.*;
 import bio.terra.pearl.core.model.workflow.HubResponse;
 import bio.terra.pearl.core.service.exception.NotFoundException;
-import bio.terra.pearl.core.service.participant.EnrolleeRelationService;
-import bio.terra.pearl.core.service.participant.EnrolleeService;
-import bio.terra.pearl.core.service.participant.ParticipantUserService;
-import bio.terra.pearl.core.service.participant.PortalParticipantUserService;
+import bio.terra.pearl.core.service.participant.*;
+import bio.terra.pearl.core.service.rule.EnrolleeContext;
+import bio.terra.pearl.core.service.rule.EnrolleeRuleEvaluator;
+import bio.terra.pearl.core.service.search.EnrolleeSearchContext;
+import bio.terra.pearl.core.service.search.EnrolleeSearchExpressionParser;
 import bio.terra.pearl.core.service.study.StudyEnvironmentConfigService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
@@ -33,10 +34,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 @Service
 @Slf4j
@@ -57,6 +55,8 @@ public class EnrollmentService {
     private final SurveyResponseService surveyResponseService;
     private final AnswerProcessingService answerProcessingService;
     private final StudyEnvironmentSurveyService studyEnvironmentSurveyService;
+    private final ProfileService profileService;
+    private final EnrolleeSearchExpressionParser enrolleeSearchExpressionParser;
 
     public EnrollmentService(SurveyService surveyService,
                              PreEnrollmentResponseDao preEnrollmentResponseDao,
@@ -71,7 +71,7 @@ public class EnrollmentService {
                              AnswerMappingDao answerMappingDao,
                              SurveyResponseService surveyResponseService,
                              AnswerProcessingService answerProcessingService,
-                             StudyEnvironmentSurveyService studyEnvironmentSurveyService) {
+                             StudyEnvironmentSurveyService studyEnvironmentSurveyService, ProfileService profileService, EnrolleeSearchExpressionParser enrolleeSearchExpressionParser) {
         this.surveyService = surveyService;
         this.preEnrollmentResponseDao = preEnrollmentResponseDao;
         this.studyEnvironmentService = studyEnvironmentService;
@@ -87,6 +87,8 @@ public class EnrollmentService {
         this.surveyResponseService = surveyResponseService;
         this.answerProcessingService = answerProcessingService;
         this.studyEnvironmentSurveyService = studyEnvironmentSurveyService;
+        this.profileService = profileService;
+        this.enrolleeSearchExpressionParser = enrolleeSearchExpressionParser;
     }
 
     /**
@@ -150,6 +152,9 @@ public class EnrollmentService {
         }
         if (isSubject && preEnrollResponseId == null && hasRequiredPreEnroll(studyEnv.getId())) {
             throw new IllegalArgumentException("user did not complete required pre-enrollment survey");
+        }
+        if (!isEligibleForStudy(user, ppUser, studyEnvConfig)) {
+            throw new IllegalArgumentException("Not eligible for this study");
         }
 
         PreEnrollmentResponse preEnrollResponse = validatePreEnrollResponse(operator, studyEnv, preEnrollResponseId, user.getId(), isSubject);
@@ -420,5 +425,21 @@ public class EnrollmentService {
             return enrollAsProxy(environmentName, studyShortcode, user, portalParticipantUser, preEnrollResponseId);
         }
         return enroll(portalParticipantUser, environmentName, studyShortcode, user, portalParticipantUser, preEnrollResponseId, true);
+    }
+
+    public boolean isEligibleForStudy(ParticipantUser user, PortalParticipantUser ppUser, StudyEnvironmentConfig envConfig) {
+        if (StringUtils.isEmpty(envConfig.getStudyEligibilityRule())) {
+            return true;
+        }
+        EnrolleeSearchContext context = new EnrolleeSearchContext(
+                Enrollee.builder()
+                        .participantUserId(ppUser.getParticipantUserId())
+                        .profileId(ppUser.getProfileId())
+                        .build(),
+                profileService.find(ppUser.getProfileId()).orElse(new Profile())
+        );
+        return enrolleeSearchExpressionParser
+                .parseRule(envConfig.getStudyEligibilityRule())
+                .evaluate(context);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/EnrollmentService.java
@@ -431,11 +431,14 @@ public class EnrollmentService {
         if (StringUtils.isEmpty(envConfig.getStudyEligibilityRule())) {
             return true;
         }
-        EnrolleeSearchContext context = new EnrolleeSearchContext(
-                Enrollee.builder()
+        StudyEnvironment primaryStudyEnv = studyEnvironmentService.findPrimaryStudyByPortalEnvId(ppUser.getPortalEnvironmentId()).orElseThrow();
+        Enrollee primaryStudyEnrollee = enrolleeService.findByParticipantUserIdAndStudyEnvId(ppUser.getId(), primaryStudyEnv.getId())
+                .orElse(Enrollee.builder()
                         .participantUserId(ppUser.getParticipantUserId())
                         .profileId(ppUser.getProfileId())
-                        .build(),
+                        .build());
+        EnrolleeSearchContext context = new EnrolleeSearchContext(
+                primaryStudyEnrollee,
                 profileService.find(ppUser.getProfileId()).orElse(new Profile())
         );
         return enrolleeSearchExpressionParser

--- a/core/src/main/resources/db/changelog/changesets/2025_08_23_eligibility_rule.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2025_08_23_eligibility_rule.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: "custom_study_eligibility"
+      author: dbush
+      changes:
+        - addColumn:
+            tableName: study_environment_config
+            columns:
+              - column:
+                  name: study_eligibility_rule
+                  type: text
+

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -413,6 +413,9 @@ databaseChangeLog:
   - include:
       file: changesets/2025_07_28_custom_kit_eligibility.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2025_08_23_eligibility_rule.yaml
+      relativeToChangelogFile: true
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements
 # are atomic. When they are grouped in a changeset and one fails the changeset cannot be
 # rolled back or rerun making recovery more difficult

--- a/core/src/test/java/bio/terra/pearl/core/dao/survey/AnswerDaoTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/survey/AnswerDaoTests.java
@@ -126,7 +126,7 @@ public class AnswerDaoTests extends BaseSpringBootTest {
     // find question that enrollee 1 filled out
     Optional<Answer> answer = answerDao.findByProfileIdStudyAndQuestion(
             enrollee1.getProfileId(),
-            studyEnvBundle.getStudy().getName(),
+            studyEnvBundle.getStudy().getShortcode(),
             surveyInEnv1.getStableId(),
             "question_env_1");
     assertThat(answer.get().getStringValue(), equalTo("answer1"));
@@ -134,7 +134,7 @@ public class AnswerDaoTests extends BaseSpringBootTest {
     // find question that enrollee 2 filled out
     answer = answerDao.findByProfileIdStudyAndQuestion(
             enrollee1.getProfileId(),
-            studyEnvBundle2.getStudy().getName(),
+            studyEnvBundle2.getStudy().getShortcode(),
             surveyInEnv2.getStableId(),
             "question_env_2");
     assertThat(answer.get().getStringValue(), equalTo("differentAnswer"));
@@ -143,7 +143,7 @@ public class AnswerDaoTests extends BaseSpringBootTest {
     // find question that enrollee 2 filled out but ask for wrong study
     answer = answerDao.findByProfileIdStudyAndQuestion(
             enrollee1.getProfileId(),
-            studyEnvBundle.getStudy().getName(),
+            studyEnvBundle.getStudy().getShortcode(),
             surveyInEnv2.getStableId(),
             "question_env_2");
     assertThat(answer.isEmpty(), equalTo(true));
@@ -151,7 +151,7 @@ public class AnswerDaoTests extends BaseSpringBootTest {
     // find question that neither enrollee 1 nor 2 filled out
     answer = answerDao.findByProfileIdStudyAndQuestion(
             enrollee1.getProfileId(),
-            studyEnvBundle2.getStudy().getName(),
+            studyEnvBundle2.getStudy().getShortcode(),
             surveyInEnv2.getStableId(),
             "different_question");
     assertThat(answer.isEmpty(), equalTo(true));

--- a/core/src/test/java/bio/terra/pearl/core/service/search/expressions/EnrolleeSearchExpressionTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/search/expressions/EnrolleeSearchExpressionTest.java
@@ -699,16 +699,16 @@ class EnrolleeSearchExpressionTest extends BaseSpringBootTest {
         surveyResponseFactory.buildWithAnswers(unrelatedEnrollee, surveyInEnv2, Map.of("question_env_2", "wrongEnrollee"));
 
 
-        String study2StableId = studyEnvBundle2.getStudy().getName();
+        String study2Shortcode = studyEnvBundle2.getStudy().getShortcode();
         String survey1StableId = surveyInEnv1.getStableId();
         String survey2StableId = surveyInEnv2.getStableId();
 
         EnrolleeSearchExpression crossStudyAnswer = enrolleeSearchExpressionParser.parseRule(
-                "{answer." + survey1StableId + ".question_env_1} = 'answer1' and {answer[\"" + study2StableId + "\"]." + survey2StableId + ".question_env_2} = 'differentAnswer'"
+                "{answer." + survey1StableId + ".question_env_1} = 'answer1' and {answer[\"" + study2Shortcode + "\"]." + survey2StableId + ".question_env_2} = 'differentAnswer'"
         );
 
         EnrolleeSearchExpression wrongOtherStudyAnswer = enrolleeSearchExpressionParser.parseRule(
-                "{answer." + survey1StableId + ".question_env_1} = 'answer1' and {answer[\"" + study2StableId + "\"]." + survey2StableId + ".question_env_2} = 'wrongEnrollee'"
+                "{answer." + survey1StableId + ".question_env_1} = 'answer1' and {answer[\"" + study2Shortcode + "\"]." + survey2StableId + ".question_env_2} = 'wrongEnrollee'"
         );
 
         EnrolleeSearchExpression wrongOtherStudyName = enrolleeSearchExpressionParser.parseRule(
@@ -716,7 +716,7 @@ class EnrolleeSearchExpressionTest extends BaseSpringBootTest {
         );
 
         EnrolleeSearchExpression wrongQuestion = enrolleeSearchExpressionParser.parseRule(
-                "{answer." + survey1StableId + ".question_env_1} = 'answer1' and {answer[\"" + study2StableId + "\"]." + survey2StableId + ".wrong_question} = 'differentAnswer'"
+                "{answer." + survey1StableId + ".question_env_1} = 'answer1' and {answer[\"" + study2Shortcode + "\"]." + survey2StableId + ".wrong_question} = 'differentAnswer'"
         );
 
 

--- a/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentServiceTests.java
@@ -228,7 +228,7 @@ public class EnrollmentServiceTests extends BaseSpringBootTest {
 
         // you can only join the second study if you've said you're nice in the first study
         StudyEnvironmentConfig studyEnvConfig = studyEnvironmentConfigService.find(bundle2.getStudyEnv().getStudyEnvironmentConfigId()).orElseThrow();
-        String eligibilityRule = "{answer[\"%s\"].%s.isNice} = 'yes'".formatted(bundle1.getStudy().getName(), survey1.getStableId());
+        String eligibilityRule = "{answer[\"%s\"].%s.isNice} = 'yes'".formatted(bundle1.getStudy().getShortcode(), survey1.getStableId());
         studyEnvConfig.setStudyEligibilityRule(eligibilityRule);
         studyEnvironmentConfigService.update(studyEnvConfig);
 

--- a/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/workflow/EnrollmentServiceTests.java
@@ -2,13 +2,17 @@ package bio.terra.pearl.core.service.workflow;
 
 import bio.terra.pearl.core.BaseSpringBootTest;
 import bio.terra.pearl.core.factory.DaoTestUtils;
+import bio.terra.pearl.core.factory.StudyEnvironmentBundle;
 import bio.terra.pearl.core.factory.StudyEnvironmentFactory;
 import bio.terra.pearl.core.factory.participant.EnrolleeAndProxy;
+import bio.terra.pearl.core.factory.participant.EnrolleeBundle;
 import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
 import bio.terra.pearl.core.factory.participant.ParticipantUserFactory;
 import bio.terra.pearl.core.factory.portal.PortalEnvironmentFactory;
 import bio.terra.pearl.core.factory.survey.AnswerFactory;
 import bio.terra.pearl.core.factory.survey.SurveyFactory;
+import bio.terra.pearl.core.factory.survey.SurveyResponseFactory;
+import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.model.participant.PortalParticipantUser;
@@ -26,6 +30,7 @@ import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import bio.terra.pearl.core.service.study.StudyService;
 import bio.terra.pearl.core.service.survey.SurveyResponseService;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -67,6 +72,8 @@ public class EnrollmentServiceTests extends BaseSpringBootTest {
     private EnrolleeService enrolleeService;
     @Autowired
     private SurveyResponseService surveyResponseService;
+    @Autowired
+    private SurveyResponseFactory surveyResponseFactory;
 
     @Test
     @Transactional
@@ -183,6 +190,82 @@ public class EnrollmentServiceTests extends BaseSpringBootTest {
                     null, false);
         });
     }
+
+    @Test
+    @Transactional
+    public void testBasicEnrollEligibilityRule(TestInfo testInfo) {
+        PortalEnvironment portalEnv = portalEnvironmentFactory.buildPersisted(getTestName(testInfo));
+        StudyEnvironment studyEnv = studyEnvironmentFactory.buildPersisted(portalEnv, getTestName(testInfo));
+        String testEmail = RandomStringUtils.randomAlphabetic(10) + "@gmail.com";
+        StudyEnvironmentConfig studyEnvConfig = studyEnvironmentConfigService.find(studyEnv.getStudyEnvironmentConfigId()).orElseThrow();
+        studyEnvConfig.setStudyEligibilityRule("{user.username} = '%s'".formatted(testEmail));
+        studyEnvironmentConfigService.update(studyEnvConfig);
+
+        ParticipantUserFactory.ParticipantUserAndPortalUser userBundle = participantUserFactory.buildPersisted(portalEnv,
+                getTestName(testInfo));
+        String studyShortcode = studyService.find(studyEnv.getStudyId()).get().getShortcode();
+        assertThrows(IllegalArgumentException.class, () -> {
+            enrollmentService.enroll(userBundle.ppUser(), studyEnv.getEnvironmentName(), studyShortcode, userBundle.user(), userBundle.ppUser(),
+                    null, true);
+        });
+
+        userBundle.user().setUsername(testEmail);
+        participantUserService.update(userBundle.user());
+        HubResponse hubResponse = enrollmentService.enroll(userBundle.ppUser(), studyEnv.getEnvironmentName(), studyShortcode,
+                userBundle.user(), userBundle.ppUser(), null, false);
+        assertThat(hubResponse.getEnrollee(), notNullValue());
+    }
+
+    @Test
+    @Transactional
+    public void testCrossStudyEligibilityRule(TestInfo testInfo) {
+        StudyEnvironmentBundle bundle1 = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.live);
+        StudyEnvironmentBundle bundle2 = studyEnvironmentFactory.buildBundle(getTestName(testInfo), EnvironmentName.live, bundle1.getPortal(), bundle1.getPortalEnv());
+        Survey survey1 = surveyFactory.buildPersisted(
+                surveyFactory.builder(getTestName(testInfo))
+                        .content("{\"pages\":[{\"elements\":[{\"type\":\"text\",\"name\":\"isNice\",\"title\":\"Are you nice?\"}]}]}")
+                                .portalId(bundle2.getPortal().getId()));
+
+        // you can only join the second study if you've said you're nice in the first study
+        StudyEnvironmentConfig studyEnvConfig = studyEnvironmentConfigService.find(bundle2.getStudyEnv().getStudyEnvironmentConfigId()).orElseThrow();
+        String eligibilityRule = "{answer[\"%s\"].%s.isNice} = 'yes'".formatted(bundle1.getStudy().getName(), survey1.getStableId());
+        studyEnvConfig.setStudyEligibilityRule(eligibilityRule);
+        studyEnvironmentConfigService.update(studyEnvConfig);
+
+        // someone who hasn't joined the other study is ineligible
+        ParticipantUserFactory.ParticipantUserAndPortalUser userBundle = participantUserFactory.buildPersisted(bundle1.getPortalEnv(),
+                getTestName(testInfo));
+        assertThrows(IllegalArgumentException.class, () -> {
+            enrollmentService.enroll(userBundle.ppUser(), bundle2.getStudyEnv().getEnvironmentName(), bundle2.getStudy().getShortcode(), userBundle.user(), userBundle.ppUser(),
+                    null, true);
+        });
+
+        // someone who has joined the other study but not answered the survey is ineligible.
+        EnrolleeBundle enrolleeBundle = enrolleeFactory.enroll(RandomStringUtils.randomAlphabetic(10) + "@test.com", bundle1.getPortal().getShortcode(), bundle1.getStudy().getShortcode(), bundle1.getStudyEnv().getEnvironmentName());
+        assertThrows(IllegalArgumentException.class, () -> {
+            enrollmentService.enroll(enrolleeBundle.portalParticipantUser(), bundle2.getStudyEnv().getEnvironmentName(), bundle2.getStudy().getShortcode(), enrolleeBundle.participantUser(), enrolleeBundle.portalParticipantUser(),
+                    null, true);
+        });
+
+        // someone who has joined with a wrong answer is ineligible
+        surveyResponseFactory.buildWithAnswers(enrolleeBundle.enrollee(), survey1, Map.of(
+                "isNice", "no"
+        ));
+        assertThrows(IllegalArgumentException.class, () -> {
+            enrollmentService.enroll(enrolleeBundle.portalParticipantUser(), bundle2.getStudyEnv().getEnvironmentName(), bundle2.getStudy().getShortcode(), enrolleeBundle.participantUser(), enrolleeBundle.portalParticipantUser(),
+                    null, true);
+        });
+
+        // someone with the correct answer can join
+        EnrolleeBundle niceEnrollee = enrolleeFactory.enroll(RandomStringUtils.randomAlphabetic(10) + "@test.com", bundle1.getPortal().getShortcode(), bundle1.getStudy().getShortcode(), bundle1.getStudyEnv().getEnvironmentName());
+        surveyResponseFactory.buildWithAnswers(niceEnrollee.enrollee(), survey1, Map.of(
+                "isNice", "yes"
+        ));
+        HubResponse hubResponse = enrollmentService.enroll(niceEnrollee.portalParticipantUser(), bundle2.getStudyEnv().getEnvironmentName(), bundle2.getStudy().getShortcode(),
+                niceEnrollee.participantUser(), niceEnrollee.portalParticipantUser(), null, false);
+        assertThat(hubResponse.getEnrollee(), notNullValue());
+    }
+
 
     @Test
     @Transactional

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/lostInterest.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/lostInterest.json
@@ -36,7 +36,7 @@
       "answerPopDtos": [
         {"questionStableId": "hd_hd_mental_phq9LostInterest", "stringValue": "3"},
         {"questionStableId": "hd_hd_mental_phq9Depressed", "stringValue": "2"},
-        {"questionStableId": "hd_hd_mental_phq9Sleeping", "stringValue": "1"},
+        {"questionStableId": "hd_hd_mental_phq9Sleeping", "stringValue": "3"},
         {"questionStableId": "hd_hd_mental_phq9Tired", "stringValue": "3"}
       ],
       "currentPageNo": 1,

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
@@ -1,5 +1,5 @@
 {
-  "name": "Heart Demo",
+  "name": "HeartDemo",
   "shortcode": "heartdemo",
   "surveyFiles": [
     "surveys/preEnroll.json",

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
@@ -1,5 +1,5 @@
 {
-  "name": "HeartDemo",
+  "name": "Heart Demo",
   "shortcode": "heartdemo",
   "surveyFiles": [
     "surveys/preEnroll.json",

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/study.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/study.json
@@ -22,7 +22,8 @@
         "passwordProtected": false,
         "password": "broad_institute",
         "initialized": true,
-        "enableInPersonKits": true
+        "enableInPersonKits": true,
+        "studyEligibilityRule": "{answer[\"HeartDemo\"].hd_hd_mental.hd_hd_mental_phq9LostInterest} = '3'"
       },
       "configuredSurveyDtos": [
         {"populateFileName": "surveys/preEnroll.json"},

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/study.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/study.json
@@ -23,7 +23,7 @@
         "password": "broad_institute",
         "initialized": true,
         "enableInPersonKits": true,
-        "studyEligibilityRule": "{answer[\"HeartDemo\"].hd_hd_mental.hd_hd_mental_phq9LostInterest} = '3'"
+        "studyEligibilityRule": "{answer[\"heartdemo\"].hd_hd_mental.hd_hd_mental_phq9LostInterest} = '3'"
       },
       "configuredSurveyDtos": [
         {"populateFileName": "surveys/preEnroll.json"},

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/surveys/preEnroll.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/surveys/preEnroll.json
@@ -22,7 +22,7 @@
         "elements": [
           {
             "type": "panel",
-            "visibleIf": "{user.username} notempty",
+            "visibleIf": "{user.username} notempty and {eligibilityResult.eligible} = true",
             "elements": [
               {
                 "type": "html",
@@ -58,6 +58,12 @@
                 ]
               }
             ]
+          },
+          {
+            "type": "html",
+            "name": "notEligible",
+            "visibleIf": "{eligibilityResult.eligible} = false and {user.username} notempty",
+            "html": "This study is only open to people who have joined the main study and are suffering from symptoms of depression."
           },
           {
             "type": "html",

--- a/ui-admin/src/study/settings/study/StudyEnrollmentSettings.tsx
+++ b/ui-admin/src/study/settings/study/StudyEnrollmentSettings.tsx
@@ -75,6 +75,12 @@ export const StudyEnrollmentSettings = (
           onChange={e => updateConfig('acceptingProxyEnrollment', e.target.checked)}/>
       </label>
     </div>
+    <div>
+      <label className="form-label">
+        eligibility rule <input type="text" className="form-control" size={80} value={config.studyEligibilityRule ?? ''}
+          onChange={e => updateConfig('studyEligibilityRule', e.target.value)}/>
+      </label>
+    </div>
     {
       userHasPermission(user, studyEnvContext.portal.id, 'prototype') && (
         <div>

--- a/ui-core/src/types/study.ts
+++ b/ui-core/src/types/study.ts
@@ -45,6 +45,7 @@ export type StudyEnvironmentConfig = {
   useDevDsmRealm: boolean
   enableInPersonKits: boolean
   timeZone: string
+  studyEligibilityRule?: string
   kitEligibilityRule?: string
 }
 

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -61,6 +61,10 @@ export type LoginResult = {
   profile: Profile
 }
 
+export type EligibilityResult = {
+  eligible: boolean
+}
+
 export type KitType = {
   id: string,
   name: string,
@@ -285,6 +289,13 @@ export default {
     if (!response.ok) {
       return Promise.reject(response)
     }
+  },
+
+  async checkEligible(studyShortcode: string):
+    Promise<EligibilityResult> {
+    const url =  `${baseStudyEnvUrl(false, studyShortcode)}/checkEligible`
+    const response = await fetch(url, { headers: this.getInitHeaders() })
+    return await this.processJsonResponse(response, { alertErrors: false })
   },
 
   async register({ preRegResponseId, email, accessToken, preferredLanguage }: {

--- a/ui-participant/src/studies/enroll/PreEnroll.tsx
+++ b/ui-participant/src/studies/enroll/PreEnroll.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import Api, {
+  EligibilityResult,
   PreEnrollmentResponse,
   Survey
 } from 'api/api'
@@ -17,6 +18,8 @@ import {
 import { useUser } from '../../providers/UserProvider'
 import { useActiveUser } from '../../providers/ActiveUserProvider'
 import { useEnrollmentParams } from './useEnrollmentParams'
+import { LoadingSpinner } from '../../util/LoadingSpinner'
+import { ApiErrorResponse, defaultApiErrorHandle } from '../../util/error-utils'
 
 /**
  * pre-enrollment surveys are expected to have a calculated value that indicates
@@ -24,9 +27,50 @@ import { useEnrollmentParams } from './useEnrollmentParams'
  * */
 const ENROLLMENT_QUALIFIED_VARIABLE = 'qualified'
 
-/** Renders a pre-enrollment form, and handles submitting the user-inputted response */
 export default function PreEnrollView({ enrollContext, survey }:
-                                        { enrollContext: StudyEnrollContext, survey: Survey }) {
+  { enrollContext: StudyEnrollContext, survey: Survey }) {
+  const eligibleRule = enrollContext.studyEnv.studyEnvironmentConfig.studyEligibilityRule
+
+  // if there's an eligibility rule, we need to check eligibility before showing the survey
+  const [isLoading, setIsLoading] = useState(!!eligibleRule)
+  const [eligibilityResult, setEligibilityResult] = useState<EligibilityResult>({ eligible: !!eligibleRule })
+
+  const checkEligibility = async () => {
+    if (eligibleRule) {
+      setIsLoading(true)
+      try {
+        const response = await Api.checkEligible(enrollContext.studyShortcode)
+        setEligibilityResult(response)
+        setIsLoading(false)
+      } catch (e: unknown) {
+        const statusCode = (e as ApiErrorResponse).statusCode
+        // ignore 401/403s -- not being logged in is handled by the survey content
+        if (statusCode === 403 || statusCode === 401) {
+          setIsLoading(false)
+        } else {
+          defaultApiErrorHandle(e as ApiErrorResponse)
+        }
+      }
+    }
+  }
+
+  useEffect(() => {
+    checkEligibility()
+  }, [eligibleRule])
+  return <>
+    { !isLoading && <EligiblePreEnrollView enrollContext={enrollContext}
+      eligibilityResult={eligibilityResult} survey={survey}/> }
+    { isLoading && <LoadingSpinner/>}
+  </>
+}
+
+
+/** Renders a pre-enrollment form, and handles submitting the user-inputted response */
+export function EligiblePreEnrollView({ enrollContext, survey, eligibilityResult }:
+                                        { enrollContext: StudyEnrollContext,
+                                          survey: Survey,
+                                          eligibilityResult: EligibilityResult
+                                        }) {
   const {
     studyEnv,
     updatePreEnrollResponseId,
@@ -61,7 +105,10 @@ export default function PreEnrollView({ enrollContext, survey }:
       studyEnvParams: { envName: studyEnv.environmentName, studyShortcode, portalShortcode },
       enrolleeShortcode: enrollee?.shortcode || '',
       referencedAnswers: [],
-      extraVariables: { isProxyEnrollment, isSubjectEnrollment, user }
+      extraVariables: {
+        isProxyEnrollment, isSubjectEnrollment, user,
+        eligibilityResult
+      }
     },
     { extraCssClasses: { container: 'my-0' } }
   )


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds the ability to configure an eligibility rule for a study.  
<img width="794" height="365" alt="image" src="https://github.com/user-attachments/assets/1e6b08e8-186b-4b4e-8a85-0d0b15b2d63d" />

A new endpoint has been added to check eligibility.  The pre-enrollment survey calls this endpoint if a rule exists for the study, and loads the answer into the available survey variables

NOTE: This refactors the rule logic to use study shortcode, rather than name (otherwise the parsing errors if the study name has spaces, and 'Heart Hive' has spaces).  I did a check in prod for any cross-study rules and didn't find any

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  go to https://sandbox.demo.localhost:3001/sleep   make sure you are not logged in 
2.  click "join sleep study"
3. confirm you see a message saying you must log in
4. log in as jsalk@test.com
5.  go back to https://sandbox.demo.localhost:3001/sleep and cliick join
6. confirm you get a different message saying enrollment is limited to participants with dpression symptoms
7. log out, log in as lostInterest@test.com
8. try to join the sleep study again
9. confirm the pre-enrollment survye appears, and you can join