### PR TITLE
[JN-1750] handle empty surveys elegantly on import

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/dataimport/TimeShiftDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/dataimport/TimeShiftDao.java
@@ -79,6 +79,16 @@ public class TimeShiftDao {
         );
     }
 
+    public void changeTaskLastUpdatedTime(UUID taskId, Instant lastUpdatedTime) {
+        jdbi.withHandle(handle ->
+                handle.createUpdate("update participant_task set last_updated_at = :lastUpdatedTime where id = :taskId;")
+                        .bind("taskId", taskId)
+                        .bind("lastUpdatedTime", lastUpdatedTime)
+                        .execute()
+        );
+    }
+
+
     public void changeSurveyResponseCreationTime(UUID surveyResponseId, Instant creationTime) {
         jdbi.withHandle(handle ->
                 handle.createUpdate("update survey_response set created_at = :creationTime where id = :surveyResponseId;")

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -612,7 +612,8 @@ public class EnrolleeImportService {
                     .findFirst()
                     .orElseThrow();
 
-            if (!hasValidResponse && response.getAnswers().isEmpty()
+            if (!hasValidResponse
+                    && response.getAnswers().isEmpty()
                     && !task.getStatus().isTerminalStatus()
                     && importedResponses.stream().anyMatch(r -> !r.getAnswers().isEmpty())) {
                 // remove any NEW tasks (i.e., no answers) that come BEFORE a later valid response.

--- a/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/EnrolleeImportService.java
@@ -576,7 +576,10 @@ public class EnrolleeImportService {
             }
         }
 
-        removeOldInProgressSurveys(enrollee, imported, auditInfo);
+        // remove any tasks/responses that are invalid, e.g.:
+        // 1. any in-progress tasks that are not the latest task
+        // 2. any new tasks w/ no answers when there are later valid response(s)
+        removeInvalidTasks(enrollee, imported, auditInfo);
 
         return imported;
     }
@@ -587,25 +590,42 @@ public class EnrolleeImportService {
      * Those in-progress surveys will cause edge cases that never happen with normal Juniper data,
      * so we remove them.
      */
-    private void removeOldInProgressSurveys(Enrollee enrollee, List<SurveyResponse> importedResponses, DataAuditInfo auditInfo) {
+    private void removeInvalidTasks(Enrollee enrollee, List<SurveyResponse> importedResponses, DataAuditInfo auditInfo) {
         List<ParticipantTask> tasks = participantTaskService.findTasksByEnrolleeAndSurveyResponse(enrollee.getId(), importedResponses.stream()
                 .map(SurveyResponse::getId)
                 .toList());
 
-        // only applies to tasks that are non-latest
+        // only applies to tasks that are longitudinal and have multiple responses
         if (tasks.isEmpty() || tasks.size() == 1) {
             return;
         }
 
         tasks.sort(Comparator.comparing(ParticipantTask::getCreatedAt).reversed());
 
-        // remove any task that isn't the latest and isn't complete
-        for (int i = 1; i < tasks.size(); i++) {
-            ParticipantTask task = tasks.get(i);
-            if (!task.getStatus().isTerminalStatus()) {
-                task.setStatus(TaskStatus.REMOVED);
+        boolean hasValidResponse = false;
 
+        // remove tasks that break juniper's assumptions
+        for (ParticipantTask task : tasks) {
+            SurveyResponse response = importedResponses
+                    .stream()
+                    .filter(r -> r.getId().equals(task.getSurveyResponseId()))
+                    .findFirst()
+                    .orElseThrow();
+
+            if (!hasValidResponse && response.getAnswers().isEmpty()
+                    && !task.getStatus().isTerminalStatus()
+                    && importedResponses.stream().anyMatch(r -> !r.getAnswers().isEmpty())) {
+                // remove any NEW tasks (i.e., no answers) that come BEFORE a later valid response.
+                // if imported participant needs a new response, it will be triggered by recurrence rules.
+                task.setStatus(TaskStatus.REMOVED);
                 participantTaskService.update(task, auditInfo);
+            } else if (!task.getStatus().isTerminalStatus() && hasValidResponse) {
+                // remove any incomplete tasks that come AFTER the latest task
+                // (should never happen, but DSM keeps lots of records like this)
+                task.setStatus(TaskStatus.REMOVED);
+                participantTaskService.update(task, auditInfo);
+            } else {
+                hasValidResponse = true;
             }
         }
     }
@@ -701,6 +721,7 @@ public class EnrolleeImportService {
             timeShiftDao.changeSurveyResponseCreationTime(surveyResponse.getId(), createdAt);
         }
         if (lastUpdatedAt != null) {
+            timeShiftDao.changeTaskLastUpdatedTime(relatedTask.getId(), lastUpdatedAt);
             timeShiftDao.changeSurveyResponseLastUpdatedTime(surveyResponse.getId(), lastUpdatedAt);
         }
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatter.java
@@ -487,7 +487,7 @@ public class SurveyFormatter extends ModuleFormatter<SurveyResponseWithTaskDto, 
 
             // even if we don't set any properties here, if any column for this response were present,
             // we want to return make sure we import it.
-            if (stringVal != null) {
+            if (!StringUtils.isEmpty(stringVal)) {
                 hasAnyColumn = true;
             }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatter.java
@@ -476,6 +476,7 @@ public class SurveyFormatter extends ModuleFormatter<SurveyResponseWithTaskDto, 
     public SurveyResponseWithTaskDto fromStringMap(UUID studyEnvironmentId, Map<String, String> enrolleeMap, int moduleRepeatNum) {
         SurveyResponseWithTaskDto response = new SurveyResponseWithTaskDto();
         boolean specifiedComplete = false;
+        boolean hasAnyColumn = false;
         for (ItemFormatter<SurveyResponseWithTaskDto> itemFormatter : itemFormatters) {
             String columnName = getColumnKey(itemFormatter, false, null, moduleRepeatNum);
             if (!enrolleeMap.containsKey(columnName)) {
@@ -483,6 +484,12 @@ public class SurveyFormatter extends ModuleFormatter<SurveyResponseWithTaskDto, 
                 columnName = stripSurveyPrefix(columnName);
             }
             String stringVal = enrolleeMap.get(columnName);
+
+            // even if we don't set any properties here, if any column for this response were present,
+            // we want to return make sure we import it.
+            if (stringVal != null) {
+                hasAnyColumn = true;
+            }
 
             // track whether the complete field was explicitly set
             if (itemFormatter.getBaseColumnKey().equals("complete") && stringVal != null) {
@@ -503,6 +510,8 @@ public class SurveyFormatter extends ModuleFormatter<SurveyResponseWithTaskDto, 
             response.setComplete(true);
         }
 
-        return (response.getAnswers().isEmpty() ? null : response);
+        // even if no answers, import if anything has been specified (e.g., status, created date, etc.).
+        // a complete or in progress survey response with no answers could technically be valid.
+        return (!hasAnyColumn ? null : response);
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/notification/email/AdminEmailService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/notification/email/AdminEmailService.java
@@ -124,6 +124,11 @@ public class AdminEmailService {
             .filter(adminUser -> emails.contains(adminUser.getUsername()))
             .toList();
 
+    // nobody to send to; no point in attempting to send.
+    if (adminUsers.isEmpty()) {
+      return;
+    }
+
 
     EmailTemplate emailTemplate = emailTemplateService.find(trigger.getEmailTemplateId())
             .orElseThrow(() -> new NotFoundException("Email template not found"));

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -270,7 +270,7 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
                 auditInfo);
 
         // now update the task status and response id
-        task = updateTaskToResponse(task, response, updatedAnswers, auditInfo);
+        task = updateTaskToResponse(operator, task, response, updatedAnswers, auditInfo);
 
         // we only want to publish the event if the survey is complete
         // eventually, we may add other types of events like SURVEY_RESPONSE_UPDATED, or something
@@ -302,10 +302,9 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         dao.update(response);
     }
 
-    protected ParticipantTask updateTaskToResponse(ParticipantTask task, SurveyResponse response,
+    protected ParticipantTask updateTaskToResponse(ResponsibleEntity operator, ParticipantTask task, SurveyResponse response,
                                                    List<Answer> updatedAnswers, DataAuditInfo auditInfo) {
-        task.setSurveyResponseId(response.getId());
-        TaskStatus updatedStatus = computeNewStatus(task, response, updatedAnswers);
+        TaskStatus updatedStatus = computeNewStatus(operator, task, response, updatedAnswers);
         if (task.getStatus() != updatedStatus || task.getSurveyResponseId() != response.getId()) {
             task.setStatus(updatedStatus);
             task.setSurveyResponseId(response.getId());
@@ -314,7 +313,7 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         return task;
     }
 
-    protected static TaskStatus computeNewStatus(ParticipantTask task, SurveyResponse response, List<Answer> updatedAnswers) {
+    protected static TaskStatus computeNewStatus(ResponsibleEntity operator, ParticipantTask task, SurveyResponse response, List<Answer> updatedAnswers) {
         if (task.getStatus() == TaskStatus.COMPLETE) {
             // task statuses shouldn't ever change from complete to not
             return TaskStatus.COMPLETE;
@@ -328,8 +327,9 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
             } else {
                 return TaskStatus.COMPLETE;
             }
-        } else if (task.getStatus() == TaskStatus.NEW && updatedAnswers.size() == 0) {
+        } else if (task.getStatus() == TaskStatus.NEW && updatedAnswers.size() == 0 && operator.getParticipantUser() != null) {
             // if the task is new and no answers we submitted, this is just indicating the survey was viewed
+            // (only if participant is the operator)
             return TaskStatus.VIEWED;
         } else if (updatedAnswers.size() > 0) {
             return TaskStatus.IN_PROGRESS;

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -230,6 +230,7 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
                 response = surveyTaskDispatcher.createPrepopulatedSurveyResponse(response);
                 newTask.setSurveyResponseId(response.getId());
                 task = participantTaskService.create(newTask, null);
+                responseDto.setComplete(false); // ensure new response is not marked complete
             }
         }
 

--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
@@ -657,8 +657,7 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
         assertThat(tasks, hasSize(1));
         assertThat(tasks.get(0).getStatus(), equalTo(TaskStatus.NEW));
         responses = surveyResponseService.findByEnrolleeId(enrollee.getId());
-        assertThat(responses, hasSize(1));
-        assertFalse(responses.get(0).isComplete());
+        assertThat(responses, hasSize(0)); // no response created, fully blank.
         // no answers
         assertEquals(0, answerService.findByEnrolleeAndSurvey(enrollee.getId(), "importTest1").size());
     }
@@ -906,6 +905,54 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
         assertThat(latestResponse.isComplete(), equalTo(true));
         assertThat(latestResponse.getLastUpdatedAt(), equalTo(instantFromZone("2023-08-21 05:17AM")));
         assertThat(latestResponse.getAnswers().stream().filter(answer -> answer.getQuestionStableId().equals("importFirstName"))
+                .findFirst().get().getStringValue(), equalTo("Jeff"));
+    }
+
+    @Test
+    @Transactional
+    public void testImportSurveyResponsesMultipleColumnsOnlyOneResponse(TestInfo info) {
+        StudyEnvironmentBundle bundle = studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.irb);
+        Survey survey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .stableId("importTest1")
+                .content(TWO_QUESTION_SURVEY_CONTENT)
+                .portalId(bundle.getPortal().getId())
+                .version(1)
+        );
+        surveyFactory.attachToEnv(survey, bundle.getStudyEnv().getId(), true);
+        String username = "test@test.com";
+
+        Map<String, String> enrolleeMap = Map.of(
+                "enrollee.subject", "true",
+                "account.username", username,
+                "importTest1.complete", "true",
+                "importTest1.importFirstName", "Jeff",
+                "importTest1.importFavColors", "[\"red\", \"blue\"]",
+                "importTest1.createdAt", "2023-08-21 05:17AM",
+                "importTest1[2].complete", "", // should just ignore this 2nd response since it's empty
+                "importTest1[2].importFirstName", "",
+                "importTest1[2].importFavColors", "",
+                "importTest1[2].createdAt", "");
+
+        Enrollee enrollee = enrolleeImportService.importEnrollee(
+                bundle.getPortal().getShortcode(),
+                bundle.getStudy().getShortcode(),
+                bundle.getStudyEnv(),
+                enrolleeMap,
+                new ExportOptions(), null);
+
+        List<SurveyResponse> responses = surveyResponseService.findByEnrolleeId(enrollee.getId());
+
+        assertThat(responses, hasSize(1));
+
+        responses.sort(Comparator.comparing(SurveyResponse::getLastUpdatedAt));
+
+        SurveyResponse response = surveyResponseService.findOneWithAnswers(responses.get(0).getId()).orElseThrow();
+
+        assertThat(response.getSurveyId(), equalTo(survey.getId()));
+        assertThat(response.isComplete(), equalTo(true));
+        assertThat(response.getLastUpdatedAt(), equalTo(instantFromZone("2023-08-21 05:17AM")));
+        assertThat(response.getCreatedAt(), equalTo(instantFromZone("2023-08-21 05:17AM")));
+        assertThat(response.getAnswers().stream().filter(answer -> answer.getQuestionStableId().equals("importFirstName"))
                 .findFirst().get().getStringValue(), equalTo("Jeff"));
     }
 

--- a/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/EnrolleeImportServiceTests.java
@@ -657,7 +657,10 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
         assertThat(tasks, hasSize(1));
         assertThat(tasks.get(0).getStatus(), equalTo(TaskStatus.NEW));
         responses = surveyResponseService.findByEnrolleeId(enrollee.getId());
-        assertThat(responses, hasSize(0));
+        assertThat(responses, hasSize(1));
+        assertFalse(responses.get(0).isComplete());
+        // no answers
+        assertEquals(0, answerService.findByEnrolleeAndSurvey(enrollee.getId(), "importTest1").size());
     }
 
     @Test
@@ -1109,6 +1112,124 @@ public class EnrolleeImportServiceTests extends BaseSpringBootTest {
         assertEquals(TaskStatus.IN_PROGRESS, survey2Tasks.get(0).getStatus());
         assertEquals(TaskStatus.COMPLETE, survey2Tasks.get(1).getStatus());
         assertEquals(TaskStatus.REMOVED, survey2Tasks.get(2).getStatus());
+    }
+
+    @Test
+    @Transactional
+    public void testImportAllowsAndRemovesEmptyInProgressResponses(TestInfo info) {
+        // we need to ensure that empty in-progress responses are removed & older complete responses are kept
+
+        StudyEnvironmentBundle bundle = studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.irb);
+        Survey survey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .stableId("importTest1")
+                .content(TWO_QUESTION_SURVEY_CONTENT)
+                .portalId(bundle.getPortal().getId())
+                .version(1)
+        );
+        surveyFactory.attachToEnv(survey, bundle.getStudyEnv().getId(), true);
+        Survey survey2 = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .stableId("importTest2")
+                .content(TWO_QUESTION_SURVEY_CONTENT)
+                .portalId(bundle.getPortal().getId())
+                .version(1)
+        );
+        surveyFactory.attachToEnv(survey2, bundle.getStudyEnv().getId(), true);
+        Survey survey3 = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .stableId("importTest3")
+                .content(TWO_QUESTION_SURVEY_CONTENT)
+                .portalId(bundle.getPortal().getId())
+                .version(1)
+        );
+        surveyFactory.attachToEnv(survey3, bundle.getStudyEnv().getId(), true);
+        String username = "test@test.com";
+
+        Map<String, String> enrolleeMap = Map.ofEntries(
+                Map.entry("enrollee.subject", "true"),
+                Map.entry("account.username", username),
+
+                // survey1: 4 responses with latest complete, second complete but empty, third in progress but incomplete, oldest complete
+                Map.entry("importTest1.complete", "true"),
+                Map.entry("importTest1.importFirstName", "Jeff"),
+                Map.entry("importTest1.importFavColors", "[\"red\", \"blue\"]"),
+                Map.entry("importTest1.createdAt", "2023-08-21 05:17AM"),
+                Map.entry("importTest1[2].complete", "true"),
+                Map.entry("importTest1[2].createdAt", "2023-08-20 05:17AM"),
+                Map.entry("importTest1[3].complete", "false"),
+                Map.entry("importTest1[3].createdAt", "2023-08-19 05:17AM"),
+                Map.entry("importTest1[4].complete", "false"),
+                Map.entry("importTest1[4].importFirstName", "Jeffrey"),
+                Map.entry("importTest1[4].importFavColors", "[\"green\"]"),
+                Map.entry("importTest1[4].createdAt", "2023-08-17 05:17AM"),
+
+
+                // survey 2: 2 responses with latest in-progress, 1 old in-progress
+                Map.entry("importTest2.complete", "false"),
+                Map.entry("importTest2.createdAt", "2023-08-21 05:17AM"),
+                Map.entry("importTest2[2].complete", "false"),
+                Map.entry("importTest2[2].createdAt", "2023-07-20 05:17AM"),
+                Map.entry("importTest2[3].complete", "false"),
+                Map.entry("importTest2[3].importFirstName", "Alex"),
+                Map.entry("importTest2[3].importFavColors", "[\"orange\"]"),
+                Map.entry("importTest2[3].createdAt", "2023-06-19 05:17AM"),
+
+                // survey 3: empty / in-progress responses in quick succession, only the latest should be kept
+                Map.entry("importTest3.complete", "false"),
+                Map.entry("importTest3.createdAt", "2023-08-21 05:17AM"),
+                Map.entry("importTest3[2].complete", "false"),
+                Map.entry("importTest3[2].createdAt", "2023-08-21 05:16AM"),
+                Map.entry("importTest3[3].complete", "false"),
+                Map.entry("importTest3[3].importFirstName", "Alex"),
+                Map.entry("importTest3[3].importFavColors", "[\"orange\"]"),
+                Map.entry("importTest3[3].createdAt", "2023-08-21 05:15AM")
+
+        );
+
+        Enrollee enrollee = enrolleeImportService.importEnrollee(
+                bundle.getPortal().getShortcode(),
+                bundle.getStudy().getShortcode(),
+                bundle.getStudyEnv(),
+                enrolleeMap,
+                new ExportOptions(), null);
+
+        List<SurveyResponse> responses = surveyResponseService.findByEnrolleeId(enrollee.getId());
+        assertThat(responses, hasSize(10));
+
+        List<ParticipantTask> tasks = participantTaskService.findByEnrolleeId(enrollee.getId());
+        assertThat(tasks, hasSize(10));
+
+        List<ParticipantTask> survey1Tasks = tasks.stream()
+                .filter(task -> task.getTargetStableId().equals(survey.getStableId()))
+                .sorted(Comparator.comparing(ParticipantTask::getCreatedAt).reversed())
+                .collect(Collectors.toList());
+
+        assertThat(survey1Tasks, hasSize(4));
+        assertEquals(TaskStatus.COMPLETE, survey1Tasks.get(0).getStatus());
+        assertEquals(TaskStatus.COMPLETE, survey1Tasks.get(1).getStatus());
+        assertEquals(TaskStatus.REMOVED, survey1Tasks.get(2).getStatus());
+        assertEquals(TaskStatus.REMOVED, survey1Tasks.get(3).getStatus());
+
+
+        List<ParticipantTask> survey2Tasks = tasks.stream()
+                .filter(task -> task.getTargetStableId().equals(survey2.getStableId()))
+                .sorted(Comparator.comparing(ParticipantTask::getCreatedAt).reversed())
+                .collect(Collectors.toList());
+
+        assertThat(survey2Tasks, hasSize(3));
+
+        assertEquals(TaskStatus.REMOVED, survey2Tasks.get(0).getStatus());
+        assertEquals(TaskStatus.REMOVED, survey2Tasks.get(1).getStatus());
+        assertEquals(TaskStatus.IN_PROGRESS, survey2Tasks.get(2).getStatus());
+
+        List<ParticipantTask> survey3Tasks = tasks.stream()
+                .filter(task -> task.getTargetStableId().equals(survey3.getStableId()))
+                .sorted(Comparator.comparing(ParticipantTask::getCreatedAt).reversed())
+                .collect(Collectors.toList());
+
+        assertThat(survey3Tasks, hasSize(3));
+
+        assertEquals(TaskStatus.REMOVED, survey3Tasks.get(0).getStatus());
+        assertEquals(TaskStatus.REMOVED, survey3Tasks.get(1).getStatus());
+        assertEquals(TaskStatus.IN_PROGRESS, survey3Tasks.get(2).getStatus());
     }
 
     @Test

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatterTests.java
@@ -326,6 +326,53 @@ public class SurveyFormatterTests extends BaseSpringBootTest {
     }
 
     @Test
+    public void testFromStringMapLongitudinalMultipleResponseColumnsOnlyOneResponse() {
+        Survey testSurvey = Survey.builder().id(UUID.randomUUID()).stableId("oh_surveyA").version(1).build();
+        SurveyQuestionDefinition question1 = SurveyQuestionDefinition.builder()
+                .questionStableId("oh_surveyA_q1")
+                .questionType("text")
+                .exportOrder(1)
+                .build();
+
+        SurveyQuestionDefinition question2 = SurveyQuestionDefinition.builder()
+                .questionStableId("oh_surveyA_q2")
+                .questionType("text")
+                .exportOrder(1)
+                .build();
+
+        SurveyQuestionDefinition question3 = SurveyQuestionDefinition.builder()
+                .questionStableId("oh_surveyA_q3")
+                .questionType("text")
+                .exportOrder(1)
+                .build();
+
+        SurveyFormatter moduleFormatter = new SurveyFormatter(new ExportOptions(), "oh_surveyA", List.of(testSurvey), List.of(question1, question2, question3), List.of(), objectMapper);
+
+        List<SurveyResponseWithTaskDto> dtos = moduleFormatter.listFromStringMap(UUID.randomUUID(),
+                Map.of(
+                        "oh_surveyA.createdAt", "2023-08-22 05:17AM",
+                        "oh_surveyA.oh_surveyA_q1", "testValue1",
+                        "oh_surveyA.oh_surveyA_q2", "testValue2",
+                        "oh_surveyA[2].createdAt", "",
+                        "oh_surveyA[2].oh_surveyA_q1", "",
+                        "oh_surveyA[2].oh_surveyA_q2", "",
+                        "oh_surveyA[2].oh_surveyA_q3", ""
+
+                )
+        );
+
+        assertEquals(1, dtos.size());
+
+        SurveyResponseWithTaskDto first = dtos.getFirst();
+        assertEquals("2023-08-22T09:17:00Z", first.getCreatedAt().toString());
+        assertEquals(2, first.getAnswers().size());
+        assertAnswers(first.getAnswers(), Map.of(
+                "oh_surveyA_q1", "testValue1",
+                "oh_surveyA_q2", "testValue2"
+        ));
+    }
+
+    @Test
     public void testFromStringMapEmptyResponse() {
         Survey testSurvey = Survey.builder().id(UUID.randomUUID()).stableId("oh_surveyA").version(1).build();
         SurveyQuestionDefinition question1 = SurveyQuestionDefinition.builder()

--- a/core/src/test/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatterTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/export/formatters/module/SurveyFormatterTests.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SurveyFormatterTests extends BaseSpringBootTest {
     @Autowired
@@ -267,6 +268,121 @@ public class SurveyFormatterTests extends BaseSpringBootTest {
         assertThat(value, equalTo("d[f}asdfja"));
     }
 
+    @Test
+    public void testBasicFromStringMapLongitudinal() {
+        Survey testSurvey = Survey.builder().id(UUID.randomUUID()).stableId("oh_surveyA").version(1).build();
+        SurveyQuestionDefinition question1 = SurveyQuestionDefinition.builder()
+                .questionStableId("oh_surveyA_q1")
+                .questionType("text")
+                .exportOrder(1)
+                .build();
+
+        SurveyQuestionDefinition question2 = SurveyQuestionDefinition.builder()
+                .questionStableId("oh_surveyA_q2")
+                .questionType("text")
+                .exportOrder(1)
+                .build();
+
+        SurveyQuestionDefinition question3 = SurveyQuestionDefinition.builder()
+                .questionStableId("oh_surveyA_q3")
+                .questionType("text")
+                .exportOrder(1)
+                .build();
+
+        SurveyFormatter moduleFormatter = new SurveyFormatter(new ExportOptions(), "oh_surveyA", List.of(testSurvey), List.of(question1, question2, question3), List.of(), objectMapper);
+
+        List<SurveyResponseWithTaskDto> dtos = moduleFormatter.listFromStringMap(UUID.randomUUID(),
+                Map.of(
+                        "oh_surveyA.createdAt", "2023-08-22 05:17AM",
+                        "oh_surveyA.oh_surveyA_q1", "testValue1",
+                        "oh_surveyA.oh_surveyA_q2", "testValue2",
+                        "oh_surveyA[2].createdAt", "2023-08-21 05:17AM",
+                        "oh_surveyA[2].oh_surveyA_q1", "testValue3",
+                        "oh_surveyA[2].oh_surveyA_q2", "testValue4",
+                        "oh_surveyA[2].oh_surveyA_q3", "testValue5"
+
+                )
+        );
+
+        assertEquals(2, dtos.size());
+
+        SurveyResponseWithTaskDto first = dtos.getFirst();
+        assertEquals("2023-08-22T09:17:00Z", first.getCreatedAt().toString());
+        assertEquals(2, first.getAnswers().size());
+        assertAnswers(first.getAnswers(), Map.of(
+                "oh_surveyA_q1", "testValue1",
+                "oh_surveyA_q2", "testValue2"
+        ));
+
+
+        SurveyResponseWithTaskDto second = dtos.get(1);
+        assertEquals("2023-08-21T09:17:00Z", second.getCreatedAt().toString());
+        assertEquals(3, second.getAnswers().size());
+        assertAnswers(second.getAnswers(), Map.of(
+                "oh_surveyA_q1", "testValue3",
+                "oh_surveyA_q2", "testValue4",
+                "oh_surveyA_q3", "testValue5"
+        ));
+    }
+
+    @Test
+    public void testFromStringMapEmptyResponse() {
+        Survey testSurvey = Survey.builder().id(UUID.randomUUID()).stableId("oh_surveyA").version(1).build();
+        SurveyQuestionDefinition question1 = SurveyQuestionDefinition.builder()
+                .questionStableId("oh_surveyA_q1")
+                .questionType("text")
+                .exportOrder(1)
+                .build();
+
+        SurveyQuestionDefinition question2 = SurveyQuestionDefinition.builder()
+                .questionStableId("oh_surveyA_q2")
+                .questionType("text")
+                .exportOrder(1)
+                .build();
+
+        SurveyQuestionDefinition question3 = SurveyQuestionDefinition.builder()
+                .questionStableId("oh_surveyA_q3")
+                .questionType("text")
+                .exportOrder(1)
+                .build();
+
+        SurveyFormatter moduleFormatter = new SurveyFormatter(new ExportOptions(), "oh_surveyA", List.of(testSurvey), List.of(question1, question2, question3), List.of(), objectMapper);
+
+        List<SurveyResponseWithTaskDto> dtos = moduleFormatter.listFromStringMap(UUID.randomUUID(),
+                Map.of(
+                        "oh_surveyA.createdAt", "2023-08-23 05:17AM",
+                        "oh_surveyA[2].createdAt", "2023-08-22 05:17AM",
+                        "oh_surveyA[3].createdAt", "2023-08-21 05:17AM",
+                        "oh_surveyA[3].oh_surveyA_q1", "testValue3",
+                        "oh_surveyA[3].oh_surveyA_q2", "testValue4",
+                        "oh_surveyA[3].oh_surveyA_q3", "testValue5"
+
+                )
+        );
+
+        assertEquals(3, dtos.size());
+
+        SurveyResponseWithTaskDto first = dtos.getFirst();
+        assertFalse(first.isComplete());
+        assertEquals("2023-08-23T09:17:00Z", first.getCreatedAt().toString());
+        assertEquals(0, first.getAnswers().size());
+
+        SurveyResponseWithTaskDto second = dtos.get(1);
+        assertFalse(second.isComplete());
+        assertEquals("2023-08-22T09:17:00Z", second.getCreatedAt().toString());
+        assertEquals(0, second.getAnswers().size());
+
+        SurveyResponseWithTaskDto third = dtos.get(2);
+        assertTrue(third.isComplete());
+        assertEquals("2023-08-21T09:17:00Z", third.getCreatedAt().toString());
+        assertEquals(3, third.getAnswers().size());
+        assertAnswers(third.getAnswers(), Map.of(
+                "oh_surveyA_q1", "testValue3",
+                "oh_surveyA_q2", "testValue4",
+                "oh_surveyA_q3", "testValue5"
+        ));
+    }
+
     /**
      * helper for testing generation of answer maps values for a single question-answer pair
      */
@@ -299,6 +415,17 @@ public class SurveyFormatterTests extends BaseSpringBootTest {
         Map<String, List<Answer>> answerMap = Map.of(mapStableId, List.of(answer));
         moduleFormatter.addAnswersToMap(itemFormatter, answerMap, valueMap, 1);
         return valueMap;
+    }
+
+    private void assertAnswers(List<Answer> answers, Map<String, String> expectedValues) {
+        assertEquals(expectedValues.size(), answers.size());
+        for (Answer answer : answers) {
+            String expectedValue = expectedValues.get(answer.getQuestionStableId());
+            if (expectedValue == null) {
+                throw new IllegalStateException("no expected value for question stable id " + answer.getQuestionStableId());
+            }
+            assertThat(answer.getStringValue(), equalTo(expectedValue));
+        }
     }
 
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Would love to have someone else double check my thought process.

Changes:
1. Instead of importing until `answers.size() == 0` (current behavior), import all survey response rows that have any values (even if it's just createdAt, etc.)
2. If we see there's an empty survey response that precedes a COMPLETE or IN_PROGRESS response for the task, remove it

These is _necessary_ because:
1. DSM export included random empty NEW survey responses (often as the LATEST row)
3. It's a big problem when we receive an empty response as the latest row because:
    1. The `answers.size() == 0` check would prevent later rows from being added to the participant's data
    2. Even _if_ we had the full response history, on longitudinal recurrence, the answers are copied from the latest response.... which would be empty for quite a few participants

This was harder than I first thought, for a few reasons:

1. Our entire import system is centered around `SurveyResponse`s
2. However, typically, in juniper, a survey response is not created until the participant edits the survey for the first time (i.e., a NEW survey has no survey response yet)
3. Thus, it should never be the case that a Survey Response with zero answers should exist (AFAIK)
4. The original import script would never process survey responses with no answers, so it preserved this behavior
5. Now that we're processing empty surveys, the import system will explicity _create_ empty survey responses
6. We _could_ have refactored the import logic to be task-centric instead of surveyresponse centric- but this felt like a bigger change than was needed to get the job done

Thus, imported participants now will ALWAYS have survey responses for all imported tasks, even if the response is empty. All of these empty survey responses should end up `REMOVED` in the end, _except_ in the case that it's the only task the participant has for the survey / the survey is not longitudinal. I think it's not a huge deal, but maybe it will cause some strange edge cases.

An alternate path would be to IGNORE any survey responses that are empty. I feel like it's more accurate to import them but hide them, but I could be convinced here.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

