### PR TITLE
[JN-1772] adding max length to excel values

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/export/DataDictionaryExcelExporter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/DataDictionaryExcelExporter.java
@@ -285,7 +285,7 @@ public class DataDictionaryExcelExporter extends ExcelExporter {
 
     protected SXSSFCell addCellToRow(SXSSFRow row, int colNum, String value) {
         SXSSFCell cell = row.createCell(colNum);
-        cell.setCellValue(value);
+        cell.setCellValue(sanitizeValue(value, DEFAULT_EMPTY_STRING_VALUE));
         cell.setCellStyle(wrapStyle);
         return cell;
     }

--- a/core/src/main/java/bio/terra/pearl/core/service/export/ExcelExporter.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/export/ExcelExporter.java
@@ -21,6 +21,7 @@ public class ExcelExporter extends BaseExporter {
 
     protected final SXSSFSheet sheet;
     private static final String SHEET_NAME = "Participants";
+    public static final int EXCEL_CELL_MAX_CHARS = 30000; // it's really 32767, but we want some margin
 
     public ExcelExporter(List<ModuleFormatter> moduleFormatters, List<Map<String, String>> enrolleeMaps, List<String> columnSorting) {
         super(moduleFormatters, enrolleeMaps, columnSorting);
@@ -71,5 +72,16 @@ public class ExcelExporter extends BaseExporter {
 
     protected String getSheetName() {
         return SHEET_NAME;
+    }
+
+    /**
+     * Take a string value and sanitize it for export. E.g. For a TSV exporter, we need to escape double quotes.
+     */
+    protected String sanitizeValue(String value, String nullValueString) {
+        String sanitized = super.sanitizeValue(value, nullValueString);
+        if (sanitized != null && sanitized.length() > EXCEL_CELL_MAX_CHARS) {
+            return sanitized.substring(0, EXCEL_CELL_MAX_CHARS) + "... (truncated)";
+        }
+        return sanitized;
     }
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

TRCC dictionary export was failing in prod.  Excel has a 32K cell character limit, and apparently one of their questions/options is too long

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

extract the portal configs from TRCC in production
upload to local env
download the data dictionary