### PR TITLE
[SIDRB-4381] all users can see participant docs

### DIFF
--- a/scripts/generate_release_notes.sh
+++ b/scripts/generate_release_notes.sh
@@ -27,8 +27,8 @@ messages=$(echo $commits | jq -r '.[].message')
 # Generate the release notes markdown. This can be pasted directly into a Jira ticket
 # or a Google Doc (if you have markdown enabled)
 while IFS= read -r message; do
-  if echo "$message" | grep -q -E 'JN-\d+'; then
-    ticket=$(echo "$message" | grep -o -E 'JN-\d+')
+  if echo "$message" | grep -q -E '(JN|SIDRB)-\d+'; then
+    ticket=$(echo "$message" | grep -o -E '(JN|SIDRB)-\d+')
     pr=$(echo "$message" | grep -o -E '#\d+' | tr -d '#')
     message=$(echo "$message" | tr -d '[]')
     echo "[${message}](https://broadworkbench.atlassian.net/browse/$ticket) [(GitHub PR)](https://github.com/broadinstitute/juniper/pull/$pr)"

--- a/ui-admin/src/study/participants/enrolleeView/EnrolleeView.tsx
+++ b/ui-admin/src/study/participants/enrolleeView/EnrolleeView.tsx
@@ -44,7 +44,6 @@ import {
   navDivStyle,
   navListItemStyle
 } from 'util/subNavStyles'
-import { RequireUserPermission } from 'util/RequireUserPermission'
 import EnrolleeDocuments from './EnrolleeDocuments'
 import { KitRequestFullDetails } from '../../kits/KitRequestFullDetails'
 
@@ -184,22 +183,20 @@ export function LoadedEnrolleeView({ enrollee, studyEnvContext, onUpdate }: {
                     responseMap={responseMap} emptyText={'No study staff forms'}/>}
                   />
                 </li>
-                <RequireUserPermission superuser>
-                  <li style={navListItemStyle}>
-                    <CollapsableMenu header={'Document Requests'} headerClass="text-black" content={
-                      <>
-                        <SurveyList surveys={surveys
-                          .filter(survey => survey.survey.surveyType === 'DOCUMENT_REQUEST')}
-                        responseMap={responseMap} emptyText={'No document requests'}
-                        />
-                        <NavLink to="documents" className={getLinkCssClasses}>
-                          <FontAwesomeIcon className="me-2" icon={faList}/>
-                          <span className={'fst-italic'}>View all documents</span>
-                        </NavLink>
-                      </>}
-                    />
-                  </li>
-                </RequireUserPermission>
+                <li style={navListItemStyle}>
+                  <CollapsableMenu header={'Document Requests'} headerClass="text-black" content={
+                    <>
+                      <SurveyList surveys={surveys
+                        .filter(survey => survey.survey.surveyType === 'DOCUMENT_REQUEST')}
+                      responseMap={responseMap} emptyText={'No document requests'}
+                      />
+                      <NavLink to="documents" className={getLinkCssClasses}>
+                        <FontAwesomeIcon className="me-2" icon={faList}/>
+                        <span className={'fst-italic'}>View all documents</span>
+                      </NavLink>
+                    </>}
+                  />
+                </li>
                 <li style={navListItemStyle}>
                   <CollapsableMenu header={'Outreach'} headerClass="text-black" content={
                     <SurveyList surveys={surveys


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Admins can now view the ParticipantFiles from the enrollee view.  Also updates generate_release_notes to support SIDRB tix too.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

