### PR TITLE
[SIDRB-4402] fixing answer ordering

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/dao/search/EnrolleeSearchExpressionDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/search/EnrolleeSearchExpressionDao.java
@@ -159,8 +159,8 @@ public class EnrolleeSearchExpressionDao {
                     id -> rowView.getRow(EnrolleeSearchExpressionResult.class));
 
             if (!isFirstRow) {
-                // Accumulate answers from additional rows produced by a multi-answer join.
-                // Deduplicate by ID so that rows caused by other joins (e.g. family) don't add duplicates.
+                // Accumulate answers and tasks from additional rows produced by multi-value joins.
+                // Deduplicate by ID so that cross-join fan-out doesn't add duplicates.
                 EnrolleeSearchExpressionResult rowResult = rowView.getRow(EnrolleeSearchExpressionResult.class);
                 Set<UUID> existingAnswerIds = searchResult.getAnswers().stream()
                         .map(Answer::getId)
@@ -168,11 +168,22 @@ public class EnrolleeSearchExpressionDao {
                 rowResult.getAnswers().stream()
                         .filter(a -> !existingAnswerIds.contains(a.getId()))
                         .forEach(searchResult.getAnswers()::add);
+                Set<UUID> existingTaskIds = searchResult.getTasks().stream()
+                        .map(ParticipantTask::getId)
+                        .collect(Collectors.toSet());
+                rowResult.getTasks().stream()
+                        .filter(t -> !existingTaskIds.contains(t.getId()))
+                        .forEach(searchResult.getTasks()::add);
             }
 
-            // Add family to enrollee
+            // Add family to enrollee, deduplicating by ID across rows caused by multi-answer fan-out
             if (isColumnPresent(rowView, "family_id", UUID.class)) {
-                searchResult.getFamilies().add(rowView.getRow(Family.class));
+                Family family = rowView.getRow(Family.class);
+                boolean alreadyPresent = searchResult.getFamilies().stream()
+                        .anyMatch(f -> f.getId().equals(family.getId()));
+                if (!alreadyPresent) {
+                    searchResult.getFamilies().add(family);
+                }
             }
         }
 

--- a/core/src/main/java/bio/terra/pearl/core/dao/search/EnrolleeSearchExpressionDao.java
+++ b/core/src/main/java/bio/terra/pearl/core/dao/search/EnrolleeSearchExpressionDao.java
@@ -35,8 +35,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 @Component
 @Slf4j
@@ -150,8 +152,23 @@ public class EnrolleeSearchExpressionDao {
     public static class EnrolleeSearchResultReducer implements LinkedHashMapRowReducer<UUID, EnrolleeSearchExpressionResult> {
         @Override
         public void accumulate(Map<UUID, EnrolleeSearchExpressionResult> map, RowView rowView) {
-            final EnrolleeSearchExpressionResult searchResult = map.computeIfAbsent(rowView.getColumn("enrollee_id", UUID.class),
+            UUID enrolleeId = rowView.getColumn("enrollee_id", UUID.class);
+            boolean isFirstRow = !map.containsKey(enrolleeId);
+
+            final EnrolleeSearchExpressionResult searchResult = map.computeIfAbsent(enrolleeId,
                     id -> rowView.getRow(EnrolleeSearchExpressionResult.class));
+
+            if (!isFirstRow) {
+                // Accumulate answers from additional rows produced by a multi-answer join.
+                // Deduplicate by ID so that rows caused by other joins (e.g. family) don't add duplicates.
+                EnrolleeSearchExpressionResult rowResult = rowView.getRow(EnrolleeSearchExpressionResult.class);
+                Set<UUID> existingAnswerIds = searchResult.getAnswers().stream()
+                        .map(Answer::getId)
+                        .collect(Collectors.toSet());
+                rowResult.getAnswers().stream()
+                        .filter(a -> !existingAnswerIds.contains(a.getId()))
+                        .forEach(searchResult.getAnswers()::add);
+            }
 
             // Add family to enrollee
             if (isColumnPresent(rowView, "family_id", UUID.class)) {

--- a/core/src/test/java/bio/terra/pearl/core/dao/search/EnrolleeSearchExpressionDaoTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/dao/search/EnrolleeSearchExpressionDaoTests.java
@@ -776,6 +776,32 @@ public class EnrolleeSearchExpressionDaoTests extends BaseSpringBootTest {
 
     @Test
     @Transactional
+    public void testIncludeAnswerMultipleResponses(TestInfo info) {
+        StudyEnvironment studyEnv = studyEnvironmentFactory.buildPersisted(getTestName(info));
+        Survey survey = surveyFactory.buildPersisted(getTestName(info));
+        surveyFactory.attachToEnv(survey, studyEnv.getId(), true);
+
+        Enrollee enrollee = enrolleeFactory.buildPersisted(getTestName(info), studyEnv);
+
+        surveyResponseFactory.buildWithAnswers(enrollee, survey, Map.of("testquestion", "yes"));
+        surveyResponseFactory.buildWithAnswers(enrollee, survey, Map.of("testquestion", "no"));
+
+        EnrolleeSearchExpression includeExp = enrolleeSearchExpressionParser.parseRule(
+                "include({answer.%s.testquestion})".formatted(survey.getStableId())
+        );
+
+        List<EnrolleeSearchExpressionResult> results = enrolleeSearchExpressionDao.executeSearch(includeExp, studyEnv.getId());
+
+        assertEquals(1, results.size());
+        EnrolleeSearchExpressionResult result = results.get(0);
+        assertEquals(enrollee.getId(), result.getEnrollee().getId());
+        assertEquals(2, result.getAnswers().size());
+        assertTrue(result.getAnswers().stream().anyMatch(a -> "yes".equals(a.getStringValue())));
+        assertTrue(result.getAnswers().stream().anyMatch(a -> "no".equals(a.getStringValue())));
+    }
+
+    @Test
+    @Transactional
     public void testIncludeUserData(TestInfo info) {
         EnrolleeBundle bundle = enrolleeFactory.buildWithPortalUser(getTestName(info));
         Instant loginTime = Instant.now();

--- a/ui-admin/src/util/table/columnUtils.tsx
+++ b/ui-admin/src/util/table/columnUtils.tsx
@@ -224,10 +224,19 @@ const dynamicAnswerColumn = <T extends EnrolleeSearchExpressionResult, >(facet: 
     id: facet.key,
     header,
     accessorFn: info => {
-      const answer = info.answers.find(ans =>
-        ans.surveyStableId === surveyStableId && ans.questionStableId === questionStableId)
-      // we can add code here at a later time to map answer stableId string values to choice labels
-      return answer?.stringValue ?? answer?.booleanValue ?? answer?.numberValue ?? answer?.objectValue ?? ''
+      const matching = info.answers
+        .filter(ans => ans.surveyStableId === surveyStableId && ans.questionStableId === questionStableId)
+        .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0))
+      const answer = matching[0]
+      return {
+        value: answer?.stringValue ?? answer?.booleanValue ?? answer?.numberValue ?? answer?.objectValue ?? '',
+        extra: matching.length - 1
+      }
+    },
+    // we can add code here at a later time to map answer stableId string values to choice labels
+    cell: info => {
+      const { value, extra } = info.getValue() as { value: unknown, extra: number }
+      return <>{value}{extra > 0 && <span className="detail"> (...)</span>}</>
     },
     meta: {
       columnType: facet.type.toLowerCase()


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

Previously, the answer shown in the participant list would be random.  This updates the logic so that it is always the most recent.  this only updates logic in the reducer for showing stuff in the returned list -- it does not impact filtering or export

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

