### PR TITLE
[JN-1740] fixing enrollment eligibility endpoint, and email subject edit

### DIFF
--- a/api-participant/src/main/resources/api/openapi.yml
+++ b/api-participant/src/main/resources/api/openapi.yml
@@ -272,6 +272,21 @@ paths:
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/public/portals/v1/{portalShortcode}/env/{envName}/studies/{studyShortcode}/checkEligible:
+    get:
+      summary: Checks whether the signed-in user is eligible for the given study
+      tags: [ enrollment ]
+      operationId: checkEligible
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: envName, in: path, required: true, schema: { type: string } }
+        - { name: studyShortcode, in: path, required: true, schema: { type: string } }
+      responses:
+        '200':
+          description: object with 'eligible' boolean
+          content: { application/json: { schema: { type: object } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/public/portals/v1/{portalShortcode}/env/{envName}/preEnroll/{preEnrollResponseId}/confirm:
     get:
       summary: Confirms a preEnrollment id
@@ -300,21 +315,6 @@ paths:
       responses:
         '200':
           description: hub response with enrollee
-          content: { application/json: { schema: { type: object } } }
-        '500':
-          $ref: '#/components/responses/ServerError'
-  /api/portals/v1/{portalShortcode}/env/{envName}/studies/{studyShortcode}/checkEligible:
-    get:
-      summary: Checks whether the signed-in user is eligible for the given study
-      tags: [ enrollment ]
-      operationId: checkEligible
-      parameters:
-        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
-        - { name: envName, in: path, required: true, schema: { type: string } }
-        - { name: studyShortcode, in: path, required: true, schema: { type: string } }
-      responses:
-        '200':
-          description: object with 'eligible' boolean
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'

--- a/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
+++ b/ui-admin/src/study/notifications/EmailTemplateEditor.tsx
@@ -71,6 +71,7 @@ export default function EmailTemplateEditor({ emailTemplate, updateEmailTemplate
 
     updateEmailTemplate({
       ...emailTemplate,
+      id: undefined,
       localizedEmailTemplates: [
         ...emailTemplate.localizedEmailTemplates,
         {
@@ -154,6 +155,7 @@ export default function EmailTemplateEditor({ emailTemplate, updateEmailTemplate
               )
               updateEmailTemplate({
                 ...emailTemplate,
+                id: undefined,
                 localizedEmailTemplates: updatedTemplates
               })
             }}/>
@@ -191,6 +193,7 @@ export default function EmailTemplateEditor({ emailTemplate, updateEmailTemplate
                 )
                 updateEmailTemplate({
                   ...emailTemplate,
+                  id: undefined,
                   localizedEmailTemplates: updatedTemplates
                 })
               }}/>

--- a/ui-admin/src/study/notifications/TriggerDesigner.test.tsx
+++ b/ui-admin/src/study/notifications/TriggerDesigner.test.tsx
@@ -44,7 +44,7 @@ describe('TriggerDesigner', () => {
         ...trigger,
         emailTemplate: {
           ...trigger.emailTemplate,
-          id: 'emailTemplate1',
+          id: undefined,
           version: 1,
           localizedEmailTemplates: [{
             subject: 'Mock subjectblah',

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -293,7 +293,7 @@ export default {
 
   async checkEligible(studyShortcode: string):
     Promise<EligibilityResult> {
-    const url =  `${baseStudyEnvUrl(false, studyShortcode)}/checkEligible`
+    const url =  `${baseStudyEnvUrl(true, studyShortcode)}/checkEligible`
     const response = await fetch(url, { headers: this.getInitHeaders() })
     return await this.processJsonResponse(response, { alertErrors: false })
   },


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Moves eligibility check to public API.  fixes subject email editing


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  edit an email template subject and save
2. from staging, click sleep study, then "join" while you are not logged in