### PR TITLE
[JN-1765] filter based on task completion time

### DIFF
--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/file/ParticipantFileController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/file/ParticipantFileController.java
@@ -104,7 +104,11 @@ public class ParticipantFileController implements ParticipantFileApi {
 
     List<ScannedParticipantFileDto> participantFiles =
         participantFileExtService.list(
-            portalShortcode, EnvironmentName.valueOf(envName), participantUser, enrolleeShortcode);
+            portalShortcode,
+            studyShortcode,
+            EnvironmentName.valueOf(envName),
+            participantUser,
+            enrolleeShortcode);
     return ResponseEntity.ok(participantFiles);
   }
 

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/service/file/ParticipantFileExtService.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/service/file/ParticipantFileExtService.java
@@ -6,11 +6,13 @@ import bio.terra.pearl.core.model.file.ParticipantFile;
 import bio.terra.pearl.core.model.file.ScannedParticipantFileDto;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
+import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.file.ParticipantFileService;
 import bio.terra.pearl.core.service.file.VirusScanResult;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackend;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackendProvider;
+import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -26,14 +28,17 @@ public class ParticipantFileExtService {
   private final ParticipantFileService participantFileService;
   private final AuthUtilService authUtilService;
   private final FileStorageBackend fileStorageBackend;
+  private final StudyEnvironmentService studyEnvironmentService;
 
   public ParticipantFileExtService(
       ParticipantFileService participantFileService,
       AuthUtilService authUtilService,
-      FileStorageBackendProvider fileStorageBackendProvider) {
+      FileStorageBackendProvider fileStorageBackendProvider,
+      StudyEnvironmentService studyEnvironmentService) {
     this.participantFileService = participantFileService;
     this.authUtilService = authUtilService;
     this.fileStorageBackend = fileStorageBackendProvider.get();
+    this.studyEnvironmentService = studyEnvironmentService;
   }
 
   public ScannedParticipantFileDto get(
@@ -105,12 +110,17 @@ public class ParticipantFileExtService {
 
   public List<ScannedParticipantFileDto> list(
       String portalShortcode,
+      String studyShortcode,
       EnvironmentName envName,
       ParticipantUser participantUser,
       String enrolleeShortcode) {
     authUtilService.authParticipantToPortal(participantUser.getId(), portalShortcode, envName);
     Enrollee enrollee =
         authUtilService.authParticipantUserToEnrollee(participantUser.getId(), enrolleeShortcode);
+    StudyEnvironment studyEnv = studyEnvironmentService.verifyStudy(studyShortcode, envName);
+    if (!studyEnv.getId().equals(enrollee.getStudyEnvironmentId())) {
+      return List.of();
+    }
     return participantFileService.findByEnrolleeId(enrollee.getId()).stream()
         .map(participantFileService::attachVirusScanResult)
         .toList();

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/TaskTerm.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/TaskTerm.java
@@ -9,14 +9,15 @@ import bio.terra.pearl.core.service.search.EnrolleeSearchContext;
 import bio.terra.pearl.core.service.search.sql.EnrolleeSearchQueryBuilder;
 import org.jooq.Condition;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static bio.terra.pearl.core.dao.BaseJdbiDao.toSnakeCase;
-import static bio.terra.pearl.core.service.search.terms.SearchValue.SearchValueType.BOOLEAN;
-import static bio.terra.pearl.core.service.search.terms.SearchValue.SearchValueType.STRING;
+import static bio.terra.pearl.core.service.search.terms.SearchValue.SearchValueType.*;
 import static org.jooq.impl.DSL.condition;
 
 /**
@@ -51,6 +52,15 @@ public class TaskTerm extends SearchTerm {
         if (field.equals("assigned")) {
             return new SearchValue(taskOpt.isPresent());
         }
+        if (field.equals("completedDaysAgo")) {
+            if (taskOpt.isPresent()) {
+                ParticipantTask task = taskOpt.get();
+                if (task.getCompletedAt() != null) {
+                    return new SearchValue((double) ChronoUnit.DAYS.between(task.getCompletedAt(), Instant.now()));
+                }
+            }
+            return new SearchValue(-1D);
+        }
 
         if (taskOpt.isEmpty()) {
             return new SearchValue();
@@ -81,8 +91,11 @@ public class TaskTerm extends SearchTerm {
 
     @Override
     public String termClause() {
-        if (field.equals("assigned"))
+        if (field.equals("assigned")) {
             return alias() + ".id IS NOT NULL";
+        } else if (field.equals("completedDaysAgo")) {
+            return "(case when %s.completed_at is not null then now()::date - %s.completed_at::date else -1 end)".formatted(alias(), alias());
+        }
         return alias() + "." + toSnakeCase(field);
     }
 
@@ -114,5 +127,7 @@ public class TaskTerm extends SearchTerm {
                                             .map(val -> new QuestionChoice(val.name(), val.name()))
                                             .toList()
                             ).build()),
-            Map.entry("assigned", SearchValueTypeDefinition.builder().type(BOOLEAN).build()));
+            Map.entry("assigned", SearchValueTypeDefinition.builder().type(BOOLEAN).build()),
+            Map.entry("completedDaysAgo", SearchValueTypeDefinition.builder().type(NUMBER).build()));
+
 }

--- a/core/src/test/java/bio/terra/pearl/core/dao/search/EnrolleeSearchExpressionDaoTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/search/EnrolleeSearchExpressionDaoTests.java
@@ -9,6 +9,7 @@ import bio.terra.pearl.core.factory.participant.*;
 import bio.terra.pearl.core.factory.survey.SurveyFactory;
 import bio.terra.pearl.core.factory.survey.SurveyResponseFactory;
 import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.audit.DataAuditInfo;
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.kit.KitRequestStatus;
 import bio.terra.pearl.core.model.participant.Enrollee;
@@ -29,6 +30,7 @@ import bio.terra.pearl.core.service.participant.ProfileService;
 import bio.terra.pearl.core.service.search.EnrolleeSearchExpression;
 import bio.terra.pearl.core.service.search.EnrolleeSearchExpressionParser;
 import bio.terra.pearl.core.service.search.EnrolleeSearchOptions;
+import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Assertions;
@@ -64,6 +66,8 @@ public class EnrolleeSearchExpressionDaoTests extends BaseSpringBootTest {
     SurveyResponseFactory surveyResponseFactory;
     @Autowired
     ParticipantTaskFactory participantTaskFactory;
+    @Autowired
+    ParticipantTaskService participantTaskService;
     @Autowired
     KitRequestFactory kitRequestFactory;
     @Autowired
@@ -346,6 +350,13 @@ public class EnrolleeSearchExpressionDaoTests extends BaseSpringBootTest {
         EnrolleeSearchExpression inProgressExp = enrolleeSearchExpressionParser.parseRule(
                 "{task.demographic_survey.status} = 'IN_PROGRESS'"
         );
+        EnrolleeSearchExpression completed3DaysAgoExp = enrolleeSearchExpressionParser.parseRule(
+                "{task.completed_task.completedDaysAgo} > 3"
+        );
+        EnrolleeSearchExpression completed5DaysAgoExp = enrolleeSearchExpressionParser.parseRule(
+                "{task.completed_task.completedDaysAgo} > 5"
+        );
+
 
         // enrollee not assigned
         EnrolleeBundle eBundleNotAssigned = enrolleeFactory.buildWithPortalUser(getTestName(info), studyEnvBundle.getPortalEnv(), studyEnvBundle.getStudyEnv());
@@ -365,6 +376,13 @@ public class EnrolleeSearchExpressionDaoTests extends BaseSpringBootTest {
         EnrolleeBundle eBundleInProgressWrongTask = enrolleeFactory.buildWithPortalUser(getTestName(info), studyEnvBundle.getPortalEnv(), studyEnvBundle.getStudyEnv());
         participantTaskFactory.buildPersisted(eBundleInProgressWrongTask, "something_else", TaskStatus.IN_PROGRESS, TaskType.SURVEY);
 
+        // completed task 4 days ago
+        EnrolleeBundle eBundleCompletedTask = enrolleeFactory.buildWithPortalUser(getTestName(info), studyEnvBundle.getPortalEnv(), studyEnvBundle.getStudyEnv());
+        ParticipantTask completedTask = participantTaskFactory.buildPersisted(eBundleCompletedTask, "completed_task", TaskStatus.COMPLETE, TaskType.SURVEY);
+        completedTask.setCompletedAt(Instant.now().minus(4, ChronoUnit.DAYS));
+        participantTaskService.update(completedTask, DataAuditInfo.builder().systemProcess(getTestName(info)).build());
+        Enrollee enrolleeCompletedTask = eBundleCompletedTask.enrollee();
+
         List<EnrolleeSearchExpressionResult> resultsAssigned = enrolleeSearchExpressionDao.executeSearch(assignedExp, studyEnvBundle.getStudyEnv().getId());
         List<EnrolleeSearchExpressionResult> resultsInProgress = enrolleeSearchExpressionDao.executeSearch(inProgressExp, studyEnvBundle.getStudyEnv().getId());
 
@@ -379,6 +397,14 @@ public class EnrolleeSearchExpressionDaoTests extends BaseSpringBootTest {
         // attaches the task to the enrollee search result
         assertTrue(resultsInProgress.stream().allMatch(r -> r.getTasks().size() == 1 && r.getTasks().get(0).getTargetStableId().equals("demographic_survey")));
         assertTrue(resultsAssigned.stream().allMatch(r -> r.getTasks().size() == 1 && r.getTasks().get(0).getTargetStableId().equals("demographic_survey")));
+
+        // check days ago expressions
+        List<EnrolleeSearchExpressionResult> completed3daysAgo = enrolleeSearchExpressionDao.executeSearch(completed3DaysAgoExp, studyEnvBundle.getStudyEnv().getId());
+        Assertions.assertEquals(1, completed3daysAgo.size());
+        assertTrue(completed3daysAgo.stream().anyMatch(r -> r.getEnrollee().getId().equals(enrolleeCompletedTask.getId())));
+
+        List<EnrolleeSearchExpressionResult> completed5daysAgo = enrolleeSearchExpressionDao.executeSearch(completed5DaysAgoExp, studyEnvBundle.getStudyEnv().getId());
+        Assertions.assertEquals(0, completed5daysAgo.size());
     }
 
     @Test
@@ -917,7 +943,7 @@ public class EnrolleeSearchExpressionDaoTests extends BaseSpringBootTest {
         Enrollee enrollee2 = enrolleeFactory.buildPersisted(getTestName(info), studyEnv); // has survey response and answer, but not 'answer1'
         Enrollee enrollee3 = enrolleeFactory.buildPersisted(getTestName(info), studyEnv); // has survey response but no answer
         Enrollee enrollee4 = enrolleeFactory.buildPersisted(getTestName(info), studyEnv); // no survey response
-        
+
         surveyResponseFactory.buildWithAnswers(enrollee1, survey, Map.of(
                 "testquestion", "answer1"
         ));

--- a/core/src/test/java/bio/terra/pearl/core/service/search/EnrolleeSearchServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/search/EnrolleeSearchServiceTest.java
@@ -226,8 +226,10 @@ class EnrolleeSearchServiceTest extends BaseSpringBootTest {
                                                 new QuestionChoice("CA", "Canada"))
                                 ).build()),
                 Map.entry("task.another_survey.status", SearchValueTypeDefinition.builder().type(STRING).choices(taskStatusChoices).build()),
+                Map.entry("task.another_survey.completedDaysAgo", SearchValueTypeDefinition.builder().type(NUMBER).build()),
                 Map.entry("task.another_survey.assigned", SearchValueTypeDefinition.builder().type(BOOLEAN).build()),
                 Map.entry("task.test_survey_1.assigned", SearchValueTypeDefinition.builder().type(BOOLEAN).build()),
+                Map.entry("task.test_survey_1.completedDaysAgo", SearchValueTypeDefinition.builder().type(NUMBER).build()),
                 Map.entry("task.test_survey_1.status", SearchValueTypeDefinition.builder().type(STRING).choices(taskStatusChoices).build()),
                 Map.entry("enrollee.subject", SearchValueTypeDefinition.builder().type(BOOLEAN).build()),
                 Map.entry("enrollee.consented", SearchValueTypeDefinition.builder().type(BOOLEAN).build()),

--- a/core/src/test/java/bio/terra/pearl/core/service/search/expressions/EnrolleeSearchExpressionTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/search/expressions/EnrolleeSearchExpressionTest.java
@@ -9,6 +9,7 @@ import bio.terra.pearl.core.factory.survey.SurveyFactory;
 import bio.terra.pearl.core.factory.survey.SurveyResponseFactory;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.address.MailingAddress;
+import bio.terra.pearl.core.model.audit.DataAuditInfo;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.Family;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
@@ -16,6 +17,7 @@ import bio.terra.pearl.core.model.participant.Profile;
 import bio.terra.pearl.core.model.portal.PortalEnvironment;
 import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.survey.Survey;
+import bio.terra.pearl.core.model.workflow.ParticipantTask;
 import bio.terra.pearl.core.model.workflow.TaskStatus;
 import bio.terra.pearl.core.model.workflow.TaskType;
 import bio.terra.pearl.core.service.kit.pepper.PepperKitStatus;
@@ -26,12 +28,15 @@ import bio.terra.pearl.core.service.rule.EnrolleeContextService;
 import bio.terra.pearl.core.service.search.EnrolleeSearchContext;
 import bio.terra.pearl.core.service.search.EnrolleeSearchExpression;
 import bio.terra.pearl.core.service.search.EnrolleeSearchExpressionParser;
+import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -60,6 +65,8 @@ class EnrolleeSearchExpressionTest extends BaseSpringBootTest {
     PortalParticipantUserService portalParticipantUserService;
     @Autowired
     ParticipantUserService participantUserService;
+    @Autowired
+    private ParticipantTaskService participantTaskService;
 
 
     @Test
@@ -369,6 +376,14 @@ class EnrolleeSearchExpressionTest extends BaseSpringBootTest {
                 "{task.demographic_survey.status} = 'IN_PROGRESS'"
         );
 
+        EnrolleeSearchExpression completed3DaysAgoExp = enrolleeSearchExpressionParser.parseRule(
+                "{task.completed_task.completedDaysAgo} > 3"
+        );
+        EnrolleeSearchExpression completed5DaysAgoExp = enrolleeSearchExpressionParser.parseRule(
+                "{task.completed_task.completedDaysAgo} > 5"
+        );
+
+
         // enrollee not assigned
         EnrolleeBundle eBundleNotAssigned = enrolleeFactory.buildWithPortalUser(getTestName(info), studyEnvBundle.getPortalEnv(), studyEnvBundle.getStudyEnv());
         Enrollee enrolleeNotAssigned = eBundleNotAssigned.enrollee();
@@ -388,6 +403,13 @@ class EnrolleeSearchExpressionTest extends BaseSpringBootTest {
         participantTaskFactory.buildPersisted(eBundleInProgressWrongTask, "something_else", TaskStatus.IN_PROGRESS, TaskType.SURVEY);
         Enrollee enrolleeInProgressWrongTask = eBundleInProgressWrongTask.enrollee();
 
+        // completed task 4 days ago
+        EnrolleeBundle eBundleCompletedTask = enrolleeFactory.buildWithPortalUser(getTestName(info), studyEnvBundle.getPortalEnv(), studyEnvBundle.getStudyEnv());
+        ParticipantTask completedTask = participantTaskFactory.buildPersisted(eBundleCompletedTask, "completed_task", TaskStatus.COMPLETE, TaskType.SURVEY);
+        completedTask.setCompletedAt(Instant.now().minus(4, ChronoUnit.DAYS));
+        participantTaskService.update(completedTask, DataAuditInfo.builder().systemProcess(getTestName(info)).build());
+        Enrollee enrolleeCompletedTask = eBundleCompletedTask.enrollee();
+
         assertTrue(assignedExp.evaluate(EnrolleeSearchContext.builder().enrollee(enrolleeNotStarted).build()));
         assertTrue(assignedExp.evaluate(EnrolleeSearchContext.builder().enrollee(enrolleeInProgress).build()));
         assertFalse(assignedExp.evaluate(EnrolleeSearchContext.builder().enrollee(enrolleeNotAssigned).build()));
@@ -397,6 +419,10 @@ class EnrolleeSearchExpressionTest extends BaseSpringBootTest {
         assertFalse(inProgressExp.evaluate(EnrolleeSearchContext.builder().enrollee(enrolleeNotStarted).build()));
         assertFalse(inProgressExp.evaluate(EnrolleeSearchContext.builder().enrollee(enrolleeNotAssigned).build()));
         assertFalse(inProgressExp.evaluate(EnrolleeSearchContext.builder().enrollee(enrolleeInProgressWrongTask).build()));
+
+        assertTrue(completed3DaysAgoExp.evaluate(EnrolleeSearchContext.builder().enrollee(enrolleeCompletedTask).build()));
+        assertFalse(completed5DaysAgoExp.evaluate(EnrolleeSearchContext.builder().enrollee(enrolleeCompletedTask).build()));
+        assertFalse(completed3DaysAgoExp.evaluate(EnrolleeSearchContext.builder().enrollee(enrolleeInProgress).build()));
     }
 
     @Test

--- a/ui-admin/src/util/table/columnUtils.tsx
+++ b/ui-admin/src/util/table/columnUtils.tsx
@@ -21,7 +21,7 @@ import Select from 'react-select'
 import { Link } from 'react-router-dom'
 import { checkboxColumnCell } from './tableUtils'
 import {
-  instantToDefaultString,
+  instantToDefaultString, dateDiff,
   ParticipantTaskStatusOptions
 } from '@juniper/ui-core'
 import _startCase from 'lodash/startCase'
@@ -202,6 +202,11 @@ const dynamicTaskColumn = <T extends EnrolleeSearchExpressionResult, >(facet: Ke
       const task = info.tasks.find(task => task.targetStableId === taskStableId)
       if (field === 'status') {
         return ParticipantTaskStatusOptions.find(opt => opt.value === task?.status)?.label || task?.status || ''
+      } else if (field === 'completedDaysAgo') {
+        if (!task?.completedAt) {
+          return ''
+        }
+        return dateDiff(new Date(), new Date(task.completedAt * 1000))
       }
 
       return get(task, field)

--- a/ui-core/src/timeUtils.tsx
+++ b/ui-core/src/timeUtils.tsx
@@ -58,3 +58,11 @@ export function isoToInstant(isoDate?: string): number | undefined {
 export function dateMinusDays(date: Date, daysAgo: number) {
   return new Date(date.getTime() - daysAgo * 24 * 60 * 60 * 1000)
 }
+
+export function dateDiff(date1: Date, date2: Date) {
+  const date2UTC = Date.UTC(date2.getFullYear(), date2.getMonth(), date2.getDate())
+  const date1ITC = Date.UTC(date1.getFullYear(), date1.getMonth(), date1.getDate())
+
+  const millisecondsDiff = date1ITC - date2UTC
+  return Math.floor(millisecondsDiff / (1000 * 60 * 60 * 24))
+}

--- a/ui-participant/src/hub/documents/DocumentLibrary.tsx
+++ b/ui-participant/src/hub/documents/DocumentLibrary.tsx
@@ -66,7 +66,8 @@ export default function DocumentLibrary() {
                     studyShortcode: pStudy.study.shortcode,
                     envName: portalEnv.environmentName as EnvironmentName
                   }}
-                  enrollee={enrollees.find(enrollee => enrollee.profileId === ppUser?.profileId)!}
+                  enrollee={enrollees.find(enrollee => enrollee.profileId === ppUser?.profileId &&
+                    enrollee.studyEnvironmentId === pStudy.study.studyEnvironments[0].id)!}
                 />
               )}
             </div>


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

OurHealth want to auto-assign a survey 90 days after a different survey is complete.  This will enable the eligibility criteria, and then they'll need to add a delay of 1 day so it gets picked up by the auto-scheduler

This also contains a fix for multi-study document access--we weren't sending the right enrollee codes to the backend for file listing

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. redeploy admin app
2.  repopulate heart demo
3.  go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants?search=%7B%22custom%22%3A%22%7Btask.hd_hd_basicInfo.completedDaysAgo%7D+%3E+4%22%7D
4. confirm 3 enrollees appear, and the correct days ago column appears
