### PR TITLE
[JN-1742] fix max cert issue 

### DIFF
--- a/terraform/gcp/k8s/environments/dev.yaml
+++ b/terraform/gcp/k8s/environments/dev.yaml
@@ -5,15 +5,18 @@ deploymentZone: dev
 replicas: 1
 dsmUrl: https://dsm-dev.datadonationplatform.org/dsm
 dsmIssuer: admin-d2p.ddp-dev.envs.broadinstitute.org
-# "portals" adds certificates for each portal - both for the juniper-cmi.dev subdomains and the custom domain
+# "portals" adds certificates for admin subdomains
 portals:
-  - name: demo
-    customDomain: juniperdemostudy.dev
-  - name: hearthive
-  - name: ourhealth
-  - name: cmi
-  - name: rgp
-  - name: atcp
+  - demo
+  - hearthive
+  - ourhealth
+  - cmi
+  - rgp
+  - atcp
+studyCertificates:
+  - groupName: demo
+    urls:
+      - juniperdemostudy.dev
 b2c:
   admin:
     clientId: 705c09dc-5cca-43d3-ae06-07de78bad29a

--- a/terraform/gcp/k8s/environments/dev.yaml
+++ b/terraform/gcp/k8s/environments/dev.yaml
@@ -17,6 +17,10 @@ studyCertificates:
   - groupName: demo
     urls:
       - juniperdemostudy.dev
+  # todo: remove after deploying new cert
+  - groupName: testextracert
+    urls:
+      - juniperdemostudy.dev
 b2c:
   admin:
     clientId: 705c09dc-5cca-43d3-ae06-07de78bad29a

--- a/terraform/gcp/k8s/environments/prod.yaml
+++ b/terraform/gcp/k8s/environments/prod.yaml
@@ -38,11 +38,9 @@ studyCertificates:
   - groupName: hearthive
     urls:
       - thehearthive.org
-  - groupName: trcc
+  - groupName: cmi
     urls:
       - trccproject.org
-      #  - groupName: pedihcc
-      #    urls:
       - pedihccproject.org
 
 b2c:

--- a/terraform/gcp/k8s/environments/prod.yaml
+++ b/terraform/gcp/k8s/environments/prod.yaml
@@ -38,6 +38,10 @@ studyCertificates:
   - groupName: hearthive
     urls:
       - thehearthive.org
+  # todo: remove after deploying cmi cert
+  - groupName: trccproject
+    urls:
+      - trccproject.org
   - groupName: cmi
     urls:
       - trccproject.org

--- a/terraform/gcp/k8s/environments/prod.yaml
+++ b/terraform/gcp/k8s/environments/prod.yaml
@@ -5,23 +5,46 @@ deploymentZone: prod
 replicas: 3
 dsmUrl: https://dsm.datadonationplatform.org/dsm
 dsmIssuer: juniper.terra.bio
-# "portals" adds certificates for each portal - both for the admin subdomains and the custom domain
+# "portals" is used only to generate the admin certificate (without wildcards):
+# e.g. for sandbox.demo.juniper-cmi.org, irb.demo.juniper-cmi.org, etc.
+# any addition to this list will require a short downtime for the admin site while the new
+# certificate is issued.
 portals:
-  - name: demo
-    customDomain: juniperdemostudy.org
-  - name: ourhealth
-    customDomain: ourhealthstudy.org
-  - name: gvasc
-    customDomain: gvascstudy.org
-  - name: atcp
-  - name: hearthive
-    customDomain: thehearthive.org
-  - name: trccproject
-    customDomain: trccproject.org
-  - name: rgp
-  - name: cmi
-  - name: pedihcc
-    customDomain: pedihccproject.org
+  - demo
+  - ourhealth
+  - gvasc
+  - atcp
+  - hearthive
+  - trccproject
+  - rgp
+  - cmi
+  - pedihcc
+
+# we have a maximum of 15 certificates per-ingress. since we have 1 admin certificate,
+# we have a maximum of 14 study certificates in this list.
+# if we need more, we will need to split into multiple ingresses (which costs money).
+# where possible, group multiple portals into a single certificate. this would mean
+# downtime for all URLs in a group when a new URL is added, but that should be rare.
+studyCertificates:
+  - groupName: demo
+    urls:
+      - juniperdemostudy.org
+  - groupName: ourhealth
+    urls:
+      - ourhealthstudy.org
+  - groupName: gvasc
+    urls:
+      - gvascstudy.org
+  - groupName: hearthive
+    urls:
+      - thehearthive.org
+  - groupName: trcc
+    urls:
+      - trccproject.org
+      #  - groupName: pedihcc
+      #    urls:
+      - pedihccproject.org
+
 b2c:
   admin:
     clientId: f02b3816-af49-4a78-a2a5-b929c78a6c47

--- a/terraform/gcp/k8s/templates/admin-cert.yml
+++ b/terraform/gcp/k8s/templates/admin-cert.yml
@@ -1,3 +1,4 @@
+{{$adminUrl := .Values.adminUrl}}
 apiVersion: networking.gke.io/v1
 kind: ManagedCertificate
 metadata:
@@ -6,4 +7,8 @@ spec:
   domains:
     - {{ .Values.adminUrl }}
     - www.{{ .Values.adminUrl }}
-
+    {{- range .Values.portals }}
+    - {{.}}.{{$adminUrl}}
+    - sandbox.{{.}}.{{$adminUrl}}
+    - irb.{{.}}.{{$adminUrl}}
+    {{ end }}

--- a/terraform/gcp/k8s/templates/ingress.yml
+++ b/terraform/gcp/k8s/templates/ingress.yml
@@ -1,9 +1,9 @@
 {{- define "customer-certs" -}}
-{{- range $idx, $val := $.Values.portals -}}
+{{- range $idx, $val := $.Values.studyCertificates -}}
 {{- if $idx }}
 {{- print ","  -}}
 {{- end -}}
-{{- $val.name -}}-admin-subdomain-cert{{if $val.customDomain}},{{- $val.name -}}-public-url-cert{{end}}
+{{- $val.groupName -}}-public-url-cert
 {{- end -}}
 {{- end -}}
 

--- a/terraform/gcp/k8s/templates/portal-certs.yml
+++ b/terraform/gcp/k8s/templates/portal-certs.yml
@@ -1,27 +1,15 @@
-{{$adminUrl := .Values.adminUrl}}
-{{range .Values.portals}}
+{{range .Values.studyCertificates}}
 apiVersion: networking.gke.io/v1
 kind: ManagedCertificate
 metadata:
-  name: {{.name}}-admin-subdomain-cert
+  name: {{.groupName}}-public-url-cert
 spec:
   domains:
-      - {{.name}}.{{$adminUrl}}
-      - sandbox.{{.name}}.{{$adminUrl}}
-      - irb.{{.name}}.{{$adminUrl}}
+    {{- range .urls }}
+      - {{.}}
+      - www.{{.}}
+      - sandbox.{{.}}
+      - irb.{{.}}
+    {{- end }}
 ---
-{{ if .customDomain }}
-apiVersion: networking.gke.io/v1
-kind: ManagedCertificate
-metadata:
-  name: {{.name}}-public-url-cert
-spec:
-  domains:
-      - {{.customDomain}}
-      - www.{{.customDomain}}
-      - sandbox.{{.customDomain}}
-      - irb.{{.customDomain}}
----
-{{ end }}
-
 {{end}}

--- a/terraform/gcp/k8s/values.yaml
+++ b/terraform/gcp/k8s/values.yaml
@@ -1,8 +1,11 @@
 adminUrl: ""
 replicas: 1
 portals:
-  - name: ""
-    customDomain: ""
+  - ""
+studyCertificates:
+  - groupName: ""
+    urls:
+      - ""
 gcpProject: ""
 gcpRegion: ""
 appVersion: 1.4.0


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

we ran out of certs trying to add pedihcc. there's a max of 15 per-ingress. we _could_ start adding more ingresses, but I think they cost a not insignificant amount of money.

consolidates admin certs into one: this means there will be some amount of downtime on the admin site. also, any new portals will cause downtime for admin site.

also, adds ability to "group" studies under one certificate: adding, removing, or changing will cause downtime within that certificate group, but we can silo those to being within the same team. 

IIRC there's no easy way to "plan" helm changes; there are plugins that can do this functionality, but it's not built into helm.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

- `cd terraform/gcp/k8s/`
- ` helm template . --values environments/dev.yaml`
- ` helm template . --values environments/prod.yaml`
validate contents of both

theoretically: if the groupName is the same as the portal name from before, the object should not change, so there _should_ be no certificate reissues.


new certs:
```
# Source: juniper/templates/admin-cert.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: admin-cert
spec:
  domains:
    - juniper-cmi.org
    - www.juniper-cmi.org
    - demo.juniper-cmi.org
    - sandbox.demo.juniper-cmi.org
    - irb.demo.juniper-cmi.org
    
    - ourhealth.juniper-cmi.org
    - sandbox.ourhealth.juniper-cmi.org
    - irb.ourhealth.juniper-cmi.org
    
    - gvasc.juniper-cmi.org
    - sandbox.gvasc.juniper-cmi.org
    - irb.gvasc.juniper-cmi.org
    
    - atcp.juniper-cmi.org
    - sandbox.atcp.juniper-cmi.org
    - irb.atcp.juniper-cmi.org
    
    - hearthive.juniper-cmi.org
    - sandbox.hearthive.juniper-cmi.org
    - irb.hearthive.juniper-cmi.org
    
    - trccproject.juniper-cmi.org
    - sandbox.trccproject.juniper-cmi.org
    - irb.trccproject.juniper-cmi.org
    
    - rgp.juniper-cmi.org
    - sandbox.rgp.juniper-cmi.org
    - irb.rgp.juniper-cmi.org
    
    - cmi.juniper-cmi.org
    - sandbox.cmi.juniper-cmi.org
    - irb.cmi.juniper-cmi.org
    
    - pedihcc.juniper-cmi.org
    - sandbox.pedihcc.juniper-cmi.org
    - irb.pedihcc.juniper-cmi.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: demo-public-url-cert
spec:
  domains:
      - juniperdemostudy.org
      - www.juniperdemostudy.org
      - sandbox.juniperdemostudy.org
      - irb.juniperdemostudy.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: ourhealth-public-url-cert
spec:
  domains:
      - ourhealthstudy.org
      - www.ourhealthstudy.org
      - sandbox.ourhealthstudy.org
      - irb.ourhealthstudy.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: gvasc-public-url-cert
spec:
  domains:
      - gvascstudy.org
      - www.gvascstudy.org
      - sandbox.gvascstudy.org
      - irb.gvascstudy.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: hearthive-public-url-cert
spec:
  domains:
      - thehearthive.org
      - www.thehearthive.org
      - sandbox.thehearthive.org
      - irb.thehearthive.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: trccproject-public-url-cert
spec:
  domains:
      - trccproject.org
      - www.trccproject.org
      - sandbox.trccproject.org
      - irb.trccproject.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: cmi-public-url-cert
spec:
  domains:
      - trccproject.org
      - www.trccproject.org
      - sandbox.trccproject.org
      - irb.trccproject.org
      - pedihccproject.org
      - www.pedihccproject.org
      - sandbox.pedihccproject.org
      - irb.pedihccproject.org
```

new ingress:

```
  annotations:
    kubernetes.io/ingress.global-static-ip-name: admin-ip
    networking.gke.io/managed-certificates: "admin-cert,demo-public-url-cert,ourhealth-public-url-cert,gvasc-public-url-cert,hearthive-public-url-cert,trccproject-public-url-cert,cmi-public-url-cert"
    networking.gke.io/v1beta1.FrontendConfig: "juniper-frontend-config"
    # If the class annotation is not specified it defaults to "gce".
    kubernetes.io/ingress.class: "gce"
```

old certs:
```
# Source: juniper/templates/admin-cert.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: admin-cert
spec:
  domains:
    - juniper-cmi.org
    - www.juniper-cmi.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: demo-admin-subdomain-cert
spec:
  domains:
      - demo.juniper-cmi.org
      - sandbox.demo.juniper-cmi.org
      - irb.demo.juniper-cmi.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: demo-public-url-cert
spec:
  domains:
      - juniperdemostudy.org
      - www.juniperdemostudy.org
      - sandbox.juniperdemostudy.org
      - irb.juniperdemostudy.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: ourhealth-admin-subdomain-cert
spec:
  domains:
      - ourhealth.juniper-cmi.org
      - sandbox.ourhealth.juniper-cmi.org
      - irb.ourhealth.juniper-cmi.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: ourhealth-public-url-cert
spec:
  domains:
      - ourhealthstudy.org
      - www.ourhealthstudy.org
      - sandbox.ourhealthstudy.org
      - irb.ourhealthstudy.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: gvasc-admin-subdomain-cert
spec:
  domains:
      - gvasc.juniper-cmi.org
      - sandbox.gvasc.juniper-cmi.org
      - irb.gvasc.juniper-cmi.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: gvasc-public-url-cert
spec:
  domains:
      - gvascstudy.org
      - www.gvascstudy.org
      - sandbox.gvascstudy.org
      - irb.gvascstudy.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: atcp-admin-subdomain-cert
spec:
  domains:
      - atcp.juniper-cmi.org
      - sandbox.atcp.juniper-cmi.org
      - irb.atcp.juniper-cmi.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: hearthive-admin-subdomain-cert
spec:
  domains:
      - hearthive.juniper-cmi.org
      - sandbox.hearthive.juniper-cmi.org
      - irb.hearthive.juniper-cmi.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: hearthive-public-url-cert
spec:
  domains:
      - thehearthive.org
      - www.thehearthive.org
      - sandbox.thehearthive.org
      - irb.thehearthive.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: trccproject-admin-subdomain-cert
spec:
  domains:
      - trccproject.juniper-cmi.org
      - sandbox.trccproject.juniper-cmi.org
      - irb.trccproject.juniper-cmi.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: trccproject-public-url-cert
spec:
  domains:
      - trccproject.org
      - www.trccproject.org
      - sandbox.trccproject.org
      - irb.trccproject.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: rgp-admin-subdomain-cert
spec:
  domains:
      - rgp.juniper-cmi.org
      - sandbox.rgp.juniper-cmi.org
      - irb.rgp.juniper-cmi.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: cmi-admin-subdomain-cert
spec:
  domains:
      - cmi.juniper-cmi.org
      - sandbox.cmi.juniper-cmi.org
      - irb.cmi.juniper-cmi.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: pedihcc-admin-subdomain-cert
spec:
  domains:
      - pedihcc.juniper-cmi.org
      - sandbox.pedihcc.juniper-cmi.org
      - irb.pedihcc.juniper-cmi.org
---
# Source: juniper/templates/portal-certs.yml
apiVersion: networking.gke.io/v1
kind: ManagedCertificate
metadata:
  name: pedihcc-public-url-cert
spec:
  domains:
      - pedihccproject.org
      - www.pedihccproject.org
      - sandbox.pedihccproject.org
      - irb.pedihccproject.org
```

old ingress:
```
# Source: juniper/templates/ingress.yml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: juniper-ingress
  annotations:
    kubernetes.io/ingress.global-static-ip-name: admin-ip
    networking.gke.io/managed-certificates: "admin-cert,demo-admin-subdomain-cert,demo-public-url-cert,ourhealth-admin-subdomain-cert,ourhealth-public-url-cert,gvasc-admin-subdomain-cert,gvasc-public-url-cert,atcp-admin-subdomain-cert,hearthive-admin-subdomain-cert,hearthive-public-url-cert,trccproject-admin-subdomain-cert,trccproject-public-url-cert,rgp-admin-subdomain-cert,cmi-admin-subdomain-cert,pedihcc-admin-subdomain-cert,pedihcc-public-url-cert"
    networking.gke.io/v1beta1.FrontendConfig: "juniper-frontend-config"
    # If the class annotation is not specified it defaults to "gce".
    kubernetes.io/ingress.class: "gce"
```
