### PR TITLE
[SIDRB-4559] cross-study answer referencing

### DIFF
--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/enrollment/PreEnrollmentController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/enrollment/PreEnrollmentController.java
@@ -17,12 +17,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.NotFoundException;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
-
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
 
 @Controller
 public class PreEnrollmentController implements PreEnrollmentApi {
@@ -83,17 +82,17 @@ public class PreEnrollmentController implements PreEnrollmentApi {
    */
   @Override
   public ResponseEntity<Object> getReferencedAnswers(
-          String portalShortcode, String envName, String surveyStableId, Integer surveyVersion) {
+      String portalShortcode, String envName, String surveyStableId, Integer surveyVersion) {
     ParticipantUser user = requestUtilService.requireUser(request);
     EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
     Survey survey =
-            surveyService
-                    .findByStableIdAndPortalShortcodeWithMappings(
-                            surveyStableId, surveyVersion, portalShortcode)
-                    .orElseThrow(NotFoundException::new);
+        surveyService
+            .findByStableIdAndPortalShortcodeWithMappings(
+                surveyStableId, surveyVersion, portalShortcode)
+            .orElseThrow(NotFoundException::new);
     Map<String, Answer> referencedAnswers =
-            surveyResponseService.getReferencedAnswersForPreEnroll(
-                    user.getId(), environmentName, survey);
+        surveyResponseService.getReferencedAnswersForPreEnroll(
+            user.getId(), environmentName, survey);
     return ResponseEntity.ok(referencedAnswers);
   }
 

--- a/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/enrollment/PreEnrollmentController.java
+++ b/api-participant/src/main/java/bio/terra/pearl/api/participant/controller/enrollment/PreEnrollmentController.java
@@ -2,19 +2,27 @@ package bio.terra.pearl.api.participant.controller.enrollment;
 
 import bio.terra.pearl.api.participant.api.PreEnrollmentApi;
 import bio.terra.pearl.api.participant.service.RequestUtilService;
+import bio.terra.pearl.core.model.EnvironmentName;
+import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.model.portal.Portal;
+import bio.terra.pearl.core.model.survey.Answer;
 import bio.terra.pearl.core.model.survey.ParsedPreEnrollResponse;
 import bio.terra.pearl.core.model.survey.PreEnrollmentResponse;
+import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.service.portal.PortalService;
+import bio.terra.pearl.core.service.survey.SurveyResponseService;
+import bio.terra.pearl.core.service.survey.SurveyService;
 import bio.terra.pearl.core.service.workflow.EnrollmentService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.NotFoundException;
-import java.util.Optional;
-import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 
 @Controller
 public class PreEnrollmentController implements PreEnrollmentApi {
@@ -23,18 +31,24 @@ public class PreEnrollmentController implements PreEnrollmentApi {
   private final RequestUtilService requestUtilService;
   private final HttpServletRequest request;
   private final PortalService portalService;
+  private final SurveyService surveyService;
+  private final SurveyResponseService surveyResponseService;
 
   public PreEnrollmentController(
       ObjectMapper objectMapper,
       EnrollmentService enrollmentService,
       RequestUtilService requestUtilService,
       PortalService portalService,
+      SurveyService surveyService,
+      SurveyResponseService surveyResponseService,
       HttpServletRequest request) {
     this.objectMapper = objectMapper;
     this.enrollmentService = enrollmentService;
     this.requestUtilService = requestUtilService;
     this.request = request;
     this.portalService = portalService;
+    this.surveyService = surveyService;
+    this.surveyResponseService = surveyResponseService;
   }
 
   @Override
@@ -60,6 +74,27 @@ public class PreEnrollmentController implements PreEnrollmentApi {
     } catch (JsonProcessingException e) {
       throw new IllegalArgumentException("malformatted response data", e);
     }
+  }
+
+  /**
+   * Gets any answers from other studies' surveys that this pre-enrollment survey references, for
+   * the signed-in user. This is needed for e.g. a participant who is already enrolled in one study
+   * within a portal and is now pre-enrolling in a second study within the same portal.
+   */
+  @Override
+  public ResponseEntity<Object> getReferencedAnswers(
+          String portalShortcode, String envName, String surveyStableId, Integer surveyVersion) {
+    ParticipantUser user = requestUtilService.requireUser(request);
+    EnvironmentName environmentName = EnvironmentName.valueOfCaseInsensitive(envName);
+    Survey survey =
+            surveyService
+                    .findByStableIdAndPortalShortcodeWithMappings(
+                            surveyStableId, surveyVersion, portalShortcode)
+                    .orElseThrow(NotFoundException::new);
+    Map<String, Answer> referencedAnswers =
+            surveyResponseService.getReferencedAnswersForPreEnroll(
+                    user.getId(), environmentName, survey);
+    return ResponseEntity.ok(referencedAnswers);
   }
 
   /**

--- a/api-participant/src/main/resources/api/openapi.yml
+++ b/api-participant/src/main/resources/api/openapi.yml
@@ -272,6 +272,24 @@ paths:
           content: { application/json: { schema: { type: object } } }
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/public/portals/v1/{portalShortcode}/env/{envName}/preEnroll/{surveyStableId}/{surveyVersion}/referencedAnswers:
+    get:
+      summary:
+        Gets any answers from other studies' surveys that this pre-enrollment survey references, for the
+        signed-in user. Requires authentication.
+      tags: [ preEnrollment ]
+      operationId: getReferencedAnswers
+      parameters:
+        - { name: portalShortcode, in: path, required: true, schema: { type: string } }
+        - { name: envName, in: path, required: true, schema: { type: string } }
+        - { name: surveyStableId, in: path, required: true, schema: { type: string } }
+        - { name: surveyVersion, in: path, required: true, schema: { type: integer } }
+      responses:
+        '200':
+          description: map of variable name to referenced Answer
+          content: { application/json: { schema: { type: object } } }
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/public/portals/v1/{portalShortcode}/env/{envName}/studies/{studyShortcode}/checkEligible:
     get:
       summary: Checks whether the signed-in user is eligible for the given study

--- a/core/src/main/java/bio/terra/pearl/core/model/survey/SurveyWithResponse.java
+++ b/core/src/main/java/bio/terra/pearl/core/model/survey/SurveyWithResponse.java
@@ -1,11 +1,13 @@
 package bio.terra.pearl.core.model.survey;
 
-import java.util.List;
+import java.util.Map;
 
 /** convenience class for grouping together a form and its configuration and most recent/active response */
 public record SurveyWithResponse(StudyEnvironmentSurvey studyEnvironmentSurvey,
                                  SurveyResponse surveyResponse,
-                                 // if the survey uses answers from other surveys, this will be populated
-                                 List<Answer> referencedAnswers) {
+                                 // if the survey uses answers from other surveys, this will be populated.
+                                 // keyed by the full variable name (e.g. "survey1.question1" or "survey1['otherStudy'].question1")
+                                 // so the frontend can set the surveyJS variable directly without needing to reconstruct it
+                                 Map<String, Answer> referencedAnswers) {
 }
 

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyParseUtils.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyParseUtils.java
@@ -170,24 +170,31 @@ public class SurveyParseUtils {
     }
 
 
-    public record QuestionReference(String surveyStableId, String questionStableId) {
+    // matches surveyStableId, optionally followed by ['studyShortcode'], followed by .questionStableId
+    private static final Pattern QUESTION_REFERENCE_PATTERN =
+            Pattern.compile("^(\\w+)(?:\\[\\s*['\"]([\\w-]+)['\"]\\s*])?\\.(.+)$");
+
+    // studyShortcode is null unless the reference points at a survey in another study, e.g. otherSurvey['otherStudy'].question
+    public record QuestionReference(String surveyStableId, String questionStableId, String studyShortcode) {
         public static QuestionReference fromString(String reference) {
-            List<String> split = new ArrayList<>(Arrays.asList(reference.split("\\.")));
-
-            String surveyStableId = split.removeFirst();
-            String questionStableId = StringUtils.join(split, ".");
-
-            return new QuestionReference(surveyStableId, questionStableId);
+            Matcher matcher = QUESTION_REFERENCE_PATTERN.matcher(reference);
+            if (!matcher.matches()) {
+                throw new IllegalArgumentException("Invalid question reference: " + reference);
+            }
+            return new QuestionReference(matcher.group(1), matcher.group(3), matcher.group(2));
         }
 
         public String toString() {
-            return surveyStableId + "." + questionStableId;
+            String studyPart = studyShortcode != null ? "['" + studyShortcode + "']" : "";
+            return surveyStableId + studyPart + "." + questionStableId;
         }
     }
 
     // looks for all variables in survey content of form {surveyStableId.questionStableId}
+    // or {surveyStableId['studyShortcode'].questionStableId} for cross-study references
     // this may pick up some false positives, so we need to filter out using the nonSurveyObjectVariables list
-    private static final Pattern surveyQuestionRegexPattern = Pattern.compile("\\{\\s*\\w+\\.[\\w.]+\\s*}");
+    private static final Pattern surveyQuestionRegexPattern =
+            Pattern.compile("\\{\\s*\\w+(?:\\[\\s*['\"][\\w-]+['\"]\\s*])?\\.[\\w.]+\\s*}");
     private static final List<String> nonSurveyObjectVariables = List.of("profile", "proxyProfile");
 
     // returns a list of all potential question references in the survey content. these will need to be checked

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -6,13 +6,16 @@ import bio.terra.pearl.core.model.audit.ParticipantDataChange;
 import bio.terra.pearl.core.model.audit.ResponsibleEntity;
 import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.PortalParticipantUser;
+import bio.terra.pearl.core.model.study.StudyEnvironment;
 import bio.terra.pearl.core.model.survey.*;
 import bio.terra.pearl.core.model.workflow.*;
 import bio.terra.pearl.core.service.CascadeProperty;
 import bio.terra.pearl.core.service.CrudService;
 import bio.terra.pearl.core.service.exception.NotFoundException;
+import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.rule.EnrolleeContext;
 import bio.terra.pearl.core.service.rule.EnrolleeContextService;
+import bio.terra.pearl.core.service.study.StudyEnvironmentService;
 import bio.terra.pearl.core.service.study.StudyEnvironmentSurveyService;
 import bio.terra.pearl.core.service.survey.event.EnrolleeSurveyEvent;
 import bio.terra.pearl.core.service.workflow.EventService;
@@ -38,6 +41,8 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
     private final SurveyTaskDispatcher surveyTaskDispatcher;
     private final EventService eventService;
     private final EnrolleeContextService enrolleeContextService;
+    private final EnrolleeService enrolleeService;
+    private final StudyEnvironmentService studyEnvironmentService;
     public static final String CONSENTED_ANSWER_STABLE_ID = "consented";
 
     public SurveyResponseService(SurveyResponseDao dao,
@@ -47,7 +52,8 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
                                  StudyEnvironmentSurveyService studyEnvironmentSurveyService,
                                  AnswerProcessingService answerProcessingService,
                                  EnrolleeContextService enrolleeContextService,
-                                 ParticipantDataChangeService participantDataChangeService, @Lazy SurveyTaskDispatcher surveyTaskDispatcher, EventService eventService) {
+                                 ParticipantDataChangeService participantDataChangeService, @Lazy SurveyTaskDispatcher surveyTaskDispatcher, EventService eventService,
+                                 EnrolleeService enrolleeService, StudyEnvironmentService studyEnvironmentService) {
         super(dao);
         this.answerService = answerService;
         this.surveyService = surveyService;
@@ -58,6 +64,8 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         this.surveyTaskDispatcher = surveyTaskDispatcher;
         this.eventService = eventService;
         this.enrolleeContextService = enrolleeContextService;
+        this.enrolleeService = enrolleeService;
+        this.studyEnvironmentService = studyEnvironmentService;
     }
 
     public List<SurveyResponse> findByEnrolleeId(UUID enrolleeId) {
@@ -131,18 +139,32 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         );
     }
 
-    private List<Answer> getReferencedAnswers(Enrollee enrollee, Survey survey) {
-        List<Answer> answers = new ArrayList<>();
+    private Map<String, Answer> getReferencedAnswers(Enrollee enrollee, Survey survey) {
+        Map<String, Answer> answers = new HashMap<>();
 
         List<SurveyParseUtils.QuestionReference> referencedQuestions = survey.getReferencedQuestions().stream().map(SurveyParseUtils.QuestionReference::fromString).toList();
 
         for (SurveyParseUtils.QuestionReference referencedQuestion : referencedQuestions) {
+            Enrollee sourceEnrollee = referencedQuestion.studyShortcode() == null
+                    ? enrollee
+                    : findEnrolleeInOtherStudy(enrollee, referencedQuestion.studyShortcode()).orElse(null);
+            if (sourceEnrollee == null) {
+                continue;
+            }
             answerService
-                    .findForEnrolleeByQuestion(enrollee.getId(), referencedQuestion.surveyStableId(), referencedQuestion.questionStableId())
-                    .ifPresent(answers::add);
+                    .findForEnrolleeByQuestion(sourceEnrollee.getId(), referencedQuestion.surveyStableId(), referencedQuestion.questionStableId())
+                    .ifPresent(answer -> answers.put(referencedQuestion.toString(), answer));
         }
 
         return answers;
+    }
+
+    /** finds the enrollee for the same participant user, but in a different study within the same environment */
+    private Optional<Enrollee> findEnrolleeInOtherStudy(Enrollee enrollee, String otherStudyShortcode) {
+        StudyEnvironment currentStudyEnv = studyEnvironmentService.find(enrollee.getStudyEnvironmentId())
+                .orElseThrow(() -> new NotFoundException("Study environment not found: " + enrollee.getStudyEnvironmentId()));
+        return enrolleeService.findByParticipantUserIdAndStudyEnv(
+                enrollee.getParticipantUserId(), otherStudyShortcode, currentStudyEnv.getEnvironmentName());
     }
 
     //if the cutoff time has passed, create a new task and response

--- a/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
+++ b/core/src/main/java/bio/terra/pearl/core/service/survey/SurveyResponseService.java
@@ -1,6 +1,7 @@
 package bio.terra.pearl.core.service.survey;
 
 import bio.terra.pearl.core.dao.survey.SurveyResponseDao;
+import bio.terra.pearl.core.model.EnvironmentName;
 import bio.terra.pearl.core.model.audit.DataAuditInfo;
 import bio.terra.pearl.core.model.audit.ParticipantDataChange;
 import bio.terra.pearl.core.model.audit.ResponsibleEntity;
@@ -140,6 +141,23 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
     }
 
     private Map<String, Answer> getReferencedAnswers(Enrollee enrollee, Survey survey) {
+        StudyEnvironment currentStudyEnv = studyEnvironmentService.find(enrollee.getStudyEnvironmentId())
+                .orElseThrow(() -> new NotFoundException("Study environment not found: " + enrollee.getStudyEnvironmentId()));
+        return resolveReferencedAnswers(enrollee, enrollee.getParticipantUserId(), currentStudyEnv.getEnvironmentName(), survey);
+    }
+
+    /**
+     * during pre-enroll, no enrollee for current study, but may be signed up in other studies.
+     */
+    public Map<String, Answer> getReferencedAnswersForPreEnroll(UUID participantUserId, EnvironmentName envName, Survey survey) {
+        return resolveReferencedAnswers(null, participantUserId, envName, survey);
+    }
+
+    /**
+     * if enrollee is null (e.g., pre-enroll), same-study ({otherSurvey.question}) references are ignored.
+     * cross-study references ({otherSurvey['otherStudy'].question}) fetched via user id + env name
+     */
+    private Map<String, Answer> resolveReferencedAnswers(Enrollee enrollee, UUID participantUserId, EnvironmentName envName, Survey survey) {
         Map<String, Answer> answers = new HashMap<>();
 
         List<SurveyParseUtils.QuestionReference> referencedQuestions = survey.getReferencedQuestions().stream().map(SurveyParseUtils.QuestionReference::fromString).toList();
@@ -147,24 +165,15 @@ public class SurveyResponseService extends CrudService<SurveyResponse, SurveyRes
         for (SurveyParseUtils.QuestionReference referencedQuestion : referencedQuestions) {
             Enrollee sourceEnrollee = referencedQuestion.studyShortcode() == null
                     ? enrollee
-                    : findEnrolleeInOtherStudy(enrollee, referencedQuestion.studyShortcode()).orElse(null);
+                    : enrolleeService.findByParticipantUserIdAndStudyEnv(participantUserId, referencedQuestion.studyShortcode(), envName).orElse(null);
             if (sourceEnrollee == null) {
                 continue;
             }
-            answerService
-                    .findForEnrolleeByQuestion(sourceEnrollee.getId(), referencedQuestion.surveyStableId(), referencedQuestion.questionStableId())
+            answerService.findForEnrolleeByQuestion(sourceEnrollee.getId(), referencedQuestion.surveyStableId(), referencedQuestion.questionStableId())
                     .ifPresent(answer -> answers.put(referencedQuestion.toString(), answer));
         }
 
         return answers;
-    }
-
-    /** finds the enrollee for the same participant user, but in a different study within the same environment */
-    private Optional<Enrollee> findEnrolleeInOtherStudy(Enrollee enrollee, String otherStudyShortcode) {
-        StudyEnvironment currentStudyEnv = studyEnvironmentService.find(enrollee.getStudyEnvironmentId())
-                .orElseThrow(() -> new NotFoundException("Study environment not found: " + enrollee.getStudyEnvironmentId()));
-        return enrolleeService.findByParticipantUserIdAndStudyEnv(
-                enrollee.getParticipantUserId(), otherStudyShortcode, currentStudyEnv.getEnvironmentName());
     }
 
     //if the cutoff time has passed, create a new task and response

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
@@ -162,7 +162,49 @@ public class SurveyResponseServiceTests extends BaseSpringBootTest {
 
         assertEquals(1, surveyWithResponse.referencedAnswers().size());
 
-        Answer answer = surveyWithResponse.referencedAnswers().get(0);
+        Answer answer = surveyWithResponse.referencedAnswers().get("survey1.diagnosis");
+
+        assertEquals(answer.getSurveyStableId(), "survey1");
+        assertEquals(answer.getQuestionStableId(), "diagnosis");
+        assertEquals(answer.getStringValue(), "cancer");
+    }
+
+    @Test
+    @Transactional
+    public void testSurveyResponseWithAnswersAttachesReferencedAnswersCrossStudy(TestInfo info) {
+        StudyEnvironmentBundle studyEnvBundle1 = studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.sandbox);
+        StudyEnvironmentBundle studyEnvBundle2 = studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.sandbox,
+                studyEnvBundle1.getPortal(), studyEnvBundle1.getPortalEnv());
+
+        Survey survey1 = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .portalId(studyEnvBundle1.getPortal().getId())
+                .stableId("survey1")
+                .content("{\"pages\":[{\"elements\":[{\"type\":\"text\",\"name\":\"diagnosis\",\"title\":\"What is your diagnosis?\"}]}]}"));
+        surveyFactory.attachToEnv(survey1, studyEnvBundle1.getStudyEnv().getId(), true);
+
+        Survey survey2 = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .portalId(studyEnvBundle2.getPortal().getId())
+                .stableId("survey2")
+                .content("{\"pages\":[{\"elements\":[{\"type\":\"text\",\"name\":\"diagnosis\",\"title\":\"Tell me more about {survey1['"
+                        + studyEnvBundle1.getStudy().getShortcode() + "'].diagnosis}\"}]}]}"));
+        surveyFactory.attachToEnv(survey2, studyEnvBundle2.getStudyEnv().getId(), true);
+
+        assertEquals(1, survey2.getReferencedQuestions().size());
+        assertEquals("survey1['" + studyEnvBundle1.getStudy().getShortcode() + "'].diagnosis", survey2.getReferencedQuestions().getFirst());
+
+        Enrollee enrolleeInStudy1 = enrolleeFactory.buildPersisted(getTestName(info), studyEnvBundle1.getStudyEnv());
+        Enrollee enrolleeInStudy2 = enrolleeFactory.buildPersisted(getTestName(info), studyEnvBundle2.getStudyEnv().getId(),
+                enrolleeInStudy1.getParticipantUserId(), enrolleeInStudy1.getProfileId());
+
+        surveyResponseFactory.buildWithAnswers(enrolleeInStudy1, survey1, Map.of("diagnosis", "cancer"));
+
+        SurveyWithResponse surveyWithResponse = surveyResponseService.findWithActiveResponse(studyEnvBundle2.getStudyEnv().getId(),
+                studyEnvBundle2.getPortal().getId(), survey2.getStableId(), survey2.getVersion(), enrolleeInStudy2, null);
+
+        assertEquals(1, surveyWithResponse.referencedAnswers().size());
+
+        Answer answer = surveyWithResponse.referencedAnswers().get(
+                "survey1['" + studyEnvBundle1.getStudy().getShortcode() + "'].diagnosis");
 
         assertEquals(answer.getSurveyStableId(), "survey1");
         assertEquals(answer.getQuestionStableId(), "diagnosis");

--- a/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/service/survey/SurveyResponseServiceTests.java
@@ -18,9 +18,12 @@ import bio.terra.pearl.core.model.participant.Enrollee;
 import bio.terra.pearl.core.model.participant.ParticipantUser;
 import bio.terra.pearl.core.model.participant.PortalParticipantUser;
 import bio.terra.pearl.core.model.survey.*;
-import bio.terra.pearl.core.model.workflow.*;
-import bio.terra.pearl.core.service.file.ParticipantFileService;
+import bio.terra.pearl.core.model.workflow.HubResponse;
+import bio.terra.pearl.core.model.workflow.ParticipantTask;
+import bio.terra.pearl.core.model.workflow.RecurrenceType;
+import bio.terra.pearl.core.model.workflow.TaskStatus;
 import bio.terra.pearl.core.service.exception.NotFoundException;
+import bio.terra.pearl.core.service.file.ParticipantFileService;
 import bio.terra.pearl.core.service.participant.EnrolleeService;
 import bio.terra.pearl.core.service.participant.ParticipantUserService;
 import bio.terra.pearl.core.service.participant.PortalParticipantUserService;
@@ -36,8 +39,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -209,6 +210,70 @@ public class SurveyResponseServiceTests extends BaseSpringBootTest {
         assertEquals(answer.getSurveyStableId(), "survey1");
         assertEquals(answer.getQuestionStableId(), "diagnosis");
         assertEquals(answer.getStringValue(), "cancer");
+    }
+
+    @Test
+    @Transactional
+    public void testGetReferencedAnswersForPreEnrollResolvesCrossStudyPreEnroll(TestInfo info) {
+        StudyEnvironmentBundle studyEnvBundle1 = studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.sandbox);
+        StudyEnvironmentBundle studyEnvBundle2 = studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.sandbox,
+                studyEnvBundle1.getPortal(), studyEnvBundle1.getPortalEnv());
+
+        Survey survey1 = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .portalId(studyEnvBundle1.getPortal().getId())
+                .stableId("survey1")
+                .content("{\"pages\":[{\"elements\":[{\"type\":\"text\",\"name\":\"diagnosis\",\"title\":\"What is your diagnosis?\"}]}]}"));
+        surveyFactory.attachToEnv(survey1, studyEnvBundle1.getStudyEnv().getId(), true);
+
+        // a pre-enroll survey for study2 that references a question from study1 -- note there is no enrollee
+        // for study2 yet, since the participant hasn't enrolled there
+        Survey preEnrollSurvey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .portalId(studyEnvBundle2.getPortal().getId())
+                .stableId("preEnroll2")
+                .content("{\"pages\":[{\"elements\":[{\"type\":\"text\",\"name\":\"diagnosisConfirm\",\"title\":\"Confirm: {survey1['"
+                        + studyEnvBundle1.getStudy().getShortcode() + "'].diagnosis}\"}]}]}"));
+        surveyFactory.attachToEnv(preEnrollSurvey, studyEnvBundle2.getStudyEnv().getId(), true);
+
+        Enrollee enrolleeInStudy1 = enrolleeFactory.buildPersisted(getTestName(info), studyEnvBundle1.getStudyEnv());
+        surveyResponseFactory.buildWithAnswers(enrolleeInStudy1, survey1, Map.of("diagnosis", "cancer"));
+
+        Map<String, Answer> referencedAnswers = surveyResponseService.getReferencedAnswersForPreEnroll(
+                enrolleeInStudy1.getParticipantUserId(), studyEnvBundle2.getStudyEnv().getEnvironmentName(), preEnrollSurvey);
+
+        assertEquals(1, referencedAnswers.size());
+        Answer answer = referencedAnswers.get("survey1['" + studyEnvBundle1.getStudy().getShortcode() + "'].diagnosis");
+        assertEquals(answer.getSurveyStableId(), "survey1");
+        assertEquals(answer.getQuestionStableId(), "diagnosis");
+        assertEquals(answer.getStringValue(), "cancer");
+    }
+
+    @Test
+    @Transactional
+    public void testGetReferencedAnswersForPreEnrollIgnoresSameStudyReferences(TestInfo info) {
+        StudyEnvironmentBundle studyEnvBundle = studyEnvironmentFactory.buildBundle(getTestName(info), EnvironmentName.sandbox);
+
+        Survey survey1 = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .portalId(studyEnvBundle.getPortal().getId())
+                .stableId("survey1")
+                .content("{\"pages\":[{\"elements\":[{\"type\":\"text\",\"name\":\"diagnosis\",\"title\":\"What is your diagnosis?\"}]}]}"));
+        surveyFactory.attachToEnv(survey1, studyEnvBundle.getStudyEnv().getId(), true);
+
+        // a same-study reference makes no sense for pre-enroll, since there's no enrollee yet -- should just be skipped
+        Survey preEnrollSurvey = surveyFactory.buildPersisted(surveyFactory.builder(getTestName(info))
+                .portalId(studyEnvBundle.getPortal().getId())
+                .stableId("preEnroll1")
+                .content("{\"pages\":[{\"elements\":[{\"type\":\"text\",\"name\":\"diagnosisConfirm\",\"title\":\"Confirm: {survey1.diagnosis}\"}]}]}"));
+        surveyFactory.attachToEnv(preEnrollSurvey, studyEnvBundle.getStudyEnv().getId(), true);
+
+        ParticipantUser participantUser = participantUserService.create(ParticipantUser.builder()
+                .username(getTestName(info))
+                .environmentName(EnvironmentName.sandbox)
+                .build());
+
+        Map<String, Answer> referencedAnswers = surveyResponseService.getReferencedAnswersForPreEnroll(
+                participantUser.getId(), studyEnvBundle.getStudyEnv().getEnvironmentName(), preEnrollSurvey);
+
+        assertEquals(0, referencedAnswers.size());
     }
 
     @Test

--- a/core/src/test/java/bio/terra/pearl/core/util/SurveyParseUtilsTests.java
+++ b/core/src/test/java/bio/terra/pearl/core/util/SurveyParseUtilsTests.java
@@ -2,6 +2,7 @@ package bio.terra.pearl.core.util;
 
 import bio.terra.pearl.core.BaseSpringBootTest;
 import bio.terra.pearl.core.factory.survey.SurveyFactory;
+import bio.terra.pearl.core.model.survey.Survey;
 import bio.terra.pearl.core.service.survey.SurveyParseUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -458,6 +459,51 @@ public class SurveyParseUtilsTests extends BaseSpringBootTest {
                         "schoolsBuDetail",
                         "schoolsOtherDetail"),
                 stableIds);
+    }
+
+    @Test
+    public void testQuestionReferenceRoundTripsSameStudy() {
+        SurveyParseUtils.QuestionReference reference = SurveyParseUtils.QuestionReference.fromString("survey1.diagnosis");
+        assertEquals("survey1", reference.surveyStableId());
+        assertEquals("diagnosis", reference.questionStableId());
+        assertEquals(null, reference.studyShortcode());
+        assertEquals("survey1.diagnosis", reference.toString());
+    }
+
+    @Test
+    public void testQuestionReferenceRoundTripsCrossStudy() {
+        SurveyParseUtils.QuestionReference reference = SurveyParseUtils.QuestionReference.fromString("survey1['otherStudy'].diagnosis");
+        assertEquals("survey1", reference.surveyStableId());
+        assertEquals("diagnosis", reference.questionStableId());
+        assertEquals("otherStudy", reference.studyShortcode());
+        assertEquals("survey1['otherStudy'].diagnosis", reference.toString());
+    }
+
+    @Test
+    public void testParseReferencedSurveyQuestionsHandlesCrossStudy() throws JsonProcessingException {
+        String form = """
+                {
+                  "pages": [
+                    {
+                      "elements": [
+                        {
+                          "name": "q1",
+                          "type": "text",
+                          "title": "Value is {survey1['otherStudy'].diagnosis}"
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """;
+        Survey survey = Survey.builder().content(form).build();
+
+        List<SurveyParseUtils.QuestionReference> references = SurveyParseUtils.parseReferencedSurveyQuestions(survey);
+
+        assertThat(references, hasSize(1));
+        assertEquals("survey1", references.get(0).surveyStableId());
+        assertEquals("otherStudy", references.get(0).studyShortcode());
+        assertEquals("diagnosis", references.get(0).questionStableId());
     }
 
 }

--- a/ui-admin/src/forms/FormPreview.tsx
+++ b/ui-admin/src/forms/FormPreview.tsx
@@ -41,7 +41,7 @@ export const FormPreview = (props: FormPreviewProps) => {
       profile: {} as Profile,
       studyEnvParams: useStudyEnvParamsFromPath(),
       enrolleeShortcode: '',
-      referencedAnswers: [],
+      referencedAnswers: {},
       extraVariables: {}
     })
     model.ignoreValidation = true

--- a/ui-core/src/components/forms/PagedSurveyView.test.tsx
+++ b/ui-core/src/components/forms/PagedSurveyView.test.tsx
@@ -74,14 +74,42 @@ describe('PagedSurveyView', () => {
       }`
     },
     undefined,
-    [{
-      format: 'NONE',
-      surveyStableId: 'otherSurvey',
-      questionStableId: 'question1',
-      stringValue: 'my custom response'
-    }])
+    {
+      'otherSurvey.question1': {
+        format: 'NONE',
+        surveyStableId: 'otherSurvey',
+        questionStableId: 'question1',
+        stringValue: 'my custom response'
+      }
+    })
 
     expect(screen.getByText('test my custom response')).toBeInTheDocument()
+  })
+
+  it('passes down cross-study referenced answers as variables', async () => {
+    setupSurveyTest({
+      ...generateSurvey(),
+      content: `{
+      "pages":[
+        {"elements":[
+          {"type":"html","html":"You are on page1"},
+          {"type":"text","name":"test","title":"test {otherSurvey['otherStudy'].question1}"}
+        ]},
+        {"elements":[{"type":"text","name":"otherPage","title":"otherpage"}]}
+      ]
+      }`
+    },
+    undefined,
+    {
+      "otherSurvey['otherStudy'].question1": {
+        format: 'NONE',
+        surveyStableId: 'otherSurvey',
+        questionStableId: 'question1',
+        stringValue: 'my custom cross-study response'
+      }
+    })
+
+    expect(screen.getByText('test my custom cross-study response')).toBeInTheDocument()
   })
   //
   it('autosaves question and page progress', async () => {
@@ -435,7 +463,7 @@ describe('PagedSurveyView', () => {
 /**
  *
  */
-const setupSurveyTest = (survey: Survey, profile?: Profile, referencedAnswers?: Answer[]) => {
+const setupSurveyTest = (survey: Survey, profile?: Profile, referencedAnswers?: Record<string, Answer>) => {
   const mockUpdateSurveyResponse = jest.fn().mockResolvedValue(mockHubResponse())
 
   const mockApi: ApiContextT = {
@@ -467,7 +495,7 @@ const setupSurveyTest = (survey: Survey, profile?: Profile, referencedAnswers?: 
       <MockI18nProvider>
         <PagedSurveyView enrollee={enrollee} form={configuredSurvey.survey} response={mockHubResponse().response}
           studyEnvParams={{ studyShortcode: 'study', portalShortcode: 'portal', envName: 'sandbox' }}
-          updateResponseMap={jest.fn()} referencedAnswers={referencedAnswers || []}
+          updateResponseMap={jest.fn()} referencedAnswers={referencedAnswers || {}}
           selectedLanguage={'en'} updateProfile={jest.fn()} setAutosaveStatus={jest.fn()} setTaskId={jest.fn()}
           taskId={'guid34'} adminUserId={null} updateEnrollee={jest.fn()} onFailure={jest.fn()} onSuccess={jest.fn()}/>
       </MockI18nProvider>

--- a/ui-core/src/components/forms/PagedSurveyView.test.tsx
+++ b/ui-core/src/components/forms/PagedSurveyView.test.tsx
@@ -101,7 +101,7 @@ describe('PagedSurveyView', () => {
     },
     undefined,
     {
-      "otherSurvey['otherStudy'].question1": {
+      'otherSurvey[\'otherStudy\'].question1': {
         format: 'NONE',
         surveyStableId: 'otherSurvey',
         questionStableId: 'question1',

--- a/ui-core/src/components/forms/PagedSurveyView.tsx
+++ b/ui-core/src/components/forms/PagedSurveyView.tsx
@@ -40,7 +40,7 @@ export function PagedSurveyView({
   studyEnvParams,
   form,
   response,
-  referencedAnswers = [],
+  referencedAnswers = {},
   updateEnrollee,
   updateProfile,
   taskId,
@@ -59,7 +59,7 @@ export function PagedSurveyView({
   studyEnvParams: StudyEnvParams,
   form: Survey,
   response: SurveyResponse,
-  referencedAnswers?: Answer[],
+  referencedAnswers?: Record<string, Answer>,
   updateResponseMap: (stableId: string, response: SurveyResponse) => void
   onSuccess: () => void, onFailure: () => void,
   selectedLanguage: string,

--- a/ui-core/src/surveyUtils.tsx
+++ b/ui-core/src/surveyUtils.tsx
@@ -104,7 +104,8 @@ export type SurveyJsVariableContext = {
   studyEnvParams?: OptionalStudyEnvParams,
   environmentName?: string,
   enrolleeShortcode?: string,
-  referencedAnswers?: Answer[],
+  // keyed by the full variable name (e.g. "survey1.question1" or "survey1['otherStudy'].question1")
+  referencedAnswers?: Record<string, Answer>,
   extraVariables?: Record<string, unknown>
 }
 
@@ -121,8 +122,8 @@ export const applySurveyJsVariables = (surveyModel: SurveyModel, varContext: Sur
   surveyModel.setVariable('studyEnvParams', studyEnvParams)
   surveyModel.setVariable('enrolleeShortcode', enrolleeShortcode)
   surveyModel.setVariable('portalEnvironmentName', environmentName || studyEnvParams?.envName)
-  referencedAnswers?.forEach(answer => {
-    surveyModel.setVariable(`${answer.surveyStableId}.${answer.questionStableId}`,
+  Object.entries(referencedAnswers ?? {}).forEach(([variableName, answer]) => {
+    surveyModel.setVariable(variableName,
       answer.stringValue ?? answer.numberValue ?? answer.booleanValue ?? answer.objectValue)
   })
   if (!isNil(extraVariables)) {

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -81,7 +81,8 @@ export type RegistrationResponse = {
 export type SurveyWithResponse = {
   studyEnvironmentSurvey: StudyEnvironmentSurvey,
   surveyResponse?: SurveyResponse
-  referencedAnswers: Answer[]
+  // keyed by the full variable name (e.g. "survey1.question1" or "survey1['otherStudy'].question1")
+  referencedAnswers: Record<string, Answer>
 }
 
 export type TaskWithSurvey = {

--- a/ui-participant/src/api/api.tsx
+++ b/ui-participant/src/api/api.tsx
@@ -280,6 +280,19 @@ export default {
   },
 
   /**
+   * gets any answers from other studies' surveys that a pre-enrollment survey references, for the
+   * signed-in user. Should only be called if the user is logged in (e.g. enrolling in a second study
+   * within a portal), since the endpoint requires authentication.
+   */
+  async getPreEnrollReferencedAnswers({ surveyStableId, surveyVersion }:
+                                        { surveyStableId: string, surveyVersion: number }):
+    Promise<Record<string, Answer>> {
+    const url = `${baseEnvUrl(true)}/preEnroll/${surveyStableId}/${surveyVersion}/referencedAnswers`
+    const response = await fetch(url, { headers: this.getInitHeaders() })
+    return await this.processJsonResponse(response)
+  },
+
+  /**
    * confirms that a client-side saved preregistration id is still valid.  For cases where the user refreshes the
    * page while on registration
    */

--- a/ui-participant/src/hub/survey/PrintSurveyView.tsx
+++ b/ui-participant/src/hub/survey/PrintSurveyView.tsx
@@ -90,7 +90,7 @@ const usePrintableSurvey = (args: UsePrintableConsentArgs) => {
           portalShortcode: portal.shortcode
         },
         enrolleeShortcode: enrollee.shortcode,
-        referencedAnswers: [],
+        referencedAnswers: {},
         extraVariables: {}
       })
 

--- a/ui-participant/src/studies/enroll/PreEnroll.tsx
+++ b/ui-participant/src/studies/enroll/PreEnroll.tsx
@@ -110,7 +110,7 @@ export function EligiblePreEnrollView({ enrollContext, survey, eligibilityResult
       proxyProfile,
       studyEnvParams: { envName: studyEnv.environmentName, studyShortcode, portalShortcode },
       enrolleeShortcode: enrollee?.shortcode || '',
-      referencedAnswers: [],
+      referencedAnswers: {},
       extraVariables: {
         isProxyEnrollment, isSubjectEnrollment, user,
         eligibilityResult

--- a/ui-participant/src/studies/enroll/PreEnroll.tsx
+++ b/ui-participant/src/studies/enroll/PreEnroll.tsx
@@ -10,6 +10,7 @@ import Api, {
 import { useNavigate } from 'react-router-dom'
 import { StudyEnrollContext } from './StudyEnrollRouter'
 import {
+  Answer,
   getResumeData,
   getSurveyJsAnswerList,
   makeSurveyJsData,
@@ -36,46 +37,59 @@ const ENROLLMENT_QUALIFIED_VARIABLE = 'qualified'
 export default function PreEnrollView({ enrollContext, survey }:
   { enrollContext: StudyEnrollContext, survey: Survey }) {
   const eligibleRule = enrollContext.studyEnv.studyEnvironmentConfig.studyEligibilityRule
+  const { user } = useUser()
 
-  // if there's an eligibility rule, we need to check eligibility before showing the survey
-  const [isLoading, setIsLoading] = useState(!!eligibleRule)
+  // if there's an eligibility rule to check, or the user is already logged in (and so may have answers
+  // in another study's survey that this one references), we need to load that before showing the survey
+  const [isLoading, setIsLoading] = useState(!!eligibleRule || !!user)
   const [eligibilityResult, setEligibilityResult] = useState<EligibilityResult>({ eligible: !!eligibleRule })
+  const [referencedAnswers, setReferencedAnswers] = useState<Record<string, Answer>>({})
 
-  const checkEligibility = async () => {
-    if (eligibleRule) {
-      setIsLoading(true)
-      try {
+  const loadPreEnrollData = async () => {
+    if (!eligibleRule && !user) {
+      return
+    }
+    setIsLoading(true)
+    try {
+      if (eligibleRule) {
         const response = await Api.checkEligible(enrollContext.studyShortcode)
         setEligibilityResult(response)
+      }
+      if (user) {
+        const answers = await Api.getPreEnrollReferencedAnswers({
+          surveyStableId: survey.stableId, surveyVersion: survey.version
+        })
+        setReferencedAnswers(answers)
+      }
+      setIsLoading(false)
+    } catch (e: unknown) {
+      const statusCode = (e as ApiErrorResponse).statusCode
+      if (statusCode === 403 || statusCode === 401) {
         setIsLoading(false)
-      } catch (e: unknown) {
-        const statusCode = (e as ApiErrorResponse).statusCode
-        // ignore 401/403s -- not being logged in is handled by the survey content
-        if (statusCode === 403 || statusCode === 401) {
-          setIsLoading(false)
-        } else {
-          defaultApiErrorHandle(e as ApiErrorResponse)
-        }
+      } else {
+        defaultApiErrorHandle(e as ApiErrorResponse)
       }
     }
   }
 
   useEffect(() => {
-    checkEligibility()
-  }, [eligibleRule])
+    loadPreEnrollData()
+  }, [eligibleRule, user?.id])
   return <>
     { !isLoading && <EligiblePreEnrollView enrollContext={enrollContext}
-      eligibilityResult={eligibilityResult} survey={survey}/> }
+      eligibilityResult={eligibilityResult} referencedAnswers={referencedAnswers}
+      survey={survey}/>}
     { isLoading && <LoadingSpinner/>}
   </>
 }
 
 
 /** Renders a pre-enrollment form, and handles submitting the user-inputted response */
-export function EligiblePreEnrollView({ enrollContext, survey, eligibilityResult }:
+export function EligiblePreEnrollView({ enrollContext, survey, eligibilityResult, referencedAnswers }:
                                         { enrollContext: StudyEnrollContext,
                                           survey: Survey,
-                                          eligibilityResult: EligibilityResult
+                                          eligibilityResult: EligibilityResult,
+                                          referencedAnswers: Record<string, Answer>
                                         }) {
   const {
     studyEnv,
@@ -110,7 +124,7 @@ export function EligiblePreEnrollView({ enrollContext, survey, eligibilityResult
       proxyProfile,
       studyEnvParams: { envName: studyEnv.environmentName, studyShortcode, portalShortcode },
       enrolleeShortcode: enrollee?.shortcode || '',
-      referencedAnswers: {},
+      referencedAnswers,
       extraVariables: {
         isProxyEnrollment, isSubjectEnrollment, user,
         eligibilityResult


### PR DESCRIPTION
#### DESCRIPTION (include screenshots, and mobile screenshots for participant UX)

allows usage of `{otherSurvey['otherStudy'].question}` in surveys to grab values across study boundaries for hearthive.

#### TO TEST:  *(simple manual steps for confirming core behavior -- used for pre-release checks)*

