### PR TITLE
[JN-1769] removing survey links for files uploaded on admin forms

### DIFF
--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/adminKits.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/surveys/adminKits.json
@@ -47,6 +47,12 @@
             "isRequired": false,
             "name": "kitNotes",
             "title": "Notes"
+          },
+          {
+            "type": "documentrequest",
+            "isRequired": true,
+            "name": "kit_document_request",
+            "title": "Kit Record Request"
           }
         ]
       }

--- a/ui-participant/src/hub/documents/DocumentLibrary.tsx
+++ b/ui-participant/src/hub/documents/DocumentLibrary.tsx
@@ -168,13 +168,19 @@ const surveyResponseIdsToTaskNames = (
     <div className={'mt-2 text-muted'}>
       <span>{i18n('documentSharedInResponseTo')}:</span>
       <ul>
-        {associatedTasks.map(task =>
-          <li key={task.id}>
+        {associatedTasks.map(task => {
+          const linkText = i18n(`${task.targetStableId}:${task.targetAssignedVersion}`,
+            { defaultValue: task.targetName })
+          // don't use a link for study staff forms -- the participant can't see them
+          if (task.taskType === 'ADMIN_FORM') {
+            return <li key={task.id}>{linkText}</li>
+          }
+          return <li key={task.id}>
             <Link to={`../${getTaskPath(task, enrollee.shortcode, studyEnvParams.studyShortcode)}`}>
-              {i18n(`${task.targetStableId}:${task.targetAssignedVersion}`, { defaultValue: task.targetName })}
+              {linkText}
             </Link>
           </li>
-        )}
+        })}
       </ul>
     </div>
   )


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

We don't want to show links to participants to admin forms -- they get "hub path not found" messages

<img width="693" height="522" alt="image" src="https://github.com/user-attachments/assets/a75f111c-a622-4b0a-95ed-ee30f6ada378" />


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*
0. repopulate demo
1. from the admin tool, upload a file for jsalk for the "kit history" admin form
2. log in to participant view as jsalk, confirm the file appears, but not linked to the survey

