### PR TITLE
[JN-1764] persist lang query param in url when changed

### DIFF
--- a/ui-core/src/participant/ParticipantNavbar.tsx
+++ b/ui-core/src/participant/ParticipantNavbar.tsx
@@ -334,13 +334,11 @@ export function LanguageDropdown({ languageOptions, selectedLanguage, changeLang
             return (
               <button key={index} className="dropdown-item" aria-label={lang.languageName}
                 onClick={() => {
-                  //If the user selects a language from the dropdown, remove the lang query param from the URL
-                  if (langQueryParam) {
-                    searchParams.delete('lang')
-                    navigate({ search: searchParams.toString() })
-                  }
+                  // persist lang as a query param - makes it easier to share internationalized links
                   changeLanguage(lang.languageCode)
-                  reloadPortal()
+
+                  searchParams.set('lang', lang.languageCode)
+                  navigate({ search: searchParams.toString() })
                 }}>
                 {lang.languageName}
               </button>

--- a/ui-core/src/participant/ParticipantNavbar.tsx
+++ b/ui-core/src/participant/ParticipantNavbar.tsx
@@ -334,10 +334,12 @@ export function LanguageDropdown({ languageOptions, selectedLanguage, changeLang
             return (
               <button key={index} className="dropdown-item" aria-label={lang.languageName}
                 onClick={() => {
-                  // persist lang as a query param - makes it easier to share internationalized links
                   changeLanguage(lang.languageCode)
 
+                  // persist lang as a query param - makes it easier to share internationalized links
                   searchParams.set('lang', lang.languageCode)
+                  // navigating with a new lang query param will also trigger a full refresh to ensure
+                  // latest portal/study content is loaded in the correct language
                   navigate({ search: searchParams.toString() })
                 }}>
                 {lang.languageName}

--- a/ui-participant/src/Navbar.test.tsx
+++ b/ui-participant/src/Navbar.test.tsx
@@ -375,33 +375,6 @@ describe('language selector', () => {
     expect(buttons[2]).toHaveTextContent('Spanish')
   })
 
-  it('reloads the portal when a language is selected', () => {
-    const languageOptions = [
-      { languageCode: 'en', languageName: 'English' },
-      { languageCode: 'es', languageName: 'Spanish' }
-    ]
-    const selectedLanguage = 'en'
-    const changeLanguage = jest.fn()
-    const reloadPortal = jest.fn()
-
-    const { RoutedComponent } = setupRouterTest(
-      <LanguageDropdown
-        languageOptions={languageOptions}
-        selectedLanguage={selectedLanguage}
-        changeLanguage={changeLanguage}
-        reloadPortal={reloadPortal}
-      />
-    )
-    render(RoutedComponent)
-
-    const languageSelector = screen.getByLabelText('Select a language')
-    languageSelector.click()
-    const spanishButton = screen.getByText('Spanish')
-    spanishButton.click()
-    expect(changeLanguage).toHaveBeenCalledWith('es')
-    expect(reloadPortal).toHaveBeenCalled()
-  })
-
   it('does not render when there is only one language', () => {
     const languageOptions = [
       { languageCode: 'en', languageName: 'English' }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

when someone changes their language, add it to the url (e.g., `?lang=es`) to make it easier to share URLs in other languages 

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

