### PR TITLE
[SIDRB-4402] easier config of database port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,8 @@ tmp/
 # direnv
 .envrc
 
+# Local environment overrides (port, etc.)
+.env.local
+
 *.hprof
 

--- a/api-admin/src/main/resources/application.yml
+++ b/api-admin/src/main/resources/application.yml
@@ -3,7 +3,7 @@
 env:
   deploymentZone: ${DEPLOYMENT_ZONE:local}
   db:
-    host: ${DATABASE_HOSTNAME:127.0.0.1}:5432
+    host: ${DATABASE_HOSTNAME:127.0.0.1}:${DATABASE_PORT:5432}
     init: ${INIT_DB:false}
     name: ${DATABASE_NAME:pearl}
     password: ${DATABASE_USER_PASSWORD:dbpwd}

--- a/api-admin/src/test/resources/application.yml
+++ b/api-admin/src/test/resources/application.yml
@@ -2,7 +2,7 @@
 # This is for deployment-specific values, which may be managed by other teams
 env:
   db:
-    host: ${DATABASE_HOSTNAME:127.0.0.1}:5432
+    host: ${DATABASE_HOSTNAME:127.0.0.1}:${DATABASE_PORT:5432}
     init: ${INIT_DB:false}
     name: ${DATABASE_NAME:pearl_test}
     password: ${DATABASE_USER_PASSWORD:dbpwd}

--- a/api-participant/src/main/resources/application.yml
+++ b/api-participant/src/main/resources/application.yml
@@ -3,7 +3,7 @@
 env:
   deploymentZone: ${DEPLOYMENT_ZONE:local}
   db:
-    host: ${DATABASE_HOSTNAME:127.0.0.1}:5432
+    host: ${DATABASE_HOSTNAME:127.0.0.1}:${DATABASE_PORT:5432}
     init: ${INIT_DB:false}
     name: ${DATABASE_NAME:pearl}
     password: ${DATABASE_USER_PASSWORD:dbpwd}

--- a/api-participant/src/test/resources/application.yml
+++ b/api-participant/src/test/resources/application.yml
@@ -2,7 +2,7 @@
 # This is for deployment-specific values, which may be managed by other teams
 env:
   db:
-    host: ${DATABASE_HOSTNAME:127.0.0.1}:5432
+    host: ${DATABASE_HOSTNAME:127.0.0.1}:${DATABASE_PORT:5432}
     init: ${INIT_DB:false}
     name: ${DATABASE_NAME:pearl_test}
     password: ${DATABASE_USER_PASSWORD:dbpwd}

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -2,7 +2,7 @@
 # This is for deployment-specific values, which may be managed by other teams
 env:
   db:
-    host: ${DATABASE_HOSTNAME:127.0.0.1}:5432
+    host: ${DATABASE_HOSTNAME:127.0.0.1}:${DATABASE_PORT:5432}
     init: ${INIT_DB:false}
     name: ${DATABASE_NAME:pearl}
     password: ${DATABASE_USER_PASSWORD:dbpwd}

--- a/core/src/test/resources/application.yml
+++ b/core/src/test/resources/application.yml
@@ -2,7 +2,7 @@
 # This is for deployment-specific values, which may be managed by other teams
 env:
   db:
-    host: ${DATABASE_HOSTNAME:127.0.0.1}:5432
+    host: ${DATABASE_HOSTNAME:127.0.0.1}:${DATABASE_PORT:5432}
     init: ${INIT_DB:false}
     name: ${DATABASE_NAME:pearl_test}
     password: ${DATABASE_USER_PASSWORD:dbpwd}

--- a/pepper-import/src/main/resources/application.yml
+++ b/pepper-import/src/main/resources/application.yml
@@ -2,7 +2,7 @@
 # This is for deployment-specific values, which may be managed by other teams
 env:
   db:
-    host: ${DATABASE_HOSTNAME:127.0.0.1}:5432
+    host: ${DATABASE_HOSTNAME:127.0.0.1}:${DATABASE_PORT:5432}
     init: ${INIT_DB:false}
     name: ${DATABASE_NAME:pearl}
     password: ${DATABASE_USER_PASSWORD:dbpwd}

--- a/pepper-import/src/test/resources/application.yml
+++ b/pepper-import/src/test/resources/application.yml
@@ -2,7 +2,7 @@
 # This is for deployment-specific values, which may be managed by other teams
 env:
   db:
-    host: ${DATABASE_HOSTNAME:127.0.0.1}:5432
+    host: ${DATABASE_HOSTNAME:127.0.0.1}:${DATABASE_PORT:5432}
     init: ${INIT_DB:false}
     name: ${DATABASE_NAME:pearl_test}
     password: ${DATABASE_USER_PASSWORD:dbpwd}

--- a/populate/src/main/resources/application.yml
+++ b/populate/src/main/resources/application.yml
@@ -2,7 +2,7 @@
 # This is for deployment-specific values, which may be managed by other teams
 env:
   db:
-    host: ${DATABASE_HOSTNAME:127.0.0.1}:5432
+    host: ${DATABASE_HOSTNAME:127.0.0.1}:${DATABASE_PORT:5432}
     init: ${INIT_DB:false}
     name: ${DATABASE_NAME:pearl}
     password: ${DATABASE_USER_PASSWORD:dbpwd}

--- a/populate/src/test/resources/application.yml
+++ b/populate/src/test/resources/application.yml
@@ -2,7 +2,7 @@
 # This is for deployment-specific values, which may be managed by other teams
 env:
   db:
-    host: ${DATABASE_HOSTNAME:127.0.0.1}:5432
+    host: ${DATABASE_HOSTNAME:127.0.0.1}:${DATABASE_PORT:5432}
     init: ${INIT_DB:false}
     name: ${DATABASE_NAME:pearl_test}
     password: ${DATABASE_USER_PASSWORD:dbpwd}

--- a/scripts/postgres/run_postgres.sh
+++ b/scripts/postgres/run_postgres.sh
@@ -35,7 +35,13 @@ stop() {
 
 CONTAINER=postgres
 COMMAND=$1
-POSTGRES_PORT=${2:-"5432"}
+
+REPO_ROOT=$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null)
+if [ -f "$REPO_ROOT/.env.local" ]; then
+    set -a; source "$REPO_ROOT/.env.local"; set +a
+fi
+
+POSTGRES_PORT=${DATABASE_PORT:-${2:-5432}}
 
 if [ ${#@} == 0 ]; then
     echo "Usage: $0 stop|start"


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

enables a DATABASE_PORT option for easier running of Juniper on other ports (e.g. to not conflict with SIDR)

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

create an .env.local file with DATABASE_PORT=5439
 have it read by intellij
restart the postgresql script