### PR TITLE
[SIDRB-4354] allow non-postal matches

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/address/SmartyAddressValidationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/address/SmartyAddressValidationService.java
@@ -43,7 +43,6 @@ public class SmartyAddressValidationService implements AddressValidationService 
         }
 
         return this.internationalClient.validate(address);
-
     }
 
     private List<AddressComponent> missingFields(MailingAddress address) {

--- a/core/src/main/java/bio/terra/pearl/core/service/address/SmartyUSAddressValidationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/address/SmartyUSAddressValidationService.java
@@ -11,11 +11,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -96,7 +92,7 @@ public class SmartyUSAddressValidationService implements AddressValidationServic
         if (Objects.isNull(candidate.getAnalysis().getDpvMatchCode())) {
             return false;
         }
-        return candidate.getAnalysis().getDpvMatchCode().contains("Y");
+        return candidate.getAnalysis().getDpvMatchCode().contains("Y") || candidate.getAnalysis().getEnhancedMatch().contains("non-postal-match");
     }
 
     private MailingAddress suggestedAddress(Candidate candidate) {

--- a/core/src/test/java/bio/terra/pearl/core/service/address/SmartyUSAddressValidationServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/address/SmartyUSAddressValidationServiceTest.java
@@ -264,6 +264,65 @@ class SmartyUSAddressValidationServiceTest extends BaseSpringBootTest {
         Assertions.assertFalse(result.getHasInferredComponents());
     }
 
+    @Test
+    public void testEnhancedMatch() throws SmartyException, IOException, InterruptedException {
+        mockResponse(
+                """
+                        {
+                            "input_index": 0,
+                            "candidate_index": 0,
+                            "delivery_line_1": "150 Ken Visage Ln",
+                            "last_line": "La Fayette GA 30728-4981",
+                            "delivery_point_barcode": "307284981503",
+                            "smarty_key": "2037752728",
+                            "components": {
+                                "primary_number": "150",
+                                "street_name": "Ken Visage",
+                                "street_suffix": "Ln",
+                                "city_name": "La Fayette",
+                                "default_city_name": "La Fayette",
+                                "state_abbreviation": "GA",
+                                "zipcode": "30728",
+                                "plus4_code": "4981",
+                                "delivery_point": "50",
+                                "delivery_point_check_digit": "3"
+                            },
+                            "metadata": {
+                                "record_type": "S",
+                                "zip_type": "Standard",
+                                "county_fips": "13295",
+                                "county_name": "Walker",
+                                "carrier_route": "R006",
+                                "congressional_district": "14",
+                                "rdi": "Residential",
+                                "elot_sequence": "0399",
+                                "elot_sort": "A",
+                                "latitude": 34.714897,
+                                "longitude": -85.218483,
+                                "coordinate_license": 1,
+                                "precision": "Rooftop",
+                                "time_zone": "Eastern",
+                                "utc_offset": -5,
+                                "dst": true
+                            },
+                            "analysis": {
+                                "dpv_match_code": "N",
+                                "dpv_footnotes": "AABB",
+                                "dpv_cmra": "N",
+                                "dpv_vacant": "N",
+                                "dpv_no_stat": "N",
+                                "active": "Y",
+                                "footnotes": "U#",
+                                "enhanced_match": "non-postal-match,missing-secondary"
+                            }
+                        }
+                        """
+        );
+        AddressValidationResultDto result = client.validate(new MailingAddress());
+
+        Assertions.assertTrue(result.isValid());
+    }
+
     void mockResponse(String jsonResponse) throws SmartyException, IOException, InterruptedException {
 
         SmartySerializer serializer = new SmartySerializer();

--- a/scripts/auto_translate.sh
+++ b/scripts/auto_translate.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+if ! command -v trans 2>&1 >/dev/null
+then
+    echo "'trans' does not exist. Please install with 'brew install translate-shell'"
+    exit 1
+fi
+
+if ! command -v jq 2>&1 >/dev/null
+then
+    echo "'jq' does not exist. Please install with 'brew install jq'"
+    exit 1
+fi
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <keyname> <english>"
+    echo "Example: $0 'helloWorld' 'Hello, World!'"
+    exit 1
+fi
+
+KEYNAME=$1
+ENGLISH=$2
+
+
+LANGUAGES[0]="de"
+LANGUAGES[1]="es"
+LANGUAGES[2]="fr"
+LANGUAGES[3]="hi"
+LANGUAGES[4]="it"
+LANGUAGES[5]="ja"
+LANGUAGES[6]="pl"
+LANGUAGES[7]="pt"
+LANGUAGES[8]="ru"
+LANGUAGES[9]="tr"
+LANGUAGES[10]="zh"
+
+LANGUAGE_INPUT=$(IFS=+ ; echo "${LANGUAGES[*]}")
+
+echo "Translating $ENGLISH to $LANGUAGE_INPUT"
+
+TRANSLATIONS_SDTOUT=$(trans -brief :"${LANGUAGE_INPUT}" "$ENGLISH")
+
+echo "Translations: $TRANSLATIONS_SDTOUT"
+
+IFS=$'\n' read -rd '' -a TRANSLATIONS <<< "$TRANSLATIONS_SDTOUT"
+
+add_translation () {
+      LANGUAGE=$1
+      KEYNAME=$2
+      TRANSLATION=$3
+      MACHINE_TRANSLATED=$4
+
+      echo "Adding translation for ${LANGUAGE}"
+
+
+      NEW_LINE="{ \"keyName\": \"$KEYNAME\", \"language\": \"${LANGUAGE}\", \"text\": \"${TRANSLATION}\" }"
+      if [ "$MACHINE_TRANSLATED" = 'true' ]; then
+          NEW_LINE="{ \"keyName\": \"$KEYNAME\", \"language\": \"${LANGUAGE}\", \"text\": \"${TRANSLATION}\", \"machineTranslated\": true }"
+      fi
+
+      echo "$NEW_LINE"
+
+      LANGUAGEPATH="populate/src/main/resources/seed/i18n/${LANGUAGE}/languageTexts.json"
+
+      # Add the new line to the file
+      jq ". += [$NEW_LINE]" < "$LANGUAGEPATH"  > tmp.json && mv tmp.json "$LANGUAGEPATH"
+}
+
+
+for i in "${!LANGUAGES[@]}"; do
+    if [ -z "${LANGUAGES[$i]}" ]; then
+        continue
+    fi
+
+    add_translation "${LANGUAGES[$i]}" "$KEYNAME" "${TRANSLATIONS[$i]}" true
+done
+
+add_translation "en" "$KEYNAME" "$ENGLISH" false
+add_translation "dev" "$KEYNAME" "dev_$ENGLISH" false


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

I started to go down the rabbithole of making it possible for participants to override invalid addresses. It was... _not_ simple, as I anticipated.

The key issue is that, wherever used, we had to gate the question via a condition like `suggestedAddress is not null and modalDismissed is false`.

since we have that condition, it won't show the modal unless we have a suggested address.

we _could_ upgrade the modals to handle invalid cases without suggested addresses and change all the conditional expressions, upon release, in all of the forms that use it to show the modal even if no suggested address exists. but.... it started to grow so large in scope, I am opting to move on and consider this "good enough" for 99% of these cases.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

Hard to test (unless you know of brand-new developments/neighborhoods off the top of your head). Covered by unit tests.