### PR TITLE
[SIDRB-4251] adding EU MixPanel routing

### DIFF
--- a/.github/workflows/require-ticket.yml
+++ b/.github/workflows/require-ticket.yml
@@ -15,7 +15,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const title = context.payload.pull_request.title;
-            const regex = /JN-|DDO-|SIDRB-\d+/;
+            const regex = /(JN|DDO|SIDRB)-\d+/;
             if (!regex.test(title)) {
               core.setFailed("PR title must contain a Jira ticket");
             }

--- a/.github/workflows/require-ticket.yml
+++ b/.github/workflows/require-ticket.yml
@@ -15,7 +15,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const title = context.payload.pull_request.title;
-            const regex = /JN|DDO-\d+/;
+            const regex = /JN|DDO|SIDRB-\d+/;
             if (!regex.test(title)) {
               core.setFailed("PR title must contain a Jira ticket");
             }

--- a/.github/workflows/require-ticket.yml
+++ b/.github/workflows/require-ticket.yml
@@ -15,7 +15,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const title = context.payload.pull_request.title;
-            const regex = /JN|DDO|SIDRB-\d+/;
+            const regex = /JN-|DDO-|SIDRB-\d+/;
             if (!regex.test(title)) {
               core.setFailed("PR title must contain a Jira ticket");
             }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,120 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Juniper is a research study management platform supporting collection of survey, genomic, and medical records data. It has two portals: an admin (study manager) interface and a participant-facing portal.
+
+## Commands
+
+### Frontend (npm workspaces)
+
+```bash
+# Install dependencies (required on macOS: brew install pkg-config cairo pango libpng jpeg giflib librsvg pixman)
+npm install
+
+# Build the shared ui-core library first (required before running admin/participant UIs)
+npm -w ui-core run build
+
+# Run admin UI (localhost:3000)
+npm run admin-dev-local           # with unauthed login (no B2C)
+npm run admin-dev                 # with HTTPS
+
+# Run participant UI (localhost:3001, accessed as sandbox.demo.localhost:3001)
+VITE_UNAUTHED_LOGIN=true HTTPS=true npm -w ui-participant start
+
+# Run all frontend tests
+npm test
+
+# Run tests for a single workspace
+npm -w ui-admin test
+npm -w ui-core test
+npm -w ui-participant test
+
+# Lint (zero warnings policy)
+npm run lint
+```
+
+### Backend (Gradle)
+
+```bash
+# Start PostgreSQL (required for tests and running the app)
+./scripts/postgres/run_postgres.sh start
+
+# Build all Java modules
+./gradlew build
+
+# Run all backend tests
+./gradlew test
+
+# Run tests for a single module
+./gradlew :core:test
+./gradlew :api-admin:test
+
+# Run a specific test class
+./gradlew :core:test --tests "bio.terra.pearl.core.dao.SomeTest"
+
+# Populate seed data (after starting ApiAdminApp)
+./scripts/populate/populate_portal.sh demo
+
+# Render environment variables for IntelliJ run configs
+bash ./scripts/render_environment_vars.sh ApiAdminApp <YOUR_EMAIL>
+bash ./scripts/render_environment_vars.sh ApiParticipantApp <YOUR_EMAIL>
+```
+
+### Spring Boot profiles
+Run both API apps with profiles: `human-readable-logging, development`
+
+## Architecture
+
+### Module Structure
+
+```
+core/          - POJOs, DAOs, services, Liquibase migrations (the data layer)
+populate/      - Data seeding/population from files and CLI
+api-admin/     - Spring Boot REST API for admin UI (port 8080)
+api-participant/ - Spring Boot REST API for participant UI (port 8081)
+compliance/    - Compliance utilities
+pepper-import/ - Data import from DSM/Pepper
+ui-core/       - Shared React component library (@juniper/ui-core)
+ui-admin/      - Admin SPA (React + Vite)
+ui-participant/ - Participant SPA (React + Vite)
+e2e-tests/     - Playwright end-to-end tests
+```
+
+### Backend Patterns
+
+**Data layer** (`core` module):
+- Models extend `BaseEntity` (`core/src/main/java/bio/terra/pearl/core/model/`)
+- DAOs extend `BaseJdbiDao` (provides create/find/delete), `BaseMutableJdbiDao`, or `BaseVersionedJdbiDao`
+- Services live in `core/src/main/java/bio/terra/pearl/core/service/`
+- DB schema managed by Liquibase changesets in `core/src/main/resources/db/changelog/changesets/`
+
+**API layer**:
+- Controllers are generated from OpenAPI specs: `api-admin/src/main/resources/api/openapi.yml` and `api-participant/src/main/resources/api/openapi.yml`
+- Add a new endpoint by editing the openapi.yml, then implementing the generated interface in `api-admin/src/main/java/bio/terra/pearl/api/admin/controller/`
+
+### Frontend Patterns
+
+- `ui-core` must be built before `ui-admin` or `ui-participant` can run (it's a local package dependency)
+- Both UIs use React 18 + React Router 6 + Bootstrap 5 + SurveyJS 1.12.4
+- Auth via `react-oidc-context` + Azure B2C; bypass with `VITE_UNAUTHED_LOGIN=true`
+- Admin UI proxies API to `http://localhost:8080`
+
+### Adding a New Model (standard workflow)
+
+1. Create POJO extending `BaseEntity` in `core/.../model/`
+2. Add Liquibase changeset in `core/.../resources/db/changelog/changesets/`
+3. Create DAO extending `BaseJdbiDao` in `core/.../dao/`
+4. Add service in `core/.../service/`
+5. Add seed data in `populate/src/main/resources/seed/` and a populator in `populate/.../populate/service/`
+6. Edit `api-admin/src/main/resources/api/openapi.yml` to add endpoint
+7. Implement the generated controller interface in `api-admin/.../controller/`
+
+### Key Tech
+
+- **Backend**: Java 21, Spring Boot 3.x, JDBI3, PostgreSQL, Liquibase, Lombok
+- **Frontend**: TypeScript 4.8, React 18, Vite, SurveyJS 1.12.4, TanStack Table
+- **Auth**: Azure B2C / Auth0 JWT (OAuth2)
+- **Infra**: GCP, Docker (JIB), Terraform, Helm

--- a/core/src/main/java/bio/terra/pearl/core/service/logging/MixpanelService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/logging/MixpanelService.java
@@ -21,7 +21,7 @@ import java.util.Map;
 @Service
 @Slf4j
 public class MixpanelService {
-    private static final String EU_DOMAIN_PROJECT = "thehearthive.org";  // if we get a second EU customer, add a useMixpanelEU boolean to PortalEnvironmentConfig
+    private static final String EU_DOMAIN_PROJECT = "thehearthive";  // if we get a second EU customer, add a useMixpanelEU boolean to PortalEnvironmentConfig
     private static final String MIXPANEL_TOKEN_ENV_VAR = "env.mixpanel.token";
     private static final String MIXPANEL_ENABLED_ENV_VAR = "env.mixpanel.enabled";
     private final MixpanelConfig mixpanelConfig;
@@ -147,7 +147,7 @@ public class MixpanelService {
     }
 
     protected boolean isEUProject(String eventDomain) {
-        return EU_DOMAIN_PROJECT.equals(eventDomain);
+        return eventDomain != null && eventDomain.contains(EU_DOMAIN_PROJECT);
     }
 
     public static String getDomainName(String url) {

--- a/core/src/main/java/bio/terra/pearl/core/service/logging/MixpanelService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/logging/MixpanelService.java
@@ -16,11 +16,13 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Service
 @Slf4j
 public class MixpanelService {
+    private static final String EU_DOMAIN_PROJECT = "thehearthive.org";  // if we get a second EU customer, add a useMixpanelEU boolean to PortalEnvironmentConfig
     private static final String MIXPANEL_TOKEN_ENV_VAR = "env.mixpanel.token";
     private static final String MIXPANEL_ENABLED_ENV_VAR = "env.mixpanel.enabled";
     private final MixpanelConfig mixpanelConfig;
@@ -66,12 +68,17 @@ public class MixpanelService {
 
         ClientDelivery delivery = new ClientDelivery();
         ClientDelivery customDelivery = null;
+        ClientDelivery euDelivery = null;
 
         for (int i = 0; i < events.length(); i++) {
             JSONObject event = events.getJSONObject(i);
             JSONObject mixpanelEvent = buildEvent(event, mixpanelConfig.token);
-            delivery.addMessage(mixpanelEvent);
             String eventDomain = getEventCurrentDomain(event);
+
+            // send all mixpanel events that aren't fron the EU to our general project
+            if (!isEUProject(eventDomain)) {
+                delivery.addMessage(mixpanelEvent);
+            }
 
             /** check if the event comes from a domain with a dedicated mixpanel token, if so, use that token to send the
              * event to that token in addition to the global mixpanel domain */
@@ -81,13 +88,21 @@ public class MixpanelService {
                 PortalEnvironmentConfig matchedConfig = configMap.get(eventDomain);
                 if (matchedConfig != null && matchedConfig.getMixpanelToken() != null) {
                     JSONObject domainEvent = buildEvent(event, matchedConfig.getMixpanelToken());
-                    customDelivery.addMessage(domainEvent);
+                    if (isEUProject(eventDomain)) {
+                        euDelivery = euDelivery == null ? new ClientDelivery() : euDelivery;
+                        euDelivery.addMessage(domainEvent);
+                    } else {
+                        customDelivery.addMessage(domainEvent);
+                    }
                 }
             }
         }
         deliverEvents(delivery);
         if (customDelivery != null) {
             deliverEvents(customDelivery);
+        }
+        if (euDelivery != null) {
+            deliverEvents(euDelivery, true);
         }
     }
 
@@ -104,7 +119,16 @@ public class MixpanelService {
     }
 
     protected void deliverEvents(ClientDelivery delivery) {
+        deliverEvents(delivery, false);
+    }
+
+    protected void deliverEvents(ClientDelivery delivery, boolean isEUDomain) {
         MixpanelAPI mixpanel = new MixpanelAPI();
+        if (isEUDomain) {
+            mixpanel = new MixpanelAPI( "https://api-eu.mixpanel.com/track",
+                    "https://api-eu.mixpanel.com/engage",
+                    "https://api-eu.mixpanel.com/groups");
+        }
         try {
             mixpanel.deliver(delivery);
         } catch (IOException e) {
@@ -122,6 +146,10 @@ public class MixpanelService {
             }
         }
         return domain;
+    }
+
+    protected boolean isEUProject(String eventDomain) {
+        return EU_DOMAIN_PROJECT.equals(eventDomain);
     }
 
     public static String getDomainName(String url) {

--- a/core/src/main/java/bio/terra/pearl/core/service/logging/MixpanelService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/logging/MixpanelService.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @Service
@@ -65,8 +64,7 @@ public class MixpanelService {
 
         //Mixpanel sends event data as urlencoded form data, so we need to parse the event data as a JSON array
         JSONArray events = new JSONArray(filteredData);
-
-        ClientDelivery delivery = new ClientDelivery();
+        ClientDelivery delivery = null;
         ClientDelivery customDelivery = null;
         ClientDelivery euDelivery = null;
 
@@ -75,15 +73,15 @@ public class MixpanelService {
             JSONObject mixpanelEvent = buildEvent(event, mixpanelConfig.token);
             String eventDomain = getEventCurrentDomain(event);
 
-            // send all mixpanel events that aren't fron the EU to our general project
+            // send all mixpanel events that aren't from the EU to our general project
             if (!isEUProject(eventDomain)) {
+                delivery = delivery == null ? new ClientDelivery() : delivery;
                 delivery.addMessage(mixpanelEvent);
             }
 
             /** check if the event comes from a domain with a dedicated mixpanel token, if so, use that token to send the
              * event to that token in addition to the global mixpanel domain */
             if (eventDomain != null) {
-                customDelivery = customDelivery == null ? new ClientDelivery() : customDelivery;
                 Map<String, PortalEnvironmentConfig> configMap = loggingConfigCache.getConfigsWithDomain();
                 PortalEnvironmentConfig matchedConfig = configMap.get(eventDomain);
                 if (matchedConfig != null && matchedConfig.getMixpanelToken() != null) {
@@ -92,18 +90,15 @@ public class MixpanelService {
                         euDelivery = euDelivery == null ? new ClientDelivery() : euDelivery;
                         euDelivery.addMessage(domainEvent);
                     } else {
+                        customDelivery = customDelivery == null ? new ClientDelivery() : customDelivery;
                         customDelivery.addMessage(domainEvent);
                     }
                 }
             }
         }
         deliverEvents(delivery);
-        if (customDelivery != null) {
-            deliverEvents(customDelivery);
-        }
-        if (euDelivery != null) {
-            deliverEvents(euDelivery, true);
-        }
+        deliverEvents(customDelivery);
+        deliverEvents(euDelivery, true);
     }
 
     protected JSONObject buildEvent(JSONObject event, String apiToken) {
@@ -123,6 +118,9 @@ public class MixpanelService {
     }
 
     protected void deliverEvents(ClientDelivery delivery, boolean isEUDomain) {
+        if (delivery == null) {
+            return;
+        }
         MixpanelAPI mixpanel = new MixpanelAPI();
         if (isEUDomain) {
             mixpanel = new MixpanelAPI( "https://api-eu.mixpanel.com/track",

--- a/core/src/test/java/bio/terra/pearl/core/service/logging/MixpanelServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/logging/MixpanelServiceTests.java
@@ -17,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 public class MixpanelServiceTests extends BaseSpringBootTest {
@@ -60,31 +62,35 @@ public class MixpanelServiceTests extends BaseSpringBootTest {
         verify(mockedMixpanelService, never()).buildEvent(any(), any());
     }
 
-    @Test
-    public void testEnableMixpanel() {
+    /** Creates a spy on a MixpanelService configured with Mixpanel enabled and token "test-token". */
+    private MixpanelService createEnabledMixpanelServiceSpy() {
         Environment env = mock(Environment.class);
         when(env.getProperty("env.mixpanel.enabled")).thenReturn("true");
         when(env.getProperty("env.mixpanel.token")).thenReturn("test-token");
         MixpanelService.MixpanelConfig mixpanelConfig = new MixpanelService.MixpanelConfig(env);
-        // Create a spy on the MixpanelService instance
-        MixpanelService mixpanelService = new MixpanelService(mixpanelConfig, loggingConfigCache);
-        MixpanelService spyMixpanelService = spy(mixpanelService);
+        return spy(new MixpanelService(mixpanelConfig, loggingConfigCache));
+    }
 
+    /** Builds a JSONObject event with the given name and properties. */
+    private JSONObject buildTestEvent(String eventName, String key, String value, String currentUrl) {
         JSONObject event = new JSONObject();
-        event.put("event", "test_event");
+        event.put("event", eventName);
         JSONObject properties = new JSONObject();
-        properties.put("key", "value");
+        properties.put(key, value);
+        if (currentUrl != null) {
+            properties.put("$current_url", currentUrl);
+        }
         event.put("properties", properties);
+        return event;
+    }
 
-        JSONObject event2 = new JSONObject();
-        event2.put("event", "test_event2");
-        JSONObject properties2 = new JSONObject();
-        properties2.put("key", "value2");
-        event2.put("properties", properties2);
+    @Test
+    public void testEnableMixpanel() {
+        MixpanelService spyMixpanelService = createEnabledMixpanelServiceSpy();
 
         JSONArray events = new JSONArray();
-        events.put(event);
-        events.put(event2);
+        events.put(buildTestEvent("test_event", "key", "value", null));
+        events.put(buildTestEvent("test_event2", "key", "value2", null));
 
         spyMixpanelService.logEvent(events.toString());
 
@@ -95,13 +101,7 @@ public class MixpanelServiceTests extends BaseSpringBootTest {
     @Test
     @Transactional
     public void testSendsToCustomProject(TestInfo info) {
-        Environment env = mock(Environment.class);
-        when(env.getProperty("env.mixpanel.enabled")).thenReturn("true");
-        when(env.getProperty("env.mixpanel.token")).thenReturn("test-token");
-        MixpanelService.MixpanelConfig mixpanelConfig = new MixpanelService.MixpanelConfig(env);
-        // Create a spy on the MixpanelService instance
-        MixpanelService mixpanelService = new MixpanelService(mixpanelConfig, loggingConfigCache);
-        MixpanelService spyMixpanelService = spy(mixpanelService);
+        MixpanelService spyMixpanelService = createEnabledMixpanelServiceSpy();
 
         PortalEnvironment portalEnv =  portalEnvironmentFactory.buildPersisted(getTestName(info));
         PortalEnvironmentConfig envConfig = portalEnvironmentConfigService.find(portalEnv.getPortalEnvironmentConfigId()).get();
@@ -111,23 +111,9 @@ public class MixpanelServiceTests extends BaseSpringBootTest {
         loggingConfigCache.configCacheEvict();
 
 
-        JSONObject event = new JSONObject();
-        event.put("event", "test_event");
-        JSONObject properties = new JSONObject();
-        properties.put("key", "value");
-        properties.put("$current_url", "https://somedomain.org/page");
-        event.put("properties", properties);
-
-        JSONObject event2 = new JSONObject();
-        event2.put("event", "test_event2");
-        JSONObject properties2 = new JSONObject();
-        properties2.put("key", "value2");
-        properties2.put("$current_url", "https://anotherdomain.com");
-        event2.put("properties", properties2);
-
         JSONArray events = new JSONArray();
-        events.put(event);
-        events.put(event2);
+        events.put(buildTestEvent("test_event", "key", "value", "https://somedomain.org/page"));
+        events.put(buildTestEvent("test_event2", "key", "value2", "https://anotherdomain.com"));
 
         spyMixpanelService.logEvent(events.toString());
         ArgumentCaptor<JSONObject> objCaptor = ArgumentCaptor.forClass(JSONObject.class);
@@ -138,6 +124,39 @@ public class MixpanelServiceTests extends BaseSpringBootTest {
         assertThat(objCaptor.getAllValues().stream().map(obj ->
                 ((JSONObject) obj.get("properties")).get("$current_url")).toList(),
                 contains("https://somedomain.org/page", "https://somedomain.org/page", "https://anotherdomain.com"));
+    }
+
+    @Test
+    @Transactional
+    public void testEUEventsRoutedToEUEndpoint(TestInfo info) {
+        MixpanelService spyMixpanelService = createEnabledMixpanelServiceSpy();
+
+        PortalEnvironment portalEnv = portalEnvironmentFactory.buildPersisted(getTestName(info));
+        PortalEnvironmentConfig envConfig = portalEnvironmentConfigService.find(portalEnv.getPortalEnvironmentConfigId()).get();
+        envConfig.setParticipantHostname("thehearthive.org");
+        envConfig.setMixpanelToken("eu-token");
+        portalEnvironmentConfigService.update(envConfig);
+        loggingConfigCache.configCacheEvict();
+
+        spyMixpanelService.logEvent(new JSONArray()
+                .put(buildTestEvent("eu_event", "key", "value", "https://thehearthive.org/page"))
+                .put(buildTestEvent("global_event", "key", "value", "https://otherstudy.com/page"))
+                .toString());
+
+        // 3 buildEvent calls: (EU event + global token), (EU event + EU token), (non-EU event + global token)
+        // The EU event's global-token build result is discarded (not added to global delivery)
+        ArgumentCaptor<JSONObject> objCaptor = ArgumentCaptor.forClass(JSONObject.class);
+        ArgumentCaptor<String> tokenCaptor = ArgumentCaptor.forClass(String.class);
+        verify(spyMixpanelService, times(3)).buildEvent(objCaptor.capture(), tokenCaptor.capture());
+        assertThat(tokenCaptor.getAllValues(), contains("test-token", "eu-token", "test-token"));
+        assertThat(objCaptor.getAllValues().stream().map(obj ->
+                ((JSONObject) obj.get("properties")).get("$current_url")).toList(),
+                contains("https://thehearthive.org/page", "https://thehearthive.org/page", "https://otherstudy.com/page"));
+
+        // EU events must be delivered to the EU Mixpanel endpoint
+        verify(spyMixpanelService, times(1)).deliverEvents(any(), eq(true));
+        // Non-EU events must not be delivered via the EU endpoint (global delivery + null customDelivery)
+        verify(spyMixpanelService, times(2)).deliverEvents(any(), eq(false));
     }
 
     @Test

--- a/core/src/test/java/bio/terra/pearl/core/service/logging/MixpanelServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/logging/MixpanelServiceTests.java
@@ -95,7 +95,8 @@ public class MixpanelServiceTests extends BaseSpringBootTest {
         spyMixpanelService.logEvent(events.toString());
 
         verify(spyMixpanelService, times(2)).buildEvent(any(), any());
-        verify(spyMixpanelService, times(1)).deliverEvents(any());
+        verify(spyMixpanelService, times(2)).deliverEvents(any());
+        verify(spyMixpanelService, times(1)).deliverEvents(notNull());
     }
 
     @Test


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

We were previously sending all mixpanel events to the US server, which would forward EU project data to EU servers so it wouldn't be stored in the US.  Mixpanel is stopping that forwarding capability in June, so we need to directly send data for EU projects to the Mixpanel EU servers

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

covered by automated tests