### PR TITLE
[SIDRB-4381] download records

### DIFF
--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/file/ParticipantFileExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/file/ParticipantFileExtService.java
@@ -51,17 +51,20 @@ public class ParticipantFileExtService {
 
   @EnforcePortalEnrolleePermission(permission = "participant_data_view")
   public ScannedParticipantFileDto get(PortalEnrolleeAuthContext authContext, String fileName) {
-    return participantFileService
-        .findByEnrolleeIdAndFileName(authContext.getEnrollee().getId(), fileName)
-        .map(participantFileService::attachVirusScanResult)
-        .orElseThrow(() -> new NotFoundException("File not found"));
+    ParticipantFile file =
+        participantFileService
+            .findByEnrolleeIdAndFileName(authContext.getEnrollee().getId(), fileName)
+            .orElseThrow(() -> new NotFoundException("File not found"));
+    participantFileService.attachDownloadRecords(List.of(file));
+    return participantFileService.attachVirusScanResult(file);
   }
 
   @EnforcePortalEnrolleePermission(permission = "participant_data_view")
   public List<ScannedParticipantFileDto> list(PortalEnrolleeAuthContext authContext) {
-    return participantFileService.findByEnrolleeId(authContext.getEnrollee().getId()).stream()
-        .map(participantFileService::attachVirusScanResult)
-        .toList();
+    List<ParticipantFile> files =
+        participantFileService.findByEnrolleeId(authContext.getEnrollee().getId());
+    participantFileService.attachDownloadRecords(files);
+    return files.stream().map(participantFileService::attachVirusScanResult).toList();
   }
 
   @EnforcePortalEnrolleePermission(permission = "participant_data_edit")

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/file/ParticipantFileExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/file/ParticipantFileExtService.java
@@ -37,7 +37,11 @@ public class ParticipantFileExtService {
   @Transactional
   @EnforcePortalEnrolleePermission(permission = "participant_data_view")
   public InputStream downloadFile(PortalEnrolleeAuthContext authContext, String fileName) {
-    ParticipantFile participantFile = get(authContext, fileName);
+    ScannedParticipantFileDto participantFile = get(authContext, fileName);
+
+    if (participantFile.getVirusScanResult() == VirusScanResult.QUARANTINED) {
+      throw new IllegalArgumentException("Virus detected in file");
+    }
 
     InputStream fileStream = fileStorageBackend.downloadFile(participantFile.getExternalFileId());
     downloadRecordDao.create(

--- a/api-admin/src/main/java/bio/terra/pearl/api/admin/service/file/ParticipantFileExtService.java
+++ b/api-admin/src/main/java/bio/terra/pearl/api/admin/service/file/ParticipantFileExtService.java
@@ -2,6 +2,8 @@ package bio.terra.pearl.api.admin.service.file;
 
 import bio.terra.pearl.api.admin.service.auth.EnforcePortalEnrolleePermission;
 import bio.terra.pearl.api.admin.service.auth.context.PortalEnrolleeAuthContext;
+import bio.terra.pearl.core.dao.file.DownloadRecordDao;
+import bio.terra.pearl.core.model.file.DownloadRecord;
 import bio.terra.pearl.core.model.file.ParticipantFile;
 import bio.terra.pearl.core.model.file.ScannedParticipantFileDto;
 import bio.terra.pearl.core.service.exception.NotFoundException;
@@ -13,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
@@ -20,19 +23,30 @@ public class ParticipantFileExtService {
 
   private final ParticipantFileService participantFileService;
   private final FileStorageBackend fileStorageBackend;
+  private final DownloadRecordDao downloadRecordDao;
 
   public ParticipantFileExtService(
       ParticipantFileService participantFileService,
-      FileStorageBackendProvider fileStorageBackendProvider) {
+      FileStorageBackendProvider fileStorageBackendProvider,
+      DownloadRecordDao downloadRecordDao) {
     this.participantFileService = participantFileService;
     this.fileStorageBackend = fileStorageBackendProvider.get();
+    this.downloadRecordDao = downloadRecordDao;
   }
 
+  @Transactional
   @EnforcePortalEnrolleePermission(permission = "participant_data_view")
   public InputStream downloadFile(PortalEnrolleeAuthContext authContext, String fileName) {
     ParticipantFile participantFile = get(authContext, fileName);
 
-    return fileStorageBackend.downloadFile(participantFile.getExternalFileId());
+    InputStream fileStream = fileStorageBackend.downloadFile(participantFile.getExternalFileId());
+    downloadRecordDao.create(
+        DownloadRecord.builder()
+            .participantFileId(participantFile.getId())
+            .adminUserId(authContext.getOperator().getId())
+            .enrolleeId(authContext.getEnrollee().getId())
+            .build());
+    return fileStream;
   }
 
   @EnforcePortalEnrolleePermission(permission = "participant_data_view")

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/service/file/ParticipantFileExtService.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/service/file/ParticipantFileExtService.java
@@ -1,7 +1,6 @@
 package bio.terra.pearl.api.participant.service.file;
 
 import bio.terra.pearl.api.participant.service.AuthUtilService;
-import bio.terra.pearl.core.dao.file.DownloadRecordDao;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.file.ParticipantFile;
 import bio.terra.pearl.core.model.file.ScannedParticipantFileDto;
@@ -14,7 +13,6 @@ import bio.terra.pearl.core.service.file.VirusScanResult;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackend;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackendProvider;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
-import bio.terra.pearl.core.service.survey.AnswerService;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -32,22 +30,16 @@ public class ParticipantFileExtService {
   private final AuthUtilService authUtilService;
   private final FileStorageBackend fileStorageBackend;
   private final StudyEnvironmentService studyEnvironmentService;
-  private final DownloadRecordDao downloadRecordDao;
-  private final AnswerService answerService;
 
   public ParticipantFileExtService(
       ParticipantFileService participantFileService,
       AuthUtilService authUtilService,
       FileStorageBackendProvider fileStorageBackendProvider,
-      StudyEnvironmentService studyEnvironmentService,
-      DownloadRecordDao downloadRecordDao,
-      AnswerService answerService) {
+      StudyEnvironmentService studyEnvironmentService) {
     this.participantFileService = participantFileService;
     this.authUtilService = authUtilService;
     this.fileStorageBackend = fileStorageBackendProvider.get();
     this.studyEnvironmentService = studyEnvironmentService;
-    this.downloadRecordDao = downloadRecordDao;
-    this.answerService = answerService;
   }
 
   public ScannedParticipantFileDto get(

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/service/file/ParticipantFileExtService.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/service/file/ParticipantFileExtService.java
@@ -3,7 +3,6 @@ package bio.terra.pearl.api.participant.service.file;
 import bio.terra.pearl.api.participant.service.AuthUtilService;
 import bio.terra.pearl.core.dao.file.DownloadRecordDao;
 import bio.terra.pearl.core.model.EnvironmentName;
-import bio.terra.pearl.core.model.file.DownloadRecord;
 import bio.terra.pearl.core.model.file.ParticipantFile;
 import bio.terra.pearl.core.model.file.ScannedParticipantFileDto;
 import bio.terra.pearl.core.model.participant.Enrollee;
@@ -15,6 +14,7 @@ import bio.terra.pearl.core.service.file.VirusScanResult;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackend;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackendProvider;
 import bio.terra.pearl.core.service.study.StudyEnvironmentService;
+import bio.terra.pearl.core.service.survey.AnswerService;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -33,18 +33,21 @@ public class ParticipantFileExtService {
   private final FileStorageBackend fileStorageBackend;
   private final StudyEnvironmentService studyEnvironmentService;
   private final DownloadRecordDao downloadRecordDao;
+  private final AnswerService answerService;
 
   public ParticipantFileExtService(
       ParticipantFileService participantFileService,
       AuthUtilService authUtilService,
       FileStorageBackendProvider fileStorageBackendProvider,
       StudyEnvironmentService studyEnvironmentService,
-      DownloadRecordDao downloadRecordDao) {
+      DownloadRecordDao downloadRecordDao,
+      AnswerService answerService) {
     this.participantFileService = participantFileService;
     this.authUtilService = authUtilService;
     this.fileStorageBackend = fileStorageBackendProvider.get();
     this.studyEnvironmentService = studyEnvironmentService;
     this.downloadRecordDao = downloadRecordDao;
+    this.answerService = answerService;
   }
 
   public ScannedParticipantFileDto get(
@@ -80,21 +83,7 @@ public class ParticipantFileExtService {
             .findByEnrolleeIdAndFileName(enrollee.getId(), fileName)
             .orElseThrow(() -> new NotFoundException("Could not find file"));
 
-    VirusScanResult virusScanResult =
-        participantFileService.getVirusScanResult(participantFile.getExternalFileId());
-
-    if (virusScanResult == VirusScanResult.QUARANTINED) {
-      throw new IllegalArgumentException("Virus detected in file");
-    }
-
-    InputStream fileStream = fileStorageBackend.downloadFile(participantFile.getExternalFileId());
-    downloadRecordDao.create(
-        DownloadRecord.builder()
-            .participantFileId(participantFile.getId())
-            .participantUserId(participantUser.getId())
-            .enrolleeId(enrollee.getId())
-            .build());
-    return fileStream;
+    return participantFileService.downloadFile(participantFile, participantUser, enrollee);
   }
 
   public ScannedParticipantFileDto uploadFile(

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/service/file/ParticipantFileExtService.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/service/file/ParticipantFileExtService.java
@@ -1,7 +1,9 @@
 package bio.terra.pearl.api.participant.service.file;
 
 import bio.terra.pearl.api.participant.service.AuthUtilService;
+import bio.terra.pearl.core.dao.file.DownloadRecordDao;
 import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.file.DownloadRecord;
 import bio.terra.pearl.core.model.file.ParticipantFile;
 import bio.terra.pearl.core.model.file.ScannedParticipantFileDto;
 import bio.terra.pearl.core.model.participant.Enrollee;
@@ -19,6 +21,7 @@ import java.util.List;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
@@ -29,16 +32,19 @@ public class ParticipantFileExtService {
   private final AuthUtilService authUtilService;
   private final FileStorageBackend fileStorageBackend;
   private final StudyEnvironmentService studyEnvironmentService;
+  private final DownloadRecordDao downloadRecordDao;
 
   public ParticipantFileExtService(
       ParticipantFileService participantFileService,
       AuthUtilService authUtilService,
       FileStorageBackendProvider fileStorageBackendProvider,
-      StudyEnvironmentService studyEnvironmentService) {
+      StudyEnvironmentService studyEnvironmentService,
+      DownloadRecordDao downloadRecordDao) {
     this.participantFileService = participantFileService;
     this.authUtilService = authUtilService;
     this.fileStorageBackend = fileStorageBackendProvider.get();
     this.studyEnvironmentService = studyEnvironmentService;
+    this.downloadRecordDao = downloadRecordDao;
   }
 
   public ScannedParticipantFileDto get(
@@ -59,6 +65,7 @@ public class ParticipantFileExtService {
     return participantFileService.attachVirusScanResult(file);
   }
 
+  @Transactional
   public InputStream downloadFile(
       String portalShortcode,
       EnvironmentName envName,
@@ -80,7 +87,14 @@ public class ParticipantFileExtService {
       throw new IllegalArgumentException("Virus detected in file");
     }
 
-    return fileStorageBackend.downloadFile(participantFile.getExternalFileId());
+    InputStream fileStream = fileStorageBackend.downloadFile(participantFile.getExternalFileId());
+    downloadRecordDao.create(
+        DownloadRecord.builder()
+            .participantFileId(participantFile.getId())
+            .participantUserId(participantUser.getId())
+            .enrolleeId(enrollee.getId())
+            .build());
+    return fileStream;
   }
 
   public ScannedParticipantFileDto uploadFile(

--- a/core/src/main/java/bio/terra/pearl/core/dao/dataimport/TimeShiftDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/dataimport/TimeShiftDao.java
@@ -164,4 +164,13 @@ public class TimeShiftDao {
         );
     }
 
+    public void changeDownloadRecordCreationTime(UUID downloadRecordId, Instant creationTime) {
+        jdbi.withHandle(handle ->
+                handle.createUpdate("update download_record set created_at = :creationTime, last_updated_at = :creationTime where id = :downloadRecordId;")
+                        .bind("downloadRecordId", downloadRecordId)
+                        .bind("creationTime", creationTime)
+                        .execute()
+        );
+    }
+
 }

--- a/core/src/main/java/bio/terra/pearl/core/dao/file/DownloadRecordDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/file/DownloadRecordDao.java
@@ -31,4 +31,8 @@ public class DownloadRecordDao extends BaseMutableJdbiDao<DownloadRecord> {
     public void deleteByParticipantFileId(UUID participantFileId) {
         deleteByProperty("participant_file_id", participantFileId);
     }
+
+    public void deleteByParticipantFileIds(List<UUID> participantFileIds) {
+        deleteByProperty("participant_file_id", participantFileIds);
+    }
 }

--- a/core/src/main/java/bio/terra/pearl/core/dao/file/DownloadRecordDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/file/DownloadRecordDao.java
@@ -1,0 +1,34 @@
+package bio.terra.pearl.core.dao.file;
+
+import bio.terra.pearl.core.dao.BaseMutableJdbiDao;
+import bio.terra.pearl.core.model.file.DownloadRecord;
+import org.jdbi.v3.core.Jdbi;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class DownloadRecordDao extends BaseMutableJdbiDao<DownloadRecord> {
+
+    public DownloadRecordDao(Jdbi jdbi) {
+        super(jdbi);
+    }
+
+    @Override
+    protected Class<DownloadRecord> getClazz() {
+        return DownloadRecord.class;
+    }
+
+    public List<DownloadRecord> findByParticipantFileId(UUID participantFileId) {
+        return findAllByProperty("participant_file_id", participantFileId);
+    }
+
+    public List<DownloadRecord> findByParticipantFileIds(List<UUID> participantFileIds) {
+        return findAllByPropertyCollection("participant_file_id", participantFileIds);
+    }
+
+    public void deleteByParticipantFileId(UUID participantFileId) {
+        deleteByProperty("participant_file_id", participantFileId);
+    }
+}

--- a/core/src/main/java/bio/terra/pearl/core/dao/file/ParticipantFileDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/file/ParticipantFileDao.java
@@ -55,7 +55,6 @@ public class ParticipantFileDao extends BaseMutableJdbiDao<ParticipantFile> {
         return participantFiles;
     }
 
-    // attaches records and returns the list for easy chaining
     public List<ParticipantFile> attachDownloadRecords(List<ParticipantFile> participantFiles) {
         List<UUID> fileIds = participantFiles.stream().map(ParticipantFile::getId).toList();
         Map<UUID, List<DownloadRecord>> downloadsByFileId = fileIds.isEmpty()
@@ -86,8 +85,10 @@ public class ParticipantFileDao extends BaseMutableJdbiDao<ParticipantFile> {
     }
 
     public void deleteByEnrolleeId(UUID enrolleeId) {
-        List<ParticipantFile> files = findByEnrolleeId(enrolleeId);
-        files.forEach(file -> downloadRecordDao.deleteByParticipantFileId(file.getId()));
+        List<UUID> fileIds = findByEnrolleeId(enrolleeId).stream().map(ParticipantFile::getId).toList();
+        if (!fileIds.isEmpty()) {
+            downloadRecordDao.deleteByParticipantFileIds(fileIds);
+        }
         deleteByProperty("enrollee_id", enrolleeId);
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/dao/file/ParticipantFileDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/file/ParticipantFileDao.java
@@ -48,6 +48,15 @@ public class ParticipantFileDao extends BaseMutableJdbiDao<ParticipantFile> {
 
         Map<String, List<Answer>> answersByFileName = answers.stream().collect(Collectors.groupingBy(Answer::getStringValue));
 
+        for (ParticipantFile file : participantFiles) {
+            file.setAssociatedAnswers(answersByFileName.getOrDefault(file.getFileName(), new ArrayList<>()));
+        }
+
+        return participantFiles;
+    }
+
+    // attaches records and returns the list for easy chaining
+    public List<ParticipantFile> attachDownloadRecords(List<ParticipantFile> participantFiles) {
         List<UUID> fileIds = participantFiles.stream().map(ParticipantFile::getId).toList();
         Map<UUID, List<DownloadRecord>> downloadsByFileId = fileIds.isEmpty()
                 ? Map.of()
@@ -55,10 +64,8 @@ public class ParticipantFileDao extends BaseMutableJdbiDao<ParticipantFile> {
                         .collect(Collectors.groupingBy(DownloadRecord::getParticipantFileId));
 
         for (ParticipantFile file : participantFiles) {
-            file.setAssociatedAnswers(answersByFileName.getOrDefault(file.getFileName(), new ArrayList<>()));
             file.setDownloads(downloadsByFileId.getOrDefault(file.getId(), new ArrayList<>()));
         }
-
         return participantFiles;
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/dao/file/ParticipantFileDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/file/ParticipantFileDao.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.core.dao.file;
 
 import bio.terra.pearl.core.dao.BaseMutableJdbiDao;
 import bio.terra.pearl.core.dao.survey.AnswerDao;
+import bio.terra.pearl.core.model.file.DownloadRecord;
 import bio.terra.pearl.core.model.file.ParticipantFile;
 import bio.terra.pearl.core.model.survey.Answer;
 import bio.terra.pearl.core.model.survey.AnswerFormat;
@@ -14,10 +15,12 @@ import java.util.stream.Collectors;
 @Component
 public class ParticipantFileDao extends BaseMutableJdbiDao<ParticipantFile> {
     private final AnswerDao answerDao;
+    private final DownloadRecordDao downloadRecordDao;
 
-    public ParticipantFileDao(Jdbi jdbi, AnswerDao answerDao) {
+    public ParticipantFileDao(Jdbi jdbi, AnswerDao answerDao, DownloadRecordDao downloadRecordDao) {
         super(jdbi);
         this.answerDao = answerDao;
+        this.downloadRecordDao = downloadRecordDao;
     }
 
     @Override
@@ -45,9 +48,15 @@ public class ParticipantFileDao extends BaseMutableJdbiDao<ParticipantFile> {
 
         Map<String, List<Answer>> answersByFileName = answers.stream().collect(Collectors.groupingBy(Answer::getStringValue));
 
+        List<UUID> fileIds = participantFiles.stream().map(ParticipantFile::getId).toList();
+        Map<UUID, List<DownloadRecord>> downloadsByFileId = fileIds.isEmpty()
+                ? Map.of()
+                : downloadRecordDao.findByParticipantFileIds(fileIds).stream()
+                        .collect(Collectors.groupingBy(DownloadRecord::getParticipantFileId));
+
         for (ParticipantFile file : participantFiles) {
-            List<Answer> fileAnswers = answersByFileName.getOrDefault(file.getFileName(), new ArrayList<>());
-            file.setAssociatedAnswers(fileAnswers);
+            file.setAssociatedAnswers(answersByFileName.getOrDefault(file.getFileName(), new ArrayList<>()));
+            file.setDownloads(downloadsByFileId.getOrDefault(file.getId(), new ArrayList<>()));
         }
 
         return participantFiles;
@@ -60,6 +69,7 @@ public class ParticipantFileDao extends BaseMutableJdbiDao<ParticipantFile> {
             Map<String, List<Answer>> answersByFileName = answers.stream().collect(Collectors.groupingBy(Answer::getStringValue));
             List<Answer> answersForFile = answersByFileName.getOrDefault(file.getFileName(), new ArrayList<>());
             file.setAssociatedAnswers(answersForFile);
+            file.setDownloads(downloadRecordDao.findByParticipantFileId(file.getId()));
         });
         return participantFile;
     }
@@ -69,6 +79,8 @@ public class ParticipantFileDao extends BaseMutableJdbiDao<ParticipantFile> {
     }
 
     public void deleteByEnrolleeId(UUID enrolleeId) {
+        List<ParticipantFile> files = findByEnrolleeId(enrolleeId);
+        files.forEach(file -> downloadRecordDao.deleteByParticipantFileId(file.getId()));
         deleteByProperty("enrollee_id", enrolleeId);
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyResponseDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/survey/SurveyResponseDao.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.dao.survey;
 
 import bio.terra.pearl.core.dao.BaseMutableJdbiDao;
+import bio.terra.pearl.core.model.file.ParticipantFile;
 import bio.terra.pearl.core.model.file.ScannedParticipantFileDto;
 import bio.terra.pearl.core.model.survey.Answer;
 import bio.terra.pearl.core.model.survey.SurveyResponse;
@@ -88,12 +89,10 @@ public class SurveyResponseDao extends BaseMutableJdbiDao<SurveyResponse> {
     }
 
     public SurveyResponse attachParticipantFiles(SurveyResponse response) {
-        List<ScannedParticipantFileDto> participantFiles = participantFileService
-                .findBySurveyResponseId(response.getId())
-                .stream()
-                .map(participantFileService::attachVirusScanResult)
-                .toList();
-        response.setParticipantFiles(participantFiles);
+        List<ParticipantFile> participantFiles = participantFileService.findBySurveyResponseId(response.getId());
+        participantFileService.attachDownloadRecords(participantFiles);
+        List<ScannedParticipantFileDto> fileDtos = participantFiles.stream().map(participantFileService::attachVirusScanResult).toList();
+        response.setParticipantFiles(fileDtos);
         return response;
     }
 

--- a/core/src/main/java/bio/terra/pearl/core/model/file/DownloadRecord.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/file/DownloadRecord.java
@@ -1,0 +1,20 @@
+package bio.terra.pearl.core.model.file;
+
+import bio.terra.pearl.core.model.BaseEntity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+public class DownloadRecord extends BaseEntity {
+    private UUID participantFileId;
+    private UUID participantUserId;
+    private UUID adminUserId;
+    private UUID enrolleeId;
+}

--- a/core/src/main/java/bio/terra/pearl/core/model/file/ParticipantFile.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/file/ParticipantFile.java
@@ -34,5 +34,8 @@ public class ParticipantFile extends BaseEntity {
     private String notes;
 
     @Builder.Default
+    private List<DownloadRecord> downloads = new ArrayList<>();
+
+    @Builder.Default
     private List<Answer> associatedAnswers = new ArrayList<>(); //list of answers that are associated with this file
 }

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/AnswerFormat.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/AnswerFormat.java
@@ -2,5 +2,6 @@ package bio.terra.pearl.core.model.survey;
 
 public enum AnswerFormat {
     NONE,
-    FILE_NAME
+    FILE_NAME,
+    VIEW
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/file/ParticipantFileService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/ParticipantFileService.java
@@ -31,6 +31,8 @@ import java.util.UUID;
 @Service
 @Slf4j
 public class ParticipantFileService extends CrudService<ParticipantFile, ParticipantFileDao> {
+    private static final String FILE_VIEWED_VALUE = "yes";
+
     private final FileStorageBackend fileStorageBackend;
     private final DownloadRecordDao downloadRecordDao;
     private final AnswerService answerService;
@@ -139,7 +141,7 @@ public class ParticipantFileService extends CrudService<ParticipantFile, Partici
                             .surveyVersion(associatedAnswer.getSurveyVersion())
                             .answerType(AnswerType.STRING)
                             .format(AnswerFormat.VIEW)
-                            .stringValue("yes")
+                            .stringValue(FILE_VIEWED_VALUE)
                             .creatingParticipantUserId(participantUser.getId())
                             .build());
         });

--- a/core/src/main/java/bio/terra/pearl/core/service/file/ParticipantFileService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/ParticipantFileService.java
@@ -1,14 +1,25 @@
 package bio.terra.pearl.core.service.file;
 
+import bio.terra.pearl.core.dao.file.DownloadRecordDao;
 import bio.terra.pearl.core.dao.file.ParticipantFileDao;
+import bio.terra.pearl.core.dao.survey.SurveyResponseDao;
+import bio.terra.pearl.core.model.file.DownloadRecord;
 import bio.terra.pearl.core.model.file.ParticipantFile;
 import bio.terra.pearl.core.model.file.ScannedParticipantFileDto;
+import bio.terra.pearl.core.model.participant.Enrollee;
+import bio.terra.pearl.core.model.participant.ParticipantUser;
+import bio.terra.pearl.core.model.survey.Answer;
+import bio.terra.pearl.core.model.survey.AnswerFormat;
+import bio.terra.pearl.core.model.survey.AnswerType;
+import bio.terra.pearl.core.model.survey.SurveyResponse;
 import bio.terra.pearl.core.service.CascadeProperty;
 import bio.terra.pearl.core.service.CrudService;
 import bio.terra.pearl.core.service.exception.NotFoundException;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackend;
 import bio.terra.pearl.core.service.file.backends.FileStorageBackendProvider;
+import bio.terra.pearl.core.service.survey.AnswerService;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import java.io.InputStream;
@@ -21,11 +32,17 @@ import java.util.UUID;
 @Slf4j
 public class ParticipantFileService extends CrudService<ParticipantFile, ParticipantFileDao> {
     private final FileStorageBackend fileStorageBackend;
+    private final DownloadRecordDao downloadRecordDao;
+    private final AnswerService answerService;
+    private final SurveyResponseDao surveyResponseDao;
 
-    public ParticipantFileService(ParticipantFileDao dao, FileStorageBackendProvider fileStorageBackendProvider) {
+    public ParticipantFileService(ParticipantFileDao dao, FileStorageBackendProvider fileStorageBackendProvider, DownloadRecordDao downloadRecordDao, @Lazy AnswerService answerService, @Lazy SurveyResponseDao surveyResponseDao) {
         super(dao);
 
         this.fileStorageBackend = fileStorageBackendProvider.get();
+        this.downloadRecordDao = downloadRecordDao;
+        this.answerService = answerService;
+        this.surveyResponseDao = surveyResponseDao;
     }
 
     public ParticipantFile uploadFileAndCreate(ParticipantFile participantFile, InputStream file) {
@@ -50,9 +67,13 @@ public class ParticipantFileService extends CrudService<ParticipantFile, Partici
         return dao.findByEnrolleeIdAndFileName(enrolleeId, fileName);
     }
 
+    public Optional<ParticipantFile> findWithAnswers(UUID id) {
+        return dao.findWithAnswers(id);
+    }
+
     @Override
     public void delete(UUID id, Set<CascadeProperty> cascade) {
-        ParticipantFile participantFile = dao.findWithAnswers(id).orElseThrow(() -> new NotFoundException("File not found"));
+        ParticipantFile participantFile = findWithAnswers(id).orElseThrow(() -> new NotFoundException("File not found"));
         if(!participantFile.getAssociatedAnswers().isEmpty()) {
             throw new IllegalArgumentException("This file is being used in a survey response and cannot be deleted. Please remove the file from the survey response first.");
         }
@@ -67,5 +88,57 @@ public class ParticipantFileService extends CrudService<ParticipantFile, Partici
 
     public VirusScanResult getVirusScanResult(UUID fileId) {
         return fileStorageBackend.scanResult(fileId);
+    }
+
+    public InputStream downloadFile(ParticipantFile participantFile, ParticipantUser participantUser, Enrollee enrollee) {
+        VirusScanResult virusScanResult =
+                getVirusScanResult(participantFile.getExternalFileId());
+
+        if (virusScanResult == VirusScanResult.QUARANTINED) {
+            throw new IllegalArgumentException("Virus detected in file");
+        }
+
+        InputStream fileStream = fileStorageBackend.downloadFile(participantFile.getExternalFileId());
+        createDownloadRecord(participantFile, participantUser, enrollee);
+        return fileStream;
+    }
+
+    /**
+     * creates the download record and also an answer
+     * this is public so that it can be easily accessed by EnrolleePopulator.
+     * it should not be accessed independently otherwise
+     */
+    public DownloadRecord createDownloadRecord(ParticipantFile participantFile, ParticipantUser participantUser, Enrollee enrollee) {
+        DownloadRecord record = downloadRecordDao.create(
+                DownloadRecord.builder()
+                        .participantFileId(participantFile.getId())
+                        .participantUserId(participantUser.getId())
+                        .enrolleeId(enrollee.getId())
+                        .build());
+
+        ParticipantFile fileWithAnswers = findWithAnswers(participantFile.getId()).orElse(participantFile);
+        fileWithAnswers.getAssociatedAnswers().stream().findFirst().ifPresent(associatedAnswer -> {
+            SurveyResponse existingResponse = surveyResponseDao.find(associatedAnswer.getSurveyResponseId()).orElseThrow();
+            SurveyResponse newResponse = surveyResponseDao.create(
+                    SurveyResponse.builder()
+                            .enrolleeId(enrollee.getId())
+                            .surveyId(existingResponse.getSurveyId())
+                            .creatingParticipantUserId(participantUser.getId())
+                            .build());
+            answerService.create(
+                    Answer.builder()
+                            .surveyResponseId(newResponse.getId())
+                            .enrolleeId(enrollee.getId())
+                            // file upload answers are postfixed by [] to enable multi-file answers.  We just want the raw stableId
+                            .questionStableId(associatedAnswer.getQuestionStableId().replaceAll("\\[.*]$", ""))
+                            .surveyStableId(associatedAnswer.getSurveyStableId())
+                            .surveyVersion(associatedAnswer.getSurveyVersion())
+                            .answerType(AnswerType.STRING)
+                            .format(AnswerFormat.VIEW)
+                            .stringValue("yes")
+                            .creatingParticipantUserId(participantUser.getId())
+                            .build());
+        });
+        return record;
     }
 }

--- a/core/src/main/java/bio/terra/pearl/core/service/file/ParticipantFileService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/file/ParticipantFileService.java
@@ -71,6 +71,10 @@ public class ParticipantFileService extends CrudService<ParticipantFile, Partici
         return dao.findWithAnswers(id);
     }
 
+    public List<ParticipantFile> attachDownloadRecords(List<ParticipantFile> participantFiles) {
+        return dao.attachDownloadRecords(participantFiles);
+    }
+
     @Override
     public void delete(UUID id, Set<CascadeProperty> cascade) {
         ParticipantFile participantFile = findWithAnswers(id).orElseThrow(() -> new NotFoundException("File not found"));

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -348,14 +348,14 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         List<String> updatedStableIds = answers.stream().map(Answer::getQuestionStableId).toList();
         // bulk-fetch any existingAnswers that will need to be updated
         // note that we do not use any answer ids returned by the client -- we'd have to run a query on them anyway
-        // to confirm they were in fact associated with this user & response.  So it's easier to just ignore user-supplied ids and
-        // use the responseId (which we have already validated) and questionStableIds to get existing answers
-        List<Answer> existingAnswers = answerService.findByResponseAndQuestions(response.getId(), updatedStableIds);
+            // to confirm they were in fact associated with this user & response.  So it's easier to just ignore user-supplied ids and
+            // use the responseId (which we have already validated) and questionStableIds to get existing answers
+            List<Answer> existingAnswers = answerService.findByResponseAndQuestions(response.getId(), updatedStableIds);
 
-        // put the answers into a map by their questionStableId so we can quickly match them to the submitted answers
-        Map<String, Answer> existingAnswerMap = new HashMap<>();
-        for (Answer answer : existingAnswers) {
-            existingAnswerMap.put(answer.getQuestionStableId(), answer);
+            // put the answers into a map by their questionStableId so we can quickly match them to the submitted answers
+            Map<String, Answer> existingAnswerMap = new HashMap<>();
+            for (Answer answer : existingAnswers) {
+                existingAnswerMap.put(answer.getQuestionStableId(), answer);
         }
         List<ParticipantDataChange> changeRecords = new ArrayList<>();
         List<Answer> updatedAnswers = answers.stream().map(answer -> {

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -348,14 +348,14 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         List<String> updatedStableIds = answers.stream().map(Answer::getQuestionStableId).toList();
         // bulk-fetch any existingAnswers that will need to be updated
         // note that we do not use any answer ids returned by the client -- we'd have to run a query on them anyway
-            // to confirm they were in fact associated with this user & response.  So it's easier to just ignore user-supplied ids and
-            // use the responseId (which we have already validated) and questionStableIds to get existing answers
-            List<Answer> existingAnswers = answerService.findByResponseAndQuestions(response.getId(), updatedStableIds);
+        // to confirm they were in fact associated with this user & response.  So it's easier to just ignore user-supplied ids and
+        // use the responseId (which we have already validated) and questionStableIds to get existing answers
+        List<Answer> existingAnswers = answerService.findByResponseAndQuestions(response.getId(), updatedStableIds);
 
-            // put the answers into a map by their questionStableId so we can quickly match them to the submitted answers
-            Map<String, Answer> existingAnswerMap = new HashMap<>();
-            for (Answer answer : existingAnswers) {
-                existingAnswerMap.put(answer.getQuestionStableId(), answer);
+        // put the answers into a map by their questionStableId so we can quickly match them to the submitted answers
+        Map<String, Answer> existingAnswerMap = new HashMap<>();
+        for (Answer answer : existingAnswers) {
+            existingAnswerMap.put(answer.getQuestionStableId(), answer);
         }
         List<ParticipantDataChange> changeRecords = new ArrayList<>();
         List<Answer> updatedAnswers = answers.stream().map(answer -> {

--- a/core/src/main/resources/db/changelog/changesets/2026_04_24_participant_file_downloads.yaml
+++ b/core/src/main/resources/db/changelog/changesets/2026_04_24_participant_file_downloads.yaml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  - changeSet:
+      id: "create_download_record_table"
+      author: dbush
+      changes:
+        - createTable:
+            tableName: download_record
+            columns:
+              - column:
+                  { name: id, type: uuid, defaultValueComputed: gen_random_uuid(), constraints: { nullable: false, primaryKey: true } }
+              - column:
+                  { name: created_at, type: datetime, constraints: { nullable: false } }
+              - column:
+                  { name: last_updated_at, type: datetime, constraints: { nullable: false } }
+              - column:
+                  { name: participant_file_id, type: uuid, constraints: { nullable: false, foreignKeyName: fk_download_record_participant_file, references: participant_file(id) } }
+              - column:
+                  { name: participant_user_id, type: uuid, constraints: { foreignKeyName: fk_download_record_participant_user, references: participant_user(id) } }
+              - column:
+                  { name: admin_user_id, type: uuid, constraints: { foreignKeyName: fk_download_record_admin_user, references: admin_user(id) } }
+              - column:
+                  { name: enrollee_id, type: uuid, constraints: { nullable: false, foreignKeyName: fk_download_record_enrollee, references: enrollee(id) } }

--- a/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -425,6 +425,9 @@ databaseChangeLog:
   - include:
       file: changesets/2025_11_24_enrollee_research_id.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026_04_24_participant_file_downloads.yaml
+      relativeToChangelogFile: true
 
 # README: it is a best practice to put each DDL statement in its own change set. DDL statements
 # are atomic. When they are grouped in a changeset and one fails the changeset cannot be

--- a/populate/src/main/java/bio/terra/pearl/populate/dto/fileupload/DownloadRecordPopDto.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/dto/fileupload/DownloadRecordPopDto.java
@@ -1,0 +1,15 @@
+package bio.terra.pearl.populate.dto.fileupload;
+
+import bio.terra.pearl.populate.dto.TimeShiftable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class DownloadRecordPopDto implements TimeShiftable {
+    /** username of the participant user who downloaded; if null, defaults to the enrollee's own participant user */
+    private String linkedUsername;
+    private Integer submittedHoursAgo;
+}

--- a/populate/src/main/java/bio/terra/pearl/populate/dto/fileupload/ParticipantFilePopDto.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/dto/fileupload/ParticipantFilePopDto.java
@@ -2,9 +2,13 @@ package bio.terra.pearl.populate.dto.fileupload;
 
 import bio.terra.pearl.core.model.file.ParticipantFile;
 import bio.terra.pearl.populate.dto.FilePopulatable;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
@@ -13,4 +17,6 @@ public class ParticipantFilePopDto extends ParticipantFile implements FilePopula
     String populateFileName;
 
     String fileContent;
+
+    List<DownloadRecordPopDto> downloadRecordPopDtos = new ArrayList<>();
 }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
@@ -189,24 +189,17 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
                 .creatingParticipantUserId(enrollee.getParticipantUserId())
                 .build();
 
-        file = participantFileService.create(file);
+        return participantFileService.create(file);
+    }
 
+    private void populateParticipantFileDownloads(ParticipantFile file, Enrollee enrollee, ParticipantFilePopDto fileDto, EnvironmentName environmentName) {
         for (DownloadRecordPopDto downloadDto : fileDto.getDownloadRecordPopDtos()) {
-            UUID userId = downloadDto.getLinkedUsername() != null
-                    ? participantUserService.findOne(downloadDto.getLinkedUsername(), environmentName).orElseThrow().getId()
-                    : enrollee.getParticipantUserId();
-            DownloadRecord record = DownloadRecord.builder()
-                    .participantFileId(file.getId())
-                    .participantUserId(userId)
-                    .enrolleeId(enrollee.getId())
-                    .build();
-            record = downloadRecordDao.create(record);
+            ParticipantUser pUser = participantUserService.findOne(downloadDto.getLinkedUsername(), environmentName).orElseThrow();
+            DownloadRecord record = participantFileService.createDownloadRecord(file, pUser, enrollee);
             if (downloadDto.isTimeShifted()) {
                 timeShiftDao.changeDownloadRecordCreationTime(record.getId(), downloadDto.shiftedInstant());
             }
         }
-
-        return file;
     }
 
     private String getTargetName(TaskType taskType, String stableId, UUID portalId, int version) {
@@ -373,6 +366,10 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
         for (SurveyResponsePopDto responsePopDto : popDto.getSurveyResponseDtos()) {
             enrolleeResponsePopulator.populateResponse(enrollee, responsePopDto, ppUser, popDto.isSimulateSubmissions(), context, responsibleUser);
         }
+        for (int i = 0; i < popDto.getParticipantFilePopDtos().size(); i++) {
+            populateParticipantFileDownloads(participantFiles.get(i), enrollee, popDto.getParticipantFilePopDtos().get(i), attachedEnv.getEnvironmentName());
+        }
+
         for (ParticipantTaskPopDto taskDto : popDto.getParticipantTaskDtos()) {
             populateTask(enrollee, ppUser, taskDto);
         }

--- a/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
+++ b/populate/src/main/java/bio/terra/pearl/populate/service/EnrolleePopulator.java
@@ -2,11 +2,13 @@ package bio.terra.pearl.populate.service;
 
 import bio.terra.pearl.core.dao.admin.AdminUserDao;
 import bio.terra.pearl.core.dao.dataimport.TimeShiftDao;
+import bio.terra.pearl.core.dao.file.DownloadRecordDao;
 import bio.terra.pearl.core.dao.kit.KitTypeDao;
 import bio.terra.pearl.core.dao.survey.PreEnrollmentResponseDao;
 import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.admin.AdminUser;
 import bio.terra.pearl.core.model.audit.DataAuditInfo;
+import bio.terra.pearl.core.model.file.DownloadRecord;
 import bio.terra.pearl.core.model.file.ParticipantFile;
 import bio.terra.pearl.core.model.kit.KitRequest;
 import bio.terra.pearl.core.model.kit.KitRequestStatus;
@@ -45,6 +47,7 @@ import bio.terra.pearl.core.service.survey.SurveyTaskDispatcher;
 import bio.terra.pearl.core.service.workflow.EnrollmentService;
 import bio.terra.pearl.core.service.workflow.ParticipantTaskService;
 import bio.terra.pearl.populate.dao.ParticipantUserPopulateDao;
+import bio.terra.pearl.populate.dto.fileupload.DownloadRecordPopDto;
 import bio.terra.pearl.populate.dto.fileupload.ParticipantFilePopDto;
 import bio.terra.pearl.populate.dto.kit.KitRequestPopDto;
 import bio.terra.pearl.populate.dto.notifications.NotificationPopDto;
@@ -95,7 +98,8 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
                              ParticipantNotePopulator participantNotePopulator,
                              ParticipantUserPopulateDao participantUserPopulateDao, PortalParticipantUserPopulator portalParticipantUserPopulator, ObjectMapper objectMapper, PortalService portalService,
                              ShortcodeService shortcodeService, StudyEnvironmentSurveyService studyEnvironmentSurveyService, EnrolleeResponsePopulator enrolleeResponsePopulator, SurveyTaskDispatcher surveyTaskDispatcher,
-                             FileStorageBackendProvider fileStorageBackendProvider, ParticipantFileService participantFileService) {
+                             FileStorageBackendProvider fileStorageBackendProvider, ParticipantFileService participantFileService,
+                             DownloadRecordDao downloadRecordDao) {
         this.portalParticipantUserService = portalParticipantUserService;
         this.preEnrollmentResponseDao = preEnrollmentResponseDao;
         this.surveyService = surveyService;
@@ -125,6 +129,7 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
         this.fileStorageBackend = fileStorageBackendProvider.get();
         this.participantFileService = participantFileService;
         this.surveyTaskDispatcher = surveyTaskDispatcher;
+        this.downloadRecordDao = downloadRecordDao;
     }
 
     private void populateTask(Enrollee enrollee, PortalParticipantUser ppUser, ParticipantTaskPopDto taskDto) {
@@ -170,7 +175,7 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
         return kitRequest;
     }
 
-    private ParticipantFile populateParticipantFile(Enrollee enrollee, ParticipantFilePopDto fileDto) {
+    private ParticipantFile populateParticipantFile(Enrollee enrollee, ParticipantFilePopDto fileDto, EnvironmentName environmentName) {
         InputStream fileContentStream = new ByteArrayInputStream(fileDto.getFileContent().getBytes());
 
         UUID uploadId = fileStorageBackend.uploadFile(fileContentStream);
@@ -184,7 +189,24 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
                 .creatingParticipantUserId(enrollee.getParticipantUserId())
                 .build();
 
-        return participantFileService.create(file);
+        file = participantFileService.create(file);
+
+        for (DownloadRecordPopDto downloadDto : fileDto.getDownloadRecordPopDtos()) {
+            UUID userId = downloadDto.getLinkedUsername() != null
+                    ? participantUserService.findOne(downloadDto.getLinkedUsername(), environmentName).orElseThrow().getId()
+                    : enrollee.getParticipantUserId();
+            DownloadRecord record = DownloadRecord.builder()
+                    .participantFileId(file.getId())
+                    .participantUserId(userId)
+                    .enrolleeId(enrollee.getId())
+                    .build();
+            record = downloadRecordDao.create(record);
+            if (downloadDto.isTimeShifted()) {
+                timeShiftDao.changeDownloadRecordCreationTime(record.getId(), downloadDto.shiftedInstant());
+            }
+        }
+
+        return file;
     }
 
     private String getTargetName(TaskType taskType, String stableId, UUID portalId, int version) {
@@ -345,7 +367,7 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
 
         List<ParticipantFile> participantFiles = new ArrayList<>();
         for (ParticipantFilePopDto fileDto : popDto.getParticipantFilePopDtos()) {
-            participantFiles.add(populateParticipantFile(enrollee, fileDto));
+            participantFiles.add(populateParticipantFile(enrollee, fileDto, attachedEnv.getEnvironmentName()));
         }
 
         for (SurveyResponsePopDto responsePopDto : popDto.getSurveyResponseDtos()) {
@@ -614,4 +636,5 @@ public class EnrolleePopulator extends BasePopulator<Enrollee, EnrolleePopDto, S
     private final EnrolleeResponsePopulator enrolleeResponsePopulator;
     private final ParticipantFileService participantFileService;
     private final SurveyTaskDispatcher surveyTaskDispatcher;
+    private final DownloadRecordDao downloadRecordDao;
 }

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
@@ -20,7 +20,8 @@
       "fileContent": "Hi!",
       "downloadRecordPopDtos": [
         {
-          "submittedHoursAgo": "15"
+          "submittedHoursAgo": "15",
+          "linkedUsername": "jsalk@test.com"
         }
       ]
     }

--- a/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
+++ b/populate/src/main/resources/seed/portals/demo/studies/heartdemo/enrollees/jsalk.json
@@ -17,7 +17,12 @@
     {
       "fileName": "medical_notes.txt",
       "fileType": "text/plain",
-      "fileContent": "Hi!"
+      "fileContent": "Hi!",
+      "downloadRecordPopDtos": [
+        {
+          "submittedHoursAgo": "15"
+        }
+      ]
     }
   ],
   "preEnrollmentResponseDto": {

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeDocuments.test.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeDocuments.test.tsx
@@ -30,7 +30,7 @@ describe('EnrolleeDocuments', () => {
     render(<EnrolleeDocuments enrollee={mockEnrollee()} studyEnvContext={mockStudyEnvContext()} />)
 
     await waitFor(() => {
-      expect(screen.getByText('This participant has not uploaded any documents')).toBeInTheDocument()
+      expect(screen.getByText('No uploaded documents')).toBeInTheDocument()
     })
   })
 })

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeDocuments.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeDocuments.tsx
@@ -18,7 +18,7 @@ export default function EnrolleeDocuments({ enrollee, studyEnvContext }: {
       enrolleeShortcode: enrollee.shortcode
     })
     setParticipantFiles(response)
-  }, [enrollee])
+  }, [enrollee.shortcode])
 
   return <LoadingSpinner isLoading={isLoading}>
     <ParticipantDocumentListView

--- a/ui-admin/src/study/participants/survey/ParticipantDocumentListView.tsx
+++ b/ui-admin/src/study/participants/survey/ParticipantDocumentListView.tsx
@@ -6,7 +6,9 @@ import {
   useReactTable
 } from '@tanstack/react-table'
 import {
+  DownloadRecord,
   Enrollee,
+  instantToDefaultString,
   ParticipantFile,
   saveBlobAsDownload
 } from '@juniper/ui-core'
@@ -38,12 +40,16 @@ export const ParticipantDocumentListView = ({
   // @ts-ignore
   const columns: ColumnDef<ParticipantFile>[] = [
     {
+      header: 'File Name',
+      accessorKey: 'fileName'
+    },
+    {
       ...createdAtColumn(),
       header: 'Uploaded At'
     },
     {
-      header: 'File Name',
-      accessorKey: 'fileName'
+      header: 'Downloads',
+      cell: ({ row }) => <DownloadRecordList records={row.original.downloads ?? []}/>
     },
     ...(showAssociatedTasks ? [{
       header: 'Associated Tasks',
@@ -121,8 +127,25 @@ export const ParticipantDocumentListView = ({
       Document Uploads
     </span>
     {basicTableLayout(table)}
-    { renderEmptyMessage(documents, 'This participant has not uploaded any documents') }
+    { renderEmptyMessage(documents, 'No uploaded documents') }
   </>
+}
+
+const DownloadRecordList = ({ records }: { records: DownloadRecord[] }) => {
+  if (records.length === 0) {
+    return <span className='fst-italic text-muted'>none</span>
+  }
+  return (
+    <ul className='ps-3 mb-0'>
+      {records.map((record, i) => (
+        <li key={i}>
+          {instantToDefaultString(record.createdAt)}
+          {' — '}
+          {record.adminUserId ? 'Admin' : 'Participant'}
+        </li>
+      ))}
+    </ul>
+  )
 }
 
 const surveyResponseIdsToTaskNames = (
@@ -133,7 +156,7 @@ const surveyResponseIdsToTaskNames = (
   }).filter(task => task !== undefined)
 
   if (associatedTasks.length === 0) {
-    return <div className={'fst-italic text-muted'}>This document is not associated with any tasks</div>
+    return <div className={'fst-italic text-muted'}>none</div>
   }
 
   return (

--- a/ui-core/src/test-utils/mocking-utils.ts
+++ b/ui-core/src/test-utils/mocking-utils.ts
@@ -221,7 +221,8 @@ export const mockParticipantFile = (fileName: string, associatedAnswers?: Answer
     lastUpdatedAt: 0,
     associatedAnswers: associatedAnswers || [],
     virusScanResult: 'CLEAN',
-    externalFileId: 'externalId'
+    externalFileId: 'externalId',
+    downloads: []
   }
 }
 

--- a/ui-core/src/types/participantFile.ts
+++ b/ui-core/src/types/participantFile.ts
@@ -2,6 +2,13 @@ import { Answer } from 'src/types/forms'
 
 export type VirusScanResult = 'UNSCANNED' | 'CLEAN' | 'QUARANTINED'
 
+export type DownloadRecord = {
+  createdAt: number
+  participantUserId?: string
+  adminUserId?: string
+  enrolleeId: string
+}
+
 export type ParticipantFile = {
   id?: string
   fileName: string
@@ -10,6 +17,7 @@ export type ParticipantFile = {
   lastUpdatedAt: number
   externalFileId: string
   associatedAnswers: Answer[]
+  downloads: DownloadRecord[]
 
   virusScanResult: VirusScanResult
 }


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Stores a record of all downloads of files.  If the file is downloaded by a participant, it also creates a survey answer so that the participant list and export will show if the participant has downloaded the file.  This survey answer is kind of wonky in that it uses the same question as the file download, but I couldn't come up with a more elegant way to make it searchable.  Probably the cleanest way would be that file upload questions create a second, shadow, "downloaded" question, that can be answered, but I wasn't sure how feasible that would be.


<img width="980" height="515" alt="image" src="https://github.com/user-attachments/assets/f780d5f2-a3cf-4165-9082-d95608ab873c" />


#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1. reload admin/participant apps
2. repopulate demo
3. go to participant list. 
4. advanced filter, look for medical_record_request  EQUAL "yes".  Jonas salk should appear
5. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants/HDSALK/surveys/med_record_request.  Confirm you see the record of the download
6. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/export/dataBrowser.  confirm an answer of "yes" for HDSALK for `med_record_request.medical_record_document_request`