### PR TITLE
[JN-1759] fixing target id input for triggers

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConfiguredSurveyController.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/controller/forms/ConfiguredSurveyController.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.api.admin.controller.forms;
 
 import bio.terra.pearl.api.admin.api.ConfiguredSurveyApi;
 import bio.terra.pearl.api.admin.service.auth.AuthUtilService;
+import bio.terra.pearl.api.admin.service.auth.context.PortalEnvAuthContext;
 import bio.terra.pearl.api.admin.service.auth.context.PortalStudyAuthContext;
 import bio.terra.pearl.api.admin.service.auth.context.PortalStudyEnvAuthContext;
 import bio.terra.pearl.api.admin.service.forms.SurveyExtService;
@@ -39,7 +40,7 @@ public class ConfiguredSurveyController implements ConfiguredSurveyApi {
    * content)
    */
   @Override
-  public ResponseEntity<Object> findWithNoContent(
+  public ResponseEntity<Object> findWithNoContentByStudy(
       String portalShortcode,
       String studyShortcode,
       String envName,
@@ -50,10 +51,29 @@ public class ConfiguredSurveyController implements ConfiguredSurveyApi {
         envName != null ? EnvironmentName.valueOfCaseInsensitive(envName) : null;
     Boolean activeVal = active != null ? Boolean.valueOf(active) : null;
     List<StudyEnvironmentSurvey> studyEnvSurveys =
-        surveyExtService.findWithSurveyNoContent(
+        surveyExtService.findWithSurveyByStudyNoContent(
             PortalStudyAuthContext.of(operator, portalShortcode, studyShortcode),
             stableId,
             environmentName,
+            activeVal);
+    return ResponseEntity.ok(studyEnvSurveys);
+  }
+
+  /**
+   * gets all StudyEnvironmentSurveys for the given study, along with their associated Survey (minus
+   * content)
+   */
+  @Override
+  public ResponseEntity<Object> findWithNoContent(
+      String portalShortcode, String envName, String stableId, String active) {
+    AdminUser operator = authUtilService.requireAdminUser(request);
+    EnvironmentName environmentName =
+        envName != null ? EnvironmentName.valueOfCaseInsensitive(envName) : null;
+    Boolean activeVal = active != null ? Boolean.valueOf(active) : null;
+    List<StudyEnvironmentSurvey> studyEnvSurveys =
+        surveyExtService.findWithSurveyNoContent(
+            PortalEnvAuthContext.of(operator, portalShortcode, environmentName),
+            stableId,
             activeVal);
     return ResponseEntity.ok(studyEnvSurveys);
   }

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/forms/SurveyExtService.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.api.admin.service.forms;
 
 import bio.terra.pearl.api.admin.service.auth.*;
 import bio.terra.pearl.api.admin.service.auth.context.PortalAuthContext;
+import bio.terra.pearl.api.admin.service.auth.context.PortalEnvAuthContext;
 import bio.terra.pearl.api.admin.service.auth.context.PortalStudyAuthContext;
 import bio.terra.pearl.api.admin.service.auth.context.PortalStudyEnvAuthContext;
 import bio.terra.pearl.core.model.BaseEntity;
@@ -78,22 +79,39 @@ public class SurveyExtService {
   }
 
   @EnforcePortalStudyPermission(permission = AuthUtilService.BASE_PERMISSION)
-  public List<StudyEnvironmentSurvey> findWithSurveyNoContent(
+  public List<StudyEnvironmentSurvey> findWithSurveyByStudyNoContent(
       PortalStudyAuthContext authContext,
       String stableId,
       EnvironmentName envName,
       Boolean active) {
     List<UUID> studyEnvIds =
-        studyEnvIds =
-            studyEnvironmentService
-                .findByStudy(authContext.getPortalStudy().getStudyId())
-                // if no envName is specified, include all environments, otherwise just include the
-                // specified one
-                .stream()
-                .filter(
-                    studyEnv -> envName == null || studyEnv.getEnvironmentName().equals(envName))
-                .map(StudyEnvironment::getId)
-                .toList();
+        studyEnvironmentService
+            .findByStudy(authContext.getPortalStudy().getStudyId())
+            // if no envName is specified, include all environments, otherwise just include the
+            // specified one
+            .stream()
+            .filter(studyEnv -> envName == null || studyEnv.getEnvironmentName().equals(envName))
+            .map(StudyEnvironment::getId)
+            .toList();
+    return studyEnvironmentSurveyService.findAllWithSurveyNoContent(studyEnvIds, stableId, active);
+  }
+
+  @EnforcePortalEnvPermission(permission = AuthUtilService.BASE_PERMISSION)
+  public List<StudyEnvironmentSurvey> findWithSurveyNoContent(
+      PortalEnvAuthContext authContext, String stableId, Boolean active) {
+    List<UUID> studyEnvIds =
+        studyEnvironmentService
+            .findAllByPortalAndEnvironment(
+                authContext.getPortal().getId(), authContext.getEnvironmentName())
+            // if no envName is specified, include all environments, otherwise just include the
+            // specified one
+            .stream()
+            .filter(
+                studyEnv ->
+                    authContext.getEnvironmentName() == null
+                        || studyEnv.getEnvironmentName().equals(authContext.getEnvironmentName()))
+            .map(StudyEnvironment::getId)
+            .toList();
     return studyEnvironmentSurveyService.findAllWithSurveyNoContent(studyEnvIds, stableId, active);
   }
 

--- a/api-admin/src/main/resources/api/openapi.yml
+++ b/api-admin/src/main/resources/api/openapi.yml
@@ -205,11 +205,27 @@ paths:
           content: *jsonContent
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/portals/v1/{portalShortcode}/configuredSurveys/findWithNoContent:
+    get:
+      summary: Lists all the configured surveys for a portal
+      tags: [ configuredSurvey ]
+      operationId: findWithNoContent
+      parameters:
+        - *portalShortcodeParam
+        - { name: envName, in: query, required: false, schema: { type: string } }
+        - { name: stableId, in: query, required: false, schema: { type: string } }
+        - { name: active, in: query, required: false, schema: { type: string, format: boolean } }
+      responses:
+        '200':
+          description: list of all the configured surveys for a portal
+          content: *jsonContent
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/portals/v1/{portalShortcode}/studies/{studyShortcode}/configuredSurveys/findWithNoContent:
     get:
       summary: Lists all the configured surveys for a study
       tags: [ configuredSurvey ]
-      operationId: findWithNoContent
+      operationId: findWithNoContentByStudy
       parameters:
         - *portalShortcodeParam
         - *studyShortcodeParam
@@ -595,7 +611,7 @@ paths:
           content: *jsonContent
         '500':
           $ref: '#/components/responses/ServerError'
-  
+
   /api/portals/v1/{portalShortcode}/env/{envName}/participantUsers/merge/plan:
     post:
       summary: gets a merge plan for the given participant users. This does not perform the merge.

--- a/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/SurveyExtServiceTests.java
+++ b/api-admin/src/test/java/bio/terra/pearl/api/admin/service/forms/SurveyExtServiceTests.java
@@ -47,27 +47,35 @@ public class SurveyExtServiceTests extends BaseSpringBootTest {
   public void assertAllMethods() {
     AuthTestUtils.assertAllMethodsAnnotated(
         surveyExtService,
-        Map.of(
-            "get",
-            AuthAnnotationSpec.withPortalPerm(AuthUtilService.BASE_PERMISSION),
-            "listVersions",
-            AuthAnnotationSpec.withPortalPerm(AuthUtilService.BASE_PERMISSION),
-            "findWithSurveyNoContent",
-            AuthAnnotationSpec.withPortalStudyPerm(AuthUtilService.BASE_PERMISSION),
-            "create",
-            AuthAnnotationSpec.withPortalPerm("survey_edit"),
-            "delete",
-            AuthAnnotationSpec.withPortalPerm("survey_edit"),
-            "createNewVersion",
-            AuthAnnotationSpec.withPortalPerm("survey_edit"),
-            "createConfiguredSurvey",
-            AuthAnnotationSpec.withPortalStudyEnvPerm("survey_edit", List.of(SandboxOnly.class)),
-            "updateConfiguredSurveys",
-            AuthAnnotationSpec.withPortalStudyEnvPerm("survey_edit", List.of(SandboxOnly.class)),
-            "removeConfiguredSurvey",
-            AuthAnnotationSpec.withPortalStudyEnvPerm("survey_edit", List.of(SandboxOnly.class)),
-            "replace",
-            AuthAnnotationSpec.withPortalStudyEnvPerm("survey_edit", List.of(SandboxOnly.class))));
+        Map.ofEntries(
+            Map.entry("get", AuthAnnotationSpec.withPortalPerm(AuthUtilService.BASE_PERMISSION)),
+            Map.entry(
+                "listVersions", AuthAnnotationSpec.withPortalPerm(AuthUtilService.BASE_PERMISSION)),
+            Map.entry(
+                "findWithSurveyNoContent",
+                AuthAnnotationSpec.withPortalEnvPerm(AuthUtilService.BASE_PERMISSION)),
+            Map.entry(
+                "findWithSurveyByStudyNoContent",
+                AuthAnnotationSpec.withPortalStudyPerm(AuthUtilService.BASE_PERMISSION)),
+            Map.entry("create", AuthAnnotationSpec.withPortalPerm("survey_edit")),
+            Map.entry("delete", AuthAnnotationSpec.withPortalPerm("survey_edit")),
+            Map.entry("createNewVersion", AuthAnnotationSpec.withPortalPerm("survey_edit")),
+            Map.entry(
+                "createConfiguredSurvey",
+                AuthAnnotationSpec.withPortalStudyEnvPerm(
+                    "survey_edit", List.of(SandboxOnly.class))),
+            Map.entry(
+                "updateConfiguredSurveys",
+                AuthAnnotationSpec.withPortalStudyEnvPerm(
+                    "survey_edit", List.of(SandboxOnly.class))),
+            Map.entry(
+                "removeConfiguredSurvey",
+                AuthAnnotationSpec.withPortalStudyEnvPerm(
+                    "survey_edit", List.of(SandboxOnly.class))),
+            Map.entry(
+                "replace",
+                AuthAnnotationSpec.withPortalStudyEnvPerm(
+                    "survey_edit", List.of(SandboxOnly.class)))));
   }
 
   @Test

--- a/ui-admin/src/api/api.tsx
+++ b/ui-admin/src/api/api.tsx
@@ -761,11 +761,13 @@ export default {
     return await this.processJsonResponse(response)
   },
 
-  async findConfiguredSurveys(portalShortcode: string, studyShortcode: string,
+  async findConfiguredSurveys(portalShortcode: string, studyShortcode: string | undefined,
     envName?: EnvironmentName, active?: boolean, stableId?: string): Promise<StudyEnvironmentSurvey[]> {
     const params = queryString.stringify({ envName, active, stableId })
-    const url = `${basePortalUrl(portalShortcode)}/studies/${studyShortcode}`
-      + `/configuredSurveys/findWithNoContent?${params}`
+    let url = `${basePortalUrl(portalShortcode)}/configuredSurveys/findWithNoContent?${params}`
+    if (studyShortcode) {
+      url = `${basePortalUrl(portalShortcode)}/studies/${studyShortcode}/configuredSurveys/findWithNoContent?${params}`
+    }
     const response = await fetch(url, this.getGetInit())
     return await this.processJsonResponse(response)
   },

--- a/ui-admin/src/study/notifications/TriggerDesignerEditor.tsx
+++ b/ui-admin/src/study/notifications/TriggerDesignerEditor.tsx
@@ -109,7 +109,8 @@ const TriggerTypeEditor = (
 
   const isTaskScopable = (trigger.triggerType === 'TASK_REMINDER') ||
     (trigger.triggerType === 'EVENT' && ['SURVEY_RESPONSE', 'KIT_RECEIVED', 'KIT_SENT'].includes(trigger.eventType))
-
+  const showMaxNotifications = (trigger.triggerType === 'TASK_REMINDER' || trigger.triggerType === 'EVENT')
+   && trigger.actionType !== 'TASK_STATUS_CHANGE'
   return <InfoCard>
     <InfoCardHeader>
       <InfoCardTitle title={'Condition'}/>
@@ -149,7 +150,7 @@ const TriggerTypeEditor = (
               <TaskReminderEditor trigger={trigger} updateTrigger={updateTrigger}/>
             </>}
 
-          {(trigger.triggerType === 'TASK_REMINDER' || trigger.triggerType === 'EVENT') &&
+          {showMaxNotifications &&
             <div>
               <label className="form-label">Max number of notifications
                 <input className="form-control" type="number" value={trigger.maxNumNotifications}
@@ -366,7 +367,7 @@ const TriggerActionEditor = (
             />}
 
           {trigger.actionType === 'TASK_STATUS_CHANGE'
-            && <TaskStatusEditor trigger={trigger} updateTrigger={updateTrigger}/>
+            && <TaskStatusEditor trigger={trigger} updateTrigger={updateTrigger} studyEnvContext={studyEnvContext}/>
           }
         </>
         }
@@ -510,10 +511,12 @@ const scopeOptions: {label: string, value: TriggerScope}[] = [
 const TaskStatusEditor = (
   {
     trigger,
-    updateTrigger
+    updateTrigger,
+    studyEnvContext
   } : {
     trigger: Trigger,
-    updateTrigger: (string: keyof Trigger, value: unknown) => void;
+    updateTrigger: (string: keyof Trigger, value: unknown) => void,
+    studyEnvContext: StudyEnvContextT
   }
 ) => {
   return <div>
@@ -535,16 +538,27 @@ const TaskStatusEditor = (
       />
     </div>
     <div>
-      <label className="form-label mt-3" htmlFor="updateTaskTargetStableIds">Target stable id </label>
-      <InfoPopup content={<span>
-            the stable id of the task to update. For survey tasks, this is the survey stable id.
-      </span>}/>
+      <TaskTargetStableIdsEditor studyEnvParams={paramsFromContext(studyEnvContext)}
+        stableIds={trigger.actionTargetStableIds}
+        setStableIds={newVals => updateTrigger('actionTargetStableIds', newVals)}
+        label={<>
+          Target surveys
+          <InfoPopup content={<span>
+            The surveys to update the status of.  This will update all tasks for the given survey(s)
+          </span>}/>
+        </>
+        }
+        isKitType={false} portalScope={true}/>
     </div>
   </div>
 }
 
-const TaskTargetStableIdsEditor = ({ studyEnvParams, stableIds, setStableIds, isKitType }:
-  {studyEnvParams: StudyEnvParams, stableIds: string[], setStableIds: (ids: string[]) => void, isKitType: boolean}) => {
+const TaskTargetStableIdsEditor = ({
+  studyEnvParams, stableIds, setStableIds, isKitType, label,
+  portalScope
+}:
+  {studyEnvParams: StudyEnvParams, stableIds: string[], setStableIds: (ids: string[]) => void, isKitType: boolean,
+  label?: React.ReactNode, portalScope?: boolean}) => {
   const [options, setOptions] = useState<{ label: string, value: string }[]>([])
   useLoadingEffect(async () => {
     if (isKitType) {
@@ -552,16 +566,19 @@ const TaskTargetStableIdsEditor = ({ studyEnvParams, stableIds, setStableIds, is
       setOptions(kitTypes.map(kitType => ({ label: kitType.displayName, value: kitType.name })))
     } else {
       const studyEnvSurveys = await Api.findConfiguredSurveys(studyEnvParams.portalShortcode,
-        studyEnvParams.studyShortcode, studyEnvParams.envName, true)
+        portalScope ? undefined : studyEnvParams.studyShortcode, studyEnvParams.envName, true)
       setOptions(studyEnvSurveys.map(ses => ({ label: ses.survey.name, value: ses.survey.stableId })))
     }
   }, [isKitType])
 
+  label = label ?? <>Limit to these {isKitType ? 'kit types' : 'surveys'}
+    <span className="fst-italic ms-2">(leave blank if automation applies to all)</span>
+  </>
+
   stableIds = stableIds ?? []
   const inputId = useId()
   return <div className="mt-3">
-    <label className="form-label" htmlFor={inputId}>Limit to these {isKitType ? 'kit types' : 'surveys'}
-      <span className="fst-italic ms-2">(leave blank if automation applies to all)</span></label>
+    <label className="form-label" htmlFor={inputId}>{label}</label>
     <Select options={options} inputId={inputId}
       value={stableIds.map(stableId => options.find(option => option.value === stableId))}
       isMulti={true}

--- a/ui-admin/src/study/workflow/workflowUtils.tsx
+++ b/ui-admin/src/study/workflow/workflowUtils.tsx
@@ -4,7 +4,8 @@ export const triggerName = (trigger: Trigger) => {
   if (trigger.actionType === 'NOTIFICATION' || trigger.actionType === 'ADMIN_NOTIFICATION') {
     return trigger.emailTemplate.name
   } else if (trigger.actionType === 'TASK_STATUS_CHANGE') {
-    return `Mark ${trigger.actionTargetStableIds.join(',')} as ${trigger.statusToUpdateTo}`
+    const targets = trigger.actionTargetStableIds.length ? trigger.actionTargetStableIds.join(',') : '[task]'
+    return `Mark ${targets} as ${trigger.statusToUpdateTo ?? '[status]'}`
   } else if (trigger.triggerType === 'TASK_REMINDER') {
     return `Remind after ${minutesToDayString(trigger.afterMinutesIncomplete)}`
   }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Looks like this input field just got lost in the refactor.  I think it used to be a plain text field, but it was easy enough to update it to use our survey selection widget

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. go to https://localhost:3000/demo/studies/demosleep/env/sandbox/triggers
2. click "add" to add a new trigger
3. Make a trigger of type "Change task status"
4. on the subsequent screen, confirm you can change the scope to "Portal", and that all surveys in both the demo and sleep study appear as selectable.