### PR TITLE
[JN-1763] add research id to search expressions + participant table

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/EnrolleeTerm.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/EnrolleeTerm.java
@@ -65,6 +65,7 @@ public class EnrolleeTerm extends SearchTerm {
 
     public static final Map<String, SearchValueTypeDefinition> FIELDS = Map.ofEntries(
             Map.entry("shortcode", SearchValueTypeDefinition.builder().type(STRING).build()),
+            Map.entry("researchId", SearchValueTypeDefinition.builder().type(STRING).build()),
             Map.entry("subject", SearchValueTypeDefinition.builder().type(BOOLEAN).build()),
             Map.entry("consented", SearchValueTypeDefinition.builder().type(BOOLEAN).build()),
             Map.entry("createdAt", SearchValueTypeDefinition.builder().type(INSTANT).build()));

--- a/core/src/test/java/bio/terra/pearl/core/dao/search/EnrolleeSearchExpressionDaoTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/search/EnrolleeSearchExpressionDaoTests.java
@@ -398,6 +398,10 @@ public class EnrolleeSearchExpressionDaoTests extends BaseSpringBootTest {
                 "{enrollee.shortcode} = 'EXAMPLE'"
         );
 
+        EnrolleeSearchExpression researchIdExp = enrolleeSearchExpressionParser.parseRule(
+                "{enrollee.researchId} = '12EXAMPLE'"
+        );
+
         Enrollee notConsented = enrolleeFactory.buildPersisted(
                 enrolleeFactory.builderWithDependencies(getTestName(info)).consented(false).subject(true).studyEnvironmentId(studyEnvId));
         timeShiftDao.changeEnrolleeCreationTime(notConsented.getId(), Instant.now().minus(5, ChronoUnit.DAYS));
@@ -410,21 +414,26 @@ public class EnrolleeSearchExpressionDaoTests extends BaseSpringBootTest {
         Enrollee consented = enrolleeFactory.buildPersisted(
                 enrolleeFactory.builderWithDependencies(getTestName(info)).consented(true).subject(true).studyEnvironmentId(studyEnvId));
         timeShiftDao.changeEnrolleeCreationTime(consented.getId(), Instant.now().minus(1, ChronoUnit.DAYS));
+        Enrollee specialResearchId = enrolleeFactory.buildPersisted(
+                enrolleeFactory.builderWithDependencies(getTestName(info)).consented(false).subject(false).researchId("12EXAMPLE").studyEnvironmentId(studyEnvId));
+        timeShiftDao.changeEnrolleeCreationTime(specialShortcode.getId(), Instant.now().minus(0, ChronoUnit.DAYS));
+
 
         List<EnrolleeSearchExpressionResult> resultsConsented = enrolleeSearchExpressionDao.executeSearch(consentedExp, studyEnvBundle.getStudyEnv().getId());
         List<EnrolleeSearchExpressionResult> resultsSubject = enrolleeSearchExpressionDao.executeSearch(subjectExp, studyEnvBundle.getStudyEnv().getId());
         List<EnrolleeSearchExpressionResult> resultsShortcode = enrolleeSearchExpressionDao.executeSearch(shortcodeExp, studyEnvBundle.getStudyEnv().getId());
+        List<EnrolleeSearchExpressionResult> resultsResearchId = enrolleeSearchExpressionDao.executeSearch(researchIdExp, studyEnvBundle.getStudyEnv().getId());
 
         Assertions.assertEquals(1, resultsConsented.size());
         Assertions.assertEquals(2, resultsSubject.size());
         Assertions.assertEquals(1, resultsShortcode.size());
+        Assertions.assertEquals(1, resultsResearchId.size());
 
         assertTrue(resultsConsented.stream().anyMatch(r -> r.getEnrollee().getId().equals(consented.getId())));
-
         assertTrue(resultsSubject.stream().anyMatch(r -> r.getEnrollee().getId().equals(notConsented.getId())));
         assertTrue(resultsSubject.stream().anyMatch(r -> r.getEnrollee().getId().equals(consented.getId())));
-
         assertTrue(resultsShortcode.stream().anyMatch(r -> r.getEnrollee().getId().equals(specialShortcode.getId())));
+        assertTrue(resultsResearchId.stream().anyMatch(r -> r.getEnrollee().getId().equals(specialResearchId.getId())));
 
         // now check time filtering
         List<EnrolleeSearchExpressionResult> resultsTime = enrolleeSearchExpressionDao.executeSearch(
@@ -439,7 +448,7 @@ public class EnrolleeSearchExpressionDaoTests extends BaseSpringBootTest {
                 studyEnvBundle.getStudyEnv().getId()
         );
         assertThat(resultsTime.stream().map(EnrolleeSearchExpressionResult::getEnrollee).map(Enrollee::getId).toList(),
-                containsInAnyOrder(specialShortcode.getId(), consented.getId()));
+                containsInAnyOrder(specialShortcode.getId(), consented.getId(), specialResearchId.getId()));
 
     }
 

--- a/core/src/test/java/bio/terra/pearl/core/service/search/EnrolleeSearchServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/search/EnrolleeSearchServiceTest.java
@@ -232,6 +232,7 @@ class EnrolleeSearchServiceTest extends BaseSpringBootTest {
                 Map.entry("enrollee.subject", SearchValueTypeDefinition.builder().type(BOOLEAN).build()),
                 Map.entry("enrollee.consented", SearchValueTypeDefinition.builder().type(BOOLEAN).build()),
                 Map.entry("enrollee.shortcode", SearchValueTypeDefinition.builder().type(STRING).build()),
+                Map.entry("enrollee.researchId", SearchValueTypeDefinition.builder().type(STRING).build()),
                 Map.entry("enrollee.createdAt", SearchValueTypeDefinition.builder().type(INSTANT).build()),
                 Map.entry("portalUser.createdAt", SearchValueTypeDefinition.builder().type(INSTANT).build()),
                 Map.entry("portalUser.lastLogin", SearchValueTypeDefinition.builder().type(INSTANT).build()),

--- a/core/src/test/java/bio/terra/pearl/core/service/search/expressions/EnrolleeSearchExpressionTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/search/expressions/EnrolleeSearchExpressionTest.java
@@ -450,6 +450,36 @@ class EnrolleeSearchExpressionTest extends BaseSpringBootTest {
                                         .shortcode("JSALK")
                                         .build())
                                 .build()));
+
+        assertFalse(enrolleeSearchExpressionParser
+                .parseRule("{enrollee.shortcode} = 'JSALK'")
+                .evaluate(
+                        EnrolleeSearchContext
+                                .builder()
+                                .enrollee(Enrollee.builder()
+                                        .shortcode("OTHER")
+                                        .build())
+                                .build()));
+
+        assertTrue(enrolleeSearchExpressionParser
+                .parseRule("{enrollee.researchId} = '12SALK'")
+                .evaluate(
+                        EnrolleeSearchContext
+                                .builder()
+                                .enrollee(Enrollee.builder()
+                                        .researchId("12SALK")
+                                        .build())
+                                .build()));
+
+        assertFalse(enrolleeSearchExpressionParser
+                .parseRule("{enrollee.researchId} = '12SALK'")
+                .evaluate(
+                        EnrolleeSearchContext
+                                .builder()
+                                .enrollee(Enrollee.builder()
+                                        .researchId("12OTHER")
+                                        .build())
+                                .build()));
     }
 
     @Test

--- a/ui-admin/src/study/participants/participantList/ParticipantListTable.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantListTable.tsx
@@ -98,7 +98,8 @@ function ParticipantListTable({
     'givenName': false,
     'familyName': false,
     'contactEmail': false,
-    'subject': false
+    'subject': false,
+    'researchId': false
   })
 
 
@@ -133,6 +134,15 @@ function ParticipantListTable({
       )
     },
     enrolleeShortcodeColumn(currentEnvPath),
+    {
+      header: 'Research ID',
+      id: 'researchId',
+      accessorKey: 'enrollee.researchId',
+      enableColumnFilter: true,
+      meta: {
+        columnType: 'string'
+      }
+    },
     {
       header: 'Created',
       id: 'createdAt',


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

I realized I forgot to add research IDs as a search exp term. Thus, it was actually not possible to see it in the main table 😞 

This PR both adds it as a search expression option, and makes it a mainline column that you can toggle visibility for. It's hidden by default, so no visible changes for studies that might not care about this feature.

<img width="1648" height="865" alt="image" src="https://github.com/user-attachments/assets/bc3a2960-aba3-4da1-a540-4478a0898c2e" />
<img width="1648" height="865" alt="image" src="https://github.com/user-attachments/assets/8773e4f9-6cbc-4abe-a2fb-11b40adb7d42" />


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

