### PR TITLE
[SIDRB-4382] participant shortcode col

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/search/EnrolleeSearchService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/EnrolleeSearchService.java
@@ -31,6 +31,7 @@ public class EnrolleeSearchService {
 
     public List<EnrolleeSearchExpressionResult> executeSearchExpression(UUID studyEnvId, String expression, EnrolleeSearchOptions opts) {
         try {
+
             return enrolleeSearchExpressionDao.executeSearch(
                     enrolleeSearchExpressionParser.parseRule(expression),
                     studyEnvId,

--- a/core/src/main/java/bio/terra/pearl/core/service/search/terms/UserTerm.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/search/terms/UserTerm.java
@@ -77,6 +77,7 @@ public class UserTerm extends SearchTerm {
 
     public static final Map<String, SearchValueTypeDefinition> FIELDS = Map.ofEntries(
             Map.entry("username", SearchValueTypeDefinition.builder().type(STRING).build()),
+            Map.entry("shortcode", SearchValueTypeDefinition.builder().type(STRING).build()),
             Map.entry("createdAt", SearchValueTypeDefinition.builder().type(INSTANT).build()),
             Map.entry("lastLogin", SearchValueTypeDefinition.builder().type(INSTANT).build()));
 

--- a/core/src/test/java/bio/terra/pearl/core/dao/search/EnrolleeSearchExpressionDaoTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/search/EnrolleeSearchExpressionDaoTests.java
@@ -1016,4 +1016,29 @@ public class EnrolleeSearchExpressionDaoTests extends BaseSpringBootTest {
         assertTrue(resultsIsNotNull.stream().anyMatch(r -> r.getEnrollee().getId().equals(enrolleeBundle3.enrollee().getId())));
         assertTrue(resultsIsNotNull.stream().anyMatch(r -> r.getEnrollee().getId().equals(enrolleeBundle4.enrollee().getId())));
     }
+
+    @Test
+    @Transactional
+    public void testUserShortcodeSearch(TestInfo info) {
+        StudyEnvironmentBundle studyEnvBundle = studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.sandbox);
+        EnrolleeBundle bundle1 = enrolleeFactory.buildWithPortalUser(getTestName(info), studyEnvBundle.getPortalEnv(), studyEnvBundle.getStudyEnv());
+        EnrolleeBundle bundle2 = enrolleeFactory.buildWithPortalUser(getTestName(info), studyEnvBundle.getPortalEnv(), studyEnvBundle.getStudyEnv());
+
+        String targetShortcode = bundle1.participantUser().getShortcode();
+
+        EnrolleeSearchExpression exactExp = enrolleeSearchExpressionParser.parseRule(
+                "{user.shortcode} = '%s'".formatted(targetShortcode)
+        );
+        EnrolleeSearchExpression containsExp = enrolleeSearchExpressionParser.parseRule(
+                "{user.shortcode} contains '%s'".formatted(targetShortcode)
+        );
+
+        List<EnrolleeSearchExpressionResult> exactResults = enrolleeSearchExpressionDao.executeSearch(exactExp, studyEnvBundle.getStudyEnv().getId());
+        List<EnrolleeSearchExpressionResult> containsResults = enrolleeSearchExpressionDao.executeSearch(containsExp, studyEnvBundle.getStudyEnv().getId());
+
+        Assertions.assertEquals(1, exactResults.size());
+        Assertions.assertEquals(1, containsResults.size());
+        assertTrue(exactResults.stream().anyMatch(r -> r.getEnrollee().getId().equals(bundle1.enrollee().getId())));
+        assertTrue(containsResults.stream().anyMatch(r -> r.getEnrollee().getId().equals(bundle1.enrollee().getId())));
+    }
 }

--- a/core/src/test/java/bio/terra/pearl/core/service/search/EnrolleeSearchServiceTest.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/search/EnrolleeSearchServiceTest.java
@@ -243,6 +243,7 @@ class EnrolleeSearchServiceTest extends BaseSpringBootTest {
                 Map.entry("user.username", SearchValueTypeDefinition.builder().type(STRING).build()),
                 Map.entry("user.createdAt", SearchValueTypeDefinition.builder().type(INSTANT).build()),
                 Map.entry("user.lastLogin", SearchValueTypeDefinition.builder().type(INSTANT).build()),
+                Map.entry("user.shortcode", SearchValueTypeDefinition.builder().type(STRING).build()),
                 Map.entry("family.shortcode", SearchValueTypeDefinition.builder().type(STRING).build())
         );
 

--- a/populate/src/main/resources/seed/i18n/en/languageTexts.json
+++ b/populate/src/main/resources/seed/i18n/en/languageTexts.json
@@ -701,7 +701,7 @@
   },
   {
     "keyName": "documentsListNone",
-    "text": "You have not uploaded any documents yet",
+    "text": "None",
     "language": "en"
   },
   {

--- a/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantList.test.tsx
@@ -169,6 +169,7 @@ test('keyword search sends search api request', async () => {
     '({profile.name} contains \'foo\' ' +
     'or {profile.contactEmail} contains \'foo\' ' +
     'or {enrollee.shortcode} contains \'foo\' ' +
+    'or {user.shortcode} contains \'foo\' ' +
     'or {family.shortcode} contains \'foo\') ' +
     'and {enrollee.subject} = true ' +
     'and include({user.username}) and include({portalUser.lastLogin})')

--- a/ui-admin/src/study/participants/participantList/ParticipantListTable.tsx
+++ b/ui-admin/src/study/participants/participantList/ParticipantListTable.tsx
@@ -96,6 +96,7 @@ function ParticipantListTable({
   const [rowSelection, setRowSelection] = React.useState<Record<string, boolean>>({})
   const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({
     'givenName': false,
+    'participantUserShortcode': false,
     'familyName': false,
     'contactEmail': false,
     'subject': false,
@@ -134,6 +135,15 @@ function ParticipantListTable({
       )
     },
     enrolleeShortcodeColumn(currentEnvPath),
+    {
+      id: 'participantUserShortcode',
+      header: 'User shortcode',
+      enableColumnFilter: true,
+      meta: {
+        columnType: 'string'
+      },
+      accessorFn: (row: EnrolleeSearchExpressionResult) => row.participantUser?.shortcode
+    },
     {
       header: 'Research ID',
       id: 'researchId',

--- a/ui-admin/src/util/participantSearchUtils.test.tsx
+++ b/ui-admin/src/util/participantSearchUtils.test.tsx
@@ -110,6 +110,7 @@ describe('toExpression', () => {
     expect(result).toEqual('({profile.name} contains \'test\' '
       + 'or {profile.contactEmail} contains \'test\' '
       + 'or {enrollee.shortcode} contains \'test\' '
+      + 'or {user.shortcode} contains \'test\' '
       + 'or {family.shortcode} contains \'test\') '
       + 'and {enrollee.subject} = false and {enrollee.consented} = true '
       + 'and {age} >= 10 and {age} <= 20 and ({profile.sexAtBirth} = \'female\') '

--- a/ui-admin/src/util/participantSearchUtils.test.tsx
+++ b/ui-admin/src/util/participantSearchUtils.test.tsx
@@ -15,6 +15,7 @@ describe('toExpression', () => {
     expect(result).toEqual('({profile.name} contains \'test\' '
       + 'or {profile.contactEmail} contains \'test\' '
       + 'or {enrollee.shortcode} contains \'test\' '
+      + 'or {user.shortcode} contains \'test\' '
       + 'or {family.shortcode} contains \'test\') '
       + 'and {enrollee.subject} = true')
   })

--- a/ui-admin/src/util/participantSearchUtils.tsx
+++ b/ui-admin/src/util/participantSearchUtils.tsx
@@ -159,6 +159,7 @@ export const toExpression = (searchState: ParticipantSearchState,
     expressions.push(`({profile.name} contains '${searchState.keywordSearch}' `
       + `or {profile.contactEmail} contains '${searchState.keywordSearch}' `
       + `or {enrollee.shortcode} contains '${searchState.keywordSearch}' `
+      + `or {user.shortcode} contains '${searchState.keywordSearch}' `
       + `or {family.shortcode} contains '${searchState.keywordSearch}')`)
   }
 


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Adds Account shortcode as a viewable column on the participant list, and as a keyword searchable term.

Also updates the empty participant document list text (SIDRB-4383)

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

1.  Redeploy admin app
2. go to https://localhost:3000/demo/studies/heartdemo/env/sandbox/participants
3. add "User shortcode" as a column
4. confirm it appears
5. do some keyword searches on user shortcodes, confirm they work