### PR TITLE
[JN-1375] Saving email template always creates a new version

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/notification/TriggerService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/TriggerService.java
@@ -47,7 +47,7 @@ public class TriggerService extends CrudService<Trigger, TriggerDao> implements 
     public Trigger create(Trigger action) {
         EmailTemplate emailTemplate = action.getEmailTemplate();
         if (emailTemplate != null && emailTemplate.getId() == null) {
-            emailTemplate = emailTemplateService.create(emailTemplate);
+            emailTemplate = emailTemplateService.createNewVersion(emailTemplate);
             action.setEmailTemplateId(emailTemplate.getId());
         }
         Trigger savedConfig = dao.create(action);

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/email/EmailTemplateService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/email/EmailTemplateService.java
@@ -3,12 +3,14 @@ package bio.terra.pearl.core.service.notification.email;
 import bio.terra.pearl.core.dao.notification.EmailTemplateDao;
 import bio.terra.pearl.core.model.notification.EmailTemplate;
 import bio.terra.pearl.core.model.notification.LocalizedEmailTemplate;
+import bio.terra.pearl.core.model.site.SiteContent;
 import bio.terra.pearl.core.service.VersionedEntityService;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class EmailTemplateService extends VersionedEntityService<EmailTemplate, EmailTemplateDao> {
@@ -27,11 +29,27 @@ public class EmailTemplateService extends VersionedEntityService<EmailTemplate, 
         EmailTemplate template = dao.create(emailTemplate);
         for (LocalizedEmailTemplate localizedEmailTemplate : emailTemplate.getLocalizedEmailTemplates()) {
             localizedEmailTemplate.setEmailTemplateId(template.getId());
+            localizedEmailTemplate.setId(null);
             LocalizedEmailTemplate savedTemplate = localizedEmailTemplateService.create(localizedEmailTemplate);
             template.getLocalizedEmailTemplates().add(savedTemplate);
         }
         return template;
     }
+
+    /**
+     * create a new version of the emailTemplate with the given content.
+     * Note that the passed-in object WILL BE MODIFIED to clean out any ids and set new versions.  It should be
+     * discarded.
+     * */
+    @Transactional
+    public EmailTemplate createNewVersion(EmailTemplate emailTemplate) {
+        cleanForCopying(emailTemplate);
+        int nextVersion = dao.getNextVersion(emailTemplate.getStableId(), emailTemplate.getPortalId());
+        emailTemplate.setVersion(nextVersion);
+        emailTemplate.setPublishedVersion(null);
+        return create(emailTemplate);
+    }
+
 
     public EmailTemplate attachLocalizedTemplate(EmailTemplate emailTemplate, String language) {
         dao.attachLocalizedTemplate(emailTemplate, language);

--- a/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
+++ b/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
@@ -1,5 +1,4 @@
 import React, {
-  useEffect,
   useRef,
   useState
 } from 'react'
@@ -19,6 +18,7 @@ import { getMediaBaseUrl } from 'api/api'
 import { usePortalLanguage } from 'portal/languages/usePortalLanguage'
 import useReactSingleSelect from 'util/react-select-utils'
 import Select from 'react-select'
+import useUpdateEffect from '../../util/useUpdateEffect'
 
 export type EmailTemplateEditorProps = {
   emailTemplate: EmailTemplate,
@@ -39,7 +39,7 @@ export default function EmailTemplateEditor({ emailTemplate, updateEmailTemplate
   const localizedEmailTemplate = emailTemplate.localizedEmailTemplates.find(template =>
     template.language === selectedLanguage?.languageCode)
 
-  useEffect(() => {
+  useUpdateEffect(() => {
     if (emailEditorRef.current?.editor && localizedEmailTemplate) {
       emailEditorRef.current.editor.loadDesign({
         // @ts-ignore
@@ -47,7 +47,7 @@ export default function EmailTemplateEditor({ emailTemplate, updateEmailTemplate
         classic: true
       })
     }
-  }, [localizedEmailTemplate, selectedLanguage])
+  }, [selectedLanguage?.languageCode])
 
   const {
     onChange: languageOnChange, options: languageOptions,
@@ -101,15 +101,22 @@ export default function EmailTemplateEditor({ emailTemplate, updateEmailTemplate
     unlayer.addEventListener('design:updated', () => {
       if (!emailEditorRef.current?.editor || !localizedEmailTemplate) { return }
       emailEditorRef.current.editor.exportHtml(data => {
+        const matchedTemplate =  emailTemplateRef.current.localizedEmailTemplates.find(template =>
+          template.language === localizedEmailTemplate.language)
+        const updatedBody = insertPlaceholders(data.html)
+        if (matchedTemplate!.body === updatedBody) {
+          return
+        }
         const updatedTemplates = emailTemplateRef.current.localizedEmailTemplates.map(template =>
           template.language === localizedEmailTemplate.language ? {
             ...localizedEmailTemplate,
             id: undefined,
-            body: insertPlaceholders(data.html)
+            body: updatedBody
           } : template
         )
         updateEmailTemplate({
           ...emailTemplateRef.current,
+          id: undefined,
           localizedEmailTemplates: updatedTemplates
         })
       })

--- a/ui-admin/src/study/notifications/TriggerDesigner.test.tsx
+++ b/ui-admin/src/study/notifications/TriggerDesigner.test.tsx
@@ -44,9 +44,8 @@ describe('TriggerDesigner', () => {
         ...trigger,
         emailTemplate: {
           ...trigger.emailTemplate,
-          id: undefined,  // confirm id and publishedVersion are cleared
-          publishedVersion: undefined,
-          version: 2, // confirm version is incremented
+          id: 'emailTemplate1',
+          version: 1,
           localizedEmailTemplates: [{
             subject: 'Mock subjectblah',
             body: 'Mock email message',

--- a/ui-admin/src/study/notifications/TriggerDesignerEditor.tsx
+++ b/ui-admin/src/study/notifications/TriggerDesignerEditor.tsx
@@ -392,8 +392,6 @@ const NotificationEditor = (
   }) => {
   const hasEmailTemplate = !!trigger?.emailTemplate
 
-  const [hasChangedTemplate, setHasChangedTemplate] = React.useState(false)
-
   return <>
     <div className="float-end position-relative">
       <NavLink to='notifications'>View sent notifications</NavLink>
@@ -441,17 +439,7 @@ const NotificationEditor = (
             emailTemplate={trigger.emailTemplate}
             portalShortcode={studyEnvContext.portal.shortcode}
             updateEmailTemplate={updatedTemplate => {
-              updatedTemplate.localizedEmailTemplates.forEach(template => {
-                template.id = undefined
-              })
-              const version = trigger?.emailTemplate?.version || 1
-              updateTrigger('emailTemplate', {
-                ...updatedTemplate,
-                id: undefined,
-                publishedVersion: undefined,
-                version: !hasChangedTemplate ? version + 1 : version
-              })
-              setHasChangedTemplate(true)
+              updateTrigger('emailTemplate', updatedTemplate)
             }
             }
           />

--- a/ui-core/src/types/study.ts
+++ b/ui-core/src/types/study.ts
@@ -96,6 +96,7 @@ export type EmailTemplate = {
   stableId: string
   name: string
   version: number
+  publishedVersion?: number
   localizedEmailTemplates: LocalizedEmailTemplate[]
 }
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

This updates the email template editor to behave similarly to the siteContent editor, where the backend handles version assignment, rather than the frontend.  This also cleans up some hooks so that editing is smoother.   This will unblock Parker editing emails for pedihcc

One thing to note is that the email editor always flickers on the first edit of an email from the demo -- the reason is that those templates were created using a different editor, and so the first edit radically changes the structure of the HTML.  This shouldn't impact customers who are working from templates Whitney and they themselves edited.  

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  pull up an email
2. edit it
3. confirm it saves as a new version