### PR TITLE
[JN-1751] clean up admin longitudinal UX

### DIFF
--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeView.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeView.tsx
@@ -84,7 +84,13 @@ export function LoadedEnrolleeView({ enrollee, studyEnvContext, onUpdate }: {
     const sortedTasks = enrollee
       .participantTasks
       .sort((a, b) => b.createdAt! - a.createdAt!)
-      .sort((a, b) => (a.status === 'REMOVED' || a.status === 'REJECTED' ? 1 : 0) - (b.status === 'REMOVED' || b.status === 'REJECTED' ? 1 : 0)) // put removed/rejected tasks at the end
+      .sort(
+        (a, b) => (
+          a.status === 'REMOVED' || a.status === 'REJECTED' ? 1 : 0
+        ) - (
+          b.status === 'REMOVED' || b.status === 'REJECTED' ? 1 : 0
+        )
+      ) // put removed/rejected tasks at the end
 
     surveys.forEach(configSurvey => {
       // to match responses to surveys, filter using the tasks, since those have the stableIds
@@ -306,16 +312,15 @@ const badgeForResponses = (responses: SurveyResponse[], tasks: ParticipantTask[]
   if (!tasks?.length) {
     return statusDisplayMap['UNASSIGNED']
   }
-  const sortedTasks = tasks
-    .sort((a, b) => b.createdAt! - a.createdAt!)
+  const nonRemovedTasks = tasks
     .filter(t => t.status !== 'REMOVED' && t.status !== 'REJECTED')
-  if (!sortedTasks.length) {
+  if (!nonRemovedTasks.length) {
     return statusDisplayMap['REMOVED']
   }
 
-  const lastTask = sortedTasks[0]
+  const lastTask = nonRemovedTasks[0]
 
-  const numResponses = sortedTasks.length
+  const numResponses = nonRemovedTasks.length
   return <div className="d-flex align-items-center justify-content-end">
     {statusDisplayMap[lastTask.status]}
     {numResponses > 1 && <span className="ms-1">({numResponses})</span>}

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeView.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeView.tsx
@@ -81,12 +81,16 @@ export function LoadedEnrolleeView({ enrollee, studyEnvContext, onUpdate }: {
    * without having to do full enrollee reloads when answers are submitted via the admin response editing UX */
   const generateResponseMap = () => {
     const updatedResponseMap: ResponseMapT = {}
+    const sortedTasks = enrollee
+      .participantTasks
+      .sort((a, b) => b.createdAt! - a.createdAt!)
+      .sort((a, b) => (a.status === 'REMOVED' || a.status === 'REJECTED' ? 1 : 0) - (b.status === 'REMOVED' || b.status === 'REJECTED' ? 1 : 0)) // put removed/rejected tasks at the end
+
     surveys.forEach(configSurvey => {
       // to match responses to surveys, filter using the tasks, since those have the stableIds
       // this is valid since it's currently enforced that all survey responses are done as part of a task,
-      const matchedTasks = enrollee.participantTasks
+      const matchedTasks = sortedTasks
         .filter(task => task.targetStableId === configSurvey.survey.stableId)
-        .sort((a, b) => b.createdAt! - a.createdAt!)
       const matchedTaskResponseIds = matchedTasks.map(task => task.surveyResponseId)
       const matchedResponses = enrollee.surveyResponses
         .filter(response => matchedTaskResponseIds.includes(response.id))

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeView.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeView.tsx
@@ -302,8 +302,20 @@ const badgeForResponses = (responses: SurveyResponse[], tasks: ParticipantTask[]
   if (!tasks?.length) {
     return statusDisplayMap['UNASSIGNED']
   }
-  const lastTask = tasks.sort((a, b) => b.createdAt! - a.createdAt!)[0]
-  return statusDisplayMap[lastTask.status]
+  const sortedTasks = tasks
+    .sort((a, b) => b.createdAt! - a.createdAt!)
+    .filter(t => t.status !== 'REMOVED' && t.status !== 'REJECTED')
+  if (!sortedTasks.length) {
+    return statusDisplayMap['REMOVED']
+  }
+
+  const lastTask = sortedTasks[0]
+
+  const numResponses = sortedTasks.length
+  return <div className="d-flex align-items-center justify-content-end">
+    {statusDisplayMap[lastTask.status]}
+    {numResponses > 1 && <span className="ms-1">({numResponses})</span>}
+  </div>
 }
 
 /** gets classes to apply to nav links */

--- a/ui-admin/src/study/participants/survey/EnrolleeSurveyView.test.tsx
+++ b/ui-admin/src/study/participants/survey/EnrolleeSurveyView.test.tsx
@@ -1,10 +1,14 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import {
+  render,
+  screen
+} from '@testing-library/react'
 import { RawEnrolleeSurveyView } from './SurveyResponseView'
 import {
   mockAnswer,
   mockConfiguredSurvey,
-  mockEnrollee, mockParticipantTask,
+  mockEnrollee,
+  mockParticipantTask,
   mockStudyEnvContext,
   mockSurveyResponse
 } from 'test-utils/mocking-utils'
@@ -27,7 +31,7 @@ describe('RawEnrolleeSurveyView', () => {
         onUpdate={jest.fn()}
         response={response}/>)
     render(RoutedComponent)
-    expect(screen.getByText('(version 2)', { exact: false })).toBeInTheDocument()
+    expect(screen.getByText('(answered on v2)', { exact: false })).toBeInTheDocument()
   })
 
   it('renders the multiple versions from the answers', async () => {
@@ -47,6 +51,6 @@ describe('RawEnrolleeSurveyView', () => {
         onUpdate={jest.fn()}
         response={response}/>)
     render(RoutedComponent)
-    expect(screen.getByText('(versions 2, 3)', { exact: false })).toBeInTheDocument()
+    expect(screen.getByText('(answered on v2, v3)', { exact: false })).toBeInTheDocument()
   })
 })

--- a/ui-admin/src/study/participants/survey/SurveyResponseView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyResponseView.tsx
@@ -9,6 +9,7 @@ import {
 } from 'api/api'
 
 import {
+  NavLink,
   useNavigate,
   useParams
 } from 'react-router-dom'
@@ -29,10 +30,10 @@ import {
 } from '@juniper/ui-core'
 import DocumentTitle from 'util/DocumentTitle'
 import _uniq from 'lodash/uniq'
-import pluralize from 'pluralize'
 import {
   paramsFromContext,
-  StudyEnvContextT
+  StudyEnvContextT,
+  studyEnvSurveyPath
 } from 'study/StudyEnvironmentRouter'
 import {
   userHasPermission,
@@ -99,6 +100,7 @@ export default function SurveyResponseView({ enrollee, responseMap, updateRespon
     .sort((a, b) => a.status === 'REMOVED' ? 1 : b.status === 'REMOVED' ? -1 : 0)  // show removed tasks last
 
   const numNonRemoved = sortedTasks.filter(t => t.status !== 'REMOVED' && t.status !== 'REJECTED').length
+  const numRemoved = sortedTasks.filter(t => t.status === 'REMOVED' || t.status === 'REJECTED').length
 
   const formatSurveyVersionLabel = (t: ParticipantTask) => {
     const isLatest = t.id == sortedTasks[0].id
@@ -119,38 +121,65 @@ export default function SurveyResponseView({ enrollee, responseMap, updateRespon
     index: idx
   }))
 
+  const stableId = task?.targetStableId || surveyAndResponses.survey.survey.stableId
+  const version = task?.targetAssignedVersion || surveyAndResponses.survey.survey.version
 
   // key forces the component to be destroyed/remounted when different survey selected
   return <div>
     <DocumentTitle title={`${enrollee.shortcode} - ${surveyAndResponses.survey.survey.name}`}/>
     <div className="d-flex justify-content-between">
 
-      <h4>{surveyAndResponses.survey.survey.name}</h4>
-      {showVersionOptions && <div style={{ minWidth: '350px' }}>
-        <Select
-          className={'w-100'}
-          options={surveyResponseVersionOptions}
-          value={surveyResponseVersionOptions.find(o => o.value === taskId)}
-          formatOptionLabel={opt => {
-            return <div className="d-flex justify-content-between align-items-center">
-              {opt.label}
-              {(opt.task.status === 'REMOVED' || opt.task.status === 'REJECTED')
-                ? <span className="ms-2 badge bg-danger">
-                  <FontAwesomeIcon icon={faX}/>
-                </span>
-                : <span className="ms-2 badge bg-secondary">
-                  {opt.index + 1} of {numNonRemoved}
-                </span>}
-            </div>
-          }}
-          onChange={opt => {
-            if (!opt) {
-              return
-            }
-            navigate(surveyResponsePath(studyEnvContext.currentEnvPath, enrollee.shortcode, surveyStableId, opt.value))
-          }}
-        />
-      </div>}
+      <div>
+        <div className="d-flex align-items-center">
+          <h4 className="me-2">
+            {surveyAndResponses.survey.survey.name}
+          </h4>
+          <span className='fs-6 fst-italic'>
+            <NavLink to={studyEnvSurveyPath({
+              studyShortcode: studyEnvContext.study.shortcode,
+              portalShortcode: studyEnvContext.portal.shortcode,
+              envName: studyEnvContext.currentEnv.environmentName
+            }, stableId, version
+            )}
+            >
+              ({stableId} v{version})
+            </NavLink>
+          </span>
+
+        </div>
+      </div>
+      <div>
+        {showVersionOptions && <div style={{ minWidth: '350px' }}>
+          <Select
+            className={'w-100'}
+            options={surveyResponseVersionOptions}
+            value={surveyResponseVersionOptions.find(o => o.value === taskId)}
+            formatOptionLabel={opt => {
+              return <div className="d-flex justify-content-between align-items-center">
+                {opt.label}
+                {(opt.task.status === 'REMOVED' || opt.task.status === 'REJECTED')
+                  ? <span className="ms-2 badge bg-danger">
+                    <FontAwesomeIcon icon={faX}/>
+                  </span>
+                  : <span className="ms-2 badge bg-secondary">
+                    {opt.index + 1} of {numNonRemoved}
+                  </span>}
+              </div>
+            }}
+            onChange={opt => {
+              if (!opt) {
+                return
+              }
+              navigate(
+                surveyResponsePath(studyEnvContext.currentEnvPath, enrollee.shortcode, surveyStableId, opt.value)
+              )
+            }}
+          />
+        </div>}
+        {numRemoved > 0 && <span className="small fst-italic">
+          {numRemoved} removed response
+        </span>}
+      </div>
     </div>
 
     {!isAssigned && <div className="d-flex align-items-center">
@@ -205,8 +234,8 @@ export function RawEnrolleeSurveyView({
               <FontAwesomeIcon icon={faPencil}/>
             </Button>
           </div>
-          {surveyVersion(task, response)}
-          <div className="ms-2">
+          {surveyAnswerVersions(task, response)}
+          <div className="ms-1">
             <Button
               variant="secondary"
               onClick={() => setShowReassignModal(true)}
@@ -346,11 +375,11 @@ const taskStatusIndicators: Record<ParticipantTaskStatus, React.ReactNode> = {
     <FontAwesomeIcon icon={faMinus}/> Removed</span>
 }
 
-function surveyVersion(task: ParticipantTask, surveyResponse?: SurveyResponse) {
+function surveyAnswerVersions(task: ParticipantTask, surveyResponse?: SurveyResponse) {
   let versionString = ''
   if (surveyResponse && surveyResponse.answers.length) {
     const answerVersions = _uniq(surveyResponse.answers.map(ans => ans.surveyVersion))
-    versionString = `${pluralize('version', answerVersions.length)} ${answerVersions.join(', ')}`
+    versionString = `(answered on ${answerVersions.map(version => `v${version}`).join(', ')})`
   }
 
   return <div className="ms-2">

--- a/ui-admin/src/study/participants/survey/SurveyResponseView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyResponseView.tsx
@@ -1,5 +1,6 @@
 import React, {
   useEffect,
+  useMemo,
   useState
 } from 'react'
 import {
@@ -92,18 +93,20 @@ export default function SurveyResponseView({ enrollee, responseMap, updateRespon
   const response = surveyAndResponses.responses.find(r => task?.surveyResponseId === r.id)
   const showVersionOptions = surveyAndResponses.tasks.length > 1
 
-  const sortedTasks = surveyAndResponses
-    .tasks
-    .sort(
-      (a, b) => b.createdAt - a.createdAt // show most recent first
-    )
-    .sort((a, b) => a.status === 'REMOVED' ? 1 : b.status === 'REMOVED' ? -1 : 0)  // show removed tasks last
+  // already sorted by createdAt desc with removed tasks last
+  const tasks = surveyAndResponses.tasks
 
-  const numNonRemoved = sortedTasks.filter(t => t.status !== 'REMOVED' && t.status !== 'REJECTED').length
-  const numRemoved = sortedTasks.filter(t => t.status === 'REMOVED' || t.status === 'REJECTED').length
+  const numNonRemoved = useMemo(
+    () => tasks.filter(t => t.status !== 'REMOVED' && t.status !== 'REJECTED').length,
+    [tasks]
+  )
+  const numRemoved = useMemo(
+    () => tasks.filter(t => t.status === 'REMOVED' || t.status === 'REJECTED').length,
+    [tasks]
+  )
 
   const formatSurveyVersionLabel = (t: ParticipantTask) => {
-    const isLatest = t.id == sortedTasks[0].id
+    const isLatest = t.id == tasks[0].id
 
     if (t.status === 'REMOVED' || t.status === 'REJECTED') {
       return `Removed ${instantToDateString(t.createdAt)}`
@@ -114,12 +117,12 @@ export default function SurveyResponseView({ enrollee, responseMap, updateRespon
     }${isLatest ? ' (latest)' : ''}`
   }
 
-  const surveyResponseVersionOptions = sortedTasks.map((t, idx) => ({
+  const surveyResponseVersionOptions = useMemo(() => tasks.map((t, idx) => ({
     value: t.id,
     task: t,
     label: formatSurveyVersionLabel(t),
     index: idx
-  }))
+  })), [tasks])
 
   const stableId = task?.targetStableId || surveyAndResponses.survey.survey.stableId
   const version = task?.targetAssignedVersion || surveyAndResponses.survey.survey.version

--- a/ui-admin/src/study/participants/survey/SurveyResponseView.tsx
+++ b/ui-admin/src/study/participants/survey/SurveyResponseView.tsx
@@ -9,7 +9,7 @@ import {
 } from 'api/api'
 
 import {
-  NavLink,
+  useNavigate,
   useParams
 } from 'react-router-dom'
 import SurveyFullDataView from './SurveyFullDataView'
@@ -48,7 +48,8 @@ import {
   faPencil,
   faPrint,
   faSave,
-  faWarning
+  faWarning,
+  faX
 } from '@fortawesome/free-solid-svg-icons'
 import { Button } from 'components/forms/Button'
 import { IconDefinition } from '@fortawesome/fontawesome-svg-core'
@@ -59,6 +60,7 @@ import { ParticipantDocumentListView } from './ParticipantDocumentListView'
 import SurveyAssignModal from './SurveyAssignModal'
 import TaskChangeModal from './TaskChangeModal'
 import PrintFormView from 'study/participants/survey/PrintFormView'
+import Select from 'react-select'
 
 
 type SurveyView = 'viewing' | 'editing' | 'printing'
@@ -72,6 +74,7 @@ export default function SurveyResponseView({ enrollee, responseMap, updateRespon
   const params = useParams<EnrolleeParams>()
   const [showAssignModal, setShowAssignModal] = useState(false)
   let { taskId } = useTaskIdParam()
+  const navigate = useNavigate()
 
   const surveyStableId: string | undefined = params.surveyStableId
 
@@ -86,11 +89,70 @@ export default function SurveyResponseView({ enrollee, responseMap, updateRespon
   }
   const task = surveyAndResponses.tasks.find(t => t.id === taskId)
   const response = surveyAndResponses.responses.find(r => task?.surveyResponseId === r.id)
-  const showTaskBar = surveyAndResponses.tasks.length > 1
+  const showVersionOptions = surveyAndResponses.tasks.length > 1
+
+  const sortedTasks = surveyAndResponses
+    .tasks
+    .sort(
+      (a, b) => b.createdAt - a.createdAt // show most recent first
+    )
+    .sort((a, b) => a.status === 'REMOVED' ? 1 : b.status === 'REMOVED' ? -1 : 0)  // show removed tasks last
+
+  const numNonRemoved = sortedTasks.filter(t => t.status !== 'REMOVED' && t.status !== 'REJECTED').length
+
+  const formatSurveyVersionLabel = (t: ParticipantTask) => {
+    const isLatest = t.id == sortedTasks[0].id
+
+    if (t.status === 'REMOVED' || t.status === 'REJECTED') {
+      return `Removed ${instantToDateString(t.createdAt)}`
+    }
+
+    return `${
+      t.completedAt ? `Completed ${instantToDateString(t.completedAt)}` : `Assigned ${instantToDateString(t.createdAt)}`
+    }${isLatest ? ' (latest)' : ''}`
+  }
+
+  const surveyResponseVersionOptions = sortedTasks.map((t, idx) => ({
+    value: t.id,
+    task: t,
+    label: formatSurveyVersionLabel(t),
+    index: idx
+  }))
+
+
   // key forces the component to be destroyed/remounted when different survey selected
   return <div>
     <DocumentTitle title={`${enrollee.shortcode} - ${surveyAndResponses.survey.survey.name}`}/>
-    <h4>{surveyAndResponses.survey.survey.name}</h4>
+    <div className="d-flex justify-content-between">
+
+      <h4>{surveyAndResponses.survey.survey.name}</h4>
+      {showVersionOptions && <div style={{ minWidth: '350px' }}>
+        <Select
+          className={'w-100'}
+          options={surveyResponseVersionOptions}
+          value={surveyResponseVersionOptions.find(o => o.value === taskId)}
+          formatOptionLabel={opt => {
+            return <div className="d-flex justify-content-between align-items-center">
+              {opt.label}
+              {(opt.task.status === 'REMOVED' || opt.task.status === 'REJECTED')
+                ? <span className="ms-2 badge bg-danger">
+                  <FontAwesomeIcon icon={faX}/>
+                </span>
+                : <span className="ms-2 badge bg-secondary">
+                  {opt.index + 1} of {numNonRemoved}
+                </span>}
+            </div>
+          }}
+          onChange={opt => {
+            if (!opt) {
+              return
+            }
+            navigate(surveyResponsePath(studyEnvContext.currentEnvPath, enrollee.shortcode, surveyStableId, opt.value))
+          }}
+        />
+      </div>}
+    </div>
+
     {!isAssigned && <div className="d-flex align-items-center">
       <span className="text-muted fst-italic me-4">Not assigned</span>
       <Button variant={'secondary'} outline={true}
@@ -99,17 +161,6 @@ export default function SurveyResponseView({ enrollee, responseMap, updateRespon
       </Button>
     </div>}
     {isAssigned && <>
-      {showTaskBar && <div className="d-flex">
-        {surveyAndResponses.tasks.map(task => <NavLink key={task.id}
-          style={({ isActive }: { isActive: boolean }) => ({
-            borderBottom: (isActive && task.id === taskId) ? '2px solid #708DBC' : '',
-            background: (isActive && task.id === taskId) ? '#E1E8F7' : ''
-          })}
-          className="p-2"
-          to={surveyResponsePath(studyEnvContext.currentEnvPath, enrollee.shortcode, surveyStableId, task.id)}>
-          {instantToDateString(task.completedAt ?? task.createdAt)}
-        </NavLink>)}
-      </div>}
       <RawEnrolleeSurveyView key={`${surveyStableId}${taskId}`} enrollee={enrollee} studyEnvContext={studyEnvContext}
         updateResponseMap={updateResponseMap}
         task={task!}
@@ -143,6 +194,7 @@ export function RawEnrolleeSurveyView({
 
   return <div>
     <div>
+      {surveyDates(task, response)}
       <div className="d-flex align-items-center justify-content-between">
         <div className="d-flex align-items-center">
           <div className="border rounded-3 p-0">
@@ -153,7 +205,7 @@ export function RawEnrolleeSurveyView({
               <FontAwesomeIcon icon={faPencil}/>
             </Button>
           </div>
-          {surveyTaskStatus(task, response)}
+          {surveyVersion(task, response)}
           <div className="ms-2">
             <Button
               variant="secondary"
@@ -163,7 +215,6 @@ export function RawEnrolleeSurveyView({
             </Button>
           </div>
         </div>
-
         <div className="d-flex align-items-center">
           <AutosaveStatusIndicator status={autosaveStatus}/>
           <div className="dropdown">
@@ -248,7 +299,8 @@ export function RawEnrolleeSurveyView({
         updateResponseMap={updateResponseMap}
         justification={justification}
         setAutosaveStatus={setAutosaveStatus}
-        survey={configSurvey.survey} response={response} adminUserId={user.id}
+        survey={configSurvey.survey} response={response}
+        adminUserId={user.id}
         enrollee={enrollee} onUpdate={onUpdate}/>}
       {showJustificationModal && <JustifyChangesModal
         saveWithJustification={justification => {
@@ -294,18 +346,33 @@ const taskStatusIndicators: Record<ParticipantTaskStatus, React.ReactNode> = {
     <FontAwesomeIcon icon={faMinus}/> Removed</span>
 }
 
-function surveyTaskStatus(task: ParticipantTask, surveyResponse?: SurveyResponse) {
+function surveyVersion(task: ParticipantTask, surveyResponse?: SurveyResponse) {
   let versionString = ''
   if (surveyResponse && surveyResponse.answers.length) {
     const answerVersions = _uniq(surveyResponse.answers.map(ans => ans.surveyVersion))
     versionString = `${pluralize('version', answerVersions.length)} ${answerVersions.join(', ')}`
   }
 
-  return <div className="d-flex align-items-center">
-    {surveyResponse && <span className="ms-2">{surveyResponse.complete ?
-      'Completed' : 'Last Updated'} {instantToDefaultString(surveyResponse.createdAt)} ({versionString})
-    </span>}
+  return <div className="ms-2">
+    {versionString}
   </div>
+}
+
+function surveyDates(task: ParticipantTask, surveyResponse?: SurveyResponse) {
+  return <>
+    <div className="d-flex small m-0 p-0 mt-1">
+      <div className="me-4">
+        <span className="fst-italic">assigned {instantToDefaultString(task?.createdAt)}</span>
+      </div>
+      <div className="me-4">
+        <span className="fst-italic">completed {instantToDefaultString(task.completedAt) || 'n/a'}</span>
+      </div>
+      <div>
+        <span
+          className="fst-italic">last updated {instantToDefaultString(surveyResponse?.lastUpdatedAt) || 'n/a'}</span>
+      </div>
+    </div>
+  </>
 }
 
 type DropdownButtonProps = {


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Cleans up the admin experience:
1. Uses dropdown to select survey versions to handle lots of longitudinal responses
2. Displays all dates (assigned, completed, etc.)
3. Displays surveys with status == REMOVED or REJECTED, but clearly denotes that they are no longer part of this enrollee's survey history
4. Displays # of responses in sidebar (if > 1)
5. Displays link to survey with the currently assigned version
    a. one thing that would be nice would be making it clear if the enrollee has an old version of the survey / isn't assigned the latest.... but I think this is enough changes for now 😄 

<img width="1237" height="818" alt="Screenshot 2025-09-19 at 9 36 22 AM" src="https://github.com/user-attachments/assets/725e7c4b-a3db-4cff-952d-2e4b21d56e35" />
<img width="1237" height="818" alt="Screenshot 2025-09-19 at 9 36 36 AM" src="https://github.com/user-attachments/assets/ca40b981-6607-4f72-8e41-34e7110931a6" />
<img width="1237" height="818" alt="Screenshot 2025-09-19 at 9 36 48 AM" src="https://github.com/user-attachments/assets/a9864fa3-3807-47af-b605-5a3a86499ab2" />
<img width="1237" height="818" alt="Screenshot 2025-09-19 at 9 36 52 AM" src="https://github.com/user-attachments/assets/ca9e6050-bd25-4862-8702-4433e2300ee2" />
<img width="1237" height="818" alt="Screenshot 2025-09-19 at 9 37 03 AM" src="https://github.com/user-attachments/assets/93f30f74-dda8-45f6-9eec-427ce05c0535" />
<img width="1237" height="818" alt="Screenshot 2025-09-19 at 9 37 13 AM" src="https://github.com/user-attachments/assets/b6a34918-653d-47a9-9137-e8313ecdbae6" />





#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

