### PR TITLE
[JN-1747] cleanup post cert release issues -> must merge before next release

### DIFF
--- a/terraform/gcp/envs/prod.tfvars
+++ b/terraform/gcp/envs/prod.tfvars
@@ -8,7 +8,8 @@ admin_url = "juniper-cmi.org"
 environment = "prod"
 # note: automatically creates DNS records for these portals under the admin domain
 
-portals = ["demo", "atcp", "ourhealth", "hearthive", "rgp", "cmi", "trccproject", "gvasc", "pedihccproject"]
+# TODO: remove pedihcc next release
+portals = ["demo", "atcp", "ourhealth", "hearthive", "rgp", "cmi", "trccproject", "gvasc", "pedihccproject", "pedihcc"]
 
 admin_dnssec = "on"
 k8s_namespace = "juniper-prod"

--- a/terraform/gcp/k8s/environments/dev.yaml
+++ b/terraform/gcp/k8s/environments/dev.yaml
@@ -17,10 +17,6 @@ studyCertificates:
   - groupName: demo
     urls:
       - juniperdemostudy.dev
-  # todo: remove after deploying new cert
-  - groupName: testextracert
-    urls:
-      - juniperdemostudy.dev
 b2c:
   admin:
     clientId: 705c09dc-5cca-43d3-ae06-07de78bad29a

--- a/terraform/gcp/k8s/environments/prod.yaml
+++ b/terraform/gcp/k8s/environments/prod.yaml
@@ -20,7 +20,7 @@ portals:
   - rgp
   - cmi
   - pedihccproject
-adminCertName: admin-cert-v2
+adminCertName: admin-cert-v3
 # we have a maximum of 15 certificates per-ingress. since we have 1 admin certificate,
 # we have a maximum of 14 study certificates in this list.
 # if we need more, we will need to split into multiple ingresses (which costs money).

--- a/terraform/gcp/k8s/environments/prod.yaml
+++ b/terraform/gcp/k8s/environments/prod.yaml
@@ -19,7 +19,7 @@ portals:
   - trccproject
   - rgp
   - cmi
-  - pedihcc
+  - pedihccproject
 adminCertName: admin-cert-v2
 # we have a maximum of 15 certificates per-ingress. since we have 1 admin certificate,
 # we have a maximum of 14 study certificates in this list.
@@ -39,10 +39,6 @@ studyCertificates:
   - groupName: hearthive
     urls:
       - thehearthive.org
-  # todo: remove after deploying cmi cert
-  - groupName: trccproject
-    urls:
-      - trccproject.org
   - groupName: cmi
     urls:
       - trccproject.org

--- a/terraform/gcp/k8s/templates/ingress.yml
+++ b/terraform/gcp/k8s/templates/ingress.yml
@@ -13,7 +13,7 @@ metadata:
   name: juniper-ingress
   annotations:
     kubernetes.io/ingress.global-static-ip-name: admin-ip
-    networking.gke.io/managed-certificates: "admin-cert,{{ template "customer-certs" . }}"
+    networking.gke.io/managed-certificates: "{{ .Values.adminCertName }},{{ template "customer-certs" . }}"
     networking.gke.io/v1beta1.FrontendConfig: "juniper-frontend-config"
     # If the class annotation is not specified it defaults to "gce".
     kubernetes.io/ingress.class: "gce"


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

last release had 2 issues:
1. I accidentally put the portal name for pedihcc as `pedihcc` instead of `pedihccproject`. This means that `pedihccproject.juniper-cmi.org` does not have a certificate. It also meant that I had to add `pedicc.juniper-cmi.org` to our DNS
2. I accidentally left the ingress referencing `admin-cert` instead of `{{ .Values.adminCertName }}` which, for prod, is now `admin-cert-v2`, so I had to manually update the ingress for it to sync.

This PR will:
1. Update ingress's admin cert name reference to point to `{{ .Values.adminCertName }}`
2. Remove pedihcc.juniper-cmi.org from admin cert
3. Remove _old_ trccproject cert (will be OK cause there's a new CMI cert w/ both trcc and pedicc URLs)
4. Remove pedihcc.juniper-cmi.org from DNS
5. Add pedihccproject.juniper-cmi.org TO the admin cert

I also think we don't need to do the `admin-cert-v2` renaming on each regen... I think the issue last time was unrelated to it needing to be a new cert entirely... So we could probably remove that if we wanted.

Steps:
1. Merge this to dev
2. Deploy to prod
3. Wait for _new_ admin cert to regen with correct pedihcc.juniper-cmi.org domain
4. Re-apply terraform on development for prod to delete pedicc.juniper-cmi.org as subdomain (cannot do before deploying because it might break admin cert)

Will have admin downtime again while cert regens. We can avoid this by just keeping the vestigial pedihcc.juniper-cmi.org DNS records and accepting that pedihccproject.juniper-cmi.org will not have valid cert. Which I don't think is a big deal cause we have the public URL. No strong feelings.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

