### PR TITLE
[JN-1738] max emails for event

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/notification/NotificationDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/notification/NotificationDao.java
@@ -3,6 +3,8 @@ package bio.terra.pearl.core.dao.notification;
 import bio.terra.pearl.core.dao.BaseMutableJdbiDao;
 import bio.terra.pearl.core.model.notification.Notification;
 import bio.terra.pearl.core.model.notification.SendgridEvent;
+import bio.terra.pearl.core.model.notification.Trigger;
+import bio.terra.pearl.core.model.participant.Enrollee;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jdbi.v3.core.Jdbi;
@@ -14,13 +16,17 @@ import java.util.UUID;
 
 @Component
 public class NotificationDao extends BaseMutableJdbiDao<Notification> {
+    private final TriggerDao triggerDao;
+    private final EmailTemplateDao emailTemplateDao;
     private ObjectMapper objectMapper;
     private final SendgridEventDao sendgridEventDao;
 
-    public NotificationDao(Jdbi jdbi, ObjectMapper objectMapper, SendgridEventDao sendgridEventDao) {
+    public NotificationDao(Jdbi jdbi, ObjectMapper objectMapper, SendgridEventDao sendgridEventDao, TriggerDao triggerDao, EmailTemplateDao emailTemplateDao) {
         super(jdbi);
         this.objectMapper = objectMapper;
         this.sendgridEventDao = sendgridEventDao;
+        this.triggerDao = triggerDao;
+        this.emailTemplateDao = emailTemplateDao;
     }
 
     @Override
@@ -76,4 +82,11 @@ public class NotificationDao extends BaseMutableJdbiDao<Notification> {
                         .findFirst()
         );
     }
+
+    public List<Notification> findByEnrolleeAndEmailStableId(Enrollee enrollee, String stableId) {
+        List<Trigger> triggers = triggerDao.findByStudyEnvAndEmailTemplate(enrollee.getStudyEnvironmentId(), stableId);
+        return findAllByTwoProperties("enrollee_id", enrollee.getId(),
+                "trigger_id", triggers.stream().map(Trigger::getId).toList());
+    }
+
 }

--- a/core/src/main/java/bio/terra/pearl/core/dao/notification/TriggerDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/notification/TriggerDao.java
@@ -38,6 +38,22 @@ public class TriggerDao extends BaseMutableJdbiDao<Trigger> implements StudyEnvA
         );
     }
 
+    /** gets the configs for the study env with the email template stableID */
+    public List<Trigger> findByStudyEnvAndEmailTemplate(UUID studyEnvId, String emailStableId) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("""
+                                select %s.* from %s
+                                join email_template on trigger.email_template_id = email_template.id
+                                where study_environment_id = :studyEnvId
+                                and stable_id = :stableId
+                                """.formatted(tableName, tableName))
+                        .bind("studyEnvId", studyEnvId)
+                        .bind("stableId", emailStableId)
+                        .mapTo(clazz)
+                        .list()
+        );
+    }
+
 
 
     public void attachTemplates(List<Trigger> actions) {

--- a/core/src/main/java/bio/terra/pearl/core/model/notification/Trigger.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/notification/Trigger.java
@@ -55,6 +55,8 @@ public class Trigger extends BaseEntity implements VersionedEntityConfig, StudyE
     private String rule;
     // if specified, skips notifications if the last sent notification was sent within this many minutes ago
     private Integer minMinutesSinceLastNotification;
+    @Builder.Default
+    private int maxNumNotifications = 5; // -1 means to keep reminding indefinitely
 
     // for admin notifications, comma separated list of admin emails.
     // will not send if the email does not have an associated admin account
@@ -73,8 +75,7 @@ public class Trigger extends BaseEntity implements VersionedEntityConfig, StudyE
     private int afterMinutesIncomplete = (int) Duration.ofHours(72).toMinutes();
     @Builder.Default
     private int reminderIntervalMinutes = (int) Duration.ofHours(72).toMinutes();
-    @Builder.Default
-    private int maxNumReminders = 5; // -1 means to keep reminding indefinitely
+
     @Override
     public Versioned versionedEntity() {
         return emailTemplate;

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/EnrolleeReminderService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/EnrolleeReminderService.java
@@ -65,7 +65,7 @@ public class EnrolleeReminderService {
         Duration timeSinceCreation = Duration.ofMinutes(trigger.getAfterMinutesIncomplete());
 
         Duration timeSinceLastNotification = Duration.ofMinutes(trigger.getReminderIntervalMinutes());
-        long maxReminders = trigger.getMaxNumReminders() <= 0 ? 100000 : trigger.getMaxNumReminders();
+        long maxReminders = trigger.getMaxNumNotifications() <= 0 ? 100000 : trigger.getMaxNumNotifications();
         Duration maxTimeSinceCreation = timeSinceCreation.plus(timeSinceLastNotification.multipliedBy(maxReminders));
 
         List<ParticipantTaskDao.EnrolleeWithTasks> enrolleesWithTasks = participantTaskQueryService

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/NotificationDispatcher.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/NotificationDispatcher.java
@@ -1,10 +1,7 @@
 package bio.terra.pearl.core.service.notification;
 
-import bio.terra.pearl.core.model.notification.Notification;
-import bio.terra.pearl.core.model.notification.NotificationDeliveryStatus;
-import bio.terra.pearl.core.model.notification.NotificationDeliveryType;
-import bio.terra.pearl.core.model.notification.Trigger;
-import bio.terra.pearl.core.model.notification.TriggerType;
+import bio.terra.pearl.core.model.notification.*;
+import bio.terra.pearl.core.service.notification.email.EmailTemplateService;
 import bio.terra.pearl.core.service.notification.email.EnrolleeEmailService;
 import bio.terra.pearl.core.service.rule.EnrolleeContext;
 import bio.terra.pearl.core.service.rule.EnrolleeRuleEvaluator;
@@ -22,15 +19,14 @@ import java.util.UUID;
 @Component
 @Slf4j
 public class NotificationDispatcher {
-    private TriggerService triggerService;
+    private final EmailTemplateService emailTemplateService;
     private NotificationService notificationService;
     private Map<NotificationDeliveryType, NotificationSender> senderMap;
 
-    public NotificationDispatcher(TriggerService triggerService,
-                                  NotificationService notificationService, EnrolleeEmailService enrolleeEmailService) {
-        this.triggerService = triggerService;
+    public NotificationDispatcher(NotificationService notificationService, EnrolleeEmailService enrolleeEmailService, EmailTemplateService emailTemplateService) {
         this.notificationService = notificationService;
         senderMap = Map.of(NotificationDeliveryType.EMAIL, enrolleeEmailService);
+        this.emailTemplateService = emailTemplateService;
     }
 
     /**
@@ -83,6 +79,4 @@ public class NotificationDispatcher {
     public NotificationContextInfo loadContextInfo(Trigger config) {
         return senderMap.get(config.getDeliveryType()).loadContextInfo(config);
     }
-
-
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/NotificationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/NotificationService.java
@@ -73,6 +73,10 @@ public class NotificationService extends CrudService<Notification, NotificationD
         return dao.findMostRecentSentByEnrolleeAndTriggerId(enrolleeId, triggerId);
     }
 
+    public List<Notification> findByEnrolleeAndEmailStableId(Enrollee enrollee, String emailStableId) {
+        return dao.findByEnrolleeAndEmailStableId(enrollee, emailStableId);
+    }
+
     private void attachEnrollees(List<Notification> notifications) {
         List<UUID> enrolleeIds = notifications
                 .stream()

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/TriggerActionService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/TriggerActionService.java
@@ -1,19 +1,18 @@
 package bio.terra.pearl.core.service.workflow;
 
 import bio.terra.pearl.core.model.audit.DataAuditInfo;
-import bio.terra.pearl.core.model.notification.Trigger;
-import bio.terra.pearl.core.model.notification.TriggerActionType;
-import bio.terra.pearl.core.model.notification.TriggerScope;
-import bio.terra.pearl.core.model.notification.TriggerType;
+import bio.terra.pearl.core.model.notification.*;
 import bio.terra.pearl.core.model.participant.Profile;
 import bio.terra.pearl.core.model.workflow.ParticipantTask;
 import bio.terra.pearl.core.service.admin.AdminUserService;
 import bio.terra.pearl.core.service.notification.NotificationDispatcher;
+import bio.terra.pearl.core.service.notification.NotificationService;
 import bio.terra.pearl.core.service.notification.TriggerService;
 import bio.terra.pearl.core.service.notification.email.AdminEmailService;
 import bio.terra.pearl.core.service.notification.email.EmailTemplateService;
 import bio.terra.pearl.core.service.participant.ProfileService;
 import bio.terra.pearl.core.service.portal.PortalService;
+import bio.terra.pearl.core.service.rule.EnrolleeContext;
 import bio.terra.pearl.core.service.search.EnrolleeSearchContext;
 import bio.terra.pearl.core.service.search.EnrolleeSearchExpression;
 import bio.terra.pearl.core.service.search.EnrolleeSearchExpressionParser;
@@ -38,6 +37,7 @@ import java.util.Optional;
 @Slf4j
 public class TriggerActionService {
     private final TriggerService triggerService;
+    private final NotificationService notificationService;
     private final NotificationDispatcher notificationDispatcher;
     private final ParticipantTaskService participantTaskService;
     private final AdminEmailService adminEmailService;
@@ -47,7 +47,7 @@ public class TriggerActionService {
     private final EnrolleeSearchExpressionParser enrolleeSearchExpressionParser;
     private final ProfileService profileService;
 
-    public TriggerActionService(TriggerService triggerService,
+    public TriggerActionService(TriggerService triggerService, NotificationService notificationService,
                                 NotificationDispatcher notificationDispatcher,
                                 ParticipantTaskService participantTaskService,
                                 AdminEmailService adminEmailService,
@@ -56,6 +56,7 @@ public class TriggerActionService {
                                 AdminUserService adminUserService,
                                 EnrolleeSearchExpressionParser enrolleeSearchExpressionParser, ProfileService profileService) {
         this.triggerService = triggerService;
+        this.notificationService = notificationService;
         this.notificationDispatcher = notificationDispatcher;
         this.participantTaskService = participantTaskService;
         this.adminEmailService = adminEmailService;
@@ -84,8 +85,10 @@ public class TriggerActionService {
 
         for (Trigger trigger: applicableTriggers) {
             if (TriggerActionType.NOTIFICATION.equals(trigger.getActionType())) {
-                notificationDispatcher.dispatchNotificationAsync(trigger, event.getEnrolleeContext(),
-                        event.getPortalParticipantUser().getPortalEnvironmentId());
+                if (!isNotificationOverLimit(trigger, event.getEnrolleeContext())) {
+                    notificationDispatcher.dispatchNotificationAsync(trigger, event.getEnrolleeContext(),
+                            event.getPortalParticipantUser().getPortalEnvironmentId());
+                }
             } else if (TriggerActionType.ADMIN_NOTIFICATION.equals(trigger.getActionType())) {
                 try {
                     adminEmailService.sendEmailFromTrigger(trigger, event);
@@ -145,5 +148,17 @@ public class TriggerActionService {
                 .enrolleeId(event.getEnrollee().getId())
                 .portalParticipantUserId(event.getPortalParticipantUser().getId())
                 .build();
+    }
+
+
+    protected boolean isNotificationOverLimit(Trigger config, EnrolleeContext enrolleeContext) {
+        if (config.getMaxNumNotifications() >= 0 && config.getEmailTemplateId() != null) {
+            EmailTemplate emailTemplate = emailTemplateService.find(config.getEmailTemplateId()).orElseThrow();
+            List<Notification> pastNotifications = notificationService.findByEnrolleeAndEmailStableId(enrolleeContext.getEnrollee(), emailTemplate.getStableId());
+            if (pastNotifications.size() >= config.getMaxNumNotifications()) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/TriggerActionService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/TriggerActionService.java
@@ -90,10 +90,12 @@ public class TriggerActionService {
                             event.getPortalParticipantUser().getPortalEnvironmentId());
                 }
             } else if (TriggerActionType.ADMIN_NOTIFICATION.equals(trigger.getActionType())) {
-                try {
-                    adminEmailService.sendEmailFromTrigger(trigger, event);
-                } catch (Exception e) {
-                    log.error("Failed to send admin email for trigger {}", trigger.getId(), e);
+                if (!isNotificationOverLimit(trigger, event.getEnrolleeContext())) {
+                    try {
+                        adminEmailService.sendEmailFromTrigger(trigger, event);
+                    } catch (Exception e) {
+                        log.error("Failed to send admin email for trigger {}", trigger.getId(), e);
+                    }
                 }
             } else if (TriggerActionType.TASK_STATUS_CHANGE.equals(trigger.getActionType())) {
                 updateTaskStatus(trigger, event);

--- a/core/src/main/resources/db/changelog/changesets/2025_08_27_rename_max_reminders.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2025_08_27_rename_max_reminders.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: "rename_max_reminders"
+      author: dbush
+      changes:
+        - renameColumn:
+            tableName: trigger
+            oldColumnName: max_num_reminders
+            newColumnName: max_num_notifications
+
+

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -419,6 +419,9 @@ databaseChangeLog:
   - include:
       file: changesets/2025_07_22_kit_metadata_sex_at_birth.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2025_08_27_rename_max_reminders.yaml
+      relativeToChangelogFile: true
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements
 # are atomic. When they are grouped in a changeset and one fails the changeset cannot be
 # rolled back or rerun making recovery more difficult

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/EnrolleeReminderServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/EnrolleeReminderServiceTests.java
@@ -311,7 +311,7 @@ public class EnrolleeReminderServiceTests extends BaseSpringBootTest {
             .deliveryType(NotificationDeliveryType.EMAIL)
             .studyEnvironmentId(studyEnv.getId())
             .portalEnvironmentId(portalEnv.getId())
-            .maxNumReminders(1)
+            .maxNumNotifications(1)
             .build();
     triggerService.create(config);
     enrolleeReminderService.sendTaskReminders(studyEnv);

--- a/core/src/test/java/bio/terra/pearl/core/service/notification/NotificationDispatcherTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/notification/NotificationDispatcherTests.java
@@ -3,6 +3,7 @@ package bio.terra.pearl.core.service.notification;
 import bio.terra.pearl.core.BaseSpringBootTest;
 import bio.terra.pearl.core.factory.kit.KitRequestFactory;
 import bio.terra.pearl.core.factory.kit.KitTypeFactory;
+import bio.terra.pearl.core.factory.notification.EmailTemplateFactory;
 import bio.terra.pearl.core.factory.participant.EnrolleeBundle;
 import bio.terra.pearl.core.factory.participant.EnrolleeFactory;
 import bio.terra.pearl.core.model.kit.KitRequest;
@@ -21,12 +22,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 public class NotificationDispatcherTests extends BaseSpringBootTest {
+    @Autowired
+    private EmailTemplateFactory emailTemplateFactory;
+
     @Test
     @Transactional
     public void testEventTriggersNotificationCreation() {
         EnrolleeBundle enrolleeBundle = enrolleeFactory
                 .buildWithPortalUser("notificationTriggers");
-        Trigger config = createNotificationConfig(enrolleeBundle, TriggerEventType.STUDY_ENROLLMENT);
+        Trigger config = createNotificationConfig(enrolleeBundle, TriggerEventType.STUDY_ENROLLMENT, 2);
 
         eventService.publishEnrolleeCreationEvent(enrolleeBundle.enrollee(), enrolleeBundle.portalParticipantUser());
         verifyNotification(config, enrolleeBundle);
@@ -38,7 +42,7 @@ public class NotificationDispatcherTests extends BaseSpringBootTest {
         String testName = getTestName(testInfo);
         EnrolleeBundle enrolleeBundle = enrolleeFactory
                 .buildWithPortalUser(testName);
-        Trigger config = createNotificationConfig(enrolleeBundle, TriggerEventType.KIT_SENT);
+        Trigger config = createNotificationConfig(enrolleeBundle, TriggerEventType.KIT_SENT, 2);
 
         KitRequest kitRequest = kitRequestFactory.buildPersisted(testName, enrolleeBundle.enrollee(), PepperKitStatus.SENT);
         eventService.publishKitStatusEvent(kitRequest, enrolleeBundle.enrollee(), enrolleeBundle.portalParticipantUser(),
@@ -52,21 +56,49 @@ public class NotificationDispatcherTests extends BaseSpringBootTest {
         String testName = getTestName(testInfo);
         EnrolleeBundle enrolleeBundle = enrolleeFactory
                 .buildWithPortalUser(testName);
-        Trigger config = createNotificationConfig(enrolleeBundle, TriggerEventType.KIT_RECEIVED);
+        Trigger config = createNotificationConfig(enrolleeBundle, TriggerEventType.KIT_RECEIVED, 2);
         KitRequest kitRequest = kitRequestFactory.buildPersisted(testName, enrolleeBundle.enrollee(), PepperKitStatus.RECEIVED);
 
         eventService.publishKitStatusEvent(kitRequest, enrolleeBundle.enrollee(), enrolleeBundle.portalParticipantUser(),
                 KitRequestStatus.SENT);
-        verifyNotification(config, enrolleeBundle);
+        verifyNotification( config, enrolleeBundle);
+        List<Notification> notifications = notificationService.findByEnrolleeId(enrolleeBundle.enrollee().getId());
+        assertThat(notifications, hasSize(1));
+
+        // a second event should send another email
+        eventService.publishKitStatusEvent(kitRequest, enrolleeBundle.enrollee(), enrolleeBundle.portalParticipantUser(),
+                KitRequestStatus.SENT);
+        notifications = notificationService.findByEnrolleeId(enrolleeBundle.enrollee().getId());
+        assertThat(notifications, hasSize(2));
     }
 
-    private Trigger createNotificationConfig(EnrolleeBundle enrolleeBundle, TriggerEventType eventType) {
+    @Test
+    @Transactional
+    void testMaxOnEvent(TestInfo testInfo) {
+        String testName = getTestName(testInfo);
+        EnrolleeBundle enrolleeBundle = enrolleeFactory.buildWithPortalUser(testName);
+        Trigger config = createNotificationConfig(enrolleeBundle, TriggerEventType.KIT_RECEIVED, 1);
+        KitRequest kitRequest = kitRequestFactory.buildPersisted(testName, enrolleeBundle.enrollee(), PepperKitStatus.RECEIVED);
+        eventService.publishKitStatusEvent(kitRequest, enrolleeBundle.enrollee(), enrolleeBundle.portalParticipantUser(),
+                KitRequestStatus.SENT);
+        verifyNotification(config, enrolleeBundle);
+
+        eventService.publishKitStatusEvent(kitRequest, enrolleeBundle.enrollee(), enrolleeBundle.portalParticipantUser(),
+                KitRequestStatus.SENT);
+        List<Notification> notifications = notificationService.findByEnrolleeId(enrolleeBundle.enrollee().getId());
+        assertThat(notifications, hasSize(1));
+    }
+
+    private Trigger createNotificationConfig(EnrolleeBundle enrolleeBundle, TriggerEventType eventType, int maxNumNotifications) {
         Enrollee enrollee = enrolleeBundle.enrollee();
+        EmailTemplate template = emailTemplateFactory.buildPersisted("test", enrolleeBundle.portalId());
         Trigger config = Trigger.builder()
                 .studyEnvironmentId(enrollee.getStudyEnvironmentId())
                 .eventType(eventType)
                 .deliveryType(NotificationDeliveryType.EMAIL)
                 .triggerType(TriggerType.EVENT)
+                .maxNumNotifications(maxNumNotifications)
+                .emailTemplateId(template.getId())
                 .portalEnvironmentId(enrolleeBundle.portalParticipantUser().getPortalEnvironmentId())
                 .build();
         config = triggerService.create(config);

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
@@ -79,6 +79,7 @@
         "triggerType": "EVENT",
         "eventType": "SURVEY_RESPONSE",
         "filterTargetStableIds": ["hd_hd_medHx"],
+        "maxNumNotifications": 1,
         "populateFileName": "emails/medHxComplete.json"
       },{
         "triggerType": "TASK_REMINDER",

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/study.json
@@ -88,14 +88,14 @@
         "triggerType": "TASK_REMINDER",
         "taskType": "SURVEY",
         "reminderIntervalMinutes": 10080,
-        "maxNumReminders": 2,
+        "maxNumNotifications": 2,
         "populateFileName": "emails/surveyReminder.json"
       },{
         "triggerType": "TASK_REMINDER",
         "taskType": "OUTREACH",
         "afterMinutesIncomplete": 0,
         "reminderIntervalMinutes": 10080,
-        "maxNumReminders": 2,
+        "maxNumNotifications": 2,
         "populateFileName": "emails/outreachReminder.json"
       },{
         "triggerType": "EVENT",
@@ -245,7 +245,7 @@
         "triggerType": "TASK_REMINDER",
         "taskType": "SURVEY",
         "reminderIntervalMinutes": 10080,
-        "maxNumReminders": 2,
+        "maxNumNotifications": 2,
         "populateFileName": "emails/surveyReminder.json"
       },{
         "triggerType": "EVENT",
@@ -301,7 +301,7 @@
         "triggerType": "TASK_REMINDER",
         "taskType": "SURVEY",
         "reminderIntervalMinutes": 10080,
-        "maxNumReminders": 2,
+        "maxNumNotifications": 2,
         "populateFileName": "emails/surveyReminder.json"
       },{
         "triggerType": "EVENT",

--- a/populate/src/main/resources/seed/portals/demo/studies/sleep/study.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/sleep/study.json
@@ -46,7 +46,7 @@
         "triggerType": "TASK_REMINDER",
         "taskType": "SURVEY",
         "reminderIntervalMinutes": 10080,
-        "maxNumReminders": 2,
+        "maxNumNotifications": 2,
         "populateFileName": "emails/surveyReminder.json"
       }],
       "enrolleeFiles": []
@@ -83,7 +83,7 @@
         "triggerType": "TASK_REMINDER",
         "taskType": "SURVEY",
         "reminderIntervalMinutes": 10080,
-        "maxNumReminders": 2,
+        "maxNumNotifications": 2,
         "populateFileName": "emails/surveyReminder.json"
       }],
       "enrolleeFiles": []
@@ -120,7 +120,7 @@
         "triggerType": "TASK_REMINDER",
         "taskType": "SURVEY",
         "reminderIntervalMinutes": 10080,
-        "maxNumReminders": 2,
+        "maxNumNotifications": 2,
         "populateFileName": "emails/surveyReminder.json"
       }],
       "enrolleeFiles": []

--- a/populate/src/main/resources/seed/portals/hearthive/studies/cmyop/study.json
+++ b/populate/src/main/resources/seed/portals/hearthive/studies/cmyop/study.json
@@ -74,7 +74,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 5,
+      "maxNumNotifications" : 5,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hh_cymop_studyEnroll-2.json"
     }, {
@@ -86,7 +86,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 5,
+      "maxNumNotifications" : 5,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hh_cymop_studyEnroll-3.json"
     }, {
@@ -98,7 +98,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 5,
+      "maxNumNotifications" : 5,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hh_cymop_studyEnroll-4.json"
     }, {
@@ -110,7 +110,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 5,
+      "maxNumNotifications" : 5,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hh_cymop_studyEnroll-5.json"
     }, {
@@ -122,7 +122,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 5,
+      "maxNumNotifications" : 5,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hh_cymop_studyEnroll-3.json"
     }, {
@@ -134,7 +134,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 5,
+      "maxNumNotifications" : 5,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hh_cymop_studyEnroll-6.json"
     }, {
@@ -147,7 +147,7 @@
       "taskType" : "CONSENT",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_hhcmConsentReminder-1.json"
     }, {
@@ -160,7 +160,7 @@
       "taskType" : "CONSENT",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_hhcmConsentReminder-2.json"
     }, {
@@ -173,7 +173,7 @@
       "taskType" : "CONSENT",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_hhcmConsentReminder-4.json"
     }, {
@@ -186,7 +186,7 @@
       "taskType" : "CONSENT",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_hhcmConsentReminder-3.json"
     }, {
@@ -198,7 +198,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 5,
+      "maxNumNotifications" : 5,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hh_cymop_studyEnroll-6.json"
     }, {
@@ -210,7 +210,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_hhcmThankyou-1.json"
     }, {
@@ -222,7 +222,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 5,
+      "maxNumNotifications" : 5,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hh_cymop_studyEnroll-1.json"
     }, {
@@ -236,7 +236,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_cmyopOutreachComplete-1.json"
     }, {
@@ -248,7 +248,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_cmyopOutreachComplete-1.json"
     }, {
@@ -260,7 +260,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_hhcmThankyou-2.json"
     }, {
@@ -272,7 +272,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_hhcmThankyou-3.json"
     }, {
@@ -284,7 +284,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_hhcmThankyou-5.json"
     }, {
@@ -296,7 +296,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_hhcmThankyou-4.json"
     } ],
@@ -348,7 +348,7 @@
       "taskType" : "CONSENT",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_hhcmConsentReminder-4.json"
     }, {
@@ -362,7 +362,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_cmyopOutreachComplete-1.json"
     }, {
@@ -374,7 +374,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_hhcmThankyou-5.json"
     } ],
@@ -426,7 +426,7 @@
       "taskType" : "CONSENT",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_hhcmConsentReminder-4.json"
     }, {
@@ -440,7 +440,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_cmyopOutreachComplete-1.json"
     }, {
@@ -452,7 +452,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_hhcmThankyou-5.json"
     } ],

--- a/populate/src/main/resources/seed/portals/hearthive/studies/hh_registry/study.json
+++ b/populate/src/main/resources/seed/portals/hearthive/studies/hh_registry/study.json
@@ -1020,7 +1020,7 @@
       "taskType" : "OUTREACH",
       "afterMinutesIncomplete" : 0,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_outreachReminder-2.json"
     }, {
@@ -1032,7 +1032,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_invitationFromDatstat-1.json"
     }, {
@@ -1045,7 +1045,7 @@
       "taskType" : "OUTREACH",
       "afterMinutesIncomplete" : 0,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_outreachReminder-4.json"
     }, {
@@ -1058,7 +1058,7 @@
       "taskType" : "OUTREACH",
       "afterMinutesIncomplete" : 0,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_outreachReminder-5.json"
     }, {
@@ -1070,7 +1070,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_invitationFromDatstat-4.json"
     }, {
@@ -1082,7 +1082,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 43200,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_heartHiveEnrollment-1.json"
     }, {
@@ -1094,7 +1094,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 43200,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_heartHiveEnrollment-2.json"
     }, {
@@ -1107,7 +1107,7 @@
       "taskType" : "CONSENT",
       "afterMinutesIncomplete" : 43200,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_consentReminder-1.json"
     }, {
@@ -1120,7 +1120,7 @@
       "taskType" : "CONSENT",
       "afterMinutesIncomplete" : 43200,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_consentReminder-2.json"
     }, {
@@ -1133,7 +1133,7 @@
       "taskType" : "CONSENT",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_consentReminder-2.json"
     }, {
@@ -1146,7 +1146,7 @@
       "taskType" : "CONSENT",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_consentReminder-4.json"
     }, {
@@ -1159,7 +1159,7 @@
       "taskType" : "CONSENT",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_consentReminder-3.json"
     }, {
@@ -1171,7 +1171,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 43200,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_heartHiveEnrollment-4.json"
     }, {
@@ -1183,7 +1183,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 43200,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_heartHiveEnrollment-3.json"
     }, {
@@ -1196,7 +1196,7 @@
       "taskType" : "OUTREACH",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_outreachReminder-1.json"
     }, {
@@ -1208,7 +1208,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_invitationFromDatstat-2.json"
     }, {
@@ -1221,7 +1221,7 @@
       "taskType" : "OUTREACH",
       "afterMinutesIncomplete" : 0,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_outreachReminder-3.json"
     }, {
@@ -1234,7 +1234,7 @@
       "taskType" : "OUTREACH",
       "afterMinutesIncomplete" : 0,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_outreachReminder-6.json"
     }, {
@@ -1246,7 +1246,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_invitationFromDatstat-3.json"
     } ],
@@ -1327,7 +1327,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 43200,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_heartHiveEnrollment-4.json"
     }, {
@@ -1340,7 +1340,7 @@
       "taskType" : "CONSENT",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_consentReminder-4.json"
     }, {
@@ -1352,7 +1352,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_invitationFromDatstat-4.json"
     }, {
@@ -1365,7 +1365,7 @@
       "taskType" : "OUTREACH",
       "afterMinutesIncomplete" : 0,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_outreachReminder-6.json"
     } ],
@@ -1441,7 +1441,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 43200,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_heartHiveEnrollment-4.json"
     }, {
@@ -1454,7 +1454,7 @@
       "taskType" : "CONSENT",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_consentReminder-4.json"
     }, {
@@ -1466,7 +1466,7 @@
       "deliveryType" : "EMAIL",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_invitationFromDatstat-4.json"
     }, {
@@ -1479,7 +1479,7 @@
       "taskType" : "OUTREACH",
       "afterMinutesIncomplete" : 0,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "../../emails/hearthive_outreachReminder-6.json"
     } ],

--- a/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/study.json
+++ b/populate/src/main/resources/seed/portals/ourhealth/studies/ourheart/study.json
@@ -58,7 +58,7 @@
         "triggerType": "TASK_REMINDER",
         "taskType": "SURVEY",
         "reminderIntervalMinutes": 10080,
-        "maxNumReminders": 2,
+        "maxNumNotifications": 2,
         "populateFileName": "emails/surveyReminder.json"
       },{
         "triggerType": "AD_HOC",

--- a/populate/src/main/resources/seed/templates/basic_study.json
+++ b/populate/src/main/resources/seed/templates/basic_study.json
@@ -31,7 +31,7 @@
       "taskType" : "CONSENT",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "emails/consentReminder.json"
     }, {
@@ -41,7 +41,7 @@
       "eventType" : "KIT_RECEIVED",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "emails/kitReturned.json"
     }, {
@@ -51,7 +51,7 @@
       "eventType" : "STUDY_ENROLLMENT",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "emails/enrollment.json"
     }, {
@@ -62,7 +62,7 @@
       "taskType" : "SURVEY",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 10080,
-      "maxNumReminders" : 2,
+      "maxNumNotifications" : 2,
       "emailTemplateVersion" : 0,
       "populateFileName" : "emails/surveyReminder.json"
     }, {
@@ -72,7 +72,7 @@
       "eventType" : "KIT_SENT",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "emails/kitSent.json"
     }, {
@@ -82,7 +82,7 @@
       "eventType" : "STUDY_CONSENT",
       "afterMinutesIncomplete" : 4320,
       "reminderIntervalMinutes" : 4320,
-      "maxNumReminders" : 3,
+      "maxNumNotifications" : 3,
       "emailTemplateVersion" : 0,
       "populateFileName" : "emails/consentSigned.json"
     }],

--- a/ui-admin/src/study/notifications/CreateTriggerModal.tsx
+++ b/ui-admin/src/study/notifications/CreateTriggerModal.tsx
@@ -30,7 +30,7 @@ const getDefaultConfig = (): Trigger => {
     reminderIntervalMinutes: 72 * 60,
     filterTargetStableIds: [],
     actionTargetStableIds: [],
-    maxNumReminders: 3,
+    maxNumNotifications: 3,
     emailTemplate: {
       stableId: 'placeholderStableId',
       name: '',

--- a/ui-admin/src/study/notifications/TriggerDesignerEditor.tsx
+++ b/ui-admin/src/study/notifications/TriggerDesignerEditor.tsx
@@ -149,6 +149,17 @@ const TriggerTypeEditor = (
               <TaskReminderEditor trigger={trigger} updateTrigger={updateTrigger}/>
             </>}
 
+          {(trigger.triggerType === 'TASK_REMINDER' || trigger.triggerType === 'EVENT') &&
+            <div>
+              <label className="form-label">Max number of notifications
+                <input className="form-control" type="number" value={trigger.maxNumNotifications}
+                  onChange={e => updateTrigger(
+                    'maxNumNotifications', parseInt(e.target.value) || 0
+                  )}/>
+              </label>
+            </div>
+          }
+
           {trigger.triggerType !== 'AD_HOC' && <TriggerRuleEditor
             studyEnvContext={studyEnvContext}
             trigger={trigger}
@@ -251,14 +262,6 @@ const TaskReminderEditor = (
               'reminderIntervalMinutes',
               parseInt(e.target.value) * 60 || 0)}/>
           hours</div>
-      </label>
-    </div>
-    <div>
-      <label className="form-label">Max reminders
-        <input className="form-control" type="number" value={trigger.maxNumReminders}
-          onChange={e => updateTrigger(
-            'maxNumReminders', parseInt(e.target.value) || 0
-          )}/>
       </label>
     </div>
   </div>

--- a/ui-admin/src/study/workflow/WorkflowView.tsx
+++ b/ui-admin/src/study/workflow/WorkflowView.tsx
@@ -398,7 +398,7 @@ const TriggerListItem = ({ trigger, studyEnvParams }:
       <span className="text-muted fst-italic">
         <FontAwesomeIcon icon={faCalendarAlt} className="ms-3 me-2"/>
         <span>
-      reminds after {minutesToDayString(trigger.afterMinutesIncomplete)} (max { trigger.maxNumReminders } reminders)
+      reminds after {minutesToDayString(trigger.afterMinutesIncomplete)} (max { trigger.maxNumNotifications } reminders)
         </span>
       </span>
     }

--- a/ui-admin/src/test-utils/mocking-utils.tsx
+++ b/ui-admin/src/test-utils/mocking-utils.tsx
@@ -423,7 +423,7 @@ export const mockTrigger = (): Trigger => {
     taskType: '',
     portalEnvironmentId: 'portalEnvId',
     studyEnvironmentId: 'studyEnvId',
-    maxNumReminders: -1,
+    maxNumNotifications: -1,
     afterMinutesIncomplete: -1,
     reminderIntervalMinutes: 10,
     filterTargetStableIds: [],

--- a/ui-core/src/types/study.ts
+++ b/ui-core/src/types/study.ts
@@ -86,7 +86,7 @@ export type Trigger = {
   statusToUpdateTo?: ParticipantTaskStatus
   afterMinutesIncomplete: number
   reminderIntervalMinutes: number
-  maxNumReminders: number
+  maxNumNotifications: number
   emailTemplateId: string
   emailTemplate: EmailTemplate
   targetEmails?: string


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Based on a request from HeartHive to limit the number of times a participant gets a "completed" email for some things.  Renames maxNumReminders to maxNumNotifications, and allows setting it 

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. In demo study, complete the medical history survey for a participant
2. confirm you get an email
3. go back to the medical history survey and update an answer and hit submit
4. confirm you don't get another email