### PR TITLE
[SIDRB-4453] fix oauth issues, make preferred language more robust

### DIFF
--- a/core/src/main/java/bio/terra/pearl/core/service/workflow/RegistrationService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/workflow/RegistrationService.java
@@ -166,6 +166,7 @@ public class RegistrationService {
         Profile governedProfile =  Profile.builder()
                 .contactEmail(proxyProfile.getContactEmail())
                 .doNotEmail(proxyProfile.isDoNotEmail())
+                .preferredLanguage(proxyProfile.getPreferredLanguage())
                 .givenName(null)
                 .familyName(null)
                 .build();

--- a/ui-core/src/participant/I18nProvider.tsx
+++ b/ui-core/src/participant/I18nProvider.tsx
@@ -59,7 +59,7 @@ export function I18nProvider({
   portalShortcode?: string,
   environmentName: EnvironmentName,
   children: React.ReactNode,
-  loadedPortalContentLang?: string,
+  loadedPortalContentLang?: string | null,
   reloadPortalContent?: (language: string) => void
 }) {
   const Api = useApiContext()

--- a/ui-participant/src/Navbar.tsx
+++ b/ui-participant/src/Navbar.tsx
@@ -12,12 +12,14 @@ import { UserManager } from 'oidc-client-ts'
 import { getOidcConfig } from 'authConfig'
 import mixpanel from 'mixpanel-browser'
 import { usePortalEnv } from 'providers/PortalProvider'
+import { useActiveUser } from 'providers/ActiveUserProvider'
 
 type NavbarProps = JSX.IntrinsicElements['nav']
 
 /** renders the navbar for participants */
 export default function Navbar(props: NavbarProps) {
   const { user, logoutUser, proxyRelations, profile, ppUsers } = useUser()
+  const { profile: governedProfile, ppUser: governedPpUser } = useActiveUser()
   const { selectedLanguage, changeLanguage } = useI18n()
   const config = useConfig()
   const envSpec = getEnvSpec()
@@ -46,6 +48,14 @@ export default function Navbar(props: NavbarProps) {
         profile: { ...profile, preferredLanguage: selectedLanguage },
         ppUserId: ppUser.id
       })
+
+      // if in proxy scenario, also update the governed user
+      if (governedPpUser && governedProfile && governedProfile.id != profile.id) {
+        await Api.updateProfile({
+          profile: { ...governedProfile, preferredLanguage: selectedLanguage },
+          ppUserId: governedPpUser.id
+        })
+      }
     }
   }
 

--- a/ui-participant/src/login/RedirectFromOAuth.tsx
+++ b/ui-participant/src/login/RedirectFromOAuth.tsx
@@ -56,6 +56,7 @@ export const RedirectFromOAuth = () => {
       }
 
       if (auth.error) {
+        console.error(auth.error)
         logError({ message: auth.error.message || 'error' }, auth.error.stack || 'stack', 'oauth-error')
         navigate('/redirect-from-oauth/error')
         return

--- a/ui-participant/src/providers/PortalProvider.tsx
+++ b/ui-participant/src/providers/PortalProvider.tsx
@@ -9,6 +9,7 @@ import Api, {
   PortalEnvironment
 } from 'api/api'
 import { SUPPORT_EMAIL_ADDRESS } from '@juniper/ui-core'
+import { useReturnToLanguage } from 'browserPersistentState'
 
 
 /** current portal object context */
@@ -50,6 +51,7 @@ export default function PortalProvider({ children }: { children: React.ReactNode
   const [envState, setEnvState] = useState<Portal | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [isError, setIsError] = useState(false)
+  const [returnToLanguage] = useReturnToLanguage()
 
   useEffect(() => {
     reloadPortal()
@@ -76,7 +78,7 @@ export default function PortalProvider({ children }: { children: React.ReactNode
   }
 
   const reloadPortal = (languageCode?: string) => {
-    const savedLanguage = localStorage.getItem('selectedLanguage')
+    const savedLanguage = localStorage.getItem('selectedLanguage') || returnToLanguage
     const selectedLanguage = languageCode || (savedLanguage === null ? undefined : savedLanguage)
     setIsLoading(true)
     // the ! below is unnecessary and wrong, but Vite ts validation insists on it?


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

We will need to follow this with a SQL update to make sure preferred languages in proxy and governed profiles match.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

change your browser settings to make spanish the top language
clear all cookies, session, and local storage for juniper
ensure that the page loads in spanish
register a new account as a self-enrolled user
ensure no oauth errors and app is still in spanish. ensure preferred language matches and emails received in spanish
clear all cookies, session, and local storage
register a new account as a proxy user
ensure no oauth errors, app is still in spanish. ensure preferred language matches for both proxy and governed user and welcome emails recieved in spanish
use language changer to change language to dev
ensure that both proxy and governed user have a preferred language of dev now